### PR TITLE
layers: Clang-Format 22 reset

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -35,8 +35,8 @@ permissions:
   contents: read
 
 jobs:
-  code-format:
-    runs-on: ubuntu-24.04
+  check_vvl:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,10 +44,33 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+      - name: install python packages
+        run: python3 -m pip install pyparsing
+      - name: Install clang-format 22
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22
+          sudo apt-get install -y clang-format-22
+          sudo ln -sf /usr/bin/clang-format-22 /usr/bin/clang-format
+      - name: Alias clang-format
+        run: |
+          mkdir -p bin
+          ln -s /usr/bin/clang-format-22 ./bin/clang-format
+          echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: clang-format version
         run: clang-format --version
       - name: Execute Source Code Format Checking Script
         run: python3 scripts/check_code_format.py --fetch-main --target-refspec=FETCH_HEAD
+      # This saves about 20 seconds for every run
+      - name: Create subset so we only clone what we need
+        run: |
+          jq '.repos |= map(select(.name == "Vulkan-Headers" or .name == "SPIRV-Headers"))' \
+          scripts/known_good.json > $RUNNER_TEMP/known_good.json
+      - name: Clone in Vulkan/SPIR-V headers
+        run: scripts/update_deps.py --dir ext --no-build --known_good_dir $RUNNER_TEMP
+      - name: Run the script to generate the code and compare it with what is checked in
+        run: scripts/generate_source.py --verify ext/Vulkan-Headers/registry/ ext/SPIRV-Headers/include/spirv/unified1/
 
   linux:
     needs: check_vvl
@@ -449,19 +472,6 @@ jobs:
       - uses: actions/checkout@v6
       - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
       - run: python scripts/gn/gn.py --args='${{ matrix.args }}'
-
-  check_vvl:
-    needs: code-format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
-      - run: python3 -m pip install pyparsing
-      - run: scripts/update_deps.py --dir ext --no-build
-      - run: scripts/generate_source.py --verify ext/Vulkan-Headers/registry/ ext/SPIRV-Headers/include/spirv/unified1/
-      - run: scripts/vk_validation_stats.py ext/Vulkan-Headers/registry/validusage.json -summary -c
 
   # "Collector Job" to funnel the requirements to a single action
   # This allows branches with SKIP-CI to skip down here, and still "pass"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We enjoy external contributions, we often see them in the form of:
 
 ## Quick check list for making a change
 
-- Make sure you run `clang-format` on any C++ code.
+- Make sure you run `clang-format` on any C++ code. (We currently use [clang-format 22.1.x](https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.1) for CI)
 - If fixing a bug, we would like a [positive test](./tests/README.md#different-categories-of-tests).
 - If addinga a new VU, we **need** a [negative test](./tests/README.md#different-categories-of-tests).
 - Try to match the code style around the code as best as possible.
@@ -22,7 +22,7 @@ We enjoy external contributions, we often see them in the form of:
 We are reasonable developers, we don't want to bikeshed on code style, but highly encourge to look at the nearby code.
 As maintainer, if we find the style is incredibly different, we will ask you kindly to fix it.
 
-our CI will run **clang-format** (version 14) **FOR EVERY COMMIT**, so make sure your change has been ran with it.
+our CI will run **clang-format** (version 22.1.x) **FOR EVERY COMMIT**, so make sure your change has been ran with it.
 
 ```bash
 # sample git workflow may look like

--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -38,7 +38,8 @@ bool BestPractices::PreCallValidateAllocateCommandBuffers(VkDevice device, const
     if (pAllocateInfo->level == VK_COMMAND_BUFFER_LEVEL_SECONDARY && (queue_flags & sec_cmd_buf_queue_flags) == 0) {
         skip |= LogWarning("BestPractices-vkAllocateCommandBuffers-unusable-secondary", device, error_obj.location,
                            "Allocating secondary level command buffer from command pool "
-                           "created against queue family %" PRIu32 " (queue flags: %s), but vkCmdExecuteCommands() is only "
+                           "created against queue family %" PRIu32
+                           " (queue flags: %s), but vkCmdExecuteCommands() is only "
                            "supported on queue families supporting VK_QUEUE_GRAPHICS_BIT, VK_QUEUE_COMPUTE_BIT, or "
                            "VK_QUEUE_TRANSFER_BIT. The allocated command buffer will not be submittable.",
                            cp_state->queueFamilyIndex, string_VkQueueFlags(queue_flags).c_str());

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -600,8 +600,7 @@ void BestPractices::UpdateBoundDescriptorSets(bp_state::CommandBufferSubState& c
                         break;
                     }
                     case vvl::DescriptorClass::ImageSampler: {
-                        if (const auto image_sampler_descriptor =
-                                static_cast<const vvl::ImageSamplerDescriptor*>(descriptor)) {
+                        if (const auto image_sampler_descriptor = static_cast<const vvl::ImageSamplerDescriptor*>(descriptor)) {
                             image_view = image_sampler_descriptor->GetImageView();
                         }
                         break;

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -386,7 +386,7 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, cons
             }
 
             if (vkuFormatHasStencil(attachment.format) && (attachment.stencilLoadOp == VK_ATTACHMENT_LOAD_OP_LOAD ||
-                                                        attachment.stencilStoreOp == VK_ATTACHMENT_STORE_OP_STORE)) {
+                                                           attachment.stencilStoreOp == VK_ATTACHMENT_STORE_OP_STORE)) {
                 bandwidth_aspects |= VK_IMAGE_ASPECT_STENCIL_BIT;
             }
 

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -22,8 +22,8 @@
 #include "state_tracker/queue_state.h"
 #include "generated/dispatch_functions.h"
 
-bool BestPractices::CheckDependencyInfo(const LogObjectList& objlist, const Location& dep_loc,
-                                        const VkDependencyInfo& dep_info, VkCommandBuffer commandBuffer) const {
+bool BestPractices::CheckDependencyInfo(const LogObjectList& objlist, const Location& dep_loc, const VkDependencyInfo& dep_info,
+                                        VkCommandBuffer commandBuffer) const {
     bool skip = false;
     for (uint32_t i = 0; i < dep_info.imageMemoryBarrierCount; ++i) {
         skip |= ValidateImageMemoryBarrier(

--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -767,8 +767,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDataGraphPipelinesARM(VkDevice device, VkDe
         for (const auto& vo : device_dispatch->object_dispatch) {
             auto lock = vo->ReadLock();
             skip |= vo->PreCallValidateCreateDataGraphPipelinesARM(device, deferredOperation, pipelineCache, createInfoCount,
-                                                                   pCreateInfos, pAllocator, pPipelines, error_obj,
-                                                                   pipeline_states, chassis_state);
+                                                                   pCreateInfos, pAllocator, pPipelines, error_obj, pipeline_states,
+                                                                   chassis_state);
             if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
         }
     }
@@ -779,8 +779,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDataGraphPipelinesARM(VkDevice device, VkDe
         for (auto& vo : device_dispatch->object_dispatch) {
             auto lock = vo->WriteLock();
             vo->PreCallRecordCreateDataGraphPipelinesARM(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos,
-                                                         pAllocator, pPipelines, record_obj, pipeline_states,
-                                                         chassis_state);
+                                                         pAllocator, pPipelines, record_obj, pipeline_states, chassis_state);
         }
     }
 
@@ -797,8 +796,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDataGraphPipelinesARM(VkDevice device, VkDe
         for (auto& vo : device_dispatch->object_dispatch) {
             auto lock = vo->WriteLock();
             vo->PostCallRecordCreateDataGraphPipelinesARM(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos,
-                                                          pAllocator, pPipelines, record_obj, pipeline_states,
-                                                          chassis_state);
+                                                          pAllocator, pPipelines, record_obj, pipeline_states, chassis_state);
         }
     }
     return result;

--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -34,19 +34,19 @@
 
 namespace vvl {
 
-void MarkSupportedExtensionsAsNotEnabled(const std::vector<VkExtensionProperties> &supported_extensions,
-                                         DeviceExtensions &extensions) {
+void MarkSupportedExtensionsAsNotEnabled(const std::vector<VkExtensionProperties>& supported_extensions,
+                                         DeviceExtensions& extensions) {
     for (size_t i = 0; i < supported_extensions.size(); i++) {
         vvl::Extension extension = GetExtension(supported_extensions[i].extensionName);
-        auto &info = extensions.GetInfo(extension);
+        auto& info = extensions.GetInfo(extension);
         if (info.state && (extensions.*(info.state)) == kNotSupported) {
             extensions.*(info.state) = kNotEnabled;
         }
     }
 }
 
-StatelessDeviceData::StatelessDeviceData(vvl::dispatch::Instance *instance, VkPhysicalDevice physical_device,
-                                         const VkDeviceCreateInfo *pCreateInfo) {
+StatelessDeviceData::StatelessDeviceData(vvl::dispatch::Instance* instance, VkPhysicalDevice physical_device,
+                                         const VkDeviceCreateInfo* pCreateInfo) {
     // Get physical device limits for device
     VkPhysicalDeviceProperties device_properties = {};
     instance->instance_dispatch_table.GetPhysicalDeviceProperties(physical_device, &device_properties);
@@ -503,7 +503,7 @@ StatelessDeviceData::StatelessDeviceData(vvl::dispatch::Instance *instance, VkPh
         DispatchEnumerateDeviceExtensionProperties(physical_device, NULL, &n_props, props.data());
 
         vvl::unordered_set<Extension> phys_dev_extensions;
-        for (const auto &ext_prop : props) {
+        for (const auto& ext_prop : props) {
             phys_dev_extensions.insert(GetExtension(ext_prop.extensionName));
         }
 
@@ -600,34 +600,34 @@ static ASHostGeomCacheInitializer as_host_geom_cache_initializer;
 
 // Generally we expect to get the same device and instance, so we keep them handy
 static std::shared_mutex instance_mutex;
-static vvl::unordered_map<void *, std::unique_ptr<Instance>> instance_data;
+static vvl::unordered_map<void*, std::unique_ptr<Instance>> instance_data;
 
 static std::shared_mutex device_mutex;
-static vvl::unordered_map<void *, std::unique_ptr<Device>> device_data;
-static std::atomic<Device *> last_used_device = nullptr;
+static vvl::unordered_map<void*, std::unique_ptr<Device>> device_data;
+static std::atomic<Device*> last_used_device = nullptr;
 
-static Instance *GetInstanceFromKey(void *key) {
+static Instance* GetInstanceFromKey(void* key) {
     ReadLockGuard lock(instance_mutex);
     return instance_data[key].get();
 }
 
-Instance *GetData(VkInstance instance) { return GetInstanceFromKey(GetDispatchKey(instance)); }
+Instance* GetData(VkInstance instance) { return GetInstanceFromKey(GetDispatchKey(instance)); }
 
-Instance *GetData(VkPhysicalDevice pd) { return GetInstanceFromKey(GetDispatchKey(pd)); }
+Instance* GetData(VkPhysicalDevice pd) { return GetInstanceFromKey(GetDispatchKey(pd)); }
 
-void SetData(VkInstance instance, std::unique_ptr<Instance> &&data) {
-    void *key = GetDispatchKey(instance);
+void SetData(VkInstance instance, std::unique_ptr<Instance>&& data) {
+    void* key = GetDispatchKey(instance);
     WriteLockGuard lock(instance_mutex);
     instance_data[key] = std::move(data);
 }
 
-void FreeData(void *key, VkInstance instance) {
+void FreeData(void* key, VkInstance instance) {
     WriteLockGuard lock(instance_mutex);
     instance_data.erase(key);
 }
 
-static Device *GetDeviceFromKey(void *key) {
-    Device *last_device = last_used_device.load();
+static Device* GetDeviceFromKey(void* key) {
+    Device* last_device = last_used_device.load();
     if (last_device && GetDispatchKey(last_device->device) == key) {
         return last_device;
     }
@@ -638,7 +638,7 @@ static Device *GetDeviceFromKey(void *key) {
         // If this occurs from atexit() using the layer, it would be better to provide a location where this happened, but
         // everything is tore down and there is not much to do. Also this is the single location where can detect this, so having it
         // here makes sure we don't miss a spot.
-        const char *error =
+        const char* error =
             "\n\nVALIDATION ERROR - The VkDevice dispatch handle was not found and Validation will crash. If you are using exit() "
             "you need to make sure to not call any Vulkan calls in your atexit() function as the layer static memory will be "
             "destroyed prior to atexit()\n\n";
@@ -653,21 +653,21 @@ static Device *GetDeviceFromKey(void *key) {
     return last_device;
 }
 
-Device *GetData(VkDevice device) { return GetDeviceFromKey(GetDispatchKey(device)); }
+Device* GetData(VkDevice device) { return GetDeviceFromKey(GetDispatchKey(device)); }
 
-Device *GetData(VkQueue queue) { return GetDeviceFromKey(GetDispatchKey(queue)); }
+Device* GetData(VkQueue queue) { return GetDeviceFromKey(GetDispatchKey(queue)); }
 
-Device *GetData(VkCommandBuffer cb) { return GetDeviceFromKey(GetDispatchKey(cb)); }
+Device* GetData(VkCommandBuffer cb) { return GetDeviceFromKey(GetDispatchKey(cb)); }
 
-Device *GetData(VkExternalComputeQueueNV queue) { return GetDeviceFromKey(GetDispatchKey(queue)); }
+Device* GetData(VkExternalComputeQueueNV queue) { return GetDeviceFromKey(GetDispatchKey(queue)); }
 
-void SetData(VkDevice device, std::unique_ptr<Device> &&data) {
-    void *key = GetDispatchKey(device);
+void SetData(VkDevice device, std::unique_ptr<Device>&& data) {
+    void* key = GetDispatchKey(device);
     WriteLockGuard lock(device_mutex);
     device_data[key] = std::move(data);
 }
 
-void FreeData(void *key, VkDevice device) {
+void FreeData(void* key, VkDevice device) {
     last_used_device.store(nullptr);
     WriteLockGuard lock(device_mutex);
     device_data.erase(key);
@@ -683,10 +683,10 @@ void FreeAllData() {
     instance_data.clear();
 }
 
-HandleWrapper::HandleWrapper(DebugReport *dr) : Logger(dr) {}
+HandleWrapper::HandleWrapper(DebugReport* dr) : Logger(dr) {}
 HandleWrapper::~HandleWrapper() {}
 
-Instance::Instance(const VkInstanceCreateInfo *pCreateInfo) : HandleWrapper(new DebugReport) {
+Instance::Instance(const VkInstanceCreateInfo* pCreateInfo) : HandleWrapper(new DebugReport) {
     uint32_t specified_version = (pCreateInfo->pApplicationInfo ? pCreateInfo->pApplicationInfo->apiVersion : VK_API_VERSION_1_0);
     api_version = VK_MAKE_API_VERSION(VK_API_VERSION_VARIANT(specified_version), VK_API_VERSION_MAJOR(specified_version),
                                       VK_API_VERSION_MINOR(specified_version), 0);
@@ -714,7 +714,7 @@ Instance::Instance(const VkInstanceCreateInfo *pCreateInfo) : HandleWrapper(new 
     // create all enabled validation, which is API specific
     InitValidationObjects();
 
-    for (auto &vo : object_dispatch) {
+    for (auto& vo : object_dispatch) {
         vo->dispatch_instance_ = this;
         vo->CopyDispatchState();
     }
@@ -745,8 +745,8 @@ void Instance::FindSupportedExtensions() {
     }
 }
 
-VkResult Instance::GetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                         VkDisplayPropertiesKHR *pProperties) {
+VkResult Instance::GetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                         VkDisplayPropertiesKHR* pProperties) {
     VkResult result = instance_dispatch_table.GetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
     if (!wrap_handles) return result;
     if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pProperties) {
@@ -757,8 +757,8 @@ VkResult Instance::GetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physic
     return result;
 }
 
-VkResult Instance::GetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                          VkDisplayProperties2KHR *pProperties) {
+VkResult Instance::GetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                          VkDisplayProperties2KHR* pProperties) {
     VkResult result = instance_dispatch_table.GetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties);
     if (!wrap_handles) return result;
     if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pProperties) {
@@ -769,28 +769,28 @@ VkResult Instance::GetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physi
     return result;
 }
 
-VkResult Instance::GetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                              VkDisplayPlanePropertiesKHR *pProperties) {
+VkResult Instance::GetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                              VkDisplayPlanePropertiesKHR* pProperties) {
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties);
     if (!wrap_handles) return result;
     if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pProperties) {
         for (uint32_t idx0 = 0; idx0 < *pPropertyCount; ++idx0) {
-            VkDisplayKHR &opt_display = pProperties[idx0].currentDisplay;
+            VkDisplayKHR& opt_display = pProperties[idx0].currentDisplay;
             if (opt_display) opt_display = MaybeWrapDisplay(opt_display);
         }
     }
     return result;
 }
 
-VkResult Instance::GetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                               VkDisplayPlaneProperties2KHR *pProperties) {
+VkResult Instance::GetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                               VkDisplayPlaneProperties2KHR* pProperties) {
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties);
     if (!wrap_handles) return result;
     if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pProperties) {
         for (uint32_t idx0 = 0; idx0 < *pPropertyCount; ++idx0) {
-            VkDisplayKHR &opt_display = pProperties[idx0].displayPlaneProperties.currentDisplay;
+            VkDisplayKHR& opt_display = pProperties[idx0].displayPlaneProperties.currentDisplay;
             if (opt_display) opt_display = MaybeWrapDisplay(opt_display);
         }
     }
@@ -798,7 +798,7 @@ VkResult Instance::GetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice 
 }
 
 VkResult Instance::GetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
-                                                       uint32_t *pDisplayCount, VkDisplayKHR *pDisplays) {
+                                                       uint32_t* pDisplayCount, VkDisplayKHR* pDisplays) {
     VkResult result =
         instance_dispatch_table.GetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays);
     if ((result == VK_SUCCESS || result == VK_INCOMPLETE) && pDisplays) {
@@ -810,8 +810,8 @@ VkResult Instance::GetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physical
     return result;
 }
 
-VkResult Instance::GetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display, uint32_t *pPropertyCount,
-                                               VkDisplayModePropertiesKHR *pProperties) {
+VkResult Instance::GetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display, uint32_t* pPropertyCount,
+                                               VkDisplayModePropertiesKHR* pProperties) {
     if (!wrap_handles)
         return instance_dispatch_table.GetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties);
     display = Unwrap(display);
@@ -825,8 +825,8 @@ VkResult Instance::GetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, 
     return result;
 }
 
-VkResult Instance::GetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display, uint32_t *pPropertyCount,
-                                                VkDisplayModeProperties2KHR *pProperties) {
+VkResult Instance::GetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display, uint32_t* pPropertyCount,
+                                                VkDisplayModeProperties2KHR* pProperties) {
     if (!wrap_handles)
         return instance_dispatch_table.GetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties);
     display = Unwrap(display);
@@ -840,8 +840,8 @@ VkResult Instance::GetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice,
     return result;
 }
 
-VkResult Instance::GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t *pToolCount,
-                                                      VkPhysicalDeviceToolPropertiesEXT *pToolProperties) {
+VkResult Instance::GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalDevice, uint32_t* pToolCount,
+                                                      VkPhysicalDeviceToolPropertiesEXT* pToolProperties) {
     VkResult result = VK_SUCCESS;
     if (instance_dispatch_table.GetPhysicalDeviceToolPropertiesEXT == nullptr) {
         // This layer is the terminator. Set pToolCount to zero.
@@ -853,8 +853,8 @@ VkResult Instance::GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevice physicalD
     return result;
 }
 
-VkResult Instance::GetPhysicalDeviceToolProperties(VkPhysicalDevice physicalDevice, uint32_t *pToolCount,
-                                                   VkPhysicalDeviceToolProperties *pToolProperties) {
+VkResult Instance::GetPhysicalDeviceToolProperties(VkPhysicalDevice physicalDevice, uint32_t* pToolCount,
+                                                   VkPhysicalDeviceToolProperties* pToolProperties) {
     VkResult result = VK_SUCCESS;
     if (instance_dispatch_table.GetPhysicalDeviceToolProperties == nullptr) {
         // This layer is the terminator. Set pToolCount to zero.
@@ -866,8 +866,8 @@ VkResult Instance::GetPhysicalDeviceToolProperties(VkPhysicalDevice physicalDevi
     return result;
 }
 
-base::Instance *Instance::GetValidationObject(LayerObjectTypeId object_type) const {
-    for (auto &validation_object : object_dispatch) {
+base::Instance* Instance::GetValidationObject(LayerObjectTypeId object_type) const {
+    for (auto& validation_object : object_dispatch) {
         if (validation_object->container_type == object_type) {
             return validation_object.get();
         }
@@ -875,7 +875,7 @@ base::Instance *Instance::GetValidationObject(LayerObjectTypeId object_type) con
     return nullptr;
 }
 
-Device::Device(Instance *instance, VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo)
+Device::Device(Instance* instance, VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo)
     : HandleWrapper(instance->debug_report),
       settings(instance->settings),
       dispatch_instance(instance),
@@ -895,7 +895,7 @@ Device::Device(Instance *instance, VkPhysicalDevice gpu, const VkDeviceCreateInf
       physical_device(gpu) {
     InitValidationObjects();
     InitObjectDispatchVectors();
-    for (auto &vo : object_dispatch) {
+    for (auto& vo : object_dispatch) {
         vo->dispatch_device_ = this;
         vo->CopyDispatchState();
     }
@@ -912,8 +912,8 @@ Device::~Device() {
     }
 }
 
-base::Device *Device::GetValidationObject(LayerObjectTypeId object_type) const {
-    for (auto &validation_object : object_dispatch) {
+base::Device* Device::GetValidationObject(LayerObjectTypeId object_type) const {
+    for (auto& validation_object : object_dispatch) {
         if (validation_object->container_type == object_type) {
             return validation_object.get();
         }
@@ -921,7 +921,7 @@ base::Device *Device::GetValidationObject(LayerObjectTypeId object_type) const {
     return nullptr;
 }
 
-void Device::DestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator) {
+void Device::DestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     device_dispatch_table.DestroyDevice(device, pAllocator);
 }
 
@@ -930,7 +930,7 @@ void Device::DestroyDevice(VkDevice device, const VkAllocationCallbacks *pAlloca
 void Device::ReleaseValidationObject(LayerObjectTypeId type_id) const {
     for (auto object_it = object_dispatch.begin(); object_it != object_dispatch.end(); object_it++) {
         if ((*object_it)->container_type == LayerObjectTypeStateTracker) {
-            auto &state_tracker = dynamic_cast<vvl::DeviceState &>(**object_it);
+            auto& state_tracker = dynamic_cast<vvl::DeviceState&>(**object_it);
             state_tracker.RemoveProxy(type_id);
         }
         if ((*object_it)->container_type == type_id) {
@@ -962,49 +962,49 @@ void Device::ReleaseValidationObject(LayerObjectTypeId type_id) const {
 #ifdef VK_USE_PLATFORM_METAL_EXT
 // The vkExportMetalObjects extension returns data from the driver -- we've created a copy of the pNext chain, so
 // copy the returned data to the caller
-void CopyExportMetalObjects(const void *src_chain, const void *dst_chain) {
+void CopyExportMetalObjects(const void* src_chain, const void* dst_chain) {
     while (src_chain && dst_chain) {
-        const VkStructureType type = reinterpret_cast<const VkBaseOutStructure *>(src_chain)->sType;
+        const VkStructureType type = reinterpret_cast<const VkBaseOutStructure*>(src_chain)->sType;
         switch (type) {
             case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT: {
-                auto *pSrc = reinterpret_cast<const VkExportMetalDeviceInfoEXT *>(src_chain);
-                auto *pDstConst = reinterpret_cast<const VkExportMetalDeviceInfoEXT *>(dst_chain);
-                auto *pDst = const_cast<VkExportMetalDeviceInfoEXT *>(pDstConst);
+                auto* pSrc = reinterpret_cast<const VkExportMetalDeviceInfoEXT*>(src_chain);
+                auto* pDstConst = reinterpret_cast<const VkExportMetalDeviceInfoEXT*>(dst_chain);
+                auto* pDst = const_cast<VkExportMetalDeviceInfoEXT*>(pDstConst);
                 pDst->mtlDevice = pSrc->mtlDevice;
                 break;
             }
             case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT: {
-                const auto *pSrc = reinterpret_cast<const VkExportMetalCommandQueueInfoEXT *>(src_chain);
-                auto *pDstConst = reinterpret_cast<const VkExportMetalCommandQueueInfoEXT *>(dst_chain);
-                auto *pDst = const_cast<VkExportMetalCommandQueueInfoEXT *>(pDstConst);
+                const auto* pSrc = reinterpret_cast<const VkExportMetalCommandQueueInfoEXT*>(src_chain);
+                auto* pDstConst = reinterpret_cast<const VkExportMetalCommandQueueInfoEXT*>(dst_chain);
+                auto* pDst = const_cast<VkExportMetalCommandQueueInfoEXT*>(pDstConst);
                 pDst->mtlCommandQueue = pSrc->mtlCommandQueue;
                 break;
             }
             case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT: {
-                const auto *pSrc = reinterpret_cast<const VkExportMetalBufferInfoEXT *>(src_chain);
-                auto *pDstConst = reinterpret_cast<const VkExportMetalBufferInfoEXT *>(dst_chain);
-                auto *pDst = const_cast<VkExportMetalBufferInfoEXT *>(pDstConst);
+                const auto* pSrc = reinterpret_cast<const VkExportMetalBufferInfoEXT*>(src_chain);
+                auto* pDstConst = reinterpret_cast<const VkExportMetalBufferInfoEXT*>(dst_chain);
+                auto* pDst = const_cast<VkExportMetalBufferInfoEXT*>(pDstConst);
                 pDst->mtlBuffer = pSrc->mtlBuffer;
                 break;
             }
             case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT: {
-                const auto *pSrc = reinterpret_cast<const VkExportMetalTextureInfoEXT *>(src_chain);
-                auto *pDstConst = reinterpret_cast<const VkExportMetalTextureInfoEXT *>(dst_chain);
-                auto *pDst = const_cast<VkExportMetalTextureInfoEXT *>(pDstConst);
+                const auto* pSrc = reinterpret_cast<const VkExportMetalTextureInfoEXT*>(src_chain);
+                auto* pDstConst = reinterpret_cast<const VkExportMetalTextureInfoEXT*>(dst_chain);
+                auto* pDst = const_cast<VkExportMetalTextureInfoEXT*>(pDstConst);
                 pDst->mtlTexture = pSrc->mtlTexture;
                 break;
             }
             case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT: {
-                const auto *pSrc = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(src_chain);
-                auto *pDstConst = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(dst_chain);
-                auto *pDst = const_cast<VkExportMetalIOSurfaceInfoEXT *>(pDstConst);
+                const auto* pSrc = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT*>(src_chain);
+                auto* pDstConst = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT*>(dst_chain);
+                auto* pDst = const_cast<VkExportMetalIOSurfaceInfoEXT*>(pDstConst);
                 pDst->ioSurface = pSrc->ioSurface;
                 break;
             }
             case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT: {
-                const auto *pSrc = reinterpret_cast<const VkExportMetalSharedEventInfoEXT *>(src_chain);
-                auto *pDstConst = reinterpret_cast<const VkExportMetalSharedEventInfoEXT *>(dst_chain);
-                auto *pDst = const_cast<VkExportMetalSharedEventInfoEXT *>(pDstConst);
+                const auto* pSrc = reinterpret_cast<const VkExportMetalSharedEventInfoEXT*>(src_chain);
+                auto* pDstConst = reinterpret_cast<const VkExportMetalSharedEventInfoEXT*>(dst_chain);
+                auto* pDst = const_cast<VkExportMetalSharedEventInfoEXT*>(pDstConst);
                 pDst->mtlSharedEvent = pSrc->mtlSharedEvent;
                 break;
             }
@@ -1014,12 +1014,12 @@ void CopyExportMetalObjects(const void *src_chain, const void *dst_chain) {
         }
 
         // Handle pNext chaining
-        src_chain = reinterpret_cast<const VkBaseOutStructure *>(src_chain)->pNext;
-        dst_chain = reinterpret_cast<const VkBaseOutStructure *>(dst_chain)->pNext;
+        src_chain = reinterpret_cast<const VkBaseOutStructure*>(src_chain)->pNext;
+        dst_chain = reinterpret_cast<const VkBaseOutStructure*>(dst_chain)->pNext;
     }
 }
 
-void Device::ExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT *pMetalObjectsInfo) {
+void Device::ExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT* pMetalObjectsInfo) {
     if (!wrap_handles) return device_dispatch_table.ExportMetalObjectsEXT(device, pMetalObjectsInfo);
     vku::safe_VkExportMetalObjectsInfoEXT local_pMetalObjectsInfo;
     {
@@ -1028,7 +1028,7 @@ void Device::ExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT 
             UnwrapPnextChainHandles(local_pMetalObjectsInfo.pNext);
         }
     }
-    device_dispatch_table.ExportMetalObjectsEXT(device, (VkExportMetalObjectsInfoEXT *)&local_pMetalObjectsInfo);
+    device_dispatch_table.ExportMetalObjectsEXT(device, (VkExportMetalObjectsInfoEXT*)&local_pMetalObjectsInfo);
     if (pMetalObjectsInfo) {
         CopyExportMetalObjects(local_pMetalObjectsInfo.pNext, pMetalObjectsInfo->pNext);
     }
@@ -1038,9 +1038,9 @@ void Device::ExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT 
 
 // The VK_EXT_pipeline_creation_feedback extension returns data from the driver -- we've created a copy of the pnext chain, so
 // copy the returned data to the caller before freeing the copy's data.
-void CopyCreatePipelineFeedbackData(const void *src_chain, const void *dst_chain) {
+void CopyCreatePipelineFeedbackData(const void* src_chain, const void* dst_chain) {
     auto src_feedback_struct = vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfo>(src_chain);
-    auto dst_feedback_struct = const_cast<VkPipelineCreationFeedbackCreateInfo *>(
+    auto dst_feedback_struct = const_cast<VkPipelineCreationFeedbackCreateInfo*>(
         vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfo>(dst_chain));
     if (!src_feedback_struct || !dst_feedback_struct) return;
     ASSERT_AND_RETURN(dst_feedback_struct->pPipelineCreationFeedback && src_feedback_struct->pPipelineCreationFeedback);
@@ -1052,12 +1052,12 @@ void CopyCreatePipelineFeedbackData(const void *src_chain, const void *dst_chain
 }
 
 VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                         const VkGraphicsPipelineCreateInfo *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                         VkPipeline *pPipelines) {
+                                         const VkGraphicsPipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                         VkPipeline* pPipelines) {
     if (!wrap_handles)
         return device_dispatch_table.CreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
                                                              pPipelines);
-    vku::safe_VkGraphicsPipelineCreateInfo *local_pCreateInfos = nullptr;
+    vku::safe_VkGraphicsPipelineCreateInfo* local_pCreateInfos = nullptr;
     if (pCreateInfos) {
         local_pCreateInfos = new vku::safe_VkGraphicsPipelineCreateInfo[createInfoCount];
         ReadLockGuard lock(dispatch_lock);
@@ -1067,7 +1067,7 @@ VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
             {
                 const auto subpasses_uses_it = renderpasses_states.find(Unwrap(pCreateInfos[idx0].renderPass));
                 if (subpasses_uses_it != renderpasses_states.end()) {
-                    const auto &subpasses_uses = subpasses_uses_it->second;
+                    const auto& subpasses_uses = subpasses_uses_it->second;
                     if (subpasses_uses.subpasses_using_color_attachment.count(pCreateInfos[idx0].subpass))
                         uses_color_attachment = true;
                     if (subpasses_uses.subpasses_using_depthstencil_attachment.count(pCreateInfos[idx0].subpass))
@@ -1081,8 +1081,8 @@ VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
                 has_fragment_output_state = (lib_info->flags & VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT) != 0;
             }
 
-            const VkFormat *original_color_attachment_formats = nullptr;
-            const VkPipelineRenderingCreateInfo *dynamic_rendering = nullptr;
+            const VkFormat* original_color_attachment_formats = nullptr;
+            const VkPipelineRenderingCreateInfo* dynamic_rendering = nullptr;
             if (pCreateInfos[idx0].renderPass == VK_NULL_HANDLE) {
                 dynamic_rendering = vku::FindStructInPNextChain<VkPipelineRenderingCreateInfo>(pCreateInfos[idx0].pNext);
             }
@@ -1098,14 +1098,14 @@ VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
                     // safe_VkGraphicsPipelineCreateInfo calls SafePnextCopy and we have no way to pass the "ignore" info to it We
                     // will just save the value, make a "safe" Safe Struct, then restore the pointer so the user doesn't notice
                     original_color_attachment_formats = dynamic_rendering->pColorAttachmentFormats;
-                    const_cast<VkPipelineRenderingCreateInfo *>(dynamic_rendering)->pColorAttachmentFormats = nullptr;
+                    const_cast<VkPipelineRenderingCreateInfo*>(dynamic_rendering)->pColorAttachmentFormats = nullptr;
                 }
             }
 
             local_pCreateInfos[idx0].initialize(&pCreateInfos[idx0], uses_color_attachment, uses_depthstencil_attachment);
 
             if (dynamic_rendering && !has_fragment_output_state) {
-                const_cast<VkPipelineRenderingCreateInfo *>(dynamic_rendering)->pColorAttachmentFormats =
+                const_cast<VkPipelineRenderingCreateInfo*>(dynamic_rendering)->pColorAttachmentFormats =
                     original_color_attachment_formats;
             }
 
@@ -1126,9 +1126,9 @@ VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
                 local_pCreateInfos[idx0].renderPass = Unwrap(pCreateInfos[idx0].renderPass);
             }
 
-            auto *link_info = vku::FindStructInPNextChain<VkPipelineLibraryCreateInfoKHR>(local_pCreateInfos[idx0].pNext);
+            auto* link_info = vku::FindStructInPNextChain<VkPipelineLibraryCreateInfoKHR>(local_pCreateInfos[idx0].pNext);
             if (link_info) {
-                auto *unwrapped_libs = const_cast<VkPipeline *>(link_info->pLibraries);
+                auto* unwrapped_libs = const_cast<VkPipeline*>(link_info->pLibraries);
                 for (uint32_t idx1 = 0; idx1 < link_info->libraryCount; ++idx1) {
                     unwrapped_libs[idx1] = Unwrap(link_info->pLibraries[idx1]);
                 }
@@ -1140,21 +1140,21 @@ VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
                 for (uint32_t idx1 = 0; idx1 < device_generated_commands->groupCount; ++idx1) {
                     for (uint32_t idx2 = 0; idx2 < device_generated_commands->pGroups[idx1].stageCount; ++idx2) {
                         auto unwrapped_stage =
-                            const_cast<VkPipelineShaderStageCreateInfo *>(&device_generated_commands->pGroups[idx1].pStages[idx2]);
+                            const_cast<VkPipelineShaderStageCreateInfo*>(&device_generated_commands->pGroups[idx1].pStages[idx2]);
                         if (device_generated_commands->pGroups[idx1].pStages[idx2].module) {
                             unwrapped_stage->module = Unwrap(device_generated_commands->pGroups[idx1].pStages[idx2].module);
                         }
                     }
                 }
-                auto unwrapped_pipelines = const_cast<VkPipeline *>(device_generated_commands->pPipelines);
+                auto unwrapped_pipelines = const_cast<VkPipeline*>(device_generated_commands->pPipelines);
                 for (uint32_t idx1 = 0; idx1 < device_generated_commands->pipelineCount; ++idx1) {
                     unwrapped_pipelines[idx1] = Unwrap(device_generated_commands->pPipelines[idx1]);
                 }
             }
 
-            auto *binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(local_pCreateInfos[idx0].pNext);
+            auto* binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(local_pCreateInfos[idx0].pNext);
             if (binary_info) {
-                auto *unwrapped_binaries = const_cast<VkPipelineBinaryKHR *>(binary_info->pPipelineBinaries);
+                auto* unwrapped_binaries = const_cast<VkPipelineBinaryKHR*>(binary_info->pPipelineBinaries);
                 for (uint32_t idx1 = 0; idx1 < binary_info->binaryCount; ++idx1) {
                     unwrapped_binaries[idx1] = Unwrap(binary_info->pPipelineBinaries[idx1]);
                 }
@@ -1185,8 +1185,8 @@ VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
 }
 
 template <typename T>
-static void UpdateCreateRenderPassState(Device *layer_data, const T *pCreateInfo, VkRenderPass renderPass) {
-    auto &renderpass_state = layer_data->renderpasses_states[renderPass];
+static void UpdateCreateRenderPassState(Device* layer_data, const T* pCreateInfo, VkRenderPass renderPass) {
+    auto& renderpass_state = layer_data->renderpasses_states[renderPass];
 
     for (uint32_t subpass = 0; subpass < pCreateInfo->subpassCount; ++subpass) {
         bool uses_color = false;
@@ -1204,12 +1204,12 @@ static void UpdateCreateRenderPassState(Device *layer_data, const T *pCreateInfo
 }
 
 template <>
-void UpdateCreateRenderPassState(Device *layer_data, const VkRenderPassCreateInfo2 *pCreateInfo, VkRenderPass renderPass) {
-    auto &renderpass_state = layer_data->renderpasses_states[renderPass];
+void UpdateCreateRenderPassState(Device* layer_data, const VkRenderPassCreateInfo2* pCreateInfo, VkRenderPass renderPass) {
+    auto& renderpass_state = layer_data->renderpasses_states[renderPass];
 
     for (uint32_t subpassIndex = 0; subpassIndex < pCreateInfo->subpassCount; ++subpassIndex) {
         bool uses_color = false;
-        const VkSubpassDescription2 &subpass = pCreateInfo->pSubpasses[subpassIndex];
+        const VkSubpassDescription2& subpass = pCreateInfo->pSubpasses[subpassIndex];
         for (uint32_t i = 0; i < subpass.colorAttachmentCount && !uses_color; ++i)
             if (subpass.pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) uses_color = true;
 
@@ -1220,7 +1220,7 @@ void UpdateCreateRenderPassState(Device *layer_data, const VkRenderPassCreateInf
         if (subpass.pResolveAttachments != nullptr) {
             for (uint32_t i = 0; i < subpass.colorAttachmentCount && !uses_color; ++i) {
                 uint32_t resolveAttachmentIndex = subpass.pResolveAttachments[i].attachment;
-                const void *resolveAtatchmentPNextChain = pCreateInfo->pAttachments[resolveAttachmentIndex].pNext;
+                const void* resolveAtatchmentPNextChain = pCreateInfo->pAttachments[resolveAttachmentIndex].pNext;
                 if (vku::FindStructInPNextChain<VkExternalFormatANDROID>(resolveAtatchmentPNextChain)) uses_color = true;
             }
         }
@@ -1235,8 +1235,8 @@ void UpdateCreateRenderPassState(Device *layer_data, const VkRenderPassCreateInf
     }
 }
 
-VkResult Device::CreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                  const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
+VkResult Device::CreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
+                                  const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) {
     VkResult result = device_dispatch_table.CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
     if (!wrap_handles) return result;
     if (result == VK_SUCCESS) {
@@ -1247,8 +1247,8 @@ VkResult Device::CreateRenderPass(VkDevice device, const VkRenderPassCreateInfo 
     return result;
 }
 
-VkResult Device::CreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                      const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
+VkResult Device::CreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                      const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) {
     VkResult result = device_dispatch_table.CreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
     if (!wrap_handles) return result;
     if (result == VK_SUCCESS) {
@@ -1259,8 +1259,8 @@ VkResult Device::CreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateI
     return result;
 }
 
-VkResult Device::CreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                   const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) {
+VkResult Device::CreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) {
     VkResult result = device_dispatch_table.CreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass);
     if (!wrap_handles) return result;
     if (result == VK_SUCCESS) {
@@ -1271,7 +1271,7 @@ VkResult Device::CreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo
     return result;
 }
 
-void Device::DestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator) {
+void Device::DestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator) {
     if (!wrap_handles) return device_dispatch_table.DestroyRenderPass(device, renderPass, pAllocator);
     renderPass = Erase(renderPass);
 
@@ -1281,8 +1281,8 @@ void Device::DestroyRenderPass(VkDevice device, VkRenderPass renderPass, const V
     renderpasses_states.erase(renderPass);
 }
 
-VkResult Device::GetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
-                                       VkImage *pSwapchainImages) {
+VkResult Device::GetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
+                                       VkImage* pSwapchainImages) {
     if (!wrap_handles)
         return device_dispatch_table.GetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages);
     VkSwapchainKHR wrapped_swapchain_handle = swapchain;
@@ -1293,7 +1293,7 @@ VkResult Device::GetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain
     if ((result == VK_SUCCESS) || (VK_INCOMPLETE == result)) {
         if ((*pSwapchainImageCount > 0) && pSwapchainImages) {
             WriteLockGuard lock(dispatch_lock);
-            auto &wrapped_swapchain_image_handles = swapchain_wrapped_image_handle_map[wrapped_swapchain_handle];
+            auto& wrapped_swapchain_image_handles = swapchain_wrapped_image_handle_map[wrapped_swapchain_handle];
             for (uint32_t i = static_cast<uint32_t>(wrapped_swapchain_image_handles.size()); i < *pSwapchainImageCount; i++) {
                 wrapped_swapchain_image_handles.emplace_back(WrapNew(pSwapchainImages[i]));
             }
@@ -1305,12 +1305,12 @@ VkResult Device::GetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain
     return result;
 }
 
-void Device::DestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator) {
+void Device::DestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator) {
     if (!wrap_handles) return device_dispatch_table.DestroySwapchainKHR(device, swapchain, pAllocator);
     WriteLockGuard lock(dispatch_lock);
 
-    auto &image_array = swapchain_wrapped_image_handle_map[swapchain];
-    for (auto &image_handle : image_array) {
+    auto& image_array = swapchain_wrapped_image_handle_map[swapchain];
+    for (auto& image_handle : image_array) {
         Erase(image_handle);
     }
     swapchain_wrapped_image_handle_map.erase(swapchain);
@@ -1320,9 +1320,9 @@ void Device::DestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, cons
     device_dispatch_table.DestroySwapchainKHR(device, swapchain, pAllocator);
 }
 
-VkResult Device::QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo) {
+VkResult Device::QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
     if (!wrap_handles) return device_dispatch_table.QueuePresentKHR(queue, pPresentInfo);
-    vku::safe_VkPresentInfoKHR *local_pPresentInfo = nullptr;
+    vku::safe_VkPresentInfoKHR* local_pPresentInfo = nullptr;
     {
         if (pPresentInfo) {
             local_pPresentInfo = new vku::safe_VkPresentInfoKHR(pPresentInfo);
@@ -1352,7 +1352,7 @@ VkResult Device::QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresent
     return result;
 }
 
-void Device::DestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, const VkAllocationCallbacks *pAllocator) {
+void Device::DestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, const VkAllocationCallbacks* pAllocator) {
     if (!wrap_handles) return device_dispatch_table.DestroyDescriptorPool(device, descriptorPool, pAllocator);
     WriteLockGuard lock(dispatch_lock);
 
@@ -1371,7 +1371,9 @@ void Device::DestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorP
 VkResult Device::ResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags) {
     if (!wrap_handles) return device_dispatch_table.ResetDescriptorPool(device, descriptorPool, flags);
     VkDescriptorPool local_descriptor_pool = VK_NULL_HANDLE;
-    { local_descriptor_pool = Unwrap(descriptorPool); }
+    {
+        local_descriptor_pool = Unwrap(descriptorPool);
+    }
     VkResult result = device_dispatch_table.ResetDescriptorPool(device, local_descriptor_pool, flags);
     if (result == VK_SUCCESS) {
         WriteLockGuard lock(dispatch_lock);
@@ -1385,10 +1387,10 @@ VkResult Device::ResetDescriptorPool(VkDevice device, VkDescriptorPool descripto
     return result;
 }
 
-VkResult Device::AllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                        VkDescriptorSet *pDescriptorSets) {
+VkResult Device::AllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                        VkDescriptorSet* pDescriptorSets) {
     if (!wrap_handles) return device_dispatch_table.AllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
-    vku::safe_VkDescriptorSetAllocateInfo *local_pAllocateInfo = nullptr;
+    vku::safe_VkDescriptorSetAllocateInfo* local_pAllocateInfo = nullptr;
     {
         if (pAllocateInfo) {
             local_pAllocateInfo = new vku::safe_VkDescriptorSetAllocateInfo(pAllocateInfo);
@@ -1402,14 +1404,14 @@ VkResult Device::AllocateDescriptorSets(VkDevice device, const VkDescriptorSetAl
             }
         }
     }
-    VkResult result = device_dispatch_table.AllocateDescriptorSets(device, (const VkDescriptorSetAllocateInfo *)local_pAllocateInfo,
+    VkResult result = device_dispatch_table.AllocateDescriptorSets(device, (const VkDescriptorSetAllocateInfo*)local_pAllocateInfo,
                                                                    pDescriptorSets);
     if (local_pAllocateInfo) {
         delete local_pAllocateInfo;
     }
     if (result == VK_SUCCESS) {
         WriteLockGuard lock(dispatch_lock);
-        auto &pool_descriptor_sets = pool_descriptor_sets_map[pAllocateInfo->descriptorPool];
+        auto& pool_descriptor_sets = pool_descriptor_sets_map[pAllocateInfo->descriptorPool];
         for (uint32_t index0 = 0; index0 < pAllocateInfo->descriptorSetCount; index0++) {
             pDescriptorSets[index0] = WrapNew(pDescriptorSets[index0]);
             pool_descriptor_sets.insert(pDescriptorSets[index0]);
@@ -1419,9 +1421,9 @@ VkResult Device::AllocateDescriptorSets(VkDevice device, const VkDescriptorSetAl
 }
 
 VkResult Device::FreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t descriptorSetCount,
-                                    const VkDescriptorSet *pDescriptorSets) {
+                                    const VkDescriptorSet* pDescriptorSets) {
     if (!wrap_handles) return device_dispatch_table.FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
-    VkDescriptorSet *local_pDescriptorSets = nullptr;
+    VkDescriptorSet* local_pDescriptorSets = nullptr;
     VkDescriptorPool local_descriptor_pool = VK_NULL_HANDLE;
     {
         local_descriptor_pool = Unwrap(descriptorPool);
@@ -1433,11 +1435,11 @@ VkResult Device::FreeDescriptorSets(VkDevice device, VkDescriptorPool descriptor
         }
     }
     VkResult result = device_dispatch_table.FreeDescriptorSets(device, local_descriptor_pool, descriptorSetCount,
-                                                               (const VkDescriptorSet *)local_pDescriptorSets);
+                                                               (const VkDescriptorSet*)local_pDescriptorSets);
     if (local_pDescriptorSets) delete[] local_pDescriptorSets;
     if ((result == VK_SUCCESS) && (pDescriptorSets)) {
         WriteLockGuard lock(dispatch_lock);
-        auto &pool_descriptor_sets = pool_descriptor_sets_map[descriptorPool];
+        auto& pool_descriptor_sets = pool_descriptor_sets_map[descriptorPool];
         for (uint32_t index0 = 0; index0 < descriptorSetCount; index0++) {
             VkDescriptorSet handle = pDescriptorSets[index0];
             pool_descriptor_sets.erase(handle);
@@ -1448,13 +1450,13 @@ VkResult Device::FreeDescriptorSets(VkDevice device, VkDescriptorPool descriptor
 }
 
 // This is the core version of this routine.  The extension version is below.
-VkResult Device::CreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator,
-                                                VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate) {
+VkResult Device::CreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator,
+                                                VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
     if (!wrap_handles)
         return device_dispatch_table.CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     vku::safe_VkDescriptorUpdateTemplateCreateInfo var_local_pCreateInfo;
-    vku::safe_VkDescriptorUpdateTemplateCreateInfo *local_pCreateInfo = nullptr;
+    vku::safe_VkDescriptorUpdateTemplateCreateInfo* local_pCreateInfo = nullptr;
     if (pCreateInfo) {
         local_pCreateInfo = &var_local_pCreateInfo;
         local_pCreateInfo->initialize(pCreateInfo);
@@ -1481,13 +1483,13 @@ VkResult Device::CreateDescriptorUpdateTemplate(VkDevice device, const VkDescrip
 }
 
 // This is the extension version of this routine.  The core version is above.
-VkResult Device::CreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator,
-                                                   VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate) {
+VkResult Device::CreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator,
+                                                   VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate) {
     if (!wrap_handles)
         return device_dispatch_table.CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     vku::safe_VkDescriptorUpdateTemplateCreateInfo var_local_pCreateInfo;
-    vku::safe_VkDescriptorUpdateTemplateCreateInfo *local_pCreateInfo = nullptr;
+    vku::safe_VkDescriptorUpdateTemplateCreateInfo* local_pCreateInfo = nullptr;
     if (pCreateInfo) {
         local_pCreateInfo = &var_local_pCreateInfo;
         local_pCreateInfo->initialize(pCreateInfo);
@@ -1516,7 +1518,7 @@ VkResult Device::CreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDesc
 
 // This is the core version of this routine.  The extension version is below.
 void Device::DestroyDescriptorUpdateTemplate(VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                             const VkAllocationCallbacks *pAllocator) {
+                                             const VkAllocationCallbacks* pAllocator) {
     if (!wrap_handles) return device_dispatch_table.DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
     WriteLockGuard lock(dispatch_lock);
     uint64_t descriptor_update_template_id = CastToUint64(descriptorUpdateTemplate);
@@ -1530,7 +1532,7 @@ void Device::DestroyDescriptorUpdateTemplate(VkDevice device, VkDescriptorUpdate
 
 // This is the extension version of this routine.  The core version is above.
 void Device::DestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                const VkAllocationCallbacks *pAllocator) {
+                                                const VkAllocationCallbacks* pAllocator) {
     if (!wrap_handles)
         return device_dispatch_table.DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
     WriteLockGuard lock(dispatch_lock);
@@ -1543,16 +1545,16 @@ void Device::DestroyDescriptorUpdateTemplateKHR(VkDevice device, VkDescriptorUpd
     device_dispatch_table.DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
 }
 
-void *BuildUnwrappedUpdateTemplateBuffer(Device *layer_data, uint64_t descriptorUpdateTemplate, const void *pData) {
+void* BuildUnwrappedUpdateTemplateBuffer(Device* layer_data, uint64_t descriptorUpdateTemplate, const void* pData) {
     auto const template_map_entry = layer_data->desc_template_createinfo_map.find(descriptorUpdateTemplate);
-    auto const &create_info = template_map_entry->second->create_info;
+    auto const& create_info = template_map_entry->second->create_info;
     size_t allocation_size = 0;
     std::vector<std::tuple<size_t, VulkanObjectType, uint64_t, size_t>> template_entries;
 
     for (uint32_t i = 0; i < create_info.descriptorUpdateEntryCount; i++) {
         for (uint32_t j = 0; j < create_info.pDescriptorUpdateEntries[i].descriptorCount; j++) {
             size_t offset = create_info.pDescriptorUpdateEntries[i].offset + j * create_info.pDescriptorUpdateEntries[i].stride;
-            char *update_entry = (char *)(pData) + offset;
+            char* update_entry = (char*)(pData) + offset;
 
             switch (create_info.pDescriptorUpdateEntries[i].descriptorType) {
                 case VK_DESCRIPTOR_TYPE_SAMPLER:
@@ -1560,10 +1562,10 @@ void *BuildUnwrappedUpdateTemplateBuffer(Device *layer_data, uint64_t descriptor
                 case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
                 case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
                 case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
-                    auto image_entry = reinterpret_cast<VkDescriptorImageInfo *>(update_entry);
+                    auto image_entry = reinterpret_cast<VkDescriptorImageInfo*>(update_entry);
                     allocation_size = std::max(allocation_size, offset + sizeof(VkDescriptorImageInfo));
 
-                    VkDescriptorImageInfo *wrapped_entry = new VkDescriptorImageInfo(*image_entry);
+                    VkDescriptorImageInfo* wrapped_entry = new VkDescriptorImageInfo(*image_entry);
                     wrapped_entry->sampler = layer_data->Unwrap(image_entry->sampler);
                     wrapped_entry->imageView = layer_data->Unwrap(image_entry->imageView);
                     template_entries.emplace_back(offset, kVulkanObjectTypeImage, CastToUint64(wrapped_entry), 0);
@@ -1573,17 +1575,17 @@ void *BuildUnwrappedUpdateTemplateBuffer(Device *layer_data, uint64_t descriptor
                 case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
                 case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
                 case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
-                    auto buffer_entry = reinterpret_cast<VkDescriptorBufferInfo *>(update_entry);
+                    auto buffer_entry = reinterpret_cast<VkDescriptorBufferInfo*>(update_entry);
                     allocation_size = std::max(allocation_size, offset + sizeof(VkDescriptorBufferInfo));
 
-                    VkDescriptorBufferInfo *wrapped_entry = new VkDescriptorBufferInfo(*buffer_entry);
+                    VkDescriptorBufferInfo* wrapped_entry = new VkDescriptorBufferInfo(*buffer_entry);
                     wrapped_entry->buffer = layer_data->Unwrap(buffer_entry->buffer);
                     template_entries.emplace_back(offset, kVulkanObjectTypeBuffer, CastToUint64(wrapped_entry), 0);
                 } break;
 
                 case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
                 case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: {
-                    auto buffer_view_handle = reinterpret_cast<VkBufferView *>(update_entry);
+                    auto buffer_view_handle = reinterpret_cast<VkBufferView*>(update_entry);
                     allocation_size = std::max(allocation_size, offset + sizeof(VkBufferView));
 
                     VkBufferView wrapped_entry = layer_data->Unwrap(*buffer_view_handle);
@@ -1598,14 +1600,14 @@ void *BuildUnwrappedUpdateTemplateBuffer(Device *layer_data, uint64_t descriptor
                     j = create_info.pDescriptorUpdateEntries[i].descriptorCount;
                 } break;
                 case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV: {
-                    auto accstruct_nv_handle = reinterpret_cast<VkAccelerationStructureNV *>(update_entry);
+                    auto accstruct_nv_handle = reinterpret_cast<VkAccelerationStructureNV*>(update_entry);
                     allocation_size = std::max(allocation_size, offset + sizeof(VkAccelerationStructureNV));
 
                     VkAccelerationStructureNV wrapped_entry = layer_data->Unwrap(*accstruct_nv_handle);
                     template_entries.emplace_back(offset, kVulkanObjectTypeAccelerationStructureNV, CastToUint64(wrapped_entry), 0);
                 } break;
                 case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR: {
-                    auto accstruct_khr_handle = reinterpret_cast<VkAccelerationStructureKHR *>(update_entry);
+                    auto accstruct_khr_handle = reinterpret_cast<VkAccelerationStructureKHR*>(update_entry);
                     allocation_size = std::max(allocation_size, offset + sizeof(VkAccelerationStructureKHR));
 
                     VkAccelerationStructureKHR wrapped_entry = layer_data->Unwrap(*accstruct_khr_handle);
@@ -1625,37 +1627,35 @@ void *BuildUnwrappedUpdateTemplateBuffer(Device *layer_data, uint64_t descriptor
         }
     }
     // Allocate required buffer size and populate with source/unwrapped data
-    void *unwrapped_data = malloc(allocation_size);
-    for (auto &this_entry : template_entries) {
+    void* unwrapped_data = malloc(allocation_size);
+    for (auto& this_entry : template_entries) {
         VulkanObjectType type = std::get<1>(this_entry);
-        void *destination = (char *)unwrapped_data + std::get<0>(this_entry);
+        void* destination = (char*)unwrapped_data + std::get<0>(this_entry);
         uint64_t source = std::get<2>(this_entry);
         size_t size = std::get<3>(this_entry);
 
         if (size != 0) {
             assert(type == kVulkanObjectTypeUnknown);
-            memcpy(destination, CastFromUint64<void *>(source), size);
+            memcpy(destination, CastFromUint64<void*>(source), size);
         } else {
             switch (type) {
                 case kVulkanObjectTypeImage:
-                    *(reinterpret_cast<VkDescriptorImageInfo *>(destination)) =
-                        *(reinterpret_cast<VkDescriptorImageInfo *>(source));
-                    delete CastFromUint64<VkDescriptorImageInfo *>(source);
+                    *(reinterpret_cast<VkDescriptorImageInfo*>(destination)) = *(reinterpret_cast<VkDescriptorImageInfo*>(source));
+                    delete CastFromUint64<VkDescriptorImageInfo*>(source);
                     break;
                 case kVulkanObjectTypeBuffer:
-                    *(reinterpret_cast<VkDescriptorBufferInfo *>(destination)) =
-                        *(CastFromUint64<VkDescriptorBufferInfo *>(source));
-                    delete CastFromUint64<VkDescriptorBufferInfo *>(source);
+                    *(reinterpret_cast<VkDescriptorBufferInfo*>(destination)) = *(CastFromUint64<VkDescriptorBufferInfo*>(source));
+                    delete CastFromUint64<VkDescriptorBufferInfo*>(source);
                     break;
                 case kVulkanObjectTypeBufferView:
-                    *(reinterpret_cast<VkBufferView *>(destination)) = CastFromUint64<VkBufferView>(source);
+                    *(reinterpret_cast<VkBufferView*>(destination)) = CastFromUint64<VkBufferView>(source);
                     break;
                 case kVulkanObjectTypeAccelerationStructureKHR:
-                    *(reinterpret_cast<VkAccelerationStructureKHR *>(destination)) =
+                    *(reinterpret_cast<VkAccelerationStructureKHR*>(destination)) =
                         CastFromUint64<VkAccelerationStructureKHR>(source);
                     break;
                 case kVulkanObjectTypeAccelerationStructureNV:
-                    *(reinterpret_cast<VkAccelerationStructureNV *>(destination)) =
+                    *(reinterpret_cast<VkAccelerationStructureNV*>(destination)) =
                         CastFromUint64<VkAccelerationStructureNV>(source);
                     break;
                 default:
@@ -1664,15 +1664,15 @@ void *BuildUnwrappedUpdateTemplateBuffer(Device *layer_data, uint64_t descriptor
             }
         }
     }
-    return (void *)unwrapped_data;
+    return (void*)unwrapped_data;
 }
 
 void Device::UpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
-                                             VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void *pData) {
+                                             VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.UpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
     uint64_t template_handle = CastToUint64(descriptorUpdateTemplate);
-    void *unwrapped_buffer = nullptr;
+    void* unwrapped_buffer = nullptr;
     {
         ReadLockGuard lock(dispatch_lock);
         descriptorSet = Unwrap(descriptorSet);
@@ -1684,11 +1684,11 @@ void Device::UpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet de
 }
 
 void Device::UpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
-                                                VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void *pData) {
+                                                VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.UpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
     uint64_t template_handle = CastToUint64(descriptorUpdateTemplate);
-    void *unwrapped_buffer = nullptr;
+    void* unwrapped_buffer = nullptr;
     {
         ReadLockGuard lock(dispatch_lock);
         descriptorSet = Unwrap(descriptorSet);
@@ -1700,12 +1700,12 @@ void Device::UpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet
 }
 
 void Device::CmdPushDescriptorSetWithTemplate(VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                              VkPipelineLayout layout, uint32_t set, const void *pData) {
+                                              VkPipelineLayout layout, uint32_t set, const void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.CmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set,
                                                                          pData);
     uint64_t template_handle = CastToUint64(descriptorUpdateTemplate);
-    void *unwrapped_buffer = nullptr;
+    void* unwrapped_buffer = nullptr;
     {
         ReadLockGuard lock(dispatch_lock);
         descriptorUpdateTemplate = Unwrap(descriptorUpdateTemplate);
@@ -1717,12 +1717,12 @@ void Device::CmdPushDescriptorSetWithTemplate(VkCommandBuffer commandBuffer, VkD
 }
 
 void Device::CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer, VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                 VkPipelineLayout layout, uint32_t set, const void *pData) {
+                                                 VkPipelineLayout layout, uint32_t set, const void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.CmdPushDescriptorSetWithTemplateKHR(commandBuffer, descriptorUpdateTemplate, layout, set,
                                                                          pData);
     uint64_t template_handle = CastToUint64(descriptorUpdateTemplate);
-    void *unwrapped_buffer = nullptr;
+    void* unwrapped_buffer = nullptr;
     {
         ReadLockGuard lock(dispatch_lock);
         descriptorUpdateTemplate = Unwrap(descriptorUpdateTemplate);
@@ -1735,44 +1735,44 @@ void Device::CmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer, 
 }
 
 void Device::CmdPushDescriptorSetWithTemplate2(VkCommandBuffer commandBuffer,
-                                               const VkPushDescriptorSetWithTemplateInfo *pPushDescriptorSetWithTemplateInfo) {
+                                               const VkPushDescriptorSetWithTemplateInfo* pPushDescriptorSetWithTemplateInfo) {
     if (!wrap_handles)
         return device_dispatch_table.CmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo);
     uint64_t template_handle = CastToUint64(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate);
-    void *unwrapped_buffer = nullptr;
+    void* unwrapped_buffer = nullptr;
     {
         ReadLockGuard lock(dispatch_lock);
-        const_cast<VkPushDescriptorSetWithTemplateInfo *>(pPushDescriptorSetWithTemplateInfo)->descriptorUpdateTemplate =
+        const_cast<VkPushDescriptorSetWithTemplateInfo*>(pPushDescriptorSetWithTemplateInfo)->descriptorUpdateTemplate =
             Unwrap(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate);
-        const_cast<VkPushDescriptorSetWithTemplateInfo *>(pPushDescriptorSetWithTemplateInfo)->layout =
+        const_cast<VkPushDescriptorSetWithTemplateInfo*>(pPushDescriptorSetWithTemplateInfo)->layout =
             Unwrap(pPushDescriptorSetWithTemplateInfo->layout);
         unwrapped_buffer = BuildUnwrappedUpdateTemplateBuffer(this, template_handle, pPushDescriptorSetWithTemplateInfo->pData);
-        const_cast<VkPushDescriptorSetWithTemplateInfo *>(pPushDescriptorSetWithTemplateInfo)->pData = unwrapped_buffer;
+        const_cast<VkPushDescriptorSetWithTemplateInfo*>(pPushDescriptorSetWithTemplateInfo)->pData = unwrapped_buffer;
     }
     device_dispatch_table.CmdPushDescriptorSetWithTemplate2(commandBuffer, pPushDescriptorSetWithTemplateInfo);
     free(unwrapped_buffer);
 }
 
 void Device::CmdPushDescriptorSetWithTemplate2KHR(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR *pPushDescriptorSetWithTemplateInfo) {
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo) {
     if (!wrap_handles)
         return device_dispatch_table.CmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo);
     uint64_t template_handle = CastToUint64(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate);
-    void *unwrapped_buffer = nullptr;
+    void* unwrapped_buffer = nullptr;
     {
         ReadLockGuard lock(dispatch_lock);
-        const_cast<VkPushDescriptorSetWithTemplateInfoKHR *>(pPushDescriptorSetWithTemplateInfo)->descriptorUpdateTemplate =
+        const_cast<VkPushDescriptorSetWithTemplateInfoKHR*>(pPushDescriptorSetWithTemplateInfo)->descriptorUpdateTemplate =
             Unwrap(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate);
-        const_cast<VkPushDescriptorSetWithTemplateInfoKHR *>(pPushDescriptorSetWithTemplateInfo)->layout =
+        const_cast<VkPushDescriptorSetWithTemplateInfoKHR*>(pPushDescriptorSetWithTemplateInfo)->layout =
             Unwrap(pPushDescriptorSetWithTemplateInfo->layout);
         unwrapped_buffer = BuildUnwrappedUpdateTemplateBuffer(this, template_handle, pPushDescriptorSetWithTemplateInfo->pData);
-        const_cast<VkPushDescriptorSetWithTemplateInfoKHR *>(pPushDescriptorSetWithTemplateInfo)->pData = unwrapped_buffer;
+        const_cast<VkPushDescriptorSetWithTemplateInfoKHR*>(pPushDescriptorSetWithTemplateInfo)->pData = unwrapped_buffer;
     }
     device_dispatch_table.CmdPushDescriptorSetWithTemplate2KHR(commandBuffer, pPushDescriptorSetWithTemplateInfo);
     free(unwrapped_buffer);
 }
 
-VkResult Device::DebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT *pTagInfo) {
+VkResult Device::DebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* pTagInfo) {
     if (!wrap_handles) return device_dispatch_table.DebugMarkerSetObjectTagEXT(device, pTagInfo);
     vku::safe_VkDebugMarkerObjectTagInfoEXT local_tag_info(pTagInfo);
 
@@ -1782,10 +1782,10 @@ VkResult Device::DebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarker
     }
 
     return device_dispatch_table.DebugMarkerSetObjectTagEXT(device,
-                                                            reinterpret_cast<VkDebugMarkerObjectTagInfoEXT *>(&local_tag_info));
+                                                            reinterpret_cast<VkDebugMarkerObjectTagInfoEXT*>(&local_tag_info));
 }
 
-VkResult Device::DebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+VkResult Device::DebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo) {
     if (!wrap_handles) return device_dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
     vku::safe_VkDebugMarkerObjectNameInfoEXT local_name_info(pNameInfo);
 
@@ -1795,11 +1795,11 @@ VkResult Device::DebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarke
     }
 
     return device_dispatch_table.DebugMarkerSetObjectNameEXT(device,
-                                                             reinterpret_cast<VkDebugMarkerObjectNameInfoEXT *>(&local_name_info));
+                                                             reinterpret_cast<VkDebugMarkerObjectNameInfoEXT*>(&local_name_info));
 }
 
 // VK_EXT_debug_utils
-VkResult Device::SetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT *pTagInfo) {
+VkResult Device::SetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT* pTagInfo) {
     if (!wrap_handles) return device_dispatch_table.SetDebugUtilsObjectTagEXT(device, pTagInfo);
     vku::safe_VkDebugUtilsObjectTagInfoEXT local_tag_info(pTagInfo);
 
@@ -1809,10 +1809,10 @@ VkResult Device::SetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsOb
     }
 
     return device_dispatch_table.SetDebugUtilsObjectTagEXT(device,
-                                                           reinterpret_cast<const VkDebugUtilsObjectTagInfoEXT *>(&local_tag_info));
+                                                           reinterpret_cast<const VkDebugUtilsObjectTagInfoEXT*>(&local_tag_info));
 }
 
-VkResult Device::SetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+VkResult Device::SetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
     if (!wrap_handles) return device_dispatch_table.SetDebugUtilsObjectNameEXT(device, pNameInfo);
     vku::safe_VkDebugUtilsObjectNameInfoEXT local_name_info(pNameInfo);
 
@@ -1822,11 +1822,11 @@ VkResult Device::SetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsO
     }
 
     return device_dispatch_table.SetDebugUtilsObjectNameEXT(
-        device, reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT *>(&local_name_info));
+        device, reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT*>(&local_name_info));
 }
 
-VkResult Device::AllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo *pAllocateInfo,
-                                        VkCommandBuffer *pCommandBuffers) {
+VkResult Device::AllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                        VkCommandBuffer* pCommandBuffers) {
     if (!wrap_handles) return device_dispatch_table.AllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers);
     vku::safe_VkCommandBufferAllocateInfo local_pAllocateInfo;
     if (pAllocateInfo) {
@@ -1835,8 +1835,8 @@ VkResult Device::AllocateCommandBuffers(VkDevice device, const VkCommandBufferAl
             local_pAllocateInfo.commandPool = Unwrap(pAllocateInfo->commandPool);
         }
     }
-    VkResult result = device_dispatch_table.AllocateCommandBuffers(
-        device, (const VkCommandBufferAllocateInfo *)&local_pAllocateInfo, pCommandBuffers);
+    VkResult result = device_dispatch_table.AllocateCommandBuffers(device, (const VkCommandBufferAllocateInfo*)&local_pAllocateInfo,
+                                                                   pCommandBuffers);
     if ((result == VK_SUCCESS) && pAllocateInfo && (pAllocateInfo->level == VK_COMMAND_BUFFER_LEVEL_SECONDARY)) {
         auto lock = WriteLockGuard(secondary_cb_map_mutex);
         for (uint32_t cb_index = 0; cb_index < pAllocateInfo->commandBufferCount; cb_index++) {
@@ -1847,7 +1847,7 @@ VkResult Device::AllocateCommandBuffers(VkDevice device, const VkCommandBufferAl
 }
 
 void Device::FreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
-                                const VkCommandBuffer *pCommandBuffers) {
+                                const VkCommandBuffer* pCommandBuffers) {
     if (!wrap_handles) return device_dispatch_table.FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
     commandPool = Unwrap(commandPool);
     device_dispatch_table.FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
@@ -1858,7 +1858,7 @@ void Device::FreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint
     }
 }
 
-void Device::DestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks *pAllocator) {
+void Device::DestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks* pAllocator) {
     if (!wrap_handles) return device_dispatch_table.DestroyCommandPool(device, commandPool, pAllocator);
 
     commandPool = Erase(commandPool);
@@ -1879,7 +1879,7 @@ bool Device::IsSecondary(VkCommandBuffer commandBuffer) const {
     return secondary_cb_map.find(commandBuffer) != secondary_cb_map.end();
 }
 
-VkResult Device::BeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *pBeginInfo) {
+VkResult Device::BeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo) {
     if (!wrap_handles || !IsSecondary(commandBuffer)) return device_dispatch_table.BeginCommandBuffer(commandBuffer, pBeginInfo);
     vku::safe_VkCommandBufferBeginInfo local_pBeginInfo;
     if (pBeginInfo) {
@@ -1893,15 +1893,15 @@ VkResult Device::BeginCommandBuffer(VkCommandBuffer commandBuffer, const VkComma
             }
         }
     }
-    VkResult result = device_dispatch_table.BeginCommandBuffer(commandBuffer, (const VkCommandBufferBeginInfo *)&local_pBeginInfo);
+    VkResult result = device_dispatch_table.BeginCommandBuffer(commandBuffer, (const VkCommandBufferBeginInfo*)&local_pBeginInfo);
     return result;
 }
 
 VkResult Device::CreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                               VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                              const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
-                                              const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) {
-    vku::safe_VkRayTracingPipelineCreateInfoKHR *local_pCreateInfos = (vku::safe_VkRayTracingPipelineCreateInfoKHR *)(pCreateInfos);
+                                              const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                              const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) {
+    vku::safe_VkRayTracingPipelineCreateInfoKHR* local_pCreateInfos = (vku::safe_VkRayTracingPipelineCreateInfoKHR*)(pCreateInfos);
     if (wrap_handles) {
         deferredOperation = Unwrap(deferredOperation);
         pipelineCache = Unwrap(pipelineCache);
@@ -1931,9 +1931,9 @@ VkResult Device::CreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperati
                     local_pCreateInfos[index0].basePipelineHandle = Unwrap(pCreateInfos[index0].basePipelineHandle);
                 }
 
-                auto *binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(local_pCreateInfos[index0].pNext);
+                auto* binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(local_pCreateInfos[index0].pNext);
                 if (binary_info) {
-                    auto *unwrapped_binaries = const_cast<VkPipelineBinaryKHR *>(binary_info->pPipelineBinaries);
+                    auto* unwrapped_binaries = const_cast<VkPipelineBinaryKHR*>(binary_info->pPipelineBinaries);
                     for (uint32_t idx1 = 0; idx1 < binary_info->binaryCount; ++idx1) {
                         unwrapped_binaries[idx1] = Unwrap(binary_info->pPipelineBinaries[idx1]);
                     }
@@ -1943,7 +1943,7 @@ VkResult Device::CreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperati
     }
 
     VkResult result = device_dispatch_table.CreateRayTracingPipelinesKHR(
-        device, deferredOperation, pipelineCache, createInfoCount, (const VkRayTracingPipelineCreateInfoKHR *)local_pCreateInfos,
+        device, deferredOperation, pipelineCache, createInfoCount, (const VkRayTracingPipelineCreateInfoKHR*)local_pCreateInfos,
         pAllocator, pPipelines);
 
     if (wrap_handles && deferredOperation == VK_NULL_HANDLE) {
@@ -1985,13 +1985,13 @@ VkResult Device::CreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperati
                     delete[] local_pCreateInfos;
                 }
                 deferred_operation_pipelines.insert(deferredOperation,
-                                                    std::pair<uint32_t, VkPipeline *>(createInfoCount, pPipelines));
+                                                    std::pair<uint32_t, VkPipeline*>(createInfoCount, pPipelines));
             };
             post_completion_fns.emplace_back(cleanup_fn);
         } else {
             auto cleanup_fn = [deferredOperation, this, createInfoCount, pPipelines]() {
                 deferred_operation_pipelines.insert(deferredOperation,
-                                                    std::pair<uint32_t, VkPipeline *>(createInfoCount, pPipelines));
+                                                    std::pair<uint32_t, VkPipeline*>(createInfoCount, pPipelines));
             };
             post_completion_fns.emplace_back(cleanup_fn);
         }
@@ -2018,7 +2018,7 @@ VkResult Device::DeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKH
     if (result == VK_SUCCESS) {
         auto post_op_completion_fns = deferred_operation_post_completion.pop(operation);
         if (post_op_completion_fns != deferred_operation_post_completion.end()) {
-            for (auto &post_op_completion_fn : post_op_completion_fns->second) {
+            for (auto& post_op_completion_fn : post_op_completion_fns->second) {
                 post_op_completion_fn();
             }
         }
@@ -2030,7 +2030,7 @@ VkResult Device::DeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKH
             auto post_check_fns = deferred_operation_post_check.pop(operation);
             auto pipelines_to_updates = deferred_operation_pipelines.pop(operation);
             if (post_check_fns->first && pipelines_to_updates->first) {
-                for (auto &post_check_fn : post_check_fns->second) {
+                for (auto& post_check_fn : post_check_fns->second) {
                     post_check_fn(pipelines_to_updates->second);
                 }
             }
@@ -2052,7 +2052,7 @@ VkResult Device::GetDeferredOperationResultKHR(VkDevice device, VkDeferredOperat
         // stored in deferred_operation_post_completion have been called
         auto post_op_completion_fns = deferred_operation_post_completion.pop(operation);
         if (post_op_completion_fns != deferred_operation_post_completion.end()) {
-            for (auto &post_op_completion_fn : post_op_completion_fns->second) {
+            for (auto& post_op_completion_fn : post_op_completion_fns->second) {
                 post_op_completion_fn();
             }
         }
@@ -2060,7 +2060,7 @@ VkResult Device::GetDeferredOperationResultKHR(VkDevice device, VkDeferredOperat
         auto post_check_fns = deferred_operation_post_check.pop(operation);
         auto pipelines_to_updates = deferred_operation_pipelines.pop(operation);
         if (post_check_fns->first && pipelines_to_updates->first) {
-            for (auto &post_check_fn : post_check_fns->second) {
+            for (auto& post_check_fn : post_check_fns->second) {
                 post_check_fn(pipelines_to_updates->second);
             }
         }
@@ -2070,11 +2070,11 @@ VkResult Device::GetDeferredOperationResultKHR(VkDevice device, VkDeferredOperat
 }
 
 void Device::CmdBuildAccelerationStructuresKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                               const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-                                               const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos) {
+                                               const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                               const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
     if (!wrap_handles)
         return device_dispatch_table.CmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
-    vku::safe_VkAccelerationStructureBuildGeometryInfoKHR *local_pInfos = nullptr;
+    vku::safe_VkAccelerationStructureBuildGeometryInfoKHR* local_pInfos = nullptr;
     {
         if (pInfos) {
             local_pInfos = new vku::safe_VkAccelerationStructureBuildGeometryInfoKHR[infoCount];
@@ -2088,7 +2088,7 @@ void Device::CmdBuildAccelerationStructuresKHR(VkCommandBuffer commandBuffer, ui
                     local_pInfos[index0].dstAccelerationStructure = Unwrap(pInfos[index0].dstAccelerationStructure);
                 }
                 for (uint32_t geometry_index = 0; geometry_index < local_pInfos[index0].geometryCount; ++geometry_index) {
-                    vku::safe_VkAccelerationStructureGeometryKHR &geometry_info =
+                    vku::safe_VkAccelerationStructureGeometryKHR& geometry_info =
                         local_pInfos[index0].pGeometries != nullptr ? local_pInfos[index0].pGeometries[geometry_index]
                                                                     : *(local_pInfos[index0].ppGeometries[geometry_index]);
 
@@ -2100,19 +2100,19 @@ void Device::CmdBuildAccelerationStructuresKHR(VkCommandBuffer commandBuffer, ui
         }
     }
     device_dispatch_table.CmdBuildAccelerationStructuresKHR(
-        commandBuffer, infoCount, (const VkAccelerationStructureBuildGeometryInfoKHR *)local_pInfos, ppBuildRangeInfos);
+        commandBuffer, infoCount, (const VkAccelerationStructureBuildGeometryInfoKHR*)local_pInfos, ppBuildRangeInfos);
     if (local_pInfos) {
         delete[] local_pInfos;
     }
 }
 
 VkResult Device::BuildAccelerationStructuresKHR(VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
-                                                const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-                                                const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos) {
+                                                const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                                const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) {
     if (!wrap_handles)
         return device_dispatch_table.BuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos,
                                                                     ppBuildRangeInfos);
-    vku::safe_VkAccelerationStructureBuildGeometryInfoKHR *local_pInfos = nullptr;
+    vku::safe_VkAccelerationStructureBuildGeometryInfoKHR* local_pInfos = nullptr;
     {
         deferredOperation = Unwrap(deferredOperation);
         if (pInfos) {
@@ -2126,7 +2126,7 @@ VkResult Device::BuildAccelerationStructuresKHR(VkDevice device, VkDeferredOpera
                     local_pInfos[index0].dstAccelerationStructure = Unwrap(pInfos[index0].dstAccelerationStructure);
                 }
                 for (uint32_t geometry_index = 0; geometry_index < local_pInfos[index0].geometryCount; ++geometry_index) {
-                    vku::safe_VkAccelerationStructureGeometryKHR &geometry_info =
+                    vku::safe_VkAccelerationStructureGeometryKHR& geometry_info =
                         local_pInfos[index0].pGeometries != nullptr ? local_pInfos[index0].pGeometries[geometry_index]
                                                                     : *(local_pInfos[index0].ppGeometries[geometry_index]);
                     if (geometry_info.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
@@ -2134,22 +2134,22 @@ VkResult Device::BuildAccelerationStructuresKHR(VkDevice device, VkDeferredOpera
                     }
                     if (geometry_info.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
                         if (geometry_info.geometry.instances.arrayOfPointers) {
-                            const uint8_t *byte_ptr =
-                                reinterpret_cast<const uint8_t *>(geometry_info.geometry.instances.data.hostAddress);
-                            VkAccelerationStructureInstanceKHR **instances =
-                                (VkAccelerationStructureInstanceKHR **)(byte_ptr +
-                                                                        ppBuildRangeInfos[index0][geometry_index].primitiveOffset);
+                            const uint8_t* byte_ptr =
+                                reinterpret_cast<const uint8_t*>(geometry_info.geometry.instances.data.hostAddress);
+                            VkAccelerationStructureInstanceKHR** instances =
+                                (VkAccelerationStructureInstanceKHR**)(byte_ptr +
+                                                                       ppBuildRangeInfos[index0][geometry_index].primitiveOffset);
                             for (uint32_t instance_index = 0;
                                  instance_index < ppBuildRangeInfos[index0][geometry_index].primitiveCount; ++instance_index) {
                                 instances[instance_index]->accelerationStructureReference =
                                     Unwrap(instances[instance_index]->accelerationStructureReference);
                             }
                         } else {
-                            const uint8_t *byte_ptr =
-                                reinterpret_cast<const uint8_t *>(geometry_info.geometry.instances.data.hostAddress);
-                            VkAccelerationStructureInstanceKHR *instances =
-                                (VkAccelerationStructureInstanceKHR *)(byte_ptr +
-                                                                       ppBuildRangeInfos[index0][geometry_index].primitiveOffset);
+                            const uint8_t* byte_ptr =
+                                reinterpret_cast<const uint8_t*>(geometry_info.geometry.instances.data.hostAddress);
+                            VkAccelerationStructureInstanceKHR* instances =
+                                (VkAccelerationStructureInstanceKHR*)(byte_ptr +
+                                                                      ppBuildRangeInfos[index0][geometry_index].primitiveOffset);
                             for (uint32_t instance_index = 0;
                                  instance_index < ppBuildRangeInfos[index0][geometry_index].primitiveCount; ++instance_index) {
                                 instances[instance_index].accelerationStructureReference =
@@ -2162,7 +2162,7 @@ VkResult Device::BuildAccelerationStructuresKHR(VkDevice device, VkDeferredOpera
         }
     }
     VkResult result = device_dispatch_table.BuildAccelerationStructuresKHR(
-        device, deferredOperation, infoCount, (const VkAccelerationStructureBuildGeometryInfoKHR *)local_pInfos, ppBuildRangeInfos);
+        device, deferredOperation, infoCount, (const VkAccelerationStructureBuildGeometryInfoKHR*)local_pInfos, ppBuildRangeInfos);
     if (local_pInfos) {
         // Fix check for deferred ray tracing pipeline creation
         // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5817
@@ -2178,9 +2178,9 @@ VkResult Device::BuildAccelerationStructuresKHR(VkDevice device, VkDeferredOpera
 }
 
 void Device::GetAccelerationStructureBuildSizesKHR(VkDevice device, VkAccelerationStructureBuildTypeKHR buildType,
-                                                   const VkAccelerationStructureBuildGeometryInfoKHR *pBuildInfo,
-                                                   const uint32_t *pMaxPrimitiveCounts,
-                                                   VkAccelerationStructureBuildSizesInfoKHR *pSizeInfo) {
+                                                   const VkAccelerationStructureBuildGeometryInfoKHR* pBuildInfo,
+                                                   const uint32_t* pMaxPrimitiveCounts,
+                                                   VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo) {
     if (!wrap_handles)
         return device_dispatch_table.GetAccelerationStructureBuildSizesKHR(device, buildType, pBuildInfo, pMaxPrimitiveCounts,
                                                                            pSizeInfo);
@@ -2195,7 +2195,7 @@ void Device::GetAccelerationStructureBuildSizesKHR(VkDevice device, VkAccelerati
                 local_pBuildInfo.dstAccelerationStructure = Unwrap(pBuildInfo->dstAccelerationStructure);
             }
             for (uint32_t geometry_index = 0; geometry_index < local_pBuildInfo.geometryCount; ++geometry_index) {
-                vku::safe_VkAccelerationStructureGeometryKHR &geometry_info =
+                vku::safe_VkAccelerationStructureGeometryKHR& geometry_info =
                     local_pBuildInfo.pGeometries != nullptr ? local_pBuildInfo.pGeometries[geometry_index]
                                                             : *(local_pBuildInfo.ppGeometries[geometry_index]);
                 if (geometry_info.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
@@ -2205,10 +2205,10 @@ void Device::GetAccelerationStructureBuildSizesKHR(VkDevice device, VkAccelerati
         }
     }
     device_dispatch_table.GetAccelerationStructureBuildSizesKHR(
-        device, buildType, (const VkAccelerationStructureBuildGeometryInfoKHR *)&local_pBuildInfo, pMaxPrimitiveCounts, pSizeInfo);
+        device, buildType, (const VkAccelerationStructureBuildGeometryInfoKHR*)&local_pBuildInfo, pMaxPrimitiveCounts, pSizeInfo);
 }
 
-void Device::GetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT *pDescriptorInfo, size_t dataSize, void *pDescriptor) {
+void Device::GetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT* pDescriptorInfo, size_t dataSize, void* pDescriptor) {
     if (!wrap_handles) return device_dispatch_table.GetDescriptorEXT(device, pDescriptorInfo, dataSize, pDescriptor);
     // When using a union of pointer we still need to unwrap the handles, but since it is a pointer, we can just use the pointer
     // from the incoming parameter instead of using safe structs as it is less complex doing it here
@@ -2303,7 +2303,7 @@ void Device::GetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT *pDe
             break;
     }
 
-    device_dispatch_table.GetDescriptorEXT(device, (const VkDescriptorGetInfoEXT *)&local_pDescriptorInfo, dataSize, pDescriptor);
+    device_dispatch_table.GetDescriptorEXT(device, (const VkDescriptorGetInfoEXT*)&local_pDescriptorInfo, dataSize, pDescriptor);
 }
 
 VkResult Device::WriteResourceDescriptorsEXT(VkDevice device, uint32_t resourceCount, const VkResourceDescriptorInfoEXT* pResources,
@@ -2356,12 +2356,12 @@ VkResult Device::WriteResourceDescriptorsEXT(VkDevice device, uint32_t resourceC
 }
 
 VkResult Device::CreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                        const VkComputePipelineCreateInfo *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                        VkPipeline *pPipelines) {
+                                        const VkComputePipelineCreateInfo* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                        VkPipeline* pPipelines) {
     if (!wrap_handles)
         return device_dispatch_table.CreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
                                                             pPipelines);
-    vku::safe_VkComputePipelineCreateInfo *local_pCreateInfos = nullptr;
+    vku::safe_VkComputePipelineCreateInfo* local_pCreateInfos = nullptr;
     {
         pipelineCache = Unwrap(pipelineCache);
         if (pCreateInfos) {
@@ -2383,7 +2383,7 @@ VkResult Device::CreateComputePipelines(VkDevice device, VkPipelineCache pipelin
         }
     }
     VkResult result = device_dispatch_table.CreateComputePipelines(
-        device, pipelineCache, createInfoCount, (const VkComputePipelineCreateInfo *)local_pCreateInfos, pAllocator, pPipelines);
+        device, pipelineCache, createInfoCount, (const VkComputePipelineCreateInfo*)local_pCreateInfos, pAllocator, pPipelines);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pCreateInfos[i].pNext != VK_NULL_HANDLE) {
             CopyCreatePipelineFeedbackData(local_pCreateInfos[i].pNext, pCreateInfos[i].pNext);
@@ -2404,12 +2404,12 @@ VkResult Device::CreateComputePipelines(VkDevice device, VkPipelineCache pipelin
 }
 
 VkResult Device::CreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                             const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) {
+                                             const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
+                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) {
     if (!wrap_handles)
         return device_dispatch_table.CreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
                                                                  pPipelines);
-    vku::safe_VkRayTracingPipelineCreateInfoNV *local_pCreateInfos = nullptr;
+    vku::safe_VkRayTracingPipelineCreateInfoNV* local_pCreateInfos = nullptr;
     {
         pipelineCache = Unwrap(pipelineCache);
         if (pCreateInfos) {
@@ -2430,9 +2430,9 @@ VkResult Device::CreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pi
                     local_pCreateInfos[index0].basePipelineHandle = Unwrap(pCreateInfos[index0].basePipelineHandle);
                 }
 
-                auto *binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(local_pCreateInfos[index0].pNext);
+                auto* binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(local_pCreateInfos[index0].pNext);
                 if (binary_info) {
-                    auto *unwrapped_binaries = const_cast<VkPipelineBinaryKHR *>(binary_info->pPipelineBinaries);
+                    auto* unwrapped_binaries = const_cast<VkPipelineBinaryKHR*>(binary_info->pPipelineBinaries);
                     for (uint32_t idx1 = 0; idx1 < binary_info->binaryCount; ++idx1) {
                         unwrapped_binaries[idx1] = Unwrap(binary_info->pPipelineBinaries[idx1]);
                     }
@@ -2440,9 +2440,9 @@ VkResult Device::CreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pi
             }
         }
     }
-    VkResult result = device_dispatch_table.CreateRayTracingPipelinesNV(
-        device, pipelineCache, createInfoCount, (const VkRayTracingPipelineCreateInfoNV *)local_pCreateInfos, pAllocator,
-        pPipelines);
+    VkResult result = device_dispatch_table.CreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount,
+                                                                        (const VkRayTracingPipelineCreateInfoNV*)local_pCreateInfos,
+                                                                        pAllocator, pPipelines);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pCreateInfos[i].pNext != VK_NULL_HANDLE) {
             CopyCreatePipelineFeedbackData(local_pCreateInfos[i].pNext, pCreateInfos[i].pNext);
@@ -2464,17 +2464,19 @@ VkResult Device::CreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pi
 
 VkResult Device::ReleasePerformanceConfigurationINTEL(VkDevice device, VkPerformanceConfigurationINTEL configuration) {
     if (!wrap_handles) return device_dispatch_table.ReleasePerformanceConfigurationINTEL(device, configuration);
-    { configuration = Unwrap(configuration); }
+    {
+        configuration = Unwrap(configuration);
+    }
     VkResult result = device_dispatch_table.ReleasePerformanceConfigurationINTEL(device, configuration);
 
     return result;
 }
 
-VkResult Device::CreatePipelineBinariesKHR(VkDevice device, const VkPipelineBinaryCreateInfoKHR *pCreateInfo,
-                                           const VkAllocationCallbacks *pAllocator, VkPipelineBinaryHandlesInfoKHR *pBinaries) {
+VkResult Device::CreatePipelineBinariesKHR(VkDevice device, const VkPipelineBinaryCreateInfoKHR* pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator, VkPipelineBinaryHandlesInfoKHR* pBinaries) {
     if (!wrap_handles) return device_dispatch_table.CreatePipelineBinariesKHR(device, pCreateInfo, pAllocator, pBinaries);
     vku::safe_VkPipelineBinaryCreateInfoKHR var_local_pCreateInfo;
-    vku::safe_VkPipelineBinaryCreateInfoKHR *local_pCreateInfo = nullptr;
+    vku::safe_VkPipelineBinaryCreateInfoKHR* local_pCreateInfo = nullptr;
     const uint32_t array_size = pBinaries->pipelineBinaryCount;
     {
         if (pCreateInfo) {
@@ -2490,7 +2492,7 @@ VkResult Device::CreatePipelineBinariesKHR(VkDevice device, const VkPipelineBina
         }
     }
     VkResult result = device_dispatch_table.CreatePipelineBinariesKHR(
-        device, (const VkPipelineBinaryCreateInfoKHR *)local_pCreateInfo, pAllocator, (VkPipelineBinaryHandlesInfoKHR *)pBinaries);
+        device, (const VkPipelineBinaryCreateInfoKHR*)local_pCreateInfo, pAllocator, (VkPipelineBinaryHandlesInfoKHR*)pBinaries);
 
     if (pBinaries->pPipelineBinaries) {
         for (uint32_t index0 = 0; index0 < array_size; index0++) {
@@ -2503,11 +2505,11 @@ VkResult Device::CreatePipelineBinariesKHR(VkDevice device, const VkPipelineBina
     return result;
 }
 
-VkResult Device::GetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKHR *pPipelineCreateInfo,
-                                   VkPipelineBinaryKeyKHR *pPipelineKey) {
+VkResult Device::GetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKHR* pPipelineCreateInfo,
+                                   VkPipelineBinaryKeyKHR* pPipelineKey) {
     if (!wrap_handles) return device_dispatch_table.GetPipelineKeyKHR(device, pPipelineCreateInfo, pPipelineKey);
     vku::safe_VkPipelineCreateInfoKHR var_local_pPipelineCreateInfo;
-    vku::safe_VkPipelineCreateInfoKHR *local_pPipelineCreateInfo = nullptr;
+    vku::safe_VkPipelineCreateInfoKHR* local_pPipelineCreateInfo = nullptr;
     {
         if (pPipelineCreateInfo) {
             local_pPipelineCreateInfo = &var_local_pPipelineCreateInfo;
@@ -2516,13 +2518,13 @@ VkResult Device::GetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKH
         }
     }
     VkResult result =
-        device_dispatch_table.GetPipelineKeyKHR(device, (const VkPipelineCreateInfoKHR *)local_pPipelineCreateInfo, pPipelineKey);
+        device_dispatch_table.GetPipelineKeyKHR(device, (const VkPipelineCreateInfoKHR*)local_pPipelineCreateInfo, pPipelineKey);
     return result;
 }
 
-VkResult Device::CreateIndirectExecutionSetEXT(VkDevice device, const VkIndirectExecutionSetCreateInfoEXT *pCreateInfo,
-                                               const VkAllocationCallbacks *pAllocator,
-                                               VkIndirectExecutionSetEXT *pIndirectExecutionSet) {
+VkResult Device::CreateIndirectExecutionSetEXT(VkDevice device, const VkIndirectExecutionSetCreateInfoEXT* pCreateInfo,
+                                               const VkAllocationCallbacks* pAllocator,
+                                               VkIndirectExecutionSetEXT* pIndirectExecutionSet) {
     if (!wrap_handles)
         return device_dispatch_table.CreateIndirectExecutionSetEXT(device, pCreateInfo, pAllocator, pIndirectExecutionSet);
 
@@ -2551,7 +2553,7 @@ VkResult Device::CreateIndirectExecutionSetEXT(VkDevice device, const VkIndirect
 
                     for (uint32_t index0 = 0; index0 < local_pCreateInfo.info.pShaderInfo->shaderCount; ++index0) {
                         if (local_pCreateInfo.info.pShaderInfo->pSetLayoutInfos) {
-                            const auto &set_layout = local_pCreateInfo.info.pShaderInfo->pSetLayoutInfos[index0];
+                            const auto& set_layout = local_pCreateInfo.info.pShaderInfo->pSetLayoutInfos[index0];
                             if (set_layout.pSetLayouts) {
                                 for (uint32_t index1 = 0; index1 < set_layout.setLayoutCount; ++index1) {
                                     shader_info.pSetLayoutInfos[index0].pSetLayouts[index1] =
@@ -2571,17 +2573,17 @@ VkResult Device::CreateIndirectExecutionSetEXT(VkDevice device, const VkIndirect
     }
 
     VkResult result = device_dispatch_table.CreateIndirectExecutionSetEXT(
-        device, (const VkIndirectExecutionSetCreateInfoEXT *)&local_pCreateInfo, pAllocator, pIndirectExecutionSet);
+        device, (const VkIndirectExecutionSetCreateInfoEXT*)&local_pCreateInfo, pAllocator, pIndirectExecutionSet);
     if (result == VK_SUCCESS) {
         *pIndirectExecutionSet = WrapNew(*pIndirectExecutionSet);
     }
     return result;
 }
 
-VkResult Device::BindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos) {
+VkResult Device::BindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos) {
     if (!wrap_handles) return device_dispatch_table.BindBufferMemory2(device, bindInfoCount, pBindInfos);
     small_vector<vku::safe_VkBindBufferMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindBufferMemoryInfo *local_pBindInfos = nullptr;
+    vku::safe_VkBindBufferMemoryInfo* local_pBindInfos = nullptr;
     {
         if (pBindInfos) {
             var_local_pBindInfos.resize(bindInfoCount);
@@ -2599,13 +2601,13 @@ VkResult Device::BindBufferMemory2(VkDevice device, uint32_t bindInfoCount, cons
         }
     }
     VkResult result =
-        device_dispatch_table.BindBufferMemory2(device, bindInfoCount, (const VkBindBufferMemoryInfo *)local_pBindInfos);
+        device_dispatch_table.BindBufferMemory2(device, bindInfoCount, (const VkBindBufferMemoryInfo*)local_pBindInfos);
 
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            auto* bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
             if (bind_memory_status) {
-                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                auto* local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
                 *bind_memory_status->pResult = *local_bind_memory_status->pResult;
             }
         }
@@ -2614,10 +2616,10 @@ VkResult Device::BindBufferMemory2(VkDevice device, uint32_t bindInfoCount, cons
     return result;
 }
 
-VkResult Device::BindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos) {
+VkResult Device::BindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) {
     if (!wrap_handles) return device_dispatch_table.BindImageMemory2(device, bindInfoCount, pBindInfos);
     small_vector<vku::safe_VkBindImageMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindImageMemoryInfo *local_pBindInfos = nullptr;
+    vku::safe_VkBindImageMemoryInfo* local_pBindInfos = nullptr;
     {
         if (pBindInfos) {
             var_local_pBindInfos.resize(bindInfoCount);
@@ -2635,14 +2637,13 @@ VkResult Device::BindImageMemory2(VkDevice device, uint32_t bindInfoCount, const
             }
         }
     }
-    VkResult result =
-        device_dispatch_table.BindImageMemory2(device, bindInfoCount, (const VkBindImageMemoryInfo *)local_pBindInfos);
+    VkResult result = device_dispatch_table.BindImageMemory2(device, bindInfoCount, (const VkBindImageMemoryInfo*)local_pBindInfos);
 
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            auto* bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
             if (bind_memory_status) {
-                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                auto* local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
                 *bind_memory_status->pResult = *local_bind_memory_status->pResult;
             }
         }
@@ -2651,10 +2652,10 @@ VkResult Device::BindImageMemory2(VkDevice device, uint32_t bindInfoCount, const
     return result;
 }
 
-VkResult Device::BindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos) {
+VkResult Device::BindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos) {
     if (!wrap_handles) return device_dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, pBindInfos);
     small_vector<vku::safe_VkBindBufferMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindBufferMemoryInfo *local_pBindInfos = nullptr;
+    vku::safe_VkBindBufferMemoryInfo* local_pBindInfos = nullptr;
     {
         if (pBindInfos) {
             var_local_pBindInfos.resize(bindInfoCount);
@@ -2672,13 +2673,13 @@ VkResult Device::BindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, c
         }
     }
     VkResult result =
-        device_dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, (const VkBindBufferMemoryInfo *)local_pBindInfos);
+        device_dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, (const VkBindBufferMemoryInfo*)local_pBindInfos);
 
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            auto* bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
             if (bind_memory_status) {
-                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                auto* local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
                 *bind_memory_status->pResult = *local_bind_memory_status->pResult;
             }
         }
@@ -2687,10 +2688,10 @@ VkResult Device::BindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, c
     return result;
 }
 
-VkResult Device::BindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos) {
+VkResult Device::BindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) {
     if (!wrap_handles) return device_dispatch_table.BindImageMemory2KHR(device, bindInfoCount, pBindInfos);
     small_vector<vku::safe_VkBindImageMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindImageMemoryInfo *local_pBindInfos = nullptr;
+    vku::safe_VkBindImageMemoryInfo* local_pBindInfos = nullptr;
     {
         if (pBindInfos) {
             var_local_pBindInfos.resize(bindInfoCount);
@@ -2709,13 +2710,13 @@ VkResult Device::BindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, co
         }
     }
     VkResult result =
-        device_dispatch_table.BindImageMemory2KHR(device, bindInfoCount, (const VkBindImageMemoryInfo *)local_pBindInfos);
+        device_dispatch_table.BindImageMemory2KHR(device, bindInfoCount, (const VkBindImageMemoryInfo*)local_pBindInfos);
 
     if (pBindInfos) {
         for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            auto* bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
             if (bind_memory_status) {
-                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                auto* local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
                 *bind_memory_status->pResult = *local_bind_memory_status->pResult;
             }
         }
@@ -2724,11 +2725,11 @@ VkResult Device::BindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, co
     return result;
 }
 
-VkResult Device::CreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
-                                  const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders) {
+VkResult Device::CreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
+                                  const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders) {
     if (!wrap_handles) return device_dispatch_table.CreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders);
     small_vector<vku::safe_VkShaderCreateInfoEXT, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pCreateInfos;
-    vku::safe_VkShaderCreateInfoEXT *local_pCreateInfos = nullptr;
+    vku::safe_VkShaderCreateInfoEXT* local_pCreateInfos = nullptr;
     if (pCreateInfos) {
         var_local_pCreateInfos.resize(createInfoCount);
         local_pCreateInfos = var_local_pCreateInfos.data();
@@ -2743,7 +2744,7 @@ VkResult Device::CreateShadersEXT(VkDevice device, uint32_t createInfoCount, con
     }
 
     VkResult result = device_dispatch_table.CreateShadersEXT(
-        device, createInfoCount, (const VkShaderCreateInfoEXT *)local_pCreateInfos, pAllocator, pShaders);
+        device, createInfoCount, (const VkShaderCreateInfoEXT*)local_pCreateInfos, pAllocator, pShaders);
 
     // Wrap anything created which is known if handles are non-null
     for (uint32_t index0 = 0; index0 < createInfoCount; index0++) {
@@ -2757,12 +2758,12 @@ VkResult Device::CreateShadersEXT(VkDevice device, uint32_t createInfoCount, con
 
 VkResult Device::CreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                              VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                             const VkDataGraphPipelineCreateInfoARM *pCreateInfos,
-                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines) {
+                                             const VkDataGraphPipelineCreateInfoARM* pCreateInfos,
+                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) {
     if (!wrap_handles)
-        return device_dispatch_table.CreateDataGraphPipelinesARM(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                            pPipelines);
-    vku::safe_VkDataGraphPipelineCreateInfoARM *local_pCreateInfos = nullptr;
+        return device_dispatch_table.CreateDataGraphPipelinesARM(device, deferredOperation, pipelineCache, createInfoCount,
+                                                                 pCreateInfos, pAllocator, pPipelines);
+    vku::safe_VkDataGraphPipelineCreateInfoARM* local_pCreateInfos = nullptr;
     {
         pipelineCache = Unwrap(pipelineCache);
         if (pCreateInfos) {
@@ -2776,9 +2777,9 @@ VkResult Device::CreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperatio
             }
         }
     }
-    VkResult result = device_dispatch_table.CreateDataGraphPipelinesARM(
-        device, deferredOperation, pipelineCache, createInfoCount, (const VkDataGraphPipelineCreateInfoARM *)local_pCreateInfos,
-        pAllocator, pPipelines);
+    VkResult result = device_dispatch_table.CreateDataGraphPipelinesARM(device, deferredOperation, pipelineCache, createInfoCount,
+                                                                        (const VkDataGraphPipelineCreateInfoARM*)local_pCreateInfos,
+                                                                        pAllocator, pPipelines);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pCreateInfos[i].pNext != VK_NULL_HANDLE) {
             CopyCreatePipelineFeedbackData(local_pCreateInfos[i].pNext, pCreateInfos[i].pNext);

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -67,7 +67,7 @@ static VkFormat GetAhbToVkFormat(uint32_t ahb_format) {
 }
 
 // Only designed to print a single usage
-static inline const char *string_AHardwareBufferGpuUsage(uint64_t usage) {
+static inline const char* string_AHardwareBufferGpuUsage(uint64_t usage) {
     if (usage & AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE) {
         return "AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE";
     } else if (usage & AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER) {
@@ -85,7 +85,7 @@ static inline const char *string_AHardwareBufferGpuUsage(uint64_t usage) {
     }
 }
 
-static inline const char *string_AHardwareBufferFormat(uint32_t format) {
+static inline const char* string_AHardwareBufferFormat(uint32_t format) {
     switch (format) {
         case (uint32_t)AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM:
             return "AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM";
@@ -133,9 +133,9 @@ static uint32_t FullMipChainLevels(VkExtent3D extent) {
 //
 // AHB-extension new APIs
 //
-bool CoreChecks::PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer *buffer,
-                                                                          VkAndroidHardwareBufferPropertiesANDROID *pProperties,
-                                                                          const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
+                                                                          VkAndroidHardwareBufferPropertiesANDROID* pProperties,
+                                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     //  buffer must be a valid Android hardware buffer object with at least one of the AHARDWAREBUFFER_USAGE_GPU_* usage flags.
     AHardwareBuffer_Desc ahb_desc;
@@ -153,9 +153,9 @@ bool CoreChecks::PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(VkDevi
 }
 
 bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice device,
-                                                                      const VkMemoryGetAndroidHardwareBufferInfoANDROID *pInfo,
-                                                                      struct AHardwareBuffer **pBuffer,
-                                                                      const ErrorObject &error_obj) const {
+                                                                      const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
+                                                                      struct AHardwareBuffer** pBuffer,
+                                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     auto mem_info = Get<vvl::DeviceMemory>(pInfo->memory);
     ASSERT_AND_RETURN_SKIP(mem_info);
@@ -193,7 +193,7 @@ bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice d
 //
 // AHB-specific validation within non-AHB APIs
 //
-bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &allocate_info, const Location &allocate_info_loc) const {
+bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo& allocate_info, const Location& allocate_info_loc) const {
     bool skip = false;
     auto import_ahb_info = vku::FindStructInPNextChain<VkImportAndroidHardwareBufferInfoANDROID>(allocate_info.pNext);
     auto exp_mem_alloc_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(allocate_info.pNext);
@@ -309,8 +309,8 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &alloc
 
             auto image_state = Get<vvl::Image>(mem_ded_alloc_info->image);
             ASSERT_AND_RETURN_SKIP(image_state);
-            const auto *ici = &image_state->create_info;
-            const Location &dedicated_image_loc = allocate_info_loc.dot(Struct::VkMemoryDedicatedAllocateInfo, Field::image);
+            const auto* ici = &image_state->create_info;
+            const Location& dedicated_image_loc = allocate_info_loc.dot(Struct::VkMemoryDedicatedAllocateInfo, Field::image);
 
             dedicated_image_usage = ici->usage;
 
@@ -383,7 +383,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &alloc
                 {VK_IMAGE_USAGE_STORAGE_BIT, (uint64_t)AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER},
             };
 
-            for (const auto &[vk_usage, ahb_usage] : ahb_usage_map_v2a) {
+            for (const auto& [vk_usage, ahb_usage] : ahb_usage_map_v2a) {
                 if (ici->usage & vk_usage) {
                     if (0 == (ahb_usage & ahb_desc.usage)) {
                         skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-02390", mem_ded_alloc_info->image, dedicated_image_loc,
@@ -449,11 +449,11 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &alloc
     return skip;
 }
 
-bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, const Location &loc) const {
+bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, const Location& loc) const {
     bool skip = false;
     if (auto image_state = Get<vvl::Image>(image)) {
         if (image_state->IsExternalBuffer() && (0 == image_state->GetBoundMemoryStates().size())) {
-            const char *vuid = loc.function == Func::vkGetImageMemoryRequirements
+            const char* vuid = loc.function == Func::vkGetImageMemoryRequirements
                                    ? "VUID-vkGetImageMemoryRequirements-image-04004"
                                    : "VUID-VkImageMemoryRequirementsInfo2-image-01897";
             skip |= LogError(vuid, image, loc,
@@ -466,12 +466,12 @@ bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, 
 }
 
 bool core::Instance::ValidateGetPhysicalDeviceImageFormatProperties2ANDROID(
-    VkPhysicalDevice physical_device, const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
-    const VkImageFormatProperties2 *pImageFormatProperties, const ErrorObject &error_obj) const {
+    VkPhysicalDevice physical_device, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    const VkImageFormatProperties2* pImageFormatProperties, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto *ahb_usage = vku::FindStructInPNextChain<VkAndroidHardwareBufferUsageANDROID>(pImageFormatProperties->pNext);
+    const auto* ahb_usage = vku::FindStructInPNextChain<VkAndroidHardwareBufferUsageANDROID>(pImageFormatProperties->pNext);
     if (ahb_usage) {
-        const auto *pdeifi = vku::FindStructInPNextChain<VkPhysicalDeviceExternalImageFormatInfo>(pImageFormatInfo->pNext);
+        const auto* pdeifi = vku::FindStructInPNextChain<VkPhysicalDeviceExternalImageFormatInfo>(pImageFormatInfo->pNext);
         if ((!pdeifi) || (VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID != pdeifi->handleType)) {
             skip |= LogError("VUID-vkGetPhysicalDeviceImageFormatProperties2-pNext-01868", physical_device,
                              error_obj.location.dot(Field::pImageFormatProperties),
@@ -485,10 +485,10 @@ bool core::Instance::ValidateGetPhysicalDeviceImageFormatProperties2ANDROID(
 }
 
 bool CoreChecks::ValidateBufferImportedHandleANDROID(VkExternalMemoryHandleTypeFlags handle_types, VkDeviceMemory memory,
-                                                     VkBuffer buffer, const Location &loc) const {
+                                                     VkBuffer buffer, const Location& loc) const {
     bool skip = false;
     if ((handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) == 0) {
-        const char *vuid = loc.function == Func::vkBindBufferMemory ? "VUID-vkBindBufferMemory-memory-02986"
+        const char* vuid = loc.function == Func::vkBindBufferMemory ? "VUID-vkBindBufferMemory-memory-02986"
                                                                     : "VUID-VkBindBufferMemoryInfo-memory-02986";
         const LogObjectList objlist(buffer, memory);
         skip |= LogError(vuid, objlist, loc.dot(Field::memory),
@@ -502,10 +502,10 @@ bool CoreChecks::ValidateBufferImportedHandleANDROID(VkExternalMemoryHandleTypeF
 }
 
 bool CoreChecks::ValidateImageImportedHandleANDROID(VkExternalMemoryHandleTypeFlags handle_types, VkDeviceMemory memory,
-                                                    VkImage image, const Location &loc) const {
+                                                    VkImage image, const Location& loc) const {
     bool skip = false;
     if ((handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) == 0) {
-        const char *vuid = loc.function == Func::vkBindImageMemory ? "VUID-vkBindImageMemory-memory-02990"
+        const char* vuid = loc.function == Func::vkBindImageMemory ? "VUID-vkBindImageMemory-memory-02990"
                                                                    : "VUID-VkBindImageMemoryInfo-memory-02990";
         const LogObjectList objlist(image, memory);
         skip |= LogError(vuid, objlist, loc.dot(Field::memory),
@@ -519,7 +519,7 @@ bool CoreChecks::ValidateImageImportedHandleANDROID(VkExternalMemoryHandleTypeFl
 }
 
 bool CoreChecks::ValidateTensorImportedHandleANDROID(VkExternalMemoryHandleTypeFlags handle_types, VkDeviceMemory memory,
-                                                     VkTensorARM tensor, const Location &loc) const {
+                                                     VkTensorARM tensor, const Location& loc) const {
     bool skip = false;
     if ((handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) == 0) {
         const LogObjectList objlist(tensor, memory);
@@ -534,10 +534,10 @@ bool CoreChecks::ValidateTensorImportedHandleANDROID(VkExternalMemoryHandleTypeF
 }
 
 // Validate creating an image with an external format
-bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
-    const VkExternalFormatANDROID *ext_fmt_android = vku::FindStructInPNextChain<VkExternalFormatANDROID>(create_info.pNext);
+    const VkExternalFormatANDROID* ext_fmt_android = vku::FindStructInPNextChain<VkExternalFormatANDROID>(create_info.pNext);
     if (ext_fmt_android && (0 != ext_fmt_android->externalFormat)) {
         if (VK_FORMAT_UNDEFINED != create_info.format) {
             skip |= LogError("VUID-VkImageCreateInfo-pNext-01974", device,
@@ -595,7 +595,7 @@ bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo &create_info
         }
     }
 
-    const VkExternalMemoryImageCreateInfo *emici = vku::FindStructInPNextChain<VkExternalMemoryImageCreateInfo>(create_info.pNext);
+    const VkExternalMemoryImageCreateInfo* emici = vku::FindStructInPNextChain<VkExternalMemoryImageCreateInfo>(create_info.pNext);
     if (emici && (emici->handleTypes & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID)) {
         if (create_info.imageType != VK_IMAGE_TYPE_2D) {
             skip |= LogError("VUID-VkImageCreateInfo-pNext-02393", device,
@@ -617,8 +617,8 @@ bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo &create_info
 }
 
 // Validate creating an image view with an AHB format
-bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo &create_info, const vvl::Image &image_state,
-                                                const Location &create_info_loc) const {
+bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo& create_info, const vvl::Image& image_state,
+                                                const Location& create_info_loc) const {
     bool skip = false;
 
     if (image_state.HasAHBFormat()) {
@@ -632,7 +632,7 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo &cre
         // Chain must include a compatible ycbcr conversion
         bool conv_found = false;
         uint64_t external_format = 0;
-        const VkSamplerYcbcrConversionInfo *ycbcr_conv_info =
+        const VkSamplerYcbcrConversionInfo* ycbcr_conv_info =
             vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(create_info.pNext);
         if (ycbcr_conv_info != nullptr) {
             if (auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(ycbcr_conv_info->conversion)) {
@@ -668,39 +668,39 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo &cre
 
 #else  // !defined(VK_USE_PLATFORM_ANDROID_KHR)
 
-bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &allocate_info, const Location &allocate_info_loc) const {
+bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo& allocate_info, const Location& allocate_info_loc) const {
     return false;
 }
 
 bool core::Instance::ValidateGetPhysicalDeviceImageFormatProperties2ANDROID(
-    VkPhysicalDevice physical_device, const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
-    const VkImageFormatProperties2 *pImageFormatProperties, const ErrorObject &error_obj) const {
+    VkPhysicalDevice physical_device, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    const VkImageFormatProperties2* pImageFormatProperties, const ErrorObject& error_obj) const {
     return false;
 }
 
-bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, const Location &loc) const { return false; }
+bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, const Location& loc) const { return false; }
 
 bool CoreChecks::ValidateBufferImportedHandleANDROID(VkExternalMemoryHandleTypeFlags handle_types, VkDeviceMemory memory,
-                                                     VkBuffer buffer, const Location &loc) const {
+                                                     VkBuffer buffer, const Location& loc) const {
     return false;
 }
 
 bool CoreChecks::ValidateImageImportedHandleANDROID(VkExternalMemoryHandleTypeFlags handle_types, VkDeviceMemory memory,
-                                                    VkImage image, const Location &loc) const {
+                                                    VkImage image, const Location& loc) const {
     return false;
 }
 
 bool CoreChecks::ValidateTensorImportedHandleANDROID(VkExternalMemoryHandleTypeFlags handle_types, VkDeviceMemory memory,
-                                                     VkTensorARM tensor, const Location &loc) const {
+                                                     VkTensorARM tensor, const Location& loc) const {
     return false;
 }
 
-bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     return false;
 }
 
-bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo &create_info, const vvl::Image &image_state,
-                                                const Location &create_info_loc) const {
+bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo& create_info, const vvl::Image& image_state,
+                                                const Location& create_info_loc) const {
     return false;
 }
 

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -34,9 +34,9 @@
 
 // Helper function to validate usage flags for buffers. For given buffer_state send actual vs. desired usage off to helper above
 // where an error will be flagged if usage is not correct
-bool CoreChecks::ValidateBufferUsageFlags(const LogObjectList &objlist, vvl::Buffer const &buffer_state,
-                                          VkBufferUsageFlags2 desired, bool strict, const char *vuid,
-                                          const Location &buffer_loc) const {
+bool CoreChecks::ValidateBufferUsageFlags(const LogObjectList& objlist, vvl::Buffer const& buffer_state,
+                                          VkBufferUsageFlags2 desired, bool strict, const char* vuid,
+                                          const Location& buffer_loc) const {
     bool skip = false;
     bool correct_usage = false;
     if (strict) {
@@ -53,11 +53,11 @@ bool CoreChecks::ValidateBufferUsageFlags(const LogObjectList &objlist, vvl::Buf
     return skip;
 }
 
-bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer &buffer_state, const VkBufferViewCreateInfo &create_info,
-                                         const Location &loc) const {
+bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer& buffer_state, const VkBufferViewCreateInfo& create_info,
+                                         const Location& loc) const {
     bool skip = false;
 
-    const VkDeviceSize &range = create_info.range;
+    const VkDeviceSize& range = create_info.range;
     if (range != VK_WHOLE_SIZE) {
         // The sum of range and offset must be less than or equal to the size of buffer
         if (range + create_info.offset > buffer_state.create_info.size) {
@@ -86,8 +86,8 @@ bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer &buffer_state, const 
     return skip;
 }
 
-bool CoreChecks::ValidateCreateBufferDescriptorBuffer(const VkBufferCreateInfo &create_info, const VkBufferUsageFlags2 &usage,
-                                                      const Location &create_info_loc) const {
+bool CoreChecks::ValidateCreateBufferDescriptorBuffer(const VkBufferCreateInfo& create_info, const VkBufferUsageFlags2& usage,
+                                                      const Location& create_info_loc) const {
     bool skip = false;
 
     if (usage & VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) {
@@ -169,9 +169,9 @@ bool CoreChecks::ValidateCreateBufferDescriptorBuffer(const VkBufferCreateInfo &
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
-                                             const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+                                             const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
+                                             const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -181,7 +181,7 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
                                                     create_info_loc, "VUID-VkBufferCreateInfo-sharingMode-01419");
     }
 
-    const auto *usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pCreateInfo->pNext);
+    const auto* usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pCreateInfo->pNext);
     const VkBufferUsageFlags2 usage = usage_flags2 ? usage_flags2->usage : pCreateInfo->usage;
 
     const bool has_decode_usage = usage & (VK_BUFFER_USAGE_2_VIDEO_DECODE_SRC_BIT_KHR | VK_BUFFER_USAGE_2_VIDEO_DECODE_DST_BIT_KHR);
@@ -198,7 +198,7 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
         const bool expect_decode_profile = has_decode_usage && !video_profile_independent;
         const bool expect_encode_profile = has_encode_usage && !video_profile_independent;
 
-        const auto *video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext);
+        const auto* video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext);
         skip |= core::ValidateVideoProfileListInfo(
             *this, video_profiles, error_obj, create_info_loc.pNext(Struct::VkVideoProfileListInfoKHR), expect_decode_profile,
             "VUID-VkBufferCreateInfo-usage-04813", expect_encode_profile, "VUID-VkBufferCreateInfo-usage-04814");
@@ -230,9 +230,9 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkBufferView *pView,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     auto buffer_state_ptr = Get<vvl::Buffer>(pCreateInfo->buffer);
@@ -240,7 +240,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
     // If this isn't a sparse buffer, it needs to have memory backing it at CreateBufferView time
     if (!buffer_state_ptr) return skip;
 
-    const auto &buffer_state = *buffer_state_ptr;
+    const auto& buffer_state = *buffer_state_ptr;
     const LogObjectList objlist(device, pCreateInfo->buffer);
 
     skip |= ValidateMemoryIsBoundToBuffer(device, buffer_state, create_info_loc.dot(Field::buffer),
@@ -380,8 +380,8 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
-                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto buffer_state = Get<vvl::Buffer>(buffer)) {
         skip |= ValidateObjectNotInUse(buffer_state.get(), error_obj.location, "VUID-vkDestroyBuffer-buffer-00922");
@@ -389,8 +389,8 @@ bool CoreChecks::PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, 
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks *pAllocator,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks* pAllocator,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto buffer_view_state = Get<vvl::BufferView>(bufferView)) {
         skip |= ValidateObjectNotInUse(buffer_view_state.get(), error_obj.location, "VUID-vkDestroyBufferView-bufferView-00936");
@@ -399,14 +399,14 @@ bool CoreChecks::PreCallValidateDestroyBufferView(VkDevice device, VkBufferView 
 }
 
 bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                              VkDeviceSize size, uint32_t data, const ErrorObject &error_obj) const {
+                                              VkDeviceSize size, uint32_t data, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto buffer_state = Get<vvl::Buffer>(dstBuffer);
     ASSERT_AND_RETURN_SKIP(cb_state_ptr && buffer_state);
 
     const LogObjectList objlist(commandBuffer, dstBuffer);
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
     const Location buffer_loc = error_obj.location.dot(Field::dstBuffer);
     skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, buffer_loc, "VUID-vkCmdFillBuffer-dstBuffer-00031");
     skip |= ValidateCmd(cb_state, error_obj.location);
@@ -603,8 +603,8 @@ bool CoreChecks::PreCallValidateCmdFillMemoryKHR(VkCommandBuffer commandBuffer, 
 }
 
 // Validates the buffer is allowed to be protected
-bool CoreChecks::ValidateProtectedBuffer(const vvl::CommandBuffer &cb_state, const vvl::Buffer &buffer_state,
-                                         const Location &buffer_loc, const char *vuid, const char *more_message) const {
+bool CoreChecks::ValidateProtectedBuffer(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state,
+                                         const Location& buffer_loc, const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values
@@ -617,8 +617,8 @@ bool CoreChecks::ValidateProtectedBuffer(const vvl::CommandBuffer &cb_state, con
 }
 
 // Validates the buffer is allowed to be unprotected
-bool CoreChecks::ValidateUnprotectedBuffer(const vvl::CommandBuffer &cb_state, const vvl::Buffer &buffer_state,
-                                           const Location &buffer_loc, const char *vuid, const char *more_message) const {
+bool CoreChecks::ValidateUnprotectedBuffer(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state,
+                                           const Location& buffer_loc, const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -41,10 +41,10 @@
 // Ran on all vkCmd* commands
 // Because it validate the implicit VUs that stateless can't, if this fails, it is likely
 // the input is very bad and other checks will crash dereferencing null pointers
-bool CoreChecks::ValidateCmd(const vvl::CommandBuffer &cb_state, const Location &loc) const {
+bool CoreChecks::ValidateCmd(const vvl::CommandBuffer& cb_state, const Location& loc) const {
     bool skip = false;
 
-    const CommandValidationInfo &info = GetCommandValidationInfo(loc.function);
+    const CommandValidationInfo& info = GetCommandValidationInfo(loc.function);
 
     // Validate the given command being added to the specified cmd buffer,
     // flagging errors if CB is not in the recording state or if there's an issue with the Cmd ordering
@@ -108,7 +108,7 @@ bool CoreChecks::ValidateCmd(const vvl::CommandBuffer &cb_state, const Location 
 }
 
 // This is a single location to report when a command buffer is invalid (which means it is not in a "recording state")
-bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
+bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
     std::ostringstream ss;
     ss << "was called in " << FormatHandle(cb_state) << " which ";
 
@@ -122,7 +122,7 @@ bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer &cb_state, 
     ss << "because the following objects bound to the command buffer were invalidated\n";
     LogObjectList objlist(cb_state.Handle());
     bool print_internal_device_range = false;
-    for (const auto &entry : cb_state.broken_bindings) {
+    for (const auto& entry : cb_state.broken_bindings) {
         if (entry.first.type == kVulkanObjectTypeInternalDeviceRange) {
             print_internal_device_range = true;
             continue;
@@ -136,7 +136,7 @@ bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer &cb_state, 
             ss << "destroyed\n";
         }
 
-        for (const auto &obj : entry.second.object_list) {
+        for (const auto& obj : entry.second.object_list) {
             objlist.add(obj);
         }
     }
@@ -156,7 +156,7 @@ bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer &cb_state, 
 }
 
 bool CoreChecks::PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
-                                                   const VkCommandBuffer *pCommandBuffers, const ErrorObject &error_obj) const {
+                                                   const VkCommandBuffer* pCommandBuffers, const ErrorObject& error_obj) const {
     bool skip = false;
     if (is_device_lost) {
         return skip;  // In case of DEVICE_LOST, all execution is considered over
@@ -175,8 +175,8 @@ bool CoreChecks::PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPoo
     return skip;
 }
 
-bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *pBeginInfo,
-                                                   const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
+                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -200,7 +200,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
             LogError("VUID-vkBeginCommandBuffer-commandBuffer-00051", commandBuffer, begin_info_loc.dot(Field::pInheritanceInfo),
                      "is null for Secondary %s.", FormatHandle(commandBuffer).c_str());
     } else {
-        const VkCommandBufferInheritanceInfo &info = *pBeginInfo->pInheritanceInfo;
+        const VkCommandBufferInheritanceInfo& info = *pBeginInfo->pInheritanceInfo;
         const Location inheritance_loc = begin_info_loc.dot(Field::pInheritanceInfo);
         skip |= ValidateBeginCommandBufferInheritanceInfo(*cb_state, info, pBeginInfo->flags, inheritance_loc);
     }
@@ -212,7 +212,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                          FormatHandle(commandBuffer).c_str());
     } else if (IsRecorded(cb_state->state)) {
         VkCommandPool cmd_pool = cb_state->allocate_info.commandPool;
-        const auto *pool = cb_state->command_pool;
+        const auto* pool = cb_state->command_pool;
         if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & pool->createFlags)) {
             const LogObjectList objlist(commandBuffer, cmd_pool);
             skip |= LogError("VUID-vkBeginCommandBuffer-commandBuffer-00050", objlist, error_obj.location,
@@ -245,10 +245,10 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateBeginCommandBufferInheritanceInfo(const vvl::CommandBuffer &cb_state,
-                                                           const VkCommandBufferInheritanceInfo &info,
+bool CoreChecks::ValidateBeginCommandBufferInheritanceInfo(const vvl::CommandBuffer& cb_state,
+                                                           const VkCommandBufferInheritanceInfo& info,
                                                            const VkCommandBufferUsageFlags begin_flags,
-                                                           const Location &inheritance_loc) const {
+                                                           const Location& inheritance_loc) const {
     bool skip = false;
 
     auto inherited_rendering_info = vku::FindStructInPNextChain<VkCommandBufferInheritanceRenderingInfo>(info.pNext);
@@ -367,10 +367,10 @@ bool CoreChecks::ValidateBeginCommandBufferInheritanceInfo(const vvl::CommandBuf
     return skip;
 }
 
-bool CoreChecks::ValidateBeginCommandBufferRenderingInheritanceInfo(const vvl::CommandBuffer &cb_state,
-                                                                    const VkCommandBufferInheritanceInfo &info,
-                                                                    const VkCommandBufferInheritanceRenderingInfo &rendering_info,
-                                                                    const Location &inheritance_loc) const {
+bool CoreChecks::ValidateBeginCommandBufferRenderingInheritanceInfo(const vvl::CommandBuffer& cb_state,
+                                                                    const VkCommandBufferInheritanceInfo& info,
+                                                                    const VkCommandBufferInheritanceRenderingInfo& rendering_info,
+                                                                    const Location& inheritance_loc) const {
     bool skip = false;
 
     auto p_attachment_sample_count_info_amd = vku::FindStructInPNextChain<VkAttachmentSampleCountInfoAMD>(info.pNext);
@@ -468,11 +468,11 @@ bool CoreChecks::ValidateBeginCommandBufferRenderingInheritanceInfo(const vvl::C
     return skip;
 }
 
-bool CoreChecks::PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
 
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
     if (cb_state.IsPrimary() || !(cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
         skip |= InsideRenderPass(cb_state, error_obj.location);
     }
@@ -486,7 +486,7 @@ bool CoreChecks::PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer, 
                      FormatHandle(commandBuffer).c_str());
     }
 
-    for (const auto &query_obj : cb_state.active_queries) {
+    for (const auto& query_obj : cb_state.active_queries) {
         skip |= LogError("VUID-vkEndCommandBuffer-commandBuffer-00061", commandBuffer, error_obj.location,
                          "Ending command buffer with a query in progress: query %" PRIu32 " in %s.", query_obj.slot,
                          FormatHandle(query_obj.pool).c_str());
@@ -502,12 +502,12 @@ bool CoreChecks::PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer, 
 }
 
 bool CoreChecks::PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags,
-                                                   const ErrorObject &error_obj) const {
+                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
     VkCommandPool cmd_pool = cb_state->allocate_info.commandPool;
-    const auto *pool = cb_state->command_pool;
+    const auto* pool = cb_state->command_pool;
 
     if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & pool->createFlags)) {
         const LogObjectList objlist(commandBuffer, cmd_pool);
@@ -525,11 +525,11 @@ bool CoreChecks::PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateCmdBindIndexBuffer(const vvl::CommandBuffer &cb_state, VkBuffer buffer, VkDeviceSize offset,
-                                            VkIndexType indexType, const Location &loc) const {
+bool CoreChecks::ValidateCmdBindIndexBuffer(const vvl::CommandBuffer& cb_state, VkBuffer buffer, VkDeviceSize offset,
+                                            VkIndexType indexType, const Location& loc) const {
     bool skip = false;
     const bool is_2 = loc.function == Func::vkCmdBindIndexBuffer2KHR || loc.function == Func::vkCmdBindIndexBuffer2;
-    const char *vuid;
+    const char* vuid;
 
     auto buffer_state = Get<vvl::Buffer>(buffer);
     if (!buffer_state) return skip;  // if using nullDescriptors
@@ -558,7 +558,7 @@ bool CoreChecks::ValidateCmdBindIndexBuffer(const vvl::CommandBuffer &cb_state, 
 }
 
 bool CoreChecks::PreCallValidateCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                   VkIndexType indexType, const ErrorObject &error_obj) const {
+                                                   VkIndexType indexType, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -567,7 +567,7 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer(VkCommandBuffer commandBuffer
 }
 
 bool CoreChecks::PreCallValidateCmdBindIndexBuffer2(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                    VkDeviceSize size, VkIndexType indexType, const ErrorObject &error_obj) const {
+                                                    VkDeviceSize size, VkIndexType indexType, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -596,7 +596,7 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer2(VkCommandBuffer commandBuffe
 
 bool CoreChecks::PreCallValidateCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                        VkDeviceSize size, VkIndexType indexType,
-                                                       const ErrorObject &error_obj) const {
+                                                       const ErrorObject& error_obj) const {
     return PreCallValidateCmdBindIndexBuffer2(commandBuffer, buffer, offset, size, indexType, error_obj);
 }
 
@@ -618,8 +618,8 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer3KHR(VkCommandBuffer commandBu
 }
 
 bool CoreChecks::PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                                     const VkBuffer *pBuffers, const VkDeviceSize *pOffsets,
-                                                     const ErrorObject &error_obj) const {
+                                                     const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
+                                                     const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
     bool skip = false;
@@ -643,7 +643,7 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuff
 }
 
 bool CoreChecks::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                VkDeviceSize dataSize, const void *pData, const ErrorObject &error_obj) const {
+                                                VkDeviceSize dataSize, const void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto dst_buffer_state = Get<vvl::Buffer>(dstBuffer);
@@ -706,7 +706,7 @@ bool CoreChecks::PreCallValidateCmdUpdateMemoryKHR(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidatePrimaryCommandBuffer(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
+bool CoreChecks::ValidatePrimaryCommandBuffer(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
     bool skip = false;
     if (cb_state.IsSecondary()) {
         skip |= LogError(vuid, cb_state.Handle(), loc, "command can't be executed on a secondary command buffer.");
@@ -791,9 +791,9 @@ bool CoreChecks::ValidateSecondaryCommandBufferDescriptorHeapInheritance(const v
     return skip;
 }
 
-bool CoreChecks::ValidateSecondaryCommandBufferState(const vvl::CommandBuffer &cb_state,
-                                                     const vvl::CommandBuffer &secondary_cb_state,
-                                                     const Location &secondary_cb_loc) const {
+bool CoreChecks::ValidateSecondaryCommandBufferState(const vvl::CommandBuffer& cb_state,
+                                                     const vvl::CommandBuffer& secondary_cb_state,
+                                                     const Location& secondary_cb_loc) const {
     bool skip = false;
     const auto primary_pool = cb_state.command_pool;
     const auto secondary_pool = secondary_cb_state.command_pool;
@@ -820,7 +820,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferState(const vvl::CommandBuffer &c
     }
 
     if (cb_state.IsSecondary()) {
-        const auto &secondary_cb_sub_state = core::SubState(secondary_cb_state);
+        const auto& secondary_cb_sub_state = core::SubState(secondary_cb_state);
         // spec: "A maxCommandBufferNestingLevel of UINT32_MAX means there is no limit to the nesting level"
         if (enabled_features.nestedCommandBuffer &&
             phys_dev_ext_props.nested_command_buffer_props.maxCommandBufferNestingLevel != UINT32_MAX) {
@@ -925,7 +925,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferQuery(const vvl::CommandBuffer& c
         }
     }
 
-    for (const auto &query_object : secondary_cb_state.started_queries) {
+    for (const auto& query_object : secondary_cb_state.started_queries) {
         if (auto query_pool_state = Get<vvl::QueryPool>(query_object.pool)) {
             if (active_types.count(query_pool_state->create_info.queryType)) {
                 const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), query_object.pool);
@@ -941,9 +941,9 @@ bool CoreChecks::ValidateSecondaryCommandBufferQuery(const vvl::CommandBuffer& c
     return skip;
 }
 
-bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &cb_state,
-                                                      const vvl::CommandBuffer &secondary_cb_state,
-                                                      const Location &secondary_cb_loc) const {
+bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer& cb_state,
+                                                      const vvl::CommandBuffer& secondary_cb_state,
+                                                      const Location& secondary_cb_loc) const {
     bool skip = false;
 
     // TODO - This logic gives false positives currently with custom resolve
@@ -955,7 +955,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
     // Validate initial layout uses vs. the primary cmd buffer state
     // Novel Valid usage: "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001"
     // initial layout usage of secondary command buffers resources must match parent command buffer
-    for (const auto &sub_layout_map_entry : secondary_cb_state.image_layout_registry) {
+    for (const auto& sub_layout_map_entry : secondary_cb_state.image_layout_registry) {
         const VkImage image = sub_layout_map_entry.first;
 
         const auto cb_layout_map = cb_state.GetImageLayoutMap(image);
@@ -963,11 +963,11 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
         if (!cb_layout_map) continue;
         if (!sub_layout_map_entry.second) continue;
 
-        const auto &sub_layout_map = *sub_layout_map_entry.second;
+        const auto& sub_layout_map = *sub_layout_map_entry.second;
         for (sparse_container::parallel_iterator<const CommandBufferImageLayoutMap> iter(sub_layout_map, *cb_layout_map, 0);
              !iter->range.empty(); ++iter) {
             VkImageLayout cb_layout = kInvalidLayout, sub_layout = kInvalidLayout;
-            const char *layout_type;
+            const char* layout_type;
 
             if (!iter->pos_A->valid || !iter->pos_B->valid) continue;
 
@@ -976,7 +976,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
             if (VK_IMAGE_LAYOUT_UNDEFINED == sub_layout) continue;  // secondary doesn't care about current or first
 
             // pos_B denotes the main CB map in the parallel iterator
-            const auto &cb_layout_state = iter->pos_B->lower_bound->second;
+            const auto& cb_layout_state = iter->pos_B->lower_bound->second;
             if (cb_layout_state.current_layout != kInvalidLayout) {
                 layout_type = "current layout";
                 cb_layout = cb_layout_state.current_layout;
@@ -1020,8 +1020,8 @@ class CoreChecks::ViewportScissorInheritanceTracker {
     static_assert(4 == sizeof(core::CommandBufferSubState::Viewport::mask), "Adjust max_viewports to match viewportMask bit width");
     static constexpr uint32_t kMaxViewports = 32, kNotTrashed = uint32_t(-2), kTrashedByPrimary = uint32_t(-1);
 
-    const Logger &log_;
-    const vvl::CommandBuffer *primary_state_ = nullptr;
+    const Logger& log_;
+    const vvl::CommandBuffer* primary_state_ = nullptr;
     uint32_t viewport_mask_;
     uint32_t scissor_mask_;
     uint32_t viewport_trashed_by_[kMaxViewports];  // filled in VisitPrimary.
@@ -1033,9 +1033,9 @@ class CoreChecks::ViewportScissorInheritanceTracker {
     uint32_t scissor_count_trashed_by_;
 
   public:
-    ViewportScissorInheritanceTracker(const Logger &log) : log_(log) {}
+    ViewportScissorInheritanceTracker(const Logger& log) : log_(log) {}
 
-    bool VisitPrimary(const core::CommandBufferSubState &primary_state) {
+    bool VisitPrimary(const core::CommandBufferSubState& primary_state) {
         assert(!primary_state_);
         primary_state_ = &primary_state.base;
 
@@ -1058,8 +1058,8 @@ class CoreChecks::ViewportScissorInheritanceTracker {
         return false;
     }
 
-    bool VisitSecondary(uint32_t cmd_buffer_idx, const Location &secondary_cb_loc,
-                        const core::CommandBufferSubState &secondary_state) {
+    bool VisitSecondary(uint32_t cmd_buffer_idx, const Location& secondary_cb_loc,
+                        const core::CommandBufferSubState& secondary_state) {
         bool skip = false;
         if (secondary_state.viewport.inherited_depths.empty()) {
             skip |= VisitSecondaryNoInheritance(cmd_buffer_idx, secondary_state);
@@ -1080,7 +1080,7 @@ class CoreChecks::ViewportScissorInheritanceTracker {
   private:
     // Track state inheritance as specified by VK_NV_inherited_scissor_viewport, including states
     // overwritten to undefined value by bound pipelines with non-dynamic state.
-    bool VisitSecondaryNoInheritance(uint32_t cmd_buffer_idx, const core::CommandBufferSubState &secondary_state) {
+    bool VisitSecondaryNoInheritance(uint32_t cmd_buffer_idx, const core::CommandBufferSubState& secondary_state) {
         viewport_mask_ |= secondary_state.viewport.mask | secondary_state.viewport.count_mask;
         scissor_mask_ |= secondary_state.scissor.mask | secondary_state.scissor.count_mask;
 
@@ -1117,15 +1117,15 @@ class CoreChecks::ViewportScissorInheritanceTracker {
     }
 
     // Validate needed inherited state as specified by VK_NV_inherited_scissor_viewport.
-    bool VisitSecondaryInheritance(uint32_t cmd_buffer_idx, const Location &cb_loc,
-                                   const core::CommandBufferSubState &secondary_state) {
+    bool VisitSecondaryInheritance(uint32_t cmd_buffer_idx, const Location& cb_loc,
+                                   const core::CommandBufferSubState& secondary_state) {
         bool skip = false;
         uint32_t check_viewport_count = 0, check_scissor_count = 0;
 
         // Common code for reporting missing inherited state (for a myriad of reasons).
         auto check_missing_inherit = [&](uint32_t was_ever_defined, uint32_t trashed_by, VkDynamicState state, uint32_t index = 0,
-                                         uint32_t static_use_count = 0, const VkViewport *inherited_viewport = nullptr,
-                                         const VkViewport *expected_viewport_depth = nullptr) {
+                                         uint32_t static_use_count = 0, const VkViewport* inherited_viewport = nullptr,
+                                         const VkViewport* expected_viewport_depth = nullptr) {
             if (was_ever_defined && trashed_by == kNotTrashed) {
                 if (state != VK_DYNAMIC_STATE_VIEWPORT) return false;
 
@@ -1149,7 +1149,7 @@ class CoreChecks::ViewportScissorInheritanceTracker {
                 }
             }
 
-            const char *state_name;
+            const char* state_name;
             bool format_index = false;
 
             switch (state) {
@@ -1247,10 +1247,10 @@ constexpr uint32_t CoreChecks::ViewportScissorInheritanceTracker::kNotTrashed;
 constexpr uint32_t CoreChecks::ViewportScissorInheritanceTracker::kTrashedByPrimary;
 
 bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBuffersCount,
-                                                   const VkCommandBuffer *pCommandBuffers, const ErrorObject &error_obj) const {
+                                                   const VkCommandBuffer* pCommandBuffers, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_sub_state = core::SubState(cb_state);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    auto& cb_sub_state = core::SubState(cb_state);
     skip |= ValidateCmd(cb_state, error_obj.location);
     ViewportScissorInheritanceTracker viewport_scissor_inheritance{*device_state};
 
@@ -1279,7 +1279,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                      "has an active query, but the inheritedQueries feature was not enabled.");
     }
 
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
     if (rp_state) {
         skip |= ValidateCmdExecuteCommandsRenderPass(cb_state, *rp_state, error_obj.location);
     }
@@ -1291,12 +1291,12 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
     vvl::unordered_map<VkCommandBuffer, uint32_t> duplicate_secondary_cb;
     bool suspended_render_pass_instance = (cb_state.last_suspend_state == vvl::CommandBuffer::SuspendState::Suspended);
-    const VkRenderingInfo *last_rendering_info =
+    const VkRenderingInfo* last_rendering_info =
         cb_state.last_rendering_info.has_value() ? cb_state.last_rendering_info.value().ptr() : nullptr;
     for (uint32_t i = 0; i < commandBuffersCount; i++) {
         const VkCommandBuffer secondary_cb = pCommandBuffers[i];
-        const auto &secondary_cb_state = *GetRead<vvl::CommandBuffer>(secondary_cb);
-        auto &secondary_sub_state = core::SubState(secondary_cb_state);
+        const auto& secondary_cb_state = *GetRead<vvl::CommandBuffer>(secondary_cb);
+        auto& secondary_sub_state = core::SubState(secondary_cb_state);
         const Location secondary_cb_loc = error_obj.location.dot(Field::pCommandBuffers, i);
 
         if (enabled_features.inheritedViewportScissor2D) {
@@ -1318,7 +1318,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                  FormatHandle(secondary_cb).c_str());
             }
         } else if (rp_state) {
-            const vvl::RenderPass *secondary_rp_state = secondary_cb_state.active_render_pass.get();
+            const vvl::RenderPass* secondary_rp_state = secondary_cb_state.active_render_pass.get();
             if (secondary_rp_state) {
                 if (cb_state.has_render_pass_instance && rp_state->UsesDynamicRendering() &&
                     secondary_rp_state->UsesDynamicRendering()) {
@@ -1382,7 +1382,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                  FormatHandle(secondary_cb).c_str());
             }
             // We use an const_cast, because one cannot query a container keyed on a non-const pointer using a const pointer
-            if (cb_state.linked_command_buffers.count(const_cast<vvl::CommandBuffer *>(&secondary_cb_state))) {
+            if (cb_state.linked_command_buffers.count(const_cast<vvl::CommandBuffer*>(&secondary_cb_state))) {
                 const LogObjectList objlist(commandBuffer, secondary_cb);
                 skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-00092", objlist, secondary_cb_loc,
                                  "%s was recorded without VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT "
@@ -1415,7 +1415,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         }
         if (secondary_cb_state.first_rendering_info.has_value() && last_rendering_info) {
             const LogObjectList objlist(commandBuffer, secondary_cb);
-            const VkRenderingInfo &rendering_info = *secondary_cb_state.first_rendering_info.value().ptr();
+            const VkRenderingInfo& rendering_info = *secondary_cb_state.first_rendering_info.value().ptr();
             // TODO: VUID is being discussed https://gitlab.khronos.org/vulkan/vulkan/-/issues/4554
             skip |= ValidateSuspendResumeMismatch("UNASSIGNED-RenderingInfo-SuspendResume-Mismatch", objlist, rendering_info,
                                                   *last_rendering_info, secondary_cb_state.first_rendering_info_loc->Get());
@@ -1435,8 +1435,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateCmdExecuteCommandsRenderPass(const vvl::CommandBuffer &cb_state, const vvl::RenderPass &rp_state,
-                                                      const Location &loc) const {
+bool CoreChecks::ValidateCmdExecuteCommandsRenderPass(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
+                                                      const Location& loc) const {
     bool skip = false;
     if (!rp_state.UsesDynamicRendering() && cb_state.IsPrimary()) {
         // check if first subpass
@@ -1477,13 +1477,13 @@ bool CoreChecks::ValidateCmdExecuteCommandsRenderPass(const vvl::CommandBuffer &
     return skip;
 }
 
-bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingSecondary(const vvl::CommandBuffer &cb_state,
-                                                                     const vvl::CommandBuffer &secondary_cb_state,
-                                                                     const vvl::RenderPass &secondary_rp_state,
-                                                                     const Location &secondary_cb_loc) const {
+bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingSecondary(const vvl::CommandBuffer& cb_state,
+                                                                     const vvl::CommandBuffer& secondary_cb_state,
+                                                                     const vvl::RenderPass& secondary_rp_state,
+                                                                     const Location& secondary_cb_loc) const {
     bool skip = false;
     const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), secondary_rp_state.Handle());
-    if (const auto *location_info =
+    if (const auto* location_info =
             vku::FindStructInPNextChain<VkRenderingAttachmentLocationInfo>(secondary_rp_state.inheritance_rendering_info.pNext)) {
         skip |= ValidateRenderingAttachmentLocations(*location_info, objlist, secondary_cb_loc.dot(Field::pNext));
 
@@ -1513,7 +1513,7 @@ bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingSecondary(const vvl::
         }
     }
 
-    if (const auto *index_info =
+    if (const auto* index_info =
             vku::FindStructInPNextChain<VkRenderingInputAttachmentIndexInfo>(secondary_rp_state.inheritance_rendering_info.pNext)) {
         skip |= ValidateRenderingInputAttachmentIndices(*index_info, objlist, secondary_cb_loc.dot(Field::pNext));
 
@@ -1568,14 +1568,14 @@ bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingSecondary(const vvl::
     return skip;
 }
 
-bool CoreChecks::ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::CommandBuffer &cb_state,
-                                                                 const vvl::RenderPass &rp_state,
-                                                                 const vvl::CommandBuffer &secondary_cb_state,
-                                                                 const VkCommandBufferInheritanceInfo &inheritance_info,
-                                                                 const Location &secondary_cb_loc) const {
+bool CoreChecks::ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::CommandBuffer& cb_state,
+                                                                 const vvl::RenderPass& rp_state,
+                                                                 const vvl::CommandBuffer& secondary_cb_state,
+                                                                 const VkCommandBufferInheritanceInfo& inheritance_info,
+                                                                 const Location& secondary_cb_loc) const {
     bool skip = false;
     bool is_dynamic_rendering = rp_state.UsesDynamicRendering();
-    auto &secondary_sub_state = core::SubState(secondary_cb_state);
+    auto& secondary_sub_state = core::SubState(secondary_cb_state);
 
     if (!(secondary_cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
         const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), rp_state.Handle());
@@ -1599,7 +1599,7 @@ bool CoreChecks::ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::Comm
         }
         // Inherit primary's activeFramebuffer, or null if using dynamic rendering,
         // and while running validate functions
-        for (auto &function : secondary_sub_state.cmd_execute_commands_functions) {
+        for (auto& function : secondary_sub_state.cmd_execute_commands_functions) {
             skip |= function(secondary_cb_state, &cb_state, cb_state.active_framebuffer.get());
         }
     }
@@ -1737,7 +1737,7 @@ bool CoreChecks::ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::Comm
         }
     }
 
-    if (auto *tile_mem_bind_info = vku::FindStructInPNextChain<VkTileMemoryBindInfoQCOM>(inheritance_info.pNext)) {
+    if (auto* tile_mem_bind_info = vku::FindStructInPNextChain<VkTileMemoryBindInfoQCOM>(inheritance_info.pNext)) {
         VulkanTypedHandle active_tile_memory_handle = {};
         VkDeviceSize active_tile_mem_size = 0;
         if (cb_state.bound_tile_memory) {
@@ -1763,11 +1763,11 @@ bool CoreChecks::ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::Comm
     return skip;
 }
 
-bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingInherited(const vvl::CommandBuffer &cb_state,
-                                                                     const vvl::RenderPass &rp_state,
-                                                                     const vvl::CommandBuffer &secondary_cb_state,
-                                                                     const vvl::RenderPass &secondary_rp_state,
-                                                                     const Location &secondary_cb_loc) const {
+bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingInherited(const vvl::CommandBuffer& cb_state,
+                                                                     const vvl::RenderPass& rp_state,
+                                                                     const vvl::CommandBuffer& secondary_cb_state,
+                                                                     const vvl::RenderPass& secondary_rp_state,
+                                                                     const Location& secondary_cb_loc) const {
     bool skip = false;
 
     const auto rendering_info = rp_state.dynamic_rendering_begin_rendering_info;
@@ -1891,7 +1891,7 @@ bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingInherited(const vvl::
                          rendering_info.viewMask);
     }
 
-    const auto &cb_sub_state = core::SubState(cb_state);
+    const auto& cb_sub_state = core::SubState(cb_state);
     // VkAttachmentSampleCountInfoAMD == VkAttachmentSampleCountInfoNV
     if (const auto amd_sample_count =
             vku::FindStructInPNextChain<VkAttachmentSampleCountInfoAMD>(inheritance_rendering_info.pNext)) {
@@ -2065,37 +2065,37 @@ bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingInherited(const vvl::
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT *pMarkerInfo,
-                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo,
+                                                       const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmd(*cb_state, error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmd(*cb_state, error_obj.location);
 }
 
 bool CoreChecks::PreCallValidateCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer,
-                                                        const VkDebugMarkerMarkerInfoEXT *pMarkerInfo,
-                                                        const ErrorObject &error_obj) const {
+                                                        const VkDebugMarkerMarkerInfoEXT* pMarkerInfo,
+                                                        const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmd(*cb_state, error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
-                                                           const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
+                                                           const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmd(*cb_state, error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
-                                                            const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
+                                                            const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmd(*cb_state, error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -2111,8 +2111,8 @@ bool CoreChecks::PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer command
     return skip;
 }
 
-bool CoreChecks::ValidateCmdDrawStrideWithStruct(const vvl::CommandBuffer &cb_state, const std::string &vuid, const uint32_t stride,
-                                                 Struct struct_name, const uint32_t struct_size, const Location &loc) const {
+bool CoreChecks::ValidateCmdDrawStrideWithStruct(const vvl::CommandBuffer& cb_state, const std::string& vuid, const uint32_t stride,
+                                                 Struct struct_name, const uint32_t struct_size, const Location& loc) const {
     bool skip = false;
     static const int condition_multiples = 0b0011;
     if ((stride & condition_multiples) || (stride < struct_size)) {
@@ -2122,10 +2122,10 @@ bool CoreChecks::ValidateCmdDrawStrideWithStruct(const vvl::CommandBuffer &cb_st
     return skip;
 }
 
-bool CoreChecks::ValidateCmdDrawStrideWithBuffer(const vvl::CommandBuffer &cb_state, const std::string &vuid, const uint32_t stride,
+bool CoreChecks::ValidateCmdDrawStrideWithBuffer(const vvl::CommandBuffer& cb_state, const std::string& vuid, const uint32_t stride,
                                                  Struct struct_name, const uint32_t struct_size, const uint32_t drawCount,
-                                                 const VkDeviceSize offset, const vvl::Buffer &buffer_state,
-                                                 const Location &loc) const {
+                                                 const VkDeviceSize offset, const vvl::Buffer& buffer_state,
+                                                 const Location& loc) const {
     bool skip = false;
     uint64_t validation_value = stride * (drawCount - 1) + offset + struct_size;
     if (validation_value > buffer_state.create_info.size) {
@@ -2141,9 +2141,9 @@ bool CoreChecks::ValidateCmdDrawStrideWithBuffer(const vvl::CommandBuffer &cb_st
 }
 
 bool CoreChecks::PreCallValidateCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                                   uint32_t bindingCount, const VkBuffer *pBuffers,
-                                                                   const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
-                                                                   const ErrorObject &error_obj) const {
+                                                                   uint32_t bindingCount, const VkBuffer* pBuffers,
+                                                                   const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
+                                                                   const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -2230,11 +2230,11 @@ bool CoreChecks::ValidateCmdBeginTransformFeedback(const vvl::CommandBuffer& cb_
             is_xfb_2 ? "VUID-vkCmdBeginTransformFeedback2EXT-None-06233" : "VUID-vkCmdBeginTransformFeedbackEXT-None-06233";
         skip |= LogError(vuid, cb_state.VkHandle(), error_obj.location, "No graphics pipeline has been bound yet.");
     } else if (pipe && pipe->pre_raster_state) {
-        const ShaderStageState *stage_state = pipe->GetShaderStageState(pipe->pre_raster_state->last_stage);
+        const ShaderStageState* stage_state = pipe->GetShaderStageState(pipe->pre_raster_state->last_stage);
         if (stage_state && stage_state->HasSpirv()) {
             if (!stage_state->entrypoint->execution_mode.Has(spirv::ExecutionModeSet::xfb_bit)) {
                 const LogObjectList objlist(cb_state.VkHandle(), pipe->Handle());
-                const char *vuid =
+                const char* vuid =
                     is_xfb_2 ? "VUID-vkCmdBeginTransformFeedback2EXT-None-04128" : "VUID-vkCmdBeginTransformFeedbackEXT-None-04128";
                 skip |=
                     LogError(vuid, objlist, error_obj.location, "The last bound pipeline (%s) has no Xfb Execution Mode for %s.",
@@ -2360,9 +2360,9 @@ bool CoreChecks::ValidateCmdEndTransformFeedback(const vvl::CommandBuffer& cb_st
 }
 
 bool CoreChecks::PreCallValidateCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                           uint32_t counterBufferCount, const VkBuffer *pCounterBuffers,
-                                                           const VkDeviceSize *pCounterBufferOffsets,
-                                                           const ErrorObject &error_obj) const {
+                                                           uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
+                                                           const VkDeviceSize* pCounterBufferOffsets,
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -2417,8 +2417,8 @@ bool CoreChecks::PreCallValidateCmdEndTransformFeedback2EXT(VkCommandBuffer comm
 }
 
 bool CoreChecks::PreCallValidateCmdBindTileMemoryQCOM(VkCommandBuffer commandBuffer,
-                                                      const VkTileMemoryBindInfoQCOM *tile_memory_bind_info,
-                                                      const ErrorObject &error_obj) const {
+                                                      const VkTileMemoryBindInfoQCOM* tile_memory_bind_info,
+                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     if (tile_memory_bind_info) {
         skip |= ValidateTileMemoryBindInfo(*tile_memory_bind_info, error_obj.location);
@@ -2427,9 +2427,9 @@ bool CoreChecks::PreCallValidateCmdBindTileMemoryQCOM(VkCommandBuffer commandBuf
 }
 
 bool CoreChecks::PreCallValidateCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                                      const VkBuffer *pBuffers, const VkDeviceSize *pOffsets,
-                                                      const VkDeviceSize *pSizes, const VkDeviceSize *pStrides,
-                                                      const ErrorObject &error_obj) const {
+                                                      const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
+                                                      const VkDeviceSize* pSizes, const VkDeviceSize* pStrides,
+                                                      const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
     bool skip = false;
@@ -2472,9 +2472,9 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers2(VkCommandBuffer commandBuf
 }
 
 bool CoreChecks::PreCallValidateCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                         uint32_t bindingCount, const VkBuffer *pBuffers,
-                                                         const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
-                                                         const VkDeviceSize *pStrides, const ErrorObject &error_obj) const {
+                                                         uint32_t bindingCount, const VkBuffer* pBuffers,
+                                                         const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
+                                                         const VkDeviceSize* pStrides, const ErrorObject& error_obj) const {
     bool skip = false;
     if (!enabled_features.extendedDynamicState && !enabled_features.shaderObject) {
         skip |= LogError("VUID-vkCmdBindVertexBuffers2-None-08971", commandBuffer, error_obj.location,
@@ -2507,8 +2507,8 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers3KHR(VkCommandBuffer command
 }
 
 bool CoreChecks::PreCallValidateCmdBeginConditionalRenderingEXT(
-    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT *pConditionalRenderingBegin,
-    const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin,
+    const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -2571,7 +2571,7 @@ bool CoreChecks::PreCallValidateCmdBeginConditionalRendering2EXT(
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -2598,7 +2598,7 @@ bool CoreChecks::PreCallValidateCmdEndConditionalRenderingEXT(VkCommandBuffer co
 }
 
 bool CoreChecks::PreCallValidateCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
-                                                          VkImageLayout imageLayout, const ErrorObject &error_obj) const {
+                                                          VkImageLayout imageLayout, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -2619,7 +2619,7 @@ bool CoreChecks::PreCallValidateCmdBindShadingRateImageNV(VkCommandBuffer comman
                          "VkImageView handle.");
         return skip;
     }
-    const auto &ivci = view_state->create_info;
+    const auto& ivci = view_state->create_info;
     if (ivci.viewType != VK_IMAGE_VIEW_TYPE_2D && ivci.viewType != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
         const LogObjectList objlist(commandBuffer, imageView);
         skip |= LogError("VUID-vkCmdBindShadingRateImageNV-imageView-02059", objlist, error_obj.location,
@@ -2646,7 +2646,7 @@ bool CoreChecks::PreCallValidateCmdBindShadingRateImageNV(VkCommandBuffer comman
     // XXX TODO: While the VUID says "each subresource", only the base mip level is
     // actually used. Since we don't have an existing convenience function to iterate
     // over all mip levels, just don't bother with non-base levels.
-    const VkImageSubresourceRange &range = view_state->normalized_subresource_range;
+    const VkImageSubresourceRange& range = view_state->normalized_subresource_range;
     VkImageSubresourceLayers subresource = {range.aspectMask, range.baseMipLevel, range.baseArrayLayer, range.layerCount};
 
     const auto* image_state = view_state->image_state.get();
@@ -2665,9 +2665,9 @@ bool CoreChecks::PreCallValidateCmdBindShadingRateImageNV(VkCommandBuffer comman
     return skip;
 }
 
-bool CoreChecks::ValidateVkConvertCooperativeVectorMatrixInfoNV(const LogObjectList &objlist,
-                                                                const VkConvertCooperativeVectorMatrixInfoNV &info,
-                                                                const Location &info_loc) const {
+bool CoreChecks::ValidateVkConvertCooperativeVectorMatrixInfoNV(const LogObjectList& objlist,
+                                                                const VkConvertCooperativeVectorMatrixInfoNV& info,
+                                                                const Location& info_loc) const {
     bool skip = false;
 
     auto const supported_matrix_type = [&](VkComponentTypeKHR component_type) {
@@ -2697,8 +2697,8 @@ bool CoreChecks::ValidateVkConvertCooperativeVectorMatrixInfoNV(const LogObjectL
 }
 
 bool CoreChecks::PreCallValidateConvertCooperativeVectorMatrixNV(VkDevice device,
-                                                                 const VkConvertCooperativeVectorMatrixInfoNV *pInfo,
-                                                                 const ErrorObject &error_obj) const {
+                                                                 const VkConvertCooperativeVectorMatrixInfoNV* pInfo,
+                                                                 const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
@@ -2709,14 +2709,14 @@ bool CoreChecks::PreCallValidateConvertCooperativeVectorMatrixNV(VkDevice device
 }
 
 bool CoreChecks::PreCallValidateCmdConvertCooperativeVectorMatrixNV(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                                    const VkConvertCooperativeVectorMatrixInfoNV *pInfos,
-                                                                    const ErrorObject &error_obj) const {
+                                                                    const VkConvertCooperativeVectorMatrixInfoNV* pInfos,
+                                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
     for (uint32_t i = 0; i < infoCount; ++i) {
-        auto const &info = pInfos[i];
+        auto const& info = pInfos[i];
         const Location info_loc = error_obj.location.dot(Field::pInfos, i);
 
         const LogObjectList objlist(commandBuffer);
@@ -2729,13 +2729,13 @@ bool CoreChecks::PreCallValidateCmdConvertCooperativeVectorMatrixNV(VkCommandBuf
     return skip;
 }
 bool CoreChecks::PreCallValidateCmdBeginCustomResolveEXT(VkCommandBuffer commandBuffer,
-                                                         const VkBeginCustomResolveInfoEXT *pBeginCustomResolveInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkBeginCustomResolveInfoEXT* pBeginCustomResolveInfo,
+                                                         const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(cb_state, error_obj.location);
 
-    const auto *rp_state = cb_state.active_render_pass.get();
+    const auto* rp_state = cb_state.active_render_pass.get();
     if (!rp_state) {
         return skip;  // called outside render pass
     } else if (!rp_state->use_dynamic_rendering) {
@@ -2753,7 +2753,7 @@ bool CoreChecks::PreCallValidateCmdBeginCustomResolveEXT(VkCommandBuffer command
         return skip;
     }
 
-    const auto &cb_sub_state = core::SubState(cb_state);
+    const auto& cb_sub_state = core::SubState(cb_state);
     if (cb_sub_state.custom_resolve.started) {
         skip |= LogError("VUID-vkCmdBeginCustomResolveEXT-None-11518", commandBuffer, error_obj.location,
                          "was already called for this render pass instance");

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1542,7 +1542,7 @@ bool CoreChecks::PreCallValidateCmdSetViewportShadingRatePaletteNV(VkCommandBuff
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
     for (uint32_t i = 0; i < viewportCount; ++i) {
-        auto *palette = &pShadingRatePalettes[i];
+        auto* palette = &pShadingRatePalettes[i];
         if (palette->shadingRatePaletteEntryCount == 0 ||
             palette->shadingRatePaletteEntryCount > phys_dev_ext_props.shading_rate_image_props.shadingRatePaletteSize) {
             skip |=
@@ -1640,7 +1640,8 @@ bool CoreChecks::PreCallValidateCmdSetDepthBias2EXT(VkCommandBuffer commandBuffe
                          "is %f (not 0.0f), but the depthBiasClamp feature was not enabled.", pDepthBiasInfo->depthBiasClamp);
     }
 
-    if (const auto *depth_bias_representation = vku::FindStructInPNextChain<VkDepthBiasRepresentationInfoEXT>(pDepthBiasInfo->pNext)) {
+    if (const auto* depth_bias_representation =
+            vku::FindStructInPNextChain<VkDepthBiasRepresentationInfoEXT>(pDepthBiasInfo->pNext)) {
         skip |= ValidateDepthBiasRepresentationInfo(error_obj.location, error_obj.objlist, *depth_bias_representation);
     }
 
@@ -2210,7 +2211,7 @@ bool CoreChecks::PreCallValidateCmdSetColorBlendEquationEXT(VkCommandBuffer comm
 
     for (uint32_t attachment = 0U; attachment < attachmentCount; ++attachment) {
         const Location equation_loc = error_obj.location.dot(Field::pColorBlendEquations, attachment);
-        VkColorBlendEquationEXT const &equation = pColorBlendEquations[attachment];
+        VkColorBlendEquationEXT const& equation = pColorBlendEquations[attachment];
         if (!enabled_features.dualSrcBlend) {
             if (IsSecondaryColorInputBlendFactor(equation.srcColorBlendFactor)) {
                 skip |= LogError(
@@ -2382,7 +2383,7 @@ bool CoreChecks::PreCallValidateCmdSetColorBlendAdvancedEXT(VkCommandBuffer comm
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
     for (uint32_t attachment = 0U; attachment < attachmentCount; ++attachment) {
-        VkColorBlendAdvancedEXT const &advanced = pColorBlendAdvanced[attachment];
+        VkColorBlendAdvancedEXT const& advanced = pColorBlendAdvanced[attachment];
         if (advanced.srcPremultiplied == VK_TRUE &&
             !phys_dev_ext_props.blend_operation_advanced_props.advancedBlendNonPremultipliedSrcColor) {
             skip |= LogError("VUID-VkColorBlendAdvancedEXT-srcPremultiplied-07505", commandBuffer,

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -57,7 +57,7 @@ struct ImageRegionIntersection {
 // Returns true if source area of first vkImageCopy/vkImageCopy2KHR region intersects dest area of second region
 // It is assumed that these are copy regions within a single image (otherwise no possibility of collision)
 template <typename RegionType>
-static ImageRegionIntersection GetRegionIntersection(const RegionType &region0, const RegionType &region1, VkImageType type,
+static ImageRegionIntersection GetRegionIntersection(const RegionType& region0, const RegionType& region1, VkImageType type,
                                                      bool is_multiplane) {
     ImageRegionIntersection result = {};
 
@@ -118,12 +118,12 @@ static ImageRegionIntersection GetRegionIntersection(const RegionType &region0, 
 // Returns true if source area of first vkImageCopy/vkImageCopy2KHR region intersects dest area of second region
 // It is assumed that these are copy regions within a single image (otherwise no possibility of collision)
 template <typename RegionType>
-static bool RegionIntersects(const RegionType *region0, const RegionType *region1, VkImageType type, bool is_multiplane) {
+static bool RegionIntersects(const RegionType* region0, const RegionType* region1, VkImageType type, bool is_multiplane) {
     return GetRegionIntersection(region0, region1, type, is_multiplane).has_instersection;
 }
 
 template <typename RegionType>
-static bool RegionIntersectsBlit(const RegionType *region0, const RegionType *region1, VkImageType type, bool is_multiplane) {
+static bool RegionIntersectsBlit(const RegionType* region0, const RegionType* region1, VkImageType type, bool is_multiplane) {
     bool result = false;
 
     // Separate planes within a multiplane image cannot intersect
@@ -156,20 +156,20 @@ static bool RegionIntersectsBlit(const RegionType *region0, const RegionType *re
     return result;
 }
 
-static inline bool IsExtentEqual(const VkExtent3D &extent, const VkExtent3D &other_extent) {
+static inline bool IsExtentEqual(const VkExtent3D& extent, const VkExtent3D& other_extent) {
     return (extent.width == other_extent.width) && (extent.height == other_extent.height) && (extent.depth == other_extent.depth);
 }
 
-static inline bool IsExtentAllZeroes(const VkExtent3D &extent) {
+static inline bool IsExtentAllZeroes(const VkExtent3D& extent) {
     return ((extent.width == 0) && (extent.height == 0) && (extent.depth == 0));
 }
 
-static inline bool IsExtentAllOne(const VkExtent3D &extent) {
+static inline bool IsExtentAllOne(const VkExtent3D& extent) {
     return ((extent.width == 1) && (extent.height == 1) && (extent.depth == 1));
 }
 
 // Test elements of a VkExtent3D structure against alignment constraints contained in another VkExtent3D structure
-static inline bool IsExtentAligned(const VkExtent3D &extent, const VkExtent3D &granularity) {
+static inline bool IsExtentAligned(const VkExtent3D& extent, const VkExtent3D& granularity) {
     bool valid = true;
     if (!IsIntegerMultipleOf(extent.depth, granularity.depth) || !IsIntegerMultipleOf(extent.width, granularity.width) ||
         !IsIntegerMultipleOf(extent.height, granularity.height)) {
@@ -178,7 +178,7 @@ static inline bool IsExtentAligned(const VkExtent3D &extent, const VkExtent3D &g
     return valid;
 }
 
-VkExtent3D CoreChecks::GetImageTransferGranularity(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state) const {
+VkExtent3D CoreChecks::GetImageTransferGranularity(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state) const {
     if (cb_state.command_pool) {
         return physical_device_state->queue_family_properties[cb_state.command_pool->queueFamilyIndex].minImageTransferGranularity;
     }
@@ -187,9 +187,9 @@ VkExtent3D CoreChecks::GetImageTransferGranularity(const vvl::CommandBuffer &cb_
 }
 
 // Check elements of a VkOffset3D structure against a queue family's Image Transfer Granularity values
-bool CoreChecks::ValidateTransferGranularityOffset(const LogObjectList &objlist, const VkOffset3D &offset,
-                                                   const VkExtent3D &granularity, const Location &offset_loc,
-                                                   const char *vuid) const {
+bool CoreChecks::ValidateTransferGranularityOffset(const LogObjectList& objlist, const VkOffset3D& offset,
+                                                   const VkExtent3D& granularity, const Location& offset_loc,
+                                                   const char* vuid) const {
     bool skip = false;
     VkExtent3D offset_extent = {};
     offset_extent.width = static_cast<uint32_t>(abs(offset.x));
@@ -215,10 +215,10 @@ bool CoreChecks::ValidateTransferGranularityOffset(const LogObjectList &objlist,
 }
 
 // Check elements of a VkExtent3D structure against a queue family's Image Transfer Granularity values
-bool CoreChecks::ValidateTransferGranularityExtent(const LogObjectList &objlist, const VkExtent3D &region_extent,
-                                                   const VkOffset3D &region_offset, const VkExtent3D &granularity,
-                                                   const VkExtent3D &subresource_extent, const vvl::Image &image_state,
-                                                   const Location &extent_loc, const char *vuid) const {
+bool CoreChecks::ValidateTransferGranularityExtent(const LogObjectList& objlist, const VkExtent3D& region_extent,
+                                                   const VkOffset3D& region_offset, const VkExtent3D& granularity,
+                                                   const VkExtent3D& subresource_extent, const vvl::Image& image_state,
+                                                   const Location& extent_loc, const char* vuid) const {
     bool skip = false;
 
     if (IsExtentAllZeroes(granularity)) {
@@ -340,13 +340,13 @@ static std::string DescribeValidAspectMaskForFormat(VkFormat format) {
 struct ImageCopyRegion {
     VkExtent3D extent;
 
-    const vvl::Image &src_state;
+    const vvl::Image& src_state;
     VkOffset3D src_offset;
     VkImageSubresourceLayers src_subresource;
     VkExtent3D src_subresource_extent;    // represented by texels (not texel blocks)
     uint32_t normalized_src_layer_count;  // fills in VK_REMAINING_ARRAY_LAYERS
 
-    const vvl::Image &dst_state;
+    const vvl::Image& dst_state;
     VkOffset3D dst_offset;
     VkImageSubresourceLayers dst_subresource;
     VkExtent3D dst_subresource_extent;    // represented by texels (not texel blocks)
@@ -400,7 +400,7 @@ struct ImageCopyRegion {
         }
     }
 
-    ImageCopyRegion(const vvl::Image &src_state, const vvl::Image &dst_state, const VkImageCopy &region)
+    ImageCopyRegion(const vvl::Image& src_state, const vvl::Image& dst_state, const VkImageCopy& region)
         : src_state(src_state), dst_state(dst_state) {
         extent = region.extent;
         src_subresource = region.srcSubresource;
@@ -410,7 +410,7 @@ struct ImageCopyRegion {
         Init();
     }
 
-    ImageCopyRegion(const vvl::Image &src_state, const vvl::Image &dst_state, const VkImageCopy2 &region)
+    ImageCopyRegion(const vvl::Image& src_state, const vvl::Image& dst_state, const VkImageCopy2& region)
         : src_state(src_state), dst_state(dst_state) {
         extent = region.extent;
         src_offset = region.srcOffset;
@@ -483,8 +483,8 @@ uint32_t GetImageHeight<VkDeviceMemoryImageCopyKHR>(VkDeviceMemoryImageCopyKHR d
 // Common between non-image to/from image copies
 // ex) BufferToImage, ImageToBuffer, MemoryToImage, and ImageToMemory
 template <typename RegionType>
-bool CoreChecks::ValidateHeterogeneousCopyData(const RegionType &region, const vvl::Image &image_state,
-                                               const LogObjectList &objlist, const Location &region_loc) const {
+bool CoreChecks::ValidateHeterogeneousCopyData(const RegionType& region, const vvl::Image& image_state,
+                                               const LogObjectList& objlist, const Location& region_loc) const {
     bool skip = false;
     const bool is_memory = IsValueIn(region_loc.function, {Func::vkCopyMemoryToImage, Func::vkCopyMemoryToImageEXT,
                                                            Func::vkCopyImageToMemory, Func::vkCopyImageToMemoryEXT});
@@ -674,8 +674,8 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const RegionType &region, const v
 // This is just a way to put the "imageless" (really stateless) checks in a seperate area
 // (We don't do this in the stateless validation object because pain of duplicating the logic to route the various functions here)
 template <typename RegionType>
-bool CoreChecks::ValidateHeterogeneousCopyImageless(const RegionType &region, const LogObjectList &objlist,
-                                                    const Location &region_loc, bool is_memory) const {
+bool CoreChecks::ValidateHeterogeneousCopyImageless(const RegionType& region, const LogObjectList& objlist,
+                                                    const Location& region_loc, bool is_memory) const {
     bool skip = false;
 
     // Make sure not a empty region
@@ -719,9 +719,9 @@ bool CoreChecks::ValidateHeterogeneousCopyImageless(const RegionType &region, co
 }
 
 template <typename RegionType>
-bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer &cb_state, const RegionType &region,
-                                             const vvl::Image &image_state, const LogObjectList &objlist,
-                                             const Location &region_loc) const {
+bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer& cb_state, const RegionType& region,
+                                             const vvl::Image& image_state, const LogObjectList& objlist,
+                                             const Location& region_loc) const {
     bool skip = false;
 
     skip |= ValidateHeterogeneousCopyData(region, image_state, objlist, region_loc);
@@ -768,7 +768,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer &cb_state,
     if (!IsIntegerMultipleOf(region.bufferOffset, 4)) {
         const VkQueueFlags required_flags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
         if (!HasRequiredQueueFlags(cb_state, *physical_device_state, required_flags)) {
-            const char *vuid = GetCopyBufferImageDeviceVUID(region_loc, vvl::CopyError::BufferOffset_07737).c_str();
+            const char* vuid = GetCopyBufferImageDeviceVUID(region_loc, vvl::CopyError::BufferOffset_07737).c_str();
             const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
             skip |=
                 LogError(vuid, objlist, region_loc.dot(Field::bufferOffset), "(%" PRIu64 ") is not a multiple of 4, but is %s",
@@ -780,14 +780,14 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer &cb_state,
 }
 
 template <typename RegionType>
-bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, const vvl::Buffer &src_buffer_state,
-                                             const vvl::Buffer &dst_buffer_state, uint32_t regionCount, const RegionType *pRegions,
-                                             const Location &loc) const {
+bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, const vvl::Buffer& src_buffer_state,
+                                             const vvl::Buffer& dst_buffer_state, uint32_t regionCount, const RegionType* pRegions,
+                                             const Location& loc) const {
     bool skip = false;
     const bool is_2 = loc.function == Func::vkCmdCopyBuffer2 || loc.function == Func::vkCmdCopyBuffer2KHR;
 
-    const auto *src_binding = src_buffer_state.Binding();
-    const auto *dst_binding = dst_buffer_state.Binding();
+    const auto* src_binding = src_buffer_state.Binding();
+    const auto* dst_binding = dst_buffer_state.Binding();
 
     const bool are_buffers_sparse = src_buffer_state.sparse || dst_buffer_state.sparse;
     const bool validate_no_memory_overlaps = !are_buffers_sparse && (regionCount > 0) && src_binding && dst_binding &&
@@ -804,12 +804,12 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
 
     for (uint32_t i = 0; i < regionCount; i++) {
         const Location region_loc = loc.dot(Field::pRegions, i);
-        const RegionType &region = pRegions[i];
+        const RegionType& region = pRegions[i];
 
         // src
         {
             if (region.srcOffset >= src_buffer_state.create_info.size) {
-                const char *vuid = is_2 ? "VUID-VkCopyBufferInfo2-srcOffset-00113" : "VUID-vkCmdCopyBuffer-srcOffset-00113";
+                const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-srcOffset-00113" : "VUID-vkCmdCopyBuffer-srcOffset-00113";
                 const LogObjectList objlist(commandBuffer, src_buffer_state.Handle());
                 skip |= LogError(vuid, objlist, region_loc.dot(Field::srcOffset),
                                  "(%" PRIuLEAST64 ") is greater than size of srcBuffer (%" PRIuLEAST64 ").", region.srcOffset,
@@ -817,7 +817,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
             }
 
             if (region.size > (src_buffer_state.create_info.size - region.srcOffset)) {
-                const char *vuid = is_2 ? "VUID-VkCopyBufferInfo2-size-00115" : "VUID-vkCmdCopyBuffer-size-00115";
+                const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-size-00115" : "VUID-vkCmdCopyBuffer-size-00115";
                 const LogObjectList objlist(commandBuffer, src_buffer_state.Handle());
                 skip |= LogError(vuid, objlist, region_loc.dot(Field::size),
                                  "(%" PRIuLEAST64 ") is greater than the source buffer size (%" PRIuLEAST64
@@ -829,7 +829,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
         // dst
         {
             if (region.dstOffset >= dst_buffer_state.create_info.size) {
-                const char *vuid = is_2 ? "VUID-VkCopyBufferInfo2-dstOffset-00114" : "VUID-vkCmdCopyBuffer-dstOffset-00114";
+                const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-dstOffset-00114" : "VUID-vkCmdCopyBuffer-dstOffset-00114";
                 const LogObjectList objlist(commandBuffer, dst_buffer_state.Handle());
                 skip |= LogError(vuid, objlist, region_loc.dot(Field::dstOffset),
                                  "(%" PRIuLEAST64 ") is greater than size of dstBuffer (%" PRIuLEAST64 ").", region.dstOffset,
@@ -837,7 +837,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
             }
 
             if (region.size > (dst_buffer_state.create_info.size - region.dstOffset)) {
-                const char *vuid = is_2 ? "VUID-VkCopyBufferInfo2-size-00116" : "VUID-vkCmdCopyBuffer-size-00116";
+                const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-size-00116" : "VUID-vkCmdCopyBuffer-size-00116";
                 const LogObjectList objlist(commandBuffer, dst_buffer_state.Handle());
                 skip |= LogError(vuid, objlist, region_loc.dot(Field::size),
                                  "(%" PRIuLEAST64 ") is greater than the destination buffer size (%" PRIuLEAST64
@@ -876,7 +876,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
 
                 const LogObjectList objlist(commandBuffer, src_binding->memory_state->Handle(), src_buffer_state.Handle(),
                                             dst_buffer_state.Handle());
-                const char *vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
+                const char* vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
                 skip |= LogError(
                     vuid, objlist, loc,
                     "Copy source buffer range %s (from buffer %s) and destination buffer range %s (from buffer %s) are bound to "
@@ -900,7 +900,7 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer commandBuffer, cons
 
 template <typename RegionType>
 bool CoreChecks::ValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
-                                       const RegionType *pRegions, const Location &loc) const {
+                                       const RegionType* pRegions, const Location& loc) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_buffer_state = Get<vvl::Buffer>(srcBuffer);
@@ -908,10 +908,10 @@ bool CoreChecks::ValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer s
     if (!src_buffer_state || !dst_buffer_state) {
         return skip;
     }
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
 
     const bool is_2 = loc.function == Func::vkCmdCopyBuffer2 || loc.function == Func::vkCmdCopyBuffer2KHR;
-    const char *vuid;
+    const char* vuid;
 
     skip |= ValidateCmd(cb_state, loc);
     skip |= ValidateCmdCopyBufferBounds(commandBuffer, *src_buffer_state, *dst_buffer_state, regionCount, pRegions, loc);
@@ -950,18 +950,18 @@ bool CoreChecks::ValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer s
 }
 
 bool CoreChecks::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                              uint32_t regionCount, const VkBufferCopy *pRegions,
-                                              const ErrorObject &error_obj) const {
+                                              uint32_t regionCount, const VkBufferCopy* pRegions,
+                                              const ErrorObject& error_obj) const {
     return ValidateCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR* pCopyBufferInfo,
+                                                  const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyBuffer2(commandBuffer, pCopyBufferInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo,
-                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
+                                               const ErrorObject& error_obj) const {
     return ValidateCmdCopyBuffer(commandBuffer, pCopyBufferInfo->srcBuffer, pCopyBufferInfo->dstBuffer,
                                  pCopyBufferInfo->regionCount, pCopyBufferInfo->pRegions,
                                  error_obj.location.dot(Field::pCopyBufferInfo));
@@ -969,10 +969,10 @@ bool CoreChecks::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, co
 
 // Check valid usage Image Transfer Granularity requirements for elements of a VkBufferImageCopy/VkBufferImageCopy2 structure
 template <typename RegionType>
-bool CoreChecks::ValidateCopyBufferImageTransferGranularityRequirements(const vvl::CommandBuffer &cb_state,
-                                                                        const vvl::Image &image_state, const RegionType &region,
-                                                                        const LogObjectList &objlist,
-                                                                        const Location &region_loc) const {
+bool CoreChecks::ValidateCopyBufferImageTransferGranularityRequirements(const vvl::CommandBuffer& cb_state,
+                                                                        const vvl::Image& image_state, const RegionType& region,
+                                                                        const LogObjectList& objlist,
+                                                                        const Location& region_loc) const {
     bool skip = false;
     std::string vuid = GetCopyBufferImageDeviceVUID(region_loc, vvl::CopyError::TransferGranularity_07747);
     const VkExtent3D granularity = GetImageTransferGranularity(cb_state, image_state);
@@ -985,9 +985,9 @@ bool CoreChecks::ValidateCopyBufferImageTransferGranularityRequirements(const vv
 }
 
 template <typename HandleT>
-bool CoreChecks::ValidateImageSubresourceLayers(HandleT handle, const vvl::Image &image_state,
-                                                const VkImageSubresourceLayers &subresource_layers,
-                                                const Location &subresource_loc) const {
+bool CoreChecks::ValidateImageSubresourceLayers(HandleT handle, const vvl::Image& image_state,
+                                                const VkImageSubresourceLayers& subresource_layers,
+                                                const Location& subresource_loc) const {
     bool skip = false;
     if (subresource_layers.layerCount == VK_REMAINING_ARRAY_LAYERS) {
         if (!enabled_features.maintenance5) {
@@ -1043,11 +1043,11 @@ bool CoreChecks::ValidateImageSubresourceLayers(HandleT handle, const vvl::Image
 }
 
 // Check valid usage Image Transfer Granularity requirements for elements of a VkImageCopy/VkImageCopy2KHR structure
-bool CoreChecks::ValidateCopyImageTransferGranularityRequirements(const vvl::CommandBuffer &cb_state, const ImageCopyRegion &region,
-                                                                  const Location &region_loc) const {
+bool CoreChecks::ValidateCopyImageTransferGranularityRequirements(const vvl::CommandBuffer& cb_state, const ImageCopyRegion& region,
+                                                                  const Location& region_loc) const {
     bool skip = false;
     const bool is_2 = region_loc.function == Func::vkCmdCopyImage2 || region_loc.function == Func::vkCmdCopyImage2KHR;
-    const char *vuid;
+    const char* vuid;
 
     {
         // Source image checks
@@ -1075,7 +1075,7 @@ bool CoreChecks::ValidateCopyImageTransferGranularityRequirements(const vvl::Com
 
 // Validate contents of a VkImageCopy or VkImageCopy2 struct
 template <typename HandleT>
-bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRegion &region, const Location &region_loc) const {
+bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRegion& region, const Location& region_loc) const {
     bool skip = false;
     const bool is_2 = region_loc.function == Func::vkCmdCopyImage2 || region_loc.function == Func::vkCmdCopyImage2KHR;
     const bool is_host = region_loc.function == Func::vkCopyImageToImage || region_loc.function == Func::vkCopyImageToImageEXT;
@@ -1084,17 +1084,17 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
 
     // Make sure not a empty region (src extent is always un-modified)
     if (region.extent.width == 0) {
-        const char *vuid = (is_2 || is_host) ? "VUID-VkImageCopy2-extent-06668" : "VUID-VkImageCopy-extent-06668";
+        const char* vuid = (is_2 || is_host) ? "VUID-VkImageCopy2-extent-06668" : "VUID-VkImageCopy-extent-06668";
         const LogObjectList src_objlist(handle, region.src_state.VkHandle());
         skip |= LogError(vuid, src_objlist, region_loc.dot(Field::extent).dot(Field::width),
                          "is zero. (empty copies are not allowed).");
     } else if (region.extent.height == 0) {
-        const char *vuid = (is_2 || is_host) ? "VUID-VkImageCopy2-extent-06669" : "VUID-VkImageCopy-extent-06669";
+        const char* vuid = (is_2 || is_host) ? "VUID-VkImageCopy2-extent-06669" : "VUID-VkImageCopy-extent-06669";
         const LogObjectList src_objlist(handle, region.src_state.VkHandle());
         skip |= LogError(vuid, src_objlist, region_loc.dot(Field::extent).dot(Field::height),
                          "is zero. (empty copies are not allowed).");
     } else if (region.extent.depth == 0) {
-        const char *vuid = (is_2 || is_host) ? "VUID-VkImageCopy2-extent-06670" : "VUID-VkImageCopy-extent-06670";
+        const char* vuid = (is_2 || is_host) ? "VUID-VkImageCopy2-extent-06670" : "VUID-VkImageCopy-extent-06670";
         const LogObjectList src_objlist(handle, region.src_state.VkHandle());
         skip |= LogError(vuid, src_objlist, region_loc.dot(Field::extent).dot(Field::depth),
                          "is zero. (empty copies are not allowed).");
@@ -1112,7 +1112,7 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
                 // For each region the layerCount member of srcSubresource and dstSubresource must match
                 if (region.normalized_src_layer_count != region.normalized_dst_layer_count) {
                     const LogObjectList objlist(handle, region.src_state.VkHandle(), region.dst_state.VkHandle());
-                    const char *vuid =
+                    const char* vuid =
                         (is_2 || is_host) ? "VUID-VkImageCopy2-apiVersion-07941" : "VUID-VkImageCopy-apiVersion-07941";
                     skip |=
                         LogError(vuid, objlist, src_subresource_loc.dot(Field::layerCount),
@@ -1124,7 +1124,7 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
                 // For each region the aspectMask member of srcSubresource and dstSubresource must match
                 if (region.src_subresource.aspectMask != region.dst_subresource.aspectMask) {
                     const LogObjectList objlist(handle, region.src_state.VkHandle(), region.dst_state.VkHandle());
-                    const char *vuid =
+                    const char* vuid =
                         (is_2 || is_host) ? "VUID-VkImageCopy2-apiVersion-07940" : "VUID-VkImageCopy-apiVersion-07940";
                     skip |= LogError(vuid, objlist, src_subresource_loc.dot(Field::aspectMask), "(%s) does not match %s (%s).",
                                      string_VkImageAspectFlags(region.src_subresource.aspectMask).c_str(),
@@ -1164,7 +1164,7 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
             if (src_image_type == VK_IMAGE_TYPE_3D || dst_image_type == VK_IMAGE_TYPE_3D) {
                 if (region.src_subresource.baseArrayLayer != 0 || region.normalized_src_layer_count != 1) {
                     const LogObjectList objlist(handle, region.src_state.Handle());
-                    const char *vuid = is_2 ? "VUID-VkCopyImageInfo2-apiVersion-07932" : "VUID-vkCmdCopyImage-apiVersion-07932";
+                    const char* vuid = is_2 ? "VUID-VkCopyImageInfo2-apiVersion-07932" : "VUID-vkCmdCopyImage-apiVersion-07932";
                     skip |= LogError(vuid, objlist, region_loc.dot(Field::srcSubresource).dot(Field::baseArrayLayer),
                                      "is %" PRIu32
                                      " and srcSubresource.layerCount is %s. For copies with either src or dst of type "
@@ -1174,7 +1174,7 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
                 }
                 if (region.dst_subresource.baseArrayLayer != 0 || region.normalized_dst_layer_count != 1) {
                     const LogObjectList objlist(handle, region.dst_state.Handle());
-                    const char *vuid = is_2 ? "VUID-VkCopyImageInfo2-apiVersion-07932" : "VUID-vkCmdCopyImage-apiVersion-07932";
+                    const char* vuid = is_2 ? "VUID-VkCopyImageInfo2-apiVersion-07932" : "VUID-vkCmdCopyImage-apiVersion-07932";
                     skip |= LogError(vuid, objlist, region_loc.dot(Field::dstSubresource).dot(Field::baseArrayLayer),
                                      "is %" PRIu32
                                      " and dstSubresource.layerCount is %s For copies with either src or dst of type "
@@ -1251,7 +1251,7 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
 
         if (((src_image_type == VK_IMAGE_TYPE_1D) || ((src_image_type == VK_IMAGE_TYPE_2D) && is_host)) &&
             ((region.src_offset.z != 0) || (region.extent.depth != 1))) {
-            const char *image_type = is_host ? "1D or 2D" : "1D";
+            const char* image_type = is_host ? "1D or 2D" : "1D";
             skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::SrcImage1D_01785), src_objlist,
                              region_loc.dot(Field::srcOffset).dot(Field::z),
                              "is %" PRId32 " and extent.depth is %" PRIu32
@@ -1260,7 +1260,7 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
         }
 
         if ((src_image_type == VK_IMAGE_TYPE_2D) && (region.src_offset.z != 0) && (!is_host)) {
-            const char *vuid = is_2 ? "VUID-VkCopyImageInfo2-srcImage-01787" : "VUID-vkCmdCopyImage-srcImage-01787";
+            const char* vuid = is_2 ? "VUID-VkCopyImageInfo2-srcImage-01787" : "VUID-vkCmdCopyImage-srcImage-01787";
             skip |= LogError(vuid, src_objlist, region_loc.dot(Field::srcOffset).dot(Field::z),
                              "is %" PRId32 ", but for VK_IMAGE_TYPE_2D images this must be 0.\n%s", region.src_offset.z,
                              region.DescribeSrcAndDstImage().c_str());
@@ -1434,14 +1434,14 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
         if (region.dst_state.create_info.imageType == VK_IMAGE_TYPE_1D ||
             (region.dst_state.create_info.imageType == VK_IMAGE_TYPE_2D && is_host)) {
             if (region.dst_offset.z != 0) {
-                const char *image_type = is_host ? "1D or 2D" : "1D";
+                const char* image_type = is_host ? "1D or 2D" : "1D";
                 skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::DstImage1D_01786), dst_objlist,
                                  region_loc.dot(Field::dstOffset).dot(Field::z),
                                  "is %" PRId32 ", for %s images the dstOffset.z must be 0\n%s%s", region.dst_offset.z, image_type,
                                  region.DescribeAdjustedExtent().c_str(), region.DescribeSrcAndDstImage().c_str());
 
             } else if (region.dst_adjusted_extent.depth != 1 && !region.src_dst_both_compressed) {
-                const char *image_type = is_host ? "1D or 2D" : "1D";
+                const char* image_type = is_host ? "1D or 2D" : "1D";
                 skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::DstImage1D_10907), dst_objlist,
                                  region_loc.dot(Field::extent).dot(Field::depth),
                                  "is %" PRIu32 ", for %s images the extent.depth must be 1\n%s%s", region.dst_adjusted_extent.depth,
@@ -1450,7 +1450,7 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
         }
 
         if ((region.dst_state.create_info.imageType == VK_IMAGE_TYPE_2D) && (region.dst_offset.z != 0) && !is_host) {
-            const char *vuid = is_2 ? "VUID-VkCopyImageInfo2-dstImage-01788" : "VUID-vkCmdCopyImage-dstImage-01788";
+            const char* vuid = is_2 ? "VUID-VkCopyImageInfo2-dstImage-01788" : "VUID-vkCmdCopyImage-dstImage-01788";
             skip |= LogError(vuid, dst_objlist, region_loc.dot(Field::dstOffset).dot(Field::z),
                              "is %" PRId32 ", but for VK_IMAGE_TYPE_2D images this must be 0.\n%s", region.dst_offset.z,
                              region.DescribeSrcAndDstImage().c_str());
@@ -1461,8 +1461,8 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
 }
 
 template <typename HandleT>
-bool CoreChecks::ValidateCopyImageCommon(HandleT handle, const vvl::Image &src_image_state, const vvl::Image &dst_image_state,
-                                         const Location &loc) const {
+bool CoreChecks::ValidateCopyImageCommon(HandleT handle, const vvl::Image& src_image_state, const vvl::Image& dst_image_state,
+                                         const Location& loc) const {
     bool skip = false;
 
     // src
@@ -1495,14 +1495,14 @@ bool CoreChecks::ValidateCopyImageCommon(HandleT handle, const vvl::Image &src_i
 template <typename RegionType>
 bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                       VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                      const RegionType *pRegions, const Location &loc) const {
+                                      const RegionType* pRegions, const Location& loc) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
     ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
 
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
     const VkFormat src_format = src_image_state->create_info.format;
     const VkFormat dst_format = dst_image_state->create_info.format;
     const VkImageType src_image_type = src_image_state->create_info.imageType;
@@ -1513,7 +1513,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
     const bool dst_is_3d = (VK_IMAGE_TYPE_3D == dst_image_type);
     const bool is_2 = loc.function == Func::vkCmdCopyImage2 || loc.function == Func::vkCmdCopyImage2KHR;
 
-    const char *vuid;
+    const char* vuid;
     const Location src_image_loc = loc.dot(Field::srcImage);
     const Location dst_image_loc = loc.dot(Field::dstImage);
 
@@ -1531,8 +1531,8 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
         const Location src_subresource_loc = region_loc.dot(Field::srcSubresource);
         const Location dst_subresource_loc = region_loc.dot(Field::dstSubresource);
         ImageCopyRegion region(*src_image_state, *dst_image_state, pRegions[i]);
-        const VkImageSubresourceLayers &src_subresource = region.src_subresource;
-        const VkImageSubresourceLayers &dst_subresource = region.dst_subresource;
+        const VkImageSubresourceLayers& src_subresource = region.src_subresource;
+        const VkImageSubresourceLayers& dst_subresource = region.dst_subresource;
 
         if (IsExtEnabled(extensions.vk_khr_maintenance1)) {
             const uint32_t src_layer_count = region.src_subresource.layerCount;
@@ -1815,8 +1815,8 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
         }
 
         auto validate_copy_color_to_or_from_depth =
-            [&, this](const VkImageSubresourceLayers &subresource_1, const Location &subresource_1_loc,
-                      const VkImageSubresourceLayers &subresource_2, const Location &subresource_2_loc, const vvl::Image &depth_img,
+            [&, this](const VkImageSubresourceLayers& subresource_1, const Location& subresource_1_loc,
+                      const VkImageSubresourceLayers& subresource_2, const Location& subresource_2_loc, const vvl::Image& depth_img,
                       Field depth_img_field) {
                 const bool is_subresource_1_aspect_color = subresource_1.aspectMask & VK_IMAGE_ASPECT_COLOR_BIT;
                 const bool is_depth_copy = subresource_2.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT;
@@ -2034,24 +2034,25 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
 
 bool CoreChecks::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                             const VkImageCopy *pRegions, const ErrorObject &error_obj) const {
+                                             const VkImageCopy* pRegions, const ErrorObject& error_obj) const {
     return ValidateCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions,
                                 error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR *pCopyImageInfo,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR* pCopyImageInfo,
+                                                 const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyImage2(commandBuffer, pCopyImageInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
-                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo,
+                                              const ErrorObject& error_obj) const {
     return ValidateCmdCopyImage(commandBuffer, pCopyImageInfo->srcImage, pCopyImageInfo->srcImageLayout, pCopyImageInfo->dstImage,
                                 pCopyImageInfo->dstImageLayout, pCopyImageInfo->regionCount, pCopyImageInfo->pRegions,
                                 error_obj.location.dot(Field::pCopyImageInfo));
 }
 
-static VkDeviceSize FindCopyBlockSize(const VkFormat image_format, const VkFormat compatible_format, VkImageAspectFlags aspectMask) {
+static VkDeviceSize FindCopyBlockSize(const VkFormat image_format, const VkFormat compatible_format,
+                                      VkImageAspectFlags aspectMask) {
     if (aspectMask & (VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT)) {
         // Spec in VkBufferImageCopy section list special cases for each format
         if (aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
@@ -2080,8 +2081,8 @@ static VkDeviceSize FindCopyBlockSize(const VkFormat image_format, const VkForma
 }
 
 template <typename RegionType>
-bool CoreChecks::ValidateBufferBounds(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state,
-                                      const vvl::Buffer &buffer_state, const RegionType &region, const Location &region_loc) const {
+bool CoreChecks::ValidateBufferBounds(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
+                                      const vvl::Buffer& buffer_state, const RegionType& region, const Location& region_loc) const {
     bool skip = false;
 
     const uint32_t normalized_layer_count = image_state.NormalizeLayerCount(region.imageSubresource);
@@ -2232,8 +2233,8 @@ bool CoreChecks::ValidateDeviceAddressBufferBounds(const vvl::CommandBuffer& cb_
 
 template <typename HandleT>
 // Validate that an image's sampleCount matches the requirement for a specific API call
-bool CoreChecks::ValidateImageSampleCount(const HandleT handle, const vvl::Image &image_state, VkSampleCountFlagBits sample_count,
-                                          const Location &loc, const std::string &vuid) const {
+bool CoreChecks::ValidateImageSampleCount(const HandleT handle, const vvl::Image& image_state, VkSampleCountFlagBits sample_count,
+                                          const Location& loc, const std::string& vuid) const {
     bool skip = false;
     if (image_state.create_info.samples != sample_count) {
         const LogObjectList objlist(handle, image_state.Handle());
@@ -2244,9 +2245,9 @@ bool CoreChecks::ValidateImageSampleCount(const HandleT handle, const vvl::Image
     return skip;
 }
 
-bool CoreChecks::ValidateQueueFamilySupport(const vvl::CommandBuffer &cb_state, const vvl::PhysicalDevice &physical_device_state,
-                                            VkImageAspectFlags aspectMask, const vvl::Image &image_state,
-                                            const Location &aspect_mask_loc, const char *vuid) const {
+bool CoreChecks::ValidateQueueFamilySupport(const vvl::CommandBuffer& cb_state, const vvl::PhysicalDevice& physical_device_state,
+                                            VkImageAspectFlags aspectMask, const vvl::Image& image_state,
+                                            const Location& aspect_mask_loc, const char* vuid) const {
     bool skip = false;
 
     if (!HasRequiredQueueFlags(cb_state, physical_device_state, VK_QUEUE_GRAPHICS_BIT) &&
@@ -2261,18 +2262,18 @@ bool CoreChecks::ValidateQueueFamilySupport(const vvl::CommandBuffer &cb_state, 
 
 template <typename RegionType>
 bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                              VkBuffer dstBuffer, uint32_t regionCount, const RegionType *pRegions,
-                                              const Location &loc) const {
+                                              VkBuffer dstBuffer, uint32_t regionCount, const RegionType* pRegions,
+                                              const Location& loc) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_buffer_state = Get<vvl::Buffer>(dstBuffer);
     ASSERT_AND_RETURN_SKIP(src_image_state && dst_buffer_state);
 
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
 
     const bool is_2 = loc.function == Func::vkCmdCopyImageToBuffer2 || loc.function == Func::vkCmdCopyImageToBuffer2KHR;
-    const char *vuid;
+    const char* vuid;
     const Location src_image_loc = loc.dot(Field::srcImage);
     const Location dst_buffer_loc = loc.dot(Field::dstBuffer);
     // Even if the error is only dealing with the image or buffer, helpful to know incase there are many copies and the other handle
@@ -2417,21 +2418,21 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
 }
 
 bool CoreChecks::PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                                     VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions,
-                                                     const ErrorObject &error_obj) const {
+                                                     VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions,
+                                                     const ErrorObject& error_obj) const {
     return ValidateCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions,
                                         error_obj.location);
 }
 
 bool CoreChecks::PreCallValidateCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
-                                                         const VkCopyImageToBufferInfo2KHR *pCopyImageToBufferInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkCopyImageToBufferInfo2KHR* pCopyImageToBufferInfo,
+                                                         const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
-                                                      const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
-                                                      const ErrorObject &error_obj) const {
+                                                      const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo,
+                                                      const ErrorObject& error_obj) const {
     return ValidateCmdCopyImageToBuffer(commandBuffer, pCopyImageToBufferInfo->srcImage, pCopyImageToBufferInfo->srcImageLayout,
                                         pCopyImageToBufferInfo->dstBuffer, pCopyImageToBufferInfo->regionCount,
                                         pCopyImageToBufferInfo->pRegions, error_obj.location.dot(Field::pCopyImageToBufferInfo));
@@ -2439,8 +2440,8 @@ bool CoreChecks::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer commandBuf
 
 template <typename RegionType>
 bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
-                                              VkImageLayout dstImageLayout, uint32_t regionCount, const RegionType *pRegions,
-                                              const Location &loc) const {
+                                              VkImageLayout dstImageLayout, uint32_t regionCount, const RegionType* pRegions,
+                                              const Location& loc) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_buffer_state = Get<vvl::Buffer>(srcBuffer);
@@ -2448,10 +2449,10 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
     ASSERT_AND_RETURN_SKIP(src_buffer_state);
     ASSERT_AND_RETURN_SKIP(dst_image_state);
 
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
 
     const bool is_2 = loc.function == Func::vkCmdCopyBufferToImage2 || loc.function == Func::vkCmdCopyBufferToImage2KHR;
-    const char *vuid;
+    const char* vuid;
     const Location src_buffer_loc = loc.dot(Field::srcBuffer);
     const Location dst_image_loc = loc.dot(Field::dstImage);
     // Even if the error is only dealing with the image or buffer, helpful to know incase there are many copies and the other handle
@@ -2597,27 +2598,27 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
 
 bool CoreChecks::PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                      VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                     const VkBufferImageCopy *pRegions, const ErrorObject &error_obj) const {
+                                                     const VkBufferImageCopy* pRegions, const ErrorObject& error_obj) const {
     return ValidateCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions,
                                         error_obj.location);
 }
 
 bool CoreChecks::PreCallValidateCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                                         const VkCopyBufferToImageInfo2KHR *pCopyBufferToImageInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkCopyBufferToImageInfo2KHR* pCopyBufferToImageInfo,
+                                                         const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
-                                                      const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
-                                                      const ErrorObject &error_obj) const {
+                                                      const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
+                                                      const ErrorObject& error_obj) const {
     return ValidateCmdCopyBufferToImage(commandBuffer, pCopyBufferToImageInfo->srcBuffer, pCopyBufferToImageInfo->dstImage,
                                         pCopyBufferToImageInfo->dstImageLayout, pCopyBufferToImageInfo->regionCount,
                                         pCopyBufferToImageInfo->pRegions, error_obj.location.dot(Field::pCopyBufferToImageInfo));
 }
 
-bool CoreChecks::UsageHostTransferCheck(const vvl::Image &image_state, const VkImageAspectFlags aspect_mask, const char *vuid_09111,
-                                        const char *vuid_09112, const char *vuid_09113, const Location &subresource_loc) const {
+bool CoreChecks::UsageHostTransferCheck(const vvl::Image& image_state, const VkImageAspectFlags aspect_mask, const char* vuid_09111,
+                                        const char* vuid_09112, const char* vuid_09113, const Location& subresource_loc) const {
     bool skip = false;
     const bool has_stencil = (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT);
     const bool has_non_stencil = (aspect_mask & ~VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -2664,7 +2665,7 @@ VkImage GetImage(VkCopyMemoryToImageInfo data) { return data.dstImage; }
 VkImage GetImage(VkCopyImageToMemoryInfo data) { return data.srcImage; }
 
 template <typename InfoPointer>
-bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Location &loc) const {
+bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Location& loc) const {
     bool skip = false;
     VkImage image = GetImage(*info_ptr);
     auto image_state = Get<vvl::Image>(image);
@@ -2682,13 +2683,13 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
         from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-07966" : "VUID-VkCopyMemoryToImageInfo-dstImage-07966");
 
     if (image_state->sparse && (!image_state->HasFullRangeBound())) {
-        const char *vuid =
+        const char* vuid =
             from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-09109" : "VUID-VkCopyMemoryToImageInfo-dstImage-09109";
         skip |= LogError(vuid, objlist, image_loc, "is a sparse image with no memory bound");
     }
 
     if (image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
-        const char *vuid =
+        const char* vuid =
             from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-07969" : "VUID-VkCopyMemoryToImageInfo-dstImage-07969";
         skip |= LogError(vuid, objlist, image_loc,
                          "must not have been created with flags containing "
@@ -2700,11 +2701,11 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
         from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-07973" : "VUID-VkCopyMemoryToImageInfo-dstImage-07973");
 
     bool check_memcpy = (info_ptr->flags & VK_HOST_IMAGE_COPY_MEMCPY);
-    const char *vuid_09111 =
+    const char* vuid_09111 =
         from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-09111" : "VUID-VkCopyMemoryToImageInfo-dstImage-09111";
-    const char *vuid_09112 =
+    const char* vuid_09112 =
         from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-09112" : "VUID-VkCopyMemoryToImageInfo-dstImage-09112";
-    const char *vuid_09113 =
+    const char* vuid_09113 =
         from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-09113" : "VUID-VkCopyMemoryToImageInfo-dstImage-09113";
     for (uint32_t i = 0; i < info_ptr->regionCount; i++) {
         const Location region_loc = loc.dot(Field::pRegions, i);
@@ -2718,7 +2719,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
 
         if (check_memcpy) {
             if (region.imageOffset.x != 0 || region.imageOffset.y != 0 || region.imageOffset.z != 0) {
-                const char *vuid = from_image ? "VUID-VkCopyImageToMemoryInfo-imageOffset-09114"
+                const char* vuid = from_image ? "VUID-VkCopyImageToMemoryInfo-imageOffset-09114"
                                               : "VUID-VkCopyMemoryToImageInfo-imageOffset-09114";
                 skip |= LogError(vuid, objlist, loc.dot(info_type).dot(Field::flags),
                                  "contains VK_HOST_IMAGE_COPY_MEMCPY which "
@@ -2727,7 +2728,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
             }
             const VkExtent3D subresource_extent = image_state->GetEffectiveSubresourceExtent(region.imageSubresource);
             if (!IsExtentEqual(region.imageExtent, subresource_extent)) {
-                const char *vuid =
+                const char* vuid =
                     from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-09115" : "VUID-VkCopyMemoryToImageInfo-dstImage-09115";
                 skip |= LogError(
                     vuid, objlist, region_loc.dot(Field::imageExtent),
@@ -2736,7 +2737,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
                     image_state->DescribeSubresourceLayers(region.imageSubresource).c_str());
             }
             if ((region.memoryRowLength != 0) || (region.memoryImageHeight != 0)) {
-                const char *vuid =
+                const char* vuid =
                     from_image ? "VUID-VkCopyImageToMemoryInfo-flags-09394" : "VUID-VkCopyMemoryToImageInfo-flags-09393";
                 skip |= LogError(vuid, objlist, region_loc.dot(Field::memoryRowLength),
                                  "(%" PRIu32 "), and memoryImageHeight (%" PRIu32
@@ -2752,12 +2753,12 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
     return skip;
 }
 
-bool CoreChecks::ValidateHostCopyImageCreateInfos(const vvl::Image &src_image_state, const vvl::Image &dst_image_state,
-                                                  const Location &loc) const {
+bool CoreChecks::ValidateHostCopyImageCreateInfos(const vvl::Image& src_image_state, const vvl::Image& dst_image_state,
+                                                  const Location& loc) const {
     bool skip = false;
     std::ostringstream mismatch_stream{};
-    const VkImageCreateInfo &src_info = src_image_state.create_info;
-    const VkImageCreateInfo &dst_info = dst_image_state.create_info;
+    const VkImageCreateInfo& src_info = src_image_state.create_info;
+    const VkImageCreateInfo& dst_info = dst_image_state.create_info;
 
     if (src_info.flags != dst_info.flags) {
         mismatch_stream << "srcImage flags = " << string_VkImageCreateFlags(src_info.flags)
@@ -2814,12 +2815,12 @@ bool CoreChecks::ValidateHostCopyImageCreateInfos(const vvl::Image &src_image_st
     return skip;
 }
 
-bool CoreChecks::ValidateHostCopyImageLayout(const VkImage image, const VkImageLayout image_layout, const Location &loc,
-                                             vvl::Field supported_name, const char *vuid) const {
+bool CoreChecks::ValidateHostCopyImageLayout(const VkImage image, const VkImageLayout image_layout, const Location& loc,
+                                             vvl::Field supported_name, const char* vuid) const {
     bool skip = false;
     const bool is_src = supported_name == Field::pCopySrcLayouts;
     const uint32_t layout_count = is_src ? phys_dev_props_core14.copySrcLayoutCount : phys_dev_props_core14.copyDstLayoutCount;
-    const VkImageLayout *supported_image_layouts =
+    const VkImageLayout* supported_image_layouts =
         is_src ? phys_dev_props_core14.pCopySrcLayouts : phys_dev_props_core14.pCopyDstLayouts;
 
     for (uint32_t i = 0; i < layout_count; ++i) {
@@ -2840,8 +2841,8 @@ bool CoreChecks::ValidateHostCopyImageLayout(const VkImage image, const VkImageL
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCopyMemoryToImage(VkDevice device, const VkCopyMemoryToImageInfo *pCopyMemoryToImageInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCopyMemoryToImage(VkDevice device, const VkCopyMemoryToImageInfo* pCopyMemoryToImageInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     const Location copy_loc = error_obj.location.dot(Field::pCopyMemoryToImageInfo);
     auto dst_image = pCopyMemoryToImageInfo->dstImage;
@@ -2852,13 +2853,13 @@ bool CoreChecks::PreCallValidateCopyMemoryToImage(VkDevice device, const VkCopyM
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCopyMemoryToImageEXT(VkDevice device, const VkCopyMemoryToImageInfoEXT *pCopyMemoryToImageInfo,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCopyMemoryToImageEXT(VkDevice device, const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCopyMemoryToImage(device, pCopyMemoryToImageInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCopyImageToMemory(VkDevice device, const VkCopyImageToMemoryInfo *pCopyImageToMemoryInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCopyImageToMemory(VkDevice device, const VkCopyImageToMemoryInfo* pCopyImageToMemoryInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     const Location copy_loc = error_obj.location.dot(Field::pCopyImageToMemoryInfo);
     auto src_image = pCopyImageToMemoryInfo->srcImage;
@@ -2869,12 +2870,12 @@ bool CoreChecks::PreCallValidateCopyImageToMemory(VkDevice device, const VkCopyI
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCopyImageToMemoryEXT(VkDevice device, const VkCopyImageToMemoryInfoEXT *pCopyImageToMemoryInfo,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCopyImageToMemoryEXT(VkDevice device, const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCopyImageToMemory(device, pCopyImageToMemoryInfo, error_obj);
 }
 
-bool CoreChecks::ValidateMemcpyExtents(const ImageCopyRegion &region, const Location &region_loc) const {
+bool CoreChecks::ValidateMemcpyExtents(const ImageCopyRegion& region, const Location& region_loc) const {
     bool skip = false;
     if (region.src_offset.x != 0 || region.src_offset.y != 0 || region.src_offset.z != 0) {
         skip |= LogError("VUID-VkCopyImageToImageInfo-srcOffset-09114", device, region_loc.dot(Field::srcOffset),
@@ -2902,7 +2903,7 @@ bool CoreChecks::ValidateMemcpyExtents(const ImageCopyRegion &region, const Loca
     return skip;
 }
 
-bool CoreChecks::ValidateHostCopyMultiplane(const ImageCopyRegion &region, const Location &region_loc) const {
+bool CoreChecks::ValidateHostCopyMultiplane(const ImageCopyRegion& region, const Location& region_loc) const {
     bool skip = false;
     const VkImageAspectFlags src_aspect_mask = region.src_subresource.aspectMask;
     if (vkuFormatPlaneCount(region.src_state.create_info.format) == 2 &&
@@ -2936,8 +2937,8 @@ bool CoreChecks::ValidateHostCopyMultiplane(const ImageCopyRegion &region, const
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCopyImageToImage(VkDevice device, const VkCopyImageToImageInfo *pCopyImageToImageInfo,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCopyImageToImage(VkDevice device, const VkCopyImageToImageInfo* pCopyImageToImageInfo,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     auto info_ptr = pCopyImageToImageInfo;
     const Location loc = error_obj.location.dot(Field::pCopyImageToImageInfo);
@@ -3005,15 +3006,15 @@ bool CoreChecks::PreCallValidateCopyImageToImage(VkDevice device, const VkCopyIm
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCopyImageToImageEXT(VkDevice device, const VkCopyImageToImageInfoEXT *pCopyImageToImageInfo,
-                                                    const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCopyImageToImageEXT(VkDevice device, const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo,
+                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCopyImageToImage(device, pCopyImageToImageInfo, error_obj);
 }
 
 template <typename RegionType>
 bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                       VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                      const RegionType *pRegions, VkFilter filter, const Location &loc) const {
+                                      const RegionType* pRegions, VkFilter filter, const Location& loc) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
@@ -3028,10 +3029,10 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
     const LogObjectList dst_objlist(commandBuffer, dstImage);
     const LogObjectList all_objlist(commandBuffer, srcImage, dstImage);
 
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
     skip |= ValidateCmd(cb_state, loc);
 
-    const char *vuid;
+    const char* vuid;
 
     // src image
     const VkFormat src_format = src_image_state->create_info.format;
@@ -3174,8 +3175,8 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
         const RegionType region = pRegions[i];
 
         // When performing blit from and to same subresource, VK_IMAGE_LAYOUT_GENERAL is the only option
-        const VkImageSubresourceLayers &src_subresource = region.srcSubresource;
-        const VkImageSubresourceLayers &dst_subresource = region.dstSubresource;
+        const VkImageSubresourceLayers& src_subresource = region.srcSubresource;
+        const VkImageSubresourceLayers& dst_subresource = region.dstSubresource;
 
         // Will resolve VK_REMAINING_ARRAY_LAYERS to actual value (some VUs just want the value)
         const uint32_t normalized_src_layer_count = src_image_state->NormalizeLayerCount(src_subresource);
@@ -3468,18 +3469,18 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
 
 bool CoreChecks::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                             const VkImageBlit *pRegions, VkFilter filter, const ErrorObject &error_obj) const {
+                                             const VkImageBlit* pRegions, VkFilter filter, const ErrorObject& error_obj) const {
     return ValidateCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter,
                                 error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR *pBlitImageInfo,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR* pBlitImageInfo,
+                                                 const ErrorObject& error_obj) const {
     return PreCallValidateCmdBlitImage2(commandBuffer, pBlitImageInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo,
-                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
+                                              const ErrorObject& error_obj) const {
     return ValidateCmdBlitImage(commandBuffer, pBlitImageInfo->srcImage, pBlitImageInfo->srcImageLayout, pBlitImageInfo->dstImage,
                                 pBlitImageInfo->dstImageLayout, pBlitImageInfo->regionCount, pBlitImageInfo->pRegions,
                                 pBlitImageInfo->filter, error_obj.location.dot(Field::pBlitImageInfo));
@@ -3488,7 +3489,7 @@ bool CoreChecks::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, con
 template <typename RegionType>
 bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                          VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                         const RegionType *pRegions, const Location &loc) const {
+                                         const RegionType* pRegions, const Location& loc) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
@@ -3497,14 +3498,14 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
     ASSERT_AND_RETURN_SKIP(dst_image_state);
 
     const bool is_2 = loc.function == Func::vkCmdResolveImage2 || loc.function == Func::vkCmdResolveImage2KHR;
-    const char *vuid;
+    const char* vuid;
     const Location src_image_loc = loc.dot(Field::srcImage);
     const Location dst_image_loc = loc.dot(Field::dstImage);
 
     const LogObjectList src_objlist(commandBuffer, srcImage);
     const LogObjectList dst_objlist(commandBuffer, dstImage);
     const LogObjectList all_objlist(commandBuffer, srcImage, dstImage);
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
     skip |= ValidateCmd(cb_state, loc);
 
     // src image
@@ -3608,8 +3609,8 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         const Location src_subresource_loc = region_loc.dot(Field::srcSubresource);
         const Location dst_subresource_loc = region_loc.dot(Field::dstSubresource);
         const RegionType region = pRegions[i];
-        const VkImageSubresourceLayers &src_subresource = region.srcSubresource;
-        const VkImageSubresourceLayers &dst_subresource = region.dstSubresource;
+        const VkImageSubresourceLayers& src_subresource = region.srcSubresource;
+        const VkImageSubresourceLayers& dst_subresource = region.dstSubresource;
 
         skip |= ValidateImageSubresourceLayers(commandBuffer, *src_image_state, src_subresource, src_subresource_loc);
         skip |= ValidateImageSubresourceLayers(commandBuffer, *dst_image_state, dst_subresource, dst_subresource_loc);
@@ -3801,25 +3802,25 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
 
 bool CoreChecks::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                const VkImageResolve *pRegions, const ErrorObject &error_obj) const {
+                                                const VkImageResolve* pRegions, const ErrorObject& error_obj) const {
     return ValidateCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions,
                                    error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR *pResolveImageInfo,
-                                                    const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR* pResolveImageInfo,
+                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCmdResolveImage2(commandBuffer, pResolveImageInfo, error_obj);
 }
 
-bool CoreChecks::ValidateResolveImageModeInfo(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
-                                              const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateResolveImageModeInfo(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location resolve_info_loc = error_obj.location.dot(Field::pResolveImageInfo);
     const Location src_image_loc = resolve_info_loc.dot(Field::srcImage);
     const LogObjectList src_objlist(commandBuffer, pResolveImageInfo->srcImage);
 
-    const auto *resolve_mode_info = vku::FindStructInPNextChain<VkResolveImageModeInfoKHR>(pResolveImageInfo->pNext);
+    const auto* resolve_mode_info = vku::FindStructInPNextChain<VkResolveImageModeInfoKHR>(pResolveImageInfo->pNext);
     if (!resolve_mode_info) {
         auto src_image_state = Get<vvl::Image>(pResolveImageInfo->srcImage);
         if (vkuFormatIsDepthOrStencil(src_image_state->create_info.format)) {
@@ -3887,7 +3888,7 @@ bool CoreChecks::ValidateResolveImageModeInfo(VkCommandBuffer commandBuffer, con
         uint32_t first_region_with_stencil_aspect = vvl::kNoIndex32;
         uint32_t first_region_without_both_depth_and_stencil_aspects = vvl::kNoIndex32;
         for (uint32_t i = 0; i < pResolveImageInfo->regionCount; i++) {
-            const VkImageResolve2 &region = pResolveImageInfo->pRegions[i];
+            const VkImageResolve2& region = pResolveImageInfo->pRegions[i];
 
             if (first_region_with_depth_aspect == vvl::kNoIndex32 &&
                 (region.srcSubresource.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT ||
@@ -3972,8 +3973,8 @@ bool CoreChecks::ValidateResolveImageModeInfo(VkCommandBuffer commandBuffer, con
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateCmdResolveImage(commandBuffer, pResolveImageInfo->srcImage, pResolveImageInfo->srcImageLayout,
                                     pResolveImageInfo->dstImage, pResolveImageInfo->dstImageLayout, pResolveImageInfo->regionCount,
@@ -3983,15 +3984,15 @@ bool CoreChecks::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, 
 }
 
 bool CoreChecks::ValidateStridedDeviceAddressRange(VkCommandBuffer command_buffer,
-                                                   const VkStridedDeviceAddressRangeKHR &strided_range,
-                                                   const Location &strided_range_loc) const {
+                                                   const VkStridedDeviceAddressRangeKHR& strided_range,
+                                                   const Location& strided_range_loc) const {
     bool skip = false;
     if (strided_range.stride > strided_range.size) {
         skip |= LogError("VUID-VkStridedDeviceAddressRangeKHR-stride-10957", command_buffer, strided_range_loc.dot(Field::stride),
                          "(%" PRIu64 ") must be less than size (%" PRIu64 ")", strided_range.stride, strided_range.size);
     }
 
-    const char *usage_vuid = strided_range_loc.function == Func::vkCmdCopyMemoryIndirectKHR
+    const char* usage_vuid = strided_range_loc.function == Func::vkCmdCopyMemoryIndirectKHR
                                  ? "VUID-VkCopyMemoryIndirectInfoKHR-copyAddressRange-12210"
                                  : "VUID-VkCopyMemoryToImageIndirectInfoKHR-copyAddressRange-12213";
 
@@ -4002,8 +4003,8 @@ bool CoreChecks::ValidateStridedDeviceAddressRange(VkCommandBuffer command_buffe
 }
 
 bool CoreChecks::ValidateCopyMemoryIndirectInfo(VkCommandBuffer command_buffer,
-                                                const VkCopyMemoryIndirectInfoKHR &memory_indirect_info,
-                                                const Location &info_loc) const {
+                                                const VkCopyMemoryIndirectInfoKHR& memory_indirect_info,
+                                                const Location& info_loc) const {
     bool skip = false;
 
     if (memory_indirect_info.srcCopyFlags & VK_ADDRESS_COPY_PROTECTED_BIT_KHR) {
@@ -4049,8 +4050,8 @@ bool CoreChecks::ValidateCopyMemoryIndirectInfo(VkCommandBuffer command_buffer,
 }
 
 bool CoreChecks::PreCallValidateCmdCopyMemoryIndirectKHR(VkCommandBuffer commandBuffer,
-                                                         const VkCopyMemoryIndirectInfoKHR *pCopyMemoryIndirectInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkCopyMemoryIndirectInfoKHR* pCopyMemoryIndirectInfo,
+                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -4078,12 +4079,12 @@ bool CoreChecks::PreCallValidateCmdCopyMemoryIndirectKHR(VkCommandBuffer command
     return skip;
 }
 
-bool CoreChecks::ValidateCopyMemoryToImageIndirectInfo(const vvl::CommandBuffer &cb_state,
-                                                       const VkCopyMemoryToImageIndirectInfoKHR &indirect_info,
-                                                       const Location &info_loc) const {
+bool CoreChecks::ValidateCopyMemoryToImageIndirectInfo(const vvl::CommandBuffer& cb_state,
+                                                       const VkCopyMemoryToImageIndirectInfoKHR& indirect_info,
+                                                       const Location& info_loc) const {
     bool skip = false;
 
-    const VkStridedDeviceAddressRangeKHR &copy_range = indirect_info.copyAddressRange;
+    const VkStridedDeviceAddressRangeKHR& copy_range = indirect_info.copyAddressRange;
     const Location copy_range_loc = info_loc.dot(Field::copyAddressRange);
     skip |= ValidateStridedDeviceAddressRange(cb_state.VkHandle(), copy_range, copy_range_loc);
 
@@ -4155,7 +4156,7 @@ bool CoreChecks::ValidateCopyMemoryToImageIndirectInfo(const vvl::CommandBuffer 
     }
 
     for (uint32_t i = 0; i < indirect_info.copyCount; ++i) {
-        const VkImageSubresourceLayers &subresource_layers = indirect_info.pImageSubresources[i];
+        const VkImageSubresourceLayers& subresource_layers = indirect_info.pImageSubresources[i];
         const Location subresource_loc = info_loc.dot(Field::pImageSubresources, i);
 
         const VkImageAspectFlags aspect_mask = subresource_layers.aspectMask;
@@ -4188,13 +4189,13 @@ bool CoreChecks::ValidateCopyMemoryToImageIndirectInfo(const vvl::CommandBuffer 
         if (dst_image->create_info.imageType == VK_IMAGE_TYPE_3D) {
             // TODO - Add https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11332
         } else if (subresource_layers.layerCount != VK_REMAINING_ARRAY_LAYERS &&
-            subresource_layers.baseArrayLayer + subresource_layers.layerCount > dst_image->create_info.arrayLayers) {
-                skip |= LogError("VUID-VkCopyMemoryToImageIndirectInfoKHR-dstImage-12288", dst_objlist,
-                    subresource_loc.dot(Field::layerCount),
-                    "(%" PRIu32 ") + baseArrayLayer (%" PRIu32
-                    ") must be less than or equal to "
-                    "the VkImageCreateInfo::arrayLayers (%" PRIu32 ") when dstImage was created.",
-                    subresource_layers.layerCount, subresource_layers.baseArrayLayer, dst_image->create_info.arrayLayers);
+                   subresource_layers.baseArrayLayer + subresource_layers.layerCount > dst_image->create_info.arrayLayers) {
+            skip |= LogError("VUID-VkCopyMemoryToImageIndirectInfoKHR-dstImage-12288", dst_objlist,
+                             subresource_loc.dot(Field::layerCount),
+                             "(%" PRIu32 ") + baseArrayLayer (%" PRIu32
+                             ") must be less than or equal to "
+                             "the VkImageCreateInfo::arrayLayers (%" PRIu32 ") when dstImage was created.",
+                             subresource_layers.layerCount, subresource_layers.baseArrayLayer, dst_image->create_info.arrayLayers);
         }
     }
 
@@ -4211,8 +4212,8 @@ bool CoreChecks::ValidateCopyMemoryToImageIndirectInfo(const vvl::CommandBuffer 
 }
 
 bool CoreChecks::PreCallValidateCmdCopyMemoryToImageIndirectKHR(
-    VkCommandBuffer commandBuffer, const VkCopyMemoryToImageIndirectInfoKHR *pCopyMemoryToImageIndirectInfo,
-    const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, const VkCopyMemoryToImageIndirectInfoKHR* pCopyMemoryToImageIndirectInfo,
+    const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -4343,7 +4344,7 @@ bool CoreChecks::ValidateCmdCopyMemoryToImage(VkCommandBuffer command_buffer,
         }
 
         {
-            const char *vuid = is_memory_to_image ? "VUID-vkCmdCopyMemoryToImageKHR-addressRange-13128"
+            const char* vuid = is_memory_to_image ? "VUID-vkCmdCopyMemoryToImageKHR-addressRange-13128"
                                                   : "VUID-vkCmdCopyImageToMemoryKHR-addressRange-13129";
             const VkBufferUsageFlagBits2 usage =
                 is_memory_to_image ? VK_BUFFER_USAGE_TRANSFER_SRC_BIT : VK_BUFFER_USAGE_TRANSFER_DST_BIT;

--- a/layers/core_checks/cc_data_graph.cpp
+++ b/layers/core_checks/cc_data_graph.cpp
@@ -135,9 +135,10 @@ bool CoreChecks::ValidateTensorSemiStructuredSparsityInfo(VkDevice device, const
         }
         auto insert_ok = sparsity_dimensions.insert(sparsity->dimension).second;
         if (!insert_ok) {
-            skip |= LogError("VUID-VkDataGraphPipelineConstantARM-pNext-09870", device,
-                             constant_loc.pNext(Struct::VkDataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM, Field::dimension),
-                             "(%" PRIu32 ") already has a defined sparsity", sparsity->dimension);
+            skip |= LogError(
+                "VUID-VkDataGraphPipelineConstantARM-pNext-09870", device,
+                constant_loc.pNext(Struct::VkDataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM, Field::dimension),
+                "(%" PRIu32 ") already has a defined sparsity", sparsity->dimension);
         }
         // We can have multiple Sparsity structures in the pNext chain.
         sparsity = vku::FindStructInPNextChain<VkDataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM>(sparsity->pNext);
@@ -177,30 +178,36 @@ bool CoreChecks::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkD
 
         if (dg_pipeline_identifier_ci || qcom_model_ci) {
             if (!(create_info.flags & VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)) {
-                skip |= LogError(
-                    "VUID-VkDataGraphPipelineCreateInfoARM-None-11840", device, create_info_loc.dot(Field::flags),
-                    "(%s) does not include VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT, but the pNext chain include one "
-                    "of VkDataGraphPipelineIdentifierCreateInfoARM or VkDataGraphPipelineBuiltinModelCreateInfoQCOM.\n%s",
-                    string_VkPipelineCreateFlags2(create_info.flags).c_str(),
-                    PrintPNextChain(Struct::VkDataGraphPipelineCreateInfoARM, create_info.pNext).c_str());
+                skip |=
+                    LogError("VUID-VkDataGraphPipelineCreateInfoARM-None-11840", device, create_info_loc.dot(Field::flags),
+                             "(%s) does not include VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT, but the pNext "
+                             "chain include one "
+                             "of VkDataGraphPipelineIdentifierCreateInfoARM or VkDataGraphPipelineBuiltinModelCreateInfoQCOM.\n%s",
+                             string_VkPipelineCreateFlags2(create_info.flags).c_str(),
+                             PrintPNextChain(Struct::VkDataGraphPipelineCreateInfoARM, create_info.pNext).c_str());
             }
             if (create_info.resourceInfoCount) {
-                skip |= LogError(
-                    "VUID-VkDataGraphPipelineCreateInfoARM-None-12363", device, create_info_loc.dot(Field::resourceInfoCount),
-                    "(%" PRIu32 ") is not zero, but the pNext chain includes one of VkDataGraphPipelineIdentifierCreateInfoARM or VkDataGraphPipelineBuiltinModelCreateInfoQCOM.\n%s",
-                    create_info.resourceInfoCount, PrintPNextChain(Struct::VkDataGraphPipelineCreateInfoARM, create_info.pNext).c_str());
+                skip |= LogError("VUID-VkDataGraphPipelineCreateInfoARM-None-12363", device,
+                                 create_info_loc.dot(Field::resourceInfoCount),
+                                 "(%" PRIu32
+                                 ") is not zero, but the pNext chain includes one of VkDataGraphPipelineIdentifierCreateInfoARM or "
+                                 "VkDataGraphPipelineBuiltinModelCreateInfoQCOM.\n%s",
+                                 create_info.resourceInfoCount,
+                                 PrintPNextChain(Struct::VkDataGraphPipelineCreateInfoARM, create_info.pNext).c_str());
             }
         } else if (create_info.resourceInfoCount == 0) {
-            skip |= LogError(
-                "VUID-VkDataGraphPipelineCreateInfoARM-None-12365", device, create_info_loc.dot(Field::resourceInfoCount),
-                "is 0, but the pNext chain doesn't include VkDataGraphPipelineIdentifierCreateInfoARM or VkDataGraphPipelineBuiltinModelCreateInfoQCOM.\n%s",
-                PrintPNextChain(Struct::VkDataGraphPipelineCreateInfoARM, create_info.pNext).c_str());
+            skip |=
+                LogError("VUID-VkDataGraphPipelineCreateInfoARM-None-12365", device, create_info_loc.dot(Field::resourceInfoCount),
+                         "is 0, but the pNext chain doesn't include VkDataGraphPipelineIdentifierCreateInfoARM or "
+                         "VkDataGraphPipelineBuiltinModelCreateInfoQCOM.\n%s",
+                         PrintPNextChain(Struct::VkDataGraphPipelineCreateInfoARM, create_info.pNext).c_str());
         }
 
         if (create_info.resourceInfoCount == 0 && create_info.pResourceInfos) {
-            skip |= LogError(
-                "VUID-VkDataGraphPipelineCreateInfoARM-resourceInfoCount-12364", device, create_info_loc.dot(Field::resourceInfoCount),
-                "(%" PRIu32 ") is 0, but pResourceInfos (%p) is not NULL.", create_info.resourceInfoCount, create_info.pResourceInfos);
+            skip |=
+                LogError("VUID-VkDataGraphPipelineCreateInfoARM-resourceInfoCount-12364", device,
+                         create_info_loc.dot(Field::resourceInfoCount), "(%" PRIu32 ") is 0, but pResourceInfos (%p) is not NULL.",
+                         create_info.resourceInfoCount, create_info.pResourceInfos);
         }
 
         if (dg_shader_ci) {
@@ -266,11 +273,13 @@ bool CoreChecks::PreCallValidateGetDataGraphPipelinePropertiesARM(VkDevice devic
     }
     for (uint32_t i = 0; i < propertiesCount; i++) {
         const VkDataGraphPipelinePropertyQueryResultARM& prop1 = pProperties[i];
-        for (uint32_t j = i+1; j < propertiesCount; j++) {
+        for (uint32_t j = i + 1; j < propertiesCount; j++) {
             const VkDataGraphPipelinePropertyQueryResultARM& prop2 = pProperties[j];
             if (prop1.property == prop2.property) {
-                skip |= LogError("VUID-vkGetDataGraphPipelinePropertiesARM-pProperties-09889", device, error_obj.location.dot(Field::pProperties, i).dot(Field::property),
-                                "and pProperties[%" PRIu32 "].property are the same (%s).", j, string_VkDataGraphPipelinePropertyARM(prop1.property));
+                skip |= LogError("VUID-vkGetDataGraphPipelinePropertiesARM-pProperties-09889", device,
+                                 error_obj.location.dot(Field::pProperties, i).dot(Field::property),
+                                 "and pProperties[%" PRIu32 "].property are the same (%s).", j,
+                                 string_VkDataGraphPipelinePropertyARM(prop1.property));
             }
         }
     }
@@ -314,7 +323,7 @@ void CoreChecks::PostCallRecordGetDataGraphPipelineSessionBindPointRequirementsA
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    if (auto session_ptr = Get<vvl::DataGraphPipelineSession>(pInfo->session)){
+    if (auto session_ptr = Get<vvl::DataGraphPipelineSession>(pInfo->session)) {
         if (pBindPointRequirements) {
             session_ptr->InitMemoryRequirements(device, pBindPointRequirements, *pBindPointRequirementCount);
         }
@@ -368,11 +377,12 @@ bool CoreChecks::PreCallValidateDestroyDataGraphPipelineSessionARM(VkDevice devi
 }
 
 bool CoreChecks::PreCallValidateCmdDispatchDataGraphARM(VkCommandBuffer commandBuffer, VkDataGraphPipelineSessionARM session,
-                                                        const VkDataGraphPipelineDispatchInfoARM *pInfo, const ErrorObject& error_obj) const {
+                                                        const VkDataGraphPipelineDispatchInfoARM* pInfo,
+                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundDataGraph();
-    const vvl::DrawDispatchVuid &dispatch_vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& last_bound_state = cb_state.GetLastBoundDataGraph();
+    const vvl::DrawDispatchVuid& dispatch_vuid = GetDrawDispatchVuid(error_obj.location.function);
     skip |= ValidateActionState(last_bound_state, dispatch_vuid);
 
     const auto session_state_ptr = Get<vvl::DataGraphPipelineSession>(session);
@@ -382,7 +392,8 @@ bool CoreChecks::PreCallValidateCmdDispatchDataGraphARM(VkCommandBuffer commandB
     const LogObjectList& objlist = LogObjectList(commandBuffer, session);
     for (const auto& bpr : session_state.BindPointReqs()) {
         /* bpr: requirement; bound_memory_map: actually bound */
-        size_t n_bound = bound_memory_map.find(bpr.bindPoint) == bound_memory_map.end() ? 0 : bound_memory_map.at(bpr.bindPoint).size();
+        size_t n_bound =
+            bound_memory_map.find(bpr.bindPoint) == bound_memory_map.end() ? 0 : bound_memory_map.at(bpr.bindPoint).size();
         if (bpr.numObjects != n_bound) {
             skip |= LogError("VUID-vkCmdDispatchDataGraphARM-session-09796", objlist, error_obj.location,
                              "%zu objects bound at bind point %s, required numObjects %" PRIu32 "; session %s.", n_bound,
@@ -404,9 +415,11 @@ bool CoreChecks::PreCallValidateCmdDispatchDataGraphARM(VkCommandBuffer commandB
 
     const VkPipeline cb_pipeline = last_bound_state.pipeline_state->VkHandle();
     if (session_state.create_info.dataGraphPipeline != cb_pipeline) {
-        skip |= LogError("VUID-vkCmdDispatchDataGraphARM-dataGraphPipeline-09951", LogObjectList(), error_obj.location,
+        skip |= LogError(
+            "VUID-vkCmdDispatchDataGraphARM-dataGraphPipeline-09951", LogObjectList(), error_obj.location,
             "The pipeline bound to the command buffer (%s) is different from the pipeline bound to the session (%s); session %s.",
-            FormatHandle(cb_pipeline).c_str(), FormatHandle(session_state.create_info.dataGraphPipeline).c_str(), FormatHandle(session_state).c_str());
+            FormatHandle(cb_pipeline).c_str(), FormatHandle(session_state.create_info.dataGraphPipeline).c_str(),
+            FormatHandle(session_state).c_str());
     }
 
     skip |=

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -56,8 +56,8 @@ using DescriptorSetLayoutId = vvl::DescriptorSetLayoutId;
 
 // Check if the |reference_dsl| (from PipelineLayout) is compatibile with |to_bind_dsl|
 // For GPL this is also used, but we don't care which DSL is which
-bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSetLayout &reference_dsl,
-                                                        const vvl::DescriptorSetLayout &to_bind_dsl, std::string &error_msg) const {
+bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSetLayout& reference_dsl,
+                                                        const vvl::DescriptorSetLayout& to_bind_dsl, std::string& error_msg) const {
     // Short circuit the detailed check.
     if (reference_dsl.IsCompatible(&to_bind_dsl)) {
         return true;
@@ -67,8 +67,8 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
     // Should only be run if trivial accept has failed, and in that context should return false.
     VkDescriptorSetLayout reference_dsl_handle = reference_dsl.VkHandle();
     VkDescriptorSetLayout to_bind_dsl_handle = to_bind_dsl.VkHandle();
-    const DescriptorSetLayoutDef *reference_ds_layout_def = reference_dsl.GetLayoutDef();
-    const DescriptorSetLayoutDef *to_bind_ds_layout_def = to_bind_dsl.GetLayoutDef();
+    const DescriptorSetLayoutDef* reference_ds_layout_def = reference_dsl.GetLayoutDef();
+    const DescriptorSetLayoutDef* to_bind_ds_layout_def = to_bind_dsl.GetLayoutDef();
 
     // Check descriptor counts
     const auto bound_total_count = to_bind_ds_layout_def->GetTotalDescriptorCount();
@@ -133,8 +133,8 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
     }
 
     // Will find the mismatch of flags for each binding
-    const auto &ds_layout_flags = reference_ds_layout_def->GetBindingFlags();
-    const auto &bound_layout_flags = to_bind_ds_layout_def->GetBindingFlags();
+    const auto& ds_layout_flags = reference_ds_layout_def->GetBindingFlags();
+    const auto& bound_layout_flags = to_bind_ds_layout_def->GetBindingFlags();
     if (bound_layout_flags != ds_layout_flags) {
         std::ostringstream error_str;
         assert(ds_layout_flags.size() == bound_layout_flags.size());
@@ -157,9 +157,9 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
 
 // For a given vkDescriptorSet, we take the list of DescriptorSetLayouts (ex, from a pipeline layout) and check if the DSL at
 // |index| is compatibile
-bool CoreChecks::VerifyDescriptorSetIsCompatibile(const vvl::DescriptorSet &to_bind_descriptor_set,
-                                                  const vvl::DescriptorSetLayout &descriptor_set_layouts,
-                                                  std::string &error_msg) const {
+bool CoreChecks::VerifyDescriptorSetIsCompatibile(const vvl::DescriptorSet& to_bind_descriptor_set,
+                                                  const vvl::DescriptorSetLayout& descriptor_set_layouts,
+                                                  std::string& error_msg) const {
     if (to_bind_descriptor_set.IsPushDescriptor()) {
         return true;
     }
@@ -167,8 +167,8 @@ bool CoreChecks::VerifyDescriptorSetIsCompatibile(const vvl::DescriptorSet &to_b
     return VerifyDescriptorSetLayoutIsCompatibile(descriptor_set_layouts, *to_bind_descriptor_set.GetLayout(), error_msg);
 }
 
-bool CoreChecks::VerifyPipelineLayoutCompatibility(const vvl::PipelineLayout &layout_a, const vvl::PipelineLayout &layout_b,
-                                                   std::string &error_msg) const {
+bool CoreChecks::VerifyPipelineLayoutCompatibility(const vvl::PipelineLayout& layout_a, const vvl::PipelineLayout& layout_b,
+                                                   std::string& error_msg) const {
     const uint32_t num_sets = static_cast<uint32_t>(std::min(layout_a.set_layouts.list.size(), layout_b.set_layouts.list.size()));
     for (uint32_t i = 0; i < num_sets; ++i) {
         const auto ds_a = layout_a.set_layouts.list[i];
@@ -182,9 +182,9 @@ bool CoreChecks::VerifyPipelineLayoutCompatibility(const vvl::PipelineLayout &la
     return true;
 }
 
-bool CoreChecks::VerifyPipelineLayoutCompatibilityUnion(const vvl::PipelineLayout &layout,
-                                                        const vvl::PipelineLayout &pre_raster_layout,
-                                                        const vvl::PipelineLayout &fs_layout, std::string &error_msg) const {
+bool CoreChecks::VerifyPipelineLayoutCompatibilityUnion(const vvl::PipelineLayout& layout,
+                                                        const vvl::PipelineLayout& pre_raster_layout,
+                                                        const vvl::PipelineLayout& fs_layout, std::string& error_msg) const {
     // When dealing with Graphics Pipeline Library, we need to get the union of pipeline states.
     // Currently this just means the VkDescriptorSetLayout may be VK_NULL_HANDLE.
     uint32_t num_sets =
@@ -206,10 +206,10 @@ bool CoreChecks::VerifyPipelineLayoutCompatibilityUnion(const vvl::PipelineLayou
     return true;
 }
 
-bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_state, VkPipelineLayout layout, uint32_t firstSet,
-                                               uint32_t descriptorSetCount, const VkDescriptorSet *pDescriptorSets,
-                                               uint32_t dynamicOffsetCount, const uint32_t *pDynamicOffsets,
-                                               const Location &loc) const {
+bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer& cb_state, VkPipelineLayout layout, uint32_t firstSet,
+                                               uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets,
+                                               uint32_t dynamicOffsetCount, const uint32_t* pDynamicOffsets,
+                                               const Location& loc) const {
     bool skip = false;
     const bool is_2 = loc.function != Func::vkCmdBindDescriptorSets;
 
@@ -223,7 +223,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
 
     // If we detect we are binding to many sets, the extra sets will always be incompatible, so check first
     if ((firstSet + descriptorSetCount) > static_cast<uint32_t>(pipeline_layout->set_layouts.list.size())) {
-        const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-firstSet-00360" : "VUID-vkCmdBindDescriptorSets-firstSet-00360";
+        const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-firstSet-00360" : "VUID-vkCmdBindDescriptorSets-firstSet-00360";
         const LogObjectList objlist(cb_state.Handle(), layout);
         skip |= LogError(vuid, objlist, loc.dot(Field::firstSet),
                          "(%" PRIu32 ") plus descriptorSetCount (%" PRIu32
@@ -246,7 +246,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
             auto pipeline_layout_node = pipeline_layout->set_layouts.list[set_idx + firstSet];
             if (!pipeline_layout_node) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline_layout->Handle(), set_handle);
-                const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-00358"
+                const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-00358"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358";
                 skip |= LogError(vuid, objlist, set_loc,
                                  "(%s) being bound is not compatible with the corresponding %s"
@@ -257,7 +257,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                      : "");
             } else if (!VerifyDescriptorSetIsCompatibile(*descriptor_set, *pipeline_layout_node, error_string)) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline_layout->Handle(), set_handle);
-                const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-00358"
+                const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-00358"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358";
                 skip |= LogError(vuid, objlist, set_loc,
                                  "(%s) being bound is not compatible with the corresponding %s"
@@ -266,10 +266,10 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                  FormatHandle(pipeline_layout_node->Handle()).c_str(), error_string.c_str());
             }
 
-            const auto &dsl = descriptor_set->GetLayout();
+            const auto& dsl = descriptor_set->GetLayout();
             if (dsl->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) {
                 const LogObjectList objlist(cb_state.Handle(), set_handle, dsl->VkHandle());
-                const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-08010"
+                const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-08010"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-08010";
                 skip |= LogError(vuid, objlist, set_loc, "was allocated from VkDescriptorSetLayout with %s flags.",
                                  string_VkDescriptorSetLayoutCreateFlags(dsl->GetCreateFlags()).c_str());
@@ -281,7 +281,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                 if ((total_dynamic_descriptors + set_dynamic_descriptor_count) > dynamicOffsetCount) {
                     // Test/report this here, such that we don't run past the end of pDynamicOffsets in the else clause
                     const LogObjectList objlist(cb_state.Handle(), set_handle);
-                    const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-dynamicOffsetCount-00359"
+                    const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-dynamicOffsetCount-00359"
                                             : "VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359";
                     skip |=
                         LogError(vuid, objlist, set_loc,
@@ -300,9 +300,9 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                     // offset into this descriptor set
                     uint32_t set_dyn_offset = 0;
                     const auto binding_count = dsl->GetBindingCount();
-                    const auto &limits = phys_dev_props.limits;
+                    const auto& limits = phys_dev_props.limits;
                     for (uint32_t i = 0; i < binding_count; i++) {
-                        const auto *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(i);
+                        const auto* binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(i);
                         // skip checking binding if not needed
                         if (vvl::IsDynamicDescriptor(binding->descriptorType) == false) {
                             continue;
@@ -326,7 +326,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                             // Validate alignment with limit
                             if ((binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) &&
                                 !IsIntegerMultipleOf(offset, limits.minUniformBufferOffsetAlignment)) {
-                                const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDynamicOffsets-01971"
+                                const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDynamicOffsets-01971"
                                                         : "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971";
                                 skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
                                                  "is %" PRIu32
@@ -336,7 +336,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                             }
                             if ((binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) &&
                                 !IsIntegerMultipleOf(offset, limits.minStorageBufferOffsetAlignment)) {
-                                const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDynamicOffsets-01972"
+                                const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDynamicOffsets-01972"
                                                         : "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972";
                                 skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
                                                  "is %" PRIu32
@@ -345,11 +345,11 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                                  offset, limits.minStorageBufferOffsetAlignment);
                             }
 
-                            auto *descriptor = descriptor_set->GetDescriptorFromDynamicOffsetIndex(set_dyn_offset);
+                            auto* descriptor = descriptor_set->GetDescriptorFromDynamicOffsetIndex(set_dyn_offset);
                             ASSERT_AND_CONTINUE(descriptor);
                             // Currently only GeneralBuffer are dynamic and need to be checked
                             if (descriptor->GetClass() == vvl::DescriptorClass::GeneralBuffer) {
-                                const auto *buffer_descriptor = static_cast<const vvl::BufferDescriptor *>(descriptor);
+                                const auto* buffer_descriptor = static_cast<const vvl::BufferDescriptor*>(descriptor);
                                 const VkDeviceSize bound_range = buffer_descriptor->GetRange();
                                 const VkDeviceSize bound_offset = buffer_descriptor->GetOffset();
                                 // NOTE: null / invalid buffers may show up here, errors are raised elsewhere for this.
@@ -358,7 +358,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                 // Validate offset didn't go over buffer
                                 if ((bound_range == VK_WHOLE_SIZE) && (offset > 0)) {
                                     const LogObjectList objlist(cb_state.Handle(), set_handle, buffer_descriptor->GetBuffer());
-                                    const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-06715"
+                                    const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-06715"
                                                             : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-06715";
                                     skip |= LogError(vuid, objlist, loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
                                                      "is %" PRIu32
@@ -372,7 +372,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                 } else if (buffer_state && (bound_range != VK_WHOLE_SIZE) &&
                                            ((offset + bound_range + bound_offset) > buffer_state->create_info.size)) {
                                     const LogObjectList objlist(cb_state.Handle(), set_handle, buffer_descriptor->GetBuffer());
-                                    const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-01979"
+                                    const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-01979"
                                                             : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979";
                                     skip |=
                                         LogError(vuid, objlist, loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
@@ -394,21 +394,21 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
             auto ds_pool_state = descriptor_set->GetPoolState();
             if (ds_pool_state && ds_pool_state->create_info.flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) {
                 const LogObjectList objlist(cb_state.Handle(), set_handle, ds_pool_state->Handle());
-                const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-04616"
+                const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-04616"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-04616";
                 skip |= LogError(vuid, objlist, set_loc,
                                  "was allocated from a pool that was created with VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT.");
             }
         } else if (!enabled_features.graphicsPipelineLibrary) {
             const LogObjectList objlist(cb_state.Handle(), set_handle);
-            const char *vuid =
+            const char* vuid =
                 is_2 ? "VUID-VkBindDescriptorSetsInfo-pDescriptorSets-06563" : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-06563";
             skip |= LogError(vuid, objlist, set_loc, "(%s) is not a valid VkDescriptorSet.", FormatHandle(set_handle).c_str());
         }
     }
     //  dynamicOffsetCount must equal the total number of dynamic descriptors in the sets being bound
     if (total_dynamic_descriptors != dynamicOffsetCount) {
-        const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-dynamicOffsetCount-00359"
+        const char* vuid = is_2 ? "VUID-VkBindDescriptorSetsInfo-dynamicOffsetCount-00359"
                                 : "VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359";
         skip |= LogError(vuid, cb_state.Handle(), loc,
                          "Attempting to bind %" PRIu32 " descriptorSets with %" PRIu32
@@ -422,8 +422,8 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
 
 bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                       VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
-                                                      const VkDescriptorSet *pDescriptorSets, uint32_t dynamicOffsetCount,
-                                                      const uint32_t *pDynamicOffsets, const ErrorObject &error_obj) const {
+                                                      const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
+                                                      const uint32_t* pDynamicOffsets, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -436,8 +436,8 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
 }
 
 bool CoreChecks::PreCallValidateCmdBindDescriptorSets2(VkCommandBuffer commandBuffer,
-                                                       const VkBindDescriptorSetsInfo *pBindDescriptorSetsInfo,
-                                                       const ErrorObject &error_obj) const {
+                                                       const VkBindDescriptorSetsInfo* pBindDescriptorSetsInfo,
+                                                       const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
 
@@ -462,15 +462,15 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets2(VkCommandBuffer commandBu
 }
 
 bool CoreChecks::PreCallValidateCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
-                                                          const VkBindDescriptorSetsInfoKHR *pBindDescriptorSetsInfo,
-                                                          const ErrorObject &error_obj) const {
+                                                          const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo,
+                                                          const ErrorObject& error_obj) const {
     return PreCallValidateCmdBindDescriptorSets2(commandBuffer, pBindDescriptorSetsInfo, error_obj);
 }
 
-bool CoreChecks::ValidateDescriptorSetLayoutBindingFlags(const VkDescriptorSetLayoutCreateInfo &create_info, uint32_t max_binding,
-                                                         uint32_t *update_after_bind, const Location &create_info_loc) const {
+bool CoreChecks::ValidateDescriptorSetLayoutBindingFlags(const VkDescriptorSetLayoutCreateInfo& create_info, uint32_t max_binding,
+                                                         uint32_t* update_after_bind, const Location& create_info_loc) const {
     bool skip = false;
-    const auto *flags_info = vku::FindStructInPNextChain<VkDescriptorSetLayoutBindingFlagsCreateInfo>(create_info.pNext);
+    const auto* flags_info = vku::FindStructInPNextChain<VkDescriptorSetLayoutBindingFlagsCreateInfo>(create_info.pNext);
     if (!flags_info) {
         return skip;
     }
@@ -485,7 +485,7 @@ bool CoreChecks::ValidateDescriptorSetLayoutBindingFlags(const VkDescriptorSetLa
         return skip;  // nothing left to validate
     }
     for (uint32_t i = 0; i < create_info.bindingCount; ++i) {
-        const auto &binding_info = create_info.pBindings[i];
+        const auto& binding_info = create_info.pBindings[i];
         const Location binding_flags_loc =
             create_info_loc.pNext(Struct::VkDescriptorSetLayoutBindingFlagsCreateInfo, Field::pBindingFlags, i);
 
@@ -591,12 +591,12 @@ bool CoreChecks::ValidateDescriptorSetLayoutBindingFlags(const VkDescriptorSetLa
 
             if ((binding_info.descriptorType == VK_DESCRIPTOR_TYPE_TENSOR_ARM) &&
                 !enabled_features.descriptorBindingStorageTensorUpdateAfterBind) {
-                skip |= LogError(
-                    "VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-descriptorBindingStorageTensorUpdateAfterBind-09697",
-                    device, binding_flags_loc,
-                    "includes VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT but pBindings[%" PRIu32
-                    "].descriptorType is %s, but the descriptorBindingStorageTensorUpdateAfterBind was not enabled.",
-                    i, string_VkDescriptorType(binding_info.descriptorType));
+                skip |=
+                    LogError("VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-descriptorBindingStorageTensorUpdateAfterBind-09697",
+                             device, binding_flags_loc,
+                             "includes VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT but pBindings[%" PRIu32
+                             "].descriptorType is %s, but the descriptorBindingStorageTensorUpdateAfterBind was not enabled.",
+                             i, string_VkDescriptorType(binding_info.descriptorType));
             }
         }
 
@@ -657,8 +657,8 @@ bool CoreChecks::ValidateDescriptorSetLayoutBindingFlags(const VkDescriptorSetLa
     return skip;
 }
 
-bool CoreChecks::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCreateInfo &create_info,
-                                                       const Location &create_info_loc) const {
+bool CoreChecks::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCreateInfo& create_info,
+                                                       const Location& create_info_loc) const {
     bool skip = false;
     vvl::unordered_set<uint32_t> bindings;
     uint64_t total_descriptors = 0;
@@ -679,7 +679,7 @@ bool CoreChecks::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayo
 
     for (uint32_t i = 0; i < create_info.bindingCount; ++i) {
         const Location binding_loc = create_info_loc.dot(Field::pBindings, i);
-        const auto &binding_info = create_info.pBindings[i];
+        const auto& binding_info = create_info.pBindings[i];
         max_binding = std::max(max_binding, binding_info.binding);
 
         if (!bindings.insert(binding_info.binding).second) {
@@ -831,26 +831,26 @@ bool CoreChecks::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayo
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator,
-                                                          VkDescriptorSetLayout *pSetLayout, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator,
+                                                          VkDescriptorSetLayout* pSetLayout, const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDescriptorSetLayoutCreateInfo(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                              VkDescriptorSetLayoutSupport *pSupport,
-                                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                              VkDescriptorSetLayoutSupport* pSupport,
+                                                              const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDescriptorSetLayoutCreateInfo(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
     return skip;
 }
 
 bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSupportKHR(VkDevice device,
-                                                                 const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                                 VkDescriptorSetLayoutSupport *pSupport,
-                                                                 const ErrorObject &error_obj) const {
+                                                                 const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                                 VkDescriptorSetLayoutSupport* pSupport,
+                                                                 const ErrorObject& error_obj) const {
     return PreCallValidateGetDescriptorSetLayoutSupport(device, pCreateInfo, pSupport, error_obj);
 }
 
@@ -858,24 +858,23 @@ bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSupportKHR(VkDevice device
 //  This includes validating that all descriptors in the given bindings are updated,
 //  that any update buffers are valid, and that any dynamic offsets are within the bounds of their buffers.
 // Return true if state is acceptable, or false and write an error message into error string
-bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet &descriptor_set, uint32_t set_index,
-                                   const BindingVariableMap &binding_req_map, const vvl::CommandBuffer &cb_state,
-                                   const vvl::DrawDispatchVuid &vuids, const LogObjectList &objlist) const {
+bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet& descriptor_set, uint32_t set_index,
+                                   const BindingVariableMap& binding_req_map, const vvl::CommandBuffer& cb_state,
+                                   const vvl::DrawDispatchVuid& vuids, const LogObjectList& objlist) const {
     bool result = false;
-    const Location &loc = vuids.loc();
+    const Location& loc = vuids.loc();
     const VkFramebuffer framebuffer = cb_state.active_framebuffer ? cb_state.active_framebuffer->VkHandle() : VK_NULL_HANDLE;
     // NOTE: GPU-AV needs non-const state objects to do lazy updates of descriptor state of only the dynamically used
     // descriptors, via the non-const version of ValidateBindingDynamic(), this code uses the const path only even it gives up
     // non-const versions of its state objects here.
-    const vvl::DescriptorValidator desc_val(const_cast<CoreChecks &>(*this), const_cast<vvl::CommandBuffer &>(cb_state),
-                                            const_cast<vvl::DescriptorSet &>(descriptor_set), set_index, framebuffer, &objlist,
-                                            loc);
+    const vvl::DescriptorValidator desc_val(const_cast<CoreChecks&>(*this), const_cast<vvl::CommandBuffer&>(cb_state),
+                                            const_cast<vvl::DescriptorSet&>(descriptor_set), set_index, framebuffer, &objlist, loc);
 
-    for (const auto &[binding_index, desc_set_reqs] : binding_req_map) {
+    for (const auto& [binding_index, desc_set_reqs] : binding_req_map) {
         ASSERT_AND_CONTINUE(desc_set_reqs.variable);
-        const auto &resource_variable = *desc_set_reqs.variable;
+        const auto& resource_variable = *desc_set_reqs.variable;
 
-        const vvl::DescriptorBinding *binding = descriptor_set.GetBinding(binding_index);
+        const vvl::DescriptorBinding* binding = descriptor_set.GetBinding(binding_index);
         if (!binding) {  //  End at construction is the condition for an invalid binding.
             const LogObjectList updated_objlist(cb_state.Handle(), objlist, descriptor_set.Handle());
             result |= LogError(vuids.descriptor_buffer_bit_set_08114, updated_objlist, loc, "%s %s is invalid.",
@@ -894,13 +893,13 @@ bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet &descriptor_set, uin
 
 // Make sure that dstArrayElement + descriptorCount does go OOB
 // While the type, stage flags & immutable sampler must match, that error is caught
-bool CoreChecks::VerifyUpdateDescriptorRange(const vvl::DescriptorSet &set, const uint32_t binding, const uint32_t array_element,
-                                             const uint32_t descriptor_count, bool is_copy, const Location &binding_loc,
+bool CoreChecks::VerifyUpdateDescriptorRange(const vvl::DescriptorSet& set, const uint32_t binding, const uint32_t array_element,
+                                             const uint32_t descriptor_count, bool is_copy, const Location& binding_loc,
                                              const vvl::Field array_element_name) const {
     bool skip = false;
     auto current_iter = set.FindBinding(binding);
-    auto &orig_binding = **current_iter;  // save for error message
-    const char *vuid = is_copy ? "VUID-VkCopyDescriptorSet-srcSet-00349" : "VUID-VkWriteDescriptorSet-dstArrayElement-00321";
+    auto& orig_binding = **current_iter;  // save for error message
+    const char* vuid = is_copy ? "VUID-VkCopyDescriptorSet-srcSet-00349" : "VUID-VkWriteDescriptorSet-dstArrayElement-00321";
 
     // check if srcArrayElement/dstArrayElement is so large it is skipping the the srcBinding/dstBinding
     // If it, find the first binding being updated
@@ -951,13 +950,13 @@ bool CoreChecks::VerifyUpdateDescriptorRange(const vvl::DescriptorSet &set, cons
     return skip;
 }
 
-bool CoreChecks::ValidateCopyUpdate(const VkCopyDescriptorSet &update, const Location &copy_loc) const {
+bool CoreChecks::ValidateCopyUpdate(const VkCopyDescriptorSet& update, const Location& copy_loc) const {
     bool skip = false;
     const auto src_set = Get<vvl::DescriptorSet>(update.srcSet);
     const auto dst_set = Get<vvl::DescriptorSet>(update.dstSet);
     ASSERT_AND_RETURN_SKIP(src_set && dst_set);
 
-    const vvl::DescriptorSetLayout &src_layout = *src_set->GetLayout();
+    const vvl::DescriptorSetLayout& src_layout = *src_set->GetLayout();
     {
         if (src_layout.Destroyed()) {
             const LogObjectList objlist(update.srcSet, src_layout.Handle());
@@ -982,7 +981,7 @@ bool CoreChecks::ValidateCopyUpdate(const VkCopyDescriptorSet &update, const Loc
         }
     }
 
-    const vvl::DescriptorSetLayout &dst_layout = *dst_set->GetLayout();
+    const vvl::DescriptorSetLayout& dst_layout = *dst_set->GetLayout();
     {
         if (dst_layout.Destroyed()) {
             const LogObjectList objlist(update.dstSet, dst_layout.Handle());
@@ -1024,10 +1023,10 @@ bool CoreChecks::ValidateCopyUpdate(const VkCopyDescriptorSet &update, const Loc
     return skip;
 }
 
-bool CoreChecks::ValidateCopyUpdateDescriptorSetLayoutFlags(const VkCopyDescriptorSet &update,
-                                                            const vvl::DescriptorSetLayout &src_layout,
-                                                            const vvl::DescriptorSetLayout &dst_layout,
-                                                            const Location &copy_loc) const {
+bool CoreChecks::ValidateCopyUpdateDescriptorSetLayoutFlags(const VkCopyDescriptorSet& update,
+                                                            const vvl::DescriptorSetLayout& src_layout,
+                                                            const vvl::DescriptorSetLayout& dst_layout,
+                                                            const Location& copy_loc) const {
     bool skip = false;
     const VkDescriptorSetLayoutCreateFlags src_flags = src_layout.GetCreateFlags();
     const VkDescriptorSetLayoutCreateFlags dst_flags = dst_layout.GetCreateFlags();
@@ -1054,8 +1053,8 @@ bool CoreChecks::ValidateCopyUpdateDescriptorSetLayoutFlags(const VkCopyDescript
     return skip;
 }
 
-bool CoreChecks::ValidateCopyUpdateDescriptorPoolFlags(const VkCopyDescriptorSet &update, const vvl::DescriptorSet &src_set,
-                                                       const vvl::DescriptorSet &dst_set, const Location &copy_loc) const {
+bool CoreChecks::ValidateCopyUpdateDescriptorPoolFlags(const VkCopyDescriptorSet& update, const vvl::DescriptorSet& src_set,
+                                                       const vvl::DescriptorSet& dst_set, const Location& copy_loc) const {
     bool skip = false;
 
     const auto src_pool = src_set.GetPoolState();
@@ -1085,9 +1084,9 @@ bool CoreChecks::ValidateCopyUpdateDescriptorPoolFlags(const VkCopyDescriptorSet
     return skip;
 }
 
-bool CoreChecks::ValidateCopyUpdateDescriptorTypes(const VkCopyDescriptorSet &update, const vvl::DescriptorSet &src_set,
-                                                   const vvl::DescriptorSet &dst_set, const vvl::DescriptorSetLayout &src_layout,
-                                                   const vvl::DescriptorSetLayout &dst_layout, const Location &copy_loc) const {
+bool CoreChecks::ValidateCopyUpdateDescriptorTypes(const VkCopyDescriptorSet& update, const vvl::DescriptorSet& src_set,
+                                                   const vvl::DescriptorSet& dst_set, const vvl::DescriptorSetLayout& src_layout,
+                                                   const vvl::DescriptorSetLayout& dst_layout, const Location& copy_loc) const {
     bool skip = false;
 
     // Note - the VkDescriptorType are prior to resolving the Mutable Descriptor Types
@@ -1142,7 +1141,7 @@ bool CoreChecks::ValidateCopyUpdateDescriptorTypes(const VkCopyDescriptorSet &up
         auto src_iter = src_set.FindDescriptor(update.srcBinding, update.srcArrayElement);
         if (src_iter.IsValid()) {
             for (uint32_t di = 0; di < update.descriptorCount && !src_iter.AtEnd(); di++, ++src_iter) {
-                const auto &mutable_src = static_cast<const vvl::MutableDescriptor &>(*src_iter);
+                const auto& mutable_src = static_cast<const vvl::MutableDescriptor&>(*src_iter);
                 if (mutable_src.ActiveType() != dst_type) {
                     const LogObjectList objlist(update.srcSet, update.dstSet, src_layout.Handle(), dst_layout.Handle());
                     skip |= LogError("VUID-VkCopyDescriptorSet-srcSet-04613", objlist, copy_loc.dot(Field::srcBinding),
@@ -1160,8 +1159,8 @@ bool CoreChecks::ValidateCopyUpdateDescriptorTypes(const VkCopyDescriptorSet &up
 
     if (dst_type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT && src_type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
         // These have been sorted already so can direct compare
-        const auto &mutable_src_types = src_layout.GetMutableTypes(update.srcBinding);
-        const auto &mutable_dst_types = dst_layout.GetMutableTypes(update.dstBinding);
+        const auto& mutable_src_types = src_layout.GetMutableTypes(update.srcBinding);
+        const auto& mutable_dst_types = dst_layout.GetMutableTypes(update.dstBinding);
         if (mutable_src_types != mutable_dst_types) {
             const LogObjectList objlist(update.srcSet, update.dstSet, src_layout.Handle(), dst_layout.Handle());
             skip |= LogError("VUID-VkCopyDescriptorSet-dstSet-04614", objlist, copy_loc.dot(Field::srcBinding),
@@ -1175,7 +1174,7 @@ bool CoreChecks::ValidateCopyUpdateDescriptorTypes(const VkCopyDescriptorSet &up
 
     if (dst_type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
         dst_type =
-            static_cast<const vvl::MutableDescriptor *>(dst_set.GetDescriptorFromBinding(update.dstBinding, update.dstArrayElement))
+            static_cast<const vvl::MutableDescriptor*>(dst_set.GetDescriptorFromBinding(update.dstBinding, update.dstArrayElement))
                 ->ActiveType();
     }
     if (dst_type == VK_DESCRIPTOR_TYPE_SAMPLER) {
@@ -1199,8 +1198,8 @@ bool CoreChecks::ValidateCopyUpdateDescriptorTypes(const VkCopyDescriptorSet &up
     return skip;
 }
 
-bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLayout image_layout, VkDescriptorType type,
-                                     const Location &image_info_loc) const {
+bool CoreChecks::ValidateImageUpdate(const vvl::ImageView& view_state, VkImageLayout image_layout, VkDescriptorType type,
+                                     const Location& image_info_loc) const {
     bool skip = false;
 
     // Note that when an imageview is created, we validated that memory is bound so no need to re-check here
@@ -1361,7 +1360,7 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLa
         type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
         struct ExtensionLayout {
             VkImageLayout layout;
-            ExtEnabled DeviceExtensions::*extension;
+            ExtEnabled DeviceExtensions::* extension;
         };
         // Layouts allowed for all three descriptor types (sampled, combined, input attachment)
         const static std::array<VkImageLayout, 3> shared_layouts = {
@@ -1386,7 +1385,7 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLa
             {VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ, &DeviceExtensions::vk_khr_dynamic_rendering_local_read},
         }};
 
-        auto is_layout = [image_layout, this](const ExtensionLayout &ext_layout) {
+        auto is_layout = [image_layout, this](const ExtensionLayout& ext_layout) {
             return IsExtEnabled(extensions.*(ext_layout.extension)) && (ext_layout.layout == image_layout);
         };
 
@@ -1404,7 +1403,7 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLa
             }
         }
         if (!is_valid) {
-            const char *vuid = kVUIDUndefined;
+            const char* vuid = kVUIDUndefined;
             switch (type) {
                 case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
                     vuid = "VUID-VkWriteDescriptorSet-descriptorType-04149";
@@ -1424,25 +1423,25 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLa
                       << FormatHandle(image_state->Handle()) << " in imageView " << FormatHandle(view_state.Handle())
                       << ". Allowed layouts are: VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, "
                       << "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL";
-            for (auto &ext_layout : shared_extended_layouts) {
+            for (auto& ext_layout : shared_extended_layouts) {
                 if (IsExtEnabled(extensions.*(ext_layout.extension))) {
                     error_str << ", " << string_VkImageLayout(ext_layout.layout);
                 }
             }
             if (type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) {
-                for (auto &ext_layout : sampled_image_layouts) {
+                for (auto& ext_layout : sampled_image_layouts) {
                     if (IsExtEnabled(extensions.*(ext_layout.extension))) {
                         error_str << ", " << string_VkImageLayout(ext_layout.layout);
                     }
                 }
             } else if (type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
-                for (auto &ext_layout : combined_image_sampler_layouts) {
+                for (auto& ext_layout : combined_image_sampler_layouts) {
                     if (IsExtEnabled(extensions.*(ext_layout.extension))) {
                         error_str << ", " << string_VkImageLayout(ext_layout.layout);
                     }
                 }
             } else if (type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
-                for (auto &ext_layout : input_attachment_layouts) {
+                for (auto& ext_layout : input_attachment_layouts) {
                     if (IsExtEnabled(extensions.*(ext_layout.extension))) {
                         error_str << ", " << string_VkImageLayout(ext_layout.layout);
                     }
@@ -1475,9 +1474,9 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLa
 // If the update hits an issue for which the callback returns "true", meaning that the call down the chain should
 //  be skipped, then true is returned.
 // If there is no issue with the update, then false is returned.
-bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, const VkWriteDescriptorSet *pDescriptorWrites,
-                                              uint32_t descriptorCopyCount, const VkCopyDescriptorSet *pDescriptorCopies,
-                                              const Location &loc) const {
+bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites,
+                                              uint32_t descriptorCopyCount, const VkCopyDescriptorSet* pDescriptorCopies,
+                                              const Location& loc) const {
     bool skip = false;
     // Validate Write updates
     for (uint32_t i = 0; i < descriptorWriteCount; i++) {
@@ -1497,10 +1496,10 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, con
     return skip;
 }
 
-vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState &device_data, VkDescriptorSet descriptorSet,
-                                                  const vvl::DescriptorUpdateTemplate &template_state, const void *pData,
+vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState& device_data, VkDescriptorSet descriptorSet,
+                                                  const vvl::DescriptorUpdateTemplate& template_state, const void* pData,
                                                   VkDescriptorSetLayout push_layout) {
-    auto const &create_info = template_state.create_info;
+    auto const& create_info = template_state.create_info;
     inline_infos.resize(create_info.descriptorUpdateEntryCount);  // Make sure we have one if we need it
     inline_infos_khr.resize(create_info.descriptorUpdateEntryCount);
     inline_infos_nv.resize(create_info.descriptorUpdateEntryCount);
@@ -1514,7 +1513,7 @@ vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState &device
 
     // Create a WriteDescriptorSet struct for each template update entry
     for (uint32_t i = 0; i < create_info.descriptorUpdateEntryCount; i++) {
-        const auto &descriptor_update_entry = create_info.pDescriptorUpdateEntries[i];
+        const auto& descriptor_update_entry = create_info.pDescriptorUpdateEntries[i];
         uint32_t binding_count = ds_layout_state->GetDescriptorCountFromBinding(descriptor_update_entry.dstBinding);
         uint32_t binding_being_updated = descriptor_update_entry.dstBinding;
         uint32_t dst_array_element = descriptor_update_entry.dstArrayElement;
@@ -1522,10 +1521,10 @@ vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState &device
         desc_writes.reserve(desc_writes.size() + descriptor_update_entry.descriptorCount);
         for (uint32_t j = 0; j < descriptor_update_entry.descriptorCount; j++) {
             desc_writes.emplace_back();
-            auto &write_entry = desc_writes.back();
+            auto& write_entry = desc_writes.back();
 
             size_t offset = descriptor_update_entry.offset + j * descriptor_update_entry.stride;
-            char *update_entry = (char *)(pData) + offset;
+            char* update_entry = (char*)(pData) + offset;
 
             if (dst_array_element >= binding_count) {
                 dst_array_element = 0;
@@ -1546,22 +1545,22 @@ vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState &device
                 case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
                 case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
                 case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-                    write_entry.pImageInfo = reinterpret_cast<VkDescriptorImageInfo *>(update_entry);
+                    write_entry.pImageInfo = reinterpret_cast<VkDescriptorImageInfo*>(update_entry);
                     break;
 
                 case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
                 case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
                 case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
                 case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-                    write_entry.pBufferInfo = reinterpret_cast<VkDescriptorBufferInfo *>(update_entry);
+                    write_entry.pBufferInfo = reinterpret_cast<VkDescriptorBufferInfo*>(update_entry);
                     break;
 
                 case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
                 case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-                    write_entry.pTexelBufferView = reinterpret_cast<VkBufferView *>(update_entry);
+                    write_entry.pTexelBufferView = reinterpret_cast<VkBufferView*>(update_entry);
                     break;
                 case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK: {
-                    VkWriteDescriptorSetInlineUniformBlock *inline_info = &inline_infos[i];
+                    VkWriteDescriptorSetInlineUniformBlock* inline_info = &inline_infos[i];
                     inline_info->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT;
                     inline_info->pNext = nullptr;
                     inline_info->dataSize = descriptor_update_entry.descriptorCount;
@@ -1574,33 +1573,33 @@ vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState &device
                     break;
                 }
                 case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR: {
-                    VkWriteDescriptorSetAccelerationStructureKHR *inline_info_khr = &inline_infos_khr[i];
+                    VkWriteDescriptorSetAccelerationStructureKHR* inline_info_khr = &inline_infos_khr[i];
                     inline_info_khr->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR;
                     inline_info_khr->pNext = nullptr;
                     inline_info_khr->accelerationStructureCount = descriptor_update_entry.descriptorCount;
-                    inline_info_khr->pAccelerationStructures = reinterpret_cast<VkAccelerationStructureKHR *>(update_entry);
+                    inline_info_khr->pAccelerationStructures = reinterpret_cast<VkAccelerationStructureKHR*>(update_entry);
                     write_entry.pNext = inline_info_khr;
                     // descriptorCount must match the accelerationStructureCount
                     write_entry.descriptorCount = inline_info_khr->accelerationStructureCount;
                     break;
                 }
                 case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV: {
-                    VkWriteDescriptorSetAccelerationStructureNV *inline_info_nv = &inline_infos_nv[i];
+                    VkWriteDescriptorSetAccelerationStructureNV* inline_info_nv = &inline_infos_nv[i];
                     inline_info_nv->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV;
                     inline_info_nv->pNext = nullptr;
                     inline_info_nv->accelerationStructureCount = descriptor_update_entry.descriptorCount;
-                    inline_info_nv->pAccelerationStructures = reinterpret_cast<VkAccelerationStructureNV *>(update_entry);
+                    inline_info_nv->pAccelerationStructures = reinterpret_cast<VkAccelerationStructureNV*>(update_entry);
                     write_entry.pNext = inline_info_nv;
                     // descriptorCount must match the accelerationStructureCount
                     write_entry.descriptorCount = inline_info_nv->accelerationStructureCount;
                     break;
                 }
                 case VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV: {
-                    VkWriteDescriptorSetPartitionedAccelerationStructureNV *inline_info_ptlas = &inline_infos_ptlas[i];
+                    VkWriteDescriptorSetPartitionedAccelerationStructureNV* inline_info_ptlas = &inline_infos_ptlas[i];
                     inline_info_ptlas->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_PARTITIONED_ACCELERATION_STRUCTURE_NV;
                     inline_info_ptlas->pNext = nullptr;
                     inline_info_ptlas->accelerationStructureCount = descriptor_update_entry.descriptorCount;
-                    inline_info_ptlas->pAccelerationStructures = reinterpret_cast<const VkDeviceAddress *>(update_entry);
+                    inline_info_ptlas->pAccelerationStructures = reinterpret_cast<const VkDeviceAddress*>(update_entry);
                     write_entry.pNext = inline_info_ptlas;
                     // descriptorCount must match the accelerationStructureCount
                     write_entry.descriptorCount = inline_info_ptlas->accelerationStructureCount;
@@ -1624,9 +1623,9 @@ vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState &device
 }
 
 // Loop through the write updates to validate for a push descriptor set, ignoring dstSet
-bool CoreChecks::ValidatePushDescriptorsUpdate(const vvl::DescriptorSet &push_set, uint32_t descriptorWriteCount,
-                                               const VkWriteDescriptorSet *pDescriptorWrites,
-                                               const vvl::DslErrorSource &dsl_error_source, const Location &loc) const {
+bool CoreChecks::ValidatePushDescriptorsUpdate(const vvl::DescriptorSet& push_set, uint32_t descriptorWriteCount,
+                                               const VkWriteDescriptorSet* pDescriptorWrites,
+                                               const vvl::DslErrorSource& dsl_error_source, const Location& loc) const {
     bool skip = false;
     for (uint32_t i = 0; i < descriptorWriteCount; i++) {
         skip |= ValidateWriteUpdate(push_set, pDescriptorWrites[i], loc.dot(Field::pDescriptorWrites, i), dsl_error_source);
@@ -1634,8 +1633,8 @@ bool CoreChecks::ValidatePushDescriptorsUpdate(const vvl::DescriptorSet &push_se
     return skip;
 }
 
-bool CoreChecks::ValidateBufferUpdate(const vvl::Buffer &buffer_state, const VkDescriptorBufferInfo &buffer_info,
-                                      VkDescriptorType type, const Location &buffer_info_loc) const {
+bool CoreChecks::ValidateBufferUpdate(const vvl::Buffer& buffer_state, const VkDescriptorBufferInfo& buffer_info,
+                                      VkDescriptorType type, const Location& buffer_info_loc) const {
     bool skip = false;
 
     skip |= ValidateMemoryIsBoundToBuffer(device, buffer_state, buffer_info_loc.dot(Field::buffer),
@@ -1706,10 +1705,10 @@ bool CoreChecks::ValidateBufferUpdate(const vvl::Buffer &buffer_state, const VkD
     return skip;
 }
 
-bool CoreChecks::ValidateWriteUpdate(const vvl::DescriptorSet &dst_set, const VkWriteDescriptorSet &update,
-                                     const Location &write_loc, const vvl::DslErrorSource &dsl_error_source) const {
+bool CoreChecks::ValidateWriteUpdate(const vvl::DescriptorSet& dst_set, const VkWriteDescriptorSet& update,
+                                     const Location& write_loc, const vvl::DslErrorSource& dsl_error_source) const {
     bool skip = false;
-    const vvl::DescriptorSetLayout *dst_layout = dst_set.GetLayout().get();
+    const vvl::DescriptorSetLayout* dst_layout = dst_set.GetLayout().get();
 
     // Verify dst layout still valid (ObjectLifetimes only checks if null, we check if valid dstSet here)
     if (dst_layout->Destroyed()) {
@@ -1730,7 +1729,7 @@ bool CoreChecks::ValidateWriteUpdate(const vvl::DescriptorSet &dst_set, const Vk
                         dsl_error_source.PrintMessage(*this).c_str());
     }
 
-    const vvl::DescriptorBinding *dst_binding = dst_set.GetBinding(update.dstBinding);
+    const vvl::DescriptorBinding* dst_binding = dst_set.GetBinding(update.dstBinding);
     if (!dst_binding) {
         // Spec: "Bindings that are not specified have a descriptorCount and stageFlags of zero"
         // If we can't find the binding, it means it was not in the layout and is same of having a zero descriptorCount
@@ -1752,7 +1751,7 @@ bool CoreChecks::ValidateWriteUpdate(const vvl::DescriptorSet &dst_set, const Vk
     }
 
     if (!vvl::IsBindless(dst_binding->binding_flags)) {
-        if (const auto *used_handle = dst_set.InUse()) {
+        if (const auto* used_handle = dst_set.InUse()) {
             const LogObjectList objlist(update.dstSet, dst_layout->Handle());
             skip |= LogError("VUID-vkUpdateDescriptorSets-None-03047", objlist, dst_binding_loc,
                              "(%" PRIu32
@@ -1891,7 +1890,7 @@ bool CoreChecks::ValidateWriteUpdate(const vvl::DescriptorSet &dst_set, const Vk
     return skip;
 }
 
-bool CoreChecks::ValidateWriteUpdateDescriptorType(const VkWriteDescriptorSet &update, const Location &write_loc) const {
+bool CoreChecks::ValidateWriteUpdateDescriptorType(const VkWriteDescriptorSet& update, const Location& write_loc) const {
     bool skip = false;
     // Always used unless dealing with Mutable where the type is found in the vvl::DescriptorBinding
     const VkDescriptorType descriptor_type = update.descriptorType;
@@ -1914,7 +1913,7 @@ bool CoreChecks::ValidateWriteUpdateDescriptorType(const VkWriteDescriptorSet &u
                           VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
                           VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM})) {
         if (update.pImageInfo == nullptr) {
-            const char *vuid =
+            const char* vuid =
                 (write_loc.function == Func::vkCmdPushDescriptorSet || write_loc.function == Func::vkCmdPushDescriptorSetKHR)
                     ? "VUID-vkCmdPushDescriptorSet-pDescriptorWrites-06494"
                 : (write_loc.function == Func::vkCmdPushDescriptorSet2 || write_loc.function == Func::vkCmdPushDescriptorSet2KHR)
@@ -1928,7 +1927,7 @@ bool CoreChecks::ValidateWriteUpdateDescriptorType(const VkWriteDescriptorSet &u
     return skip;
 }
 
-bool CoreChecks::ValidateWriteUpdateBufferInfo(const VkWriteDescriptorSet &update, const Location &write_loc) const {
+bool CoreChecks::ValidateWriteUpdateBufferInfo(const VkWriteDescriptorSet& update, const Location& write_loc) const {
     bool skip = false;
     const VkDescriptorType descriptor_type = update.descriptorType;
     if (!update.pBufferInfo) {
@@ -1941,7 +1940,7 @@ bool CoreChecks::ValidateWriteUpdateBufferInfo(const VkWriteDescriptorSet &updat
     const VkDeviceSize storage_alignment = phys_dev_props.limits.minStorageBufferOffsetAlignment;
 
     for (uint32_t i = 0; i < update.descriptorCount; ++i) {
-        const auto &buffer_info = update.pBufferInfo[i];
+        const auto& buffer_info = update.pBufferInfo[i];
 
         if (enabled_features.nullDescriptor) {
             if (buffer_info.buffer == VK_NULL_HANDLE && (buffer_info.offset != 0 || buffer_info.range != VK_WHOLE_SIZE)) {
@@ -1975,7 +1974,7 @@ bool CoreChecks::ValidateWriteUpdateBufferInfo(const VkWriteDescriptorSet &updat
     return skip;
 }
 
-bool CoreChecks::ValidateWriteUpdateInlineUniformBlock(const VkWriteDescriptorSet &update, const Location &write_loc) const {
+bool CoreChecks::ValidateWriteUpdateInlineUniformBlock(const VkWriteDescriptorSet& update, const Location& write_loc) const {
     bool skip = false;
     if (!IsIntegerMultipleOf(update.dstArrayElement, 4)) {
         skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02219", device, write_loc.dot(Field::dstBinding),
@@ -1989,7 +1988,7 @@ bool CoreChecks::ValidateWriteUpdateInlineUniformBlock(const VkWriteDescriptorSe
                          ") is not a multiple of 4.",
                          update.dstBinding, update.descriptorCount);
     }
-    const auto *write_inline_info = vku::FindStructInPNextChain<VkWriteDescriptorSetInlineUniformBlock>(update.pNext);
+    const auto* write_inline_info = vku::FindStructInPNextChain<VkWriteDescriptorSetInlineUniformBlock>(update.pNext);
     if (!write_inline_info) {
         skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02221", device, write_loc.dot(Field::dstBinding),
                          "(%" PRIu32
@@ -2010,10 +2009,10 @@ bool CoreChecks::ValidateWriteUpdateInlineUniformBlock(const VkWriteDescriptorSe
     return skip;
 }
 
-bool CoreChecks::ValidateWriteUpdateAccelerationStructureKHR(const VkWriteDescriptorSet &update, const Location &write_loc) const {
+bool CoreChecks::ValidateWriteUpdateAccelerationStructureKHR(const VkWriteDescriptorSet& update, const Location& write_loc) const {
     bool skip = false;
 
-    const auto *write_as = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(update.pNext);
+    const auto* write_as = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(update.pNext);
     if (!write_as) {
         skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02382", device, write_loc.dot(Field::descriptorType),
                          "is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, but the pNext chain doesn't include "
@@ -2066,10 +2065,10 @@ bool CoreChecks::ValidateWriteUpdateAccelerationStructureKHR(const VkWriteDescri
     return skip;
 }
 
-bool CoreChecks::ValidateWriteUpdateAccelerationStructureNV(const VkWriteDescriptorSet &update, const Location &write_loc) const {
+bool CoreChecks::ValidateWriteUpdateAccelerationStructureNV(const VkWriteDescriptorSet& update, const Location& write_loc) const {
     bool skip = false;
 
-    const auto *write_as = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
+    const auto* write_as = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
     if (!write_as || (write_as->accelerationStructureCount != update.descriptorCount)) {
         skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-03817", device, write_loc,
                          "If descriptorType is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, the pNext"
@@ -2099,10 +2098,10 @@ bool CoreChecks::ValidateWriteUpdateAccelerationStructureNV(const VkWriteDescrip
     return skip;
 }
 
-bool CoreChecks::ValidateWriteUpdateTensor(const VkWriteDescriptorSet &update, const Location &write_loc) const {
+bool CoreChecks::ValidateWriteUpdateTensor(const VkWriteDescriptorSet& update, const Location& write_loc) const {
     bool skip = false;
 
-    const auto *write_as = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(update.pNext);
+    const auto* write_as = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(update.pNext);
     if (!write_as) {
         skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-09945", device, write_loc,
                          "is missing a VkWriteDescriptorSetTensorARM in the pNext chain");
@@ -2120,8 +2119,8 @@ bool CoreChecks::ValidateWriteUpdateTensor(const VkWriteDescriptorSet &update, c
 }
 
 // Verify that the contents of the update are ok, but don't perform actual update
-bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, const VkWriteDescriptorSet &update,
-                                           const Location &write_loc) const {
+bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet& dst_set, const VkWriteDescriptorSet& update,
+                                           const Location& write_loc) const {
     bool skip = false;
 
     switch (update.descriptorType) {
@@ -2138,7 +2137,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
                 if (iter->GetClass() == vvl::DescriptorClass::Mutable) {
                     continue;  // undefined to cast to ImageSamplerDescriptor
                 }
-                const vvl::ImageSamplerDescriptor &desc = (const vvl::ImageSamplerDescriptor &)*iter;
+                const vvl::ImageSamplerDescriptor& desc = (const vvl::ImageSamplerDescriptor&)*iter;
                 const Location image_info_loc = write_loc.dot(Field::pImageInfo, di);
                 const VkImageView image_view = update.pImageInfo[di].imageView;
                 if (image_view == VK_NULL_HANDLE) {
@@ -2163,7 +2162,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
                     continue;
                 }
 
-                const auto *image_state = iv_state->image_state.get();
+                const auto* image_state = iv_state->image_state.get();
                 skip |= ValidateImageUpdate(*iv_state, image_layout, update.descriptorType, image_info_loc);
 
                 // Samplers can't be VK_NULL_HANDLE from nullDescriptor, but if there is an immutble sampler, it can be set as
@@ -2248,7 +2247,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
             }
             // only need to check the first descriptor, VU like VUID-VkWriteDescriptorSet-descriptorCount-00318 force all
             // Consecutive Binding Updates to be immutable or non-immutable
-            const vvl::SamplerDescriptor &desc = (const vvl::SamplerDescriptor &)*iter;
+            const vvl::SamplerDescriptor& desc = (const vvl::SamplerDescriptor&)*iter;
             if (desc.IsImmutableSampler() && !dst_set.IsPushDescriptor()) {
                 skip |=
                     LogError("VUID-VkWriteDescriptorSet-descriptorType-02752", update.dstSet, write_loc.dot(Field::descriptorType),
@@ -2290,7 +2289,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
                         ValidateImageUpdate(*iv_state, image_layout, update.descriptorType, write_loc.dot(Field::pImageInfo, di));
                 } else if (image_view != VK_NULL_HANDLE && !enabled_features.nullDescriptor) {
                     // This is to catch Template updates, normal updates can be caught in ObjectTracker
-                    const char *vuid = image_view == VK_NULL_HANDLE ? "VUID-VkWriteDescriptorSet-descriptorType-02997"
+                    const char* vuid = image_view == VK_NULL_HANDLE ? "VUID-VkWriteDescriptorSet-descriptorType-02997"
                                                                     : "VUID-VkWriteDescriptorSet-descriptorType-02996";
                     skip |=
                         LogError(vuid, device, write_loc.dot(Field::pImageInfo, di).dot(Field::imageView),
@@ -2327,7 +2326,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
                 }
 
                 // vkspec.html#resources-buffer-views-usage
-                const auto *usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(bv_state->create_info.pNext);
+                const auto* usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(bv_state->create_info.pNext);
                 VkBufferUsageFlags2 buffer_view_usage = usage_flags2 ? usage_flags2->usage : buffer_state->usage;
 
                 if (update.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
@@ -2361,7 +2360,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
         case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
             if (!update.pBufferInfo) break;
             for (uint32_t di = 0; di < update.descriptorCount; ++di) {
-                const auto &buffer_info = update.pBufferInfo[di];
+                const auto& buffer_info = update.pBufferInfo[di];
                 if (buffer_info.buffer == VK_NULL_HANDLE && enabled_features.nullDescriptor) {
                     continue;
                 }
@@ -2384,7 +2383,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
         case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
             break;
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV: {
-            const auto *acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
+            const auto* acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
             if (!acc_info) break;
             for (uint32_t di = 0; di < update.descriptorCount; ++di) {
                 VkAccelerationStructureNV as = acc_info->pAccelerationStructures[di];
@@ -2411,9 +2410,9 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet &dst_set, co
     return skip;
 }
 
-bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer &cb_state, VkPipelineLayout layout,
-                                                       uint32_t firstSet, uint32_t setCount, const uint32_t *pBufferIndices,
-                                                       const VkDeviceSize *pOffsets, const Location &loc) const {
+bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer& cb_state, VkPipelineLayout layout,
+                                                       uint32_t firstSet, uint32_t setCount, const uint32_t* pBufferIndices,
+                                                       const VkDeviceSize* pOffsets, const Location& loc) const {
     bool skip = false;
     skip |= ValidateCmd(cb_state, loc);
 
@@ -2425,7 +2424,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
     const bool is_2 = loc.function != Func::vkCmdSetDescriptorBufferOffsetsEXT;
 
     if ((firstSet + setCount) > pipeline_layout->set_layouts.list.size()) {
-        const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-08066"
+        const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-08066"
                                 : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-08066";
         skip |= LogError(vuid, cb_state.Handle(), loc,
                          "The sum of firstSet (%" PRIu32 ") and setCount (%" PRIu32
@@ -2437,7 +2436,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
     }
 
     if (cb_state.descriptor_buffer.binding_info.empty()) {
-        const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08065"
+        const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08065"
                                 : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pBufferIndices-08065";
         const LogObjectList objlist(cb_state.Handle(), pipeline_layout->Handle());
         skip |=
@@ -2456,7 +2455,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         const VkDescriptorSetLayoutCreateFlags create_flags = set_layout->GetCreateFlags();
         if ((create_flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) == 0) {
             const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-09006"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-09006"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-09006";
             skip |= LogError(vuid, objlist, loc,
                              "%s for set %" PRIu32
@@ -2466,7 +2465,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         }
         if ((create_flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR) != 0) {
             const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-11803"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-11803"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-11803";
             skip |= LogError(
                 vuid, objlist, loc,
@@ -2479,7 +2478,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         }
         if ((create_flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT) != 0) {
             const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-11804"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-11804"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-11804";
             skip |= LogError(vuid, objlist, loc,
                              "%s for set %" PRIu32
@@ -2492,7 +2491,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
 
         const uint32_t buffer_index = pBufferIndices[i];
         if (buffer_index >= cb_state.descriptor_buffer.binding_info.size()) {
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08065"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08065"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pBufferIndices-08065";
             const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
             skip |= LogError(vuid, objlist, loc.dot(Field::pBufferIndices, i),
@@ -2501,12 +2500,12 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
             continue;  // the buffer is not valid
         }
 
-        const auto &binding_info = cb_state.descriptor_buffer.binding_info[buffer_index];
+        const auto& binding_info = cb_state.descriptor_buffer.binding_info[buffer_index];
         const VkDeviceAddress start = binding_info.address;
         const auto buffer_states = GetBuffersByAddress(start);
 
         if (buffer_states.empty()) {
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08065"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08065"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pBufferIndices-08065";
             const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
             skip |=
@@ -2523,7 +2522,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         }
         if (binding_info.usage & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) {
             if (offset > phys_dev_ext_props.descriptor_buffer_props.maxResourceDescriptorBufferRange) {
-                const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08127"
+                const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08127"
                                         : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08127";
                 const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
                 skip |= LogError(vuid, objlist, loc.dot(Field::pOffset, i),
@@ -2535,7 +2534,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         }
         if (binding_info.usage & VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) {
             if (offset > phys_dev_ext_props.descriptor_buffer_props.maxSamplerDescriptorBufferRange) {
-                const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08126"
+                const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08126"
                                         : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08126";
                 const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
                 skip |= LogError(vuid, objlist, loc.dot(Field::pOffset, i),
@@ -2580,7 +2579,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
 
         if (!valid_binding) {
             const vvl::range<VkDeviceAddress> access_range = {start + offset, start + offset + set_layout_size};
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08063"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08063"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08063";
             const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
             skip |=
@@ -2600,8 +2599,8 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
 bool CoreChecks::PreCallValidateCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer,
                                                                  VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
                                                                  uint32_t firstSet, uint32_t setCount,
-                                                                 const uint32_t *pBufferIndices, const VkDeviceSize *pOffsets,
-                                                                 const ErrorObject &error_obj) const {
+                                                                 const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets,
+                                                                 const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
     bool skip = false;
@@ -2614,8 +2613,8 @@ bool CoreChecks::PreCallValidateCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer
 }
 
 bool CoreChecks::PreCallValidateCmdSetDescriptorBufferOffsets2EXT(
-    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT *pSetDescriptorBufferOffsetsInfo,
-    const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo,
+    const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
 
@@ -2638,14 +2637,14 @@ bool CoreChecks::PreCallValidateCmdSetDescriptorBufferOffsets2EXT(
     return skip;
 }
 
-bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::CommandBuffer &cb_state, VkPipelineLayout layout,
-                                                                 uint32_t set, const Location &loc) const {
+bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::CommandBuffer& cb_state, VkPipelineLayout layout,
+                                                                 uint32_t set, const Location& loc) const {
     bool skip = false;
     skip |= ValidateCmd(cb_state, loc);
     const bool is_2 = loc.function != Func::vkCmdBindDescriptorBufferEmbeddedSamplersEXT;
 
     if (!enabled_features.descriptorBuffer) {
-        const char *vuid = is_2 ? "VUID-vkCmdBindDescriptorBufferEmbeddedSamplers2EXT-descriptorBuffer-09472"
+        const char* vuid = is_2 ? "VUID-vkCmdBindDescriptorBufferEmbeddedSamplers2EXT-descriptorBuffer-09472"
                                 : "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-None-08068";
         skip |= LogError(vuid, cb_state.Handle(), loc, "descriptorBuffer feature was not enabled.");
     }
@@ -2654,7 +2653,7 @@ bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::Comm
     if (!pipeline_layout) return skip;  // dynamicPipelineLayout
 
     if (set >= pipeline_layout->set_layouts.list.size()) {
-        const char *vuid = is_2 ? "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-set-08071"
+        const char* vuid = is_2 ? "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-set-08071"
                                 : "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-set-08071";
         skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::set),
                          "(%" PRIu32
@@ -2664,7 +2663,7 @@ bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::Comm
     } else {
         auto set_layout = pipeline_layout->set_layouts.list[set];
         if (!(set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT)) {
-            const char *vuid = is_2 ? "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-set-08070"
+            const char* vuid = is_2 ? "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-set-08070"
                                     : "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-set-08070";
             skip |= LogError(vuid, cb_state.Handle(), loc,
                              "layout must have been created with the "
@@ -2678,7 +2677,7 @@ bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::Comm
 bool CoreChecks::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
                                                                            VkPipelineBindPoint pipelineBindPoint,
                                                                            VkPipelineLayout layout, uint32_t set,
-                                                                           const ErrorObject &error_obj) const {
+                                                                           const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
 
@@ -2689,8 +2688,8 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCom
 }
 
 bool CoreChecks::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplers2EXT(
-    VkCommandBuffer commandBuffer, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT *pBindDescriptorBufferEmbeddedSamplersInfo,
-    const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo,
+    const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
 
@@ -2712,8 +2711,8 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplers2EXT(
 }
 
 bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                                            const VkDescriptorBufferBindingInfoEXT *pBindingInfos,
-                                                            const ErrorObject &error_obj) const {
+                                                            const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
+                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -2734,7 +2733,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
 
     for (uint32_t i = 0; i < bufferCount; i++) {
         const Location binding_loc = error_obj.location.dot(Field::pBindingInfos, i);
-        const VkDescriptorBufferBindingInfoEXT &binding_info = pBindingInfos[i];
+        const VkDescriptorBufferBindingInfoEXT& binding_info = pBindingInfos[i];
         VkBufferUsageFlags2 buffer_usage = binding_info.usage;
         if (const auto usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(binding_info.pNext)) {
             buffer_usage = usage_flags2->usage;
@@ -2751,7 +2750,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
 
         BufferAddressValidation<4> buffer_address_validator = {{{
             {"VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-08055",
-             [buffer_usage](const vvl::Buffer &buffer_state) {
+             [buffer_usage](const vvl::Buffer& buffer_state) {
                  return ((buffer_state.usage & descriptor_buffer_usage) != (buffer_usage & descriptor_buffer_usage));
              },
              [buffer_usage, i]() {
@@ -2759,12 +2758,12 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
                         string_VkBufferUsageFlags2(buffer_usage & descriptor_buffer_usage) +
                         " but none of the following buffers contain it";
              },
-             [](const vvl::Buffer &buffer_state) {
+             [](const vvl::Buffer& buffer_state) {
                  return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage & descriptor_buffer_usage);
              }},
 
             {"VUID-VkDescriptorBufferBindingInfoEXT-usage-08122",
-             [buffer_usage](const vvl::Buffer &buffer_state) {
+             [buffer_usage](const vvl::Buffer& buffer_state) {
                  if (buffer_usage & VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) {
                      if (!(buffer_state.usage & VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT)) {
                          return true;
@@ -2776,7 +2775,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
              kUsageErrorMsgBuffer},
 
             {"VUID-VkDescriptorBufferBindingInfoEXT-usage-08123",
-             [buffer_usage](const vvl::Buffer &buffer_state) {
+             [buffer_usage](const vvl::Buffer& buffer_state) {
                  if (buffer_usage & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) {
                      if (!(buffer_state.usage & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT)) {
                          return true;
@@ -2788,7 +2787,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
              kUsageErrorMsgBuffer},
 
             {"VUID-VkDescriptorBufferBindingInfoEXT-usage-08124",
-             [buffer_usage](const vvl::Buffer &buffer_state) {
+             [buffer_usage](const vvl::Buffer& buffer_state) {
                  if (buffer_usage & VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT) {
                      if (!(buffer_state.usage & VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT)) {
                          return true;
@@ -2801,7 +2800,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
         }}};
 
         buffer_address_validator.update_callback = [buffer_usage, &push_descriptor_buffers, &resource_buffers,
-                                                    &sampler_buffers](const vvl::Buffer &buffer_state) {
+                                                    &sampler_buffers](const vvl::Buffer& buffer_state) {
             if (buffer_usage & VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT) {
                 push_descriptor_buffers.push_back(buffer_state.VkHandle());
             }
@@ -2816,7 +2815,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
         skip |= buffer_address_validator.ValidateDeviceAddress(*this, binding_loc.dot(Field::address), LogObjectList(device),
                                                                binding_info.address);
 
-        const auto *buffer_handle =
+        const auto* buffer_handle =
             vku::FindStructInPNextChain<VkDescriptorBufferBindingPushDescriptorBufferHandleEXT>(pBindingInfos[i].pNext);
         if (!phys_dev_ext_props.descriptor_buffer_props.bufferlessPushDescriptors &&
             (pBindingInfos[i].usage & VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT) && !buffer_handle) {
@@ -2846,10 +2845,10 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
         }
     }
 
-    auto list_buffers = [this](std::vector<VkBuffer> &buffer_list) {
+    auto list_buffers = [this](std::vector<VkBuffer>& buffer_list) {
         vvl::unordered_set<VkBuffer> unique_buffers;
         std::ostringstream msg;
-        for (const VkBuffer &buffer : buffer_list) {
+        for (const VkBuffer& buffer : buffer_list) {
             msg << FormatHandle(buffer) << '\n';
             unique_buffers.insert(buffer);
         }
@@ -2902,8 +2901,8 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
 }
 
 bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout,
-                                                              VkDeviceSize *pLayoutSizeInBytes,
-                                                              const ErrorObject &error_obj) const {
+                                                              VkDeviceSize* pLayoutSizeInBytes,
+                                                              const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!enabled_features.descriptorBuffer) {
@@ -2938,8 +2937,8 @@ bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSizeEXT(VkDevice device, V
 }
 
 bool CoreChecks::PreCallValidateGetDescriptorSetLayoutBindingOffsetEXT(VkDevice device, VkDescriptorSetLayout layout,
-                                                                       uint32_t binding, VkDeviceSize *pOffset,
-                                                                       const ErrorObject &error_obj) const {
+                                                                       uint32_t binding, VkDeviceSize* pOffset,
+                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!enabled_features.descriptorBuffer) {
@@ -2974,8 +2973,8 @@ bool CoreChecks::PreCallValidateGetDescriptorSetLayoutBindingOffsetEXT(VkDevice 
 }
 
 bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice device,
-                                                                        const VkBufferCaptureDescriptorDataInfoEXT *pInfo,
-                                                                        void *pData, const ErrorObject &error_obj) const {
+                                                                        const VkBufferCaptureDescriptorDataInfoEXT* pInfo,
+                                                                        void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!enabled_features.descriptorBufferCaptureReplay) {
@@ -3004,8 +3003,8 @@ bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice
 }
 
 bool CoreChecks::PreCallValidateGetImageOpaqueCaptureDescriptorDataEXT(VkDevice device,
-                                                                       const VkImageCaptureDescriptorDataInfoEXT *pInfo,
-                                                                       void *pData, const ErrorObject &error_obj) const {
+                                                                       const VkImageCaptureDescriptorDataInfoEXT* pInfo,
+                                                                       void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!enabled_features.descriptorBufferCaptureReplay) {
@@ -3034,8 +3033,8 @@ bool CoreChecks::PreCallValidateGetImageOpaqueCaptureDescriptorDataEXT(VkDevice 
 }
 
 bool CoreChecks::PreCallValidateGetImageViewOpaqueCaptureDescriptorDataEXT(VkDevice device,
-                                                                           const VkImageViewCaptureDescriptorDataInfoEXT *pInfo,
-                                                                           void *pData, const ErrorObject &error_obj) const {
+                                                                           const VkImageViewCaptureDescriptorDataInfoEXT* pInfo,
+                                                                           void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!enabled_features.descriptorBufferCaptureReplay) {
@@ -3064,8 +3063,8 @@ bool CoreChecks::PreCallValidateGetImageViewOpaqueCaptureDescriptorDataEXT(VkDev
 }
 
 bool CoreChecks::PreCallValidateGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevice device,
-                                                                         const VkSamplerCaptureDescriptorDataInfoEXT *pInfo,
-                                                                         void *pData, const ErrorObject &error_obj) const {
+                                                                         const VkSamplerCaptureDescriptorDataInfoEXT* pInfo,
+                                                                         void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!enabled_features.descriptorBufferCaptureReplay) {
@@ -3094,8 +3093,8 @@ bool CoreChecks::PreCallValidateGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevic
 }
 
 bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorDataEXT(
-    VkDevice device, const VkAccelerationStructureCaptureDescriptorDataInfoEXT *pInfo, void *pData,
-    const ErrorObject &error_obj) const {
+    VkDevice device, const VkAccelerationStructureCaptureDescriptorDataInfoEXT* pInfo, void* pData,
+    const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!enabled_features.descriptorBufferCaptureReplay) {
@@ -3157,7 +3156,7 @@ bool CoreChecks::ValidateDescriptorAddressInfoEXT(const VkDescriptorAddressInfoE
 
     // Could be a VkBufferUsageFlagBits, but simpler for the string_VkBufferUsageFlags function to be used in the lambda
     VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_FLAG_BITS_MAX_ENUM;
-    const char *usage_vuid = nullptr;
+    const char* usage_vuid = nullptr;
     const char* limit_vuid = nullptr;
     Field limit_field = Field::Empty;
     VkDeviceSize limit_value = 0;
@@ -3240,8 +3239,8 @@ bool CoreChecks::ValidateDescriptorAddressInfoEXT(const VkDescriptorAddressInfoE
     return skip;
 }
 
-bool CoreChecks::ValidateDescriptorAddressInfoTexelBufferAlignment(const VkDescriptorAddressInfoEXT &address_info,
-                                                                   const Location &address_loc) const {
+bool CoreChecks::ValidateDescriptorAddressInfoTexelBufferAlignment(const VkDescriptorAddressInfoEXT& address_info,
+                                                                   const Location& address_loc) const {
     bool skip = false;
     VkDeviceSize texel_block_size = GetTexelBufferFormatSize(address_info.format);
     bool texel_size_of_three = false;
@@ -3308,8 +3307,8 @@ bool CoreChecks::ValidateDescriptorAddressInfoTexelBufferAlignment(const VkDescr
     return skip;
 }
 
-bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &descriptor_info, const size_t data_size,
-                                               const Location &descriptor_info_loc) const {
+bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT& descriptor_info, const size_t data_size,
+                                               const Location& descriptor_info_loc) const {
     bool skip = false;
 
     size_t size = 0u;
@@ -3383,7 +3382,7 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
             break;
     }
 
-    const VkDescriptorImageInfo *combined_image_sampler = descriptor_info.data.pCombinedImageSampler;
+    const VkDescriptorImageInfo* combined_image_sampler = descriptor_info.data.pCombinedImageSampler;
     if (descriptor_info.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER && combined_image_sampler) {
         if (combined_image_sampler->imageView == VK_NULL_HANDLE) {
             // Only hit if using nullDescriptor
@@ -3440,12 +3439,12 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT *pDescriptorInfo, size_t dataSize,
-                                                 void *pDescriptor, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT* pDescriptorInfo, size_t dataSize,
+                                                 void* pDescriptor, const ErrorObject& error_obj) const {
     bool skip = false;
 
     // update on first pass of switch case
-    const VkDescriptorAddressInfoEXT *address_info = nullptr;
+    const VkDescriptorAddressInfoEXT* address_info = nullptr;
     Field data_field = Field::Empty;
     const Location descriptor_info_loc = error_obj.location.dot(Field::pDescriptorInfo);
     switch (pDescriptorInfo->type) {
@@ -3569,11 +3568,12 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
                     const auto found_buffers = GetBuffersByAddress(as_address);
                     if (!found_buffers.empty()) {
                         ss << "\nThe follow buffers were found at this address:\n";
-                        for (const auto &buffer_state : found_buffers) {
+                        for (const auto& buffer_state : found_buffers) {
                             ss << "  " << buffer_state->Describe(*this) << "\n";
                         }
                     }
-                    skip |= LogError("VUID-VkDescriptorGetInfoEXT-type-08028", device, descriptor_info_loc.dot(Field::type), "%s", ss.str().c_str());
+                    skip |= LogError("VUID-VkDescriptorGetInfoEXT-type-08028", device, descriptor_info_loc.dot(Field::type), "%s",
+                                     ss.str().c_str());
                 }
             }
         } break;
@@ -3592,7 +3592,7 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
             }
             break;
         case VK_DESCRIPTOR_TYPE_TENSOR_ARM: {
-            const auto *tensor_struct = vku::FindStructInPNextChain<VkDescriptorGetTensorInfoARM>(pDescriptorInfo->pNext);
+            const auto* tensor_struct = vku::FindStructInPNextChain<VkDescriptorGetTensorInfoARM>(pDescriptorInfo->pNext);
             if (!tensor_struct) {
                 skip |= LogError("VUID-VkDescriptorGetInfoEXT-type-09701", device, descriptor_info_loc.dot(Field::type),
                                  "is VK_DESCRIPTOR_TYPE_TENSOR_ARM and pNext does not contain a valid "
@@ -3612,7 +3612,7 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
         const VkDeviceSize texels =
             SafeDivision(address_info->range, texel_block_size) * static_cast<VkDeviceSize>(texels_per_block);
         if (texels > static_cast<VkDeviceSize>(phys_dev_props.limits.maxTexelBufferElements)) {
-            const char *vuid = pDescriptorInfo->type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
+            const char* vuid = pDescriptorInfo->type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
                                    ? "VUID-VkDescriptorGetInfoEXT-type-09427"
                                    : "VUID-VkDescriptorGetInfoEXT-type-09428";
             skip |= LogError(vuid, device, data_loc.dot(data_field).dot(Field::range),
@@ -3713,7 +3713,7 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
 }
 
 bool CoreChecks::PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
-                                                    VkDescriptorPoolResetFlags flags, const ErrorObject &error_obj) const {
+                                                    VkDescriptorPoolResetFlags flags, const ErrorObject& error_obj) const {
     // Make sure sets being destroyed are not currently in-use
     if (disabled[object_in_use]) return false;
     bool skip = false;
@@ -3725,7 +3725,7 @@ bool CoreChecks::PreCallValidateResetDescriptorPool(VkDevice device, VkDescripto
 }
 
 bool CoreChecks::PreCallValidateDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
-                                                      const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
+                                                      const VkAllocationCallbacks* pAllocator, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto ds_pool_state = Get<vvl::DescriptorPool>(descriptorPool)) {
         skip |=
@@ -3737,16 +3737,16 @@ bool CoreChecks::PreCallValidateDestroyDescriptorPool(VkDevice device, VkDescrip
 // Ensure the pool contains enough descriptors and descriptor sets to satisfy
 // an allocation request. Fills common_data with the total number of descriptors of each type required,
 // as well as DescriptorSetLayout ptrs used for later update.
-bool CoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                                       VkDescriptorSet *pDescriptorSets, const ErrorObject &error_obj,
-                                                       vvl::AllocateDescriptorSetsData &ds_data) const {
+bool CoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                                       VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj,
+                                                       vvl::AllocateDescriptorSetsData& ds_data) const {
     bool skip = false;
     auto ds_pool_state = Get<vvl::DescriptorPool>(pAllocateInfo->descriptorPool);
     ASSERT_AND_RETURN_SKIP(ds_pool_state);
 
     const Location allocate_info_loc = error_obj.location.dot(Field::pAllocateInfo);
 
-    const auto *count_allocate_info =
+    const auto* count_allocate_info =
         vku::FindStructInPNextChain<VkDescriptorSetVariableDescriptorCountAllocateInfo>(pAllocateInfo->pNext);
     if (count_allocate_info && count_allocate_info->descriptorSetCount != 0 &&
         count_allocate_info->descriptorSetCount != pAllocateInfo->descriptorSetCount) {
@@ -3927,7 +3927,7 @@ bool CoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const Vk
 // func_str is the name of the calling function
 // Return false if no errors occur
 // Return true if validation error occurs and callback returns true (to skip upcoming API call down the chain)
-bool CoreChecks::ValidateIdleDescriptorSet(VkDescriptorSet set, const Location &loc) const {
+bool CoreChecks::ValidateIdleDescriptorSet(VkDescriptorSet set, const Location& loc) const {
     if (disabled[object_in_use]) return false;
     bool skip = false;
     if (auto set_node = Get<vvl::DescriptorSet>(set)) {
@@ -3937,7 +3937,7 @@ bool CoreChecks::ValidateIdleDescriptorSet(VkDescriptorSet set, const Location &
 }
 
 bool CoreChecks::PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
-                                                   const VkDescriptorSet *pDescriptorSets, const ErrorObject &error_obj) const {
+                                                   const VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj) const {
     // Make sure that no sets being destroyed are in-flight
     bool skip = false;
     // First make sure sets being destroyed are not currently in-use
@@ -3958,9 +3958,9 @@ bool CoreChecks::PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptor
 }
 
 bool CoreChecks::PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
-                                                     const VkWriteDescriptorSet *pDescriptorWrites, uint32_t descriptorCopyCount,
-                                                     const VkCopyDescriptorSet *pDescriptorCopies,
-                                                     const ErrorObject &error_obj) const {
+                                                     const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
+                                                     const VkCopyDescriptorSet* pDescriptorCopies,
+                                                     const ErrorObject& error_obj) const {
     // First thing to do is perform map look-ups.
     // NOTE : UpdateDescriptorSets is somewhat unique in that it's operating on a number of DescriptorSets
     //  so we can't just do a single map look-up up-front, but do them individually in functions below
@@ -3972,14 +3972,14 @@ bool CoreChecks::PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t d
                                         error_obj.location);
 }
 
-bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state, VkPipelineLayout layout, uint32_t set,
-                                              uint32_t descriptorWriteCount, const VkWriteDescriptorSet *pDescriptorWrites,
-                                              const Location &loc) const {
+bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer& cb_state, VkPipelineLayout layout, uint32_t set,
+                                              uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites,
+                                              const Location& loc) const {
     bool skip = false;
     const bool is_2 = loc.function != Func::vkCmdPushDescriptorSetKHR && loc.function != Func::vkCmdPushDescriptorSet;
 
     if (!IsExtEnabledByCreateinfo(extensions.vk_khr_push_descriptor) && !enabled_features.pushDescriptor) {
-        const char *vuid = is_2 ? "VUID-vkCmdPushDescriptorSet2-None-10357" : "VUID-vkCmdPushDescriptorSet-None-10356";
+        const char* vuid = is_2 ? "VUID-vkCmdPushDescriptorSet2-None-10357" : "VUID-vkCmdPushDescriptorSet-None-10356";
         skip |= LogError(vuid, cb_state.Handle(), loc,
                          "was called but the VK_KHR_push_descriptor extension nor VkPhysicalDeviceVulkan14Features::pushDescriptor "
                          "feature was enabled");
@@ -3991,9 +3991,9 @@ bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state
     }
 
     // Validate the set index points to a push descriptor set and is in range
-    const auto &set_layouts = pipeline_layout->set_layouts;
+    const auto& set_layouts = pipeline_layout->set_layouts;
     if (set >= set_layouts.list.size()) {
-        const char *vuid = is_2 ? "VUID-VkPushDescriptorSetInfo-set-00364" : "VUID-vkCmdPushDescriptorSet-set-00364";
+        const char* vuid = is_2 ? "VUID-VkPushDescriptorSetInfo-set-00364" : "VUID-vkCmdPushDescriptorSet-set-00364";
         const LogObjectList objlist(cb_state.Handle(), layout);
         skip |= LogError(vuid, objlist, loc.dot(Field::set),
                          "(%" PRIu32 ") is indexing outside the range for %s (which had a setLayoutCount of only %" PRIu32 ").",
@@ -4001,11 +4001,11 @@ bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state
         return skip;
     }
 
-    const auto &dsl = set_layouts.list[set];
+    const auto& dsl = set_layouts.list[set];
     ASSERT_AND_RETURN_SKIP(dsl);
 
     if (!dsl->IsPushDescriptor()) {
-        const char *vuid = is_2 ? "VUID-VkPushDescriptorSetInfo-set-00365" : "VUID-vkCmdPushDescriptorSet-set-00365";
+        const char* vuid = is_2 ? "VUID-VkPushDescriptorSetInfo-set-00365" : "VUID-vkCmdPushDescriptorSet-set-00365";
         const LogObjectList objlist(cb_state.Handle(), layout);
         skip |= LogError(vuid, objlist, loc.dot(Field::set),
                          "(%" PRIu32
@@ -4017,7 +4017,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state
         // TODO move the validation (like this) that doesn't need descriptor set state to the DSL object so we
         // don't have to do this. Note we need to const_cast<>(this) because GPU-AV needs a non-const version of
         // the state tracker. The proxy here could get away with const.
-        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<vvl::DeviceState *>(device_state));
+        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<vvl::DeviceState*>(device_state));
         vvl::DslErrorSource dsl_error_source(loc, layout, set);
         skip |= ValidatePushDescriptorsUpdate(proxy_ds, descriptorWriteCount, pDescriptorWrites, dsl_error_source, loc);
     }
@@ -4029,8 +4029,8 @@ bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSet(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                      VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                                     const VkWriteDescriptorSet *pDescriptorWrites,
-                                                     const ErrorObject &error_obj) const {
+                                                     const VkWriteDescriptorSet* pDescriptorWrites,
+                                                     const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -4041,15 +4041,15 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSet(VkCommandBuffer commandBuff
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                         VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                                        const VkWriteDescriptorSet *pDescriptorWrites,
-                                                        const ErrorObject &error_obj) const {
+                                                        const VkWriteDescriptorSet* pDescriptorWrites,
+                                                        const ErrorObject& error_obj) const {
     return PreCallValidateCmdPushDescriptorSet(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount,
                                                pDescriptorWrites, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSet2(VkCommandBuffer commandBuffer,
-                                                      const VkPushDescriptorSetInfo *pPushDescriptorSetInfo,
-                                                      const ErrorObject &error_obj) const {
+                                                      const VkPushDescriptorSetInfo* pPushDescriptorSetInfo,
+                                                      const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -4072,16 +4072,16 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSet2(VkCommandBuffer commandBuf
 }
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
-                                                         const VkPushDescriptorSetInfoKHR *pPushDescriptorSetInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo,
+                                                         const ErrorObject& error_obj) const {
     return PreCallValidateCmdPushDescriptorSet2(commandBuffer, pPushDescriptorSetInfo, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device,
-                                                               const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                               const VkAllocationCallbacks *pAllocator,
-                                                               VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                               const ErrorObject &error_obj) const {
+                                                               const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                               const VkAllocationCallbacks* pAllocator,
+                                                               VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                               const ErrorObject& error_obj) const {
     bool skip = false;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     auto ds_layout_state = Get<vvl::DescriptorSetLayout>(pCreateInfo->descriptorSetLayout);
@@ -4122,7 +4122,7 @@ bool CoreChecks::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device,
             }
         }
     } else if (ds_layout_state && (VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET == pCreateInfo->templateType)) {
-        for (const auto &binding : ds_layout_state->GetBindings()) {
+        for (const auto& binding : ds_layout_state->GetBindings()) {
             if (binding.descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
                 skip |= LogError(
                     "VUID-VkDescriptorUpdateTemplateCreateInfo-templateType-04615", device,
@@ -4133,7 +4133,7 @@ bool CoreChecks::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device,
         }
     }
     for (uint32_t i = 0; i < pCreateInfo->descriptorUpdateEntryCount; ++i) {
-        const auto &descriptor_update = pCreateInfo->pDescriptorUpdateEntries[i];
+        const auto& descriptor_update = pCreateInfo->pDescriptorUpdateEntries[i];
         if (descriptor_update.descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) {
             if (!IsIntegerMultipleOf(descriptor_update.dstArrayElement, 4)) {
                 skip |= LogError("VUID-VkDescriptorUpdateTemplateEntry-descriptor-02226", pCreateInfo->pipelineLayout,
@@ -4155,16 +4155,16 @@ bool CoreChecks::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device,
 }
 
 bool CoreChecks::PreCallValidateCreateDescriptorUpdateTemplateKHR(VkDevice device,
-                                                                  const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                                  const VkAllocationCallbacks *pAllocator,
-                                                                  VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                                  const ErrorObject &error_obj) const {
+                                                                  const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                                  const ErrorObject& error_obj) const {
     return PreCallValidateCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, error_obj);
 }
 
 bool CoreChecks::PreCallValidateUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
                                                                 VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                const void *pData, const ErrorObject &error_obj) const {
+                                                                const void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
     auto template_state = Get<vvl::DescriptorUpdateTemplate>(descriptorUpdateTemplate);
     // Object tracker will report errors for invalid descriptorUpdateTemplate values, avoiding a crash in release builds
@@ -4185,14 +4185,14 @@ bool CoreChecks::PreCallValidateUpdateDescriptorSetWithTemplate(VkDevice device,
 
 bool CoreChecks::PreCallValidateUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
                                                                    VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                   const void *pData, const ErrorObject &error_obj) const {
+                                                                   const void* pData, const ErrorObject& error_obj) const {
     return PreCallValidateUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, error_obj);
 }
 
 bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer commandBuffer,
                                                           VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                          VkPipelineLayout layout, uint32_t set, const void *pData,
-                                                          const Location &loc) const {
+                                                          VkPipelineLayout layout, uint32_t set, const void* pData,
+                                                          const Location& loc) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, loc);
@@ -4201,7 +4201,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
         loc.function != Func::vkCmdPushDescriptorSetWithTemplateKHR && loc.function != Func::vkCmdPushDescriptorSetWithTemplate;
 
     if (!IsExtEnabledByCreateinfo(extensions.vk_khr_push_descriptor) && !enabled_features.pushDescriptor) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-None-10359" : "VUID-vkCmdPushDescriptorSetWithTemplate-None-10358";
         skip |= LogError(vuid, commandBuffer, loc,
                          "was called but the VK_KHR_push_descriptor extension nor VkPhysicalDeviceVulkan14Features::pushDescriptor "
@@ -4213,9 +4213,9 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
         return skip;  // dynamicPipelineLayout
     }
 
-    const auto &set_layouts = pipeline_layout->set_layouts;
+    const auto& set_layouts = pipeline_layout->set_layouts;
     if (set >= set_layouts.list.size()) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-set-07304" : "VUID-vkCmdPushDescriptorSetWithTemplate-set-07304";
         const LogObjectList objlist(commandBuffer, layout);
         skip |= LogError(vuid, objlist, loc.dot(Field::set),
@@ -4224,11 +4224,11 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
         return skip;
     }
 
-    const auto &dsl = set_layouts.list[set];
+    const auto& dsl = set_layouts.list[set];
     ASSERT_AND_RETURN_SKIP(dsl);
 
     if (!dsl->IsPushDescriptor()) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-set-07305" : "VUID-vkCmdPushDescriptorSetWithTemplate-set-07305";
         const LogObjectList objlist(commandBuffer, layout);
         skip |= LogError(vuid, objlist, loc.dot(Field::set),
@@ -4242,20 +4242,20 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
     if (!template_state) {
         return skip;
     }
-    const auto &template_ci = template_state->create_info;
+    const auto& template_ci = template_state->create_info;
 
     skip |= ValidatePipelineBindPoint(*cb_state, template_ci.pipelineBindPoint, loc);
     skip |= ValidateInheritanceDescriptorHeapInfo(*cb_state, loc);
 
     if (template_ci.templateType != VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS) {
-        const char *vuid = is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-descriptorUpdateTemplate-07994"
+        const char* vuid = is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-descriptorUpdateTemplate-07994"
                                 : "VUID-vkCmdPushDescriptorSetWithTemplate-descriptorUpdateTemplate-07994";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::descriptorUpdateTemplate),
                          "(%s) was not created with VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS.",
                          FormatHandle(descriptorUpdateTemplate).c_str());
     }
     if (template_ci.set != set) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-set-07995" : "VUID-vkCmdPushDescriptorSetWithTemplate-set-07995";
         skip |=
             LogError(vuid, commandBuffer, loc.dot(Field::set),
@@ -4265,7 +4265,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
     auto template_layout = Get<vvl::PipelineLayout>(template_ci.pipelineLayout);
     if (!IsPipelineLayoutSetCompatible(set, pipeline_layout.get(), template_layout.get())) {
         const LogObjectList objlist(commandBuffer, descriptorUpdateTemplate, template_ci.pipelineLayout, layout);
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-layout-07993" : "VUID-vkCmdPushDescriptorSetWithTemplate-layout-07993";
         skip |= LogError(vuid, objlist, loc.dot(Field::descriptorUpdateTemplate),
                          "%s created with %s is incompatible "
@@ -4279,12 +4279,12 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
     if (!pData) {
         // Seems there is a VUID-VkPushDescriptorSetWithTemplateInfo-pData-parameter generated, but not for
         // vkCmdPushDescriptorSetWithTemplate
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-pData-01686" : "VUID-vkCmdPushDescriptorSetWithTemplate-pData-01686";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::pData), "is NULL.");
     } else if (!Get<vvl::DescriptorSetLayout>(dsl->VkHandle())) {
         const LogObjectList objlist(commandBuffer, descriptorUpdateTemplate, layout);
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-VkPushDescriptorSetWithTemplateInfo-set-11854" : "VUID-vkCmdPushDescriptorSetWithTemplate-set-11854";
         skip |= LogError(vuid, objlist, loc.dot(Field::set),
                          "(%" PRIu32
@@ -4293,7 +4293,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
                          set);
     } else {
         // Create an empty proxy in order to use the existing descriptor set update validation
-        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<vvl::DeviceState *>(device_state));
+        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<vvl::DeviceState*>(device_state));
         // Decode the template into a set of write updates
         vvl::DecodedTemplateUpdate decoded_template(*device_state, VK_NULL_HANDLE, *template_state, pData, dsl->VkHandle());
         // Validate the decoded update against the proxy_ds
@@ -4307,22 +4307,22 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer commandBuffer,
                                                                  VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                 VkPipelineLayout layout, uint32_t set, const void *pData,
-                                                                 const ErrorObject &error_obj) const {
+                                                                 VkPipelineLayout layout, uint32_t set, const void* pData,
+                                                                 const ErrorObject& error_obj) const {
     return ValidateCmdPushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, layout, set, pData,
                                                     error_obj.location);
 }
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
                                                                     VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                    VkPipelineLayout layout, uint32_t set, const void *pData,
-                                                                    const ErrorObject &error_obj) const {
+                                                                    VkPipelineLayout layout, uint32_t set, const void* pData,
+                                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCmdPushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, layout, set, pData, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplate2(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfo *pPushDescriptorSetWithTemplateInfo,
-    const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfo* pPushDescriptorSetWithTemplateInfo,
+    const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateCmdPushDescriptorSetWithTemplate(
         commandBuffer, pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate, pPushDescriptorSetWithTemplateInfo->layout,
@@ -4332,8 +4332,8 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplate2(
 }
 
 bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplate2KHR(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR *pPushDescriptorSetWithTemplateInfo,
-    const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo,
+    const ErrorObject& error_obj) const {
     return PreCallValidateCmdPushDescriptorSetWithTemplate2(commandBuffer, pPushDescriptorSetWithTemplateInfo, error_obj);
 }
 
@@ -4354,7 +4354,7 @@ enum DSL_DESCRIPTOR_GROUPS {
 // Returns an array of size DSL_NUM_DESCRIPTOR_GROUPS of the maximum number of descriptors used in any single pipeline stage
 // Use 64-bit because lots of limts are really just UINT32_MAX and need to catch them
 static std::valarray<uint64_t> GetDescriptorCountMaxPerStage(
-    const DeviceFeatures *enabled_features, const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>> &set_layouts,
+    const DeviceFeatures* enabled_features, const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>>& set_layouts,
     bool skip_update_after_bind) {
     // Identify active pipeline stages
     std::vector<VkShaderStageFlags> stage_flags = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -4394,7 +4394,7 @@ static std::valarray<uint64_t> GetDescriptorCountMaxPerStage(
     std::valarray<uint64_t> max_sum(init_value, val_array_size);  // max descriptor sum among all pipeline stages
     for (auto stage : stage_flags) {
         std::valarray<uint64_t> stage_sum(init_value, val_array_size);  // per-stage sums
-        for (const auto &dsl : set_layouts) {
+        for (const auto& dsl : set_layouts) {
             if (!dsl) {
                 continue;
             }
@@ -4403,7 +4403,7 @@ static std::valarray<uint64_t> GetDescriptorCountMaxPerStage(
             }
 
             for (uint32_t binding_idx = 0; binding_idx < dsl->GetBindingCount(); binding_idx++) {
-                const VkDescriptorSetLayoutBinding *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
+                const VkDescriptorSetLayoutBinding* binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
                 // Bindings with a descriptorCount of 0 are "reserved" and should be skipped
                 if (0 != (stage & binding->stageFlags) && binding->descriptorCount > 0) {
                     switch (binding->descriptorType) {
@@ -4463,9 +4463,9 @@ static std::valarray<uint64_t> GetDescriptorCountMaxPerStage(
 // Note: descriptors only count against the limit once even if used by multiple stages.
 // Use 64-bit because lots of limts are really just UINT32_MAX and need to catch them
 static std::map<uint32_t, uint64_t> GetDescriptorSum(
-    const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>> &set_layouts, bool skip_update_after_bind) {
+    const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>>& set_layouts, bool skip_update_after_bind) {
     std::map<uint32_t, uint64_t> sum_by_type;
-    for (const auto &dsl : set_layouts) {
+    for (const auto& dsl : set_layouts) {
         if (!dsl) {
             continue;
         }
@@ -4474,7 +4474,7 @@ static std::map<uint32_t, uint64_t> GetDescriptorSum(
         }
 
         for (uint32_t binding_idx = 0; binding_idx < dsl->GetBindingCount(); binding_idx++) {
-            const VkDescriptorSetLayoutBinding *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
+            const VkDescriptorSetLayoutBinding* binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
             // Bindings with a descriptorCount of 0 are "reserved" and should be skipped
             if (binding->descriptorCount > 0) {
                 sum_by_type[binding->descriptorType] += binding->descriptorCount;
@@ -4484,10 +4484,10 @@ static std::map<uint32_t, uint64_t> GetDescriptorSum(
     return sum_by_type;
 }
 
-uint64_t GetInlineUniformBlockBindingCount(const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>> &set_layouts,
+uint64_t GetInlineUniformBlockBindingCount(const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>>& set_layouts,
                                            bool skip_update_after_bind) {
     uint64_t sum = 0;
-    for (const auto &dsl : set_layouts) {
+    for (const auto& dsl : set_layouts) {
         if (!dsl) {
             continue;
         }
@@ -4496,7 +4496,7 @@ uint64_t GetInlineUniformBlockBindingCount(const std::vector<std::shared_ptr<vvl
         }
 
         for (uint32_t binding_idx = 0; binding_idx < dsl->GetBindingCount(); binding_idx++) {
-            const VkDescriptorSetLayoutBinding *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
+            const VkDescriptorSetLayoutBinding* binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
             // Bindings with a descriptorCount of 0 are "reserved" and should be skipped
             if (binding->descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK && binding->descriptorCount > 0) {
                 ++sum;
@@ -4506,9 +4506,9 @@ uint64_t GetInlineUniformBlockBindingCount(const std::vector<std::shared_ptr<vvl
     return sum;
 }
 
-bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
+                                                     const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -5062,14 +5062,14 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
     // Extension exposes new properties limits
     if (IsExtEnabled(extensions.vk_ext_fragment_density_map2)) {
         uint32_t sum_subsampled_samplers = 0;
-        for (const auto &dsl : set_layouts) {
+        for (const auto& dsl : set_layouts) {
             // find the number of subsampled samplers across all stages
             // NOTE: this does not use the GetDescriptorSum patter because it needs the Get<vvl::Sampler> method
             if ((dsl->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT)) {
                 continue;
             }
             for (uint32_t binding_idx = 0; binding_idx < dsl->GetBindingCount(); binding_idx++) {
-                const VkDescriptorSetLayoutBinding *binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
+                const VkDescriptorSetLayoutBinding* binding = dsl->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
 
                 // Bindings with a descriptorCount of 0 are "reserved" and should be skipped
                 if (binding->descriptorCount == 0) {
@@ -5113,7 +5113,7 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 }
 
 bool CoreChecks::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags,
-                                          uint32_t offset, uint32_t size, const Location &loc) const {
+                                          uint32_t offset, uint32_t size, const Location& loc) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, loc);
@@ -5127,13 +5127,13 @@ bool CoreChecks::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipel
     }
 
     const bool is_2 = loc.function != Func::vkCmdPushConstants;
-    const auto &ranges = *layout_state->push_constant_ranges_layout;
+    const auto& ranges = *layout_state->push_constant_ranges_layout;
     VkShaderStageFlags found_stages = 0;
-    for (const auto &range : ranges) {
+    for (const auto& range : ranges) {
         if ((offset >= range.offset) && (offset + size <= range.offset + range.size)) {
             VkShaderStageFlags matching_stages = range.stageFlags & stageFlags;
             if (matching_stages != range.stageFlags) {
-                const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-01796" : "VUID-vkCmdPushConstants-offset-01796";
+                const char* vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-01796" : "VUID-vkCmdPushConstants-offset-01796";
                 skip |=
                     LogError(vuid, commandBuffer, loc,
                              "is called with\n  stageFlags (%s), offset (%" PRIu32 "), size (%" PRIu32
@@ -5167,20 +5167,20 @@ bool CoreChecks::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipel
             // may have case where trying to set Vertex|Fragment and only one stage is valid
         }
         ss << "\n";
-        const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-01795" : "VUID-vkCmdPushConstants-offset-01795";
+        const char* vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-01795" : "VUID-vkCmdPushConstants-offset-01795";
         skip |= LogError(vuid, commandBuffer, loc, "%s", ss.str().c_str());
     }
     return skip;
 }
 
 bool CoreChecks::PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
-                                                 VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void *pValues,
-                                                 const ErrorObject &error_obj) const {
+                                                 VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues,
+                                                 const ErrorObject& error_obj) const {
     return ValidateCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo *pPushConstantsInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo* pPushConstantsInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateCmdPushConstants(commandBuffer, pPushConstantsInfo->layout, pPushConstantsInfo->stageFlags,
                                      pPushConstantsInfo->offset, pPushConstantsInfo->size,
@@ -5190,16 +5190,16 @@ bool CoreChecks::PreCallValidateCmdPushConstants2(VkCommandBuffer commandBuffer,
 }
 
 bool CoreChecks::PreCallValidateCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
-                                                     const VkPushConstantsInfoKHR *pPushConstantsInfo,
-                                                     const ErrorObject &error_obj) const {
+                                                     const VkPushConstantsInfoKHR* pPushConstantsInfo,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCmdPushConstants2(commandBuffer, pPushConstantsInfo, error_obj);
 }
 
-bool CoreChecks::ValidateSamplerCreateInfo(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const {
+bool CoreChecks::ValidateSamplerCreateInfo(const VkSamplerCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
     if (enabled_features.samplerYcbcrConversion == VK_TRUE) {
-        if (const auto *conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(create_info.pNext)) {
+        if (const auto* conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(create_info.pNext)) {
             const VkSamplerYcbcrConversion sampler_ycbcr_conversion = conversion_info->conversion;
             auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(sampler_ycbcr_conversion);
             if (ycbcr_state && (ycbcr_state->format_features &
@@ -5250,9 +5250,9 @@ bool CoreChecks::ValidateSamplerCreateInfo(const VkSamplerCreateInfo &create_inf
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
-                                              const VkAllocationCallbacks *pAllocator, VkSampler *pSampler,
-                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                              const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidateDeviceQueueSupport(error_obj.location);
@@ -5513,10 +5513,9 @@ bool CoreChecks::PreCallValidateWriteResourceDescriptorsEXT(VkDevice device, uin
             } else if (resource.type == VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV) {
                 // PTLAS uses buffer addresses directly, not VkAccelerationStructureKHR objects
                 // Validate that the address points to a buffer with ACCELERATION_STRUCTURE_STORAGE_BIT
-                skip |= ValidateDeviceAddressRange(address_range.address, address_range.size, false,
-                                                   data_loc.dot(Field::pAddressRange), LogObjectList(device),
-                                                   VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
-                                                   "VUID-VkResourceDescriptorInfoEXT-type-11483");
+                skip |= ValidateDeviceAddressRange(
+                    address_range.address, address_range.size, false, data_loc.dot(Field::pAddressRange), LogObjectList(device),
+                    VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR, "VUID-VkResourceDescriptorInfoEXT-type-11483");
             } else if (resource.type == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV) {
                 if (address_range.size != 0) {
                     skip |= LogError("VUID-VkResourceDescriptorInfoEXT-type-11468", device,

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -41,7 +41,7 @@
 #include "utils/spirv_tools_utils.h"
 #include "containers/container_utils.h"
 
-bool CoreChecks::ValidateDeviceQueueFamily(uint32_t queue_family, const Location &loc, const char *vuid,
+bool CoreChecks::ValidateDeviceQueueFamily(uint32_t queue_family, const Location& loc, const char* vuid,
                                            bool optional = false) const {
     bool skip = false;
     if (!optional && queue_family == VK_QUEUE_FAMILY_IGNORED) {
@@ -59,8 +59,8 @@ bool CoreChecks::ValidateDeviceQueueFamily(uint32_t queue_family, const Location
 }
 
 // Validate the specified queue families against the families supported by the physical device that owns this device
-bool CoreChecks::ValidatePhysicalDeviceQueueFamilies(uint32_t queue_family_count, const uint32_t *queue_families,
-                                                     const Location &loc, const char *vuid) const {
+bool CoreChecks::ValidatePhysicalDeviceQueueFamilies(uint32_t queue_family_count, const uint32_t* queue_families,
+                                                     const Location& loc, const char* vuid) const {
     bool skip = false;
     if (queue_families) {
         vvl::unordered_set<uint32_t> set;
@@ -87,8 +87,8 @@ bool CoreChecks::ValidatePhysicalDeviceQueueFamilies(uint32_t queue_family_count
     return skip;
 }
 
-bool CoreChecks::GetPhysicalDeviceImageFormatProperties(vvl::Image &image_state, const char *vuid_string,
-                                                        const Location &loc) const {
+bool CoreChecks::GetPhysicalDeviceImageFormatProperties(vvl::Image& image_state, const char* vuid_string,
+                                                        const Location& loc) const {
     bool skip = false;
     const auto image_create_info = image_state.create_info;
     VkResult image_properties_result = VK_SUCCESS;
@@ -121,8 +121,8 @@ bool CoreChecks::GetPhysicalDeviceImageFormatProperties(vvl::Image &image_state,
     return skip;
 }
 
-bool CoreChecks::ValidateDeviceMaskToPhysicalDeviceCount(uint32_t deviceMask, const LogObjectList &objlist, const Location &loc,
-                                                         const char *vuid) const {
+bool CoreChecks::ValidateDeviceMaskToPhysicalDeviceCount(uint32_t deviceMask, const LogObjectList& objlist, const Location& loc,
+                                                         const char* vuid) const {
     bool skip = false;
     uint32_t count = 1 << device_state->physical_device_count;
     if (count <= deviceMask) {
@@ -132,8 +132,8 @@ bool CoreChecks::ValidateDeviceMaskToPhysicalDeviceCount(uint32_t deviceMask, co
     return skip;
 }
 
-bool CoreChecks::ValidateDeviceMaskToZero(uint32_t deviceMask, const LogObjectList &objlist, const Location &loc,
-                                          const char *vuid) const {
+bool CoreChecks::ValidateDeviceMaskToZero(uint32_t deviceMask, const LogObjectList& objlist, const Location& loc,
+                                          const char* vuid) const {
     bool skip = false;
     if (deviceMask == 0) {
         skip |= LogError(vuid, objlist, loc, "is zero.");
@@ -141,8 +141,8 @@ bool CoreChecks::ValidateDeviceMaskToZero(uint32_t deviceMask, const LogObjectLi
     return skip;
 }
 
-bool CoreChecks::ValidateDeviceMaskToCommandBuffer(const vvl::CommandBuffer &cb_state, uint32_t deviceMask,
-                                                   const LogObjectList &objlist, const Location &loc, const char *vuid) const {
+bool CoreChecks::ValidateDeviceMaskToCommandBuffer(const vvl::CommandBuffer& cb_state, uint32_t deviceMask,
+                                                   const LogObjectList& objlist, const Location& loc, const char* vuid) const {
     bool skip = false;
     if ((deviceMask & cb_state.initial_device_mask) != deviceMask) {
         skip |= LogError(vuid, objlist, loc, "(0x%" PRIx32 ") is not a subset of %s initial device mask (0x%" PRIx32 ").",
@@ -151,8 +151,8 @@ bool CoreChecks::ValidateDeviceMaskToCommandBuffer(const vvl::CommandBuffer &cb_
     return skip;
 }
 
-bool CoreChecks::ValidateDeviceMaskToRenderPass(const vvl::CommandBuffer &cb_state, uint32_t deviceMask, const Location &loc,
-                                                const char *vuid) const {
+bool CoreChecks::ValidateDeviceMaskToRenderPass(const vvl::CommandBuffer& cb_state, uint32_t deviceMask, const Location& loc,
+                                                const char* vuid) const {
     bool skip = false;
     if (cb_state.active_render_pass && ((deviceMask & cb_state.render_pass_device_mask) != deviceMask)) {
         skip |= LogError(vuid, cb_state.Handle(), loc, "(0x%" PRIx32 ") is not a subset of %s device mask (0x%" PRIx32 ").",
@@ -161,12 +161,12 @@ bool CoreChecks::ValidateDeviceMaskToRenderPass(const vvl::CommandBuffer &cb_sta
     return skip;
 }
 
-bool core::Instance::ValidateQueueFamilyIndex(const vvl::PhysicalDevice &pd_state, uint32_t requested_queue_family,
-                                              const char *vuid, const Location &loc) const {
+bool core::Instance::ValidateQueueFamilyIndex(const vvl::PhysicalDevice& pd_state, uint32_t requested_queue_family,
+                                              const char* vuid, const Location& loc) const {
     bool skip = false;
 
     if (requested_queue_family >= pd_state.queue_family_known_count) {
-        const char *conditional_ext_cmd =
+        const char* conditional_ext_cmd =
             extensions.vk_khr_get_physical_device_properties2 ? " or vkGetPhysicalDeviceQueueFamilyProperties2[KHR]" : "";
 
         skip |= LogError(vuid, pd_state.Handle(), loc,
@@ -213,7 +213,7 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice& p
         }
 
         VkQueueGlobalPriority global_priority = VK_QUEUE_GLOBAL_PRIORITY_MEDIUM;  // Implicit default value
-        const auto *global_priority_ci = vku::FindStructInPNextChain<VkDeviceQueueGlobalPriorityCreateInfo>(infos[i].pNext);
+        const auto* global_priority_ci = vku::FindStructInPNextChain<VkDeviceQueueGlobalPriorityCreateInfo>(infos[i].pNext);
         if (global_priority_ci) {
             global_priority = global_priority_ci->globalPriority;
         }
@@ -260,7 +260,7 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice& p
             const uint32_t available_queue_count = queue_family_has_props ? requested_queue_family_props.queueCount : 1;
 
             if (requested_queue_count > available_queue_count) {
-                const char *conditional_ext_cmd =
+                const char* conditional_ext_cmd =
                     extensions.vk_khr_get_physical_device_properties2 ? " or vkGetPhysicalDeviceQueueFamilyProperties2[KHR]" : "";
                 const std::string count_note =
                     queue_family_has_props
@@ -293,9 +293,9 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice& p
     return skip;
 }
 
-bool core::Instance::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                                 const ErrorObject &error_obj) const {
+bool core::Instance::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     // TODO: object_tracker should perhaps do this instead
     //       and it does not seem to currently work anyway -- the loader just crashes before this point
@@ -318,7 +318,7 @@ bool core::Instance::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkD
     return skip;
 }
 
-void CoreChecks::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void CoreChecks::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) {
     BaseClass::FinishDeviceSetup(pCreateInfo, loc);
 
     spirv_environment = PickSpirvEnv(api_version, IsExtEnabled(extensions.vk_khr_spirv_1_4));
@@ -353,8 +353,8 @@ void CoreChecks::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const 
     }
 }
 
-void CoreChecks::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
-                                            const RecordObject &record_obj) {
+void CoreChecks::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
+                                            const RecordObject& record_obj) {
     if (!device) return;
 
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
@@ -362,11 +362,11 @@ void CoreChecks::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationC
     if (core_validation_cache) {
         Location loc(Func::vkDestroyDevice);
         size_t validation_cache_size = 0;
-        void *validation_cache_data = nullptr;
+        void* validation_cache_data = nullptr;
 
         CoreLayerGetValidationCacheDataEXT(device, core_validation_cache, &validation_cache_size, nullptr);
 
-        validation_cache_data = (char *)malloc(sizeof(char) * validation_cache_size);
+        validation_cache_data = (char*)malloc(sizeof(char) * validation_cache_size);
         if (!validation_cache_data) {
             LogInfo("WARNING-cache-memory-error", device, loc, "Validation Cache Memory Error");
             return;
@@ -384,7 +384,7 @@ void CoreChecks::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationC
         if (validation_cache_path.size() > 0) {
             std::ofstream write_file(validation_cache_path.c_str(), std::ios::out | std::ios::binary);
             if (write_file) {
-                write_file.write(static_cast<char *>(validation_cache_data), validation_cache_size);
+                write_file.write(static_cast<char*>(validation_cache_data), validation_cache_size);
                 write_file.close();
             } else {
                 LogInfo("WARNING-cache-write-error", device, loc, "Cannot open shader validation cache at %s for writing",
@@ -396,8 +396,8 @@ void CoreChecks::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationC
     }
 }
 
-bool CoreChecks::PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue *pQueue,
-                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidateDeviceQueueFamily(queueFamilyIndex, error_obj.location.dot(Field::queueFamilyIndex),
@@ -429,8 +429,8 @@ bool CoreChecks::PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFa
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2 *pQueueInfo, VkQueue *pQueue,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue,
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (pQueueInfo) {
@@ -478,11 +478,11 @@ bool CoreChecks::PreCallValidateGetDeviceQueue2(VkDevice device, const VkDeviceQ
 }
 
 bool core::Instance::ValidateGetPhysicalDeviceImageFormatProperties2(VkPhysicalDevice gpu,
-                                                                     const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
-                                                                     VkImageFormatProperties2 *pImageFormatProperties,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+                                                                     VkImageFormatProperties2* pImageFormatProperties,
+                                                                     const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto *copy_perf_query = vku::FindStructInPNextChain<VkHostImageCopyDevicePerformanceQuery>(pImageFormatProperties->pNext);
+    const auto* copy_perf_query = vku::FindStructInPNextChain<VkHostImageCopyDevicePerformanceQuery>(pImageFormatProperties->pNext);
     if (copy_perf_query) {
         if ((pImageFormatInfo->usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT) == 0) {
             skip |= LogError("VUID-vkGetPhysicalDeviceImageFormatProperties2-pNext-09004", gpu, error_obj.location,
@@ -496,8 +496,8 @@ bool core::Instance::ValidateGetPhysicalDeviceImageFormatProperties2(VkPhysicalD
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceImageFormatProperties2(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
-    VkImageFormatProperties2 *pImageFormatProperties, const ErrorObject &error_obj) const {
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties, const ErrorObject& error_obj) const {
     // Can't wrap AHB-specific validation in a device extension check here, but no harm
     bool skip = false;
     skip |=
@@ -507,8 +507,8 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceImageFormatProperties2(
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceImageFormatProperties2KHR(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
-    VkImageFormatProperties2 *pImageFormatProperties, const ErrorObject &error_obj) const {
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties, const ErrorObject& error_obj) const {
     return PreCallValidateGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties,
                                                                   error_obj);
 }
@@ -533,32 +533,32 @@ VkFormatProperties3 CoreChecks::GetPDFormatProperties(const VkFormat format) con
     return fmt_props_3;
 }
 
-VkResult CoreChecks::CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT *pCreateInfo,
-                                                       const VkAllocationCallbacks *pAllocator,
-                                                       VkValidationCacheEXT *pValidationCache) {
+VkResult CoreChecks::CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator,
+                                                       VkValidationCacheEXT* pValidationCache) {
     *pValidationCache = ValidationCache::Create(pCreateInfo, spirv_val_option_hash);
     return *pValidationCache ? VK_SUCCESS : VK_ERROR_INITIALIZATION_FAILED;
 }
 
 void CoreChecks::CoreLayerDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
-                                                    const VkAllocationCallbacks *pAllocator) {
-    delete CastFromHandle<ValidationCache *>(validationCache);
+                                                    const VkAllocationCallbacks* pAllocator) {
+    delete CastFromHandle<ValidationCache*>(validationCache);
 }
 
-VkResult CoreChecks::CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t *pDataSize,
-                                                        void *pData) {
+VkResult CoreChecks::CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
+                                                        void* pData) {
     size_t in_size = *pDataSize;
-    CastFromHandle<ValidationCache *>(validationCache)->Write(pDataSize, pData);
+    CastFromHandle<ValidationCache*>(validationCache)->Write(pDataSize, pData);
     return (pData && *pDataSize != in_size) ? VK_INCOMPLETE : VK_SUCCESS;
 }
 
 VkResult CoreChecks::CoreLayerMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount,
-                                                       const VkValidationCacheEXT *pSrcCaches) {
+                                                       const VkValidationCacheEXT* pSrcCaches) {
     bool skip = false;
-    auto dst = CastFromHandle<ValidationCache *>(dstCache);
+    auto dst = CastFromHandle<ValidationCache*>(dstCache);
     VkResult result = VK_SUCCESS;
     for (uint32_t i = 0; i < srcCacheCount; i++) {
-        auto src = CastFromHandle<const ValidationCache *>(pSrcCaches[i]);
+        auto src = CastFromHandle<const ValidationCache*>(pSrcCaches[i]);
         if (src == dst) {
             const Location loc(Func::vkMergePipelineCaches, Field::dstCache);
             skip |= LogError("VUID-vkMergeValidationCachesEXT-dstCache-01536", device, loc,
@@ -574,11 +574,11 @@ VkResult CoreChecks::CoreLayerMergeValidationCachesEXT(VkDevice device, VkValida
 }
 
 bool CoreChecks::PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask,
-                                                 const ErrorObject &error_obj) const {
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
 
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
     const LogObjectList objlist(commandBuffer);
     skip |= ValidateCmd(cb_state, error_obj.location);
     const Location loc = error_obj.location.dot(Field::deviceMask);
@@ -590,20 +590,20 @@ bool CoreChecks::PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, 
 }
 
 bool CoreChecks::PreCallValidateCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask,
-                                                    const ErrorObject &error_obj) const {
+                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCmdSetDeviceMask(commandBuffer, deviceMask, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfoEXT *pCreateInfo,
-                                                         const VkAllocationCallbacks *pAllocator,
-                                                         VkPrivateDataSlotEXT *pPrivateDataSlot,
-                                                         const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfoEXT* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator,
+                                                         VkPrivateDataSlotEXT* pPrivateDataSlot,
+                                                         const ErrorObject& error_obj) const {
     return PreCallValidateCreatePrivateDataSlot(device, pCreateInfo, pAllocator, pPrivateDataSlot, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCreatePrivateDataSlot(VkDevice device, const VkPrivateDataSlotCreateInfo *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkPrivateDataSlot *pPrivateDataSlot,
-                                                      const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreatePrivateDataSlot(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot,
+                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     if (!enabled_features.privateData) {
         skip |= LogError("VUID-vkCreatePrivateDataSlot-privateData-04564", device, error_obj.location,
@@ -612,9 +612,9 @@ bool CoreChecks::PreCallValidateCreatePrivateDataSlot(VkDevice device, const VkP
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     skip |= ValidateDeviceQueueFamily(pCreateInfo->queueFamilyIndex, create_info_loc.dot(Field::queueFamilyIndex),
@@ -628,7 +628,7 @@ bool CoreChecks::PreCallValidateCreateCommandPool(VkDevice device, const VkComma
 }
 
 bool CoreChecks::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
-                                                   const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
+                                                   const VkAllocationCallbacks* pAllocator, const ErrorObject& error_obj) const {
     bool skip = false;
     if (is_device_lost) {
         return skip;  // In case of DEVICE_LOST, all execution is considered over
@@ -640,7 +640,7 @@ bool CoreChecks::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPoo
     }
 
     // Verify that command buffers in pool are complete (not in-flight)
-    for (auto &entry : cp_state->commandBuffers) {
+    for (auto& entry : cp_state->commandBuffers) {
         auto cb_state = entry.second;
         if (cb_state->InUse()) {
             const LogObjectList objlist(cb_state->Handle(), commandPool);
@@ -652,12 +652,12 @@ bool CoreChecks::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPoo
 }
 
 bool CoreChecks::PreCallValidateResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags,
-                                                 const ErrorObject &error_obj) const {
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     auto cp_state = Get<vvl::CommandPool>(commandPool);
     ASSERT_AND_RETURN_SKIP(cp_state);
     // Verify that command buffers in pool are complete (not in-flight)
-    for (auto &entry : cp_state->commandBuffers) {
+    for (auto& entry : cp_state->commandBuffers) {
         auto cb_state = entry.second;
         if (cb_state->InUse()) {
             const LogObjectList objlist(cb_state->Handle(), commandPool);
@@ -669,7 +669,7 @@ bool CoreChecks::PreCallValidateResetCommandPool(VkDevice device, VkCommandPool 
 }
 
 // For given obj node, if it is use, flag a validation error and return callback result, else return false
-bool CoreChecks::ValidateObjectNotInUse(const vvl::StateObject *obj_node, const Location &loc, const char *error_code) const {
+bool CoreChecks::ValidateObjectNotInUse(const vvl::StateObject* obj_node, const Location& loc, const char* error_code) const {
     if (disabled[object_in_use]) {
         return false;
     } else if (is_device_lost) {
@@ -677,8 +677,8 @@ bool CoreChecks::ValidateObjectNotInUse(const vvl::StateObject *obj_node, const 
     }
     bool skip = false;
 
-    const VulkanTypedHandle &obj_struct = obj_node->Handle();
-    const VulkanTypedHandle *used_handle = obj_node->InUse();
+    const VulkanTypedHandle& obj_struct = obj_node->Handle();
+    const VulkanTypedHandle* used_handle = obj_node->InUse();
     if (used_handle) {
         skip |= LogError(error_code, device, loc, "can't be called on %s that is currently in use by %s.",
                          FormatHandle(obj_struct).c_str(), FormatHandle(*used_handle).c_str());
@@ -687,17 +687,17 @@ bool CoreChecks::ValidateObjectNotInUse(const vvl::StateObject *obj_node, const 
 }
 
 bool CoreChecks::PreCallValidateGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount,
-                                                           const VkCalibratedTimestampInfoEXT *pTimestampInfos,
-                                                           uint64_t *pTimestamps, uint64_t *pMaxDeviation,
-                                                           const ErrorObject &error_obj) const {
+                                                           const VkCalibratedTimestampInfoEXT* pTimestampInfos,
+                                                           uint64_t* pTimestamps, uint64_t* pMaxDeviation,
+                                                           const ErrorObject& error_obj) const {
     return PreCallValidateGetCalibratedTimestampsKHR(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation,
                                                      error_obj);
 }
 
 bool CoreChecks::PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint32_t timestampCount,
-                                                           const VkCalibratedTimestampInfoKHR *pTimestampInfos,
-                                                           uint64_t *pTimestamps, uint64_t *pMaxDeviation,
-                                                           const ErrorObject &error_obj) const {
+                                                           const VkCalibratedTimestampInfoKHR* pTimestampInfos,
+                                                           uint64_t* pTimestamps, uint64_t* pMaxDeviation,
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto query_function = (error_obj.location.function == Func::vkGetCalibratedTimestampsKHR)
@@ -713,7 +713,7 @@ bool CoreChecks::PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint
         const VkTimeDomainKHR time_domain = pTimestampInfos[i].timeDomain;
 
         // The VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT domain can be duplicated if the present stage is different
-        const auto *present_stage_info =
+        const auto* present_stage_info =
             vku::FindStructInPNextChain<VkSwapchainCalibratedTimestampInfoEXT>(pTimestampInfos[i].pNext);
         const VkPresentStageFlagsEXT present_stage = (time_domain == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT && present_stage_info)
                                                          ? present_stage_info->presentStage
@@ -737,9 +737,9 @@ bool CoreChecks::PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint
 }
 
 // These were all added from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6672
-bool CoreChecks::ValidateDeviceQueueSupport(const Location &loc) const {
+bool CoreChecks::ValidateDeviceQueueSupport(const Location& loc) const {
     bool skip = false;
-    const char *vuid = kVUIDUndefined;
+    const char* vuid = kVUIDUndefined;
     VkQueueFlags flags = 0;
 
     switch (loc.function) {
@@ -819,8 +819,8 @@ bool CoreChecks::ValidateDeviceQueueSupport(const Location &loc) const {
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetDeviceFaultInfoEXT(VkDevice device, VkDeviceFaultCountsEXT *pFaultCounts,
-                                                      VkDeviceFaultInfoEXT *pFaultInfo, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetDeviceFaultInfoEXT(VkDevice device, VkDeviceFaultCountsEXT* pFaultCounts,
+                                                      VkDeviceFaultInfoEXT* pFaultInfo, const ErrorObject& error_obj) const {
     bool skip = false;
     if (!is_device_lost) {
         skip |= LogError("VUID-vkGetDeviceFaultInfoEXT-device-07336", device, error_obj.location,
@@ -829,10 +829,10 @@ bool CoreChecks::PreCallValidateGetDeviceFaultInfoEXT(VkDevice device, VkDeviceF
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreatePipelineBinariesKHR(VkDevice device, const VkPipelineBinaryCreateInfoKHR *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator,
-                                                          VkPipelineBinaryHandlesInfoKHR *pBinaries,
-                                                          const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreatePipelineBinariesKHR(VkDevice device, const VkPipelineBinaryCreateInfoKHR* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator,
+                                                          VkPipelineBinaryHandlesInfoKHR* pBinaries,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
 
     uint32_t pointerCount = 0;
@@ -860,7 +860,7 @@ bool CoreChecks::PreCallValidateCreatePipelineBinariesKHR(VkDevice device, const
     }
 
     if (pCreateInfo->pPipelineCreateInfo != nullptr) {
-        auto *props = &phys_dev_ext_props.pipeline_binary_props;
+        auto* props = &phys_dev_ext_props.pipeline_binary_props;
 
         if (!props->pipelineBinaryInternalCache) {
             skip |=
@@ -873,7 +873,7 @@ bool CoreChecks::PreCallValidateCreatePipelineBinariesKHR(VkDevice device, const
                              create_info_loc.dot(Field::pPipelineCreateInfo), "is not NULL, but disableInternalCache is true.");
         }
 
-        const auto *binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(pCreateInfo->pPipelineCreateInfo);
+        const auto* binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(pCreateInfo->pPipelineCreateInfo);
         if (binary_info && (binary_info->binaryCount > 0)) {
             skip |= LogError("VUID-VkPipelineBinaryCreateInfoKHR-pPipelineCreateInfo-09606", device,
                              create_info_loc.dot(Field::pPipelineCreateInfo).dot(Field::binaryCount), "(%" PRIu32 ") is not zero",

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -42,11 +42,11 @@
 #include "containers/container_utils.h"
 
 // For given mem object, verify that it is not null or UNBOUND, if it is, report error. Return skip value.
-bool CoreChecks::VerifyBoundMemoryIsValid(const vvl::DeviceMemory *memory_state, const LogObjectList &objlist,
-                                          const VulkanTypedHandle &typed_handle, const Location &loc, const char *vuid) const {
+bool CoreChecks::VerifyBoundMemoryIsValid(const vvl::DeviceMemory* memory_state, const LogObjectList& objlist,
+                                          const VulkanTypedHandle& typed_handle, const Location& loc, const char* vuid) const {
     bool skip = false;
     if (!memory_state) {
-        const char *type_name = string_VulkanObjectType(typed_handle.type);
+        const char* type_name = string_VulkanObjectType(typed_handle.type);
         skip |=
             LogError(vuid, objlist, loc, "(%s) is used with no memory bound. Memory should be bound by calling vkBind%sMemory().",
                      FormatHandle(typed_handle).c_str(), type_name + 2);
@@ -57,9 +57,9 @@ bool CoreChecks::VerifyBoundMemoryIsValid(const vvl::DeviceMemory *memory_state,
     return skip;
 }
 
-bool CoreChecks::VerifyBoundMemoryIsDeviceVisible(const vvl::DeviceMemory *memory_state, const LogObjectList &objlist,
-                                                  const VulkanTypedHandle &typed_handle, const Location &loc,
-                                                  const char *vuid) const {
+bool CoreChecks::VerifyBoundMemoryIsDeviceVisible(const vvl::DeviceMemory* memory_state, const LogObjectList& objlist,
+                                                  const VulkanTypedHandle& typed_handle, const Location& loc,
+                                                  const char* vuid) const {
     bool result = false;
     if (memory_state) {
         if ((phys_dev_mem_props.memoryTypes[memory_state->allocate_info.memoryTypeIndex].propertyFlags &
@@ -72,8 +72,8 @@ bool CoreChecks::VerifyBoundMemoryIsDeviceVisible(const vvl::DeviceMemory *memor
 }
 
 // Check to see if memory was ever bound to this image
-bool CoreChecks::ValidateMemoryIsBoundToImage(const LogObjectList &objlist, const vvl::Image &image_state, const Location &loc,
-                                              const char *vuid) const {
+bool CoreChecks::ValidateMemoryIsBoundToImage(const LogObjectList& objlist, const vvl::Image& image_state, const Location& loc,
+                                              const char* vuid) const {
     bool result = false;
     if (image_state.create_from_swapchain != VK_NULL_HANDLE) {
         if (!image_state.bind_swapchain) {
@@ -94,13 +94,13 @@ bool CoreChecks::ValidateMemoryIsBoundToImage(const LogObjectList &objlist, cons
         // TODO look into how to properly check for a valid bound memory for an external AHB
     } else if (!image_state.sparse) {
         // No need to optimize this since the size will only be 3 at most
-        const auto &memory_states = image_state.GetBoundMemoryStates();
+        const auto& memory_states = image_state.GetBoundMemoryStates();
         if (memory_states.empty()) {
             result |=
                 LogError(vuid, objlist, loc, "%s used with no memory bound. Memory should be bound by calling vkBindImageMemory().",
                          FormatHandle(image_state).c_str());
         } else {
-            for (const auto &state : memory_states) {
+            for (const auto& state : memory_states) {
                 result |= VerifyBoundMemoryIsValid(state.get(), objlist, image_state.Handle(), loc, vuid);
             }
         }
@@ -108,14 +108,14 @@ bool CoreChecks::ValidateMemoryIsBoundToImage(const LogObjectList &objlist, cons
     return result;
 }
 
-bool CoreChecks::ValidateMemoryIsBoundToTensor(const LogObjectList &objlist, const vvl::Tensor &tensor_state, const Location &loc,
-                                               const char *vuid) const {
+bool CoreChecks::ValidateMemoryIsBoundToTensor(const LogObjectList& objlist, const vvl::Tensor& tensor_state, const Location& loc,
+                                               const char* vuid) const {
     bool result = false;
-    const auto &memory_states = tensor_state.GetBoundMemoryStates();
+    const auto& memory_states = tensor_state.GetBoundMemoryStates();
     if (memory_states.empty()) {
         result |= LogError(vuid, objlist, loc, "has no memory bound. Memory should be bound by calling vkBindTensorMemory().");
     } else {
-        for (const auto &state : memory_states) {
+        for (const auto& state : memory_states) {
             result |= VerifyBoundMemoryIsValid(state.get(), objlist, tensor_state.Handle(), loc, vuid);
         }
         if (!tensor_state.sparse) {
@@ -127,14 +127,14 @@ bool CoreChecks::ValidateMemoryIsBoundToTensor(const LogObjectList &objlist, con
     return result;
 }
 
-bool CoreChecks::ValidateAccelStructsMemoryDoNotOverlap(const Location &function_loc, LogObjectList objlist,
-                                                        const vvl::AccelerationStructureKHR &accel_struct_a, const Location &loc_a,
-                                                        const vvl::AccelerationStructureKHR &accel_struct_b, const Location &loc_b,
-                                                        const char *vuid) const {
+bool CoreChecks::ValidateAccelStructsMemoryDoNotOverlap(const Location& function_loc, LogObjectList objlist,
+                                                        const vvl::AccelerationStructureKHR& accel_struct_a, const Location& loc_a,
+                                                        const vvl::AccelerationStructureKHR& accel_struct_b, const Location& loc_b,
+                                                        const char* vuid) const {
     bool skip = false;
 
-    const vvl::Buffer &buffer_a = *accel_struct_a.buffer_state;
-    const vvl::Buffer &buffer_b = *accel_struct_b.buffer_state;
+    const vvl::Buffer& buffer_a = *accel_struct_a.buffer_state;
+    const vvl::Buffer& buffer_b = *accel_struct_b.buffer_state;
 
     const vvl::range<VkDeviceSize> range_a(accel_struct_a.GetOffset(), accel_struct_a.GetSize());
     const vvl::range<VkDeviceSize> range_b(accel_struct_b.GetOffset(), accel_struct_b.GetSize());
@@ -155,8 +155,8 @@ bool CoreChecks::ValidateAccelStructsMemoryDoNotOverlap(const Location &function
 }
 
 // Check to see if host-visible memory was bound to this buffer
-bool CoreChecks::ValidateAccelStructBufferMemoryIsHostVisible(const vvl::AccelerationStructureKHR &accel_struct,
-                                                              const Location &buffer_loc, const char *vuid) const {
+bool CoreChecks::ValidateAccelStructBufferMemoryIsHostVisible(const vvl::AccelerationStructureKHR& accel_struct,
+                                                              const Location& buffer_loc, const char* vuid) const {
     bool result = false;
     result |= ValidateMemoryIsBoundToBuffer(device, *accel_struct.buffer_state, buffer_loc, vuid);
     if (!result) {
@@ -172,10 +172,10 @@ bool CoreChecks::ValidateAccelStructBufferMemoryIsHostVisible(const vvl::Acceler
     return result;
 }
 
-bool CoreChecks::ValidateAccelStructBufferMemoryIsNotMultiInstance(const vvl::AccelerationStructureKHR &accel_struct,
-                                                                   const Location &accel_struct_loc, const char *vuid) const {
+bool CoreChecks::ValidateAccelStructBufferMemoryIsNotMultiInstance(const vvl::AccelerationStructureKHR& accel_struct,
+                                                                   const Location& accel_struct_loc, const char* vuid) const {
     bool skip = false;
-    if (const vvl::DeviceMemory *memory_state = accel_struct.buffer_state->MemoryState()) {
+    if (const vvl::DeviceMemory* memory_state = accel_struct.buffer_state->MemoryState()) {
         if (memory_state->multi_instance) {
             const LogObjectList objlist(accel_struct.Handle(), accel_struct.buffer_state->Handle(), memory_state->Handle());
             skip |= LogError(vuid, objlist, accel_struct_loc,
@@ -192,8 +192,8 @@ bool CoreChecks::ValidateAccelStructBufferMemoryIsNotMultiInstance(const vvl::Ac
 //  IF a previous binding existed, output validation error
 //  Otherwise, add reference from objectInfo to memoryInfo
 //  Add reference off of objInfo
-bool CoreChecks::ValidateSetMemBinding(const vvl::DeviceMemory &memory_state, const vvl::Bindable &mem_binding,
-                                       const Location &loc) const {
+bool CoreChecks::ValidateSetMemBinding(const vvl::DeviceMemory& memory_state, const vvl::Bindable& mem_binding,
+                                       const Location& loc) const {
     bool skip = false;
 
     const bool bind_2 = (loc.function != Func::vkBindBufferMemory) && (loc.function != Func::vkBindImageMemory);
@@ -203,8 +203,8 @@ bool CoreChecks::ValidateSetMemBinding(const vvl::DeviceMemory &memory_state, co
     const bool is_tensor = typed_handle.type == kVulkanObjectTypeTensorARM;
 
     if (mem_binding.sparse) {
-        const char *vuid = kVUIDUndefined;
-        const char *handle_type = is_buffer ? "BUFFER" : is_image ? "IMAGE" : "TENSOR";
+        const char* vuid = kVUIDUndefined;
+        const char* handle_type = is_buffer ? "BUFFER" : is_image ? "IMAGE" : "TENSOR";
         if (is_buffer) {
             vuid = bind_2 ? "VUID-VkBindBufferMemoryInfo-buffer-01030" : "VUID-vkBindBufferMemory-buffer-01030";
         } else if (is_image) {
@@ -221,9 +221,9 @@ bool CoreChecks::ValidateSetMemBinding(const vvl::DeviceMemory &memory_state, co
                          FormatHandle(memory_state.Handle()).c_str(), FormatHandle(typed_handle).c_str(), handle_type);
     }
 
-    const auto *prev_binding = mem_binding.MemoryState();
+    const auto* prev_binding = mem_binding.MemoryState();
     if (prev_binding || mem_binding.indeterminate_state) {
-        const char *vuid = kVUIDUndefined;
+        const char* vuid = kVUIDUndefined;
         if (is_buffer) {
             vuid = bind_2 ? "VUID-VkBindBufferMemoryInfo-buffer-07459" : "VUID-vkBindBufferMemory-buffer-07459";
         } else if (is_image) {
@@ -236,7 +236,7 @@ bool CoreChecks::ValidateSetMemBinding(const vvl::DeviceMemory &memory_state, co
             Func bind_call = is_buffer  ? Func::vkBindBufferMemory2
                              : is_image ? Func::vkBindImageMemory2
                                         : Func::vkBindTensorMemoryARM;
-            const char *handle_type = is_buffer ? "buffer" : is_image ? "image" : "tensor";
+            const char* handle_type = is_buffer ? "buffer" : is_image ? "image" : "tensor";
             const LogObjectList objlist(memory_state.Handle(), typed_handle);
             skip |= LogError(
                 vuid, objlist, loc,
@@ -254,7 +254,7 @@ bool CoreChecks::ValidateSetMemBinding(const vvl::DeviceMemory &memory_state, co
     return skip;
 }
 
-bool CoreChecks::IgnoreAllocationSize(const VkMemoryAllocateInfo &allocate_info) const {
+bool CoreChecks::IgnoreAllocationSize(const VkMemoryAllocateInfo& allocate_info) const {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const VkExternalMemoryHandleTypeFlags ignored_allocation = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT |
                                                                VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_KMT_BIT |
@@ -283,7 +283,7 @@ bool CoreChecks::IgnoreAllocationSize(const VkMemoryAllocateInfo &allocate_info)
     return false;
 }
 
-bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Buffer &buffer, VkExternalMemoryHandleTypeFlagBits handle_type) const {
+bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Buffer& buffer, VkExternalMemoryHandleTypeFlagBits handle_type) const {
     VkPhysicalDeviceExternalBufferInfo info = vku::InitStructHelper();
     info.flags = buffer.create_info.flags;
     // TODO - Add VkBufferUsageFlags2CreateInfo support
@@ -294,7 +294,7 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Buffer &buffer, VkExt
     return (properties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT) != 0;
 }
 
-bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image &image, VkExternalMemoryHandleTypeFlagBits handle_type) const {
+bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image& image, VkExternalMemoryHandleTypeFlagBits handle_type) const {
     VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;
     VkPhysicalDeviceImageFormatInfo2 info = vku::InitStructHelper(&external_info);
@@ -350,7 +350,7 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image &image, VkExter
     return (external_properties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT) != 0;
 }
 
-bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Tensor &tensor, VkExternalMemoryHandleTypeFlagBits handle_type) const {
+bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Tensor& tensor, VkExternalMemoryHandleTypeFlagBits handle_type) const {
     VkPhysicalDeviceExternalTensorInfoARM info = vku::InitStructHelper();
     info.flags = tensor.create_info.flags;
     info.handleType = handle_type;
@@ -359,9 +359,9 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Tensor &tensor, VkExt
     return (properties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT) != 0;
 }
 
-bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
-                                               const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory,
-                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                               const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     if (Count<vvl::DeviceMemory>() >= phys_dev_props.limits.maxMemoryAllocationCount) {
         skip |=
@@ -556,10 +556,10 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
             const Location tensor_loc = allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfoTensorARM, Field::tensor);
             const LogObjectList objlist(device, dedicated_tensor);
             skip |= LogError("VUID-VkMemoryDedicatedAllocateInfoTensorARM-allocationSize-09710", objlist,
-                                allocate_info_loc.dot(Field::allocationSize),
-                                "(%" PRIu64 ") needs to be equal to %s (%s) VkMemoryRequirements::size (%" PRIu64 ").",
-                                pAllocateInfo->allocationSize, tensor_loc.Fields().c_str(), FormatHandle(dedicated_tensor).c_str(),
-                                mem_reqs.size);
+                             allocate_info_loc.dot(Field::allocationSize),
+                             "(%" PRIu64 ") needs to be equal to %s (%s) VkMemoryRequirements::size (%" PRIu64 ").",
+                             pAllocateInfo->allocationSize, tensor_loc.Fields().c_str(), FormatHandle(dedicated_tensor).c_str(),
+                             mem_reqs.size);
         }
     }
 
@@ -794,8 +794,8 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
     return skip;
 }
 
-bool CoreChecks::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator,
-                                           const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator,
+                                           const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto mem_info = Get<vvl::DeviceMemory>(memory)) {
         skip |= ValidateObjectNotInUse(mem_info.get(), error_obj.location, "VUID-vkFreeMemory-memory-00677");
@@ -803,12 +803,12 @@ bool CoreChecks::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory memor
     return skip;
 }
 
-bool CoreChecks::ValidateInsertMemoryRange(const VulkanTypedHandle &typed_handle, const vvl::DeviceMemory &mem_info,
-                                           VkDeviceSize memoryOffset, const Location &loc) const {
+bool CoreChecks::ValidateInsertMemoryRange(const VulkanTypedHandle& typed_handle, const vvl::DeviceMemory& mem_info,
+                                           VkDeviceSize memoryOffset, const Location& loc) const {
     bool skip = false;
 
     if (!IgnoreAllocationSize(mem_info.allocate_info) && memoryOffset >= mem_info.allocate_info.allocationSize) {
-        const char *vuid = nullptr;
+        const char* vuid = nullptr;
         if (typed_handle.type == kVulkanObjectTypeBuffer) {
             vuid = loc.function == Func::vkBindBufferMemory ? "VUID-vkBindBufferMemory-memoryOffset-01031"
                                                             : "VUID-VkBindBufferMemoryInfo-memoryOffset-01031";
@@ -836,8 +836,8 @@ bool CoreChecks::ValidateInsertMemoryRange(const VulkanTypedHandle &typed_handle
     return skip;
 }
 
-bool CoreChecks::ValidateMemoryTypes(const vvl::DeviceMemory &mem_info, const uint32_t memory_type_bits,
-                                     const Location &resource_loc, const char *vuid) const {
+bool CoreChecks::ValidateMemoryTypes(const vvl::DeviceMemory& mem_info, const uint32_t memory_type_bits,
+                                     const Location& resource_loc, const char* vuid) const {
     bool skip = false;
     if (((1 << mem_info.allocate_info.memoryTypeIndex) & memory_type_bits) == 0) {
         skip |= LogError(vuid, mem_info.Handle(), resource_loc,
@@ -855,7 +855,7 @@ bool CoreChecks::HasTileMemoryType(uint32_t memory_type_index) const {
     return (phys_dev_mem_props.memoryHeaps[memory_heap_index].flags & VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM);
 }
 
-bool CoreChecks::ValidateTileMemoryBindInfo(const VkTileMemoryBindInfoQCOM &tile_memory_bind_info, const Location &loc) const {
+bool CoreChecks::ValidateTileMemoryBindInfo(const VkTileMemoryBindInfoQCOM& tile_memory_bind_info, const Location& loc) const {
     bool skip = false;
     auto dev_mem = Get<vvl::DeviceMemory>(tile_memory_bind_info.memory);
     if (!HasTileMemoryType(dev_mem->allocate_info.memoryTypeIndex)) {
@@ -867,13 +867,13 @@ bool CoreChecks::ValidateTileMemoryBindInfo(const VkTileMemoryBindInfoQCOM &tile
     return skip;
 }
 
-bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset, const void *pNext,
-                                          const Location &loc) const {
+bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset, const void* pNext,
+                                          const Location& loc) const {
     bool skip = false;
 
-    const auto &device_group_create_info = device_state->device_group_create_info;
+    const auto& device_group_create_info = device_state->device_group_create_info;
     // Validate device group information
-    if (const auto *bind_buffer_memory_device_group_info = vku::FindStructInPNextChain<VkBindBufferMemoryDeviceGroupInfo>(pNext)) {
+    if (const auto* bind_buffer_memory_device_group_info = vku::FindStructInPNextChain<VkBindBufferMemoryDeviceGroupInfo>(pNext)) {
         if (bind_buffer_memory_device_group_info->deviceIndexCount != 0 &&
             bind_buffer_memory_device_group_info->deviceIndexCount != device_group_create_info.physicalDeviceCount &&
             device_group_create_info.physicalDeviceCount > 0) {
@@ -902,7 +902,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
     const bool bind_buffer_mem_2 = loc.function != Func::vkBindBufferMemory;
 
     if (auto mem_info = Get<vvl::DeviceMemory>(memory)) {
-        const char *mem_type_vuid =
+        const char* mem_type_vuid =
             bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-01035" : "VUID-vkBindBufferMemory-memory-01035";
 
         if (!HasTileMemoryType(mem_info->allocate_info.memoryTypeIndex)) {
@@ -910,7 +910,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
                 ValidateMemoryTypes(*mem_info, buffer_state->requirements.memoryTypeBits, loc.dot(Field::buffer), mem_type_vuid);
 
             if (!IsIntegerMultipleOf(memoryOffset, buffer_state->requirements.alignment)) {
-                const char *vuid =
+                const char* vuid =
                     bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-None-10739" : "VUID-vkBindBufferMemory-None-10739";
                 const LogObjectList objlist(buffer, memory);
                 skip |= LogError(vuid, objlist, loc.dot(Field::memoryOffset),
@@ -920,7 +920,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
             }
 
             if (buffer_state->requirements.size > (mem_info->allocate_info.allocationSize - memoryOffset)) {
-                const char *vuid =
+                const char* vuid =
                     bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-None-10741" : "VUID-vkBindBufferMemory-None-10741";
                 const LogObjectList objlist(buffer, memory);
                 std::ostringstream ss;
@@ -956,7 +956,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
                                         mem_type_vuid);
 
             if (!IsIntegerMultipleOf(memoryOffset, tile_memory_requirements.alignment)) {
-                const char *vuid =
+                const char* vuid =
                     bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-10740" : "VUID-vkBindBufferMemory-memory-10740";
                 const LogObjectList objlist(buffer, memory);
                 skip |= LogError(vuid, objlist, loc.dot(Field::memoryOffset),
@@ -966,7 +966,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
             }
 
             if (tile_memory_requirements.size > (mem_info->allocate_info.allocationSize - memoryOffset)) {
-                const char *vuid =
+                const char* vuid =
                     bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-10742" : " VUID-vkBindBufferMemory-memory-10742";
                 const LogObjectList objlist(buffer, memory);
                 skip |= LogError(vuid, objlist, loc,
@@ -1043,7 +1043,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         // Validate dedicated allocation
         const VkBuffer dedicated_buffer = mem_info->GetDedicatedBuffer();
         if (dedicated_buffer != VK_NULL_HANDLE && ((dedicated_buffer != buffer) || (memoryOffset != 0))) {
-            const char *vuid =
+            const char* vuid =
                 bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-01508" : "VUID-vkBindBufferMemory-memory-01508";
             const LogObjectList objlist(buffer, memory, dedicated_buffer);
             skip |= LogError(vuid, objlist, loc.dot(Field::memory),
@@ -1082,7 +1082,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         const VkImage dedicated_image = mem_info->GetDedicatedImage();
         if (dedicated_image != VK_NULL_HANDLE) {
             const LogObjectList objlist(buffer, memory);
-            const char *vuid =
+            const char* vuid =
                 bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-10925" : "VUID-vkBindBufferMemory-memory-10925";
             skip |= LogError(vuid, objlist, loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::pNext).dot(Field::image),
                              "is %s (not VK_NULL_HANDLE), but VkBindBufferMemoryInfo::buffer is %s.",
@@ -1093,7 +1093,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         if (enabled_features.bufferDeviceAddress && (buffer_state->usage & VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT) &&
             (!chained_flags_struct || !(chained_flags_struct->flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT))) {
             const LogObjectList objlist(buffer, memory);
-            const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-bufferDeviceAddress-03339"
+            const char* vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-bufferDeviceAddress-03339"
                                                  : "VUID-vkBindBufferMemory-bufferDeviceAddress-03339";
             skip |= LogError(vuid, objlist, loc.dot(Field::buffer),
                              "was created with VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT, "
@@ -1103,7 +1103,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         const VkMemoryAllocateFlags memory_allocate_flags = chained_flags_struct ? chained_flags_struct->flags : 0;
         if (buffer_state->create_info.flags & VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) {
             if (!(memory_allocate_flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT)) {
-                const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-descriptorBufferCaptureReplay-08112"
+                const char* vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-descriptorBufferCaptureReplay-08112"
                                                      : "VUID-vkBindBufferMemory-descriptorBufferCaptureReplay-08112";
                 const LogObjectList objlist(buffer, memory);
                 skip |= LogError(vuid, objlist, loc.dot(Field::buffer),
@@ -1114,7 +1114,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
             }
 
             if (!(memory_allocate_flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT)) {
-                const char *vuid =
+                const char* vuid =
                     bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-buffer-09201" : "VUID-vkBindBufferMemory-buffer-09201";
                 const LogObjectList objlist(buffer, memory);
                 skip |= LogError(vuid, objlist, loc.dot(Field::buffer),
@@ -1126,7 +1126,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
 
             if (enabled_features.descriptorBufferCaptureReplay) {
                 if (!(memory_allocate_flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT)) {
-                    const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-bufferDeviceAddressCaptureReplay-09200"
+                    const char* vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-bufferDeviceAddressCaptureReplay-09200"
                                                          : "VUID-vkBindBufferMemory-bufferDeviceAddressCaptureReplay-09200";
                     const LogObjectList objlist(buffer, memory);
                     skip |= LogError(vuid, objlist, loc.dot(Field::buffer),
@@ -1151,7 +1151,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         }
         // Validate export memory handles. Check if the memory meets the buffer's external memory requirements
         if (mem_info->IsExport() && (mem_info->export_handle_types & buffer_state->external_memory_handle_types) == 0) {
-            const char *vuid =
+            const char* vuid =
                 bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-02726" : "VUID-vkBindBufferMemory-memory-02726";
             const LogObjectList objlist(buffer, memory);
             skip |= LogError(vuid, objlist, loc.dot(Field::memory),
@@ -1168,7 +1168,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
             skip |= ValidateBufferImportedHandleANDROID(buffer_state->external_memory_handle_types, memory, buffer, loc);
         } else if (mem_info->IsImport()) {
             if ((mem_info->import_handle_type.value() & buffer_state->external_memory_handle_types) == 0) {
-                const char *vuid =
+                const char* vuid =
                     bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-02985" : "VUID-vkBindBufferMemory-memory-02985";
                 const LogObjectList objlist(buffer, memory);
                 skip |= LogError(vuid, objlist, loc.dot(Field::memory),
@@ -1191,14 +1191,14 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
 
         // Validate mix of protected buffer and memory
         if ((buffer_state->unprotected == false) && (mem_info->unprotected == true)) {
-            const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-None-01898" : "VUID-vkBindBufferMemory-None-01898";
+            const char* vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-None-01898" : "VUID-vkBindBufferMemory-None-01898";
             const LogObjectList objlist(buffer, memory);
             skip |= LogError(vuid, objlist, loc.dot(Field::memory),
                              "(%s) was not created with protected memory but the VkBuffer (%s) was set "
                              "to use protected memory.",
                              FormatHandle(memory).c_str(), FormatHandle(buffer).c_str());
         } else if ((buffer_state->unprotected == true) && (mem_info->unprotected == false)) {
-            const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-None-01899" : "VUID-vkBindBufferMemory-None-01899";
+            const char* vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-None-01899" : "VUID-vkBindBufferMemory-None-01899";
             const LogObjectList objlist(buffer, memory);
             skip |= LogError(vuid, objlist, loc.dot(Field::memory),
                              "(%s) was created with protected memory but the VkBuffer (%s) was not set "
@@ -1210,12 +1210,12 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
 }
 
 bool CoreChecks::PreCallValidateBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                                 const ErrorObject &error_obj) const {
+                                                 const ErrorObject& error_obj) const {
     return ValidateBindBufferMemory(buffer, memory, memoryOffset, nullptr, error_obj.location);
 }
 
-bool CoreChecks::PreCallValidateBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         const Location loc = error_obj.location.dot(Field::pBindInfos, i);
@@ -1226,13 +1226,13 @@ bool CoreChecks::PreCallValidateBindBufferMemory2(VkDevice device, uint32_t bind
 }
 
 bool CoreChecks::PreCallValidateBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount,
-                                                     const VkBindBufferMemoryInfo *pBindInfos, const ErrorObject &error_obj) const {
+                                                     const VkBindBufferMemoryInfo* pBindInfos, const ErrorObject& error_obj) const {
     return PreCallValidateBindBufferMemory2(device, bindInfoCount, pBindInfos, error_obj);
 }
 
 bool CoreChecks::PreCallValidateGetImageMemoryRequirements(VkDevice device, VkImage image,
-                                                           VkMemoryRequirements *pMemoryRequirements,
-                                                           const ErrorObject &error_obj) const {
+                                                           VkMemoryRequirements* pMemoryRequirements,
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     const Location image_loc = error_obj.location.dot(Field::image);
     skip |= ValidateGetImageMemoryRequirementsANDROID(image, image_loc);
@@ -1249,9 +1249,9 @@ bool CoreChecks::PreCallValidateGetImageMemoryRequirements(VkDevice device, VkIm
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2 *pInfo,
-                                                            VkMemoryRequirements2 *pMemoryRequirements,
-                                                            const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
+                                                            VkMemoryRequirements2* pMemoryRequirements,
+                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     const Location info_loc = error_obj.location.dot(Field::pInfo);
     const Location image_loc = info_loc.dot(Field::image);
@@ -1261,7 +1261,7 @@ bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, con
     ASSERT_AND_RETURN_SKIP(image_state);
     const VkFormat image_format = image_state->create_info.format;
     const VkImageTiling image_tiling = image_state->create_info.tiling;
-    const auto *image_plane_info = vku::FindStructInPNextChain<VkImagePlaneMemoryRequirementsInfo>(pInfo->pNext);
+    const auto* image_plane_info = vku::FindStructInPNextChain<VkImagePlaneMemoryRequirementsInfo>(pInfo->pNext);
     if (!image_plane_info && image_state->disjoint) {
         if (vkuFormatIsMultiplane(image_format)) {
             skip |= LogError("VUID-VkImageMemoryRequirementsInfo2-image-01589", pInfo->image, image_loc,
@@ -1319,14 +1319,14 @@ bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, con
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2 *pInfo,
-                                                               VkMemoryRequirements2 *pMemoryRequirements,
-                                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
+                                                               VkMemoryRequirements2* pMemoryRequirements,
+                                                               const ErrorObject& error_obj) const {
     return PreCallValidateGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, error_obj);
 }
 
-bool CoreChecks::ValidateMapMemory(const vvl::DeviceMemory &mem_info, VkDeviceSize offset, VkDeviceSize size,
-                                   const Location &offset_loc, const Location &size_loc) const {
+bool CoreChecks::ValidateMapMemory(const vvl::DeviceMemory& mem_info, VkDeviceSize offset, VkDeviceSize size,
+                                   const Location& offset_loc, const Location& size_loc) const {
     bool skip = false;
     const bool map2 = offset_loc.function != Func::vkMapMemory;
     const Location loc(offset_loc.function);
@@ -1375,7 +1375,7 @@ bool CoreChecks::ValidateMapMemory(const vvl::DeviceMemory &mem_info, VkDeviceSi
 }
 
 bool CoreChecks::PreCallValidateMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size,
-                                          VkFlags flags, void **ppData, const ErrorObject &error_obj) const {
+                                          VkFlags flags, void** ppData, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto mem_info = Get<vvl::DeviceMemory>(memory)) {
         skip |= ValidateMapMemory(*mem_info.get(), offset, size, error_obj.location.dot(Field::offset),
@@ -1389,8 +1389,8 @@ bool CoreChecks::PreCallValidateMapMemory(VkDevice device, VkDeviceMemory memory
     return skip;
 }
 
-bool CoreChecks::PreCallValidateMapMemory2(VkDevice device, const VkMemoryMapInfo *pMemoryMapInfo, void **ppData,
-                                           const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateMapMemory2(VkDevice device, const VkMemoryMapInfo* pMemoryMapInfo, void** ppData,
+                                           const ErrorObject& error_obj) const {
     bool skip = false;
     auto mem_info = Get<vvl::DeviceMemory>(pMemoryMapInfo->memory);
     ASSERT_AND_RETURN_SKIP(mem_info);
@@ -1485,12 +1485,12 @@ bool CoreChecks::PreCallValidateMapMemory2(VkDevice device, const VkMemoryMapInf
     return skip;
 }
 
-bool CoreChecks::PreCallValidateMapMemory2KHR(VkDevice device, const VkMemoryMapInfoKHR *pMemoryMapInfo, void **ppData,
-                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateMapMemory2KHR(VkDevice device, const VkMemoryMapInfoKHR* pMemoryMapInfo, void** ppData,
+                                              const ErrorObject& error_obj) const {
     return PreCallValidateMapMemory2(device, pMemoryMapInfo, ppData, error_obj);
 }
 
-bool CoreChecks::PreCallValidateUnmapMemory(VkDevice device, VkDeviceMemory memory, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateUnmapMemory(VkDevice device, VkDeviceMemory memory, const ErrorObject& error_obj) const {
     bool skip = false;
     auto mem_info = Get<vvl::DeviceMemory>(memory);
     ASSERT_AND_RETURN_SKIP(mem_info);
@@ -1501,8 +1501,8 @@ bool CoreChecks::PreCallValidateUnmapMemory(VkDevice device, VkDeviceMemory memo
     return skip;
 }
 
-bool CoreChecks::PreCallValidateUnmapMemory2(VkDevice device, const VkMemoryUnmapInfo *pMemoryUnmapInfo,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateUnmapMemory2(VkDevice device, const VkMemoryUnmapInfo* pMemoryUnmapInfo,
+                                             const ErrorObject& error_obj) const {
     bool skip = false;
     auto mem_info = Get<vvl::DeviceMemory>(pMemoryUnmapInfo->memory);
     ASSERT_AND_RETURN_SKIP(mem_info);
@@ -1529,13 +1529,13 @@ bool CoreChecks::PreCallValidateUnmapMemory2(VkDevice device, const VkMemoryUnma
     return skip;
 }
 
-bool CoreChecks::PreCallValidateUnmapMemory2KHR(VkDevice device, const VkMemoryUnmapInfoKHR *pMemoryUnmapInfo,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateUnmapMemory2KHR(VkDevice device, const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo,
+                                                const ErrorObject& error_obj) const {
     return PreCallValidateUnmapMemory2(device, pMemoryUnmapInfo, error_obj);
 }
 
-bool CoreChecks::ValidateMemoryIsMapped(uint32_t mem_range_count, const VkMappedMemoryRange *mem_ranges,
-                                        const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateMemoryIsMapped(uint32_t mem_range_count, const VkMappedMemoryRange* mem_ranges,
+                                        const ErrorObject& error_obj) const {
     bool skip = false;
     for (uint32_t i = 0; i < mem_range_count; ++i) {
         const Location memory_range_loc = error_obj.location.dot(Field::pMemoryRanges, i);
@@ -1576,8 +1576,8 @@ bool CoreChecks::ValidateMemoryIsMapped(uint32_t mem_range_count, const VkMapped
     return skip;
 }
 
-bool CoreChecks::ValidateMappedMemoryRangeDeviceLimits(uint32_t mem_range_count, const VkMappedMemoryRange *mem_ranges,
-                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateMappedMemoryRangeDeviceLimits(uint32_t mem_range_count, const VkMappedMemoryRange* mem_ranges,
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     for (uint32_t i = 0; i < mem_range_count; ++i) {
         const Location memory_range_loc = error_obj.location.dot(Field::pMemoryRanges, i);
@@ -1620,8 +1620,8 @@ bool CoreChecks::ValidateMappedMemoryRangeDeviceLimits(uint32_t mem_range_count,
 }
 
 bool CoreChecks::PreCallValidateFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
-                                                        const VkMappedMemoryRange *pMemoryRanges,
-                                                        const ErrorObject &error_obj) const {
+                                                        const VkMappedMemoryRange* pMemoryRanges,
+                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateMappedMemoryRangeDeviceLimits(memoryRangeCount, pMemoryRanges, error_obj);
     skip |= ValidateMemoryIsMapped(memoryRangeCount, pMemoryRanges, error_obj);
@@ -1629,16 +1629,16 @@ bool CoreChecks::PreCallValidateFlushMappedMemoryRanges(VkDevice device, uint32_
 }
 
 bool CoreChecks::PreCallValidateInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
-                                                             const VkMappedMemoryRange *pMemoryRanges,
-                                                             const ErrorObject &error_obj) const {
+                                                             const VkMappedMemoryRange* pMemoryRanges,
+                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateMappedMemoryRangeDeviceLimits(memoryRangeCount, pMemoryRanges, error_obj);
     skip |= ValidateMemoryIsMapped(memoryRangeCount, pMemoryRanges, error_obj);
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory, VkDeviceSize *pCommittedMem,
-                                                          const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory, VkDeviceSize* pCommittedMem,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto mem_info = Get<vvl::DeviceMemory>(memory)) {
         if ((phys_dev_mem_props.memoryTypes[mem_info->allocate_info.memoryTypeIndex].propertyFlags &
@@ -1652,11 +1652,11 @@ bool CoreChecks::PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDev
     return skip;
 }
 
-bool CoreChecks::ValidateBindTensorMemoryARM(uint32_t bindInfoCount, const VkBindTensorMemoryInfoARM *pBindInfos,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateBindTensorMemoryARM(uint32_t bindInfoCount, const VkBindTensorMemoryInfoARM* pBindInfos,
+                                             const ErrorObject& error_obj) const {
     bool skip = false;
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        const VkBindTensorMemoryInfoARM &bind_info = pBindInfos[i];
+        const VkBindTensorMemoryInfoARM& bind_info = pBindInfos[i];
         const Location bind_info_loc = error_obj.location.dot(Field::pBindInfos, i);
 
         const auto tensor_state = Get<vvl::Tensor>(bind_info.tensor);
@@ -1719,27 +1719,28 @@ bool CoreChecks::ValidateBindTensorMemoryARM(uint32_t bindInfoCount, const VkBin
         if (mem_info->IsExport() && (mem_info->export_handle_types & tensor_state->external_memory_handle_types) == 0) {
             const LogObjectList objlist(bind_info.tensor, bind_info.memory);
             skip |= LogError("VUID-VkBindTensorMemoryInfoARM-memory-09895", objlist, bind_info_loc.dot(Field::memory),
-                            "(%s) has an external handleType of %s which does not include at least one "
-                            "handle from VkTensorARM (%s) handleType %s.",
-                            FormatHandle(bind_info.memory).c_str(),
-                            string_VkExternalMemoryHandleTypeFlags(mem_info->export_handle_types).c_str(),
-                            FormatHandle(bind_info.tensor).c_str(),
-                            string_VkExternalMemoryHandleTypeFlags(tensor_state->external_memory_handle_types).c_str());
+                             "(%s) has an external handleType of %s which does not include at least one "
+                             "handle from VkTensorARM (%s) handleType %s.",
+                             FormatHandle(bind_info.memory).c_str(),
+                             string_VkExternalMemoryHandleTypeFlags(mem_info->export_handle_types).c_str(),
+                             FormatHandle(bind_info.tensor).c_str(),
+                             string_VkExternalMemoryHandleTypeFlags(tensor_state->external_memory_handle_types).c_str());
         }
 
         // Validate import memory handles
         if (mem_info->IsImportAHB()) {
-            skip |= ValidateTensorImportedHandleANDROID(tensor_state->external_memory_handle_types, bind_info.memory, bind_info.tensor, bind_info_loc);
+            skip |= ValidateTensorImportedHandleANDROID(tensor_state->external_memory_handle_types, bind_info.memory,
+                                                        bind_info.tensor, bind_info_loc);
         } else if (mem_info->IsImport()) {
             if ((mem_info->import_handle_type.value() & tensor_state->external_memory_handle_types) == 0) {
                 const LogObjectList objlist(bind_info.tensor, bind_info.memory);
                 skip |= LogError("VUID-VkBindTensorMemoryInfoARM-memory-09896", objlist, bind_info_loc.dot(Field::memory),
-                                "(%s) was created with an import operation with handleType of %s which "
-                                "is not set in VkExternalMemoryTensorCreateInfoARM::handleTypes (%s) for (%s)",
-                                FormatHandle(bind_info.memory).c_str(),
-                                string_VkExternalMemoryHandleTypeFlagBits(mem_info->import_handle_type.value()),
-                                string_VkExternalMemoryHandleTypeFlags(tensor_state->external_memory_handle_types).c_str(),
-                                FormatHandle(bind_info.tensor).c_str());
+                                 "(%s) was created with an import operation with handleType of %s which "
+                                 "is not set in VkExternalMemoryTensorCreateInfoARM::handleTypes (%s) for (%s)",
+                                 FormatHandle(bind_info.memory).c_str(),
+                                 string_VkExternalMemoryHandleTypeFlagBits(mem_info->import_handle_type.value()),
+                                 string_VkExternalMemoryHandleTypeFlags(tensor_state->external_memory_handle_types).c_str(),
+                                 FormatHandle(bind_info.tensor).c_str());
             }
             // Check if buffer can be bound to memory imported from specific handle type
             if (!HasExternalMemoryImportSupport(*tensor_state, mem_info->import_handle_type.value())) {
@@ -1747,7 +1748,8 @@ bool CoreChecks::ValidateBindTensorMemoryARM(uint32_t bindInfoCount, const VkBin
                 skip |= LogError(
                     "VUID-VkImportMemoryWin32HandleInfoKHR-handleType-09861", objlist, bind_info_loc.dot(Field::memory),
                     "(%s) was imported from handleType %s but VkExternalTensorProperties does not report it as importable.",
-                    FormatHandle(bind_info.memory).c_str(), string_VkExternalMemoryHandleTypeFlagBits(mem_info->import_handle_type.value()));
+                    FormatHandle(bind_info.memory).c_str(),
+                    string_VkExternalMemoryHandleTypeFlagBits(mem_info->import_handle_type.value()));
             }
         }
         if (tensor_state->create_info.flags & VK_TENSOR_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_ARM) {
@@ -1773,8 +1775,8 @@ bool CoreChecks::ValidateBindTensorMemoryARM(uint32_t bindInfoCount, const VkBin
     return skip;
 }
 
-bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
-                                         const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                         const ErrorObject& error_obj) const {
     bool skip = false;
     const bool bind_image_mem_2 = error_obj.location.function != Func::vkBindImageMemory;
 
@@ -1880,7 +1882,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                                 loc.dot(Field::image), vuid_mem_type);
 
                     if (!IsIntegerMultipleOf(bind_info.memoryOffset, tile_mem_requirements.alignment)) {
-                        const char *vuid =
+                        const char* vuid =
                             bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-pNext-12329" : "VUID-vkBindImageMemory-memory-10736";
                         const LogObjectList objlist(bind_info.image, bind_info.memory);
                         skip |= LogError(
@@ -1892,7 +1894,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
 
                     if (!IgnoreAllocationSize(allocate_info) &&
                         tile_mem_requirements.size > allocate_info.allocationSize - bind_info.memoryOffset) {
-                        const char *vuid =
+                        const char* vuid =
                             bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-pNext-12330" : "VUID-vkBindImageMemory-memory-10738";
                         const LogObjectList objlist(bind_info.image, bind_info.memory);
                         skip |= LogError(vuid, objlist, loc,
@@ -2460,7 +2462,7 @@ bool CoreChecks::ValidateBindImageMemoryDeviceGroupInfo(const VkBindImageMemoryI
 }
 
 bool CoreChecks::PreCallValidateBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                                const ErrorObject &error_obj) const {
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto image_state = Get<vvl::Image>(image)) {
         // Checks for no disjoint bit
@@ -2480,7 +2482,7 @@ bool CoreChecks::PreCallValidateBindImageMemory(VkDevice device, VkImage image, 
 }
 
 void CoreChecks::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                               const RecordObject &record_obj) {
+                                               const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2490,13 +2492,13 @@ void CoreChecks::PostCallRecordBindImageMemory(VkDevice device, VkImage image, V
     }
 }
 
-bool CoreChecks::PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                                 const ErrorObject& error_obj) const {
     return ValidateBindImageMemory(bindInfoCount, pBindInfos, error_obj);
 }
 
-void CoreChecks::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
-                                                const RecordObject &record_obj) {
+void CoreChecks::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                                const RecordObject& record_obj) {
     // Don't check |record_obj.result| as some binds might still be valid
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
@@ -2509,17 +2511,17 @@ void CoreChecks::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindIn
 }
 
 bool CoreChecks::PreCallValidateBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount,
-                                                    const VkBindImageMemoryInfo *pBindInfos, const ErrorObject &error_obj) const {
+                                                    const VkBindImageMemoryInfo* pBindInfos, const ErrorObject& error_obj) const {
     return PreCallValidateBindImageMemory2(device, bindInfoCount, pBindInfos, error_obj);
 }
 
-void CoreChecks::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
-                                                   const RecordObject &record_obj) {
+void CoreChecks::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                                   const RecordObject& record_obj) {
     PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 }
 
-bool CoreChecks::ValidateBufferSparseMemoryBindAlignments(const VkSparseMemoryBind &bind, const vvl::Buffer &buffer,
-                                                          const Location &bind_loc, const Location &buffer_bind_info_loc) const {
+bool CoreChecks::ValidateBufferSparseMemoryBindAlignments(const VkSparseMemoryBind& bind, const vvl::Buffer& buffer,
+                                                          const Location& bind_loc, const Location& buffer_bind_info_loc) const {
     bool skip = false;
 
     if (!IsIntegerMultipleOf(bind.resourceOffset, buffer.requirements.alignment)) {
@@ -2550,8 +2552,8 @@ bool CoreChecks::ValidateBufferSparseMemoryBindAlignments(const VkSparseMemoryBi
     return skip;
 }
 
-bool CoreChecks::ValidateImageSparseMemoryBindAlignments(const VkSparseMemoryBind &bind, const vvl::Image &image,
-                                                         const Location &bind_loc, const Location &image_bind_info_loc) const {
+bool CoreChecks::ValidateImageSparseMemoryBindAlignments(const VkSparseMemoryBind& bind, const vvl::Image& image,
+                                                         const Location& bind_loc, const Location& image_bind_info_loc) const {
     bool skip = false;
 
     if (!IsIntegerMultipleOf(bind.resourceOffset, image.requirements[0].alignment)) {
@@ -2574,9 +2576,9 @@ bool CoreChecks::ValidateImageSparseMemoryBindAlignments(const VkSparseMemoryBin
     return skip;
 }
 
-bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind &bind, const VkMemoryRequirements &requirements,
+bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind& bind, const VkMemoryRequirements& requirements,
                                           VkDeviceSize resource_size, VkExternalMemoryHandleTypeFlags external_handle_types,
-                                          const VulkanTypedHandle &resource_handle, const Location &loc) const {
+                                          const VulkanTypedHandle& resource_handle, const Location& loc) const {
     bool skip = false;
     if (auto memory_state = Get<vvl::DeviceMemory>(bind.memory)) {
         if (!((uint32_t(1) << memory_state->allocate_info.memoryTypeIndex) & requirements.memoryTypeBits)) {
@@ -2663,8 +2665,8 @@ bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind &bind, const 
     return skip;
 }
 
-bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(vvl::Image const &image_state, VkImageSubresource const &subresource,
-                                                               const Location &bind_loc, const Location &subresource_loc) const {
+bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(vvl::Image const& image_state, VkImageSubresource const& subresource,
+                                                               const Location& bind_loc, const Location& subresource_loc) const {
     bool skip = false;
     skip |= ValidateImageAspectMask(image_state.VkHandle(), image_state.create_info.format, subresource.aspectMask,
                                     image_state.disjoint, bind_loc, "VUID-VkSparseImageMemoryBindInfo-subresource-01106");
@@ -2687,8 +2689,8 @@ bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(vvl::Image const 
 }
 
 // This will only be called after we are sure the image was created with VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT
-bool CoreChecks::ValidateSparseImageMemoryBind(vvl::Image const *image_state, VkSparseImageMemoryBind const &bind,
-                                               const Location &bind_loc, const Location &memory_loc) const {
+bool CoreChecks::ValidateSparseImageMemoryBind(vvl::Image const* image_state, VkSparseImageMemoryBind const& bind,
+                                               const Location& bind_loc, const Location& memory_loc) const {
     bool skip = false;
 
     if (auto const memory_state = Get<vvl::DeviceMemory>(bind.memory)) {
@@ -2702,7 +2704,7 @@ bool CoreChecks::ValidateSparseImageMemoryBind(vvl::Image const *image_state, Vk
 
         // TODO: We cannot validate the requirement size since there is no way
         // to calculate the size of an optimal tiled arbitrary image region (as of now).
-        const VkMemoryRequirements &requirement = image_state->requirements[0];
+        const VkMemoryRequirements& requirement = image_state->requirements[0];
 
         if (!IsIntegerMultipleOf(bind.memoryOffset, requirement.alignment)) {
             skip |= LogError("VUID-VkSparseImageMemoryBind-memory-01105", bind.memory, memory_loc.dot(Field::memoryOffset),
@@ -2743,7 +2745,7 @@ bool CoreChecks::ValidateSparseImageMemoryBind(vvl::Image const *image_state, Vk
     skip |=
         ValidateImageSubresourceSparseImageMemoryBind(*image_state, bind.subresource, bind_loc, memory_loc.dot(Field::subresource));
 
-    const VkSparseImageMemoryRequirements *requirements = nullptr;
+    const VkSparseImageMemoryRequirements* requirements = nullptr;
     for (size_t memoryReqNdx = 0; memoryReqNdx < image_state->sparse_requirements.size(); ++memoryReqNdx) {
         if (image_state->sparse_requirements[memoryReqNdx].formatProperties.aspectMask & bind.subresource.aspectMask) {
             requirements = &image_state->sparse_requirements[memoryReqNdx];
@@ -2751,7 +2753,7 @@ bool CoreChecks::ValidateSparseImageMemoryBind(vvl::Image const *image_state, Vk
         }
     }
     if (requirements) {
-        VkExtent3D const &granularity = requirements->formatProperties.imageGranularity;
+        VkExtent3D const& granularity = requirements->formatProperties.imageGranularity;
         if (!IsIntegerMultipleOf(bind.offset.x, granularity.width)) {
             skip |= LogError(
                 "VUID-VkSparseImageMemoryBind-offset-01107", image_state->Handle(), bind_loc.dot(Field::offset).dot(Field::x),
@@ -2805,8 +2807,8 @@ bool CoreChecks::ValidateSparseImageMemoryBind(vvl::Image const *image_state, Vk
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     const LogObjectList objlist(device, pInfo->buffer);
     if (!enabled_features.bufferDeviceAddress && !enabled_features.bufferDeviceAddressEXT) {
@@ -2837,18 +2839,18 @@ bool CoreChecks::PreCallValidateGetBufferDeviceAddress(VkDevice device, const Vk
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                          const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                          const ErrorObject& error_obj) const {
     return PreCallValidateGetBufferDeviceAddress(device, pInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                          const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                          const ErrorObject& error_obj) const {
     return PreCallValidateGetBufferDeviceAddress(device, pInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureAddress(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                              const ErrorObject& error_obj) const {
     bool skip = false;
     const LogObjectList objlist(device, pInfo->buffer);
 
@@ -2880,14 +2882,14 @@ bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureAddress(VkDevice device, c
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                                 const ErrorObject& error_obj) const {
     return PreCallValidateGetBufferOpaqueCaptureAddress(device, pInfo, error_obj);
 }
 
 bool CoreChecks::PreCallValidateGetDeviceMemoryOpaqueCaptureAddress(VkDevice device,
-                                                                    const VkDeviceMemoryOpaqueCaptureAddressInfo *pInfo,
-                                                                    const ErrorObject &error_obj) const {
+                                                                    const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo,
+                                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     const LogObjectList objlst(device, pInfo->memory);
 
@@ -2929,13 +2931,13 @@ bool CoreChecks::PreCallValidateGetDeviceMemoryOpaqueCaptureAddress(VkDevice dev
 }
 
 bool CoreChecks::PreCallValidateGetDeviceMemoryOpaqueCaptureAddressKHR(VkDevice device,
-                                                                       const VkDeviceMemoryOpaqueCaptureAddressInfo *pInfo,
-                                                                       const ErrorObject &error_obj) const {
+                                                                       const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo,
+                                                                       const ErrorObject& error_obj) const {
     return PreCallValidateGetDeviceMemoryOpaqueCaptureAddress(device, pInfo, error_obj);
 }
 
-bool CoreChecks::ValidateMemoryIsBoundToBuffer(LogObjectList objlist, const vvl::Buffer &buffer_state, const Location &buffer_loc,
-                                               const char *vuid) const {
+bool CoreChecks::ValidateMemoryIsBoundToBuffer(LogObjectList objlist, const vvl::Buffer& buffer_state, const Location& buffer_loc,
+                                               const char* vuid) const {
     bool skip = false;
     if (!buffer_state.sparse) {
         objlist.add(buffer_state.Handle());
@@ -2945,7 +2947,7 @@ bool CoreChecks::ValidateMemoryIsBoundToBuffer(LogObjectList objlist, const vvl:
 }
 
 // Used when only need to check a VkDeviceAddress is tied to a VkBuffer
-bool CoreChecks::ValidateDeviceAddress(const Location &device_address_loc, const LogObjectList &objlist,
+bool CoreChecks::ValidateDeviceAddress(const Location& device_address_loc, const LogObjectList& objlist,
                                        VkDeviceAddress device_address) const {
     BufferAddressValidation<0> buffer_address_validator = {};
     return buffer_address_validator.ValidateDeviceAddress(*this, device_address_loc, objlist, device_address);
@@ -2984,27 +2986,27 @@ bool CoreChecks::ValidateDeviceAddressRange(VkDeviceAddress address, VkDeviceSiz
 }
 
 bool CoreChecks::PreCallValidateBindTensorMemoryARM(VkDevice device, uint32_t bindInfoCount,
-                                                    const VkBindTensorMemoryInfoARM *pBindInfos,
-                                                    const ErrorObject &error_obj) const {
+                                                    const VkBindTensorMemoryInfoARM* pBindInfos,
+                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateBindTensorMemoryARM(bindInfoCount, pBindInfos, error_obj);
     return skip;
 }
 
-bool CoreChecks::ValidateBindDataGraphPipelineSessionMemoryARM(const VkBindDataGraphPipelineSessionMemoryInfoARM &bind_info,
-                                                               const Location &bind_info_loc) const {
+bool CoreChecks::ValidateBindDataGraphPipelineSessionMemoryARM(const VkBindDataGraphPipelineSessionMemoryInfoARM& bind_info,
+                                                               const Location& bind_info_loc) const {
     bool skip = false;
     auto session_state = Get<vvl::DataGraphPipelineSession>(bind_info.session);
     ASSERT_AND_RETURN_SKIP(session_state);
     const LogObjectList objlist(bind_info.session, bind_info.memory);
 
     const auto& bp_requirements = session_state->BindPointReqs();
-    const auto bpr_match = std::find_if(bp_requirements.begin(), bp_requirements.end(), [bind_info](const VkDataGraphPipelineSessionBindPointRequirementARM& bpr) {
-        return bpr.bindPoint == bind_info.bindPoint;
-    });
+    const auto bpr_match = std::find_if(
+        bp_requirements.begin(), bp_requirements.end(),
+        [bind_info](const VkDataGraphPipelineSessionBindPointRequirementARM& bpr) { return bpr.bindPoint == bind_info.bindPoint; });
     if (bpr_match == bp_requirements.end()) {
         std::ostringstream required_bindpoints;
-        for (auto &bpr : bp_requirements) {
+        for (auto& bpr : bp_requirements) {
             if (!required_bindpoints.str().empty()) {
                 required_bindpoints << ", ";
             }
@@ -3029,9 +3031,9 @@ bool CoreChecks::ValidateBindDataGraphPipelineSessionMemoryARM(const VkBindDataG
     }
 
     const auto& mem_reqs_map = session_state->MemReqsMap();
-    const auto &bound_memory_map = session_state->BoundMemoryMap();
+    const auto& bound_memory_map = session_state->BoundMemoryMap();
     if (bound_memory_map.find(bind_info.bindPoint) != bound_memory_map.end()) {
-        for (const auto &bound_mem : bound_memory_map.at(bind_info.bindPoint)) {
+        for (const auto& bound_mem : bound_memory_map.at(bind_info.bindPoint)) {
             if (bound_mem.memory_state->VkHandle() == bind_info.memory) {
                 skip |= LogError(
                     "VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-session-09785", objlist, bind_info_loc.dot(Field::bindPoint),
@@ -3046,7 +3048,7 @@ bool CoreChecks::ValidateBindDataGraphPipelineSessionMemoryARM(const VkBindDataG
     skip |= ValidateInsertMemoryRange(VulkanTypedHandle(bind_info.session, kVulkanObjectTypeDataGraphPipelineSessionARM), *mem_info,
                                       bind_info.memoryOffset, bind_info_loc.dot(Field::memoryOffset));
     if (mem_reqs_map.find(bind_info.bindPoint) != mem_reqs_map.end()) {
-        const auto &mem_reqs = mem_reqs_map.at(bind_info.bindPoint)[bind_info.objectIndex];
+        const auto& mem_reqs = mem_reqs_map.at(bind_info.bindPoint)[bind_info.objectIndex];
         skip |= ValidateMemoryTypes(*mem_info, mem_reqs.memoryTypeBits, bind_info_loc.dot(Field::session),
                                     "VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-memory-09788");
         if (!IsIntegerMultipleOf(bind_info.memoryOffset, mem_reqs.alignment)) {
@@ -3066,13 +3068,13 @@ bool CoreChecks::ValidateBindDataGraphPipelineSessionMemoryARM(const VkBindDataG
 
     // Validate compatible protected session and memory
     if (!session_state->Unprotected() && mem_info->unprotected) {
-        const char *vuid = "VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-session-09791";
+        const char* vuid = "VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-session-09791";
         skip |= LogError(vuid, objlist, bind_info_loc.dot(Field::memory),
                          "(%s) was not created with protected memory but the VkDataGraphPipelineSessionARM (%s) was "
                          "set to use protected memory.",
                          FormatHandle(bind_info.memory).c_str(), FormatHandle(bind_info.session).c_str());
     } else if (session_state->Unprotected() && !mem_info->unprotected) {
-        const char *vuid = "VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-session-09792";
+        const char* vuid = "VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-session-09792";
         skip |= LogError(vuid, objlist, bind_info_loc.dot(Field::memory),
                          "(%s) was created with protected memory but the VkDataGraphPipelineSessionARM (%s) was not "
                          "set to use protected memory.",
@@ -3109,7 +3111,7 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
 
             BufferAddressValidation<2> buffer_address_validator = {
                 {{{"VUID-VkDecompressMemoryRegionEXT-srcAddress-07686",
-                   [start, size](const vvl::Buffer &buffer_state) {
+                   [start, size](const vvl::Buffer& buffer_state) {
                        const VkDeviceSize end =
                            buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
                        return size > end;
@@ -3117,7 +3119,7 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
                    [size]() { return "The compressedSize (" + std::to_string(size) + ") does not fit in any buffer"; },
                    kEmptyErrorMsgBuffer},
                   {"VUID-VkDecompressMemoryRegionEXT-srcAddress-11764",
-                   [](const vvl::Buffer &buffer_state) {
+                   [](const vvl::Buffer& buffer_state) {
                        return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
                    },
                    []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
@@ -3132,7 +3134,7 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
             const VkDeviceSize size = region.decompressedSize;
             BufferAddressValidation<2> dst_range_validator = {
                 {{{"VUID-VkDecompressMemoryRegionEXT-dstAddress-07688",
-                   [start, size](const vvl::Buffer &buffer_state) {
+                   [start, size](const vvl::Buffer& buffer_state) {
                        const VkDeviceSize end =
                            buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
                        return size > end;
@@ -3140,7 +3142,7 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
                    [size]() { return "The decompressedSize (" + std::to_string(size) + ") does not fit in any buffer"; },
                    kEmptyErrorMsgBuffer},
                   {"VUID-VkDecompressMemoryRegionEXT-dstAddress-11765",
-                   [](const vvl::Buffer &buffer_state) {
+                   [](const vvl::Buffer& buffer_state) {
                        return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
                    },
                    []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
@@ -3168,11 +3170,11 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
         const VkDeviceSize max_range_size = static_cast<VkDeviceSize>(stride) * static_cast<VkDeviceSize>(maxDecompressionCount);
         BufferAddressValidation<2> buffer_address_validator = {
             {{{"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsAddress-07694",
-               [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
+               [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
                []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer},
 
               {"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsAddress-11794",
-               [indirectCommandsAddress, stride, maxDecompressionCount](const vvl::Buffer &buffer_state) {
+               [indirectCommandsAddress, stride, maxDecompressionCount](const vvl::Buffer& buffer_state) {
                    if (maxDecompressionCount == 0 || stride == 0) return false;
                    const vvl::range<VkDeviceSize> required_range(
                        indirectCommandsAddress, indirectCommandsAddress + static_cast<VkDeviceSize>(stride) *
@@ -3194,7 +3196,7 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
     {
         BufferAddressValidation<1> buffer_address_validator = {
             {{{"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsCountAddress-07697",
-               [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
+               [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
                []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer}}}};
 
         const Location ic_count_loc = error_obj.location.dot(Field::indirectCommandsCountAddress);

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -58,7 +58,7 @@ bool CoreChecks::ValidateGraphicsIndexedCmd(const vvl::CommandBuffer& cb_state, 
     bool skip = false;
     // maintenance6 allows null buffers to be bound
     if (!cb_state.index_buffer_binding.bound) {
-        const char *extra =
+        const char* extra =
             enabled_features.maintenance6
                 ? "Even with maintenance6, you need to set the buffer in vkCmdBindIndexBuffer to be VK_NULL_HANDLE, not "
                   "calling vkCmdBindIndexBuffer still has the buffer as undeclared."
@@ -74,8 +74,8 @@ bool CoreChecks::ValidateGraphicsIndexedCmd(const vvl::CommandBuffer& cb_state, 
 bool CoreChecks::ValidateCmdDrawInstance(const LastBound& last_bound_state, uint32_t instanceCount, uint32_t firstInstance,
                                          const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const auto *pipeline_state = last_bound_state.pipeline_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    const auto* pipeline_state = last_bound_state.pipeline_state;
 
     // Verify maxMultiviewInstanceIndex
     if (cb_state.active_render_pass && cb_state.active_render_pass->has_multiview_enabled &&
@@ -95,8 +95,8 @@ bool CoreChecks::ValidateCmdDrawInstance(const LastBound& last_bound_state, uint
     if (IsExtEnabled(extensions.vk_khr_vertex_attribute_divisor) && !phys_dev_props_core14.supportsNonZeroFirstInstance) {
         if (last_bound_state.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
             if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT) && firstInstance != 0u) {
-                for (const auto &binding_state : cb_state.dynamic_state_value.vertex_bindings) {
-                    const auto &desc = binding_state.second.desc;
+                for (const auto& binding_state : cb_state.dynamic_state_value.vertex_bindings) {
+                    const auto& desc = binding_state.second.desc;
                     if (desc.divisor != 1u) {
                         skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::VERTEX_INPUT_09462),
                                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), loc,
@@ -148,8 +148,8 @@ bool CoreChecks::ValidateVTGShaderStages(const LastBound& last_bound_state, cons
 
 bool CoreChecks::ValidateMeshShaderStage(const LastBound& last_bound_state, const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const auto *pipeline_state = last_bound_state.pipeline_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    const auto* pipeline_state = last_bound_state.pipeline_state;
 
     if (pipeline_state) {
         if (!(pipeline_state->active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT)) {
@@ -181,7 +181,7 @@ bool CoreChecks::ValidateMeshShaderStage(const LastBound& last_bound_state, cons
                 string_VkShaderStageFlags(pipeline_state->active_shaders).c_str());
         }
     }
-    for (const auto &query : cb_state.active_queries) {
+    for (const auto& query : cb_state.active_queries) {
         if (const auto query_pool_state = Get<vvl::QueryPool>(query.pool)) {
             const VkQueryType query_type = query_pool_state->create_info.queryType;
             if (query_type == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT) {
@@ -226,11 +226,11 @@ bool CoreChecks::ValidateMeshShaderStage(const LastBound& last_bound_state, cons
 }
 
 bool CoreChecks::PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                        uint32_t firstVertex, uint32_t firstInstance, const ErrorObject &error_obj) const {
+                                        uint32_t firstVertex, uint32_t firstInstance, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdDrawInstance(last_bound_state, instanceCount, firstInstance, error_obj.location);
@@ -239,12 +239,12 @@ bool CoreChecks::PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t 
 }
 
 bool CoreChecks::PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
-                                                uint32_t firstInstance, uint32_t stride, const ErrorObject &error_obj) const {
+                                                const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
+                                                uint32_t firstInstance, uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdDrawInstance(last_bound_state, instanceCount, firstInstance, error_obj.location);
@@ -307,11 +307,11 @@ bool CoreChecks::ValidateCmdDrawIndexedBufferSize(const vvl::CommandBuffer& cb_s
 
 bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
-                                               const ErrorObject &error_obj) const {
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdDrawInstance(last_bound_state, instanceCount, firstInstance, error_obj.location);
@@ -327,13 +327,13 @@ bool CoreChecks::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, ui
 }
 
 bool CoreChecks::PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                       const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
-                                                       uint32_t firstInstance, uint32_t stride, const int32_t *pVertexOffset,
-                                                       const ErrorObject &error_obj) const {
+                                                       const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
+                                                       uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset,
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdDrawInstance(last_bound_state, instanceCount, firstInstance, error_obj.location);
@@ -370,9 +370,9 @@ bool CoreChecks::PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBu
             return skip;
         }
 
-        const auto info_bytes = reinterpret_cast<const char *>(pIndexInfo);
+        const auto info_bytes = reinterpret_cast<const char*>(pIndexInfo);
         for (uint32_t i = 0; i < drawCount; i++) {
-            const auto info_ptr = reinterpret_cast<const VkMultiDrawIndexedInfoEXT *>(info_bytes + i * stride);
+            const auto info_ptr = reinterpret_cast<const VkMultiDrawIndexedInfoEXT*>(info_bytes + i * stride);
             skip |= ValidateCmdDrawIndexedBufferSize(cb_state, info_ptr->indexCount, info_ptr->firstIndex,
                                                      error_obj.location.dot(Field::pIndexInfo, i),
                                                      "VUID-vkCmdDrawMultiIndexedEXT-robustBufferAccess2-08798");
@@ -382,11 +382,11 @@ bool CoreChecks::PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer commandBu
 }
 
 bool CoreChecks::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                uint32_t drawCount, uint32_t stride, const ErrorObject &error_obj) const {
+                                                uint32_t drawCount, uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateVTGShaderStages(last_bound_state, error_obj.location);
@@ -454,11 +454,11 @@ bool CoreChecks::PreCallValidateCmdDrawIndirect2KHR(VkCommandBuffer commandBuffe
 }
 
 bool CoreChecks::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                       uint32_t drawCount, uint32_t stride, const ErrorObject &error_obj) const {
+                                                       uint32_t drawCount, uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateVTGShaderStages(last_bound_state, error_obj.location);
@@ -535,11 +535,11 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirect2KHR(VkCommandBuffer comma
 }
 
 bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                            uint32_t groupCountZ, const ErrorObject &error_obj) const {
+                                            uint32_t groupCountZ, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundCompute();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundCompute();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
 
@@ -569,11 +569,11 @@ bool CoreChecks::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint3
 
 bool CoreChecks::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                 uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                uint32_t groupCountZ, const ErrorObject &error_obj) const {
+                                                uint32_t groupCountZ, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundCompute();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundCompute();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
 
@@ -631,7 +631,7 @@ bool CoreChecks::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer, u
                                  baseGroupX, baseGroupY, baseGroupZ);
             }
         } else {
-            const auto *shader_object = last_bound_state.GetShaderObjectState(ShaderObjectStage::COMPUTE);
+            const auto* shader_object = last_bound_state.GetShaderObjectState(ShaderObjectStage::COMPUTE);
             if (shader_object && ((shader_object->create_info.flags & VK_SHADER_CREATE_DISPATCH_BASE_BIT_EXT) == 0)) {
                 skip |= LogError("VUID-vkCmdDispatchBase-baseGroupX-00427", cb_state.GetObjectList(VK_SHADER_STAGE_COMPUTE_BIT),
                                  error_obj.location,
@@ -648,17 +648,17 @@ bool CoreChecks::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer, u
 
 bool CoreChecks::PreCallValidateCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                    uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                   uint32_t groupCountZ, const ErrorObject &error_obj) const {
+                                                   uint32_t groupCountZ, const ErrorObject& error_obj) const {
     return PreCallValidateCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ,
                                           error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                    const ErrorObject &error_obj) const {
+                                                    const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundCompute();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundCompute();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
 
@@ -704,11 +704,11 @@ bool CoreChecks::PreCallValidateCmdDispatchIndirect2KHR(VkCommandBuffer commandB
 
 bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                     uint32_t stride, const ErrorObject &error_obj) const {
+                                                     uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateVTGShaderStages(last_bound_state, error_obj.location);
@@ -756,7 +756,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuff
 
 bool CoreChecks::PreCallValidateCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                        uint32_t stride, const ErrorObject &error_obj) const {
+                                                        uint32_t stride, const ErrorObject& error_obj) const {
     return PreCallValidateCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                                error_obj);
 }
@@ -787,11 +787,11 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount2KHR(VkCommandBuffer command
 bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                             VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                             uint32_t maxDrawCount, uint32_t stride,
-                                                            const ErrorObject &error_obj) const {
+                                                            const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateVTGShaderStages(last_bound_state, error_obj.location);
@@ -841,7 +841,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer comm
 bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride,
-                                                               const ErrorObject &error_obj) const {
+                                                               const ErrorObject& error_obj) const {
     return PreCallValidateCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount,
                                                       stride, error_obj);
 }
@@ -875,11 +875,11 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount2KHR(VkCommandBuffer 
 bool CoreChecks::PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
                                                             uint32_t firstInstance, VkBuffer counterBuffer,
                                                             VkDeviceSize counterBufferOffset, uint32_t counterOffset,
-                                                            uint32_t vertexStride, const ErrorObject &error_obj) const {
+                                                            uint32_t vertexStride, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdDrawInstance(last_bound_state, instanceCount, firstInstance, error_obj.location);
@@ -950,11 +950,11 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
                                                VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                                VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                                uint32_t width, uint32_t height, uint32_t depth,
-                                               const ErrorObject &error_obj) const {
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundRayTracing();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundRayTracing();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
 
@@ -1089,22 +1089,22 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
     return skip;
 }
 
-bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &last_bound_state,
-                                         const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                         const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                         const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                         const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable) const {
+bool CoreChecks::ValidateCmdTraceRaysKHR(const Location& loc, const LastBound& last_bound_state,
+                                         const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                         const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                         const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                         const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable) const {
     bool skip = false;
-    const vvl::Pipeline *pipeline_state = last_bound_state.pipeline_state;
+    const vvl::Pipeline* pipeline_state = last_bound_state.pipeline_state;
     if (!pipeline_state) return skip;  // possible wasn't bound correctly, check caught elsewhere
     const bool is_indirect = loc.function == Func::vkCmdTraceRaysIndirectKHR;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     if (pHitShaderBindingTable) {
         const Location table_loc = loc.dot(Field::pHitShaderBindingTable);
         if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR) {
             if ((pHitShaderBindingTable->size == 0 || pHitShaderBindingTable->stride == 0)) {
-                const char *vuid =
+                const char* vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03514" : "VUID-vkCmdTraceRaysKHR-flags-03514";
                 skip |= LogError(vuid, cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR), table_loc,
                                  "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.", pHitShaderBindingTable->size,
@@ -1113,7 +1113,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
         }
         if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) {
             if ((pHitShaderBindingTable->size == 0 || pHitShaderBindingTable->stride == 0)) {
-                const char *vuid =
+                const char* vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03513" : "VUID-vkCmdTraceRaysKHR-flags-03513";
                 skip |= LogError(vuid, cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR), table_loc,
                                  "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.", pHitShaderBindingTable->size,
@@ -1124,7 +1124,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
             // No vuid to check for pHitShaderBindingTable->deviceAddress == 0 with this flag
 
             if (pHitShaderBindingTable->size == 0 || pHitShaderBindingTable->stride == 0) {
-                const char *vuid =
+                const char* vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03512" : "VUID-vkCmdTraceRaysKHR-flags-03512";
                 skip |= LogError(vuid, cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR), table_loc,
                                  "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.", pHitShaderBindingTable->size,
@@ -1132,14 +1132,14 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
             }
         }
 
-        const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pHitShaderBindingTable-03688"
+        const char* vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pHitShaderBindingTable-03688"
                                                           : "VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03688";
         skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_binding_table_flag, *pHitShaderBindingTable);
     }
 
     if (pRaygenShaderBindingTable) {
         const Location table_loc = loc.dot(Field::pRaygenShaderBindingTable);
-        const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pRayGenShaderBindingTable-03681"
+        const char* vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pRayGenShaderBindingTable-03681"
                                                           : "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03681";
         // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9368
         // TODO - waiting for https://gitlab.khronos.org/vulkan/vulkan/-/issues/4173
@@ -1153,14 +1153,14 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
 
     if (pMissShaderBindingTable) {
         const Location table_loc = loc.dot(Field::pMissShaderBindingTable);
-        const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pMissShaderBindingTable-03684"
+        const char* vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pMissShaderBindingTable-03684"
                                                           : "VUID-vkCmdTraceRaysKHR-pMissShaderBindingTable-03684";
         skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_binding_table_flag, *pMissShaderBindingTable);
     }
 
     if (pCallableShaderBindingTable) {
         const Location table_loc = loc.dot(Field::pCallableShaderBindingTable);
-        const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pCallableShaderBindingTable-03692"
+        const char* vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pCallableShaderBindingTable-03692"
                                                           : "VUID-vkCmdTraceRaysKHR-pCallableShaderBindingTable-03692";
         skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_binding_table_flag, *pCallableShaderBindingTable);
     }
@@ -1168,15 +1168,15 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
 }
 
 bool CoreChecks::PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                                const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable, uint32_t width,
-                                                uint32_t height, uint32_t depth, const ErrorObject &error_obj) const {
+                                                const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width,
+                                                uint32_t height, uint32_t depth, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundRayTracing();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundRayTracing();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdTraceRaysKHR(error_obj.location, last_bound_state, pRaygenShaderBindingTable, pMissShaderBindingTable,
@@ -1184,16 +1184,16 @@ bool CoreChecks::PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
     return skip;
 }
 
-bool CoreChecks::ValidateCmdTraceRaysIndirect(const Location &loc, const LastBound &last_bound_state,
+bool CoreChecks::ValidateCmdTraceRaysIndirect(const Location& loc, const LastBound& last_bound_state,
                                               VkDeviceAddress indirect_device_address) const {
     bool skip = false;
     const bool is_2khr = loc.function == Func::vkCmdTraceRaysIndirect2KHR;
 
-    const char *usage_vuid = is_2khr ? "VUID-vkCmdTraceRaysIndirect2KHR-indirectDeviceAddress-03633"
+    const char* usage_vuid = is_2khr ? "VUID-vkCmdTraceRaysIndirect2KHR-indirectDeviceAddress-03633"
                                      : "VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03633";
     BufferAddressValidation<1> buffer_address_validator = {
         {{{usage_vuid,
-           [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
+           [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
            []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer}}}};
 
     skip |= buffer_address_validator.ValidateDeviceAddress(
@@ -1202,15 +1202,15 @@ bool CoreChecks::ValidateCmdTraceRaysIndirect(const Location &loc, const LastBou
 }
 
 bool CoreChecks::PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                        const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                        const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                        const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                        const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                        VkDeviceAddress indirectDeviceAddress, const ErrorObject &error_obj) const {
+                                                        const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                        const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                        const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                        const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                        VkDeviceAddress indirectDeviceAddress, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundRayTracing();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundRayTracing();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdTraceRaysKHR(error_obj.location, last_bound_state, pRaygenShaderBindingTable, pMissShaderBindingTable,
@@ -1220,11 +1220,11 @@ bool CoreChecks::PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer commandB
 }
 
 bool CoreChecks::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
-                                                         const ErrorObject &error_obj) const {
+                                                         const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundRayTracing();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundRayTracing();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateCmdTraceRaysIndirect(error_obj.location, last_bound_state, indirectDeviceAddress);
@@ -1232,11 +1232,11 @@ bool CoreChecks::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer command
 }
 
 bool CoreChecks::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
-                                                   const ErrorObject &error_obj) const {
+                                                   const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateMeshShaderStage(last_bound_state, error_obj.location);
@@ -1254,11 +1254,11 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer
 
 bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                            uint32_t drawCount, uint32_t stride,
-                                                           const ErrorObject &error_obj) const {
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateMeshShaderStage(last_bound_state, error_obj.location);
@@ -1311,11 +1311,11 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
 bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                 uint32_t maxDrawCount, uint32_t stride,
-                                                                const ErrorObject &error_obj) const {
+                                                                const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateMeshShaderStage(last_bound_state, error_obj.location);
@@ -1357,11 +1357,11 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
 }
 
 bool CoreChecks::PreCallValidateCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                                    uint32_t groupCountZ, const ErrorObject &error_obj) const {
+                                                    uint32_t groupCountZ, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateMeshShaderStage(last_bound_state, error_obj.location);
@@ -1430,11 +1430,11 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffe
 
 bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                             uint32_t drawCount, uint32_t stride,
-                                                            const ErrorObject &error_obj) const {
+                                                            const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateMeshShaderStage(last_bound_state, error_obj.location);
@@ -1487,11 +1487,11 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer comm
 bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                  VkDeviceSize offset, VkBuffer countBuffer,
                                                                  VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                                 uint32_t stride, const ErrorObject &error_obj) const {
+                                                                 uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
-    const auto &last_bound_state = cb_state.GetLastBoundGraphics();
-    const DrawDispatchVuid &vuid = GetDrawDispatchVuid(error_obj.location.function);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& last_bound_state = cb_state.GetLastBoundGraphics();
+    const DrawDispatchVuid& vuid = GetDrawDispatchVuid(error_obj.location.function);
 
     skip |= ValidateActionState(last_bound_state, vuid);
     skip |= ValidateMeshShaderStage(last_bound_state, error_obj.location);
@@ -1588,10 +1588,10 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCount2EXT(VkCommandBuffe
 
 // Action command == vkCmdDraw*, vkCmdDispatch*, vkCmdTraceRays*
 // This is the main logic shared by all action commands
-bool CoreChecks::ValidateActionState(const LastBound &last_bound_state, const DrawDispatchVuid &vuid) const {
-    const Location &loc = vuid.loc();
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const vvl::Pipeline *pipeline = last_bound_state.pipeline_state;
+bool CoreChecks::ValidateActionState(const LastBound& last_bound_state, const DrawDispatchVuid& vuid) const {
+    const Location& loc = vuid.loc();
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    const vvl::Pipeline* pipeline = last_bound_state.pipeline_state;
     const VkPipelineBindPoint bind_point = last_bound_state.bind_point;
 
     bool skip = false;
@@ -1617,7 +1617,7 @@ bool CoreChecks::ValidateActionState(const LastBound &last_bound_state, const Dr
         if (cb_state.active_render_pass && cb_state.active_render_pass->UsesDynamicRendering()) {
             skip |= ValidateDrawDynamicRenderingFsOutputs(last_bound_state, cb_state, loc);
             skip |= ValidateDrawDynamicRenderpassExternalFormatResolve(last_bound_state, *cb_state.active_render_pass, loc);
-            const auto &cb_sub_state = core::SubState(cb_state);
+            const auto& cb_sub_state = core::SubState(cb_state);
             skip |= ValidateDrawCustomResolve(last_bound_state, *cb_state.active_render_pass, cb_sub_state, loc);
         }
 
@@ -1677,8 +1677,8 @@ bool CoreChecks::ValidateActionState(const LastBound &last_bound_state, const Dr
 // any dynamic descriptors, always revalidate rather than caching the values. We currently only
 // apply this optimization if IsManyDescriptors is true, to avoid the overhead of copying the
 // binding_req_map which could potentially be expensive.
-static bool NeedDrawStateValidated(const vvl::CommandBuffer &cb_state, const vvl::DescriptorSet *descriptor_set,
-                                   const LastBound::DescriptorSetSlot &ds_slot, bool disabled_image_layout_validation) {
+static bool NeedDrawStateValidated(const vvl::CommandBuffer& cb_state, const vvl::DescriptorSet* descriptor_set,
+                                   const LastBound::DescriptorSetSlot& ds_slot, bool disabled_image_layout_validation) {
     return ds_slot.dynamic_offsets.size() > 0 ||
            // Revalidate if descriptor set (or contents) has changed
            ds_slot.validated_set != descriptor_set || ds_slot.validated_set_change_count != descriptor_set->GetChangeCount() ||
@@ -1686,8 +1686,8 @@ static bool NeedDrawStateValidated(const vvl::CommandBuffer &cb_state, const vvl
             ds_slot.validated_set_image_layout_change_count != cb_state.image_layout_change_count);
 }
 
-bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound &last_bound_state, const VkPipelineBindPoint bind_point,
-                                                        const vvl::Pipeline &pipeline, const vvl::DrawDispatchVuid &vuid) const {
+bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
+                                                        const vvl::Pipeline& pipeline, const vvl::DrawDispatchVuid& vuid) const {
     bool skip = false;
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
@@ -1712,7 +1712,7 @@ bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound &last_bo
         return skip;
     }
 
-    for (const auto &ds_slot : last_bound_state.ds_slots) {
+    for (const auto& ds_slot : last_bound_state.ds_slots) {
         // TODO - This currently implicitly is checking for VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT being set
         if (pipeline.descriptor_buffer_mode) {
             if (ds_slot.ds_state && !ds_slot.ds_state->IsPushDescriptor()) {
@@ -1770,7 +1770,7 @@ bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound &last_bo
         std::ostringstream pipe_layouts_log;
         if (layouts.size() > 1) {
             pipe_layouts_log << "a union of layouts [ ";
-            for (const auto &layout : layouts) {
+            for (const auto& layout : layouts) {
                 objlist.add(layout->Handle());
                 pipe_layouts_log << FormatHandle(*layout) << " ";
             }
@@ -1792,7 +1792,7 @@ bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound &last_bo
                          last_bound_state.DescribeNonCompatibleSet(pipeline.max_active_slot, *pipeline_layout).c_str());
     } else {
         // if the bound set is not compatible, the rest will just be extra redundant errors
-        for (const auto &[set_index, binding_req_map] : pipeline.active_slots) {
+        for (const auto& [set_index, binding_req_map] : pipeline.active_slots) {
             std::string error_string;
             const auto ds_slot = last_bound_state.ds_slots[set_index];
             if (!ds_slot.ds_state) {
@@ -1812,7 +1812,7 @@ bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound &last_bo
                                  error_string.c_str());
             } else {  // Valid set is bound and layout compatible, validate that it's updated
                 // Pull the set node
-                const auto *descriptor_set = ds_slot.ds_state.get();
+                const auto* descriptor_set = ds_slot.ds_state.get();
                 ASSERT_AND_CONTINUE(descriptor_set);
 
                 const bool need_validate =
@@ -1980,10 +1980,10 @@ bool CoreChecks::ValidateActionStateDescriptorHeapSamplers(const vvl::CommandBuf
     return skip;
 }
 
-bool CoreChecks::ValidateActionStateDescriptorsShaderObject(const LastBound &last_bound_state, const VkPipelineBindPoint bind_point,
-                                                            const vvl::DrawDispatchVuid &vuid) const {
+bool CoreChecks::ValidateActionStateDescriptorsShaderObject(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
+                                                            const vvl::DrawDispatchVuid& vuid) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     // Check if the current shader objects are compatible for the maximum used set with the bound sets.
     for (const auto& shader_object_ptr : last_bound_state.shader_object_states) {
@@ -2058,7 +2058,7 @@ bool CoreChecks::ValidateActionStateDescriptorsShaderObject(const LastBound &las
                                      error_string.c_str());
                 } else {  // Valid set is bound and layout compatible, validate that it's updated
                     // Pull the set node
-                    const auto *descriptor_set = ds_slot.ds_state.get();
+                    const auto* descriptor_set = ds_slot.ds_state.get();
                     ASSERT_AND_CONTINUE(descriptor_set);
 
                     const bool need_validate =
@@ -2125,7 +2125,7 @@ bool CoreChecks::ValidateActionStatePushConstantDescriptorHeap(const vvl::Comman
 bool CoreChecks::ValidateActionStatePushConstant(const LastBound& last_bound_state, const vvl::Pipeline* pipeline,
                                                  const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     // Push constants validation for DGC will need to be done in GPU-AV
     if (loc.function == vvl::Func::vkCmdExecuteGeneratedCommandsEXT) {
@@ -2143,7 +2143,7 @@ bool CoreChecks::ValidateActionStatePushConstant(const LastBound& last_bound_sta
                                                                       last_bound_state.bind_point, loc);
             }
         }
-        auto const &pipeline_layout = pipeline->PipelineLayoutState();
+        auto const& pipeline_layout = pipeline->PipelineLayoutState();
         if (pipeline_layout) {
             if (!cb_state.push_constant_ranges_layout ||
                 (pipeline_layout->push_constant_ranges_layout == cb_state.push_constant_ranges_layout)) {
@@ -2193,7 +2193,7 @@ bool CoreChecks::ValidateActionStatePushConstant(const LastBound& last_bound_sta
 bool CoreChecks::ValidateActionStateProtectedMemory(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
                                                     const vvl::Pipeline* pipeline, const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     if (pipeline) {
         for (const ShaderStageState& stage : pipeline->stage_states) {
@@ -2226,8 +2226,8 @@ bool CoreChecks::ValidateActionStateProtectedMemory(const LastBound& last_bound_
 
 // Note, these don't include the RTX Indirect commands (vkCmdTraceRaysIndirectKHR) because
 // they use a VkDeviceAddress instead of a VkBuffer
-bool CoreChecks::ValidateIndirectCmd(const vvl::CommandBuffer &cb_state, const vvl::Buffer &buffer_state,
-                                     const DrawDispatchVuid &vuid) const {
+bool CoreChecks::ValidateIndirectCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state,
+                                     const DrawDispatchVuid& vuid) const {
     bool skip = false;
     LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
     objlist.add(buffer_state.Handle());
@@ -2243,8 +2243,8 @@ bool CoreChecks::ValidateIndirectCmd(const vvl::CommandBuffer &cb_state, const v
     return skip;
 }
 
-bool CoreChecks::ValidateIndirectCountCmd(const vvl::CommandBuffer &cb_state, const vvl::Buffer &count_buffer_state,
-                                          VkDeviceSize count_buffer_offset, const DrawDispatchVuid &vuid) const {
+bool CoreChecks::ValidateIndirectCountCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& count_buffer_state,
+                                          VkDeviceSize count_buffer_offset, const DrawDispatchVuid& vuid) const {
     bool skip = false;
     LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
     objlist.add(count_buffer_state.Handle());
@@ -2310,9 +2310,9 @@ bool CoreChecks::ValidateIndirectCountBufferDeviceAddress(const vvl::CommandBuff
     return skip;
 }
 
-bool CoreChecks::ValidateDrawPrimitivesGeneratedQuery(const LastBound &last_bound_state, const Location &loc) const {
+bool CoreChecks::ValidateDrawPrimitivesGeneratedQuery(const LastBound& last_bound_state, const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     const bool with_rasterizer_discard = enabled_features.primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE;
     const bool with_non_zero_streams = enabled_features.primitivesGeneratedQueryWithNonZeroStreams == VK_TRUE;
@@ -2321,7 +2321,7 @@ bool CoreChecks::ValidateDrawPrimitivesGeneratedQuery(const LastBound &last_boun
         return skip;
     }
 
-    for (const auto &query : cb_state.active_queries) {
+    for (const auto& query : cb_state.active_queries) {
         auto query_pool_state = Get<vvl::QueryPool>(query.pool);
         if (!query_pool_state || query_pool_state->create_info.queryType != VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
             continue;
@@ -2338,7 +2338,7 @@ bool CoreChecks::ValidateDrawPrimitivesGeneratedQuery(const LastBound &last_boun
         }
 
         // rasterizationStream doesn't have dynamic state, so only possible from a pipeline
-        const vvl::Pipeline *pipeline = last_bound_state.pipeline_state;
+        const vvl::Pipeline* pipeline = last_bound_state.pipeline_state;
         if (!with_non_zero_streams && pipeline) {
             const auto rasterization_state_stream_ci =
                 vku::FindStructInPNextChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(pipeline->RasterizationStatePNext());
@@ -2361,8 +2361,8 @@ bool CoreChecks::ValidateDrawPrimitivesGeneratedQuery(const LastBound &last_boun
 
 bool CoreChecks::ValidateDrawFragmentShadingRate(const LastBound& last_bound_state, const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const auto *pipeline = last_bound_state.pipeline_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    const auto* pipeline = last_bound_state.pipeline_state;
 
     if (!enabled_features.primitiveFragmentShadingRate ||
         phys_dev_ext_props.fragment_shading_rate_props.primitiveFragmentShadingRateWithMultipleViewports) {
@@ -2370,7 +2370,7 @@ bool CoreChecks::ValidateDrawFragmentShadingRate(const LastBound& last_bound_sta
     }
 
     if (pipeline) {
-        for (auto &stage_state : pipeline->stage_states) {
+        for (auto& stage_state : pipeline->stage_states) {
             const VkShaderStageFlagBits stage = stage_state.GetStage();
             if (!IsValueIn(stage, {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_GEOMETRY_BIT, VK_SHADER_STAGE_MESH_BIT_EXT})) {
                 continue;
@@ -2413,7 +2413,7 @@ bool CoreChecks::ValidateDrawFragmentShadingRate(const LastBound& last_bound_sta
 bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_state, const Location& loc) const {
     bool skip = false;
 
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const bool has_pipeline = last_bound_state.pipeline_state != nullptr;
 
     if (has_pipeline && !last_bound_state.pipeline_state->ColorBlendState()) {
@@ -2455,8 +2455,8 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound& last_bound_st
     const spirv::EntryPoint* fragment_entry_point = last_bound_state.GetFragmentEntryPoint();
 
     for (uint32_t i = 0; i < cb_state.active_attachments.size(); ++i) {
-        const auto &attachment_info = cb_state.active_attachments[i];
-        const auto *attachment = attachment_info.image_view;
+        const auto& attachment_info = cb_state.active_attachments[i];
+        const auto* attachment = attachment_info.image_view;
         if (!attachment || !attachment_info.IsColor()) {
             continue;
         }
@@ -2622,11 +2622,11 @@ bool CoreChecks::ValidateDrawAttachmentSampleLocation(const LastBound& last_boun
         return skip;
     }
 
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     if (last_bound_state.IsSampleLocationsEnable()) {
         for (uint32_t i = 0; i < cb_state.active_attachments.size(); i++) {
-            const auto &attachment_info = cb_state.active_attachments[i];
-            const auto *attachment = attachment_info.image_view;
+            const auto& attachment_info = cb_state.active_attachments[i];
+            const auto* attachment = attachment_info.image_view;
             if (!attachment || !attachment_info.IsDepth()) {
                 continue;
             }
@@ -2650,10 +2650,10 @@ bool CoreChecks::ValidateDrawAttachmentSampleLocation(const LastBound& last_boun
 bool CoreChecks::ValidateDrawDepthStencilAttachments(const LastBound& last_bound_state, const Location& loc) const {
     bool skip = false;
 
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     for (uint32_t i = 0; i < cb_state.active_attachments.size(); i++) {
-        const auto &attachment_info = cb_state.active_attachments[i];
-        const auto *attachment = attachment_info.image_view;
+        const auto& attachment_info = cb_state.active_attachments[i];
+        const auto* attachment = attachment_info.image_view;
         if (!attachment) {
             continue;
         }
@@ -2710,11 +2710,11 @@ bool CoreChecks::ValidateDrawTessellation(const LastBound& last_bound_state, con
         return skip;
     }
 
-    const spirv::ExecutionModeSet *tesc_execution_mode = nullptr;
-    const spirv::ExecutionModeSet *tese_execution_mode = nullptr;
+    const spirv::ExecutionModeSet* tesc_execution_mode = nullptr;
+    const spirv::ExecutionModeSet* tese_execution_mode = nullptr;
 
     if (last_bound_state.pipeline_state) {
-        for (const auto &stage_state : last_bound_state.pipeline_state->stage_states) {
+        for (const auto& stage_state : last_bound_state.pipeline_state->stage_states) {
             const VkShaderStageFlagBits stage = stage_state.GetStage();
             if (stage & VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT) {
                 if (stage_state.entrypoint) {
@@ -2787,9 +2787,9 @@ bool CoreChecks::ValidateDrawTessellation(const LastBound& last_bound_state, con
     return skip;
 }
 
-bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vvl::DrawDispatchVuid &vuid) const {
+bool CoreChecks::ValidateDrawVertexBinding(const LastBound& last_bound, const vvl::DrawDispatchVuid& vuid) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound.cb_state;
 
     if ((last_bound.GetAllActiveBoundStages() & VK_SHADER_STAGE_VERTEX_BIT) == 0) {
         return skip;
@@ -2806,7 +2806,7 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vv
     }
 
     const bool has_dynamic_descriptions = last_bound.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT);
-    const auto &vertex_bindings = has_dynamic_descriptions ? cb_state.dynamic_state_value.vertex_bindings
+    const auto& vertex_bindings = has_dynamic_descriptions ? cb_state.dynamic_state_value.vertex_bindings
                                                            : last_bound.pipeline_state->vertex_input_state->bindings;
 
     const bool robust_pipeline = last_bound.pipeline_state && last_bound.pipeline_state->uses_pipeline_vertex_robustness;
@@ -2820,8 +2820,8 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vv
         }
         ss << " has pVertexBindingDescriptions[" << binding_description.index << "].binding (" << binding_description.desc.binding
            << ") (pointing to Locations [";
-        const char *separator = "";
-        for (const auto &location : binding_description.locations) {
+        const char* separator = "";
+        for (const auto& location : binding_description.locations) {
             ss << separator << location.first;
             separator = ", ";
         }
@@ -2829,25 +2829,25 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vv
         return ss.str();
     };
 
-    const spirv::EntryPoint *vertex_entry_point = last_bound.GetVertexEntryPoint();
+    const spirv::EntryPoint* vertex_entry_point = last_bound.GetVertexEntryPoint();
     // Can be NULL if pipeline binaries are used
     if (!vertex_entry_point) {
         return skip;
     }
     vvl::unordered_set<uint32_t> spirv_input_locations;
-    for (const auto &pair : vertex_entry_point->input_interface_slots) {
+    for (const auto& pair : vertex_entry_point->input_interface_slots) {
         spirv_input_locations.emplace(pair.first.Location());
     }
 
     // It is ok to have binding descriptions not used, them and find if there is matching buffer tied to it or not
-    for (const auto &[binding_index, binding_description] : vertex_bindings) {
+    for (const auto& [binding_index, binding_description] : vertex_bindings) {
         // If no attribute points to a binding, it is unused
         if (binding_description.locations.empty()) {
             continue;
         }
 
         bool shader_has_location = false;
-        for (const auto &location : binding_description.locations) {
+        for (const auto& location : binding_description.locations) {
             if (spirv_input_locations.find(location.first) != spirv_input_locations.end()) {
                 shader_has_location = true;
                 break;
@@ -2858,7 +2858,7 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vv
             continue;
         }
 
-        const auto *vertex_buffer_binding = vvl::Find(cb_state.current_vertex_buffer_binding_info, binding_index);
+        const auto* vertex_buffer_binding = vvl::Find(cb_state.current_vertex_buffer_binding_info, binding_index);
         if (!vertex_buffer_binding || !vertex_buffer_binding->bound) {
             // Likely to not get
             skip |= LogError(CreateActionVuid(vuid, vvl::ActionVUID::VERTEX_BINDING_04007),
@@ -2890,9 +2890,9 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vv
             }
         }
 
-        for (const auto &location : binding_description.locations) {
+        for (const auto& location : binding_description.locations) {
             const auto attr_index = location.second.index;
-            const auto &attr_desc = location.second.desc;
+            const auto& attr_desc = location.second.desc;
 
             if (last_bound.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE)) {
                 const VkDeviceSize attribute_binding_extent = attr_desc.offset + GetVertexInputFormatSize(attr_desc.format);
@@ -2965,11 +2965,11 @@ bool CoreChecks::ValidateDrawCustomResolve(const LastBound& last_bound, const vv
     // The remaining checks are only for pipeline, Shader Object doesn't have an explicit custom resolve info (except FDM)
     if (!last_bound.pipeline_state) {
         if (last_bound.IsStageBound(VK_SHADER_STAGE_FRAGMENT_BIT) && enabled_features.fragmentDensityMap && rp_has_custom_resolve) {
-            const AttachmentInfo &fdm_attachment =
+            const AttachmentInfo& fdm_attachment =
                 cb_sub_state.base.active_attachments[cb_sub_state.base.GetDynamicRenderingAttachmentIndex(
                     AttachmentInfo::Type::FragmentDensityMap)];
             if (fdm_attachment.image_view) {
-                const auto &shader_object = last_bound.GetShaderObjectState(ShaderObjectStage::FRAGMENT);
+                const auto& shader_object = last_bound.GetShaderObjectState(ShaderObjectStage::FRAGMENT);
                 if (const auto shader_object_cr_info =
                         vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(shader_object->create_info.pNext)) {
                     if (cb_sub_state.custom_resolve.started && !shader_object_cr_info->customResolve) {
@@ -3003,7 +3003,7 @@ bool CoreChecks::ValidateDrawCustomResolve(const LastBound& last_bound, const vv
         return skip;
     }
 
-    const VkCustomResolveCreateInfoEXT *pipeline_cr_info = nullptr;
+    const VkCustomResolveCreateInfoEXT* pipeline_cr_info = nullptr;
     if (last_bound.pipeline_state->fragment_output_state) {
         // Will get normal and GPL Fragment Output pipelines
         pipeline_cr_info = vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(
@@ -3052,7 +3052,7 @@ bool CoreChecks::ValidateDrawCustomResolve(const LastBound& last_bound, const vv
         return skip;
     }
 
-    const VkRenderingInfo &rendering_info = *rp_state.dynamic_rendering_begin_rendering_info.ptr();
+    const VkRenderingInfo& rendering_info = *rp_state.dynamic_rendering_begin_rendering_info.ptr();
 
     if (pipeline_cr_info->colorAttachmentCount != rendering_info.colorAttachmentCount &&
         !enabled_features.dynamicRenderingUnusedAttachments) {
@@ -3206,9 +3206,9 @@ bool CoreChecks::ValidateDrawDynamicRenderpassExternalFormatResolve(const LastBo
         return skip;
     }
 
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
-    const VkRenderingInfo &rendering_info = *(rp_state.dynamic_rendering_begin_rendering_info.ptr());
+    const VkRenderingInfo& rendering_info = *(rp_state.dynamic_rendering_begin_rendering_info.ptr());
 
     if (rendering_info.colorAttachmentCount == 1 &&
         rendering_info.pColorAttachments[0].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID) {
@@ -3279,7 +3279,7 @@ bool CoreChecks::ValidateBoundTileMemory(const vvl::Bindable& bindable, const vv
     auto bound_memory_states = bindable.GetBoundMemoryStates();
     VkDeviceMemory bound_tile_memory_handle =
         (cb_state.bound_tile_memory != VK_NULL_HANDLE) ? cb_state.bound_tile_memory->VkHandle() : VK_NULL_HANDLE;
-    for (const auto &bound_memory : bound_memory_states) {
+    for (const auto& bound_memory : bound_memory_states) {
         if (HasTileMemoryType(bound_memory->allocate_info.memoryTypeIndex) &&
             (bound_memory->VkHandle() != bound_tile_memory_handle)) {
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::TILE_MEMORY_HEAP_10746), cb_state.Handle(), loc,

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -46,8 +46,8 @@ bool CoreChecks::CanFenceExportFromImported(VkExternalFenceHandleTypeFlagBits ex
     return (imported_type & fence_properties.exportFromImportedHandleTypes) != 0;
 }
 
-bool CoreChecks::PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     if (const auto memory_state = Get<vvl::DeviceMemory>(pGetFdInfo->memory)) {
         const auto export_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(memory_state->allocate_info.pNext);
@@ -68,8 +68,8 @@ bool CoreChecks::PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGe
     return skip;
 }
 
-bool CoreChecks::PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR *pImportSemaphoreFdInfo,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo,
+                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreFdInfo->semaphore);
     ASSERT_AND_RETURN_SKIP(sem_state);
@@ -110,8 +110,8 @@ bool CoreChecks::PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkIm
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     auto sem_state = Get<vvl::Semaphore>(pGetFdInfo->semaphore);
     ASSERT_AND_RETURN_SKIP(sem_state);
@@ -152,7 +152,7 @@ bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemap
     return skip;
 }
 
-bool CoreChecks::ValidateImportFence(VkFence fence, const char *vuid, const Location &loc) const {
+bool CoreChecks::ValidateImportFence(VkFence fence, const char* vuid, const Location& loc) const {
     auto fence_node = Get<vvl::Fence>(fence);
     bool skip = false;
     ASSERT_AND_RETURN_SKIP(fence_node);
@@ -162,14 +162,14 @@ bool CoreChecks::ValidateImportFence(VkFence fence, const char *vuid, const Loca
     return skip;
 }
 
-bool CoreChecks::PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR *pImportFenceFdInfo,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo,
+                                                 const ErrorObject& error_obj) const {
     return ValidateImportFence(pImportFenceFdInfo->fence, "VUID-vkImportFenceFdKHR-fence-01463",
                                error_obj.location.dot(Field::pImportFenceFdInfo));
 }
 
-bool CoreChecks::PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto fence_state = Get<vvl::Fence>(pGetFdInfo->fence)) {
         const Location info_loc = error_obj.location.dot(Field::pGetFdInfo);
@@ -188,7 +188,8 @@ bool CoreChecks::PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetF
                              string_VkExternalFenceHandleTypeFlagBits(fence_state->ImportedHandleType().value()));
         }
 
-        if (pGetFdInfo->handleType == VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT && fence_state->State() == vvl::Fence::kUnsignaled) {
+        if (pGetFdInfo->handleType == VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT &&
+            fence_state->State() == vvl::Fence::kUnsignaled) {
             skip |= LogError("VUID-VkFenceGetFdInfoKHR-handleType-01454", fence_state->Handle(), info_loc.dot(Field::handleType),
                              "is VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT which cannot be exported unless the fence has a pending "
                              "signal operation or is already signaled.");
@@ -198,8 +199,8 @@ bool CoreChecks::PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetF
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-bool CoreChecks::PreCallValidateGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR *pGetWin32HandleInfo,
-                                                        HANDLE *pHandle, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                        HANDLE* pHandle, const ErrorObject& error_obj) const {
     bool skip = false;
     if (const auto memory_state = Get<vvl::DeviceMemory>(pGetWin32HandleInfo->memory)) {
         const auto export_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(memory_state->allocate_info.pNext);
@@ -221,8 +222,8 @@ bool CoreChecks::PreCallValidateGetMemoryWin32HandleKHR(VkDevice device, const V
 }
 
 bool CoreChecks::PreCallValidateImportSemaphoreWin32HandleKHR(
-    VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *pImportSemaphoreWin32HandleInfo,
-    const ErrorObject &error_obj) const {
+    VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo,
+    const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreWin32HandleInfo->semaphore)) {
         // Waiting for: https://gitlab.khronos.org/vulkan/vulkan/-/issues/3507
@@ -239,8 +240,8 @@ bool CoreChecks::PreCallValidateImportSemaphoreWin32HandleKHR(
 }
 
 bool CoreChecks::PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device,
-                                                           const VkSemaphoreGetWin32HandleInfoKHR *pGetWin32HandleInfo,
-                                                           HANDLE *pHandle, const ErrorObject &error_obj) const {
+                                                           const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                           HANDLE* pHandle, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto sem_state = Get<vvl::Semaphore>(pGetWin32HandleInfo->semaphore)) {
         if ((pGetWin32HandleInfo->handleType & sem_state->export_handle_types) == 0) {
@@ -264,14 +265,14 @@ bool CoreChecks::PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device,
 }
 
 bool CoreChecks::PreCallValidateImportFenceWin32HandleKHR(VkDevice device,
-                                                          const VkImportFenceWin32HandleInfoKHR *pImportFenceWin32HandleInfo,
-                                                          const ErrorObject &error_obj) const {
+                                                          const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo,
+                                                          const ErrorObject& error_obj) const {
     return ValidateImportFence(pImportFenceWin32HandleInfo->fence, "VUID-vkImportFenceWin32HandleKHR-fence-04448",
                                error_obj.location.dot(Field::pImportFenceWin32HandleInfo));
 }
 
-bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR *pGetWin32HandleInfo,
-                                                       HANDLE *pHandle, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                       HANDLE* pHandle, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto fence_state = Get<vvl::Fence>(pGetWin32HandleInfo->fence)) {
         if ((pGetWin32HandleInfo->handleType & fence_state->export_handle_types) == 0) {
@@ -297,8 +298,8 @@ bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const Vk
 
 #ifdef VK_USE_PLATFORM_FUCHSIA
 bool CoreChecks::PreCallValidateImportSemaphoreZirconHandleFUCHSIA(
-    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA *pImportSemaphoreZirconHandleInfo,
-    const ErrorObject &error_obj) const {
+    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo,
+    const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreZirconHandleInfo->semaphore)) {
         skip |= ValidateObjectNotInUse(sem_state.get(), error_obj.location,
@@ -314,8 +315,8 @@ bool CoreChecks::PreCallValidateImportSemaphoreZirconHandleFUCHSIA(
 }
 
 void CoreChecks::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
-    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA *pImportSemaphoreZirconHandleInfo,
-    const RecordObject &record_obj) {
+    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo,
+    const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -324,8 +325,8 @@ void CoreChecks::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
 }
 
 void CoreChecks::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
-                                                               const VkSemaphoreGetZirconHandleInfoFUCHSIA *pGetZirconHandleInfo,
-                                                               zx_handle_t *pZirconHandle, const RecordObject &record_obj) {
+                                                               const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
+                                                               zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -335,10 +336,10 @@ void CoreChecks::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
 #endif
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT *pMetalObjectsInfo,
-                                                      const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT* pMetalObjectsInfo,
+                                                      const ErrorObject& error_obj) const {
     bool skip = false;
-    const VkBaseOutStructure *metal_objects_info_ptr = reinterpret_cast<const VkBaseOutStructure *>(pMetalObjectsInfo->pNext);
+    const VkBaseOutStructure* metal_objects_info_ptr = reinterpret_cast<const VkBaseOutStructure*>(pMetalObjectsInfo->pNext);
     while (metal_objects_info_ptr) {
         switch (metal_objects_info_ptr->sType) {
             case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT:
@@ -369,7 +370,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                 break;
 
             case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT: {
-                auto metal_buffer_ptr = reinterpret_cast<const VkExportMetalBufferInfoEXT *>(metal_objects_info_ptr);
+                auto metal_buffer_ptr = reinterpret_cast<const VkExportMetalBufferInfoEXT*>(metal_objects_info_ptr);
                 if (auto mem_info = Get<vvl::DeviceMemory>(metal_buffer_ptr->memory)) {
                     if (!mem_info->metal_buffer_export) {
                         skip |= LogError(
@@ -384,7 +385,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
             } break;
 
             case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT: {
-                auto metal_texture_ptr = reinterpret_cast<const VkExportMetalTextureInfoEXT *>(metal_objects_info_ptr);
+                auto metal_texture_ptr = reinterpret_cast<const VkExportMetalTextureInfoEXT*>(metal_objects_info_ptr);
                 if ((metal_texture_ptr->image == VK_NULL_HANDLE && metal_texture_ptr->imageView == VK_NULL_HANDLE &&
                      metal_texture_ptr->bufferView == VK_NULL_HANDLE) ||
                     (metal_texture_ptr->image &&
@@ -506,7 +507,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
             } break;
 
             case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT: {
-                auto metal_io_surface_ptr = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(metal_objects_info_ptr);
+                auto metal_io_surface_ptr = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT*>(metal_objects_info_ptr);
                 if (auto image_info = Get<vvl::Image>(metal_io_surface_ptr->image)) {
                     if (!image_info->metal_io_surface_export) {
                         skip |= LogError(
@@ -521,7 +522,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
             } break;
 
             case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT: {
-                auto metal_shared_event_ptr = reinterpret_cast<const VkExportMetalSharedEventInfoEXT *>(metal_objects_info_ptr);
+                auto metal_shared_event_ptr = reinterpret_cast<const VkExportMetalSharedEventInfoEXT*>(metal_objects_info_ptr);
                 if ((metal_shared_event_ptr->event == VK_NULL_HANDLE && metal_shared_event_ptr->semaphore == VK_NULL_HANDLE) ||
                     (metal_shared_event_ptr->event != VK_NULL_HANDLE && metal_shared_event_ptr->semaphore != VK_NULL_HANDLE)) {
                     skip |= LogError("VUID-VkExportMetalObjectsInfoEXT-pNext-06804", device, error_obj.location,
@@ -566,9 +567,9 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
     return skip;
 }
 
-bool CoreChecks::ValidateAllocateMemoryMetal(const VkMemoryAllocateInfo &allocate_info,
-                                             const VkMemoryDedicatedAllocateInfo *dedicated_allocation_info,
-                                             const Location &allocate_info_loc) const {
+bool CoreChecks::ValidateAllocateMemoryMetal(const VkMemoryAllocateInfo& allocate_info,
+                                             const VkMemoryDedicatedAllocateInfo* dedicated_allocation_info,
+                                             const Location& allocate_info_loc) const {
     bool skip = false;
 
     // When dealing with Metal external memory, we can have the following 3 scenarios:
@@ -604,8 +605,8 @@ bool CoreChecks::ValidateAllocateMemoryMetal(const VkMemoryAllocateInfo &allocat
         (import_memory_metal_info->handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT) &&
         (import_memory_metal_info->handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLHEAP_BIT_EXT)) {
         skip |= LogError("VUID-VkImportMemoryMetalHandleInfoEXT-handleType-10410", device,
-                         allocate_info_loc.pNext(Struct::VkImportMemoryMetalHandleInfoEXT, Field::handleType), "current value is %s",
-                         string_VkExternalMemoryHandleTypeFlagBits(import_memory_metal_info->handleType));
+                         allocate_info_loc.pNext(Struct::VkImportMemoryMetalHandleInfoEXT, Field::handleType),
+                         "current value is %s", string_VkExternalMemoryHandleTypeFlagBits(import_memory_metal_info->handleType));
         return skip;
     }
 
@@ -615,14 +616,12 @@ bool CoreChecks::ValidateAllocateMemoryMetal(const VkMemoryAllocateInfo &allocat
     // operations on buffers.
     if (import_memory_metal_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT) {
         if (allocate_info.allocationSize != 0) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-10397", device,
-                             allocate_info_loc.dot(Field::allocationSize), "is %" PRId64,
-                             allocate_info.allocationSize);
+            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-10397", device, allocate_info_loc.dot(Field::allocationSize),
+                             "is %" PRId64, allocate_info.allocationSize);
         }
 
         if (dedicated_allocation_info == nullptr) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-10395", device,
-                             allocate_info_loc.dot(Field::pNext),
+            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-10395", device, allocate_info_loc.dot(Field::pNext),
                              "VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT requires textures to be imported as a dedicated"
                              "allocation.");
             // Early out since the image comes from VkMemoryDedicatedAllocateInfoKHR and there's none.
@@ -663,8 +662,8 @@ bool CoreChecks::ValidateAllocateMemoryMetal(const VkMemoryAllocateInfo &allocat
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetMemoryMetalHandleEXT(VkDevice device, const VkMemoryGetMetalHandleInfoEXT *pGetMetalHandleInfo,
-                                                        void **pHandle, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetMemoryMetalHandleEXT(VkDevice device, const VkMemoryGetMetalHandleInfoEXT* pGetMetalHandleInfo,
+                                                        void** pHandle, const ErrorObject& error_obj) const {
     bool skip = false;
     const Location get_metal_handle_info = error_obj.location.dot(Field::pGetMetalHandleInfo);
     auto memory = Get<vvl::DeviceMemory>(pGetMetalHandleInfo->memory);
@@ -675,35 +674,35 @@ bool CoreChecks::PreCallValidateGetMemoryMetalHandleEXT(VkDevice device, const V
                          get_metal_handle_info.dot(Field::memory).dot(Field::pNext),
                          "device memory missing VkExportMemoryAllocateInfo at creation");
     } else if ((export_memory_allocate_info->handleTypes & pGetMetalHandleInfo->handleType) == 0u) {
-        skip |= LogError("VUID-VkMemoryGetMetalHandleInfoEXT-handleType-10414", device,
-                         get_metal_handle_info.dot(Field::handleType),
-                         "device memory was created with (%s) handle types. Missing %s type",
-                         string_VkExternalMemoryHandleTypeFlags(export_memory_allocate_info->handleTypes).c_str(),
-                         string_VkExternalMemoryHandleTypeFlagBits(pGetMetalHandleInfo->handleType));
+        skip |=
+            LogError("VUID-VkMemoryGetMetalHandleInfoEXT-handleType-10414", device, get_metal_handle_info.dot(Field::handleType),
+                     "device memory was created with (%s) handle types. Missing %s type",
+                     string_VkExternalMemoryHandleTypeFlags(export_memory_allocate_info->handleTypes).c_str(),
+                     string_VkExternalMemoryHandleTypeFlagBits(pGetMetalHandleInfo->handleType));
     }
 
     if ((pGetMetalHandleInfo->handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_EXT) &&
         (pGetMetalHandleInfo->handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT) &&
         (pGetMetalHandleInfo->handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLHEAP_BIT_EXT)) {
-        skip |= LogError("VUID-VkMemoryGetMetalHandleInfoEXT-handleType-10415", device,
-                         get_metal_handle_info.dot(Field::handleType), "current value is %s",
-                         string_VkExternalMemoryHandleTypeFlagBits(pGetMetalHandleInfo->handleType));
+        skip |=
+            LogError("VUID-VkMemoryGetMetalHandleInfoEXT-handleType-10415", device, get_metal_handle_info.dot(Field::handleType),
+                     "current value is %s", string_VkExternalMemoryHandleTypeFlagBits(pGetMetalHandleInfo->handleType));
     }
     return skip;
 }
 
 bool CoreChecks::PreCallValidateGetMemoryMetalHandlePropertiesEXT(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
-                                                                  const void *handle,
-                                                                  VkMemoryMetalHandlePropertiesEXT *pMemoryMetalHandleProperties,
-                                                                  const ErrorObject &error_obj) const {
+                                                                  const void* handle,
+                                                                  VkMemoryMetalHandlePropertiesEXT* pMemoryMetalHandleProperties,
+                                                                  const ErrorObject& error_obj) const {
     bool skip = false;
 
     if ((handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLBUFFER_BIT_EXT) &&
         (handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT) &&
         (handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLHEAP_BIT_EXT)) {
-        skip |= LogError("VUID-vkGetMemoryMetalHandlePropertiesEXT-handleType-10417", device,
-                         error_obj.location.dot(Field::handleType), "current value is %s",
-                         string_VkExternalMemoryHandleTypeFlagBits(handleType));
+        skip |=
+            LogError("VUID-vkGetMemoryMetalHandlePropertiesEXT-handleType-10417", device, error_obj.location.dot(Field::handleType),
+                     "current value is %s", string_VkExternalMemoryHandleTypeFlagBits(handleType));
     }
 
     return skip;

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -46,7 +46,7 @@ bool CoreChecks::IsMixSamplingSupported() const {
            enabled_features.multisampledRenderToSingleSampled;
 }
 
-bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo &create_info, const Location &loc) const {
+bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo& create_info, const Location& loc) const {
     bool skip = false;
 
     // validates based on imageCreateFormatFeatures from vkspec.html#resources-image-creation-limits
@@ -65,9 +65,9 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo &create_inf
         }
     } else if (image_tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
         vvl::unordered_set<uint64_t> drm_format_modifiers;
-        const VkImageDrmFormatModifierExplicitCreateInfoEXT *drm_explicit =
+        const VkImageDrmFormatModifierExplicitCreateInfoEXT* drm_explicit =
             vku::FindStructInPNextChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(create_info.pNext);
-        const VkImageDrmFormatModifierListCreateInfoEXT *drm_implicit =
+        const VkImageDrmFormatModifierListCreateInfoEXT* drm_implicit =
             vku::FindStructInPNextChain<VkImageDrmFormatModifierListCreateInfoEXT>(create_info.pNext);
 
         if (drm_explicit != nullptr) {
@@ -139,8 +139,8 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo &create_inf
     return skip;
 }
 
-bool CoreChecks::ValidateImageAlignmentControlCreateInfo(const VkImageCreateInfo &create_info,
-                                                         const Location &create_info_loc) const {
+bool CoreChecks::ValidateImageAlignmentControlCreateInfo(const VkImageCreateInfo& create_info,
+                                                         const Location& create_info_loc) const {
     bool skip = false;
     const auto alignment_control_create_info =
         vku::FindStructInPNextChain<VkImageAlignmentControlCreateInfoMESA>(create_info.pNext);
@@ -183,8 +183,8 @@ bool CoreChecks::ValidateImageAlignmentControlCreateInfo(const VkImageCreateInfo
     return skip;
 }
 
-bool CoreChecks::ValidateImageVideo(const VkImageCreateInfo &create_info, const Location &create_info_loc,
-                                    const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateImageVideo(const VkImageCreateInfo& create_info, const Location& create_info_loc,
+                                    const ErrorObject& error_obj) const {
     bool skip = false;
 
     const bool has_decode_usage =
@@ -258,7 +258,7 @@ bool CoreChecks::ValidateImageVideo(const VkImageCreateInfo &create_info, const 
             valid_quantization_map_format = false;
         }
 
-        const auto *video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(create_info.pNext);
+        const auto* video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(create_info.pNext);
         if (video_profiles == nullptr) {
             skip |= LogError("VUID-VkImageCreateInfo-usage-10254", device, create_info_loc.dot(Field::usage),
                              "has VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR or "
@@ -278,7 +278,7 @@ bool CoreChecks::ValidateImageVideo(const VkImageCreateInfo &create_info, const 
                                                    create_info_loc.dot(Field::pProfiles, 0));
 
             vvl::VideoProfileDesc profile_desc(physical_device, &video_profiles->pProfiles[0]);
-            const auto &profile_caps = profile_desc.GetCapabilities();
+            const auto& profile_caps = profile_desc.GetCapabilities();
 
             if (profile_desc.IsEncode()) {
                 if ((create_info.usage & VK_IMAGE_USAGE_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR) != 0 &&
@@ -344,7 +344,7 @@ bool CoreChecks::ValidateImageVideo(const VkImageCreateInfo &create_info, const 
         const bool expect_decode_profile = has_decode_usage && !video_profile_independent;
         const bool expect_encode_profile = has_encode_usage && !video_profile_independent;
 
-        const auto *video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(create_info.pNext);
+        const auto* video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(create_info.pNext);
         // Quantization map video profile list info validation happens in the previous block
         if (!has_quantization_map_usage) {
             skip |= core::ValidateVideoProfileListInfo(
@@ -371,7 +371,7 @@ bool CoreChecks::ValidateImageVideo(const VkImageCreateInfo &create_info, const 
     return skip;
 }
 
-bool CoreChecks::ValidateImageSwapchain(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool CoreChecks::ValidateImageSwapchain(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
     const auto swapchain_create_info = vku::FindStructInPNextChain<VkImageSwapchainCreateInfoKHR>(create_info.pNext);
@@ -386,7 +386,7 @@ bool CoreChecks::ValidateImageSwapchain(const VkImageCreateInfo &create_info, co
     const VkSwapchainCreateFlagsKHR swapchain_flags = swapchain_state->create_info.flags;
 
     // Validate rest of Swapchain Image create check that require swapchain state
-    const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
+    const char* vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
     if (((swapchain_flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) != 0) &&
         ((create_info.flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT) == 0)) {
         skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
@@ -465,8 +465,8 @@ bool CoreChecks::ValidateImageSwapchain(const VkImageCreateInfo &create_info, co
     return skip;
 }
 
-bool CoreChecks::ValidateImageExternalMemory(const VkImageCreateInfo &create_info, const Location &create_info_loc,
-                                             VkPhysicalDeviceImageFormatInfo2 &image_format_info) const {
+bool CoreChecks::ValidateImageExternalMemory(const VkImageCreateInfo& create_info, const Location& create_info_loc,
+                                             VkPhysicalDeviceImageFormatInfo2& image_format_info) const {
     bool skip = false;
 
     const auto external_memory_create_info_nv = vku::FindStructInPNextChain<VkExternalMemoryImageCreateInfoNV>(create_info.pNext);
@@ -581,9 +581,9 @@ bool CoreChecks::ValidateImageExternalMemory(const VkImageCreateInfo &create_inf
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
-                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage,
-                                            const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkImage* pImage,
+                                            const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -686,8 +686,8 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
         }
     } else {
-        auto *modifier_list = vku::FindStructInPNextChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
-        auto *explicit_modifier = vku::FindStructInPNextChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
+        auto* modifier_list = vku::FindStructInPNextChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
+        auto* explicit_modifier = vku::FindStructInPNextChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
         VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
         drm_format_modifier.sharingMode = pCreateInfo->sharingMode;
         drm_format_modifier.queueFamilyIndexCount = pCreateInfo->queueFamilyIndexCount;
@@ -880,9 +880,9 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     return skip;
 }
 
-void CoreChecks::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
-                                           const VkAllocationCallbacks *pAllocator, VkImage *pImage,
-                                           const RecordObject &record_obj) {
+void CoreChecks::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator, VkImage* pImage,
+                                           const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -895,8 +895,8 @@ void CoreChecks::PostCallRecordCreateImage(VkDevice device, const VkImageCreateI
     }
 }
 
-bool CoreChecks::PreCallValidateDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
+                                             const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto image_state = Get<vvl::Image>(image)) {
         if (image_state->IsSwapchainImage() && image_state->owned_by_swapchain) {
@@ -910,14 +910,14 @@ bool CoreChecks::PreCallValidateDestroyImage(VkDevice device, VkImage image, con
     return skip;
 }
 
-void CoreChecks::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,
-                                           const RecordObject &record_obj) {
+void CoreChecks::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
+                                           const RecordObject& record_obj) {
     // Clean up validation specific data
     qfo_release_image_barrier_map.erase(image);
 }
 
-bool CoreChecks::ValidateClearImageSubresourceRange(const LogObjectList &objlist, const VkImageSubresourceRange &range,
-                                                    const Location &loc) const {
+bool CoreChecks::ValidateClearImageSubresourceRange(const LogObjectList& objlist, const VkImageSubresourceRange& range,
+                                                    const Location& loc) const {
     bool skip = false;
 
     if (range.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT) {
@@ -929,16 +929,16 @@ bool CoreChecks::ValidateClearImageSubresourceRange(const LogObjectList &objlist
 }
 
 bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                                   const VkClearColorValue *pColor, uint32_t rangeCount,
-                                                   const VkImageSubresourceRange *pRanges, const ErrorObject &error_obj) const {
+                                                   const VkClearColorValue* pColor, uint32_t rangeCount,
+                                                   const VkImageSubresourceRange* pRanges, const ErrorObject& error_obj) const {
     bool skip = false;
     // TODO : Verify memory is in VK_IMAGE_STATE_CLEAR state
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto image_state_ptr = Get<vvl::Image>(image);
     ASSERT_AND_RETURN_SKIP(image_state_ptr);
 
-    const auto &cb_state = *cb_state_ptr;
-    const auto &image_state = *image_state_ptr;
+    const auto& cb_state = *cb_state_ptr;
+    const auto& image_state = *image_state_ptr;
     const Location image_loc = error_obj.location.dot(Field::image);
     LogObjectList objlist(commandBuffer, image);
     skip |= ValidateMemoryIsBoundToImage(objlist, image_state, image_loc, "VUID-vkCmdClearColorImage-image-00003");
@@ -987,7 +987,7 @@ bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer
 }
 
 bool CoreChecks::ValidateClearDepthStencilValue(VkCommandBuffer commandBuffer, VkClearDepthStencilValue clearValue,
-                                                const Location &loc) const {
+                                                const Location& loc) const {
     bool skip = false;
 
     if (!IsExtEnabled(extensions.vk_ext_depth_range_unrestricted)) {
@@ -1004,9 +1004,9 @@ bool CoreChecks::ValidateClearDepthStencilValue(VkCommandBuffer commandBuffer, V
 }
 
 bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                                          const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount,
-                                                          const VkImageSubresourceRange *pRanges,
-                                                          const ErrorObject &error_obj) const {
+                                                          const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
+                                                          const VkImageSubresourceRange* pRanges,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
 
     // TODO : Verify memory is in VK_IMAGE_STATE_CLEAR state
@@ -1014,8 +1014,8 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     auto image_state_ptr = Get<vvl::Image>(image);
     ASSERT_AND_RETURN_SKIP(image_state_ptr);
 
-    const auto &cb_state = *cb_state_ptr;
-    const auto &image_state = *image_state_ptr;
+    const auto& cb_state = *cb_state_ptr;
+    const auto& image_state = *image_state_ptr;
     const Location image_loc = error_obj.location.dot(Field::image);
 
     const VkFormat image_format = image_state.create_info.format;
@@ -1093,9 +1093,9 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     return skip;
 }
 
-bool CoreChecks::ValidateClearAttachmentExtent(const vvl::CommandBuffer &cb_state, const VkRect2D &render_area,
+bool CoreChecks::ValidateClearAttachmentExtent(const vvl::CommandBuffer& cb_state, const VkRect2D& render_area,
                                                uint32_t render_pass_layer_count, uint32_t rect_count,
-                                               const VkClearRect *clear_rects, const Location &loc) const {
+                                               const VkClearRect* clear_rects, const Location& loc) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < rect_count; i++) {
@@ -1122,15 +1122,15 @@ bool CoreChecks::ValidateClearAttachmentExtent(const vvl::CommandBuffer &cb_stat
 }
 
 bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                    const VkClearAttachment *pAttachments, uint32_t rectCount,
-                                                    const VkClearRect *pRects, const ErrorObject &error_obj) const {
+                                                    const VkClearAttachment* pAttachments, uint32_t rectCount,
+                                                    const VkClearRect* pRects, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
-    const vvl::CommandBuffer &cb_state = *cb_state_ptr;
+    const vvl::CommandBuffer& cb_state = *cb_state_ptr;
 
     skip |= ValidateCmd(cb_state, error_obj.location);
 
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
     if (!rp_state) {
         return skip;
     }
@@ -1148,16 +1148,16 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
     }
 
     for (uint32_t attachment_index = 0; attachment_index < attachmentCount; attachment_index++) {
-        const Location &attachment_loc = error_obj.location.dot(Field::pAttachments, attachment_index);
+        const Location& attachment_loc = error_obj.location.dot(Field::pAttachments, attachment_index);
         const VkClearAttachment& clear_desc = pAttachments[attachment_index];
 
         const VkImageAspectFlags aspect_mask = clear_desc.aspectMask;
 
-        const vvl::ImageView *color_view_state = nullptr;
+        const vvl::ImageView* color_view_state = nullptr;
         uint32_t color_attachment_count = 0;
 
-        const vvl::ImageView *depth_view_state = nullptr;
-        const vvl::ImageView *stencil_view_state = nullptr;
+        const vvl::ImageView* depth_view_state = nullptr;
+        const vvl::ImageView* stencil_view_state = nullptr;
 
         bool external_format_resolve = false;
 
@@ -1186,9 +1186,9 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
 
             external_format_resolve = cb_state.HasExternalFormatResolveAttachment();
         } else {
-            const auto *renderpass_create_info = rp_state->create_info.ptr();
-            const auto *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.GetActiveSubpass()];
-            const auto *framebuffer = cb_state.active_framebuffer.get();
+            const auto* renderpass_create_info = rp_state->create_info.ptr();
+            const auto* subpass_desc = &renderpass_create_info->pSubpasses[cb_state.GetActiveSubpass()];
+            const auto* framebuffer = cb_state.active_framebuffer.get();
 
             if (subpass_desc) {
                 if (framebuffer && (clear_desc.colorAttachment != VK_ATTACHMENT_UNUSED) &&
@@ -1290,7 +1290,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                              "is %s.", string_VkImageAspectFlags(aspect_mask).c_str());
         }
 
-        std::array<const vvl::ImageView *, 3> image_views = {nullptr, nullptr, nullptr};
+        std::array<const vvl::ImageView*, 3> image_views = {nullptr, nullptr, nullptr};
         if (aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) {
             image_views[0] = color_view_state;
         }
@@ -1341,8 +1341,8 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
 }
 
 // Helper function to validate usage flags for images
-bool CoreChecks::ValidateImageUsageFlags(VkCommandBuffer commandBuffer, vvl::Image const &image_state, VkImageUsageFlags desired,
-                                         bool strict, const char *vuid, const Location &image_loc) const {
+bool CoreChecks::ValidateImageUsageFlags(VkCommandBuffer commandBuffer, vvl::Image const& image_state, VkImageUsageFlags desired,
+                                         bool strict, const char* vuid, const Location& image_loc) const {
     bool skip = false;
     LogObjectList objlist(commandBuffer, image_state.Handle());
     bool correct_usage = false;
@@ -1360,8 +1360,8 @@ bool CoreChecks::ValidateImageUsageFlags(VkCommandBuffer commandBuffer, vvl::Ima
     return skip;
 }
 
-bool CoreChecks::ValidateImageFormatFeatureFlags(VkCommandBuffer commandBuffer, vvl::Image const &image_state,
-                                                 VkFormatFeatureFlags2 desired, const Location &image_loc, const char *vuid,
+bool CoreChecks::ValidateImageFormatFeatureFlags(VkCommandBuffer commandBuffer, vvl::Image const& image_state,
+                                                 VkFormatFeatureFlags2 desired, const Location& image_loc, const char* vuid,
                                                  bool all_bits_required) const {
     bool skip = false;
     const VkFormatFeatureFlags2 image_format_features = image_state.format_features;
@@ -1391,7 +1391,7 @@ bool CoreChecks::ValidateImageFormatFeatureFlags(VkCommandBuffer commandBuffer, 
 
 // For the given format verify that the aspect masks make sense
 bool CoreChecks::ValidateImageAspectMask(VkImage image, VkFormat format, VkImageAspectFlags aspect_mask, bool is_image_disjoint,
-                                         const Location &loc, const char *vuid) const {
+                                         const Location& loc, const char* vuid) const {
     bool skip = false;
     // checks color format and (single-plane or non-disjoint)
     // if ycbcr extension is not supported then single-plane and non-disjoint are always both true
@@ -1459,8 +1459,8 @@ bool CoreChecks::ValidateImageAspectMask(VkImage image, VkFormat format, VkImage
 }
 
 bool CoreChecks::ValidateImageSubresourceRange(const uint32_t image_mip_count, const uint32_t image_layer_count,
-                                               const VkImageSubresourceRange &subresourceRange, vvl::Field image_layer_count_var,
-                                               const LogObjectList &objlist, const Location &subresource_loc) const {
+                                               const VkImageSubresourceRange& subresourceRange, vvl::Field image_layer_count_var,
+                                               const LogObjectList& objlist, const Location& subresource_loc) const {
     bool skip = false;
 
     // Validate mip levels
@@ -1556,9 +1556,9 @@ bool CoreChecks::ValidateImageSubresourceRange(const uint32_t image_mip_count, c
     return skip;
 }
 
-bool CoreChecks::ValidateCreateImageViewSubresourceRange(const vvl::Image &image_state, bool is_depth_slice_view,
-                                                         const VkImageSubresourceRange &subresourceRange,
-                                                         const Location &loc) const {
+bool CoreChecks::ValidateCreateImageViewSubresourceRange(const vvl::Image& image_state, bool is_depth_slice_view,
+                                                         const VkImageSubresourceRange& subresourceRange,
+                                                         const Location& loc) const {
     uint32_t image_layer_count;
     if (is_depth_slice_view) {
         const VkExtent3D extent = image_state.GetEffectiveSubresourceExtent(subresourceRange);
@@ -1573,9 +1573,9 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const vvl::Image &image
                                          image_layer_count_var, image_state.VkHandle(), loc.dot(Field::subresourceRange));
 }
 
-bool CoreChecks::ValidateCmdClearColorSubresourceRange(const VkImageCreateInfo &create_info,
-                                                       const VkImageSubresourceRange &subresourceRange,
-                                                       const LogObjectList &objlist, const Location &loc) const {
+bool CoreChecks::ValidateCmdClearColorSubresourceRange(const VkImageCreateInfo& create_info,
+                                                       const VkImageSubresourceRange& subresourceRange,
+                                                       const LogObjectList& objlist, const Location& loc) const {
     auto image_layer_count_var = Field::arrayLayers;
     uint32_t image_layer_count = create_info.arrayLayers;
     if (enabled_features.maintenance9 && (create_info.flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) != 0) {
@@ -1588,9 +1588,9 @@ bool CoreChecks::ValidateCmdClearColorSubresourceRange(const VkImageCreateInfo &
                                          loc.dot(Field::subresourceRange));
 }
 
-bool CoreChecks::ValidateCmdClearDepthSubresourceRange(const VkImageCreateInfo &create_info,
-                                                       const VkImageSubresourceRange &subresourceRange,
-                                                       const LogObjectList &objlist, const Location &loc) const {
+bool CoreChecks::ValidateCmdClearDepthSubresourceRange(const VkImageCreateInfo& create_info,
+                                                       const VkImageSubresourceRange& subresourceRange,
+                                                       const LogObjectList& objlist, const Location& loc) const {
     auto image_layer_count_var = Field::arrayLayers;
     uint32_t image_layer_count = create_info.arrayLayers;
     if (enabled_features.maintenance9 && (create_info.flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) != 0) {
@@ -1603,10 +1603,10 @@ bool CoreChecks::ValidateCmdClearDepthSubresourceRange(const VkImageCreateInfo &
                                          loc.dot(Field::subresourceRange));
 }
 
-bool CoreChecks::ValidateImageBarrierSubresourceRange(const VkImageCreateInfo &create_info,
-                                                      const VkImageSubresourceRange &subresource_range,
-                                                      const vvl::Image &image_state, const LogObjectList &objlist,
-                                                      const Location &loc) const {
+bool CoreChecks::ValidateImageBarrierSubresourceRange(const VkImageCreateInfo& create_info,
+                                                      const VkImageSubresourceRange& subresource_range,
+                                                      const vvl::Image& image_state, const LogObjectList& objlist,
+                                                      const Location& loc) const {
     bool skip = false;
 
     // Warning about forward compatibility issue: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4308
@@ -1632,12 +1632,12 @@ bool CoreChecks::ValidateImageBarrierSubresourceRange(const VkImageCreateInfo &c
         image_layer_count = extent.depth;
     }
     skip |= ValidateImageSubresourceRange(create_info.mipLevels, image_layer_count, subresource_range, image_layer_count_var,
-                                         objlist, loc.dot(Field::subresourceRange));
+                                          objlist, loc.dot(Field::subresourceRange));
     return skip;
 }
 
-bool CoreChecks::ValidateImageViewFormatFeatures(const vvl::Image &image_state, const VkFormat view_format,
-                                                 const VkImageUsageFlags image_usage, const Location &create_info_loc) const {
+bool CoreChecks::ValidateImageViewFormatFeatures(const vvl::Image& image_state, const VkFormat view_format,
+                                                 const VkImageUsageFlags image_usage, const Location& create_info_loc) const {
     // Pass in image_usage here instead of extracting it from image_state in case there's a chained VkImageViewUsageCreateInfo
     bool skip = false;
 
@@ -1804,7 +1804,8 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const vvl::Image &image_state, 
 bool FormatsEqualComponentBits(VkFormat format_a, VkFormat format_b) {
     const VKU_FORMAT_INFO format_info_a = vkuGetFormatInfo(format_a);
     const VKU_FORMAT_INFO format_info_b = vkuGetFormatInfo(format_b);
-    if (format_info_a.compatibility == VKU_FORMAT_COMPATIBILITY_CLASS_NONE || format_info_b.compatibility == VKU_FORMAT_COMPATIBILITY_CLASS_NONE) {
+    if (format_info_a.compatibility == VKU_FORMAT_COMPATIBILITY_CLASS_NONE ||
+        format_info_b.compatibility == VKU_FORMAT_COMPATIBILITY_CLASS_NONE) {
         return false;
     } else if (format_info_a.component_count != format_info_b.component_count) {
         return false;
@@ -1828,9 +1829,9 @@ bool FormatsEqualComponentBits(VkFormat format_a, VkFormat format_b) {
     return true;
 }
 
-bool CoreChecks::ValidateImageViewSlicedCreateInfo(const VkImageViewCreateInfo &create_info, const vvl::Image &image_state,
-                                                   const VkImageSubresourceRange &normalized_subresource_range,
-                                                   const Location &create_info_loc) const {
+bool CoreChecks::ValidateImageViewSlicedCreateInfo(const VkImageViewCreateInfo& create_info, const vvl::Image& image_state,
+                                                   const VkImageSubresourceRange& normalized_subresource_range,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
     const auto sliced_create_info_ext = vku::FindStructInPNextChain<VkImageViewSlicedCreateInfoEXT>(create_info.pNext);
     if (!sliced_create_info_ext) {
@@ -1894,12 +1895,12 @@ bool CoreChecks::ValidateImageViewSlicedCreateInfo(const VkImageViewCreateInfo &
     return skip;
 }
 
-bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo &create_info, const Location &create_info_loc) const {
+bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
     auto image_state_ptr = Get<vvl::Image>(create_info.image);
     ASSERT_AND_RETURN_SKIP(image_state_ptr);
-    const auto &image_state = *image_state_ptr;
+    const auto& image_state = *image_state_ptr;
 
     const VkImageUsageFlags valid_usage_flags =
         VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
@@ -2002,7 +2003,8 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo &create
     if ((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) && (image_format != view_format)) {
         const auto view_class = vkuFormatCompatibilityClass(view_format);
         if (multiplane_image) {
-            const VkFormat compat_format = vkuFindMultiplaneCompatibleFormat(image_format, static_cast<VkImageAspectFlagBits>(aspect_mask));
+            const VkFormat compat_format =
+                vkuFindMultiplaneCompatibleFormat(image_format, static_cast<VkImageAspectFlagBits>(aspect_mask));
             const auto image_class = vkuFormatCompatibilityClass(compat_format);
             // Need valid aspect mask otherwise will throw extra error when getting compatible format
             // Also this can be VK_IMAGE_ASPECT_COLOR_BIT
@@ -2411,9 +2413,9 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo &create
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
-                                                [[maybe_unused]] const VkAllocationCallbacks *pAllocator,
-                                                [[maybe_unused]] VkImageView *pView, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                                [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
+                                                [[maybe_unused]] VkImageView* pView, const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidateDeviceQueueSupport(error_obj.location);
@@ -2423,8 +2425,8 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks *pAllocator,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks* pAllocator,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto image_view_state = Get<vvl::ImageView>(imageView)) {
         skip |= ValidateObjectNotInUse(image_view_state.get(), error_obj.location, "VUID-vkDestroyImageView-imageView-01026");
@@ -2432,15 +2434,15 @@ bool CoreChecks::PreCallValidateDestroyImageView(VkDevice device, VkImageView im
     return skip;
 }
 
-bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state, const VkImageSubresource &subresource,
-                                                   const Location &subresource_loc) const {
+bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image& image_state, const VkImageSubresource& subresource,
+                                                   const Location& subresource_loc) const {
     bool skip = false;
     const bool is_2 = subresource_loc.function != Func::vkGetImageSubresourceLayout;
     const VkImageAspectFlags aspect_mask = subresource.aspectMask;
 
     // The aspectMask member of pSubresource must only have a single bit set
     if (CountSetBits(aspect_mask) != 1) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2-aspectMask-00997" : "VUID-vkGetImageSubresourceLayout-aspectMask-00997";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask), "(%s) must have exactly 1 bit set.",
                          string_VkImageAspectFlags(aspect_mask).c_str());
@@ -2448,7 +2450,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
 
     // mipLevel must be less than the mipLevels specified in VkImageCreateInfo when the image was created
     if (subresource.mipLevel >= image_state.create_info.mipLevels) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2-mipLevel-01716" : "VUID-vkGetImageSubresourceLayout-mipLevel-01716";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::mipLevel),
                          "(%" PRIu32 ") must be less than the mipLevel used to create the image (%" PRIu32 ").",
@@ -2457,7 +2459,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
 
     // arrayLayer must be less than the arrayLayers specified in VkImageCreateInfo when the image was created
     if (subresource.arrayLayer >= image_state.create_info.arrayLayers) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2-arrayLayer-01717" : "VUID-vkGetImageSubresourceLayout-arrayLayer-01717";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::arrayLayer),
                          "(%" PRIu32 ") must be less than the arrayLayer used to create the image (%" PRIu32 ").",
@@ -2469,7 +2471,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
         image_state.create_info.tiling == VK_IMAGE_TILING_LINEAR || image_state.create_info.tiling == VK_IMAGE_TILING_OPTIMAL;
     if (vkuFormatIsColor(image_format) && !vkuFormatIsMultiplane(image_format) && (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT) &&
         tiling_linear_optimal) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2-format-08886" : "VUID-vkGetImageSubresourceLayout-format-08886";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                          "is %s but image was created with color format %s.", string_VkImageAspectFlags(aspect_mask).c_str(),
@@ -2477,7 +2479,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     }
 
     if (vkuFormatHasDepth(image_format) && ((aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) == 0)) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2-format-04462" : "VUID-vkGetImageSubresourceLayout-format-04462";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                          "is %s but image was created with depth format %s.", string_VkImageAspectFlags(aspect_mask).c_str(),
@@ -2485,7 +2487,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     }
 
     if (vkuFormatHasStencil(image_format) && ((aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) == 0)) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2-format-04463" : "VUID-vkGetImageSubresourceLayout-format-04463";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                          "is %s but image was created with stencil format %s.", string_VkImageAspectFlags(aspect_mask).c_str(),
@@ -2494,7 +2496,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
 
     if (!vkuFormatHasDepth(image_format) && !vkuFormatHasStencil(image_format)) {
         if ((aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) != 0) {
-            const char *vuid =
+            const char* vuid =
                 is_2 ? "VUID-vkGetImageSubresourceLayout2-format-04464" : "VUID-vkGetImageSubresourceLayout-format-04464";
             skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                              "is %s but image was created with format %s.", string_VkImageAspectFlags(aspect_mask).c_str(),
@@ -2505,7 +2507,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     // subresource's aspect must be compatible with image's format.
     if (image_state.create_info.tiling == VK_IMAGE_TILING_LINEAR) {
         if (vkuFormatIsMultiplane(image_format) && !IsOnlyOneValidPlaneAspect(image_format, aspect_mask)) {
-            const char *vuid =
+            const char* vuid =
                 is_2 ? "VUID-vkGetImageSubresourceLayout2-tiling-08717" : "VUID-vkGetImageSubresourceLayout-tiling-08717";
             skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask), "(%s) is invalid for format %s.",
                              string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_format));
@@ -2513,7 +2515,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     } else if (image_state.create_info.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
         if ((aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT) && (aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT) &&
             (aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT) && (aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT)) {
-            const char *vuid =
+            const char* vuid =
                 is_2 ? "VUID-vkGetImageSubresourceLayout2-tiling-09435" : "VUID-vkGetImageSubresourceLayout-tiling-09433";
             skip |=
                 LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
@@ -2533,7 +2535,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
 
             uint32_t max_plane_count = 0u;
 
-            for (auto const &drm_property : drm_properties) {
+            for (auto const& drm_property : drm_properties) {
                 if (drm_format_properties.drmFormatModifier == drm_property.drmFormatModifier) {
                     max_plane_count = drm_property.drmFormatModifierPlaneCount;
                     break;
@@ -2554,7 +2556,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
             }
 
             if (!is_valid) {
-                const char *vuid =
+                const char* vuid =
                     is_2 ? "VUID-vkGetImageSubresourceLayout2-tiling-09435" : "VUID-vkGetImageSubresourceLayout-tiling-09433";
                 skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                                  "is %s for image format %s, but drmFormatModifierPlaneCount is %" PRIu32
@@ -2566,7 +2568,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     }
 
     if (image_state.IsExternalBuffer() && image_state.GetBoundMemoryStates().empty()) {
-        const char *vuid = is_2 ? "VUID-vkGetImageSubresourceLayout2-image-09434" : "VUID-vkGetImageSubresourceLayout-image-09432";
+        const char* vuid = is_2 ? "VUID-vkGetImageSubresourceLayout2-image-09434" : "VUID-vkGetImageSubresourceLayout-image-09432";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc,
                          "Attempt to query layout from an image created with "
                          "VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID handleType which has not yet been "
@@ -2576,8 +2578,8 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource *pSubresource,
-                                                          VkSubresourceLayout *pLayout, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource* pSubresource,
+                                                          VkSubresourceLayout* pLayout, const ErrorObject& error_obj) const {
     bool skip = false;
     auto image_state = Get<vvl::Image>(image);
     if (pSubresource && pLayout && image_state) {
@@ -2591,8 +2593,8 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetImageSubresourceLayout2(VkDevice device, VkImage image, const VkImageSubresource2 *pSubresource,
-                                                           VkSubresourceLayout2 *pLayout, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetImageSubresourceLayout2(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
+                                                           VkSubresourceLayout2* pLayout, const ErrorObject& error_obj) const {
     bool skip = false;
     auto image_state = Get<vvl::Image>(image);
     if (pSubresource && pLayout && image_state) {
@@ -2603,22 +2605,22 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout2(VkDevice device, VkIm
 }
 
 bool CoreChecks::PreCallValidateGetImageSubresourceLayout2KHR(VkDevice device, VkImage image,
-                                                              const VkImageSubresource2KHR *pSubresource,
-                                                              VkSubresourceLayout2KHR *pLayout,
-                                                              const ErrorObject &error_obj) const {
+                                                              const VkImageSubresource2KHR* pSubresource,
+                                                              VkSubresourceLayout2KHR* pLayout,
+                                                              const ErrorObject& error_obj) const {
     return PreCallValidateGetImageSubresourceLayout2(device, image, pSubresource, pLayout, error_obj);
 }
 
 bool CoreChecks::PreCallValidateGetImageSubresourceLayout2EXT(VkDevice device, VkImage image,
-                                                              const VkImageSubresource2EXT *pSubresource,
-                                                              VkSubresourceLayout2EXT *pLayout,
-                                                              const ErrorObject &error_obj) const {
+                                                              const VkImageSubresource2EXT* pSubresource,
+                                                              VkSubresourceLayout2EXT* pLayout,
+                                                              const ErrorObject& error_obj) const {
     return PreCallValidateGetImageSubresourceLayout2(device, image, pSubresource, pLayout, error_obj);
 }
 
 bool CoreChecks::PreCallValidateGetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image,
-                                                                       VkImageDrmFormatModifierPropertiesEXT *pProperties,
-                                                                       const ErrorObject &error_obj) const {
+                                                                       VkImageDrmFormatModifierPropertiesEXT* pProperties,
+                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto image_state = Get<vvl::Image>(image)) {
         if (image_state->create_info.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
@@ -2631,13 +2633,13 @@ bool CoreChecks::PreCallValidateGetImageDrmFormatModifierPropertiesEXT(VkDevice 
 }
 
 bool CoreChecks::PreCallValidateTransitionImageLayout(VkDevice device, uint32_t transitionCount,
-                                                      const VkHostImageLayoutTransitionInfo *pTransitions,
-                                                      const ErrorObject &error_obj) const {
+                                                      const VkHostImageLayoutTransitionInfo* pTransitions,
+                                                      const ErrorObject& error_obj) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < transitionCount; ++i) {
         const Location transition_loc = error_obj.location.dot(Struct::VkHostImageLayoutTransitionInfo, Field::pTransitions, i);
-        const auto &transition = pTransitions[i];
+        const auto& transition = pTransitions[i];
         const auto image_state = Get<vvl::Image>(transition.image);
         if (!image_state) continue;
         const auto image_format = image_state->create_info.format;
@@ -2831,20 +2833,20 @@ bool CoreChecks::PreCallValidateTransitionImageLayout(VkDevice device, uint32_t 
 }
 
 bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32_t transitionCount,
-                                                         const VkHostImageLayoutTransitionInfoEXT *pTransitions,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkHostImageLayoutTransitionInfoEXT* pTransitions,
+                                                         const ErrorObject& error_obj) const {
     return PreCallValidateTransitionImageLayout(device, transitionCount, pTransitions, error_obj);
 }
 
 void CoreChecks::PostCallRecordTransitionImageLayout(VkDevice device, uint32_t transitionCount,
-                                                     const VkHostImageLayoutTransitionInfo *pTransitions,
-                                                     const RecordObject &record_obj) {
+                                                     const VkHostImageLayoutTransitionInfo* pTransitions,
+                                                     const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
 
     for (uint32_t i = 0; i < transitionCount; ++i) {
-        auto &transition = pTransitions[i];
+        auto& transition = pTransitions[i];
         auto image_state = Get<vvl::Image>(transition.image);
         if (!image_state) continue;
         image_state->SetImageLayout(transition.subresourceRange, transition.newLayout);
@@ -2852,14 +2854,14 @@ void CoreChecks::PostCallRecordTransitionImageLayout(VkDevice device, uint32_t t
 }
 
 void CoreChecks::PostCallRecordTransitionImageLayoutEXT(VkDevice device, uint32_t transitionCount,
-                                                        const VkHostImageLayoutTransitionInfoEXT *pTransitions,
-                                                        const RecordObject &record_obj) {
+                                                        const VkHostImageLayoutTransitionInfoEXT* pTransitions,
+                                                        const RecordObject& record_obj) {
     PostCallRecordTransitionImageLayout(device, transitionCount, pTransitions, record_obj);
 }
 
 // Validates the image is allowed to be protected
-bool CoreChecks::ValidateProtectedImage(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state, const Location &loc,
-                                        const char *vuid, const char *more_message) const {
+bool CoreChecks::ValidateProtectedImage(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, const Location& loc,
+                                        const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values
@@ -2872,8 +2874,8 @@ bool CoreChecks::ValidateProtectedImage(const vvl::CommandBuffer &cb_state, cons
 }
 
 // Validates the image is allowed to be unprotected
-bool CoreChecks::ValidateUnprotectedImage(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state, const Location &loc,
-                                          const char *vuid, const char *more_message) const {
+bool CoreChecks::ValidateUnprotectedImage(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, const Location& loc,
+                                          const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values
@@ -2885,8 +2887,8 @@ bool CoreChecks::ValidateUnprotectedImage(const vvl::CommandBuffer &cb_state, co
     return skip;
 }
 
-bool CoreChecks::ValidateImageViewSampleWeightQCOM(const VkImageViewCreateInfo &create_info, const vvl::Image &image_state,
-                                                   const Location &create_info_loc) const {
+bool CoreChecks::ValidateImageViewSampleWeightQCOM(const VkImageViewCreateInfo& create_info, const vvl::Image& image_state,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
 
     auto sample_weight_info = vku::FindStructInPNextChain<VkImageViewSampleWeightCreateInfoQCOM>(create_info.pNext);

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -46,13 +46,13 @@ struct LayoutUseCheckAndMessage {
     const static VkImageAspectFlags kDepthOrStencil = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
     const VkImageLayout expected_layout;
     const VkImageAspectFlags aspect_mask;
-    const char *message;
+    const char* message;
     VkImageLayout layout;
 
     LayoutUseCheckAndMessage() = delete;
     LayoutUseCheckAndMessage(VkImageLayout expected, const VkImageAspectFlags aspect_mask_ = 0)
         : expected_layout{expected}, aspect_mask{aspect_mask_}, message(nullptr), layout(kInvalidLayout) {}
-    bool Check(const ImageLayoutState &state) {
+    bool Check(const ImageLayoutState& state) {
         message = nullptr;
         layout = kInvalidLayout;  // Success status
         if (state.current_layout != kInvalidLayout) {
@@ -100,10 +100,10 @@ bool CoreChecks::ValidateDescriptorImageLayout(const LogObjectList& objlist, con
     return skip;
 }
 
-bool CoreChecks::ValidateSubresourceImageLayout(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state,
-                                                const VkImageSubresourceLayers &subresource_layers, int32_t depth_offset,
-                                                uint32_t depth_extent, VkImageLayout explicit_layout, const Location &loc,
-                                                const char *vuid) const {
+bool CoreChecks::ValidateSubresourceImageLayout(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
+                                                const VkImageSubresourceLayers& subresource_layers, int32_t depth_offset,
+                                                uint32_t depth_extent, VkImageLayout explicit_layout, const Location& loc,
+                                                const char* vuid) const {
     bool skip = false;
     if (disabled[image_layout_validation]) {
         return skip;
@@ -130,7 +130,7 @@ bool CoreChecks::ValidateSubresourceImageLayout(const vvl::CommandBuffer &cb_sta
     LayoutUseCheckAndMessage layout_check(explicit_layout, normalized_subresource_range.aspectMask);
     skip |= ForEachMatchingLayoutMapRange(
         *image_layout_map, std::move(range_gen),
-        [this, &cb_state, &image_state, &layout_check, vuid, loc](const LayoutRange &range, const ImageLayoutState &state) {
+        [this, &cb_state, &image_state, &layout_check, vuid, loc](const LayoutRange& range, const ImageLayoutState& state) {
             bool local_skip = false;
             if (!layout_check.Check(state)) {
                 const subresource_adapter::Subresource subresource = image_state.subresource_encoder.Decode(range.begin);
@@ -148,10 +148,10 @@ bool CoreChecks::ValidateSubresourceImageLayout(const vvl::CommandBuffer &cb_sta
     return skip;
 }
 
-bool CoreChecks::ValidateVideoImageLayout(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state,
-                                          const VkImageSubresourceRange &normalized_subresource_range,
-                                          VkImageLayout explicit_layout, const Location &loc,
-                                          const char *mismatch_layout_vuid) const {
+bool CoreChecks::ValidateVideoImageLayout(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
+                                          const VkImageSubresourceRange& normalized_subresource_range,
+                                          VkImageLayout explicit_layout, const Location& loc,
+                                          const char* mismatch_layout_vuid) const {
     if (disabled[image_layout_validation]) {
         return false;
     }
@@ -170,7 +170,7 @@ bool CoreChecks::ValidateVideoImageLayout(const vvl::CommandBuffer &cb_state, co
     skip |= ForEachMatchingLayoutMapRange(
         *image_layout_map, std::move(range_gen),
         [this, &cb_state, &image_state, &layout_check, &layout_check_general, mismatch_layout_vuid, loc](
-            const LayoutRange &range, const ImageLayoutState &state) {
+            const LayoutRange& range, const ImageLayoutState& state) {
             bool local_skip = false;
             if (!layout_check.Check(state) && (!enabled_features.unifiedImageLayoutsVideo || !layout_check_general.Check(state))) {
                 const subresource_adapter::Subresource subresource = image_state.subresource_encoder.Decode(range.begin);
@@ -191,20 +191,20 @@ bool CoreChecks::ValidateVideoImageLayout(const vvl::CommandBuffer &cb_state, co
     return skip;
 }
 
-void CoreChecks::TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_state) {
+void CoreChecks::TransitionFinalSubpassLayouts(vvl::CommandBuffer& cb_state) {
     auto render_pass_state = cb_state.active_render_pass.get();
     auto framebuffer_state = cb_state.active_framebuffer.get();
     if (!render_pass_state || !framebuffer_state) {
         return;
     }
 
-    const VkRenderPassCreateInfo2 *render_pass_info = render_pass_state->create_info.ptr();
+    const VkRenderPassCreateInfo2* render_pass_info = render_pass_state->create_info.ptr();
     for (uint32_t i = 0; i < render_pass_info->attachmentCount; ++i) {
-        auto *view_state = cb_state.GetActiveAttachmentImageViewState(i);
+        auto* view_state = cb_state.GetActiveAttachmentImageViewState(i);
         if (!view_state) continue;
 
         VkImageLayout stencil_layout = kInvalidLayout;
-        const auto *attachment_description_stencil_layout =
+        const auto* attachment_description_stencil_layout =
             vku::FindStructInPNextChain<VkAttachmentDescriptionStencilLayout>(render_pass_info->pAttachments[i].pNext);
         if (attachment_description_stencil_layout) {
             stencil_layout = attachment_description_stencil_layout->stencilFinalLayout;
@@ -214,7 +214,7 @@ void CoreChecks::TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_state) {
 }
 
 struct GlobalLayoutUpdater {
-    bool update(VkImageLayout &dst, const ImageLayoutState &src) const {
+    bool update(VkImageLayout& dst, const ImageLayoutState& src) const {
         if (src.current_layout != kInvalidLayout && dst != src.current_layout) {
             dst = src.current_layout;
             return true;
@@ -222,7 +222,7 @@ struct GlobalLayoutUpdater {
         return false;
     }
 
-    std::optional<VkImageLayout> insert(const ImageLayoutState &src) const {
+    std::optional<VkImageLayout> insert(const ImageLayoutState& src) const {
         std::optional<VkImageLayout> result;
         if (src.current_layout != kInvalidLayout) {
             result.emplace(src.current_layout);
@@ -233,15 +233,14 @@ struct GlobalLayoutUpdater {
 
 // This validates that the first layout specified in the command buffer for the image
 // is the same as this image's global (actual/current) layout
-bool CoreChecks::ValidateCmdBufImageLayouts(
-    const Location &loc, const vvl::CommandBuffer &cb_state,
-    vvl::unordered_map<const vvl::Image *, ImageLayoutMap> &local_image_layout_state) const {
+bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBuffer& cb_state,
+                                            vvl::unordered_map<const vvl::Image*, ImageLayoutMap>& local_image_layout_state) const {
     if (disabled[image_layout_validation]) {
         return false;
     }
     bool skip = false;
     // Iterate over the layout maps for each referenced image
-    for (const auto &[image, cb_layout_map] : cb_state.image_layout_registry) {
+    for (const auto& [image, cb_layout_map] : cb_state.image_layout_registry) {
         if (!cb_layout_map || cb_layout_map->empty()) {
             continue;
         }
@@ -259,9 +258,9 @@ bool CoreChecks::ValidateCmdBufImageLayouts(
         // Validate the initial_uses for each subresource referenced
         const auto subresource_count = image_state->subresource_encoder.SubresourceCount();
         auto it = local_image_layout_state.try_emplace(image_state.get(), subresource_count).first;
-        ImageLayoutMap &local_layout_map = it->second;
+        ImageLayoutMap& local_layout_map = it->second;
 
-        const auto *global_layout_map = image_state->layout_map.get();
+        const auto* global_layout_map = image_state->layout_map.get();
         ASSERT_AND_CONTINUE(global_layout_map);
         auto global_layout_map_guard = image_state->LayoutMapReadLock();
 
@@ -270,7 +269,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(
         sparse_container::parallel_iterator<const ImageLayoutMap> current_layout(local_layout_map, *global_layout_map,
                                                                                  pos->first.begin);
         while (pos != end) {
-            const ImageLayoutState &cb_layout_state = pos->second;
+            const ImageLayoutState& cb_layout_state = pos->second;
             VkImageLayout first_layout = cb_layout_state.first_layout;
             if (first_layout == kInvalidLayout) {
                 continue;
@@ -324,8 +323,8 @@ bool CoreChecks::ValidateCmdBufImageLayouts(
     return skip;
 }
 
-void CoreChecks::UpdateCmdBufImageLayouts(const vvl::CommandBuffer &cb_state) {
-    for (const auto &[image, cb_layout_map] : cb_state.image_layout_registry) {
+void CoreChecks::UpdateCmdBufImageLayouts(const vvl::CommandBuffer& cb_state) {
+    for (const auto& [image, cb_layout_map] : cb_state.image_layout_registry) {
         const auto image_state = Get<vvl::Image>(image);
         if (image_state && cb_layout_map && image_state->GetId() == cb_layout_map->image_id) {
             auto guard = image_state->LayoutMapWriteLock();
@@ -338,8 +337,8 @@ void CoreChecks::UpdateCmdBufImageLayouts(const vvl::CommandBuffer &cb_state) {
 // VkAttachmentDescription structs that are used by the sub-passes of a renderpass. Initial check is to make sure that READ_ONLY
 // layout attachments don't have CLEAR as their loadOp.
 bool CoreChecks::ValidateLayoutVsAttachmentDescription(const VkImageLayout first_layout, const uint32_t attachment,
-                                                       const VkAttachmentDescription2 &attachment_description,
-                                                       const Location &layout_loc) const {
+                                                       const VkAttachmentDescription2& attachment_description,
+                                                       const Location& layout_loc) const {
     bool skip = false;
     const bool use_rp2 = layout_loc.function != Func::vkCreateRenderPass;
 
@@ -391,8 +390,8 @@ bool CoreChecks::ValidateLayoutVsAttachmentDescription(const VkImageLayout first
 }
 
 bool CoreChecks::ValidateMultipassRenderedToSingleSampledSampleCount(VkFramebuffer framebuffer, VkRenderPass renderpass,
-                                                                     vvl::Image &image_state, VkSampleCountFlagBits msrtss_samples,
-                                                                     const Location &rasterization_samples_loc) const {
+                                                                     vvl::Image& image_state, VkSampleCountFlagBits msrtss_samples,
+                                                                     const Location& rasterization_samples_loc) const {
     bool skip = false;
     const auto image_create_info = image_state.create_info;
     if (!image_state.image_format_properties.sampleCounts) {
@@ -416,17 +415,17 @@ bool CoreChecks::ValidateMultipassRenderedToSingleSampledSampleCount(VkFramebuff
     return skip;
 }
 
-bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(VkImageLayout layout, const vvl::ImageView &image_view_state,
+bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(VkImageLayout layout, const vvl::ImageView& image_view_state,
                                                                       VkFramebuffer framebuffer, VkRenderPass renderpass,
-                                                                      uint32_t attachment_index, const Location &rp_loc,
-                                                                      const Location &attachment_reference_loc) const {
+                                                                      uint32_t attachment_index, const Location& rp_loc,
+                                                                      const Location& attachment_reference_loc) const {
     bool skip = false;
-    const auto *image_state = image_view_state.image_state.get();
+    const auto* image_state = image_view_state.image_state.get();
     if (!image_state) {
         return skip;  // validated at VUID-VkRenderPassBeginInfo-framebuffer-parameter
     }
     const bool use_rp2 = rp_loc.function != Func::vkCmdBeginRenderPass;
-    const char *vuid = kVUIDUndefined;
+    const char* vuid = kVUIDUndefined;
     VkImageUsageFlags image_usage = image_view_state.inherited_usage;
 
     // Check for layouts that mismatch image usages in the framebuffer
@@ -482,9 +481,9 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(VkImageLay
 }
 
 bool CoreChecks::ValidateRenderPassStencilLayoutAgainstFramebufferImageUsage(VkImageLayout layout,
-                                                                             const vvl::ImageView &image_view_state,
+                                                                             const vvl::ImageView& image_view_state,
                                                                              VkFramebuffer framebuffer, VkRenderPass renderpass,
-                                                                             const Location &layout_loc) const {
+                                                                             const Location& layout_loc) const {
     bool skip = false;
     const auto* image_state = image_view_state.image_state.get();
     if (!image_state) {
@@ -493,7 +492,7 @@ bool CoreChecks::ValidateRenderPassStencilLayoutAgainstFramebufferImageUsage(VkI
 
     if (IsImageLayoutStencilOnly(layout) && !(image_view_state.inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
         const bool use_rp2 = layout_loc.function != Func::vkCmdBeginRenderPass;
-        const char *vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-stencilInitialLayout-02845"
+        const char* vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-stencilInitialLayout-02845"
                                    : "VUID-vkCmdBeginRenderPass-stencilInitialLayout-02843";
         const LogObjectList objlist(renderpass, framebuffer, image_view_state.Handle(), image_state->Handle());
         skip |= LogError(vuid, objlist, layout_loc,
@@ -506,16 +505,16 @@ bool CoreChecks::ValidateRenderPassStencilLayoutAgainstFramebufferImageUsage(VkI
     return skip;
 }
 
-bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffer &cb_state,
-                                                         const VkRenderPassBeginInfo &begin_info,
-                                                         const vvl::RenderPass &render_pass_state,
-                                                         const vvl::Framebuffer &framebuffer_state,
-                                                         const Location &rp_begin_loc) const {
+bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffer& cb_state,
+                                                         const VkRenderPassBeginInfo& begin_info,
+                                                         const vvl::RenderPass& render_pass_state,
+                                                         const vvl::Framebuffer& framebuffer_state,
+                                                         const Location& rp_begin_loc) const {
     bool skip = false;
-    const auto *render_pass_info = render_pass_state.create_info.ptr();
+    const auto* render_pass_info = render_pass_state.create_info.ptr();
     const VkRenderPass render_pass = render_pass_state.VkHandle();
-    auto const &framebuffer_info = framebuffer_state.create_info;
-    const VkImageView *attachments = framebuffer_info.pAttachments;
+    auto const& framebuffer_info = framebuffer_state.create_info;
+    const VkImageView* attachments = framebuffer_info.pAttachments;
 
     const VkFramebuffer framebuffer = framebuffer_state.VkHandle();
 
@@ -528,7 +527,7 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
                          render_pass_info->attachmentCount, framebuffer_info.attachmentCount);
     }
 
-    const auto *attachment_info = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(begin_info.pNext);
+    const auto* attachment_info = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(begin_info.pNext);
     if (((framebuffer_info.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) != 0) && attachment_info != nullptr) {
         attachments = attachment_info->pAttachments;
     }
@@ -555,7 +554,7 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
         }
 
         const VkImage image = view_state->create_info.image;
-        const auto *image_state = view_state->image_state.get();
+        const auto* image_state = view_state->image_state.get();
 
         if (!image_state) {
             const LogObjectList objlist(render_pass, framebuffer_state.Handle(), image_view, image);
@@ -577,7 +576,7 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
         auto attachment_stencil_initial_layout = attachment_initial_layout;
 
         // If a separate layout is specified, look for that.
-        const auto *attachment_desc_stencil_layout =
+        const auto* attachment_desc_stencil_layout =
             vku::FindStructInPNextChain<VkAttachmentDescriptionStencilLayout>(render_pass_info->pAttachments[i].pNext);
         if (attachment_desc_stencil_layout) {
             attachment_stencil_initial_layout = attachment_desc_stencil_layout->stencilInitialLayout;
@@ -625,11 +624,11 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
                 [this, &layout_check, i, cb = cb_state.Handle(), render_pass = render_pass,
                  framebuffer = framebuffer_state.Handle(), image = view_state->image_state->Handle(),
                  image_view = view_state->Handle(), attachment_loc,
-                 rp_begin_loc](const LayoutRange &range, const ImageLayoutState &state) {
+                 rp_begin_loc](const LayoutRange& range, const ImageLayoutState& state) {
                     bool subres_skip = false;
                     if (!layout_check.Check(state)) {
                         const LogObjectList objlist(cb, render_pass, framebuffer, image, image_view);
-                        const char *vuid = rp_begin_loc.function != Func::vkCmdBeginRenderPass
+                        const char* vuid = rp_begin_loc.function != Func::vkCmdBeginRenderPass
                                                ? "VUID-vkCmdBeginRenderPass2-initialLayout-03100"
                                                : "VUID-vkCmdBeginRenderPass-initialLayout-00900";
                         subres_skip |= LogError(vuid, objlist, attachment_loc,
@@ -662,11 +661,11 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
 
     for (uint32_t j = 0; j < render_pass_info->subpassCount; ++j) {
         const Location subpass_loc = rp_create_info.dot(Field::pSubpasses, j);
-        auto &subpass = render_pass_info->pSubpasses[j];
-        const auto *ms_rendered_to_single_sampled =
+        auto& subpass = render_pass_info->pSubpasses[j];
+        const auto* ms_rendered_to_single_sampled =
             vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(render_pass_info->pSubpasses[j].pNext);
         for (uint32_t k = 0; k < render_pass_info->pSubpasses[j].inputAttachmentCount; ++k) {
-            auto &attachment_ref = subpass.pInputAttachments[k];
+            auto& attachment_ref = subpass.pInputAttachments[k];
             if (attachment_ref.attachment == VK_ATTACHMENT_UNUSED) continue;
             const Location input_loc = subpass_loc.dot(Field::pInputAttachments, k);
             auto image_view = attachments[attachment_ref.attachment];
@@ -687,7 +686,7 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
         }
 
         for (uint32_t k = 0; k < render_pass_info->pSubpasses[j].colorAttachmentCount; ++k) {
-            auto &attachment_ref = subpass.pColorAttachments[k];
+            auto& attachment_ref = subpass.pColorAttachments[k];
             if (attachment_ref.attachment == VK_ATTACHMENT_UNUSED) continue;
             const Location color_attachment_loc = subpass_loc.dot(Field::pColorAttachments, k);
             auto image_view = attachments[attachment_ref.attachment];
@@ -713,7 +712,7 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
         }
 
         if (render_pass_info->pSubpasses[j].pDepthStencilAttachment) {
-            auto &attachment_ref = *subpass.pDepthStencilAttachment;
+            auto& attachment_ref = *subpass.pDepthStencilAttachment;
             if (attachment_ref.attachment == VK_ATTACHMENT_UNUSED) continue;
             const Location ds_loc = subpass_loc.dot(Field::pDepthStencilAttachment);
             auto image_view = attachments[attachment_ref.attachment];
@@ -723,7 +722,7 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
                                                                              render_pass, attachment_ref.attachment, rp_loc,
                                                                              ds_loc.dot(Field::layout));
 
-                if (const auto *stencil_layout =
+                if (const auto* stencil_layout =
                         vku::FindStructInPNextChain<VkAttachmentReferenceStencilLayout>(attachment_ref.pNext);
                     stencil_layout != nullptr) {
                     skip |= ValidateRenderPassStencilLayoutAgainstFramebufferImageUsage(
@@ -744,10 +743,10 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuffer &cb_state,
-                                                          const VkRenderingAttachmentInfo &attachment_info,
-                                                          VkImageAspectFlags aspect_mask, const Location &attachment_loc,
-                                                          const char *vuid) const {
+bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuffer& cb_state,
+                                                          const VkRenderingAttachmentInfo& attachment_info,
+                                                          VkImageAspectFlags aspect_mask, const Location& attachment_loc,
+                                                          const char* vuid) const {
     bool skip = false;
     if (disabled[image_layout_validation]) {
         return skip;
@@ -756,7 +755,7 @@ bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuff
     if (!image_view_state) {
         return skip;
     }
-    const vvl::Image &image_state = *image_view_state->image_state;
+    const vvl::Image& image_state = *image_view_state->image_state;
     const auto image_layout_map = cb_state.GetImageLayoutMap(image_state.VkHandle());
     if (!image_layout_map) {
         return skip;
@@ -770,8 +769,8 @@ bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuff
 
     skip |= ForEachMatchingLayoutMapRange(
         *image_layout_map, RangeGenerator(image_view_state->image_state->subresource_encoder, image_layout_range),
-        [this, &cb_state, &image_state, &image_view_state, &layout_check, vuid, attachment_loc](const LayoutRange &range,
-                                                                                                const ImageLayoutState &state) {
+        [this, &cb_state, &image_state, &image_view_state, &layout_check, vuid, attachment_loc](const LayoutRange& range,
+                                                                                                const ImageLayoutState& state) {
             bool local_skip = false;
             if (!layout_check.Check(state)) {
                 const subresource_adapter::Subresource subresource = image_state.subresource_encoder.Decode(range.begin);
@@ -788,12 +787,12 @@ bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuff
     return skip;
 }
 
-void CoreChecks::TransitionAttachmentRefLayout(vvl::CommandBuffer &cb_state, const vku::safe_VkAttachmentReference2 &ref) {
+void CoreChecks::TransitionAttachmentRefLayout(vvl::CommandBuffer& cb_state, const vku::safe_VkAttachmentReference2& ref) {
     if (ref.attachment == VK_ATTACHMENT_UNUSED) return;
-    vvl::ImageView *image_view = cb_state.GetActiveAttachmentImageViewState(ref.attachment);
+    vvl::ImageView* image_view = cb_state.GetActiveAttachmentImageViewState(ref.attachment);
     if (image_view) {
         VkImageLayout stencil_layout = kInvalidLayout;
-        const auto *attachment_reference_stencil_layout =
+        const auto* attachment_reference_stencil_layout =
             vku::FindStructInPNextChain<VkAttachmentReferenceStencilLayout>(ref.pNext);
         if (attachment_reference_stencil_layout) {
             stencil_layout = attachment_reference_stencil_layout->stencilLayout;
@@ -803,9 +802,9 @@ void CoreChecks::TransitionAttachmentRefLayout(vvl::CommandBuffer &cb_state, con
     }
 }
 
-void CoreChecks::TransitionSubpassLayouts(vvl::CommandBuffer &cb_state, const vvl::RenderPass &render_pass_state,
+void CoreChecks::TransitionSubpassLayouts(vvl::CommandBuffer& cb_state, const vvl::RenderPass& render_pass_state,
                                           const int subpass_index) {
-    auto const &subpass = render_pass_state.create_info.pSubpasses[subpass_index];
+    auto const& subpass = render_pass_state.create_info.pSubpasses[subpass_index];
     for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
         TransitionAttachmentRefLayout(cb_state, subpass.pInputAttachments[j]);
     }
@@ -820,18 +819,18 @@ void CoreChecks::TransitionSubpassLayouts(vvl::CommandBuffer &cb_state, const vv
 // Transition the layout state for renderpass attachments based on the BeginRenderPass() call. This includes:
 // 1. Transition into initialLayout state
 // 2. Transition from initialLayout to layout used in subpass 0
-void CoreChecks::TransitionBeginRenderPassLayouts(vvl::CommandBuffer &cb_state, const vvl::RenderPass &render_pass_state) {
+void CoreChecks::TransitionBeginRenderPassLayouts(vvl::CommandBuffer& cb_state, const vvl::RenderPass& render_pass_state) {
     // First record expected initialLayout as a potential initial layout usage.
     auto const rpci = render_pass_state.create_info.ptr();
     for (uint32_t i = 0; i < rpci->attachmentCount; ++i) {
-        auto *view_state = cb_state.GetActiveAttachmentImageViewState(i);
+        auto* view_state = cb_state.GetActiveAttachmentImageViewState(i);
         if (!view_state) continue;
 
-        vvl::Image *image_state = view_state->image_state.get();
+        vvl::Image* image_state = view_state->image_state.get();
         ASSERT_AND_CONTINUE(image_state);
 
         const auto initial_layout = rpci->pAttachments[i].initialLayout;
-        const auto *attachment_description_stencil_layout =
+        const auto* attachment_description_stencil_layout =
             vku::FindStructInPNextChain<VkAttachmentDescriptionStencilLayout>(rpci->pAttachments[i].pNext);
         if (attachment_description_stencil_layout) {
             const auto stencil_initial_layout = attachment_description_stencil_layout->stencilInitialLayout;
@@ -857,9 +856,9 @@ void CoreChecks::TransitionBeginRenderPassLayouts(vvl::CommandBuffer &cb_state, 
     TransitionSubpassLayouts(cb_state, render_pass_state, 0);
 }
 
-bool CoreChecks::ValidateClearImageLayout(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state,
-                                          const VkImageSubresourceRange &range, VkImageLayout dest_image_layout,
-                                          const Location &loc) const {
+bool CoreChecks::ValidateClearImageLayout(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
+                                          const VkImageSubresourceRange& range, VkImageLayout dest_image_layout,
+                                          const Location& loc) const {
     bool skip = false;
     if (loc.function == Func::vkCmdClearDepthStencilImage) {
         if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL)) {
@@ -891,11 +890,11 @@ bool CoreChecks::ValidateClearImageLayout(const vvl::CommandBuffer &cb_state, co
             auto range_gen = RangeGenerator(image_state.subresource_encoder, normalized_isr);
             skip |= ForEachMatchingLayoutMapRange(
                 *image_layout_map, std::move(range_gen),
-                [this, &cb_state, &layout_check, loc, image = image_state.Handle()](const LayoutRange &range,
-                                                                                    const ImageLayoutState &state) {
+                [this, &cb_state, &layout_check, loc, image = image_state.Handle()](const LayoutRange& range,
+                                                                                    const ImageLayoutState& state) {
                     bool subres_skip = false;
                     if (!layout_check.Check(state)) {
-                        const char *vuid = (loc.function == Func::vkCmdClearDepthStencilImage)
+                        const char* vuid = (loc.function == Func::vkCmdClearDepthStencilImage)
                                                ? "VUID-vkCmdClearDepthStencilImage-imageLayout-00011"
                                                : "VUID-vkCmdClearColorImage-imageLayout-00004";
                         LogObjectList objlist(cb_state.Handle(), image);
@@ -912,9 +911,9 @@ bool CoreChecks::ValidateClearImageLayout(const vvl::CommandBuffer &cb_state, co
     return skip;
 }
 
-bool CoreChecks::ValidateImageBarrierLayouts(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state,
-                                             const Location &image_loc, const ImageBarrier &image_barrier,
-                                             ImageLayoutRegistry &local_layout_registry) const {
+bool CoreChecks::ValidateImageBarrierLayouts(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
+                                             const Location& image_loc, const ImageBarrier& image_barrier,
+                                             ImageLayoutRegistry& local_layout_registry) const {
     bool skip = false;
 
     std::shared_ptr<CommandBufferImageLayoutMap> local_layout_map;
@@ -934,7 +933,7 @@ bool CoreChecks::ValidateImageBarrierLayouts(const vvl::CommandBuffer &cb_state,
     }
 
     std::shared_ptr<const CommandBufferImageLayoutMap> cb_layout_map = cb_state.GetImageLayoutMap(image_state.VkHandle());
-    const auto &layout_map = (existing_local_map || cb_layout_map == nullptr) ? local_layout_map : cb_layout_map;
+    const auto& layout_map = (existing_local_map || cb_layout_map == nullptr) ? local_layout_map : cb_layout_map;
 
     // Validate aspects in isolation.
     // This is required when handling separate depth-stencil layouts.
@@ -958,11 +957,11 @@ bool CoreChecks::ValidateImageBarrierLayouts(const vvl::CommandBuffer &cb_state,
         if (image_state.subresource_encoder.InRange(normalized_isr)) {
             skip |= ForEachMatchingLayoutMapRange(
                 *layout_map, RangeGenerator(image_state.subresource_encoder, normalized_isr),
-                [this, &cb_state, &layout_check, &image_loc, &image_barrier, &image_state](const LayoutRange &range,
-                                                                                           const ImageLayoutState &state) {
+                [this, &cb_state, &layout_check, &image_loc, &image_barrier, &image_state](const LayoutRange& range,
+                                                                                           const ImageLayoutState& state) {
                     bool subres_skip = false;
                     if (!layout_check.Check(state)) {
-                        const auto &vuid = GetImageBarrierVUID(image_loc, vvl::ImageError::kConflictingLayout);
+                        const auto& vuid = GetImageBarrierVUID(image_loc, vvl::ImageError::kConflictingLayout);
                         const subresource_adapter::Subresource subresource = image_state.subresource_encoder.Decode(range.begin);
                         const VkImageSubresource vk_subresource = image_state.subresource_encoder.MakeVkSubresource(subresource);
                         const LogObjectList objlist(cb_state.Handle(), image_barrier.image);
@@ -985,7 +984,7 @@ bool CoreChecks::ValidateImageBarrierLayouts(const vvl::CommandBuffer &cb_state,
     return skip;
 }
 
-static std::vector<uint32_t> GetUsedColorAttachments(const vvl::CommandBuffer &cb_state) {
+static std::vector<uint32_t> GetUsedColorAttachments(const vvl::CommandBuffer& cb_state) {
     std::vector<uint32_t> attachments;
     attachments.reserve(cb_state.rendering_attachments.color_locations.size());
     for (size_t i = 0; i < cb_state.rendering_attachments.color_locations.size(); ++i) {
@@ -998,9 +997,9 @@ static std::vector<uint32_t> GetUsedColorAttachments(const vvl::CommandBuffer &c
     return attachments;
 }
 
-bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state,
-                                                           const VkRenderingInfo &rendering_info,
-                                                           const Location &barrier_loc) const {
+bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
+                                                           const VkRenderingInfo& rendering_info,
+                                                           const Location& barrier_loc) const {
     bool skip = false;
     auto cb_image_layouts = cb_state.GetImageLayoutMap(image_state.VkHandle());
     if (!cb_image_layouts) {
@@ -1013,7 +1012,7 @@ bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuf
         if (color_attachment_idx >= rendering_info.colorAttachmentCount) {
             continue;
         }
-        const auto &color_attachment = rendering_info.pColorAttachments[color_attachment_idx];
+        const auto& color_attachment = rendering_info.pColorAttachments[color_attachment_idx];
         auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView);
         if (image_view_state && image_view_state->image_state->VkHandle() == image_state.VkHandle()) {
             matching_attatchment_view_state = std::move(image_view_state);
@@ -1039,7 +1038,7 @@ bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuf
     // Validate layout of the found attachment
     skip |= ForEachMatchingLayoutMapRange(
         *cb_image_layouts, RangeGenerator(matching_attatchment_view_state->range_generator),
-        [this, &image_state, &barrier_loc](const LayoutRange &range, const ImageLayoutState &state) {
+        [this, &image_state, &barrier_loc](const LayoutRange& range, const ImageLayoutState& state) {
             // Use current layout if it is specified (we tracked actual image layout transition).
             // Otherwise use expected layout (specified by various APIs): during execution the
             // correct programs must ensure the image layout is in the expected layout at this point.
@@ -1047,7 +1046,7 @@ bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuf
 
             bool local_skip = false;
             if (layout != VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ && layout != VK_IMAGE_LAYOUT_GENERAL) {
-                const auto &vuid = GetDynamicRenderingBarrierVUID(barrier_loc, vvl::DynamicRenderingBarrierError::kImageLayout);
+                const auto& vuid = GetDynamicRenderingBarrierVUID(barrier_loc, vvl::DynamicRenderingBarrierError::kImageLayout);
                 local_skip |=
                     LogError(vuid, image_state.VkHandle(), barrier_loc, "image layout is %s.", string_VkImageLayout(layout));
             }
@@ -1056,25 +1055,25 @@ bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuf
     return skip;
 }
 
-void CoreChecks::EnqueueValidateDynamicRenderingImageBarrierLayouts(const Location barrier_loc, vvl::CommandBuffer &cb_state,
-                                                                    const ImageBarrier &image_barrier) {
+void CoreChecks::EnqueueValidateDynamicRenderingImageBarrierLayouts(const Location barrier_loc, vvl::CommandBuffer& cb_state,
+                                                                    const ImageBarrier& image_barrier) {
     if (!cb_state.active_render_pass || !cb_state.active_render_pass->UsesDynamicRendering()) {
         return;
     }
-    const VkRenderingInfo &rendering_info = *cb_state.active_render_pass->dynamic_rendering_begin_rendering_info.ptr();
+    const VkRenderingInfo& rendering_info = *cb_state.active_render_pass->dynamic_rendering_begin_rendering_info.ptr();
     std::shared_ptr<const CommandBufferImageLayoutMap> image_layout_map = cb_state.GetImageLayoutMap(image_barrier.image);
 
-    auto &cb_sub_state = core::SubState(cb_state);
+    auto& cb_sub_state = core::SubState(cb_state);
 
     auto process_image_view = [&image_barrier, &image_layout_map, &cb_sub_state,
-                               &barrier_loc](const vvl::ImageView &image_view_state) {
+                               &barrier_loc](const vvl::ImageView& image_view_state) {
         // Skip attachments that use different image than a barrier
         if (image_barrier.image != image_view_state.image_state->VkHandle()) {
             return;
         }
         // Skip images that already have image layout specified so layout validation was done at record time
         if (image_layout_map) {
-            auto any_range_pred = [](const LayoutRange &, const ImageLayoutState &) { return true; };
+            auto any_range_pred = [](const LayoutRange&, const ImageLayoutState&) { return true; };
             if (ForEachMatchingLayoutMapRange(*image_layout_map, RangeGenerator(image_view_state.range_generator),
                                               any_range_pred)) {
                 return;
@@ -1082,8 +1081,8 @@ void CoreChecks::EnqueueValidateDynamicRenderingImageBarrierLayouts(const Locati
         }
         // Enqueue distinct subresource ranges for this image.
         // Then during submit time the layouts of these subresources are validated against allowed values
-        auto &enqueued_subresources = cb_sub_state.submit_validate_dynamic_rendering_barrier_subresources[image_barrier.image];
-        auto it = std::find_if(enqueued_subresources.begin(), enqueued_subresources.end(), [&image_view_state](const auto &entry) {
+        auto& enqueued_subresources = cb_sub_state.submit_validate_dynamic_rendering_barrier_subresources[image_barrier.image];
+        auto it = std::find_if(enqueued_subresources.begin(), enqueued_subresources.end(), [&image_view_state](const auto& entry) {
             return entry.first == image_view_state.normalized_subresource_range;
         });
         if (it == enqueued_subresources.end()) {
@@ -1096,20 +1095,20 @@ void CoreChecks::EnqueueValidateDynamicRenderingImageBarrierLayouts(const Locati
         if (color_attachment_idx >= rendering_info.colorAttachmentCount) {
             continue;
         }
-        const auto &color_attachment = rendering_info.pColorAttachments[color_attachment_idx];
+        const auto& color_attachment = rendering_info.pColorAttachments[color_attachment_idx];
         if (const auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView)) {
             process_image_view(*image_view_state);
         }
     }
     if (rendering_info.pDepthAttachment) {
-        const AttachmentInfo &attachment =
+        const AttachmentInfo& attachment =
             cb_state.active_attachments[cb_state.GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Depth)];
         if (attachment.image_view) {
             process_image_view(*attachment.image_view);
         }
     }
     if (rendering_info.pStencilAttachment) {
-        const AttachmentInfo &attachment =
+        const AttachmentInfo& attachment =
             cb_state.active_attachments[cb_state.GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Stencil)];
         if (attachment.image_view) {
             process_image_view(*attachment.image_view);
@@ -1117,8 +1116,8 @@ void CoreChecks::EnqueueValidateDynamicRenderingImageBarrierLayouts(const Locati
     }
 }
 
-void CoreChecks::RecordTransitionImageLayout(vvl::CommandBuffer &cb_state, const ImageBarrier &mem_barrier,
-                                             const vvl::Image &image_state) {
+void CoreChecks::RecordTransitionImageLayout(vvl::CommandBuffer& cb_state, const ImageBarrier& mem_barrier,
+                                             const vvl::Image& image_state) {
     if (enabled_features.synchronization2) {
         if (mem_barrier.oldLayout == mem_barrier.newLayout) {
             return;
@@ -1156,7 +1155,7 @@ void CoreChecks::RecordTransitionImageLayout(vvl::CommandBuffer &cb_state, const
     }
 }
 
-bool CoreChecks::IsCompliantSubresourceRange(const VkImageSubresourceRange &subres_range, const vvl::Image &image_state) const {
+bool CoreChecks::IsCompliantSubresourceRange(const VkImageSubresourceRange& subres_range, const vvl::Image& image_state) const {
     if (!(subres_range.layerCount) || !(subres_range.levelCount)) return false;
     if (subres_range.baseMipLevel + subres_range.levelCount > image_state.create_info.mipLevels) return false;
     if ((subres_range.baseArrayLayer + subres_range.layerCount) > image_state.create_info.arrayLayers) {
@@ -1177,13 +1176,13 @@ bool CoreChecks::IsCompliantSubresourceRange(const VkImageSubresourceRange &subr
     return true;
 }
 
-bool CoreChecks::ValidateHostCopyCurrentLayout(const VkImageLayout expected_layout, const VkImageSubresourceLayers &subres_layers,
-                                               const vvl::Image &image_state, const Location &loc) const {
+bool CoreChecks::ValidateHostCopyCurrentLayout(const VkImageLayout expected_layout, const VkImageSubresourceLayers& subres_layers,
+                                               const vvl::Image& image_state, const Location& loc) const {
     return ValidateHostCopyCurrentLayout(expected_layout, RangeFromLayers(subres_layers), image_state, loc);
 }
 
-bool CoreChecks::ValidateHostCopyCurrentLayout(const VkImageLayout expected_layout, const VkImageSubresourceRange &validate_range,
-                                               const vvl::Image &image_state, const Location &loc) const {
+bool CoreChecks::ValidateHostCopyCurrentLayout(const VkImageLayout expected_layout, const VkImageSubresourceRange& validate_range,
+                                               const vvl::Image& image_state, const Location& loc) const {
     bool skip = false;
     if (disabled[image_layout_validation]) return false;
     if (!image_state.layout_map) return false;
@@ -1209,7 +1208,7 @@ bool CoreChecks::ValidateHostCopyCurrentLayout(const VkImageLayout expected_layo
 
     auto guard = image_state.LayoutMapReadLock();
     ForEachMatchingLayoutMapRange(*image_state.layout_map, std::move(range_gen),
-                                  [&check_state](const ImageLayoutMap::key_type &range, const VkImageLayout &layout) {
+                                  [&check_state](const ImageLayoutMap::key_type& range, const VkImageLayout& layout) {
                                       bool mismatch = false;
                                       if (!ImageLayoutMatches(check_state.aspect_mask, layout, check_state.expected_layout)) {
                                           check_state.found_range = range;

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -45,9 +45,9 @@ bool CoreChecks::IsBeforeCtsVersion(uint32_t major, uint32_t minor, uint32_t sub
 }
 
 // This can be chained in the vkCreate*Pipelines() function or the VkPipelineShaderStageCreateInfo
-bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipeline,
-                                                      const VkPipelineRobustnessCreateInfo &pipeline_robustness_info,
-                                                      const Location &loc) const {
+bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline& pipeline,
+                                                      const VkPipelineRobustnessCreateInfo& pipeline_robustness_info,
+                                                      const Location& loc) const {
     bool skip = false;
 
     if (!enabled_features.pipelineRobustness) {
@@ -169,18 +169,18 @@ bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipel
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetPipelineExecutablePropertiesKHR(VkDevice device, const VkPipelineInfoKHR *pPipelineInfo,
-                                                                   uint32_t *pExecutableCount,
-                                                                   VkPipelineExecutablePropertiesKHR *pProperties,
-                                                                   const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetPipelineExecutablePropertiesKHR(VkDevice device, const VkPipelineInfoKHR* pPipelineInfo,
+                                                                   uint32_t* pExecutableCount,
+                                                                   VkPipelineExecutablePropertiesKHR* pProperties,
+                                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidatePipelineExecutableInfo(device, nullptr, error_obj.location,
                                            "VUID-vkGetPipelineExecutablePropertiesKHR-pipelineExecutableInfo-03270");
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineExecutableInfo(VkDevice device, const VkPipelineExecutableInfoKHR *pExecutableInfo,
-                                                const Location &loc, const char *feature_vuid) const {
+bool CoreChecks::ValidatePipelineExecutableInfo(VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo,
+                                                const Location& loc, const char* feature_vuid) const {
     bool skip = false;
 
     // If feature is not enabled, not allowed to call dispatch call below
@@ -209,10 +209,10 @@ bool CoreChecks::ValidatePipelineExecutableInfo(VkDevice device, const VkPipelin
 }
 
 bool CoreChecks::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDevice device,
-                                                                   const VkPipelineExecutableInfoKHR *pExecutableInfo,
-                                                                   uint32_t *pStatisticCount,
-                                                                   VkPipelineExecutableStatisticKHR *pStatistics,
-                                                                   const ErrorObject &error_obj) const {
+                                                                   const VkPipelineExecutableInfoKHR* pExecutableInfo,
+                                                                   uint32_t* pStatisticCount,
+                                                                   VkPipelineExecutableStatisticKHR* pStatistics,
+                                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidatePipelineExecutableInfo(device, pExecutableInfo, error_obj.location,
                                            "VUID-vkGetPipelineExecutableStatisticsKHR-pipelineExecutableInfo-03272");
@@ -229,8 +229,8 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDevice devi
 }
 
 bool CoreChecks::PreCallValidateGetPipelineExecutableInternalRepresentationsKHR(
-    VkDevice device, const VkPipelineExecutableInfoKHR *pExecutableInfo, uint32_t *pInternalRepresentationCount,
-    VkPipelineExecutableInternalRepresentationKHR *pStatistics, const ErrorObject &error_obj) const {
+    VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo, uint32_t* pInternalRepresentationCount,
+    VkPipelineExecutableInternalRepresentationKHR* pStatistics, const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidatePipelineExecutableInfo(device, pExecutableInfo, error_obj.location,
                                            "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipelineExecutableInfo-03276");
@@ -247,8 +247,8 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableInternalRepresentationsKHR(
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator,
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto pipeline_state = Get<vvl::Pipeline>(pipeline)) {
         skip |= ValidateObjectNotInUse(pipeline_state.get(), error_obj.location, "VUID-vkDestroyPipeline-pipeline-00765");
@@ -256,7 +256,7 @@ bool CoreChecks::PreCallValidateDestroyPipeline(VkDevice device, VkPipeline pipe
     return skip;
 }
 
-static bool MatchSampleLocationsInfo(const vku::safe_VkSampleLocationsInfoEXT &info_1, const VkSampleLocationsInfoEXT &info_2) {
+static bool MatchSampleLocationsInfo(const vku::safe_VkSampleLocationsInfoEXT& info_1, const VkSampleLocationsInfoEXT& info_2) {
     if (info_1.sampleLocationsPerPixel != info_2.sampleLocationsPerPixel ||
         info_1.sampleLocationGridSize.width != info_2.sampleLocationGridSize.width ||
         info_1.sampleLocationGridSize.height != info_2.sampleLocationGridSize.height ||
@@ -272,11 +272,11 @@ static bool MatchSampleLocationsInfo(const vku::safe_VkSampleLocationsInfoEXT &i
     return true;
 }
 
-bool CoreChecks::ValidateCmdBindPipelineRenderPassMultisample(const vvl::CommandBuffer &cb_state,
-                                                              const vvl::Pipeline &pipeline_state, const vvl::RenderPass &rp_state,
-                                                              const Location &loc) const {
+bool CoreChecks::ValidateCmdBindPipelineRenderPassMultisample(const vvl::CommandBuffer& cb_state,
+                                                              const vvl::Pipeline& pipeline_state, const vvl::RenderPass& rp_state,
+                                                              const Location& loc) const {
     bool skip = false;
-    const auto *multisample_state = pipeline_state.MultisampleState();
+    const auto* multisample_state = pipeline_state.MultisampleState();
     if (!multisample_state) {
         return skip;
     } else if (rp_state.UsesDynamicRendering()) {
@@ -287,12 +287,12 @@ bool CoreChecks::ValidateCmdBindPipelineRenderPassMultisample(const vvl::Command
 
     const uint32_t subpass = cb_state.GetActiveSubpass();
     if (!phys_dev_ext_props.sample_locations_props.variableSampleLocations) {
-        const auto *sample_locations = vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(multisample_state);
+        const auto* sample_locations = vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(multisample_state);
         if (sample_locations && sample_locations->sampleLocationsEnable == VK_TRUE &&
             !pipeline_state.IsDynamic(CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT)) {
             bool found = false;
             for (uint32_t i = 0; i < cb_state.sample_locations_begin_info.postSubpassSampleLocationsCount; ++i) {
-                const auto &post_subpass_sample_location = cb_state.sample_locations_begin_info.pPostSubpassSampleLocations[i];
+                const auto& post_subpass_sample_location = cb_state.sample_locations_begin_info.pPostSubpassSampleLocations[i];
                 if (post_subpass_sample_location.subpassIndex == subpass) {
                     if (MatchSampleLocationsInfo(post_subpass_sample_location.sampleLocationsInfo,
                                                  sample_locations->sampleLocationsInfo)) {
@@ -340,7 +340,7 @@ bool CoreChecks::ValidateCmdBindPipelineRenderPassMultisample(const vvl::Command
 }
 
 bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                                VkPipeline pipeline, const ErrorObject &error_obj) const {
+                                                VkPipeline pipeline, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
     bool skip = false;
@@ -349,7 +349,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
 
     auto pipeline_ptr = Get<vvl::Pipeline>(pipeline);
     ASSERT_AND_RETURN_SKIP(pipeline_ptr);
-    const vvl::Pipeline &pipeline_state = *pipeline_ptr;
+    const vvl::Pipeline& pipeline_state = *pipeline_ptr;
 
     if (pipelineBindPoint != pipeline_state.pipeline_type) {
         const LogObjectList objlist(cb_state->Handle(), pipeline);
@@ -426,10 +426,10 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
 // Validates that the supplied bind point is supported for the command buffer (vis. the command pool)
 // Takes array of error codes as some of the VUID's (e.g. vkCmdBindPipeline) are written per bindpoint
 // TODO add vkCmdBindPipeline bind_point validation using this call.
-bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer &cb_state, VkPipelineBindPoint bind_point,
-                                           const Location &loc) const {
+bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer& cb_state, VkPipelineBindPoint bind_point,
+                                           const Location& loc) const {
     bool skip = false;
-    const auto *pool = cb_state.command_pool;
+    const auto* pool = cb_state.command_pool;
     // The loss of a pool in a recording cmd is reported in DestroyCommandPool
     if (!pool) {
         return skip;
@@ -442,10 +442,10 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer &cb_state, V
                                            ? (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)
                                            : VK_QUEUE_FLAG_BITS_MAX_ENUM;
 
-    const auto &qfp = physical_device_state->queue_family_properties[pool->queueFamilyIndex];
+    const auto& qfp = physical_device_state->queue_family_properties[pool->queueFamilyIndex];
     if (0 == (qfp.queueFlags & required_mask)) {
         const LogObjectList objlist(cb_state.Handle(), pool->Handle());
-        const char *vuid = kVUIDUndefined;
+        const char* vuid = kVUIDUndefined;
         switch (loc.function) {
             case Func::vkCmdBindDescriptorSets:
                 vuid = "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361";
@@ -504,7 +504,7 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer &cb_state, V
 }
 
 // Validate that data for each specialization entry is fully contained within the buffer.
-bool CoreChecks::ValidateSpecializations(const vku::safe_VkSpecializationInfo *spec, const Location &loc) const {
+bool CoreChecks::ValidateSpecializations(const vku::safe_VkSpecializationInfo* spec, const Location& loc) const {
     bool skip = false;
     if (!spec) {
         return skip;
@@ -512,7 +512,7 @@ bool CoreChecks::ValidateSpecializations(const vku::safe_VkSpecializationInfo *s
 
     for (auto i = 0u; i < spec->mapEntryCount; i++) {
         const Location map_loc = loc.dot(Field::pMapEntries, i);
-        const auto &map_entry = spec->pMapEntries[i];
+        const auto& map_entry = spec->pMapEntries[i];
         if (map_entry.offset >= spec->dataSize) {
             skip |= LogError("VUID-VkSpecializationInfo-offset-00773", device, map_loc.dot(Field::offset),
                              "is %" PRIu32 " but dataSize is %zu (for constantID %" PRIu32 ").", map_entry.offset, spec->dataSize,
@@ -536,12 +536,12 @@ bool CoreChecks::ValidateSpecializations(const vku::safe_VkSpecializationInfo *s
     return skip;
 }
 
-bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const vvl::Pipeline &pipeline,
-                                                 const Location &loc) const {
+bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const vvl::Pipeline& pipeline,
+                                                 const Location& loc) const {
     bool skip = false;
     uint32_t total_resources = 0;
 
-    const auto &rp_state = pipeline.RenderPassState();
+    const auto& rp_state = pipeline.RenderPassState();
     if ((stage == VK_SHADER_STAGE_FRAGMENT_BIT) && rp_state) {
         if (rp_state->UsesDynamicRendering()) {
             total_resources += rp_state->dynamic_pipeline_rendering_create_info.colorAttachmentCount;
@@ -555,9 +555,9 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
 
     // TODO: This reuses a lot of GetDescriptorCountMaxPerStage but currently would need to make it agnostic in a way to handle
     // input from CreatePipeline and CreatePipelineLayout level
-    const auto &layout_state = pipeline.PipelineLayoutState();
+    const auto& layout_state = pipeline.PipelineLayoutState();
     if (layout_state) {
-        for (const auto &set_layout : layout_state->set_layouts.list) {
+        for (const auto& set_layout : layout_state->set_layouts.list) {
             if (!set_layout) {
                 continue;
             }
@@ -567,7 +567,7 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
             }
 
             for (uint32_t binding_idx = 0; binding_idx < set_layout->GetBindingCount(); binding_idx++) {
-                const VkDescriptorSetLayoutBinding *binding = set_layout->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
+                const VkDescriptorSetLayoutBinding* binding = set_layout->GetDescriptorSetLayoutBindingPtrFromIndex(binding_idx);
                 // Bindings with a descriptorCount of 0 are "reserved" and should be skipped
                 if (((stage & binding->stageFlags) != 0) && (binding->descriptorCount > 0)) {
                     // Check only descriptor types listed in maxPerStageResources description in spec
@@ -593,7 +593,7 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
     }
 
     if (total_resources > phys_dev_props.limits.maxPerStageResources) {
-        const char *vuid = nullptr;
+        const char* vuid = nullptr;
         if (stage == VK_SHADER_STAGE_COMPUTE_BIT) {
             vuid = "VUID-VkComputePipelineCreateInfo-layout-01687";
         } else if ((stage & VK_SHADER_STAGE_ALL_GRAPHICS) == 0) {
@@ -610,14 +610,13 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineShaderStage(const vvl::Pipeline &pipeline,
-                                             const vku::safe_VkPipelineShaderStageCreateInfo &stage_ci, const void *pipeline_ci_pnext,
-                                             const Location &loc) const {
+bool CoreChecks::ValidatePipelineShaderStage(const vvl::Pipeline& pipeline,
+                                             const vku::safe_VkPipelineShaderStageCreateInfo& stage_ci,
+                                             const void* pipeline_ci_pnext, const Location& loc) const {
     bool skip = false;
     const auto binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(pipeline_ci_pnext);
 
-    if (binary_info && binary_info->binaryCount != 0)
-    {
+    if (binary_info && binary_info->binaryCount != 0) {
         return skip;
     }
 
@@ -711,14 +710,14 @@ bool CoreChecks::ValidatePipelineShaderStage(const vvl::Pipeline &pipeline,
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKHR *pPipelineCreateInfo,
-                                                  VkPipelineBinaryKeyKHR *pPipelineKey, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKHR* pPipelineCreateInfo,
+                                                  VkPipelineBinaryKeyKHR* pPipelineKey, const ErrorObject& error_obj) const {
     bool skip = false;
 
     // Used when getting global key
     if (!pPipelineCreateInfo) return skip;
 
-    const VkBaseOutStructure *pipeline_create_info = reinterpret_cast<const VkBaseOutStructure *>(pPipelineCreateInfo->pNext);
+    const VkBaseOutStructure* pipeline_create_info = reinterpret_cast<const VkBaseOutStructure*>(pPipelineCreateInfo->pNext);
     if (pipeline_create_info) {
         if (pipeline_create_info->sType != VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX &&
             pipeline_create_info->sType != VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO &&
@@ -732,7 +731,7 @@ bool CoreChecks::PreCallValidateGetPipelineKeyKHR(VkDevice device, const VkPipel
         }
     }
 
-    const auto *binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(pPipelineCreateInfo->pNext);
+    const auto* binary_info = vku::FindStructInPNextChain<VkPipelineBinaryInfoKHR>(pPipelineCreateInfo->pNext);
     if (binary_info && (binary_info->binaryCount > 0)) {
         skip |=
             LogError("VUID-vkGetPipelineKeyKHR-pNext-09605", device,
@@ -743,9 +742,9 @@ bool CoreChecks::PreCallValidateGetPipelineKeyKHR(VkDevice device, const VkPipel
     return skip;
 }
 
-bool CoreChecks::PreCallValidateReleaseCapturedPipelineDataKHR(VkDevice device, const VkReleaseCapturedPipelineDataInfoKHR *pInfo,
-                                                               const VkAllocationCallbacks *pAllocator,
-                                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateReleaseCapturedPipelineDataKHR(VkDevice device, const VkReleaseCapturedPipelineDataInfoKHR* pInfo,
+                                                               const VkAllocationCallbacks* pAllocator,
+                                                               const ErrorObject& error_obj) const {
     auto pipeline_state = Get<vvl::Pipeline>(pInfo->pipeline);
     bool skip = false;
 
@@ -760,16 +759,16 @@ bool CoreChecks::PreCallValidateReleaseCapturedPipelineDataKHR(VkDevice device, 
     }
 
     if (pipeline_state->binary_data_released) {
-        skip |= LogError("VUID-VkReleaseCapturedPipelineDataInfoKHR-pipeline-09618", pInfo->pipeline, error_obj.location.dot(Field::pInfo).dot(Field::pipeline),
-                         "has been called multiple times.");
+        skip |= LogError("VUID-VkReleaseCapturedPipelineDataInfoKHR-pipeline-09618", pInfo->pipeline,
+                         error_obj.location.dot(Field::pInfo).dot(Field::pipeline), "has been called multiple times.");
     }
 
     return skip;
 }
 
-void CoreChecks::PostCallRecordReleaseCapturedPipelineDataKHR(VkDevice device, const VkReleaseCapturedPipelineDataInfoKHR *pInfo,
-                                                              const VkAllocationCallbacks *pAllocator,
-                                                              const RecordObject &record_obj) {
+void CoreChecks::PostCallRecordReleaseCapturedPipelineDataKHR(VkDevice device, const VkReleaseCapturedPipelineDataInfoKHR* pInfo,
+                                                              const VkAllocationCallbacks* pAllocator,
+                                                              const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }

--- a/layers/core_checks/cc_pipeline_compute.cpp
+++ b/layers/core_checks/cc_pipeline_compute.cpp
@@ -24,20 +24,20 @@
 #include "state_tracker/pipeline_state.h"
 
 bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                       const VkComputePipelineCreateInfo *pCreateInfos,
-                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                       const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                       chassis::CreateComputePipelines &chassis_state) const {
+                                                       const VkComputePipelineCreateInfo* pCreateInfos,
+                                                       const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                       const ErrorObject& error_obj, PipelineStates& pipeline_states,
+                                                       chassis::CreateComputePipelines& chassis_state) const {
     bool skip = false;
 
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     for (uint32_t i = 0; i < count; i++) {
-        const vvl::Pipeline *pipeline = pipeline_states[i].get();
+        const vvl::Pipeline* pipeline = pipeline_states[i].get();
         ASSERT_AND_CONTINUE(pipeline);
 
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
         const Location stage_info = create_info_loc.dot(Field::stage);
-        const auto &stage_state = pipeline->stage_states[0];
+        const auto& stage_state = pipeline->stage_states[0];
         skip |= ValidateShaderStage(stage_state, pipeline, stage_info);
         if (stage_state.pipeline_create_info) {
             skip |= ValidatePipelineShaderStage(*pipeline, *stage_state.pipeline_create_info, pCreateInfos[i].pNext, stage_info);
@@ -45,7 +45,7 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
 
         skip |= ValidateComputePipelineDerivatives(pipeline_states, i, create_info_loc);
 
-        if (const auto *pipeline_robustness_info =
+        if (const auto* pipeline_robustness_info =
                 vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pCreateInfos[i].pNext)) {
             skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, *pipeline_robustness_info, create_info_loc);
         }
@@ -65,16 +65,16 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
     return skip;
 }
 
-bool CoreChecks::ValidateComputePipelineDerivatives(PipelineStates &pipeline_states, uint32_t pipe_index,
-                                                    const Location &loc) const {
+bool CoreChecks::ValidateComputePipelineDerivatives(PipelineStates& pipeline_states, uint32_t pipe_index,
+                                                    const Location& loc) const {
     bool skip = false;
-    const auto &pipeline = *pipeline_states[pipe_index].get();
+    const auto& pipeline = *pipeline_states[pipe_index].get();
     // If create derivative bit is set, check that we've specified a base
     // pipeline correctly, and that the base pipeline was created to allow
     // derivatives.
     if (pipeline.create_flags & VK_PIPELINE_CREATE_2_DERIVATIVE_BIT) {
         std::shared_ptr<const vvl::Pipeline> base_pipeline;
-        const auto &pipeline_ci = pipeline.ComputeCreateInfo();
+        const auto& pipeline_ci = pipeline.ComputeCreateInfo();
         const VkPipeline base_handle = pipeline_ci.basePipelineHandle;
         const int32_t base_index = pipeline_ci.basePipelineIndex;
         if (base_index != -1 && base_index < static_cast<int32_t>(pipeline_states.size())) {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -47,10 +47,10 @@
 #include "error_message/error_strings.h"
 
 bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                        const VkGraphicsPipelineCreateInfo *pCreateInfos,
-                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                        const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                        chassis::CreateGraphicsPipelines &chassis_state) const {
+                                                        const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                        const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                        const ErrorObject& error_obj, PipelineStates& pipeline_states,
+                                                        chassis::CreateGraphicsPipelines& chassis_state) const {
     bool skip = false;
 
     skip |= ValidateDeviceQueueSupport(error_obj.location);
@@ -76,12 +76,12 @@ bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipel
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const void *pipeline_ci_pnext,
-                                          const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline& pipeline, const void* pipeline_ci_pnext,
+                                          const Location& create_info_loc) const {
     bool skip = false;
     // It would be ideal to split all pipeline checks into Dynamic and Non-Dynamic renderpasses, but with GPL it gets a bit tricky.
     // Also you might be deep in a function and it is easier to do a if/else check if it is dynamic rendering or not there.
-    vku::safe_VkSubpassDescription2 *subpass_desc = nullptr;
+    vku::safe_VkSubpassDescription2* subpass_desc = nullptr;
     const auto rp_state = pipeline.RenderPassState();
 
     if (pipeline.descriptor_heap_embedded_samplers_count > 0) {
@@ -127,7 +127,7 @@ bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const v
     if (pipeline.OwnsLibState(pipeline.pre_raster_state) || pipeline.OwnsLibState(pipeline.fragment_shader_state)) {
         vvl::unordered_map<VkShaderStageFlags, uint32_t> unique_stage_map;
         uint32_t index = 0;
-        for (const auto &stage_ci : pipeline.shader_stages_ci) {
+        for (const auto& stage_ci : pipeline.shader_stages_ci) {
             auto it = unique_stage_map.find(stage_ci.stage);
             if (it != unique_stage_map.end()) {
                 skip |=
@@ -161,14 +161,14 @@ bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const v
     // pStages are ignored if not using one of these library states
     if (pipeline.OwnsLibState(pipeline.fragment_shader_state) || pipeline.OwnsLibState(pipeline.pre_raster_state)) {
         uint32_t stage_index = 0;
-        for (const auto &stage_ci : pipeline.shader_stages_ci) {
+        for (const auto& stage_ci : pipeline.shader_stages_ci) {
             skip |= ValidatePipelineShaderStage(pipeline, stage_ci, pipeline_ci_pnext,
                                                 create_info_loc.dot(Field::pStages, stage_index++));
         }
     }
 
-    const void *pipeline_pnext = pipeline.GetCreateInfoPNext();
-    if (const auto *discard_rectangle_state =
+    const void* pipeline_pnext = pipeline.GetCreateInfoPNext();
+    if (const auto* discard_rectangle_state =
             vku::FindStructInPNextChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pipeline_pnext)) {
         skip |= ValidatePipelineDiscardRectangleStateCreateInfo(pipeline, *discard_rectangle_state, create_info_loc);
     }
@@ -178,16 +178,16 @@ bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const v
         skip |= ValidatePipelineAttachmentSampleCountInfo(pipeline, *attachment_sample_count_info, create_info_loc);
     }
 
-    if (const auto *pipeline_robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pipeline_pnext)) {
+    if (const auto* pipeline_robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pipeline_pnext)) {
         skip |= ValidatePipelineRobustnessCreateInfo(pipeline, *pipeline_robustness_info, create_info_loc);
     }
 
-    if (const auto *fragment_shading_rate_state =
+    if (const auto* fragment_shading_rate_state =
             vku::FindStructInPNextChain<VkPipelineFragmentShadingRateStateCreateInfoKHR>(pipeline_pnext)) {
         skip |= ValidateGraphicsPipelineFragmentShadingRateState(pipeline, *fragment_shading_rate_state, create_info_loc);
     }
 
-    if (const auto *fragment_density_map_layered =
+    if (const auto* fragment_density_map_layered =
             vku::FindStructInPNextChain<VkPipelineFragmentDensityMapLayeredCreateInfoVALVE>(pipeline_pnext)) {
         if (fragment_density_map_layered->maxFragmentDensityMapLayers >
             phys_dev_ext_props.fragment_density_map_layered_props.maxFragmentDensityMapLayers) {
@@ -205,7 +205,7 @@ bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const v
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
     if (!enabled_features.triangleFans && (pipeline.topology_at_rasterizer == VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN)) {
         skip |= LogError("VUID-VkPipelineInputAssemblyStateCreateInfo-triangleFans-04452", device, create_info_loc,
@@ -215,8 +215,8 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT) &&
         !pipeline.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE)) {
         // Validate vertex inputs
-        for (const auto &state : pipeline.vertex_input_state->bindings) {
-            const auto &desc = state.second.desc;
+        for (const auto& state : pipeline.vertex_input_state->bindings) {
+            const auto& desc = state.second.desc;
             const uint32_t min_alignment = phys_dev_ext_props.portability_props.minVertexInputBindingStrideAlignment;
             if (min_alignment != 0 && !IsIntegerMultipleOf(desc.stride, min_alignment)) {
                 skip |= LogError(
@@ -231,10 +231,10 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
 
         // Validate vertex attributes
         if (!enabled_features.vertexAttributeAccessBeyondStride) {
-            for (const auto &binding_state : pipeline.vertex_input_state->bindings) {
-                for (const auto &attrib_state : binding_state.second.locations) {
-                    const auto &attrib = attrib_state.second.desc;
-                    const auto &desc = binding_state.second.desc;
+            for (const auto& binding_state : pipeline.vertex_input_state->bindings) {
+                for (const auto& attrib_state : binding_state.second.locations) {
+                    const auto& attrib = attrib_state.second.desc;
+                    const auto& desc = binding_state.second.desc;
                     if ((attrib.offset + GetVertexInputFormatSize(attrib.format)) > desc.stride) {
                         skip |= LogError("VUID-VkVertexInputAttributeDescription-vertexAttributeAccessBeyondStride-04457", device,
                                          create_info_loc,
@@ -275,7 +275,7 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
             raster_state_ci->rasterizerDiscardEnable ||
             (pipeline.rendering_create_info ? (pipeline.rendering_create_info->colorAttachmentCount == 0)
                                             : (render_pass->create_info.pSubpasses[subpass].colorAttachmentCount == 0));
-        const auto *color_blend_state = pipeline.ColorBlendState();
+        const auto* color_blend_state = pipeline.ColorBlendState();
         if (!enabled_features.constantAlphaColorBlendFactors && !ignore_color_blend_state && color_blend_state) {
             const auto attachments = color_blend_state->pAttachments;
             for (uint32_t color_attachment_index = 0; color_attachment_index < color_blend_state->attachmentCount;
@@ -305,9 +305,9 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline,
-                                                   const VkPipelineLibraryCreateInfoKHR &library_create_info,
-                                                   const Location &create_info_loc) const {
+bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline& pipeline,
+                                                   const VkPipelineLibraryCreateInfoKHR& library_create_info,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
 
     const VkPipelineCreateFlags2 pipeline_flags = pipeline.create_flags;
@@ -330,7 +330,7 @@ bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline
             continue;
         }
 
-        const Location &library_loc = create_info_loc.pNext(Struct::VkPipelineLibraryCreateInfoKHR, Field::pLibraries, i);
+        const Location& library_loc = create_info_loc.pNext(Struct::VkPipelineLibraryCreateInfoKHR, Field::pLibraries, i);
         const VkPipelineCreateFlags2 lib_pipeline_flags = lib->create_flags;
 
         const bool lib_has_retain_link_time_opt =
@@ -423,7 +423,7 @@ bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline
         if (lib_has_capture_internal) {
             lib_all_has_capture_internal = true;
             if (!has_capture_internal && incoming_gpl) {
-                const Location &gpl_flags_loc = create_info_loc.pNext(Struct::VkGraphicsPipelineLibraryCreateInfoEXT, Field::flags);
+                const Location& gpl_flags_loc = create_info_loc.pNext(Struct::VkGraphicsPipelineLibraryCreateInfoEXT, Field::flags);
                 skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06647", lib->Handle(), library_loc,
                                  "(%s) was created with %s\n"
                                  "%s is %s\n"
@@ -440,7 +440,7 @@ bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline
                              "(%s) was created with %s.", string_VkGraphicsPipelineLibraryFlagsEXT(lib->graphics_lib_type).c_str(),
                              string_VkPipelineCreateFlags2(lib_pipeline_flags).c_str());
             } else if (has_capture_internal && incoming_gpl) {
-                const Location &gpl_flags_loc = create_info_loc.pNext(Struct::VkGraphicsPipelineLibraryCreateInfoEXT, Field::flags);
+                const Location& gpl_flags_loc = create_info_loc.pNext(Struct::VkGraphicsPipelineLibraryCreateInfoEXT, Field::flags);
                 skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-flags-06645", lib->Handle(), library_loc,
                                  "(%s) was created with %s\n"
                                  "%s is %s\n"
@@ -532,7 +532,7 @@ bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline
 }
 
 // vkspec.html#pipelines-graphics-subsets-vertex-input
-bool CoreChecks::ValidateGraphicsPipelineVertexInputState(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineVertexInputState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
     // If using a mesh shader, all vertex input is ignored
     if (!pipeline.OwnsLibState(pipeline.vertex_input_state) || (pipeline.active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT)) {
@@ -549,8 +549,8 @@ bool CoreChecks::ValidateGraphicsPipelineVertexInputState(const vvl::Pipeline &p
         skip |= ValidatePipelineVertexDivisors(pipeline, create_info_loc);
     }
 
-    const auto *input_state = pipeline.InputState();
-    const auto *assembly_state = pipeline.InputAssemblyState();
+    const auto* input_state = pipeline.InputState();
+    const auto* assembly_state = pipeline.InputAssemblyState();
     const bool invalid_input_state = !ignore_vertex_input_state && !input_state;
     const bool invalid_assembly_state = !ignore_input_assembly_state && !assembly_state;
 
@@ -603,7 +603,7 @@ bool CoreChecks::ValidateGraphicsPipelineVertexInputState(const vvl::Pipeline &p
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineNullRenderPass(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineNullRenderPass(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
     // If the vertex input is by itself renderpass is ignored
     if (!pipeline.IsRenderPassStateRequired()) return skip;
@@ -621,7 +621,7 @@ bool CoreChecks::ValidateGraphicsPipelineNullRenderPass(const vvl::Pipeline &pip
             gpl_info && (gpl_info->flags & (VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT |
                                             VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT |
                                             VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT)) != 0;
-        const char *vuid =
+        const char* vuid =
             has_flags ? "VUID-VkGraphicsPipelineCreateInfo-flags-06643" : "VUID-VkGraphicsPipelineCreateInfo-renderPass-06603";
         skip |= LogError(vuid, device, create_info_loc.dot(Field::renderPass), "is not a valid render pass.");
     }
@@ -629,7 +629,7 @@ bool CoreChecks::ValidateGraphicsPipelineNullRenderPass(const vvl::Pipeline &pip
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
 
     const VkPipelineCreateFlags2 pipeline_flags = pipeline.create_flags;
@@ -640,7 +640,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
     if (pipeline.OwnsLibState(pipeline.pre_raster_state) && !pipeline.OwnsLibState(pipeline.fragment_shader_state) &&
         ((pipeline.create_info_shaders & FragmentShaderState::ValidShaderStages()) != 0)) {
         // Hint to help as shown from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8761
-        const char *hint = is_create_library ? "" : " (Is rasterizerDiscardEnable mistakenly set to VK_TRUE?)";
+        const char* hint = is_create_library ? "" : " (Is rasterizerDiscardEnable mistakenly set to VK_TRUE?)";
         skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pStages-06894", device, create_info_loc,
                          "does not have fragment shader state, but stages (%s) contains VK_SHADER_STAGE_FRAGMENT_BIT.%s",
                          string_VkShaderStageFlags(pipeline.create_info_shaders).c_str(), hint);
@@ -688,7 +688,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
     }
 
     // note this is the incoming layout an not ones from the pipeline library
-    const auto &pipeline_ci = pipeline.GraphicsCreateInfo();
+    const auto& pipeline_ci = pipeline.GraphicsCreateInfo();
     const auto pipeline_layout_state = Get<vvl::PipelineLayout>(pipeline_ci.layout);
 
     if (pipeline.HasFullState()) {
@@ -755,7 +755,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
 
             if (pre_raster_independent_set && fs_independent_set) {
                 const bool has_link_time_opt = (pipeline.create_flags & VK_PIPELINE_CREATE_2_LINK_TIME_OPTIMIZATION_BIT_EXT) != 0;
-                const char *vuid = has_link_time_opt ? "VUID-VkGraphicsPipelineCreateInfo-flags-06729"
+                const char* vuid = has_link_time_opt ? "VUID-VkGraphicsPipelineCreateInfo-flags-06729"
                                                      : "VUID-VkGraphicsPipelineCreateInfo-flags-06730";
 
                 if (pipeline_layout_state) {
@@ -801,10 +801,10 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
     struct GPLValidInfo {
         GPLInitType init = GPLInitType::uninitialized;
         VkPipelineLayoutCreateFlags flags = VK_PIPELINE_LAYOUT_CREATE_FLAG_BITS_MAX_ENUM;
-        const vvl::PipelineLayout *layout = nullptr;
+        const vvl::PipelineLayout* layout = nullptr;
         // Can't use MultisampleState() to get this value as we are checking here if they are identical
-        const VkPipelineMultisampleStateCreateInfo *ms_state = nullptr;
-        const VkPipelineFragmentShadingRateStateCreateInfoKHR *shading_rate_state = nullptr;
+        const VkPipelineMultisampleStateCreateInfo* ms_state = nullptr;
+        const VkPipelineFragmentShadingRateStateCreateInfoKHR* shading_rate_state = nullptr;
     };
 
     GPLValidInfo pre_raster_info;
@@ -850,7 +850,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                 continue;
             }
 
-            const auto &lib_ci = lib->GraphicsCreateInfo();
+            const auto& lib_ci = lib->GraphicsCreateInfo();
             if (lib->graphics_lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT) {
                 pre_raster_info.init = GPLInitType::link_libraries;
                 const auto layout_state = lib->PreRasterPipelineLayoutState();
@@ -885,7 +885,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
 
     if ((pipeline.OwnsLibState(pipeline.pre_raster_state) || pipeline.OwnsLibState(pipeline.fragment_shader_state)) &&
         !pipeline_layout_state && !pipeline.descriptor_heap_mode) {
-        const char *vuid = (pre_raster_info.init == GPLInitType::gpl_flags || frag_shader_info.init == GPLInitType::gpl_flags)
+        const char* vuid = (pre_raster_info.init == GPLInitType::gpl_flags || frag_shader_info.init == GPLInitType::gpl_flags)
                                ? "VUID-VkGraphicsPipelineCreateInfo-flags-06642"
                                : "VUID-VkGraphicsPipelineCreateInfo-layout-06602";
         skip |= LogError(vuid, device, create_info_loc.dot(Field::layout), "is not a valid VkPipelineLayout.");
@@ -929,7 +929,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         const auto fs_independant_set = (frag_shader_info.flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
         const bool not_independent_sets = !pre_raster_independant_set && !fs_independant_set;
         if (pre_raster_independant_set ^ fs_independant_set) {
-            const char *vuid =
+            const char* vuid =
                 only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06615" : "VUID-VkGraphicsPipelineCreateInfo-flags-06614";
             LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
             skip |= LogError(
@@ -945,7 +945,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             // Inside VkPipelineLayoutCreateInfo, |pSetLayouts| and |pPushConstantRanges| are checked below, this leaves this VU to
             // cover everything else. Currently no valid pNext structs are extending pipeline layout creation
             if (pre_raster_info.layout->create_flags != frag_shader_info.layout->create_flags) {
-                const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                const char* vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                              : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
                 LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                 skip |=
@@ -967,7 +967,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             const uint32_t frag_shader_count = static_cast<uint32_t>(frag_shader_info.layout->push_constant_ranges_layout->size());
 
             if (pre_raster_count != frag_shader_count) {
-                const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
+                const char* vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
                                              : "VUID-VkGraphicsPipelineCreateInfo-flags-06620";
                 LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                 skip |= LogError(vuid, objlist, create_info_loc,
@@ -982,7 +982,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                     VkPushConstantRange frag_shader_range = frag_shader_info.layout->push_constant_ranges_layout->at(i);
                     if (pre_raster_range.stageFlags != frag_shader_range.stageFlags ||
                         pre_raster_range.offset != frag_shader_range.offset || pre_raster_range.size != frag_shader_range.size) {
-                        const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
+                        const char* vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
                                                      : "VUID-VkGraphicsPipelineCreateInfo-flags-06620";
                         LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                         skip |= LogError(vuid, objlist, create_info_loc,
@@ -1002,7 +1002,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
 
         // Check VkPipelineFragmentShadingRateStateCreateInfoKHR
         if (frag_shader_info.shading_rate_state || pre_raster_info.shading_rate_state) {
-            const char *vuid =
+            const char* vuid =
                 only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06639" : "VUID-VkGraphicsPipelineCreateInfo-flags-06638";
             if (!pre_raster_info.shading_rate_state) {
                 skip |= LogError(
@@ -1041,12 +1041,12 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         }
 
         // Check for consistent shader bindings + layout across libraries
-        const auto &pre_raster_set_layouts = pre_raster_info.layout->set_layouts;
-        const auto &fs_set_layouts = frag_shader_info.layout->set_layouts;
+        const auto& pre_raster_set_layouts = pre_raster_info.layout->set_layouts;
+        const auto& fs_set_layouts = frag_shader_info.layout->set_layouts;
         const uint32_t pre_raster_count = pre_raster_info.layout ? static_cast<uint32_t>(pre_raster_set_layouts.list.size()) : 0;
         const uint32_t frag_shader_count = frag_shader_info.layout ? static_cast<uint32_t>(fs_set_layouts.list.size()) : 0;
         if (not_independent_sets && pre_raster_count != frag_shader_count && !pipeline.descriptor_heap_mode) {
-            const char *vuid =
+            const char* vuid =
                 only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613" : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
             LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
             skip |=
@@ -1067,7 +1067,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             if (!pre_raster_dsl && fs_dsl) {
                 // Null DSL at pSetLayouts[i] in pre-raster state. Make sure that shader bindings in corresponding DSL in
                 // fragment shader state do not overlap.
-                for (const auto &fs_binding : fs_dsl->GetBindings()) {
+                for (const auto& fs_binding : fs_dsl->GetBindings()) {
                     const VkShaderStageFlags overlap_flags = fs_binding.stageFlags & PreRasterState::ValidShaderStages();
                     if (overlap_flags == 0) {
                         continue;
@@ -1075,7 +1075,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                     const auto pre_raster_layout_handle_str = FormatHandle(pre_raster_info.layout->Handle());
                     const auto fs_layout_handle_str = FormatHandle(frag_shader_info.layout->Handle());
                     const auto fs_dsl_handle_str = FormatHandle(fs_dsl->Handle());
-                    const char *vuid = nullptr;
+                    const char* vuid = nullptr;
                     std::ostringstream msg;
                     if (pre_raster_info.init == GPLInitType::gpl_flags) {
                         vuid = "VUID-VkGraphicsPipelineCreateInfo-flags-06756";
@@ -1113,7 +1113,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             } else if (pre_raster_dsl && !fs_dsl) {
                 // Null DSL at pSetLayouts[i] in FS state. Make sure that shader bindings in corresponding DSL in pre-raster
                 // state do not overlap.
-                for (const auto &pre_raster_binding : pre_raster_dsl->GetBindings()) {
+                for (const auto& pre_raster_binding : pre_raster_dsl->GetBindings()) {
                     const VkShaderStageFlags overlap_flags =
                         pre_raster_binding.stageFlags & FragmentShaderState::ValidShaderStages();
                     if (overlap_flags == 0) {
@@ -1122,7 +1122,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                     const auto pre_raster_layout_handle_str = FormatHandle(pre_raster_info.layout->Handle());
                     const auto fs_layout_handle_str = FormatHandle(frag_shader_info.layout->Handle());
                     const auto pre_raster_dsl_handle_str = FormatHandle(pre_raster_dsl->Handle());
-                    const char *vuid = nullptr;
+                    const char* vuid = nullptr;
                     std::ostringstream msg;
                     if (frag_shader_info.init == GPLInitType::gpl_flags) {
                         vuid = "VUID-VkGraphicsPipelineCreateInfo-flags-06756";
@@ -1167,7 +1167,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                 }
                 const auto pre_raster_layout_handle_str = FormatHandle(pre_raster_info.layout->Handle());
                 const auto fs_layout_handle_str = FormatHandle(frag_shader_info.layout->Handle());
-                const char *vuid = nullptr;
+                const char* vuid = nullptr;
                 std::ostringstream msg;
                 if (frag_shader_info.init == GPLInitType::gpl_flags) {
                     vuid = "VUID-VkGraphicsPipelineCreateInfo-flags-06679";
@@ -1197,7 +1197,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                 // both handles are valid, but without VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, need to check everything
                 // is identically defined
                 if (pre_raster_dsl->GetCreateFlags() != fs_dsl->GetCreateFlags()) {
-                    const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                    const char* vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
                     LogObjectList objlist(pre_raster_dsl->Handle(), pre_raster_info.layout->Handle(), fs_dsl->Handle(),
                                           frag_shader_info.layout->Handle());
@@ -1212,7 +1212,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                                      FormatHandle(frag_shader_info.layout->Handle()).c_str(), i,
                                      string_VkDescriptorSetLayoutCreateFlags(fs_dsl->GetCreateFlags()).c_str());
                 } else if (pre_raster_dsl->GetBindingCount() != fs_dsl->GetBindingCount()) {
-                    const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                    const char* vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
                     LogObjectList objlist(pre_raster_dsl->Handle(), pre_raster_info.layout->Handle(), fs_dsl->Handle(),
                                           frag_shader_info.layout->Handle());
@@ -1225,13 +1225,13 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                                      FormatHandle(frag_shader_info.layout->Handle()).c_str(), i, fs_dsl->GetBindingCount());
                 } else {
                     const uint32_t binding_count = pre_raster_dsl->GetBindingCount();
-                    const auto &pre_raster_bindings = pre_raster_dsl->GetBindings();
-                    const auto &fs_bindings = fs_dsl->GetBindings();
+                    const auto& pre_raster_bindings = pre_raster_dsl->GetBindings();
+                    const auto& fs_bindings = fs_dsl->GetBindings();
                     for (uint32_t binding_index = 0; binding_index < binding_count; binding_index++) {
-                        const auto &pre_raster_binding = pre_raster_bindings[binding_index];
-                        const auto &fs_binding = fs_bindings[binding_index];
+                        const auto& pre_raster_binding = pre_raster_bindings[binding_index];
+                        const auto& fs_binding = fs_bindings[binding_index];
                         if (!CompareDescriptorSetLayoutBinding(*pre_raster_binding.ptr(), *fs_binding.ptr())) {
-                            const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                            const char* vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                                          : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
                             LogObjectList objlist(pre_raster_dsl->Handle(), pre_raster_info.layout->Handle(), fs_dsl->Handle(),
                                                   frag_shader_info.layout->Handle());
@@ -1276,7 +1276,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         if (!frag_shader_info.ms_state && frag_output_info.ms_state) {
             // if Fragment Output has sampleShadingEnable == false, Fragement Shader may be null
             if (frag_output_info.ms_state->sampleShadingEnable) {
-                const char *vuid =
+                const char* vuid =
                     (frag_shader_info.init == GPLInitType::gpl_flags)   ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-09567"
                     : (frag_output_info.init == GPLInitType::gpl_flags) ? "VUID-VkGraphicsPipelineCreateInfo-flags-06637"
                                                                         : "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06636";
@@ -1286,7 +1286,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                     "VK_TRUE, but Fragment Shader has a pMultisampleState of NULL.");
             }
         } else if (frag_shader_info.ms_state && !frag_output_info.ms_state) {
-            const char *vuid = (frag_shader_info.init == GPLInitType::gpl_flags) ? "VUID-VkGraphicsPipelineCreateInfo-flags-06633"
+            const char* vuid = (frag_shader_info.init == GPLInitType::gpl_flags) ? "VUID-VkGraphicsPipelineCreateInfo-flags-06633"
                                : (frag_output_info.init == GPLInitType::gpl_flags)
                                    ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06634"
                                    : "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06635";
@@ -1295,7 +1295,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                              "a pMultisampleState of NULL.");
         } else if (frag_shader_info.ms_state && frag_output_info.ms_state) {
             if (!ComparePipelineMultisampleStateCreateInfo(*frag_shader_info.ms_state, *frag_output_info.ms_state)) {
-                const char *vuid =
+                const char* vuid =
                     (frag_shader_info.init == GPLInitType::gpl_flags)   ? "VUID-VkGraphicsPipelineCreateInfo-flags-06633"
                     : (frag_output_info.init == GPLInitType::gpl_flags) ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06634"
                                                                         : "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06635";
@@ -1334,7 +1334,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
     const auto rp_state = pipeline.RenderPassState();
     if (!rp_state || rp_state->UsesDynamicRendering()) {
@@ -1342,7 +1342,7 @@ bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline &pipeli
     }
 
     const auto subpass = pipeline.Subpass();
-    const auto *subpass_desc = &rp_state->create_info.pSubpasses[subpass];
+    const auto* subpass_desc = &rp_state->create_info.pSubpasses[subpass];
     if (!subpass_desc) {
         return skip;
     }
@@ -1369,7 +1369,7 @@ bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline &pipeli
 
         if (attachment_desc.format == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 &&
             !pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT)) {
-            const VkColorComponentFlags &color_write_mask = pipeline.AttachmentStates()[i].colorWriteMask;
+            const VkColorComponentFlags& color_write_mask = pipeline.AttachmentStates()[i].colorWriteMask;
             VkColorComponentFlags rgb = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
             if ((color_write_mask & rgb) != rgb && (color_write_mask & rgb) != 0) {
                 skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-None-09043", device, create_info_loc.dot(Field::renderPass),
@@ -1384,12 +1384,12 @@ bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline &pipeli
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineMeshTask(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineMeshTask(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
 
-    const ShaderStageState *task_state = nullptr;
-    const ShaderStageState *mesh_state = nullptr;
-    for (const auto &stage_state : pipeline.stage_states) {
+    const ShaderStageState* task_state = nullptr;
+    const ShaderStageState* mesh_state = nullptr;
+    for (const auto& stage_state : pipeline.stage_states) {
         const VkShaderStageFlagBits stage = stage_state.GetStage();
         if (stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
             mesh_state = &stage_state;
@@ -1412,9 +1412,9 @@ bool CoreChecks::ValidateGraphicsPipelineMeshTask(const vvl::Pipeline &pipeline,
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolve(const vvl::Pipeline &pipeline, const vvl::RenderPass &rp_state,
-                                                               const vku::safe_VkSubpassDescription2 &subpass_desc,
-                                                               const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolve(const vvl::Pipeline& pipeline, const vvl::RenderPass& rp_state,
+                                                               const vku::safe_VkSubpassDescription2& subpass_desc,
+                                                               const Location& create_info_loc) const {
     bool skip = false;
     if (!enabled_features.externalFormatResolve) return skip;
 
@@ -1431,7 +1431,7 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolve(const vvl::Pipeli
         return skip;
     }
 
-    const auto *multisample_state = pipeline.MultisampleState();
+    const auto* multisample_state = pipeline.MultisampleState();
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT) && multisample_state) {
         if (multisample_state->rasterizationSamples != VK_SAMPLE_COUNT_1_BIT) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-externalFormatResolve-09313", device,
@@ -1441,7 +1441,7 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolve(const vvl::Pipeli
         }
     }
 
-    const auto *color_blend_state = pipeline.ColorBlendState();
+    const auto* color_blend_state = pipeline.ColorBlendState();
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) && color_blend_state) {
         for (uint32_t i = 0; i < color_blend_state->attachmentCount; i++) {
             if (color_blend_state->pAttachments[i].blendEnable) {
@@ -1475,13 +1475,13 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolve(const vvl::Pipeli
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolveDynamicRendering(const vvl::Pipeline &pipeline,
-                                                                               const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolveDynamicRendering(const vvl::Pipeline& pipeline,
+                                                                               const Location& create_info_loc) const {
     bool skip = false;
     if (!enabled_features.externalFormatResolve) return skip;
 
     const uint64_t external_format = GetExternalFormat(pipeline.GetCreateInfoPNext());
-    const auto *rendering_struct = pipeline.rendering_create_info;
+    const auto* rendering_struct = pipeline.rendering_create_info;
     if (external_format == 0 || !rendering_struct) {
         return skip;
     }
@@ -1511,7 +1511,7 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolveDynamicRendering(c
         }
     }
 
-    const auto *multisample_state = pipeline.MultisampleState();
+    const auto* multisample_state = pipeline.MultisampleState();
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT) && multisample_state) {
         if (multisample_state->rasterizationSamples != VK_SAMPLE_COUNT_1_BIT) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-externalFormatResolve-09304", device,
@@ -1521,7 +1521,7 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolveDynamicRendering(c
         }
     }
 
-    const auto *color_blend_state = pipeline.ColorBlendState();
+    const auto* color_blend_state = pipeline.ColorBlendState();
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) && color_blend_state) {
         for (uint32_t i = 0; i < color_blend_state->attachmentCount; i++) {
             if (color_blend_state->pAttachments[i].blendEnable) {
@@ -1554,12 +1554,12 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolveDynamicRendering(c
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineInputAssemblyState(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineInputAssemblyState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
     const Location ia_loc = create_info_loc.dot(Field::pInputAssemblyState);
 
     // if vertex_input_state is not set, will be null
-    const auto *ia_state = pipeline.InputAssemblyState();
+    const auto* ia_state = pipeline.InputAssemblyState();
     if (ia_state) {
         const VkPrimitiveTopology topology = ia_state->topology;
         if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE) && ia_state->primitiveRestartEnable) {
@@ -1608,14 +1608,14 @@ bool CoreChecks::ValidateGraphicsPipelineInputAssemblyState(const vvl::Pipeline 
                              ia_state ? string_VkPrimitiveTopology(ia_state->topology) : "null");
         }
         if (!has_tessellation && (ia_state && ia_state->topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
-            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-topology-08889", device,  ia_loc.dot(Field::topology),
+            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-topology-08889", device, ia_loc.dot(Field::topology),
                              "is VK_PRIMITIVE_TOPOLOGY_PATCH_LIST but no tessellation shaders.");
         }
     };
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineTessellationState(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineTessellationState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
 
     if (pipeline.OwnsLibState(pipeline.pre_raster_state) &&
@@ -1634,8 +1634,8 @@ bool CoreChecks::ValidateGraphicsPipelineTessellationState(const vvl::Pipeline &
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelinePreRasterizationState(const vvl::Pipeline &pipeline,
-                                                               const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelinePreRasterizationState(const vvl::Pipeline& pipeline,
+                                                               const Location& create_info_loc) const {
     bool skip = false;
     // Only validate once during creation
     if (!pipeline.OwnsLibState(pipeline.pre_raster_state)) {
@@ -1700,11 +1700,11 @@ bool CoreChecks::ValidateGraphicsPipelinePreRasterizationState(const vvl::Pipeli
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pipeline &pipeline,
-                                                                   const vku::safe_VkSubpassDescription2 *subpass_desc,
-                                                                   const Location &color_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pipeline& pipeline,
+                                                                   const vku::safe_VkSubpassDescription2* subpass_desc,
+                                                                   const Location& color_loc) const {
     bool skip = false;
-    const auto &attachment_states = pipeline.AttachmentStates();
+    const auto& attachment_states = pipeline.AttachmentStates();
     if (attachment_states.empty()) return skip;
     if (pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) return skip;
 
@@ -1723,8 +1723,8 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pi
     const VkBlendOp first_alpha_blend_op = attachment_states[0].alphaBlendOp;
 
     for (size_t i = 0; i < attachment_states.size(); i++) {
-        const VkPipelineColorBlendAttachmentState &attachment_state = attachment_states[i];
-        const Location &attachment_loc = color_loc.dot(Field::pAttachments, (uint32_t)i);
+        const VkPipelineColorBlendAttachmentState& attachment_state = attachment_states[i];
+        const Location& attachment_loc = color_loc.dot(Field::pAttachments, (uint32_t)i);
         if (!enabled_features.dualSrcBlend) {
             if (IsSecondaryColorInputBlendFactor(attachment_state.srcColorBlendFactor)) {
                 skip |= LogError("VUID-VkPipelineColorBlendAttachmentState-srcColorBlendFactor-00608", device,
@@ -1855,19 +1855,19 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pi
     return skip;
 }
 
-bool CoreChecks::IsColorBlendStateAttachmentCountIgnore(const vvl::Pipeline &pipeline) const {
+bool CoreChecks::IsColorBlendStateAttachmentCountIgnore(const vvl::Pipeline& pipeline) const {
     return pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) &&
            pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT) &&
            pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT) &&
            (pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT) || !enabled_features.advancedBlendCoherentOperations);
 }
 bool CoreChecks::ValidatePipelineColorBlendAdvancedStateCreateInfo(
-    const vvl::Pipeline &pipeline, const VkPipelineColorBlendAdvancedStateCreateInfoEXT &color_blend_advanced,
-    const Location &color_loc) const {
+    const vvl::Pipeline& pipeline, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& color_blend_advanced,
+    const Location& color_loc) const {
     bool skip = false;
     if (pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT)) return skip;
 
-    const auto &prop = phys_dev_ext_props.blend_operation_advanced_props;
+    const auto& prop = phys_dev_ext_props.blend_operation_advanced_props;
     if (!prop.advancedBlendCorrelatedOverlap && color_blend_advanced.blendOverlap != VK_BLEND_OVERLAP_UNCORRELATED_EXT) {
         skip |= LogError("VUID-VkPipelineColorBlendAdvancedStateCreateInfoEXT-blendOverlap-01426", device,
                          color_loc.pNext(Struct::VkPipelineColorBlendAdvancedStateCreateInfoEXT, Field::blendOverlap),
@@ -1888,9 +1888,9 @@ bool CoreChecks::ValidatePipelineColorBlendAdvancedStateCreateInfo(
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline &pipeline,
-                                                         const vku::safe_VkSubpassDescription2 *subpass_desc,
-                                                         const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline& pipeline,
+                                                         const vku::safe_VkSubpassDescription2* subpass_desc,
+                                                         const Location& create_info_loc) const {
     bool skip = false;
     const Location color_loc = create_info_loc.dot(Field::pColorBlendState);
     const auto color_blend_state = pipeline.ColorBlendState();
@@ -1902,9 +1902,9 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline &pi
     if (!null_rp && !rp_state) return skip;  // invalid render pass
 
     // VkAttachmentSampleCountInfoAMD == VkAttachmentSampleCountInfoNV
-    const auto *attachment_sample_count_info =
+    const auto* attachment_sample_count_info =
         vku::FindStructInPNextChain<VkAttachmentSampleCountInfoAMD>(pipeline.GetCreateInfoPNext());
-    const auto *rendering_struct = pipeline.rendering_create_info;
+    const auto* rendering_struct = pipeline.rendering_create_info;
     if (null_rp && rendering_struct && attachment_sample_count_info &&
         (attachment_sample_count_info->colorAttachmentCount != rendering_struct->colorAttachmentCount)) {
         skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06063", device,
@@ -1949,7 +1949,7 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline &pi
         }
     }
 
-    if (const auto *color_blend_advanced =
+    if (const auto* color_blend_advanced =
             vku::FindStructInPNextChain<VkPipelineColorBlendAdvancedStateCreateInfoEXT>(color_blend_state->pNext)) {
         skip |= ValidatePipelineColorBlendAdvancedStateCreateInfo(pipeline, *color_blend_advanced, color_loc);
     }
@@ -1957,8 +1957,8 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline &pi
 }
 
 bool CoreChecks::ValidatePipelineRasterizationStateStreamCreateInfo(
-    const vvl::Pipeline &pipeline, const VkPipelineRasterizationStateStreamCreateInfoEXT &rasterization_state_stream_ci,
-    const Location &raster_loc) const {
+    const vvl::Pipeline& pipeline, const VkPipelineRasterizationStateStreamCreateInfoEXT& rasterization_state_stream_ci,
+    const Location& raster_loc) const {
     bool skip = false;
     if (!enabled_features.geometryStreams) {
         skip |= LogError("VUID-VkPipelineRasterizationStateStreamCreateInfoEXT-geometryStreams-02324", device,
@@ -1966,7 +1966,7 @@ bool CoreChecks::ValidatePipelineRasterizationStateStreamCreateInfo(
                          "chain includes VkPipelineRasterizationStateStreamCreateInfoEXT, but "
                          "geometryStreams feature was not enabled.");
     } else if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT)) {
-        const auto &props = phys_dev_ext_props.transform_feedback_props;
+        const auto& props = phys_dev_ext_props.transform_feedback_props;
         if (props.transformFeedbackRasterizationStreamSelect == VK_FALSE &&
             rasterization_state_stream_ci.rasterizationStream != 0) {
             skip |= LogError("VUID-VkPipelineRasterizationStateStreamCreateInfoEXT-rasterizationStream-02326", device,
@@ -1984,8 +1984,8 @@ bool CoreChecks::ValidatePipelineRasterizationStateStreamCreateInfo(
 }
 
 bool CoreChecks::ValidatePipelineRasterizationConservativeStateCreateInfo(
-    const vvl::Pipeline &pipeline, const VkPipelineRasterizationConservativeStateCreateInfoEXT &rasterization_conservative_state_ci,
-    const Location &raster_loc) const {
+    const vvl::Pipeline& pipeline, const VkPipelineRasterizationConservativeStateCreateInfoEXT& rasterization_conservative_state_ci,
+    const Location& raster_loc) const {
     bool skip = false;
 
     if (rasterization_conservative_state_ci.extraPrimitiveOverestimationSize < 0.0f ||
@@ -2017,7 +2017,7 @@ bool CoreChecks::ValidatePipelineRasterizationConservativeStateCreateInfo(
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineRasterizationState(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineRasterizationState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
     const auto raster_state = pipeline.RasterizationState();
     if (!raster_state) return skip;
@@ -2084,7 +2084,7 @@ bool CoreChecks::ValidateGraphicsPipelineRasterizationState(const vvl::Pipeline 
         }
     }
 
-    if (const auto *depth_bias_representation = vku::FindStructInPNextChain<VkDepthBiasRepresentationInfoEXT>(raster_state->pNext);
+    if (const auto* depth_bias_representation = vku::FindStructInPNextChain<VkDepthBiasRepresentationInfoEXT>(raster_state->pNext);
         depth_bias_representation != nullptr) {
         skip |= ValidateDepthBiasRepresentationInfo(raster_loc, LogObjectList(device), *depth_bias_representation);
     }
@@ -2092,9 +2092,9 @@ bool CoreChecks::ValidateGraphicsPipelineRasterizationState(const vvl::Pipeline 
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineRenderPassRasterization(const vvl::Pipeline &pipeline, const vvl::RenderPass &rp_state,
-                                                                 const vku::safe_VkSubpassDescription2 &subpass_desc,
-                                                                 const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineRenderPassRasterization(const vvl::Pipeline& pipeline, const vvl::RenderPass& rp_state,
+                                                                 const vku::safe_VkSubpassDescription2& subpass_desc,
+                                                                 const Location& create_info_loc) const {
     bool skip = false;
     const auto raster_state = pipeline.RasterizationState();
     if (!raster_state || raster_state->rasterizerDiscardEnable) return skip;
@@ -2173,7 +2173,7 @@ bool CoreChecks::ValidateGraphicsPipelineRenderPassRasterization(const vvl::Pipe
     return skip;
 }
 
-bool CoreChecks::ValidateSampleLocationsInfo(const VkSampleLocationsInfoEXT &sample_location_info, const Location &loc) const {
+bool CoreChecks::ValidateSampleLocationsInfo(const VkSampleLocationsInfoEXT& sample_location_info, const Location& loc) const {
     bool skip = false;
     const VkSampleCountFlagBits sample_count = sample_location_info.sampleLocationsPerPixel;
     const uint32_t sample_total_size = sample_location_info.sampleLocationGridSize.width *
@@ -2197,15 +2197,15 @@ bool CoreChecks::ValidateSampleLocationsInfo(const VkSampleLocationsInfoEXT &sam
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &pipeline, const vvl::RenderPass &rp_state,
-                                                          const vku::safe_VkSubpassDescription2 &subpass_desc,
-                                                          const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline& pipeline, const vvl::RenderPass& rp_state,
+                                                          const vku::safe_VkSubpassDescription2& subpass_desc,
+                                                          const Location& create_info_loc) const {
     bool skip = false;
-    const auto *multisample_state = pipeline.MultisampleState();
+    const auto* multisample_state = pipeline.MultisampleState();
     if (!multisample_state) return skip;
     const Location ms_loc = create_info_loc.dot(Field::pMultisampleState);
 
-    auto accum_color_samples = [&subpass_desc, &rp_state](uint32_t &samples) {
+    auto accum_color_samples = [&subpass_desc, &rp_state](uint32_t& samples) {
         for (uint32_t i = 0; i < subpass_desc.colorAttachmentCount; i++) {
             const auto attachment = subpass_desc.pColorAttachments[i].attachment;
             if (attachment != VK_ATTACHMENT_UNUSED) {
@@ -2294,7 +2294,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
 
                 if (multisample_state) {
                     bool truncate_mode = false;
-                    if (const auto *coverage_reduction_mode_state =
+                    if (const auto* coverage_reduction_mode_state =
                             vku::FindStructInPNextChain<VkPipelineCoverageReductionStateCreateInfoNV>(multisample_state->pNext)) {
                         truncate_mode =
                             enabled_features.coverageReductionMode &&
@@ -2309,7 +2309,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                                      raster_samples, subpass_color_samples);
                     }
 
-                    const auto *coverage_modulation_state =
+                    const auto* coverage_modulation_state =
                         vku::FindStructInPNextChain<VkPipelineCoverageModulationStateCreateInfoNV>(multisample_state->pNext);
 
                     if (coverage_modulation_state && (coverage_modulation_state->coverageModulationTableEnable == VK_TRUE)) {
@@ -2338,7 +2338,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
 
             if (multisample_state && IsPowerOfTwo(subpass_color_samples) &&
                 (subpass_depth_samples == 0 || IsPowerOfTwo(subpass_depth_samples))) {
-                const auto *coverage_reduction_state =
+                const auto* coverage_reduction_state =
                     vku::FindStructInPNextChain<VkPipelineCoverageReductionStateCreateInfoNV>(multisample_state->pNext);
 
                 if (coverage_reduction_state) {
@@ -2352,7 +2352,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                                                                                             &combinations[0]);
 
                     bool combination_found = false;
-                    for (const auto &combination : combinations) {
+                    for (const auto& combination : combinations) {
                         if (coverage_reduction_mode == combination.coverageReductionMode &&
                             raster_samples == combination.rasterizationSamples &&
                             subpass_depth_samples == combination.depthStencilSamples &&
@@ -2405,9 +2405,9 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
         std::string error_detail;
 
         if (coverage_to_color_state->coverageToColorLocation < subpass_desc.colorAttachmentCount) {
-            const auto &color_attachment_ref = subpass_desc.pColorAttachments[coverage_to_color_state->coverageToColorLocation];
+            const auto& color_attachment_ref = subpass_desc.pColorAttachments[coverage_to_color_state->coverageToColorLocation];
             if (color_attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
-                const auto &color_attachment = rp_state.create_info.pAttachments[color_attachment_ref.attachment];
+                const auto& color_attachment = rp_state.create_info.pAttachments[color_attachment_ref.attachment];
 
                 switch (color_attachment.format) {
                     case VK_FORMAT_R8_UINT:
@@ -2446,7 +2446,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
     }
 
     // VK_EXT_sample_locations
-    const auto *sample_location_state =
+    const auto* sample_location_state =
         vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(multisample_state->pNext);
     if (sample_location_state != nullptr) {
         if ((sample_location_state->sampleLocationsEnable == VK_TRUE) &&
@@ -2525,7 +2525,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineNullState(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineNullState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
 
     const bool null_rp = pipeline.IsRenderPassNull();
@@ -2551,7 +2551,7 @@ bool CoreChecks::ValidateGraphicsPipelineNullState(const vvl::Pipeline &pipeline
         }
     }
 
-    const auto &pipeline_ci = pipeline.GraphicsCreateInfo();
+    const auto& pipeline_ci = pipeline.GraphicsCreateInfo();
     if (!pipeline_ci.pMultisampleState && pipeline.OwnsLibState(pipeline.fragment_output_state)) {
         const bool dynamic_alpha_to_one =
             pipeline.IsDynamic(CB_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT) || !enabled_features.alphaToOne;
@@ -2616,9 +2616,9 @@ bool CoreChecks::ValidateGraphicsPipelineNullState(const vvl::Pipeline &pipeline
 }
 
 // VK_EXT_rasterization_order_attachment_access
-bool CoreChecks::ValidateGraphicsPipelineRasterizationOrderAttachmentAccess(const vvl::Pipeline &pipeline,
-                                                                            const vku::safe_VkSubpassDescription2 *subpass_desc,
-                                                                            const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineRasterizationOrderAttachmentAccess(const vvl::Pipeline& pipeline,
+                                                                            const vku::safe_VkSubpassDescription2* subpass_desc,
+                                                                            const Location& create_info_loc) const {
     bool skip = false;
     const auto rp_state = pipeline.RenderPassState();
     const bool null_rp = pipeline.IsRenderPassNull();
@@ -2706,7 +2706,7 @@ bool CoreChecks::ValidateGraphicsPipelineRasterizationOrderAttachmentAccess(cons
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineDynamicState(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineDynamicState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     auto get_state_index = [&pipeline](const VkDynamicState state) {
         const auto dynamic_info = pipeline.GraphicsCreateInfo().pDynamicState;
         for (uint32_t i = 0; i < dynamic_info->dynamicStateCount; i++) {
@@ -3087,8 +3087,8 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicState(const vvl::Pipeline &pipel
 }
 
 bool CoreChecks::ValidateGraphicsPipelineFragmentShadingRateState(
-    const vvl::Pipeline &pipeline, const VkPipelineFragmentShadingRateStateCreateInfoKHR &fragment_shading_rate_state,
-    const Location &create_info_loc) const {
+    const vvl::Pipeline& pipeline, const VkPipelineFragmentShadingRateStateCreateInfoKHR& fragment_shading_rate_state,
+    const Location& create_info_loc) const {
     bool skip = false;
     if (pipeline.IsDynamic(CB_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR)) {
         return skip;
@@ -3201,15 +3201,15 @@ bool CoreChecks::ValidateGraphicsPipelineFragmentShadingRateState(
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
-    const auto &pipeline_ci = pipeline.GraphicsCreateInfo();
+    const auto& pipeline_ci = pipeline.GraphicsCreateInfo();
     if (pipeline_ci.renderPass != VK_NULL_HANDLE) {
         return skip;
     }
 
     const auto color_blend_state = pipeline.ColorBlendState();
-    const auto *rendering_struct = pipeline.rendering_create_info;
+    const auto* rendering_struct = pipeline.rendering_create_info;
     if (!rendering_struct) {
         // The spec says when thie struct is not included it is same as
         // viewMask = 0, colorAttachmentCount = 0, formats = VK_FORMAT_UNDEFINED.
@@ -3255,8 +3255,8 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline &p
         if (pipeline.fragment_shader_state && pipeline.fragment_output_state) {
             const auto input_attachment_index = vku::FindStructInPNextChain<VkRenderingInputAttachmentIndexInfo>(pipeline_ci.pNext);
             if (input_attachment_index) {
-                skip |= ValidateRenderingInputAttachmentIndices(
-                    *input_attachment_index, device, create_info_loc.pNext(Struct::VkRenderingInputAttachmentIndexInfo));
+                skip |= ValidateRenderingInputAttachmentIndices(*input_attachment_index, device,
+                                                                create_info_loc.pNext(Struct::VkRenderingInputAttachmentIndexInfo));
                 if (input_attachment_index->colorAttachmentCount != rendering_struct->colorAttachmentCount) {
                     const Location loc =
                         create_info_loc.pNext(Struct::VkRenderingInputAttachmentIndexInfo, Field::colorAttachmentCount);
@@ -3270,7 +3270,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline &p
             const auto attachment_location = vku::FindStructInPNextChain<VkRenderingAttachmentLocationInfo>(pipeline_ci.pNext);
             if (attachment_location) {
                 skip |= ValidateRenderingAttachmentLocations(*attachment_location, device,
-                                                                create_info_loc.pNext(Struct::VkRenderingAttachmentLocationInfo));
+                                                             create_info_loc.pNext(Struct::VkRenderingAttachmentLocationInfo));
                 if (attachment_location->colorAttachmentCount != rendering_struct->colorAttachmentCount) {
                     const Location loc =
                         create_info_loc.pNext(Struct::VkRenderingAttachmentLocationInfo, Field::colorAttachmentCount);
@@ -3306,7 +3306,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline &p
             }
 
             if (color_blend_state && color_index < color_blend_state->attachmentCount) {
-                const auto &color_blend_attachment = color_blend_state->pAttachments[color_index];
+                const auto& color_blend_attachment = color_blend_state->pAttachments[color_index];
 
                 if (((format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT) == 0) &&
                     color_blend_attachment.blendEnable) {
@@ -3373,7 +3373,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline &p
                              color_blend_state->attachmentCount);
         }
 
-        if (const auto *custom_resolve = vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(pipeline.GetCreateInfoPNext())) {
+        if (const auto* custom_resolve = vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(pipeline.GetCreateInfoPNext())) {
             skip |= ValidateCustomResolveCreateInfoEXT(*custom_resolve, create_info_loc);
             // The formats themselve can be different between the structs, but the color count must be the same
             if (custom_resolve->colorAttachmentCount != rendering_struct->colorAttachmentCount) {
@@ -3405,11 +3405,11 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline &p
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer &cb_state, const vvl::Pipeline &pipeline,
-                                                   const Location &loc) const {
+bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
+                                                   const Location& loc) const {
     bool skip = false;
 
-    auto &cb_sub_state = core::SubState(cb_state);
+    auto& cb_sub_state = core::SubState(cb_state);
     if (!cb_sub_state.viewport.inherited_depths.empty()) {
         bool dyn_viewport =
             pipeline.IsDynamic(CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) || pipeline.IsDynamic(CB_DYNAMIC_STATE_VIEWPORT);
@@ -3419,7 +3419,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer &cb_
             skip |= LogError("VUID-vkCmdBindPipeline-commandBuffer-04808", objlist, loc,
                              "Graphics pipeline incompatible with viewport/scissor inheritance.");
         }
-        const auto *discard_rectangle_state =
+        const auto* discard_rectangle_state =
             vku::FindStructInPNextChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pipeline.GetCreateInfoPNext());
         if ((discard_rectangle_state && discard_rectangle_state->discardRectangleCount != 0) ||
             (pipeline.IsDynamic(CB_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT))) {
@@ -3444,8 +3444,8 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer &cb_
 
     if (phys_dev_ext_props.provoking_vertex_props.provokingVertexModePerPipeline == VK_FALSE) {
         // Render passes only occur in graphics pipelines
-        const auto &last_bound = cb_state.GetLastBoundGraphics();
-        const vvl::Pipeline *old_pipeline_state = last_bound.pipeline_state;
+        const auto& last_bound = cb_state.GetLastBoundGraphics();
+        const vvl::Pipeline* old_pipeline_state = last_bound.pipeline_state;
         if (old_pipeline_state) {
             auto old_provoking_vertex_state_ci =
                 vku::FindStructInPNextChain<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>(
@@ -3489,11 +3489,11 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer &cb_
 }
 
 // Validate draw-time state related to the PSO
-bool CoreChecks::ValidateDrawPipeline(const LastBound &last_bound_state, const vvl::Pipeline &pipeline,
-                                      const vvl::DrawDispatchVuid &vuid) const {
+bool CoreChecks::ValidateDrawPipeline(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+                                      const vvl::DrawDispatchVuid& vuid) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
     if (!rp_state) return skip;
 
     if (rp_state->UsesDynamicRendering()) {
@@ -3522,7 +3522,7 @@ bool CoreChecks::ValidateDrawPipeline(const LastBound &last_bound_state, const v
 
     if ((pipeline.create_info_shaders & (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
                                          VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) != 0) {
-        for (const auto &query : cb_state.active_queries) {
+        for (const auto& query : cb_state.active_queries) {
             const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
             if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline.Handle(), query.pool);
@@ -3542,10 +3542,10 @@ bool CoreChecks::ValidateDrawPipeline(const LastBound &last_bound_state, const v
 bool CoreChecks::ValidateDrawPipelineRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                 const vvl::RenderPass& rp_state, const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     // Can use RenderPassState() here even GPL because we only need to check for compatible renderpasses
-    const auto &pipeline_rp_state = pipeline.RenderPassState();
+    const auto& pipeline_rp_state = pipeline.RenderPassState();
     // TODO: AMD extension codes are included here, but actual function entrypoints are not yet intercepted
     if (rp_state.VkHandle() != pipeline_rp_state->VkHandle()) {
         // renderPass that PSO was created with must be compatible with active renderPass that PSO is being used with
@@ -3565,7 +3565,7 @@ bool CoreChecks::ValidateDrawPipelineRenderpass(const LastBound& last_bound_stat
 bool CoreChecks::ValidateDrawPipelineDynamicRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                        const vvl::RenderPass& rp_state, const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     // Can use RenderPassState() here even GPL because we only need to check for it being null
     const auto pipeline_rp_state = pipeline.RenderPassState();
@@ -3609,12 +3609,12 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassDepthStencil(const LastBou
                                                                    const VkPipelineRenderingCreateInfo& pipeline_rendering_ci,
                                                                    const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    auto &cb_sub_state = core::SubState(cb_state);
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    auto& cb_sub_state = core::SubState(cb_state);
 
     if (last_bound_state.IsDepthTestEnable()) {
         if (cb_sub_state.custom_resolve.started) {
-            if (const auto *custom_resolve =
+            if (const auto* custom_resolve =
                     vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(pipeline.GetCreateInfoPNext())) {
                 if (custom_resolve->depthAttachmentFormat == VK_FORMAT_UNDEFINED &&
                     rp_state.dynamic_rendering_begin_rendering_info.pDepthAttachment) {
@@ -3657,7 +3657,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassDepthStencil(const LastBou
 
     if (last_bound_state.IsStencilTestEnable()) {
         if (cb_sub_state.custom_resolve.started) {
-            if (const auto *custom_resolve =
+            if (const auto* custom_resolve =
                     vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(pipeline.GetCreateInfoPNext())) {
                 if (custom_resolve->stencilAttachmentFormat == VK_FORMAT_UNDEFINED &&
                     rp_state.dynamic_rendering_begin_rendering_info.pStencilAttachment) {
@@ -3735,8 +3735,8 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassFragmentFormat(const LastB
         return skip;
     }
 
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    auto &cb_sub_state = core::SubState(cb_state);
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    auto& cb_sub_state = core::SubState(cb_state);
 
     const uint32_t color_count = rp_state.use_dynamic_rendering
                                      ? rp_state.dynamic_rendering_begin_rendering_info.colorAttachmentCount
@@ -3750,7 +3750,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassFragmentFormat(const LastB
         }
 
         if (cb_sub_state.custom_resolve.started) {
-            const auto *custom_resolve = vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(pipeline.GetCreateInfoPNext());
+            const auto* custom_resolve = vku::FindStructInPNextChain<VkCustomResolveCreateInfoEXT>(pipeline.GetCreateInfoPNext());
             if (!custom_resolve) {
                 continue;
             }
@@ -3814,7 +3814,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderingAttachmentFlags(const LastB
         return skip;
     }
 
-    auto validate_feedback_loop = [&](const vku::safe_VkRenderingAttachmentInfo *attachment, const Location &loc) {
+    auto validate_feedback_loop = [&](const vku::safe_VkRenderingAttachmentInfo* attachment, const Location& loc) {
         if (!attachment) {
             return;
         }
@@ -3849,7 +3849,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
                                                                         const VkPipelineRenderingCreateInfo& pipeline_rendering_ci,
                                                                         const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     if (!enabled_features.dynamicRenderingUnusedAttachments) {
         const auto color_attachment_count = pipeline_rendering_ci.colorAttachmentCount;
@@ -3866,7 +3866,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
         }
     }
 
-    const VkRenderingInfo &rendering_info = *(rp_state.dynamic_rendering_begin_rendering_info.ptr());
+    const VkRenderingInfo& rendering_info = *(rp_state.dynamic_rendering_begin_rendering_info.ptr());
 
     for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
         if (enabled_features.dynamicRenderingUnusedAttachments) {
@@ -4038,7 +4038,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassFragmentShadingRate(const 
                                                                           const Location& loc) const {
     bool skip = false;
 
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     auto rendering_fragment_shading_rate_attachment_info =
         vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(
             rp_state.dynamic_rendering_begin_rendering_info.pNext);
@@ -4075,7 +4075,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassLegacyDithering(const Last
     if (!enabled_features.legacyDithering) {
         return skip;
     }
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     const VkRenderingFlags render_flags = rp_state.GetRenderingFlags();
     const bool has_legacy_dithering_pipeline =
@@ -4106,14 +4106,14 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassLegacyDithering(const Last
 bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                                   const vvl::RenderPass& rp_state, const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    auto &cb_sub_state = core::SubState(cb_state);
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    auto& cb_sub_state = core::SubState(cb_state);
 
     // VkAttachmentSampleCountInfoAMD == VkAttachmentSampleCountInfoNV
     if (auto sample_count_info = vku::FindStructInPNextChain<VkAttachmentSampleCountInfoAMD>(pipeline.GetCreateInfoPNext())) {
         for (uint32_t i = 0; i < cb_state.active_attachments.size(); ++i) {
-            const auto &attachment_info = cb_state.active_attachments[i];
-            const auto *attachment = attachment_info.image_view;
+            const auto& attachment_info = cb_state.active_attachments[i];
+            const auto* attachment = attachment_info.image_view;
             if (!attachment) {
                 continue;
             } else if (attachment_info.IsColor() &&
@@ -4147,8 +4147,8 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
         const VkSampleCountFlagBits rasterization_samples = last_bound_state.GetRasterizationSamples();
 
         for (uint32_t i = 0; i < cb_state.active_attachments.size(); ++i) {
-            const auto &attachment_info = cb_state.active_attachments[i];
-            const auto *attachment = attachment_info.image_view;
+            const auto& attachment_info = cb_state.active_attachments[i];
+            const auto* attachment = attachment_info.image_view;
             if (attachment && rasterization_samples != attachment->samples &&
                 (attachment_info.IsColor() || attachment_info.IsDepthOrStencil())) {
                 vvl::ActionVUID vuid = attachment_info.IsColor()   ? vvl::ActionVUID::DYNAMIC_RENDERING_07285
@@ -4167,9 +4167,9 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineVertexDivisors(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidatePipelineVertexDivisors(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
-    const auto *input_state = pipeline.InputState();
+    const auto* input_state = pipeline.InputState();
     if (!input_state) {
         return skip;
     }
@@ -4181,12 +4181,12 @@ bool CoreChecks::ValidatePipelineVertexDivisors(const vvl::Pipeline &pipeline, c
     const Location vertex_input_loc = create_info_loc.dot(Field::pVertexInputState);
     // Can use raw Pipeline state values because not using the stride (which can be dynamic with
     // VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE)
-    const auto &binding_descriptions = pipeline.GraphicsCreateInfo().pVertexInputState->pVertexBindingDescriptions;
+    const auto& binding_descriptions = pipeline.GraphicsCreateInfo().pVertexInputState->pVertexBindingDescriptions;
     const auto& binding_desc_count = pipeline.GraphicsCreateInfo().pVertexInputState->vertexBindingDescriptionCount;
     for (uint32_t j = 0; j < divisor_state_info->vertexBindingDivisorCount; j++) {
         const Location divisor_loc =
             vertex_input_loc.pNext(Struct::VkVertexInputBindingDivisorDescription, Field::pVertexBindingDivisors, j);
-        const auto *vibdd = &(divisor_state_info->pVertexBindingDivisors[j]);
+        const auto* vibdd = &(divisor_state_info->pVertexBindingDivisors[j]);
         if (vibdd->binding >= phys_dev_props.limits.maxVertexInputBindings) {
             skip |= LogError("VUID-VkVertexInputBindingDivisorDescription-binding-01869", device, divisor_loc.dot(Field::binding),
                              "(%" PRIu32 ") exceeds device maxVertexInputBindings (%" PRIu32 ").", vibdd->binding,
@@ -4226,16 +4226,16 @@ bool CoreChecks::ValidatePipelineVertexDivisors(const vvl::Pipeline &pipeline, c
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineDerivatives(PipelineStates &pipeline_states, uint32_t pipe_index,
-                                                     const Location &loc) const {
+bool CoreChecks::ValidateGraphicsPipelineDerivatives(PipelineStates& pipeline_states, uint32_t pipe_index,
+                                                     const Location& loc) const {
     bool skip = false;
-    const auto &pipeline = *pipeline_states[pipe_index].get();
+    const auto& pipeline = *pipeline_states[pipe_index].get();
     // If create derivative bit is set, check that we've specified a base
     // pipeline correctly, and that the base pipeline was created to allow
     // derivatives.
     if (pipeline.create_flags & VK_PIPELINE_CREATE_2_DERIVATIVE_BIT) {
         std::shared_ptr<const vvl::Pipeline> base_pipeline;
-        const auto &pipeline_ci = pipeline.GraphicsCreateInfo();
+        const auto& pipeline_ci = pipeline.GraphicsCreateInfo();
         const VkPipeline base_handle = pipeline_ci.basePipelineHandle;
         const int32_t base_index = pipeline_ci.basePipelineIndex;
         if (base_index != -1 && base_index < static_cast<int32_t>(pipeline_states.size())) {
@@ -4259,13 +4259,13 @@ bool CoreChecks::ValidateGraphicsPipelineDerivatives(PipelineStates &pipeline_st
     return skip;
 }
 
-bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline &pipeline, const Location &multiview_loc, uint32_t view_mask,
+bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline& pipeline, const Location& multiview_loc, uint32_t view_mask,
                                           bool dynamic_rendering) const {
     bool skip = false;
     const VkShaderStageFlags stages = pipeline.create_info_shaders;
     if (!enabled_features.multiviewTessellationShader &&
         (stages & (VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT))) {
-        const char *vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-06057"
+        const char* vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-06057"
                                              : "VUID-VkGraphicsPipelineCreateInfo-renderPass-06047";
         skip |= LogError(vuid, device, multiview_loc,
                          "is 0x%" PRIx32
@@ -4274,7 +4274,7 @@ bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline &pipeline, const L
     }
 
     if (!enabled_features.multiviewGeometryShader && (stages & VK_SHADER_STAGE_GEOMETRY_BIT)) {
-        const char *vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-06058"
+        const char* vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-06058"
                                              : "VUID-VkGraphicsPipelineCreateInfo-renderPass-06048";
         skip |= LogError(vuid, device, multiview_loc,
                          "is 0x%" PRIx32
@@ -4284,7 +4284,7 @@ bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline &pipeline, const L
 
     if (stages & VK_SHADER_STAGE_MESH_BIT_EXT) {
         if (!enabled_features.multiviewMeshShader) {
-            const char *vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-07720"
+            const char* vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-07720"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-renderPass-07064";
             skip |=
                 LogError(vuid, device, multiview_loc,
@@ -4294,7 +4294,7 @@ bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline &pipeline, const L
 
         uint32_t highest_view_bit = static_cast<uint32_t>(MostSignificantBit(view_mask));
         if (highest_view_bit > 0 && highest_view_bit >= phys_dev_ext_props.mesh_shader_props_ext.maxMeshMultiviewViewCount) {
-            const char *vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-12326"
+            const char* vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-12326"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-renderPass-12325";
             skip |= LogError(vuid, device, multiview_loc,
                              "is 0x%" PRIx32 ", its highest bit (%" PRIu32
@@ -4310,7 +4310,7 @@ bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline &pipeline, const L
 
         if (stage.spirv_state->static_data_.has_built_in_layer) {
             // Special case for GLSL and Mesh Shading discussed in https://gitlab.khronos.org/vulkan/vulkan/-/issues/4194
-            const char *vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059"
+            const char* vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-renderPass-06050";
             skip |= LogError(vuid, device, multiview_loc, "is 0x%" PRIx32 " but %s stage contains a Layer decorated OpVariable.%s",
                              view_mask, string_VkShaderStageFlagBits(stage.GetStage()),
@@ -4382,16 +4382,16 @@ bool CoreChecks::ValidateMultiviewPerViewViewports(const vvl::Pipeline& pipeline
     return skip;
 }
 
-bool CoreChecks::ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer &cb_state, const vvl::Pipeline &pipeline,
-                                                 const vvl::DrawDispatchVuid &vuid) const {
+bool CoreChecks::ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
+                                                 const vvl::DrawDispatchVuid& vuid) const {
     bool skip = false;
     if (!cb_state.active_framebuffer) return skip;
 
     // Verify attachments for unprotected/protected command buffer.
     if (enabled_features.protectedMemory == VK_TRUE) {
         for (uint32_t i = 0; i < cb_state.active_attachments.size(); i++) {
-            const auto *view_state = cb_state.active_attachments[i].image_view;
-            const auto &subpass = cb_state.active_subpasses[i];
+            const auto* view_state = cb_state.active_attachments[i].image_view;
+            const auto& subpass = cb_state.active_subpasses[i];
             if (subpass.used && view_state && !view_state->Destroyed()) {
                 std::string image_desc = " Image is ";
                 image_desc.append(string_VkImageUsageFlagBits(subpass.usage));
@@ -4407,7 +4407,7 @@ bool CoreChecks::ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer &cb_st
         }
     }
 
-    for (auto &stage_state : pipeline.stage_states) {
+    for (auto& stage_state : pipeline.stage_states) {
         const VkShaderStageFlagBits stage = stage_state.GetStage();
         if (stage_state.entrypoint && stage_state.entrypoint->written_built_in_layer &&
             cb_state.active_framebuffer->create_info.layers == 1) {
@@ -4434,7 +4434,7 @@ bool CoreChecks::ValidateDrawPipelineFragmentDensityMapLayered(const vvl::Comman
         return skip;
     }
 
-    if (const auto *fragment_density_map_layered =
+    if (const auto* fragment_density_map_layered =
             vku::FindStructInPNextChain<VkPipelineFragmentDensityMapLayeredCreateInfoVALVE>(pipeline.GetCreateInfoPNext())) {
         if (rp_state.UsesDynamicRendering()) {
             if (rp_state.GetRenderingFlags() & VK_RENDERING_PER_LAYER_FRAGMENT_DENSITY_BIT_VALVE) {
@@ -4468,8 +4468,8 @@ bool CoreChecks::ValidateDrawPipelineFragmentDensityMapLayered(const vvl::Comman
 bool CoreChecks::ValidateDrawPipelineRasterizationState(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                         const Location& loc) const {
     bool skip = false;
-    const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
+    const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
     ASSERT_AND_RETURN_SKIP(rp_state);
 
     // Verify that any MSAA request in PSO matches sample# in bound FB
@@ -4540,8 +4540,8 @@ bool CoreChecks::ValidateDrawPipelineRasterizationState(const LastBound& last_bo
 }
 
 bool CoreChecks::ValidatePipelineDiscardRectangleStateCreateInfo(
-    const vvl::Pipeline &pipeline, const VkPipelineDiscardRectangleStateCreateInfoEXT &discard_rectangle_state,
-    const Location &create_info_loc) const {
+    const vvl::Pipeline& pipeline, const VkPipelineDiscardRectangleStateCreateInfoEXT& discard_rectangle_state,
+    const Location& create_info_loc) const {
     bool skip = false;
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT) &&
         discard_rectangle_state.discardRectangleCount > phys_dev_ext_props.discard_rectangle_props.maxDiscardRectangles) {
@@ -4554,9 +4554,9 @@ bool CoreChecks::ValidatePipelineDiscardRectangleStateCreateInfo(
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineAttachmentSampleCountInfo(const vvl::Pipeline &pipeline,
-                                                           const VkAttachmentSampleCountInfoAMD &attachment_sample_count_info,
-                                                           const Location &create_info_loc) const {
+bool CoreChecks::ValidatePipelineAttachmentSampleCountInfo(const vvl::Pipeline& pipeline,
+                                                           const VkAttachmentSampleCountInfoAMD& attachment_sample_count_info,
+                                                           const Location& create_info_loc) const {
     bool skip = false;
     const uint32_t bits = CountSetBits(static_cast<uint32_t>(attachment_sample_count_info.depthStencilAttachmentSamples));
     if (pipeline.fragment_output_state && attachment_sample_count_info.depthStencilAttachmentSamples != 0 &&

--- a/layers/core_checks/cc_pipeline_ray_tracing.cpp
+++ b/layers/core_checks/cc_pipeline_ray_tracing.cpp
@@ -24,7 +24,7 @@
 #include "chassis/chassis_modification_state.h"
 #include "state_tracker/pipeline_state.h"
 
-bool CoreChecks::GroupHasValidIndex(const vvl::Pipeline &pipeline, uint32_t group, uint32_t stage) const {
+bool CoreChecks::GroupHasValidIndex(const vvl::Pipeline& pipeline, uint32_t group, uint32_t stage) const {
     if (group == VK_SHADER_UNUSED_KHR) {
         return true;
     }
@@ -54,19 +54,19 @@ bool CoreChecks::GroupHasValidIndex(const vvl::Pipeline &pipeline, uint32_t grou
     return false;
 }
 
-bool CoreChecks::ValidateRayTracingPipeline(const vvl::Pipeline &pipeline,
-                                            const vku::safe_VkRayTracingPipelineCreateInfoCommon &create_info,
-                                            const Location &create_info_loc) const {
+bool CoreChecks::ValidateRayTracingPipeline(const vvl::Pipeline& pipeline,
+                                            const vku::safe_VkRayTracingPipelineCreateInfoCommon& create_info,
+                                            const Location& create_info_loc) const {
     bool skip = false;
     const bool isKHR = create_info_loc.function == Func::vkCreateRayTracingPipelinesKHR;
-    const auto *groups = create_info.ptr()->pGroups;
+    const auto* groups = create_info.ptr()->pGroups;
     const VkPipelineCreateFlags2 create_flags = pipeline.create_flags;
 
     for (uint32_t i = 0; i < pipeline.stage_states.size(); i++) {
         skip |= ValidateShaderStage(pipeline.stage_states[i], &pipeline, create_info_loc.dot(Field::pStages, i));
     }
 
-    if (const auto *pipeline_robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(create_info.pNext)) {
+    if (const auto* pipeline_robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(create_info.pNext)) {
         skip |= ValidatePipelineRobustnessCreateInfo(pipeline, *pipeline_robustness_info, create_info_loc);
     }
 
@@ -87,8 +87,8 @@ bool CoreChecks::ValidateRayTracingPipeline(const vvl::Pipeline &pipeline,
     }
 
     for (uint32_t group_index = 0; group_index < create_info.groupCount; group_index++) {
-        const auto &group = groups[group_index];
-        const Location &group_loc = create_info_loc.dot(Field::pGroups, group_index);
+        const auto& group = groups[group_index];
+        const Location& group_loc = create_info_loc.dot(Field::pGroups, group_index);
 
         if (group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR) {
             if (group.generalShader == VK_SHADER_UNUSED_KHR ||
@@ -136,7 +136,7 @@ bool CoreChecks::ValidateRayTracingPipeline(const vvl::Pipeline &pipeline,
             }
         }
     }
-    if (const auto *cluster_accel_info =
+    if (const auto* cluster_accel_info =
             vku::FindStructInPNextChain<VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV>(create_info.pNext)) {
         const Location cluster_loc = create_info_loc.pNext(Struct::VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV);
 
@@ -153,18 +153,18 @@ bool CoreChecks::ValidateRayTracingPipeline(const vvl::Pipeline &pipeline,
 }
 
 bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                            const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-                                                            const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                            const ErrorObject &error_obj, PipelineStates &pipeline_states) const {
+                                                            const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
+                                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                            const ErrorObject& error_obj, PipelineStates& pipeline_states) const {
     bool skip = false;
 
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     for (uint32_t i = 0; i < count; i++) {
-        const vvl::Pipeline *pipeline = pipeline_states[i].get();
+        const vvl::Pipeline* pipeline = pipeline_states[i].get();
         ASSERT_AND_CONTINUE(pipeline);
 
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
-        const auto &create_info = pipeline->RayTracingCreateInfo();
+        const auto& create_info = pipeline->RayTracingCreateInfo();
         if (pipeline->create_flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const vvl::Pipeline> base_pipeline;
             const auto bpi = create_info.basePipelineIndex;
@@ -184,7 +184,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
         }
         skip |= ValidateRayTracingPipeline(*pipeline, create_info, create_info_loc);
         uint32_t stage_index = 0;
-        for (const auto &stage_ci : pipeline->shader_stages_ci) {
+        for (const auto& stage_ci : pipeline->shader_stages_ci) {
             skip |= ValidatePipelineShaderStage(*pipeline, stage_ci, pCreateInfos[i].pNext,
                                                 create_info_loc.dot(Field::pStages, stage_index++));
         }
@@ -207,10 +207,10 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
 
 bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                              VkPipelineCache pipelineCache, uint32_t count,
-                                                             const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
-                                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                             const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                             chassis::CreateRayTracingPipelinesKHR &chassis_state) const {
+                                                             const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                             const ErrorObject& error_obj, PipelineStates& pipeline_states,
+                                                             chassis::CreateRayTracingPipelinesKHR& chassis_state) const {
     bool skip = false;
 
     skip |= ValidateDeviceQueueSupport(error_obj.location);
@@ -218,11 +218,11 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                                       "VUID-vkCreateRayTracingPipelinesKHR-deferredOperation-03678");
 
     for (uint32_t i = 0; i < count; i++) {
-        const vvl::Pipeline *pipeline = pipeline_states[i].get();
+        const vvl::Pipeline* pipeline = pipeline_states[i].get();
         ASSERT_AND_CONTINUE(pipeline);
 
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
-        const auto &create_info = pipeline->RayTracingCreateInfo();
+        const auto& create_info = pipeline->RayTracingCreateInfo();
         if (pipeline->create_flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const vvl::Pipeline> base_pipeline;
             const auto bpi = create_info.basePipelineIndex;
@@ -243,14 +243,15 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
 
         skip |= ValidateRayTracingPipeline(*pipeline, create_info, create_info_loc);
         uint32_t stage_index = 0;
-        for (const auto &stage_ci : pipeline->shader_stages_ci) {
+        for (const auto& stage_ci : pipeline->shader_stages_ci) {
             skip |= ValidatePipelineShaderStage(*pipeline, stage_ci, pCreateInfos[i].pNext,
                                                 create_info_loc.dot(Field::pStages, stage_index++));
         }
 
         uint32_t stateless_data_i = 0;
         for (uint32_t stage = 0; stage < pCreateInfos[i].stageCount; stage++) {
-            if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(pCreateInfos[i].pStages[stage].pNext)) {
+            if (const auto shader_ci =
+                    vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(pCreateInfos[i].pStages[stage].pNext)) {
                 (void)shader_ci;
                 skip |= stateless_spirv_validator.Validate(
                     *chassis_state.stateless_data[stateless_data_i].pipeline_pnext_module,
@@ -282,10 +283,10 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
     return skip;
 }
 
-bool CoreChecks::ValidateRayTracingPipelineLibrary(const vvl::Pipeline &pipeline,
-                                                   const VkRayTracingPipelineCreateInfoKHR &pipeline_create_info,
-                                                   const VkPipelineLibraryCreateInfoKHR &library_create_info,
-                                                   const Location &create_info_loc) const {
+bool CoreChecks::ValidateRayTracingPipelineLibrary(const vvl::Pipeline& pipeline,
+                                                   const VkRayTracingPipelineCreateInfoKHR& pipeline_create_info,
+                                                   const VkPipelineLibraryCreateInfoKHR& library_create_info,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
 
     constexpr std::array<std::pair<const char*, VkPipelineCreateFlags>, 7> vuid_map = {{
@@ -314,7 +315,7 @@ bool CoreChecks::ValidateRayTracingPipelineLibrary(const vvl::Pipeline &pipeline
             skip |= LogError("VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-03381", lib->Handle(), library_loc,
                              "was created with %s.", string_VkPipelineCreateFlags2(lib->create_flags).c_str());
         }
-        for (const auto &[vuid, flag] : vuid_map) {
+        for (const auto& [vuid, flag] : vuid_map) {
             if (pipeline_create_flags & flag) {
                 if ((lib->create_flags & flag) == 0) {
                     skip |= LogError(vuid, lib->Handle(), library_loc, "was created with %s, which is missing %s (%s is %s).",
@@ -356,7 +357,7 @@ bool CoreChecks::ValidateRayTracingPipelineLibrary(const vvl::Pipeline &pipeline
             }
         }
 
-        const auto &lib_create_info = lib->RayTracingCreateInfo();
+        const auto& lib_create_info = lib->RayTracingCreateInfo();
         if (lib_create_info.maxPipelineRayRecursionDepth != pipeline_create_info.maxPipelineRayRecursionDepth) {
             skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraries-03591", lib->Handle(), library_loc,
                              "was created with maxPipelineRayRecursionDepth (%" PRIu32 ") which is not equal %s (%" PRIu32 ") .",
@@ -365,8 +366,8 @@ bool CoreChecks::ValidateRayTracingPipelineLibrary(const vvl::Pipeline &pipeline
                              pipeline_create_info.maxPipelineRayRecursionDepth);
         }
         if (lib_create_info.pLibraryInfo && pipeline_create_info.pLibraryInterface) {
-            const auto &pipeline_interface = *pipeline_create_info.pLibraryInterface;
-            const auto &lib_interface = *lib_create_info.pLibraryInterface;
+            const auto& pipeline_interface = *pipeline_create_info.pLibraryInterface;
+            const auto& lib_interface = *lib_create_info.pLibraryInterface;
 
             if (lib_interface.maxPipelineRayHitAttributeSize != pipeline_interface.maxPipelineRayHitAttributeSize ||
                 lib_interface.maxPipelineRayPayloadSize != pipeline_interface.maxPipelineRayPayloadSize) {

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -32,7 +32,7 @@
 #include "state_tracker/cmd_buffer_state.h"
 #include "utils/math_utils.h"
 
-static QueryState GetLocalQueryState(const QueryMap *local_query_to_state_map, VkQueryPool queryPool, uint32_t queryIndex,
+static QueryState GetLocalQueryState(const QueryMap* local_query_to_state_map, VkQueryPool queryPool, uint32_t queryIndex,
                                      uint32_t perf_query_pass) {
     QueryObject query = QueryObject(queryPool, queryIndex, perf_query_pass);
 
@@ -42,8 +42,8 @@ static QueryState GetLocalQueryState(const QueryMap *local_query_to_state_map, V
     return QUERYSTATE_UNKNOWN;
 }
 
-bool CoreChecks::PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks *pAllocator,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks* pAllocator,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     if (queryPool == VK_NULL_HANDLE) return skip;
@@ -64,8 +64,8 @@ bool CoreChecks::PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool qu
     return skip;
 }
 
-bool CoreChecks::ValidatePerformanceQueryResults(const vvl::QueryPool &query_pool_state, uint32_t firstQuery, uint32_t queryCount,
-                                                 VkQueryResultFlags flags, const Location &loc) const {
+bool CoreChecks::ValidatePerformanceQueryResults(const vvl::QueryPool& query_pool_state, uint32_t firstQuery, uint32_t queryCount,
+                                                 VkQueryResultFlags flags, const Location& loc) const {
     bool skip = false;
 
     if (flags & (VK_QUERY_RESULT_WITH_AVAILABILITY_BIT | VK_QUERY_RESULT_WITH_STATUS_BIT_KHR | VK_QUERY_RESULT_PARTIAL_BIT |
@@ -115,8 +115,8 @@ bool CoreChecks::ValidatePerformanceQueryResults(const vvl::QueryPool &query_poo
     return skip;
 }
 
-bool CoreChecks::ValidateQueryPoolWasReset(const vvl::QueryPool &query_pool_state, uint32_t firstQuery, uint32_t queryCount,
-                                           const Location &loc, QueryMap *local_query_to_state_map,
+bool CoreChecks::ValidateQueryPoolWasReset(const vvl::QueryPool& query_pool_state, uint32_t firstQuery, uint32_t queryCount,
+                                           const Location& loc, QueryMap* local_query_to_state_map,
                                            uint32_t perf_query_pass) const {
     bool skip = false;
 
@@ -142,8 +142,8 @@ bool CoreChecks::ValidateQueryPoolWasReset(const vvl::QueryPool &query_pool_stat
 }
 
 bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,
-                                                    uint32_t queryCount, size_t dataSize, void *pData, VkDeviceSize stride,
-                                                    VkQueryResultFlags flags, const ErrorObject &error_obj) const {
+                                                    uint32_t queryCount, size_t dataSize, void* pData, VkDeviceSize stride,
+                                                    VkQueryResultFlags flags, const ErrorObject& error_obj) const {
     if (disabled[query_validation]) return false;
     bool skip = false;
 
@@ -265,9 +265,9 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool,
+                                                const ErrorObject& error_obj) const {
     if (disabled[query_validation]) return false;
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
@@ -275,15 +275,15 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
     switch (pCreateInfo->queryType) {
         case VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR: {
             if (auto perf_ci = vku::FindStructInPNextChain<VkQueryPoolPerformanceCreateInfoKHR>(pCreateInfo->pNext)) {
-                auto *core_instance = static_cast<core::Instance *>(instance_proxy);
+                auto* core_instance = static_cast<core::Instance*>(instance_proxy);
                 skip |= core_instance->ValidateQueueFamilyIndex(
                     *physical_device_state, perf_ci->queueFamilyIndex,
                     "VUID-VkQueryPoolPerformanceCreateInfoKHR-queueFamilyIndex-03236",
                     create_info_loc.pNext(Struct::VkQueryPoolPerformanceCreateInfoKHR, Field::queueFamilyIndex));
 
-                const auto &perf_counter_iter = physical_device_state->perf_counters.find(perf_ci->queueFamilyIndex);
+                const auto& perf_counter_iter = physical_device_state->perf_counters.find(perf_ci->queueFamilyIndex);
                 if (perf_counter_iter != physical_device_state->perf_counters.end()) {
-                    const QueueFamilyPerfCounters *perf_counters = perf_counter_iter->second.get();
+                    const QueueFamilyPerfCounters* perf_counters = perf_counter_iter->second.get();
                     for (uint32_t idx = 0; idx < perf_ci->counterIndexCount; idx++) {
                         if (perf_ci->pCounterIndices[idx] >= perf_counters->counters.size()) {
                             skip |= LogError(
@@ -303,9 +303,9 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
             }
 
             {
-                const auto &queue_family_ext_props = device_state->queue_family_ext_props;
+                const auto& queue_family_ext_props = device_state->queue_family_ext_props;
                 auto it = std::find_if(queue_family_ext_props.begin(), queue_family_ext_props.end(),
-                                       [](const auto &entry) { return entry.query_result_status_props.queryResultStatusSupport; });
+                                       [](const auto& entry) { return entry.query_result_status_props.queryResultStatusSupport; });
                 if (it == queue_family_ext_props.end()) {
                     skip |= LogError("VUID-VkQueryPoolCreateInfo-queryType-11839", device, create_info_loc.dot(Field::queryType),
                                      "is VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR, but none of the queue families supports "
@@ -316,7 +316,7 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
             break;
         }
         case VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR: {
-            const char *pnext_chain_msg =
+            const char* pnext_chain_msg =
                 "is VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR but missing %s from the pNext chain of pCreateInfo";
 
             auto video_profile = vku::FindStructInPNextChain<VkVideoProfileInfoKHR>(pCreateInfo->pNext);
@@ -373,7 +373,7 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
     return skip;
 }
 
-bool CoreChecks::HasRequiredQueueFlags(const vvl::CommandBuffer &cb_state, const vvl::PhysicalDevice &physical_device_state,
+bool CoreChecks::HasRequiredQueueFlags(const vvl::CommandBuffer& cb_state, const vvl::PhysicalDevice& physical_device_state,
                                        VkQueueFlags required_flags) const {
     auto pool = cb_state.command_pool;
     if (pool) {
@@ -386,15 +386,15 @@ bool CoreChecks::HasRequiredQueueFlags(const vvl::CommandBuffer &cb_state, const
     return true;
 }
 
-std::string CoreChecks::DescribeRequiredQueueFlag(const vvl::CommandBuffer &cb_state,
-                                                  const vvl::PhysicalDevice &physical_device_state,
+std::string CoreChecks::DescribeRequiredQueueFlag(const vvl::CommandBuffer& cb_state,
+                                                  const vvl::PhysicalDevice& physical_device_state,
                                                   VkQueueFlags required_flags) const {
     std::ostringstream ss;
     auto pool = cb_state.command_pool;
     const uint32_t queue_family_index = pool->queueFamilyIndex;
     const VkQueueFlags queue_flags = physical_device_state.queue_family_properties[queue_family_index].queueFlags;
     std::string required_flags_string;
-    for (const auto &flag : AllVkQueueFlags) {
+    for (const auto& flag : AllVkQueueFlags) {
         if (flag & required_flags) {
             if (required_flags_string.size()) {
                 required_flags_string += " or ";
@@ -411,18 +411,18 @@ std::string CoreChecks::DescribeRequiredQueueFlag(const vvl::CommandBuffer &cb_s
     return ss.str();
 }
 
-bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, VkQueryControlFlags flags,
-                                    uint32_t index, const Location &loc) const {
+bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const QueryObject& query_obj, VkQueryControlFlags flags,
+                                    uint32_t index, const Location& loc) const {
     bool skip = false;
     const bool is_indexed = loc.function == Func::vkCmdBeginQueryIndexedEXT;
     auto query_pool_state = Get<vvl::QueryPool>(query_obj.pool);
     ASSERT_AND_RETURN_SKIP(query_pool_state);
-    const auto &query_pool_ci = query_pool_state->create_info;
+    const auto& query_pool_ci = query_pool_state->create_info;
 
     switch (query_pool_ci.queryType) {
         case VK_QUERY_TYPE_TIMESTAMP: {
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-            const char *vuid =
+            const char* vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-02804" : "VUID-vkCmdBeginQuery-queryType-02804";
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with VK_QUERY_TYPE_TIMESTAMP.",
                              FormatHandle(query_obj.pool).c_str());
@@ -431,7 +431,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         case VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT: {
             // There are tighter queue constraints to test for certain query pools
             if (!HasRequiredQueueFlags(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT)) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-02338" : "VUID-vkCmdBeginQuery-queryType-02327";
                 const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
                 skip |= LogError(vuid, objlist, loc, "%s",
@@ -439,7 +439,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
 
             if (!phys_dev_ext_props.transform_feedback_props.transformFeedbackQueries) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-02341" : "VUID-vkCmdBeginQuery-queryType-02328";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc.dot(Field::queryPool),
@@ -451,7 +451,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
         case VK_QUERY_TYPE_OCCLUSION: {
             if (!HasRequiredQueueFlags(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT)) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-00803" : "VUID-vkCmdBeginQuery-queryType-00803";
                 const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
                 skip |= LogError(vuid, objlist, loc, "%s",
@@ -461,7 +461,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
         case VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR: {
             if (!cb_state.performance_lock_acquired) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-03223" : "VUID-vkCmdBeginQuery-queryPool-03223";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc,
@@ -470,7 +470,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
 
             if (query_pool_state->has_perf_scope_command_buffer && cb_state.command_count > 0) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-03224" : "VUID-vkCmdBeginQuery-queryPool-03224";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc.dot(Field::queryPool),
@@ -481,7 +481,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
 
             if (query_pool_state->has_perf_scope_render_pass && cb_state.active_render_pass) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-03225" : "VUID-vkCmdBeginQuery-queryPool-03225";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc.dot(Field::queryPool),
@@ -491,7 +491,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
 
             if (cb_state.command_pool->queueFamilyIndex != query_pool_state->perf_counter_queue_family_index) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-07289" : "VUID-vkCmdBeginQuery-queryPool-07289";
                 const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc.dot(Field::queryPool),
@@ -504,7 +504,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR:
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR: {
-            const char *vuid =
+            const char* vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-04728" : "VUID-vkCmdBeginQuery-queryType-04728";
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with queryType %s.",
@@ -512,7 +512,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             break;
         }
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV: {
-            const char *vuid =
+            const char* vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-04729" : "VUID-vkCmdBeginQuery-queryType-04729";
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with queryType %s.",
@@ -521,7 +521,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SIZE_KHR:
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR: {
-            const char *vuid =
+            const char* vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-06741" : "VUID-vkCmdBeginQuery-queryType-06741";
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with queryType %s.",
@@ -540,7 +540,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                      VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT |
                      VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT |
                      VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT)) {
-                    const char *vuid =
+                    const char* vuid =
                         is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-00804" : "VUID-vkCmdBeginQuery-queryType-00804";
                     const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                     skip |= LogError(
@@ -555,7 +555,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
             if ((cb_state.command_pool->queue_flags & VK_QUEUE_COMPUTE_BIT) == 0) {
                 if (query_pool_ci.pipelineStatistics & VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT) {
-                    const char *vuid =
+                    const char* vuid =
                         is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-00805" : "VUID-vkCmdBeginQuery-queryType-00805";
                     const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                     skip |= LogError(
@@ -572,7 +572,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
         case VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT: {
             if ((cb_state.command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-06689" : "VUID-vkCmdBeginQuery-queryType-06687";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |=
@@ -585,9 +585,9 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             break;
         }
         case VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR: {
-            const auto &qf_ext_props = device_state->queue_family_ext_props[cb_state.command_pool->queueFamilyIndex];
+            const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state.command_pool->queueFamilyIndex];
             if (!qf_ext_props.query_result_status_props.queryResultStatusSupport) {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07126" : "VUID-vkCmdBeginQuery-queryType-07126";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc,
@@ -616,11 +616,11 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
     }
 
     // Check for nested queries
-    for (const auto &active_query_obj : cb_state.active_queries) {
+    for (const auto& active_query_obj : cb_state.active_queries) {
         auto active_query_pool_state = Get<vvl::QueryPool>(active_query_obj.pool);
         if (active_query_pool_state && (active_query_pool_state->create_info.queryType == query_pool_ci.queryType) &&
             (active_query_obj.index == index)) {
-            const char *vuid =
+            const char* vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-04753" : "VUID-vkCmdBeginQuery-queryPool-01922";
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool, active_query_obj.pool);
             skip |= LogError(vuid, objlist, loc,
@@ -634,14 +634,14 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
 
     if (flags & VK_QUERY_CONTROL_PRECISE_BIT) {
         if (!enabled_features.occlusionQueryPrecise) {
-            const char *vuid =
+            const char* vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-00800" : "VUID-vkCmdBeginQuery-queryType-00800";
             skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::flags),
                              "includes VK_QUERY_CONTROL_PRECISE_BIT, but occlusionQueryPrecise feature was not enabled.");
         }
 
         if (query_pool_ci.queryType != VK_QUERY_TYPE_OCCLUSION) {
-            const char *vuid =
+            const char* vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-00800" : "VUID-vkCmdBeginQuery-queryType-00800";
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuid, objlist, loc.dot(Field::flags),
@@ -650,25 +650,25 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
     }
 
     if (query_obj.slot >= query_pool_ci.queryCount) {
-        const char *vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-query-00802" : "VUID-vkCmdBeginQuery-query-00802";
+        const char* vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-query-00802" : "VUID-vkCmdBeginQuery-query-00802";
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
         skip |= LogError(vuid, objlist, loc, "Query index %" PRIu32 " must be less than query count %" PRIu32 " of %s.",
                          query_obj.slot, query_pool_ci.queryCount, FormatHandle(query_obj.pool).c_str());
     }
 
     if (cb_state.unprotected == false) {
-        const char *vuid =
+        const char* vuid =
             is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-commandBuffer-01885" : "VUID-vkCmdBeginQuery-commandBuffer-01885";
         skip |= LogError(vuid, cb_state.Handle(), loc, "command can't be used in protected command buffers.");
     }
 
     if (cb_state.active_render_pass && !cb_state.active_render_pass->UsesDynamicRendering()) {
-        const auto *render_pass_info = cb_state.active_render_pass->create_info.ptr();
-        const auto *subpass_desc = &render_pass_info->pSubpasses[cb_state.GetActiveSubpass()];
+        const auto* render_pass_info = cb_state.active_render_pass->create_info.ptr();
+        const auto* subpass_desc = &render_pass_info->pSubpasses[cb_state.GetActiveSubpass()];
         if (subpass_desc) {
             uint32_t bits = CountSetBits(subpass_desc->viewMask);
             if (query_obj.slot + bits > query_pool_state->create_info.queryCount) {
-                const char *vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-query-00808" : "VUID-vkCmdBeginQuery-query-00808";
+                const char* vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-query-00808" : "VUID-vkCmdBeginQuery-query-00808";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc,
                                  "query (%" PRIu32 ") + bits set in current subpass viewMask (0x%" PRIx32
@@ -680,7 +680,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
 
     if (cb_state.bound_video_session) {
         if (cb_state.bound_video_session->create_info.flags & VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR) {
-            const char *vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-None-08370" : "VUID-vkCmdBeginQuery-None-08370";
+            const char* vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-None-08370" : "VUID-vkCmdBeginQuery-None-08370";
             const LogObjectList objlist(cb_state.Handle(), cb_state.bound_video_session->Handle());
             skip |= LogError(vuid, objlist, loc,
                              "cannot start a query with this command as the bound video session "
@@ -689,7 +689,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
 
         if (!cb_state.active_queries.empty()) {
-            const char *vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-None-07127" : "VUID-vkCmdBeginQuery-None-07127";
+            const char* vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-None-07127" : "VUID-vkCmdBeginQuery-None-07127";
             const LogObjectList objlist(cb_state.Handle(), cb_state.bound_video_session->Handle());
             skip |= LogError(vuid, objlist, loc,
                              "cannot start another query while there is already an active query in a "
@@ -700,7 +700,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         switch (query_pool_ci.queryType) {
             case VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR: {
                 if (cb_state.bound_video_session->profile != query_pool_state->supported_video_profile) {
-                    const char *vuid =
+                    const char* vuid =
                         is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07128" : "VUID-vkCmdBeginQuery-queryType-07128";
                     const LogObjectList objlist(cb_state.Handle(), query_pool_state->Handle(),
                                                 cb_state.bound_video_session->Handle());
@@ -714,7 +714,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
 
             case VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR: {
                 if (cb_state.bound_video_session->profile != query_pool_state->supported_video_profile) {
-                    const char *vuid =
+                    const char* vuid =
                         is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07130" : "VUID-vkCmdBeginQuery-queryType-07130";
                     const LogObjectList objlist(cb_state.Handle(), query_pool_state->Handle(),
                                                 cb_state.bound_video_session->Handle());
@@ -727,7 +727,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
 
             default: {
-                const char *vuid =
+                const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07131" : "VUID-vkCmdBeginQuery-queryType-07131";
                 const LogObjectList objlist(cb_state.Handle(), cb_state.bound_video_session->Handle());
                 skip |= LogError(vuid, objlist, loc, "invalid query type used in a video coding scope (%s is bound).",
@@ -736,7 +736,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
         }
     } else if (query_pool_ci.queryType == VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR) {
-        const char *vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07129" : "VUID-vkCmdBeginQuery-queryType-07129";
+        const char* vuid = is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07129" : "VUID-vkCmdBeginQuery-queryType-07129";
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
         skip |= LogError(vuid, objlist, loc,
                          "there is no bound video session but query type is VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR.");
@@ -746,7 +746,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
 }
 
 bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                              VkQueryControlFlags flags, const ErrorObject &error_obj) const {
+                                              VkQueryControlFlags flags, const ErrorObject& error_obj) const {
     if (disabled[query_validation]) return false;
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -767,14 +767,14 @@ bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
     return skip;
 }
 
-bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, const Location &loc,
-                                    uint32_t perf_query_pass, QueryMap *local_query_to_state_map) {
+bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer& cb_state, const QueryObject& query_obj, const Location& loc,
+                                    uint32_t perf_query_pass, QueryMap* local_query_to_state_map) {
     bool skip = false;
-    const auto &state_data = cb_state.dev_data;
+    const auto& state_data = cb_state.dev_data;
 
     auto query_pool_state = state_data.Get<vvl::QueryPool>(query_obj.pool);
     ASSERT_AND_RETURN_SKIP(query_pool_state);
-    const auto &query_pool_ci = query_pool_state->create_info;
+    const auto& query_pool_ci = query_pool_state->create_info;
 
     QueryState state = GetLocalQueryState(local_query_to_state_map, query_obj.pool, query_obj.slot, perf_query_pass);
     // If reset was in another command buffer, check the global map
@@ -796,8 +796,8 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
 
         // Most of these VUIDs and the call sites of this function are not tested so we set here
         // some default VUID name and assert in debug builds to detect unexpected callers.
-        const char *unexpected_caller_vuid = "UNASSIGNED-CoreValidation-QueryReset";
-        const char *vuid = (command == Func::vkCmdBeginQuery)             ? "VUID-vkCmdBeginQuery-None-00807"
+        const char* unexpected_caller_vuid = "UNASSIGNED-CoreValidation-QueryReset";
+        const char* vuid = (command == Func::vkCmdBeginQuery)             ? "VUID-vkCmdBeginQuery-None-00807"
                            : (command == Func::vkCmdBeginQueryIndexedEXT) ? "VUID-vkCmdBeginQueryIndexedEXT-None-00807"
                            : (command == Func::vkCmdWriteTimestamp)       ? "VUID-vkCmdWriteTimestamp-None-00830"
                            : (command == Func::vkCmdWriteTimestamp2)      ? "VUID-vkCmdWriteTimestamp2-None-03864"
@@ -820,15 +820,15 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
     return skip;
 }
 
-bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, const Location &loc,
-                                          VkQueryPool &first_perf_query_pool, uint32_t perf_query_pass,
-                                          QueryMap *local_query_to_state_map) {
+bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer& cb_state, const QueryObject& query_obj, const Location& loc,
+                                          VkQueryPool& first_perf_query_pool, uint32_t perf_query_pass,
+                                          QueryMap* local_query_to_state_map) {
     bool skip = false;
-    const auto &state_data = cb_state.dev_data;
+    const auto& state_data = cb_state.dev_data;
     auto query_pool_state = state_data.Get<vvl::QueryPool>(query_obj.pool);
     ASSERT_AND_RETURN_SKIP(query_pool_state);
 
-    const auto &query_pool_ci = query_pool_state->create_info;
+    const auto& query_pool_ci = query_pool_state->create_info;
 
     if (query_pool_ci.queryType != VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) return skip;
 
@@ -875,13 +875,13 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
     return skip;
 }
 
-bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQueryPool queryPool, uint32_t slot, uint32_t index,
-                                     const Location &loc) const {
+bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer& cb_state, VkQueryPool queryPool, uint32_t slot, uint32_t index,
+                                     const Location& loc) const {
     bool skip = false;
     const bool is_indexed = loc.function == Func::vkCmdEndQueryIndexedEXT;
     auto query_payload = cb_state.active_queries.find({queryPool, slot});
     if (query_payload == cb_state.active_queries.end()) {
-        const char *vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-None-02342" : "VUID-vkCmdEndQuery-None-01923";
+        const char* vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-None-02342" : "VUID-vkCmdEndQuery-None-01923";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc, "Ending a query before it was started: %s, index %" PRIu32 ".",
                          FormatHandle(queryPool).c_str(), slot);
@@ -889,8 +889,8 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
     ASSERT_AND_RETURN_SKIP(query_pool_state);
 
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
-    const auto &query_pool_ci = query_pool_state->create_info;
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
+    const auto& query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         if (query_pool_state->has_perf_scope_render_pass && rp_state) {
             const LogObjectList objlist(cb_state.Handle(), queryPool);
@@ -902,33 +902,33 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
     }
 
     if (cb_state.unprotected == false) {
-        const char *vuid =
+        const char* vuid =
             is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-commandBuffer-02344" : "VUID-vkCmdEndQuery-commandBuffer-01886";
         skip |= LogError(vuid, cb_state.Handle(), loc, "command can't be used in protected command buffers.");
     }
     if (rp_state && (query_payload != cb_state.active_queries.end())) {
         if (!query_payload->inside_render_pass) {
-            const char *vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-None-07007" : "VUID-vkCmdEndQuery-None-07007";
+            const char* vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-None-07007" : "VUID-vkCmdEndQuery-None-07007";
             const LogObjectList objlist(cb_state.Handle(), queryPool, rp_state->Handle());
             skip |= LogError(vuid, objlist, loc, "query (%" PRIu32 ") was started outside a renderpass", slot);
         }
 
-        const auto *render_pass_info = rp_state->create_info.ptr();
+        const auto* render_pass_info = rp_state->create_info.ptr();
         if (!rp_state->UsesDynamicRendering()) {
             const uint32_t subpass = cb_state.GetActiveSubpass();
             if (query_payload->subpass != subpass) {
-                const char *vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-None-07007" : "VUID-vkCmdEndQuery-None-07007";
+                const char* vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-None-07007" : "VUID-vkCmdEndQuery-None-07007";
                 const LogObjectList objlist(cb_state.Handle(), queryPool, rp_state->Handle());
                 skip |= LogError(vuid, objlist, loc,
                                  "query (%" PRIu32 ") was started in subpass %" PRIu32 ", but ending in subpass %" PRIu32 ".", slot,
                                  query_payload->subpass, subpass);
             }
 
-            const auto *subpass_desc = &render_pass_info->pSubpasses[subpass];
+            const auto* subpass_desc = &render_pass_info->pSubpasses[subpass];
             if (subpass_desc) {
                 const uint32_t bits = CountSetBits(subpass_desc->viewMask);
                 if (slot + bits > query_pool_state->create_info.queryCount) {
-                    const char *vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-query-02345" : "VUID-vkCmdEndQuery-query-00812";
+                    const char* vuid = is_indexed ? "VUID-vkCmdEndQueryIndexedEXT-query-02345" : "VUID-vkCmdEndQuery-query-00812";
                     const LogObjectList objlist(cb_state.Handle(), queryPool, rp_state->Handle());
                     skip |= LogError(vuid, objlist, loc,
                                      "query (%" PRIu32 ") + bits set in current subpass (%" PRIu32 ") viewMask (0x%" PRIx32
@@ -942,7 +942,7 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
 }
 
 bool CoreChecks::PreCallValidateCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                            const ErrorObject &error_obj) const {
+                                            const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -963,9 +963,9 @@ bool CoreChecks::PreCallValidateCmdEndQuery(VkCommandBuffer commandBuffer, VkQue
     return skip;
 }
 
-bool CoreChecks::ValidateQueryPoolIndex(LogObjectList objlist, const vvl::QueryPool &query_pool_state, uint32_t firstQuery,
-                                        uint32_t queryCount, const Location &loc, const char *first_vuid,
-                                        const char *sum_vuid) const {
+bool CoreChecks::ValidateQueryPoolIndex(LogObjectList objlist, const vvl::QueryPool& query_pool_state, uint32_t firstQuery,
+                                        uint32_t queryCount, const Location& loc, const char* first_vuid,
+                                        const char* sum_vuid) const {
     bool skip = false;
     const uint32_t available_query_count = query_pool_state.create_info.queryCount;
     if (firstQuery >= available_query_count) {
@@ -984,8 +984,8 @@ bool CoreChecks::ValidateQueryPoolIndex(LogObjectList objlist, const vvl::QueryP
     return skip;
 }
 
-bool CoreChecks::ValidateQueriesNotActive(const vvl::CommandBuffer &cb_state, VkQueryPool queryPool, uint32_t firstQuery,
-                                          uint32_t queryCount, const Location &loc, const char *vuid) const {
+bool CoreChecks::ValidateQueriesNotActive(const vvl::CommandBuffer& cb_state, VkQueryPool queryPool, uint32_t firstQuery,
+                                          uint32_t queryCount, const Location& loc, const char* vuid) const {
     bool skip = false;
     for (uint32_t i = 0; i < queryCount; i++) {
         const uint32_t slot = firstQuery + i;
@@ -1001,7 +1001,7 @@ bool CoreChecks::ValidateQueriesNotActive(const vvl::CommandBuffer &cb_state, Vk
 }
 
 bool CoreChecks::PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
-                                                  uint32_t queryCount, const ErrorObject &error_obj) const {
+                                                  uint32_t queryCount, const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -1021,7 +1021,7 @@ bool CoreChecks::PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer,
 bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                                         uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                         VkDeviceSize stride, VkQueryResultFlags flags,
-                                                        const ErrorObject &error_obj) const {
+                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -1233,8 +1233,8 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResultsToMemoryKHR(VkCommandBuff
     return skip;
 }
 
-bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, VkQueryPool queryPool, uint32_t slot,
-                                           const Location &loc) const {
+bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer& cb_state, VkQueryPool queryPool, uint32_t slot,
+                                           const Location& loc) const {
     bool skip = false;
     skip |= ValidateCmd(cb_state, loc);
     const bool is_2 = loc.function == Func::vkCmdWriteTimestamp2 || loc.function == Func::vkCmdWriteTimestamp2KHR;
@@ -1242,7 +1242,7 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
     const uint32_t timestamp_valid_bits =
         physical_device_state->queue_family_properties[cb_state.command_pool->queueFamilyIndex].timestampValidBits;
     if (timestamp_valid_bits == 0) {
-        const char *vuid =
+        const char* vuid =
             is_2 ? "VUID-vkCmdWriteTimestamp2-timestampValidBits-03863" : "VUID-vkCmdWriteTimestamp-timestampValidBits-00829";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |=
@@ -1254,14 +1254,14 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
     ASSERT_AND_RETURN_SKIP(query_pool_state);
 
     if (query_pool_state->create_info.queryType != VK_QUERY_TYPE_TIMESTAMP) {
-        const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-queryPool-03861" : "VUID-vkCmdWriteTimestamp-queryPool-01416";
+        const char* vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-queryPool-03861" : "VUID-vkCmdWriteTimestamp-queryPool-01416";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc, "Query Pool %s was not created with VK_QUERY_TYPE_TIMESTAMP.",
                          FormatHandle(queryPool).c_str());
     }
 
     if (slot >= query_pool_state->create_info.queryCount) {
-        const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-04903" : "VUID-vkCmdWriteTimestamp-query-04904";
+        const char* vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-04903" : "VUID-vkCmdWriteTimestamp-query-04904";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc,
                          "query (%" PRIu32 ") is not lower than the number of queries (%" PRIu32 ") in Query pool %s.", slot,
@@ -1270,7 +1270,7 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
     const uint32_t view_mask = cb_state.GetViewMask();
     const uint32_t view_mask_bits = CountSetBits(view_mask);
     if (cb_state.active_render_pass && (slot + view_mask_bits) > query_pool_state->create_info.queryCount) {
-        const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-03865" : "VUID-vkCmdWriteTimestamp-query-00831";
+        const char* vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-03865" : "VUID-vkCmdWriteTimestamp-query-00831";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |=
             LogError(vuid, objlist, loc,
@@ -1283,7 +1283,7 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
 }
 
 bool CoreChecks::PreCallValidateCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
-                                                  VkQueryPool queryPool, uint32_t slot, const ErrorObject &error_obj) const {
+                                                  VkQueryPool queryPool, uint32_t slot, const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -1295,7 +1295,7 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp(VkCommandBuffer commandBuffer,
 }
 
 bool CoreChecks::PreCallValidateCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
-                                                   VkQueryPool queryPool, uint32_t slot, const ErrorObject &error_obj) const {
+                                                   VkQueryPool queryPool, uint32_t slot, const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -1316,13 +1316,13 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp2(VkCommandBuffer commandBuffer
 }
 
 bool CoreChecks::PreCallValidateCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR stage,
-                                                      VkQueryPool queryPool, uint32_t query, const ErrorObject &error_obj) const {
+                                                      VkQueryPool queryPool, uint32_t query, const ErrorObject& error_obj) const {
     return PreCallValidateCmdWriteTimestamp2(commandBuffer, stage, queryPool, query, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
                                                         VkQueryControlFlags flags, uint32_t index,
-                                                        const ErrorObject &error_obj) const {
+                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -1334,7 +1334,7 @@ bool CoreChecks::PreCallValidateCmdBeginQueryIndexedEXT(VkCommandBuffer commandB
     const auto query_pool_state = Get<vvl::QueryPool>(query_obj.pool);
     ASSERT_AND_RETURN_SKIP(query_pool_state);
 
-    const auto &query_pool_ci = query_pool_state->create_info;
+    const auto& query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
         if (!enabled_features.primitivesGeneratedQuery) {
             const LogObjectList objlist(commandBuffer, queryPool);
@@ -1380,7 +1380,7 @@ bool CoreChecks::PreCallValidateCmdBeginQueryIndexedEXT(VkCommandBuffer commandB
 }
 
 bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                                      uint32_t index, const ErrorObject &error_obj) const {
+                                                      uint32_t index, const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -1390,7 +1390,7 @@ bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuf
     const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
     ASSERT_AND_RETURN_SKIP(query_pool_state);
 
-    const auto &query_pool_ci = query_pool_state->create_info;
+    const auto& query_pool_ci = query_pool_state->create_info;
     const uint32_t available_query_count = query_pool_ci.queryCount;
     if (slot >= available_query_count) {
         const LogObjectList objlist(commandBuffer, queryPool);
@@ -1406,7 +1406,7 @@ bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuf
                              "VkPhysicalDeviceTransformFeedbackPropertiesEXT::maxTransformFeedbackStreams %" PRIu32 ".",
                              index, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackStreams);
         }
-        for (const auto &query_object : cb_state->started_queries) {
+        for (const auto& query_object : cb_state->started_queries) {
             if (query_object.pool == queryPool && query_object.slot == slot) {
                 if (query_object.index != index) {
                     const LogObjectList objlist(commandBuffer, queryPool);
@@ -1431,7 +1431,7 @@ bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuf
 }
 
 bool CoreChecks::PreCallValidateResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
-                                               const ErrorObject &error_obj) const {
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     if (disabled[query_validation]) return skip;
 
@@ -1458,13 +1458,13 @@ bool CoreChecks::PreCallValidateResetQueryPool(VkDevice device, VkQueryPool quer
 }
 
 bool CoreChecks::PreCallValidateResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
-                                                  const ErrorObject &error_obj) const {
+                                                  const ErrorObject& error_obj) const {
     return PreCallValidateResetQueryPool(device, queryPool, firstQuery, queryCount, error_obj);
 }
 
 void CoreChecks::PostCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
-                                                   size_t dataSize, void *pData, VkDeviceSize stride, VkQueryResultFlags flags,
-                                                   const RecordObject &record_obj) {
+                                                   size_t dataSize, void* pData, VkDeviceSize stride, VkQueryResultFlags flags,
+                                                   const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1478,7 +1478,7 @@ void CoreChecks::PostCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool 
     }
 }
 
-bool CoreChecks::PreCallValidateReleaseProfilingLockKHR(VkDevice device, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateReleaseProfilingLockKHR(VkDevice device, const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (!device_state->performance_lock_acquired) {

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -36,8 +36,8 @@
 
 // Holds common information between all command buffers being submitted
 struct CommandBufferSubmitState {
-    const CoreChecks &core;
-    const vvl::Queue &queue_state;
+    const CoreChecks& core;
+    const vvl::Queue& queue_state;
     QFOTransferCBScoreboards<QFOImageTransferBarrier> qfo_image_scoreboards;
     QFOTransferCBScoreboards<QFOBufferTransferBarrier> qfo_buffer_scoreboards;
     std::vector<VkCommandBuffer> current_cmds;
@@ -51,7 +51,7 @@ struct CommandBufferSubmitState {
     EventMap local_event_signal_info;
     vvl::unordered_map<VkVideoSessionKHR, vvl::VideoSessionDeviceState> local_video_session_state{};
 
-    CommandBufferSubmitState(const CoreChecks &c, const vvl::Queue &q) : core(c), queue_state(q) {
+    CommandBufferSubmitState(const CoreChecks& c, const vvl::Queue& q) : core(c), queue_state(q) {
         // Queue label state is updated during PostRecord phase.
         // Copy state to be able to track labels during validation.
         cmdbuf_label_stack = queue_state.cmdbuf_label_stack;
@@ -59,7 +59,7 @@ struct CommandBufferSubmitState {
         found_unbalanced_cmdbuf_label = queue_state.found_unbalanced_cmdbuf_label;
     }
 
-    bool Validate(const Location &loc, const vvl::CommandBuffer &cb_state, uint32_t perf_pass) {
+    bool Validate(const Location& loc, const vvl::CommandBuffer& cb_state, uint32_t perf_pass) {
         bool skip = false;
         const VkCommandBuffer cmd = cb_state.VkHandle();
         current_cmds.push_back(cmd);
@@ -74,30 +74,30 @@ struct CommandBufferSubmitState {
             return true;
         }
 
-        auto &cb_sub_state = core::SubState(cb_state);
-        for (auto &function : cb_sub_state.event_updates) {
-            skip |= function(const_cast<vvl::CommandBuffer &>(cb_state), /*do_validate*/ true, local_event_signal_info,
+        auto& cb_sub_state = core::SubState(cb_state);
+        for (auto& function : cb_sub_state.event_updates) {
+            skip |= function(const_cast<vvl::CommandBuffer&>(cb_state), /*do_validate*/ true, local_event_signal_info,
                              queue_state.VkHandle(), loc);
         }
         VkQueryPool first_perf_query_pool = VK_NULL_HANDLE;
-        for (auto &function : cb_sub_state.query_updates) {
-            skip |= function(const_cast<vvl::CommandBuffer &>(cb_state), /*do_validate*/ true, first_perf_query_pool, perf_pass,
+        for (auto& function : cb_sub_state.query_updates) {
+            skip |= function(const_cast<vvl::CommandBuffer&>(cb_state), /*do_validate*/ true, first_perf_query_pool, perf_pass,
                              &local_query_to_state_map);
         }
 
-        for (const auto &it : cb_state.video_session_updates) {
+        for (const auto& it : cb_state.video_session_updates) {
             auto video_session_state = core.Get<vvl::VideoSession>(it.first);
             auto local_state_it = local_video_session_state.find(it.first);
             if (video_session_state && (local_state_it == local_video_session_state.end())) {
                 local_state_it = local_video_session_state.insert({it.first, video_session_state->DeviceStateCopy()}).first;
             }
-            for (const auto &function : it.second) {
+            for (const auto& function : it.second) {
                 skip |= function(video_session_state.get(), local_state_it->second, /*do_validate*/ true);
             }
         }
 
         // Validate TensorMemoryBarrierARM
-        for (auto &barrier : cb_state.tensor_barriers) {
+        for (auto& barrier : cb_state.tensor_barriers) {
             auto tensor_state = core.Get<vvl::Tensor>(barrier.tensor);
             ASSERT_AND_RETURN_SKIP(tensor_state);
             if (VK_SHARING_MODE_EXCLUSIVE == tensor_state->create_info.sharingMode &&
@@ -116,15 +116,15 @@ struct CommandBufferSubmitState {
         return skip;
     }
 
-private:
-    bool ValidateCmdBufLabelMatching(const Location &loc, const vvl::CommandBuffer &cb_state) {
+  private:
+    bool ValidateCmdBufLabelMatching(const Location& loc, const vvl::CommandBuffer& cb_state) {
         bool skip = false;
         if (found_unbalanced_cmdbuf_label) {
             // We already reported an error. After the first error, do not perform further validation or state tracking.
             // The assumption that after label mismatch the label stack is corrupted and can't be reasoned about.
             return skip;
         }
-        for (const auto &command : cb_state.GetLabelCommands()) {
+        for (const auto& command : cb_state.GetLabelCommands()) {
             if (command.begin) {
                 cmdbuf_label_stack.emplace_back(command.label_name);
             } else {
@@ -153,8 +153,8 @@ private:
     }
 };
 
-bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
-                                            const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
+                                            const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto fence_state = Get<vvl::Fence>(fence)) {
         const LogObjectList objlist(queue, fence);
@@ -170,7 +170,7 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
 
     // Now verify each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        const VkSubmitInfo &submit = pSubmits[submit_idx];
+        const VkSubmitInfo& submit = pSubmits[submit_idx];
         const Location submit_loc = error_obj.location.dot(Struct::VkSubmitInfo, Field::pSubmits, submit_idx);
         const auto perf_submit = vku::FindStructInPNextChain<VkPerformanceQuerySubmitInfoKHR>(submit.pNext);
         uint32_t perf_pass = perf_submit ? perf_submit->counterPassIndex : 0;
@@ -188,7 +188,7 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
         }
 
         bool suspended_render_pass_instance = false;
-        const VkRenderingInfo *last_rendering_info = nullptr;
+        const VkRenderingInfo* last_rendering_info = nullptr;
         for (uint32_t i = 0; i < submit.commandBufferCount; i++) {
             const Location cb_loc = submit_loc.dot(Field::pCommandBuffers, i);
             auto cb_state = GetRead<vvl::CommandBuffer>(submit.pCommandBuffers[i]);
@@ -237,7 +237,7 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
             }
             if (cb_state->first_rendering_info.has_value() && last_rendering_info) {
                 const LogObjectList objlist(cb_state->Handle(), queue);
-                const VkRenderingInfo &rendering_info = *cb_state->first_rendering_info.value().ptr();
+                const VkRenderingInfo& rendering_info = *cb_state->first_rendering_info.value().ptr();
                 // TODO: VUID is being discussed https://gitlab.khronos.org/vulkan/vulkan/-/issues/4554
                 skip |= ValidateSuspendResumeMismatch("UNASSIGNED-RenderingInfo-SuspendResume-Mismatch", objlist, rendering_info,
                                                       *last_rendering_info, cb_state->first_rendering_info_loc->Get());
@@ -295,12 +295,12 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
     return skip;
 }
 
-bool CoreChecks::ValidateRenderPassStripeSubmitInfo(VkQueue queue, const vvl::CommandBuffer &cb_state, const void *pNext,
-                                                    const Location &loc) const {
+bool CoreChecks::ValidateRenderPassStripeSubmitInfo(VkQueue queue, const vvl::CommandBuffer& cb_state, const void* pNext,
+                                                    const Location& loc) const {
     bool skip = false;
     LogObjectList objlist(queue, cb_state.Handle());
 
-    const VkRenderPassStripeSubmitInfoARM *rp_submit_info = vku::FindStructInPNextChain<VkRenderPassStripeSubmitInfoARM>(pNext);
+    const VkRenderPassStripeSubmitInfoARM* rp_submit_info = vku::FindStructInPNextChain<VkRenderPassStripeSubmitInfoARM>(pNext);
     if (!rp_submit_info) {
         if (cb_state.has_render_pass_striped && !cb_state.resumes_render_pass_instance) {
             skip |= LogError("VUID-VkCommandBufferSubmitInfo-commandBuffer-09445", objlist, loc.dot(Field::pNext),
@@ -333,8 +333,8 @@ bool CoreChecks::ValidateRenderPassStripeSubmitInfo(VkQueue queue, const vvl::Co
     return skip;
 }
 
-bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                      const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                      const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto fence_state = Get<vvl::Fence>(fence)) {
         const LogObjectList objlist(queue, fence);
@@ -358,7 +358,7 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
     // Now verify each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
         const Location submit_loc = error_obj.location.dot(Struct::VkSubmitInfo2, Field::pSubmits, submit_idx);
-        const VkSubmitInfo2 &submit = pSubmits[submit_idx];
+        const VkSubmitInfo2& submit = pSubmits[submit_idx];
         const auto perf_submit = vku::FindStructInPNextChain<VkPerformanceQuerySubmitInfoKHR>(submit.pNext);
         const uint32_t perf_pass = perf_submit ? perf_submit->counterPassIndex : 0;
 
@@ -373,7 +373,7 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
         }
 
         bool suspended_render_pass_instance = false;
-        const VkRenderingInfo *last_rendering_info = nullptr;
+        const VkRenderingInfo* last_rendering_info = nullptr;
         for (uint32_t i = 0; i < submit.commandBufferInfoCount; i++) {
             const Location info_loc = submit_loc.dot(Struct::VkCommandBufferSubmitInfo, Field::pCommandBufferInfos, i);
             auto cb_state = GetRead<vvl::CommandBuffer>(submit.pCommandBufferInfos[i].commandBuffer);
@@ -425,7 +425,7 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
             }
             if (cb_state->first_rendering_info.has_value() && last_rendering_info) {
                 const LogObjectList objlist(cb_state->Handle(), queue);
-                const VkRenderingInfo &rendering_info = *cb_state->first_rendering_info.value().ptr();
+                const VkRenderingInfo& rendering_info = *cb_state->first_rendering_info.value().ptr();
                 // TODO: VUID is being discussed https://gitlab.khronos.org/vulkan/vulkan/-/issues/4554
                 skip |= ValidateSuspendResumeMismatch("UNASSIGNED-RenderingInfo-SuspendResume-Mismatch", objlist, rendering_info,
                                                       *last_rendering_info, cb_state->first_rendering_info_loc->Get());
@@ -454,29 +454,29 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
     return skip;
 }
 
-bool CoreChecks::PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits,
-                                                VkFence fence, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits,
+                                                VkFence fence, const ErrorObject& error_obj) const {
     return PreCallValidateQueueSubmit2(queue, submitCount, pSubmits, fence, error_obj);
 }
 
-bool CoreChecks::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                             const ErrorObject& error_obj) const {
     return ValidateQueueSubmit2(queue, submitCount, pSubmits, fence, error_obj);
 }
 
-void CoreChecks::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
-                                           const RecordObject &record_obj) {
+void CoreChecks::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
+                                           const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     // The triply nested for duplicates that in the StateTracker, but avoids the need for two additional callbacks.
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        const VkSubmitInfo &submit = pSubmits[submit_idx];
+        const VkSubmitInfo& submit = pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit.commandBufferCount; i++) {
             auto cb_state = GetWrite<vvl::CommandBuffer>(submit.pCommandBuffers[i]);
             ASSERT_AND_CONTINUE(cb_state);
 
-            for (auto *secondary_cmd_buffer : cb_state->linked_command_buffers) {
+            for (auto* secondary_cmd_buffer : cb_state->linked_command_buffers) {
                 RecordQueuedQFOTransfers(*secondary_cmd_buffer);
             }
             RecordQueuedQFOTransfers(*cb_state);
@@ -484,19 +484,19 @@ void CoreChecks::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, 
     }
 }
 
-void CoreChecks::RecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                    const RecordObject &record_obj) {
+void CoreChecks::RecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                    const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     // The triply nested for duplicates that in the StateTracker, but avoids the need for two additional callbacks.
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        const VkSubmitInfo2 &submit = pSubmits[submit_idx];
+        const VkSubmitInfo2& submit = pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit.commandBufferInfoCount; i++) {
             auto cb_state = GetWrite<vvl::CommandBuffer>(submit.pCommandBufferInfos[i].commandBuffer);
             ASSERT_AND_CONTINUE(cb_state);
 
-            for (auto *secondary_cmd_buffer : cb_state->linked_command_buffers) {
+            for (auto* secondary_cmd_buffer : cb_state->linked_command_buffers) {
                 RecordQueuedQFOTransfers(*secondary_cmd_buffer);
             }
             RecordQueuedQFOTransfers(*cb_state);
@@ -504,20 +504,20 @@ void CoreChecks::RecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const V
     }
 }
 
-void CoreChecks::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                               const RecordObject &record_obj) {
+void CoreChecks::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                               const RecordObject& record_obj) {
     PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
 }
 
-void CoreChecks::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                            const RecordObject &record_obj) {
+void CoreChecks::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                            const RecordObject& record_obj) {
     RecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
 }
 
 // Check that the queue family index of 'queue' matches one of the entries in pQueueFamilyIndices
-bool CoreChecks::ValidImageBufferQueue(const vvl::CommandBuffer &cb_state, const VulkanTypedHandle &object,
-                                       uint32_t queueFamilyIndex, uint32_t count, const uint32_t *indices,
-                                       const Location &loc) const {
+bool CoreChecks::ValidImageBufferQueue(const vvl::CommandBuffer& cb_state, const VulkanTypedHandle& object,
+                                       uint32_t queueFamilyIndex, uint32_t count, const uint32_t* indices,
+                                       const Location& loc) const {
     bool found = false;
     bool skip = false;
     for (uint32_t i = 0; i < count; i++) {
@@ -539,15 +539,15 @@ bool CoreChecks::ValidImageBufferQueue(const vvl::CommandBuffer &cb_state, const
 
 // Validate that queueFamilyIndices of primary command buffers match this queue
 // Secondary command buffers were previously validated in vkCmdExecuteCommands().
-bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const vvl::CommandBuffer &cb_state,
-                                            const vvl::Queue &queue_state) const {
+bool CoreChecks::ValidateQueueFamilyIndices(const Location& loc, const vvl::CommandBuffer& cb_state,
+                                            const vvl::Queue& queue_state) const {
     bool skip = false;
     auto pool = cb_state.command_pool;
     ASSERT_AND_RETURN_SKIP(pool);
 
     if (pool->queueFamilyIndex != queue_state.queue_family_index) {
         const LogObjectList objlist(cb_state.Handle(), queue_state.Handle());
-        const auto &vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kCmdWrongQueueFamily);
+        const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kCmdWrongQueueFamily);
         skip |= LogError(vuid, objlist, loc,
                          "Primary command buffer %s created in queue family %" PRIu32
                          " is being submitted on %s "
@@ -557,10 +557,10 @@ bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const vvl::Comm
     }
 
     // Ensure that any bound images or buffers created with SHARING_MODE_CONCURRENT have access to the current queue family
-    for (const auto &state_object : cb_state.object_bindings) {
+    for (const auto& state_object : cb_state.object_bindings) {
         switch (state_object->Type()) {
             case kVulkanObjectTypeImage: {
-                auto image_state = static_cast<const vvl::Image *>(state_object.get());
+                auto image_state = static_cast<const vvl::Image*>(state_object.get());
                 if (image_state && image_state->create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
                     skip |= ValidImageBufferQueue(cb_state, image_state->Handle(), queue_state.queue_family_index,
                                                   image_state->create_info.queueFamilyIndexCount,
@@ -569,7 +569,7 @@ bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const vvl::Comm
                 break;
             }
             case kVulkanObjectTypeBuffer: {
-                auto buffer_state = static_cast<const vvl::Buffer *>(state_object.get());
+                auto buffer_state = static_cast<const vvl::Buffer*>(state_object.get());
                 if (buffer_state && buffer_state->create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
                     skip |= ValidImageBufferQueue(cb_state, buffer_state->Handle(), queue_state.queue_family_index,
                                                   buffer_state->create_info.queueFamilyIndexCount,
@@ -585,8 +585,8 @@ bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const vvl::Comm
     return skip;
 }
 
-bool CoreChecks::ValidateCommandBufferState(const vvl::CommandBuffer &cb_state, const Location &loc, uint32_t current_submit_count,
-                                            const char *vuid) const {
+bool CoreChecks::ValidateCommandBufferState(const vvl::CommandBuffer& cb_state, const Location& loc, uint32_t current_submit_count,
+                                            const char* vuid) const {
     bool skip = false;
     if (disabled[command_buffer_state]) {
         return skip;
@@ -625,12 +625,12 @@ bool CoreChecks::ValidateCommandBufferState(const vvl::CommandBuffer &cb_state, 
     return skip;
 }
 
-bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location &loc, const vvl::CommandBuffer &cb_state,
+bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location& loc, const vvl::CommandBuffer& cb_state,
                                                       int current_submit_count) const {
     bool skip = false;
     if ((cb_state.InUse() || current_submit_count > 1) &&
         !(cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
-        const auto &vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kCmdNotSimultaneous);
+        const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kCmdNotSimultaneous);
 
         skip |= LogError(vuid, device, loc, "%s is already in use and is not marked for simultaneous use.",
                          FormatHandle(cb_state).c_str());
@@ -639,24 +639,23 @@ bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location &loc, const
 }
 
 bool CoreChecks::ValidatePrimaryCommandBufferState(
-    const Location &loc, const vvl::CommandBuffer &cb_state, uint32_t current_submit_count,
-    QFOTransferCBScoreboards<QFOImageTransferBarrier> *qfo_image_scoreboards,
-    QFOTransferCBScoreboards<QFOBufferTransferBarrier> *qfo_buffer_scoreboards) const {
-
+    const Location& loc, const vvl::CommandBuffer& cb_state, uint32_t current_submit_count,
+    QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
+    QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const {
     // Track in-use for resources off of primary and any secondary CBs
     bool skip = false;
 
     if (cb_state.IsSecondary()) {
-        const auto &vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kSecondaryCmdInSubmit);
+        const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kSecondaryCmdInSubmit);
         skip |= LogError(vuid, cb_state.Handle(), loc, "Command buffer %s must be allocated with VK_COMMAND_BUFFER_LEVEL_PRIMARY.",
                          FormatHandle(cb_state).c_str());
     } else {
-        for (const auto *sub_cb : cb_state.linked_command_buffers) {
+        for (const auto* sub_cb : cb_state.linked_command_buffers) {
             skip |= ValidateQueuedQFOTransfers(*sub_cb, qfo_image_scoreboards, qfo_buffer_scoreboards, loc);
             // TODO: replace with InvalidateCommandBuffers() at recording.
             if ((sub_cb->primary_command_buffer != cb_state.VkHandle()) &&
                 !(sub_cb->begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
-                const auto &vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kSecondaryCmdNotSimultaneous);
+                const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kSecondaryCmdNotSimultaneous);
                 const LogObjectList objlist(device, cb_state.Handle(), sub_cb->Handle(), sub_cb->primary_command_buffer);
                 skip |= LogError(vuid, objlist, loc,
                                  "%s was submitted with secondary %s but that buffer has subsequently been bound to "
@@ -666,7 +665,7 @@ bool CoreChecks::ValidatePrimaryCommandBufferState(
             }
 
             if (!IsRecorded(sub_cb->state)) {
-                const char *const finished_cb_vuid = (loc.function == Func::vkQueueSubmit)
+                const char* const finished_cb_vuid = (loc.function == Func::vkQueueSubmit)
                                                          ? "VUID-vkQueueSubmit-pCommandBuffers-00072"
                                                          : "VUID-vkQueueSubmit2-commandBuffer-03876";
                 const LogObjectList objlist(device, cb_state.Handle(), sub_cb->Handle(), sub_cb->primary_command_buffer);
@@ -682,14 +681,14 @@ bool CoreChecks::ValidatePrimaryCommandBufferState(
 
     skip |= ValidateQueuedQFOTransfers(cb_state, qfo_image_scoreboards, qfo_buffer_scoreboards, loc);
 
-    const char *const vuid = (loc.function == Func::vkQueueSubmit) ? "VUID-vkQueueSubmit-pCommandBuffers-00070"
+    const char* const vuid = (loc.function == Func::vkQueueSubmit) ? "VUID-vkQueueSubmit-pCommandBuffers-00070"
                                                                    : "VUID-vkQueueSubmit2-commandBuffer-03874";
     skip |= ValidateCommandBufferState(cb_state, loc, current_submit_count, vuid);
     return skip;
 }
 
-bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                                VkFence fence, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                                                VkFence fence, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto fence_state = Get<vvl::Fence>(fence)) {
         const LogObjectList objlist(queue, fence);
@@ -709,18 +708,18 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
     SemaphoreSubmitState sem_submit_state(*this, queue, queue_flags);
     for (uint32_t bind_idx = 0; bind_idx < bindInfoCount; ++bind_idx) {
         const Location bind_info_loc = error_obj.location.dot(Struct::VkBindSparseInfo, Field::pBindInfo, bind_idx);
-        const VkBindSparseInfo &bind_info = pBindInfo[bind_idx];
+        const VkBindSparseInfo& bind_info = pBindInfo[bind_idx];
 
         skip |= ValidateSemaphoresForSubmit(sem_submit_state, bind_info, bind_info_loc);
 
         if (bind_info.pBufferBinds) {
             for (uint32_t buffer_idx = 0; buffer_idx < bind_info.bufferBindCount; ++buffer_idx) {
-                const VkSparseBufferMemoryBindInfo &buffer_bind = bind_info.pBufferBinds[buffer_idx];
+                const VkSparseBufferMemoryBindInfo& buffer_bind = bind_info.pBufferBinds[buffer_idx];
                 if (buffer_bind.pBinds) {
                     auto buffer_state = Get<vvl::Buffer>(buffer_bind.buffer);
                     ASSERT_AND_CONTINUE(buffer_state);
                     for (uint32_t buffer_bind_idx = 0; buffer_bind_idx < buffer_bind.bindCount; ++buffer_bind_idx) {
-                        const VkSparseMemoryBind &memory_bind = buffer_bind.pBinds[buffer_bind_idx];
+                        const VkSparseMemoryBind& memory_bind = buffer_bind.pBinds[buffer_bind_idx];
                         const Location buffer_bind_info_loc = bind_info_loc.dot(Field::pBufferBinds, buffer_idx);
                         const Location bind_loc = buffer_bind_info_loc.dot(Field::pBinds, buffer_bind_idx);
                         skip |=
@@ -735,13 +734,13 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
 
         if (bind_info.pImageOpaqueBinds) {
             for (uint32_t image_opaque_idx = 0; image_opaque_idx < bind_info.imageOpaqueBindCount; ++image_opaque_idx) {
-                const VkSparseImageOpaqueMemoryBindInfo &image_opaque_bind = bind_info.pImageOpaqueBinds[image_opaque_idx];
+                const VkSparseImageOpaqueMemoryBindInfo& image_opaque_bind = bind_info.pImageOpaqueBinds[image_opaque_idx];
                 if (image_opaque_bind.pBinds) {
                     auto image_state = Get<vvl::Image>(image_opaque_bind.image);
                     ASSERT_AND_CONTINUE(image_state);
                     for (uint32_t image_opaque_bind_idx = 0; image_opaque_bind_idx < image_opaque_bind.bindCount;
                          ++image_opaque_bind_idx) {
-                        const VkSparseMemoryBind &memory_bind = image_opaque_bind.pBinds[image_opaque_bind_idx];
+                        const VkSparseMemoryBind& memory_bind = image_opaque_bind.pBinds[image_opaque_bind_idx];
                         const Location image_bind_info_loc = bind_info_loc.dot(Field::pImageOpaqueBinds, image_opaque_idx);
                         const Location bind_loc = image_bind_info_loc.dot(Field::pBinds, image_opaque_bind_idx);
                         // Assuming that no multiplanar disjointed images are possible with sparse memory binding. Needs
@@ -758,7 +757,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
         if (bind_info.pImageBinds) {
             for (uint32_t image_idx = 0; image_idx < bind_info.imageBindCount; ++image_idx) {
                 const Location bind_loc = bind_info_loc.dot(Field::pImageBinds, image_idx);
-                const VkSparseImageMemoryBindInfo &image_bind = bind_info.pImageBinds[image_idx];
+                const VkSparseImageMemoryBindInfo& image_bind = bind_info.pImageBinds[image_idx];
                 auto image_state = Get<vvl::Image>(image_bind.image);
                 ASSERT_AND_CONTINUE(image_state);
 
@@ -770,7 +769,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
 
                 for (uint32_t image_bind_idx = 0; image_bind_idx < image_bind.bindCount; ++image_bind_idx) {
                     const Location image_bind_loc = bind_loc.dot(Field::pBinds, image_bind_idx);
-                    const VkSparseImageMemoryBind &memory_bind = image_bind.pBinds[image_bind_idx];
+                    const VkSparseImageMemoryBind& memory_bind = image_bind.pBinds[image_bind_idx];
                     skip |= ValidateSparseImageMemoryBind(image_state.get(), memory_bind, bind_loc, image_bind_loc);
                 }
             }

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -37,10 +37,10 @@
 #include "error_message/error_strings.h"
 
 bool CoreChecks::PreCallValidateCreateAccelerationStructureKHR(VkDevice device,
-                                                               const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
-                                                               const VkAllocationCallbacks *pAllocator,
-                                                               VkAccelerationStructureKHR *pAccelerationStructure,
-                                                               const ErrorObject &error_obj) const {
+                                                               const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
+                                                               const VkAllocationCallbacks* pAllocator,
+                                                               VkAccelerationStructureKHR* pAccelerationStructure,
+                                                               const ErrorObject& error_obj) const {
     bool skip = false;
     auto buffer_state = Get<vvl::Buffer>(pCreateInfo->buffer);
     ASSERT_AND_RETURN_SKIP(buffer_state);
@@ -126,8 +126,8 @@ bool CoreChecks::PreCallValidateCreateAccelerationStructure2KHR(VkDevice device,
 }
 
 bool CoreChecks::PreCallValidateGetAccelerationStructureBuildSizesKHR(
-    VkDevice device, VkAccelerationStructureBuildTypeKHR buildType, const VkAccelerationStructureBuildGeometryInfoKHR *pBuildInfo,
-    const uint32_t *pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR *pSizeInfo, const ErrorObject &error_obj) const {
+    VkDevice device, VkAccelerationStructureBuildTypeKHR buildType, const VkAccelerationStructureBuildGeometryInfoKHR* pBuildInfo,
+    const uint32_t* pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo, const ErrorObject& error_obj) const {
     bool skip = false;
     if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
         !enabled_features.bufferDeviceAddressMultiDeviceEXT) {
@@ -140,13 +140,13 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureBuildSizesKHR(
     return skip;
 }
 
-bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectList &objlist, uint32_t infoCount,
-                                                               const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-                                                               uint32_t info_i, const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectList& objlist, uint32_t infoCount,
+                                                               const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                                               uint32_t info_i, const ErrorObject& error_obj) const {
     using vvl::range;
 
     bool skip = false;
-    const VkAccelerationStructureBuildGeometryInfoKHR &info = pInfos[info_i];
+    const VkAccelerationStructureBuildGeometryInfoKHR& info = pInfos[info_i];
     const Location info_i_loc = error_obj.location.dot(Field::pInfos, info_i);
     const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
     const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure);
@@ -154,7 +154,7 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectLi
     const bool info_in_mode_update = info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR;
 
     if (info_in_mode_update && info.srcAccelerationStructure != info.dstAccelerationStructure && src_as_state && dst_as_state) {
-        const char *vuid = error_obj.location.function == Func::vkCmdBuildAccelerationStructuresKHR
+        const char* vuid = error_obj.location.function == Func::vkCmdBuildAccelerationStructuresKHR
                                ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03668"
                            : error_obj.location.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
                                ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03668"
@@ -182,7 +182,7 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectLi
         // memory that is going to be updated by this cmd
         if (dst_as_state && other_src_as_state) {
             if (other_info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
-                const char *vuid = error_obj.location.function == Func::vkCmdBuildAccelerationStructuresKHR
+                const char* vuid = error_obj.location.function == Func::vkCmdBuildAccelerationStructuresKHR
                                        ? "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03701"
                                    : error_obj.location.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
                                        ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03701"
@@ -196,7 +196,7 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectLi
 
         // Validate that there is no destination acceleration structures' memory overlaps
         if (dst_as_state && other_dst_as_state) {
-            const char *vuid = error_obj.location.function == Func::vkCmdBuildAccelerationStructuresKHR
+            const char* vuid = error_obj.location.function == Func::vkCmdBuildAccelerationStructuresKHR
                                    ? "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702"
                                : error_obj.location.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
                                    ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03702"
@@ -212,8 +212,8 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectLi
 }
 
 bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing(
-    VkCommandBuffer cmd_buffer, uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR *p_infos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *pp_range_infos, const Location &loc) const {
+    VkCommandBuffer cmd_buffer, uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR* p_infos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* pp_range_infos, const Location& loc) const {
     assert(loc.function != Func::vkBuildAccelerationStructuresKHR);
 
     bool skip = false;
@@ -229,7 +229,7 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
     std::vector<AddressRange> address_ranges;
     address_ranges.reserve(3 * info_count);
 
-    const auto insert_address = [](std::vector<AddressRange> &address_ranges, const AddressRange address_range) {
+    const auto insert_address = [](std::vector<AddressRange>& address_ranges, const AddressRange address_range) {
         std::optional<AddressRange> overlapped_range = std::nullopt;
         auto insert_pos =
             std::lower_bound(address_ranges.begin(), address_ranges.end(), address_range,
@@ -383,7 +383,7 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
         // Do not attempt looking for memory overlaps here if any buffer associated to scratch address is sparse
         const auto scratch_buffers = GetBuffersByAddress(info.scratchData.deviceAddress);
         const bool any_scratch_sparse = std::any_of(scratch_buffers.begin(), scratch_buffers.end(),
-                                                    [](const vvl::Buffer *buffer) { return buffer && buffer->sparse; });
+                                                    [](const vvl::Buffer* buffer) { return buffer && buffer->sparse; });
         if (!any_scratch_sparse) {
             const VkDeviceSize assumed_scratch_size =
                 rt::ComputeScratchSize(rt::BuildType::Device, device, info, pp_range_infos[info_i]);
@@ -446,8 +446,8 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
 }
 
 bool CoreChecks::PreCallValidateGetAccelerationStructureDeviceAddressKHR(VkDevice device,
-                                                                         const VkAccelerationStructureDeviceAddressInfoKHR *pInfo,
-                                                                         const ErrorObject &error_obj) const {
+                                                                         const VkAccelerationStructureDeviceAddressInfoKHR* pInfo,
+                                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkGetAccelerationStructureDeviceAddressKHR-accelerationStructure-08935", device, error_obj.location,
@@ -524,7 +524,7 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
     const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges, const Location& info_loc) const {
     bool skip = false;
 
-    const auto pick_vuid = [&info_loc](const char *direct_build_vu, const char *indirect_build_vu) -> const char * {
+    const auto pick_vuid = [&info_loc](const char* direct_build_vu, const char* indirect_build_vu) -> const char* {
         return info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR ? direct_build_vu : indirect_build_vu;
     };
 
@@ -549,13 +549,13 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
     for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
         const Location p_geom_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
         const Location p_geom_geom_loc = p_geom_loc.dot(Field::geometry);
-        const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
+        const VkAccelerationStructureGeometryKHR& geom = rt::GetGeometry(info, geom_i);
         const uint32_t geometry_build_range_primitive_count =
             geometry_build_ranges ? geometry_build_ranges[geom_i].primitiveCount : 0;
 
         if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
             const Location p_geom_geom_triangles_loc = p_geom_geom_loc.dot(Field::triangles);
-            const auto &triangles = geom.geometry.triangles;
+            const auto& triangles = geom.geometry.triangles;
 
             if (geometry_build_range_primitive_count > 0) {
                 if (triangles.vertexData.deviceAddress == 0) {
@@ -618,7 +618,7 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
                 skip |= buffer_check(triangles.transformData, p_geom_geom_triangles_loc.dot(Field::transformData));
             }
 
-            if (const auto *micromap =
+            if (const auto* micromap =
                     vku::FindStructInPNextChain<VkAccelerationStructureTrianglesOpacityMicromapEXT>(triangles.pNext)) {
                 if (micromap->indexType == VK_INDEX_TYPE_NONE_KHR) {
                     if (!micromap->indexBuffer.deviceAddress) {
@@ -641,7 +641,7 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
             if (geometry_build_range_primitive_count > 0) {
                 const Location instances_loc = p_geom_geom_loc.dot(Field::instances);
                 const Location instances_data_loc = instances_loc.dot(Field::data);
-                const auto &instances = geom.geometry.instances;
+                const auto& instances = geom.geometry.instances;
                 if (instances.data.deviceAddress == 0) {
                     skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03813",
                                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03813"),
@@ -654,7 +654,7 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
             if (geometry_build_range_primitive_count > 0) {
                 const Location aabbs_loc = p_geom_geom_loc.dot(Field::aabbs);
                 const Location aabbs_data_loc = aabbs_loc.dot(Field::data);
-                const auto &aabbs = geom.geometry.aabbs;
+                const auto& aabbs = geom.geometry.aabbs;
 
                 if (aabbs.data.deviceAddress == 0) {
                     skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03811",
@@ -666,7 +666,7 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
             }
         } else if (geom.geometryType == VK_GEOMETRY_TYPE_SPHERES_NV) {
             const Location p_geom_geom_spheres_loc = p_geom_geom_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV);
-            auto sphere_struct = reinterpret_cast<VkAccelerationStructureGeometrySpheresDataNV const *>(geom.pNext);
+            auto sphere_struct = reinterpret_cast<VkAccelerationStructureGeometrySpheresDataNV const*>(geom.pNext);
             ASSERT_AND_RETURN_SKIP(sphere_struct);
 
             if (geometry_build_range_primitive_count > 0) {
@@ -731,7 +731,7 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
             const Location p_geom_geom_linear_spheres_loc =
                 p_geom_geom_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV);
             auto sphere_linear_struct =
-                reinterpret_cast<VkAccelerationStructureGeometryLinearSweptSpheresDataNV const *>(geom.pNext);
+                reinterpret_cast<VkAccelerationStructureGeometryLinearSweptSpheresDataNV const*>(geom.pNext);
             ASSERT_AND_RETURN_SKIP(sphere_linear_struct);
 
             if (geometry_build_range_primitive_count > 0) {
@@ -1018,8 +1018,8 @@ bool CoreChecks::ValidateAccelerationStructureBuildDst(const vvl::AccelerationSt
 }
 
 bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const ErrorObject& error_obj) const {
     using vvl::range;
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -1092,8 +1092,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
 
 bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
-    const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const ErrorObject &error_obj) const {
+    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeferredOperation(device, deferredOperation, error_obj.location.dot(Field::deferredOperation),
                                       "VUID-vkBuildAccelerationStructuresKHR-deferredOperation-03678");
@@ -1184,7 +1184,7 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
         }
 
         for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
-            const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
+            const VkAccelerationStructureGeometryKHR& geom = rt::GetGeometry(info, geom_i);
 
             if (geom.geometryType != VK_GEOMETRY_TYPE_INSTANCES_KHR) {
                 continue;
@@ -1199,7 +1199,7 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
                              "vkCreateAccelerationStructure2KHR (needs to be created with vkCreateAccelerationStructureKHR)");
             }
 
-            const VkAccelerationStructureBuildRangeInfoKHR &build_range = ppBuildRangeInfos[info_i][geom_i];
+            const VkAccelerationStructureBuildRangeInfoKHR& build_range = ppBuildRangeInfos[info_i][geom_i];
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && src_as_state &&
                 src_as_state->build_info_khr.has_value()) {
                 if (geom_i < src_as_state->build_range_infos.size()) {
@@ -1220,7 +1220,7 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
                 if (!geom.geometry.instances.data.hostAddress) {
                     continue;
                 }
-                const VkAccelerationStructureInstanceKHR *instance = nullptr;
+                const VkAccelerationStructureInstanceKHR* instance = nullptr;
                 if (geom.geometry.instances.arrayOfPointers) {
                     auto instance_pointers_array = reinterpret_cast<VkAccelerationStructureInstanceKHR const* const*>(
                         geom.geometry.instances.data.hostAddress);
@@ -1271,11 +1271,11 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
 }
 
 bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                                          const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-                                                                          const VkDeviceAddress *pIndirectDeviceAddresses,
-                                                                          const uint32_t *pIndirectStrides,
-                                                                          const uint32_t *const *ppMaxPrimitiveCounts,
-                                                                          const ErrorObject &error_obj) const {
+                                                                          const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                                                          const VkDeviceAddress* pIndirectDeviceAddresses,
+                                                                          const uint32_t* pIndirectStrides,
+                                                                          const uint32_t* const* ppMaxPrimitiveCounts,
+                                                                          const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -1324,8 +1324,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
 }
 
 bool CoreChecks::PreCallValidateDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                const ErrorObject &error_obj) const {
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto as_state = Get<vvl::AccelerationStructureKHR>(accelerationStructure)) {
         skip |= ValidateObjectNotInUse(as_state.get(), error_obj.location,
@@ -1335,9 +1335,9 @@ bool CoreChecks::PreCallValidateDestroyAccelerationStructureKHR(VkDevice device,
 }
 
 bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevice device, uint32_t accelerationStructureCount,
-                                                                         const VkAccelerationStructureKHR *pAccelerationStructures,
-                                                                         VkQueryType queryType, size_t dataSize, void *pData,
-                                                                         size_t stride, const ErrorObject &error_obj) const {
+                                                                         const VkAccelerationStructureKHR* pAccelerationStructures,
+                                                                         VkQueryType queryType, size_t dataSize, void* pData,
+                                                                         size_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
     for (uint32_t i = 0; i < accelerationStructureCount; ++i) {
         const Location as_loc = error_obj.location.dot(Field::pAccelerationStructures, i);
@@ -1371,14 +1371,14 @@ bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevic
 }
 
 bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
-    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR *pAccelerationStructures,
-    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures,
+    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
     ASSERT_AND_RETURN_SKIP(query_pool_state);
-    const auto &query_pool_ci = query_pool_state->create_info;
+    const auto& query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType != queryType) {
         skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryPool-02493", commandBuffer,
                          error_obj.location.dot(Field::queryType),
@@ -1402,20 +1402,20 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
         skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *as_state->buffer_state, as_loc.dot(Field::buffer),
                                               "VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-buffer-03736");
 
-            if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR && as_state->build_info_khr.has_value()) {
-                if (!(as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
-                    skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431",
-                                     commandBuffer, as_loc,
-                                     "was built with %s, but queryType is VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR.",
-                                     string_VkBuildAccelerationStructureFlagsKHR(as_state->build_info_khr->flags).c_str());
-                }
+        if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR && as_state->build_info_khr.has_value()) {
+            if (!(as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
+                skip |=
+                    LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431", commandBuffer,
+                             as_loc, "was built with %s, but queryType is VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR.",
+                             string_VkBuildAccelerationStructureFlagsKHR(as_state->build_info_khr->flags).c_str());
             }
+        }
     }
     return skip;
 }
 
-bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerationStructureInfoKHR &as_info,
-                                                          const VulkanTypedHandle &handle, const Location &info_loc) const {
+bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerationStructureInfoKHR& as_info,
+                                                          const VulkanTypedHandle& handle, const Location& info_loc) const {
     bool skip = false;
 
     auto src_as_state = Get<vvl::AccelerationStructureKHR>(as_info.src);
@@ -1459,8 +1459,8 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
 }
 
 bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                                const ErrorObject &error_obj) const {
+                                                                const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                                const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -1471,8 +1471,8 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuffer 
 }
 
 bool CoreChecks::PreCallValidateDestroyDeferredOperationKHR(VkDevice device, VkDeferredOperationKHR operation,
-                                                            const VkAllocationCallbacks *pAllocator,
-                                                            const ErrorObject &error_obj) const {
+                                                            const VkAllocationCallbacks* pAllocator,
+                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeferredOperation(device, operation, error_obj.location.dot(Field::operation),
                                       "VUID-vkDestroyDeferredOperationKHR-operation-03436");
@@ -1480,8 +1480,8 @@ bool CoreChecks::PreCallValidateDestroyDeferredOperationKHR(VkDevice device, VkD
 }
 
 bool CoreChecks::PreCallValidateCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
-                                                             const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                             const ErrorObject &error_obj) const {
+                                                             const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeferredOperation(device, deferredOperation, error_obj.location.dot(Field::deferredOperation),
                                       "VUID-vkCopyAccelerationStructureKHR-deferredOperation-03678");
@@ -1520,8 +1520,8 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureKHR(VkDevice device, Vk
 }
 
 bool CoreChecks::PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
-                                                                     const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
+                                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeferredOperation(device, deferredOperation, error_obj.location.dot(Field::deferredOperation),
                                       "VUID-vkCopyAccelerationStructureToMemoryKHR-deferredOperation-03678");
@@ -1548,8 +1548,8 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice de
 }
 
 bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
-                                                                        const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
-                                                                        const ErrorObject &error_obj) const {
+                                                                        const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
+                                                                        const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -1579,8 +1579,8 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkComman
 }
 
 bool CoreChecks::PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
-                                                                     const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
+                                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeferredOperation(device, deferredOperation, error_obj.location.dot(Field::deferredOperation),
                                       "VUID-vkCopyMemoryToAccelerationStructureKHR-deferredOperation-03678");
@@ -1603,8 +1603,8 @@ bool CoreChecks::PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevice de
 }
 
 bool CoreChecks::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                        const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
-                                                                        const ErrorObject &error_obj) const {
+                                                                        const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
+                                                                        const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -1626,9 +1626,9 @@ bool CoreChecks::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkComman
 }
 
 // Calculates the total number of shader groups taking libraries into account.
-static uint32_t CalcTotalShaderGroupCount(const CoreChecks &validator, const vvl::Pipeline &pipeline) {
+static uint32_t CalcTotalShaderGroupCount(const CoreChecks& validator, const vvl::Pipeline& pipeline) {
     uint32_t total = 0;
-    const vku::safe_VkRayTracingPipelineCreateInfoCommon &create_info = pipeline.RayTracingCreateInfo();
+    const vku::safe_VkRayTracingPipelineCreateInfoCommon& create_info = pipeline.RayTracingCreateInfo();
     total = create_info.groupCount;
 
     if (create_info.pLibraryInfo) {
@@ -1642,8 +1642,8 @@ static uint32_t CalcTotalShaderGroupCount(const CoreChecks &validator, const vvl
 }
 
 bool CoreChecks::PreCallValidateGetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup,
-                                                                   uint32_t groupCount, size_t dataSize, void *pData,
-                                                                   const ErrorObject &error_obj) const {
+                                                                   uint32_t groupCount, size_t dataSize, void* pData,
+                                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     auto pipeline_ptr = Get<vvl::Pipeline>(pipeline);
     ASSERT_AND_RETURN_SKIP(pipeline_ptr);
@@ -1654,7 +1654,7 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupHandlesKHR(VkDevice devi
         return skip;
     }
 
-    const vvl::Pipeline &pipeline_state = *pipeline_ptr;
+    const vvl::Pipeline& pipeline_state = *pipeline_ptr;
     if (pipeline_state.create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) {
         if (!enabled_features.pipelineLibraryGroupHandles) {
             skip |= LogError("VUID-vkGetRayTracingShaderGroupHandlesKHR-pipeline-07828", pipeline,
@@ -1692,8 +1692,8 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupHandlesKHR(VkDevice devi
 
 bool CoreChecks::PreCallValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline,
                                                                                 uint32_t firstGroup, uint32_t groupCount,
-                                                                                size_t dataSize, void *pData,
-                                                                                const ErrorObject &error_obj) const {
+                                                                                size_t dataSize, void* pData,
+                                                                                const ErrorObject& error_obj) const {
     bool skip = false;
     if (dataSize < (phys_dev_ext_props.ray_tracing_props_khr.shaderGroupHandleCaptureReplaySize * groupCount)) {
         skip |= LogError("VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-dataSize-03484", device,
@@ -1746,14 +1746,14 @@ bool CoreChecks::PreCallValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR(
 }
 
 bool CoreChecks::PreCallValidateCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmd(*cb_state, error_obj.location);
 }
 
-static vku::safe_VkRayTracingShaderGroupCreateInfoKHR *GetRayTracingShaderGroup(const CoreChecks &validator,
-                                                                                const vvl::Pipeline &pipeline, uint32_t group_i) {
-    const vku::safe_VkRayTracingPipelineCreateInfoCommon &create_info = pipeline.RayTracingCreateInfo();
+static vku::safe_VkRayTracingShaderGroupCreateInfoKHR* GetRayTracingShaderGroup(const CoreChecks& validator,
+                                                                                const vvl::Pipeline& pipeline, uint32_t group_i) {
+    const vku::safe_VkRayTracingPipelineCreateInfoCommon& create_info = pipeline.RayTracingCreateInfo();
     // Target group is in currently explored pipeline
     if (group_i < create_info.groupCount) {
         return &create_info.pGroups[group_i];
@@ -1775,7 +1775,7 @@ static vku::safe_VkRayTracingShaderGroupCreateInfoKHR *GetRayTracingShaderGroup(
 
 bool CoreChecks::PreCallValidateGetRayTracingShaderGroupStackSizeKHR(VkDevice device, VkPipeline pipeline, uint32_t group,
                                                                      VkShaderGroupShaderKHR groupShader,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     auto pipeline_state = Get<vvl::Pipeline>(pipeline);
     ASSERT_AND_RETURN_SKIP(pipeline_state);
@@ -1785,7 +1785,7 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupStackSizeKHR(VkDevice de
                          error_obj.location.dot(Field::pipeline), "is a %s pipeline.",
                          string_VkPipelineBindPoint(pipeline_state->pipeline_type));
     } else {
-        const auto &create_info = pipeline_state->RayTracingCreateInfo();
+        const auto& create_info = pipeline_state->RayTracingCreateInfo();
         const uint32_t total_group_count = CalcTotalShaderGroupCount(*this, *pipeline_state);
         if (group >= total_group_count) {
             skip |= LogError(
@@ -1794,7 +1794,7 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupStackSizeKHR(VkDevice de
                 " and %" PRIu32 " got added from pLibraryInfo).",
                 group, create_info.groupCount, total_group_count - create_info.groupCount);
         } else {
-            const auto *group_info = GetRayTracingShaderGroup(*this, *pipeline_state, group);
+            const auto* group_info = GetRayTracingShaderGroup(*this, *pipeline_state, group);
             ASSERT_AND_RETURN_SKIP(group_info);
             bool unused_group = false;
             switch (groupShader) {
@@ -1834,9 +1834,9 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupStackSizeKHR(VkDevice de
     return skip;
 }
 
-bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer &cb_state, const Location &table_loc,
-                                                      const char *vuid_binding_table_flag,
-                                                      const VkStridedDeviceAddressRegionKHR &binding_table) const {
+bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer& cb_state, const Location& table_loc,
+                                                      const char* vuid_binding_table_flag,
+                                                      const VkStridedDeviceAddressRegionKHR& binding_table) const {
     bool skip = false;
 
     if (binding_table.deviceAddress == 0 || binding_table.size == 0) {
@@ -1848,13 +1848,13 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer &
 
     BufferAddressValidation<3> buffer_address_validator = {{{
         {vuid_binding_table_flag,
-         [](const vvl::Buffer &buffer_state) {
+         [](const vvl::Buffer& buffer_state) {
              return (static_cast<uint32_t>(buffer_state.usage) & VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR) == 0;
          },
          []() { return "The following buffers are missing VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR"; }, kUsageErrorMsgBuffer},
 
         {"VUID-VkStridedDeviceAddressRegionKHR-size-04631",
-         [&requested_range](const vvl::Buffer &buffer_state) {
+         [&requested_range](const vvl::Buffer& buffer_state) {
              const auto buffer_address_range = buffer_state.DeviceAddressRange();
              return !buffer_address_range.includes(requested_range);
          },
@@ -1865,7 +1865,7 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer &
          kEmptyErrorMsgBuffer},
 
         {"VUID-VkStridedDeviceAddressRegionKHR-size-04632",
-         [&binding_table](const vvl::Buffer &buffer_state) { return binding_table.stride > buffer_state.create_info.size; },
+         [&binding_table](const vvl::Buffer& buffer_state) { return binding_table.stride > buffer_state.create_info.size; },
          [table_loc, &binding_table]() {
              return "The " + table_loc.Fields() + "->stride (" + std::to_string(binding_table.stride) +
                     ") does not fit in any buffer";
@@ -1880,8 +1880,8 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer &
     return skip;
 }
 
-bool CoreChecks::ValidateDeferredOperation(VkDevice device, VkDeferredOperationKHR deferred_operation, const Location &loc,
-                                           const char *vuid) const {
+bool CoreChecks::ValidateDeferredOperation(VkDevice device, VkDeferredOperationKHR deferred_operation, const Location& loc,
+                                           const char* vuid) const {
     // validate in core check because need to make sure it is a valid VkDeferredOperationKHR object
     bool skip = false;
     if (deferred_operation != VK_NULL_HANDLE) {

--- a/layers/core_checks/cc_ray_tracing_nv.cpp
+++ b/layers/core_checks/cc_ray_tracing_nv.cpp
@@ -134,7 +134,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
     }
 
     if (pInfo != nullptr && pInfo->geometryCount > phys_dev_ext_props.ray_tracing_props_nv.maxGeometryCount) {
-        skip |= LogError("VUID-vkCmdBuildAccelerationStructureNV-geometryCount-02241", commandBuffer, error_obj.location.dot(Field::pInfo).dot(Field::geometryCount),
+        skip |= LogError("VUID-vkCmdBuildAccelerationStructureNV-geometryCount-02241", commandBuffer,
+                         error_obj.location.dot(Field::pInfo).dot(Field::geometryCount),
                          "geometryCount [%" PRIu32
                          "] must be less than or equal to "
                          "VkPhysicalDeviceRayTracingPropertiesNV::maxGeometryCount.",
@@ -579,13 +580,12 @@ bool CoreChecks::PreCallValidateCmdBuildPartitionedAccelerationStructuresNV(
                 const vvl::range<VkDeviceAddress> dst_address_range = dst_buffer_state->DeviceAddressRange();
                 if (src_address_range.intersects(dst_address_range)) {
                     const LogObjectList objlist(commandBuffer, src_buffer_state->Handle(), dst_buffer_state->Handle());
-                    skip |=
-                        LogError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10549", objlist,
-                                    error_obj.location.dot(Field::pBuildInfo).dot(Field::srcAccelerationStructureData),
-                                    "(%s) address range %s intersects "
-                                    "dstAccelerationStructureData (%s) address range %s",
-                                    FormatHandle(src_buffer_state->Handle()).c_str(), string_range_hex(src_address_range).c_str(),
-                                    FormatHandle(dst_buffer_state->Handle()).c_str(), string_range_hex(dst_address_range).c_str());
+                    skip |= LogError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10549", objlist,
+                                     error_obj.location.dot(Field::pBuildInfo).dot(Field::srcAccelerationStructureData),
+                                     "(%s) address range %s intersects "
+                                     "dstAccelerationStructureData (%s) address range %s",
+                                     FormatHandle(src_buffer_state->Handle()).c_str(), string_range_hex(src_address_range).c_str(),
+                                     FormatHandle(dst_buffer_state->Handle()).c_str(), string_range_hex(dst_address_range).c_str());
                 }
             }
         }

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -56,8 +56,8 @@ bool CoreChecks::ValidateAttachmentCompatibility(const VulkanTypedHandle& rp1_ob
                                                  uint32_t primary_attachment, uint32_t secondary_attachment,
                                                  const Location& caller_loc, const Location& attachment_loc) const {
     bool skip = false;
-    const auto &primary_pass_ci = rp1_state.create_info;
-    const auto &secondary_pass_ci = rp2_state.create_info;
+    const auto& primary_pass_ci = rp1_state.create_info;
+    const auto& secondary_pass_ci = rp2_state.create_info;
     if (primary_pass_ci.attachmentCount <= primary_attachment) {
         primary_attachment = VK_ATTACHMENT_UNUSED;
     }
@@ -127,8 +127,8 @@ bool CoreChecks::ValidateSubpassCompatibility(const VulkanTypedHandle& rp1_objec
                                               const VulkanTypedHandle& rp2_object, const vvl::RenderPass& rp2_state,
                                               const int subpass, const Location& loc) const {
     bool skip = false;
-    const auto &primary_desc = rp1_state.create_info.pSubpasses[subpass];
-    const auto &secondary_desc = rp2_state.create_info.pSubpasses[subpass];
+    const auto& primary_desc = rp1_state.create_info.pSubpasses[subpass];
+    const auto& secondary_desc = rp2_state.create_info.pSubpasses[subpass];
     const Location subpass_loc(Func::Empty, Field::pSubpasses, subpass);
 
     uint32_t max_input_attachment_count = std::max(primary_desc.inputAttachmentCount, secondary_desc.inputAttachmentCount);
@@ -262,8 +262,8 @@ bool CoreChecks::ValidateDependencyCompatibility(const VulkanTypedHandle& rp1_ob
                                                  const uint32_t dependency, const Location& loc) const {
     bool skip = false;
 
-    const auto &primary_dep = rp1_state.create_info.pDependencies[dependency];
-    const auto &secondary_dep = rp2_state.create_info.pDependencies[dependency];
+    const auto& primary_dep = rp1_state.create_info.pDependencies[dependency];
+    const auto& secondary_dep = rp2_state.create_info.pDependencies[dependency];
 
     VkPipelineStageFlags2 primary_src_stage_mask = primary_dep.srcStageMask;
     VkPipelineStageFlags2 primary_dst_stage_mask = primary_dep.dstStageMask;
@@ -489,8 +489,8 @@ bool CoreChecks::ValidateRenderPassCompatibility(const VulkanTypedHandle& rp1_ob
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto rp_state = Get<vvl::RenderPass>(renderPass)) {
         skip |= ValidateObjectNotInUse(rp_state.get(), error_obj.location, "VUID-vkDestroyRenderPass-renderPass-00873");
@@ -512,10 +512,10 @@ static bool FormatSpecificLoadAndStoreOpSettings(VkFormat format, T color_depth_
     return ((check_color_depth_load_op && (color_depth_op == op)) || (check_stencil_load_op && (stencil_op == op)));
 }
 
-bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                            VkSubpassContents contents, const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                            VkSubpassContents contents, const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     const auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     const auto fb_state = Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
     ASSERT_AND_RETURN_SKIP(rp_state && fb_state);
@@ -531,7 +531,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
         for (uint32_t i = 0; i < sample_locations_begin_info->attachmentInitialSampleLocationsCount; ++i) {
             const Location sampler_loc =
                 rp_begin_loc.pNext(Struct::VkRenderPassSampleLocationsBeginInfoEXT, Field::pAttachmentInitialSampleLocations, i);
-            const VkAttachmentSampleLocationsEXT &sample_location =
+            const VkAttachmentSampleLocationsEXT& sample_location =
                 sample_locations_begin_info->pAttachmentInitialSampleLocations[i];
             skip |= ValidateSampleLocationsInfo(sample_location.sampleLocationsInfo, sampler_loc.dot(Field::sampleLocationsInfo));
             if (sample_location.attachmentIndex >= rp_state->create_info.attachmentCount) {
@@ -546,7 +546,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
         for (uint32_t i = 0; i < sample_locations_begin_info->postSubpassSampleLocationsCount; ++i) {
             const Location sampler_loc =
                 rp_begin_loc.pNext(Struct::VkRenderPassSampleLocationsBeginInfoEXT, Field::pPostSubpassSampleLocations, i);
-            const VkSubpassSampleLocationsEXT &sample_location = sample_locations_begin_info->pPostSubpassSampleLocations[i];
+            const VkSubpassSampleLocationsEXT& sample_location = sample_locations_begin_info->pPostSubpassSampleLocations[i];
             skip |= ValidateSampleLocationsInfo(sample_location.sampleLocationsInfo, sampler_loc.dot(Field::sampleLocationsInfo));
             if (sample_location.subpassIndex >= rp_state->create_info.subpassCount) {
                 const LogObjectList objlist(commandBuffer, pRenderPassBegin->renderPass);
@@ -626,7 +626,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
 
     if (contents == VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_KHR && !enabled_features.nestedCommandBuffer &&
         !enabled_features.maintenance7) {
-        const char *vuid = error_obj.location.function == Func::vkCmdBeginRenderPass ? "VUID-vkCmdBeginRenderPass-contents-09640"
+        const char* vuid = error_obj.location.function == Func::vkCmdBeginRenderPass ? "VUID-vkCmdBeginRenderPass-contents-09640"
                                                                                      : "VUID-VkSubpassBeginInfo-contents-09382";
         skip |= LogError(vuid, commandBuffer, error_obj.location.dot(Field::contents),
                          "is VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_KHR, but nestedCommandBuffer nor "
@@ -649,34 +649,34 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
         }
 
         skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(commandBuffer, *counters_begin_info, objlist,
-                                                                    rp_state->create_info.subpassCount, layer_or_view_count,
-                                                                    pRenderPassBegin->renderArea, rp_begin_loc);
+                                                                       rp_state->create_info.subpassCount, layer_or_view_count,
+                                                                       pRenderPassBegin->renderArea, rp_begin_loc);
     }
 
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                   VkSubpassContents contents, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                   VkSubpassContents contents, const ErrorObject& error_obj) const {
     return ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                       const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                       const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                       const ErrorObject& error_obj) const {
     return PreCallValidateCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                    const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                    const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                    const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                    const ErrorObject& error_obj) const {
     return ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, pSubpassBeginInfo->contents, error_obj);
 }
 
-bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(VkCommandBuffer commandBuffer, const VkRenderPassPerformanceCountersByRegionBeginInfoARM &counters_begin_info,
-                                                                        const LogObjectList &objlist, uint32_t subpass_count,
-                                                                        uint32_t layer_or_view_count, VkRect2D render_area,
-                                                                        const Location &begin_loc) const {
+bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(
+    VkCommandBuffer commandBuffer, const VkRenderPassPerformanceCountersByRegionBeginInfoARM& counters_begin_info,
+    const LogObjectList& objlist, uint32_t subpass_count, uint32_t layer_or_view_count, VkRect2D render_area,
+    const Location& begin_loc) const {
     bool skip = false;
 
     if (counters_begin_info.counterAddressCount != subpass_count * layer_or_view_count) {
@@ -703,8 +703,10 @@ bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(VkComman
         const auto buffer_states = GetBuffersByAddress(counters_begin_info.pCounterAddresses[i]);
 
         for (auto& buffer_state : buffer_states) {
-            skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, begin_loc.pNext(Struct::VkRenderPassPerformanceCountersByRegionBeginInfoARM, Field::pCounterAddresses),
-                                                  "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11816");
+            skip |= ValidateMemoryIsBoundToBuffer(
+                commandBuffer, *buffer_state,
+                begin_loc.pNext(Struct::VkRenderPassPerformanceCountersByRegionBeginInfoARM, Field::pCounterAddresses),
+                "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11816");
         }
 
         auto first_buffer = *buffer_states.begin();
@@ -712,7 +714,8 @@ bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(VkComman
         auto address = counters_begin_info.pCounterAddresses[i];
         const vvl::range<VkDeviceSize> counter_address_range(address, address + counter_buffer_size);
         if (!buffer_range.includes(counter_address_range)) {
-            skip |= LogError("VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11817", objlist, begin_loc.pNext(Struct::VkRenderPassPerformanceCountersByRegionBeginInfoARM, Field::pCounterAddresses),
+            skip |= LogError("VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11817", objlist,
+                             begin_loc.pNext(Struct::VkRenderPassPerformanceCountersByRegionBeginInfoARM, Field::pCounterAddresses),
                              "%s does not fully fit into the address range of the buffer %s.",
                              string_range_hex(counter_address_range).c_str(), FormatHandle(*first_buffer).c_str());
         }
@@ -733,17 +736,17 @@ bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(VkComman
     return skip;
 }
 
-bool CoreChecks::ValidateCmdEndRenderPass(const vvl::CommandBuffer& cb_state, const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateCmdEndRenderPass(const vvl::CommandBuffer& cb_state, const ErrorObject& error_obj) const {
     bool skip = false;
     const bool use_rp2 = error_obj.location.function != Func::vkCmdEndRenderPass;
-    const char *vuid;
+    const char* vuid;
 
     skip |= ValidateCmd(cb_state, error_obj.location);
 
-    const auto *rp_state_ptr = cb_state.active_render_pass.get();
+    const auto* rp_state_ptr = cb_state.active_render_pass.get();
     if (!rp_state_ptr) return skip;
 
-    const auto &rp_state = *rp_state_ptr;
+    const auto& rp_state = *rp_state_ptr;
     if (!rp_state.UsesDynamicRendering() && (cb_state.GetActiveSubpass() != rp_state.create_info.subpassCount - 1)) {
         vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-03103" : "VUID-vkCmdEndRenderPass-None-00910";
         const LogObjectList objlist(cb_state.Handle(), rp_state.Handle());
@@ -763,7 +766,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(const vvl::CommandBuffer& cb_state, co
         skip |= LogError(vuid, objlist, error_obj.location, "transform feedback is active.");
     }
 
-    for (const auto &query : cb_state.render_pass_queries) {
+    for (const auto& query : cb_state.render_pass_queries) {
         vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-07005" : "VUID-vkCmdEndRenderPass-None-07004";
         const LogObjectList objlist(cb_state.Handle(), rp_state.Handle(), query.pool);
         skip |= LogError(vuid, objlist, error_obj.location,
@@ -774,9 +777,9 @@ bool CoreChecks::ValidateCmdEndRenderPass(const vvl::CommandBuffer& cb_state, co
     return skip;
 }
 
-bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &cb_state, const vvl::RenderPass &rp_state,
-                                                     const VkRenderPassFragmentDensityMapOffsetEndInfoEXT &fdm_offset_end_info,
-                                                     const Location &end_info_loc) const {
+bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
+                                                     const VkRenderPassFragmentDensityMapOffsetEndInfoEXT& fdm_offset_end_info,
+                                                     const Location& end_info_loc) const {
     bool skip = false;
 
     if ((!enabled_features.fragmentDensityMapOffset) || (!enabled_features.fragmentDensityMap)) {
@@ -789,7 +792,7 @@ bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &c
     }
 
     for (uint32_t i = 0; i < fdm_offset_end_info.fragmentDensityOffsetCount; i++) {
-        const VkOffset2D &layer_offset = fdm_offset_end_info.pFragmentDensityOffsets[i];
+        const VkOffset2D& layer_offset = fdm_offset_end_info.pFragmentDensityOffsets[i];
         if (layer_offset.x != 0 || layer_offset.y != 0) {
             const uint32_t width = phys_dev_ext_props.fragment_density_map_offset_props.fragmentDensityOffsetGranularity.width;
             if (!IsIntegerMultipleOf(layer_offset.x, width)) {
@@ -814,8 +817,8 @@ bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &c
     }
 
     for (uint32_t i = 0; i < cb_state.active_attachments.size(); ++i) {
-        const AttachmentInfo &attachment_info = cb_state.active_attachments[i];
-        const vvl::ImageView *attachment = attachment_info.image_view;
+        const AttachmentInfo& attachment_info = cb_state.active_attachments[i];
+        const vvl::ImageView* attachment = attachment_info.image_view;
         if (!attachment) continue;  // VK_ATTACHMENT_UNUSED
         ASSERT_AND_CONTINUE(attachment->image_state);
 
@@ -934,26 +937,26 @@ bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &c
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+bool CoreChecks::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmdEndRenderPass(cb_state, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
 
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmdEndRenderPass(cb_state, error_obj);
 
-    const auto *rp_state_ptr = cb_state.active_render_pass.get();
+    const auto* rp_state_ptr = cb_state.active_render_pass.get();
     if (rp_state_ptr && pSubpassEndInfo) {
-        const auto *fdm_offset_end_info =
+        const auto* fdm_offset_end_info =
             vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapOffsetEndInfoEXT>(pSubpassEndInfo->pNext);
         if (fdm_offset_end_info && fdm_offset_end_info->fragmentDensityOffsetCount != 0) {
             skip |= ValidateFragmentDensityMapOffsetEnd(
@@ -965,23 +968,23 @@ bool CoreChecks::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer,
     return skip;
 }
 
-bool CoreChecks::VerifyRenderAreaBounds(const VkRenderPassBeginInfo &begin_info, const Location &begin_info_loc) const {
+bool CoreChecks::VerifyRenderAreaBounds(const VkRenderPassBeginInfo& begin_info, const Location& begin_info_loc) const {
     bool skip = false;
 
-    const auto *device_group_render_pass_begin_info =
+    const auto* device_group_render_pass_begin_info =
         vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(begin_info.pNext);
     const uint32_t device_group_area_count =
         device_group_render_pass_begin_info ? device_group_render_pass_begin_info->deviceRenderAreaCount : 0;
 
     auto framebuffer_state = Get<vvl::Framebuffer>(begin_info.framebuffer);
     ASSERT_AND_RETURN_SKIP(framebuffer_state);
-    const auto *framebuffer_info = &framebuffer_state->create_info;
+    const auto* framebuffer_info = &framebuffer_state->create_info;
     // These VUs depend on count being non-zero, or else acts like struct is not there
     if (device_group_area_count > 0) {
         for (uint32_t i = 0; i < device_group_area_count; ++i) {
             const Location render_area_loc =
                 begin_info_loc.pNext(Struct::VkDeviceGroupRenderPassBeginInfo, Field::pDeviceRenderAreas, i);
-            const auto &deviceRenderArea = device_group_render_pass_begin_info->pDeviceRenderAreas[i];
+            const auto& deviceRenderArea = device_group_render_pass_begin_info->pDeviceRenderAreas[i];
             if (deviceRenderArea.offset.x < 0) {
                 skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166", begin_info.renderPass,
                                  render_area_loc.dot(Field::offset).dot(Field::x), "is negative (%" PRId32 ").",
@@ -1042,10 +1045,10 @@ bool CoreChecks::VerifyRenderAreaBounds(const VkRenderPassBeginInfo &begin_info,
     return skip;
 }
 
-bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBeginInfo &begin_info,
-                                                          const Location &begin_info_loc) const {
+bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBeginInfo& begin_info,
+                                                          const Location& begin_info_loc) const {
     bool skip = false;
-    const auto *render_pass_attachment_begin_info = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(begin_info.pNext);
+    const auto* render_pass_attachment_begin_info = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(begin_info.pNext);
     if (!render_pass_attachment_begin_info || render_pass_attachment_begin_info->attachmentCount == 0) {
         return false;
     }
@@ -1053,7 +1056,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
     const auto framebuffer_state = Get<vvl::Framebuffer>(begin_info.framebuffer);
     ASSERT_AND_RETURN_SKIP(framebuffer_state);
 
-    const auto &framebuffer_create_info = framebuffer_state->create_info;
+    const auto& framebuffer_create_info = framebuffer_state->create_info;
     if ((framebuffer_create_info.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
         const LogObjectList objlist(begin_info.renderPass, begin_info.framebuffer);
         skip |= LogError("VUID-VkRenderPassBeginInfo-framebuffer-03207", objlist,
@@ -1064,7 +1067,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
         return skip;  // not marked as imageless so ignore rest of checks
     }
 
-    const auto *framebuffer_attachments_create_info =
+    const auto* framebuffer_attachments_create_info =
         vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(framebuffer_create_info.pNext);
     if (!framebuffer_attachments_create_info) {
         return skip;
@@ -1083,17 +1086,17 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
 
     auto render_pass_state = Get<vvl::RenderPass>(begin_info.renderPass);
     ASSERT_AND_RETURN_SKIP(render_pass_state);
-    const auto *render_pass_create_info = &render_pass_state->create_info;
+    const auto* render_pass_create_info = &render_pass_state->create_info;
     for (uint32_t i = 0; i < render_pass_attachment_begin_info->attachmentCount; ++i) {
         const Location attachment_loc = begin_info_loc.pNext(Struct::VkRenderPassAttachmentBeginInfo, Field::pAttachments, i);
         auto image_view_state = Get<vvl::ImageView>(render_pass_attachment_begin_info->pAttachments[i]);
         ASSERT_AND_CONTINUE(image_view_state);
 
-        const VkImageViewCreateInfo *image_view_create_info = &image_view_state->create_info;
-        const auto &subresource_range = image_view_state->normalized_subresource_range;
-        const VkFramebufferAttachmentImageInfo *framebuffer_attachment_image_info =
+        const VkImageViewCreateInfo* image_view_create_info = &image_view_state->create_info;
+        const auto& subresource_range = image_view_state->normalized_subresource_range;
+        const VkFramebufferAttachmentImageInfo* framebuffer_attachment_image_info =
             &framebuffer_attachments_create_info->pAttachmentImageInfos[i];
-        const auto *image_create_info = &image_view_state->image_state->create_info;
+        const auto* image_create_info = &image_view_state->image_state->create_info;
         const LogObjectList objlist(begin_info.renderPass, begin_info.framebuffer, image_view_state->Handle(),
                                     image_view_state->image_state->Handle());
 
@@ -1147,7 +1150,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
                              layerCount, i, framebuffer_attachment_image_info->layerCount);
         }
 
-        const auto *image_format_list_create_info =
+        const auto* image_format_list_create_info =
             vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image_create_info->pNext);
         if (image_format_list_create_info) {
             if (image_format_list_create_info->viewFormatCount != framebuffer_attachment_image_info->viewFormatCount) {
@@ -1193,7 +1196,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
         }
 
         const VkSampleCountFlagBits attachment_samples = render_pass_create_info->pAttachments[i].samples;
-        const auto *ms_render_to_single_sample =
+        const auto* ms_render_to_single_sample =
             vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(begin_info.pNext);
         const bool single_sample_enabled = ms_render_to_single_sample &&
                                            ms_render_to_single_sample->multisampledRenderToSingleSampledEnable &&
@@ -1259,12 +1262,12 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
     return skip;
 }
 
-bool CoreChecks::ValidateAttachmentIndex(uint32_t attachment, uint32_t attachment_count, const Location &loc) const {
+bool CoreChecks::ValidateAttachmentIndex(uint32_t attachment, uint32_t attachment_count, const Location& loc) const {
     bool skip = false;
     const bool use_rp2 = loc.function != Func::vkCreateRenderPass;
     assert(attachment != VK_ATTACHMENT_UNUSED);
     if (attachment >= attachment_count) {
-        const char *vuid =
+        const char* vuid =
             use_rp2 ? "VUID-VkRenderPassCreateInfo2-attachment-03051" : "VUID-VkRenderPassCreateInfo-attachment-00834";
         skip |= LogError(vuid, device, loc.dot(Field::attachment),
                          "is %" PRIu32 ", but must be less than the total number of attachments (%" PRIu32 ").", attachment,
@@ -1281,7 +1284,7 @@ enum AttachmentType {
     ATTACHMENT_RESOLVE = 16,
 };
 
-const char *StringAttachmentType(uint8_t type) {
+const char* StringAttachmentType(uint8_t type) {
     switch (type) {
         case ATTACHMENT_COLOR:
             return "color";
@@ -1298,14 +1301,14 @@ const char *StringAttachmentType(uint8_t type) {
     }
 }
 
-bool CoreChecks::AddAttachmentUse(std::vector<uint8_t> &attachment_uses, std::vector<VkImageLayout> &attachment_layouts,
-                                  uint32_t attachment, uint8_t new_use, VkImageLayout new_layout, const Location &loc) const {
+bool CoreChecks::AddAttachmentUse(std::vector<uint8_t>& attachment_uses, std::vector<VkImageLayout>& attachment_layouts,
+                                  uint32_t attachment, uint8_t new_use, VkImageLayout new_layout, const Location& loc) const {
     if (attachment >= attachment_uses.size()) return false; /* out of range, but already reported */
 
     bool skip = false;
-    auto &uses = attachment_uses[attachment];
+    auto& uses = attachment_uses[attachment];
     const bool use_rp2 = loc.function != Func::vkCreateRenderPass;
-    const char *vuid;
+    const char* vuid;
 
     if (uses & new_use) {
         if (attachment_layouts[attachment] != new_layout) {
@@ -1335,16 +1338,16 @@ bool CoreChecks::AddAttachmentUse(std::vector<uint8_t> &attachment_uses, std::ve
 // Handles attachment references regardless of type (input, color, depth, etc)
 // Input attachments have extra VUs associated with them
 bool CoreChecks::ValidateAttachmentReference(VkAttachmentReference2 reference, const VkFormat attachment_format, bool input,
-                                             const Location &loc) const {
+                                             const Location& loc) const {
     bool skip = false;
     const bool use_rp2 = loc.function != Func::vkCreateRenderPass;
-    const char *vuid;
+    const char* vuid;
 
     // Currently all VUs require attachment to not be UNUSED
     assert(reference.attachment != VK_ATTACHMENT_UNUSED);
 
     // currently VkAttachmentReference and VkAttachmentReference2 have no overlapping VUs
-    const auto *attachment_reference_stencil_layout =
+    const auto* attachment_reference_stencil_layout =
         vku::FindStructInPNextChain<VkAttachmentReferenceStencilLayout>(reference.pNext);
     switch (reference.layout) {
         case VK_IMAGE_LAYOUT_UNDEFINED:
@@ -1421,12 +1424,12 @@ bool CoreChecks::ValidateAttachmentReference(VkAttachmentReference2 reference, c
     return skip;
 }
 
-bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2 &create_info,
-                                                   const Location &create_info_loc) const {
+bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2& create_info,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
     const bool use_rp2 = create_info_loc.function != Func::vkCreateRenderPass;
 
-    const auto *fragment_density_map_info =
+    const auto* fragment_density_map_info =
         vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
 
     // Track when we're observing the first use of an attachment
@@ -1434,7 +1437,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
     for (uint32_t i = 0; i < create_info.subpassCount; ++i) {
         const Location subpass_loc = create_info_loc.dot(Field::pSubpasses, i);
-        const VkSubpassDescription2 &subpass = create_info.pSubpasses[i];
+        const VkSubpassDescription2& subpass = create_info.pSubpasses[i];
         const auto ms_render_to_single_sample =
             vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(subpass.pNext);
         const auto subpass_depth_stencil_resolve =
@@ -1447,7 +1450,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
         if (subpass.pipelineBindPoint != VK_PIPELINE_BIND_POINT_GRAPHICS &&
             subpass.pipelineBindPoint != VK_PIPELINE_BIND_POINT_SUBPASS_SHADING_HUAWEI) {
-            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pipelineBindPoint-04953"
+            const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-pipelineBindPoint-04953"
                                        : "VUID-VkSubpassDescription-pipelineBindPoint-04952";
             skip |= LogError(vuid, device, subpass_loc.dot(Field::pipelineBindPoint), "is %s.",
                              string_VkPipelineBindPoint(subpass.pipelineBindPoint));
@@ -1457,7 +1460,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
         // - so we can detect first-use-as-input for VU #00349
         // - if other color or depth/stencil is also input, it limits valid layouts
         for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
-            auto const &attachment_ref = subpass.pInputAttachments[j];
+            auto const& attachment_ref = subpass.pInputAttachments[j];
             const uint32_t attachment_index = attachment_ref.attachment;
             if (attachment_index == VK_ATTACHMENT_UNUSED) {
                 continue;
@@ -1470,13 +1473,13 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             skip |= ValidateAttachmentIndex(attachment_index, create_info.attachmentCount, input_loc);
 
             if (aspect_mask & VK_IMAGE_ASPECT_METADATA_BIT) {
-                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-02801"
+                const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-02801"
                                            : "VUID-VkInputAttachmentAspectReference-aspectMask-01964";
                 skip |= LogError(vuid, device, input_loc.dot(Field::aspectMask), "is %s.",
                                  string_VkImageAspectFlags(aspect_mask).c_str());
             } else if (aspect_mask & (VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT |
                                       VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT)) {
-                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-04563"
+                const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-04563"
                                            : "VUID-VkInputAttachmentAspectReference-aspectMask-02250";
                 skip |= LogError(vuid, device, input_loc.dot(Field::aspectMask), "is %s.",
                                  string_VkImageAspectFlags(aspect_mask).c_str());
@@ -1485,27 +1488,27 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             const VkImageLayout attachment_layout = attachment_ref.layout;
             if (IsValueIn(attachment_layout,
                           {VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL})) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06912" : "VUID-VkSubpassDescription-attachment-06912";
                 skip |= LogError(vuid, device, input_loc.dot(Field::layout), "(%s) is invalid.",
                                  string_VkImageLayout(attachment_layout));
             }
             if (IsValueIn(attachment_layout,
                           {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL})) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06918" : "VUID-VkSubpassDescription-attachment-06918";
                 skip |= LogError(vuid, device, input_loc.dot(Field::layout), "(%s) is invalid.",
                                  string_VkImageLayout(attachment_layout));
             }
             if (attachment_layout == VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06921" : "VUID-VkSubpassDescription-attachment-06921";
                 skip |= LogError(vuid, device, input_loc.dot(Field::layout), "(%s) is invalid.",
                                  string_VkImageLayout(attachment_layout));
             }
 
             if (fragment_density_map_info) {
-                const auto &fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
+                const auto& fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
                 if ((fdm_attachment_index != VK_ATTACHMENT_UNUSED) && (attachment_index == fdm_attachment_index)) {
                     skip |= LogError("VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548", device,
                                      input_loc,
@@ -1516,7 +1519,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
             // safe to dereference pCreateInfo->pAttachments[]
             if (attachment_index < create_info.attachmentCount) {
-                const VkAttachmentDescription2 &attachment_description = create_info.pAttachments[attachment_index];
+                const VkAttachmentDescription2& attachment_description = create_info.pAttachments[attachment_index];
                 const VkFormat attachment_format = attachment_description.format;
                 skip |= ValidateAttachmentReference(attachment_ref, attachment_format, true, input_loc);
 
@@ -1524,7 +1527,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                                          attachment_ref.layout, input_loc);
 
                 {
-                    const char *vuid =
+                    const char* vuid =
                         use_rp2 ? "VUID-VkRenderPassCreateInfo2-attachment-02525" : "VUID-VkRenderPassCreateInfo-pNext-01963";
                     // Assuming no disjoint image since there's no handle
                     skip |= ValidateImageAspectMask(VK_NULL_HANDLE, attachment_format, aspect_mask, false, create_info_loc, vuid);
@@ -1541,7 +1544,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                         used_as_color = (subpass.pColorAttachments[k].attachment == attachment_index);
                     }
                     if (!used_as_depth && !used_as_color && attachment_description.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
-                        const char *vuid =
+                        const char* vuid =
                             use_rp2 ? "VUID-VkSubpassDescription2-loadOp-00846" : "VUID-VkSubpassDescription-loadOp-00846";
                         skip |= LogError(vuid, device, attachment_loc.dot(Field::loadOp), "is VK_ATTACHMENT_LOAD_OP_CLEAR.");
                     }
@@ -1551,10 +1554,10 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                 const VkFormatFeatureFlags2 valid_flags =
                     VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT;
                 const VkFormatFeatureFlags2 format_features = GetPotentialFormatFeatures(attachment_format);
-                const void *pNext = (use_rp2) ? attachment_description.pNext : nullptr;
+                const void* pNext = (use_rp2) ? attachment_description.pNext : nullptr;
                 if ((format_features & valid_flags) == 0 && GetExternalFormat(pNext) == 0) {
                     if (!enabled_features.linearColorAttachment) {
-                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pInputAttachments-02897"
+                        const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-pInputAttachments-02897"
                                                    : "VUID-VkSubpassDescription-pInputAttachments-02647";
                         skip |= LogError(vuid, device, attachment_loc.dot(Field::format),
                                          "%s (referenced by %s) doesn't support "
@@ -1562,7 +1565,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                                          string_VkFormat(attachment_format), input_loc.Fields().c_str(),
                                          string_VkFormatFeatureFlags2(format_features).c_str());
                     } else if ((format_features & VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV) == 0) {
-                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06499"
+                        const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06499"
                                                    : "VUID-VkSubpassDescription-linearColorAttachment-06496";
                         skip |= LogError(vuid, device, attachment_loc.dot(Field::format),
                                          "%s (referenced by %s) doesn't support "
@@ -1602,7 +1605,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             const Location preserve_loc = subpass_loc.dot(Field::preserveAttachmentCount, j);
             const uint32_t preserve_index = subpass.pPreserveAttachments[j];
             if (preserve_index == VK_ATTACHMENT_UNUSED) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-03073" : "VUID-VkSubpassDescription-attachment-00853";
                 skip |= LogError(vuid, device, preserve_loc, "must not be VK_ATTACHMENT_UNUSED.");
             } else {
@@ -1630,7 +1633,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             if (!subpass.pResolveAttachments) {
                 continue;
             }
-            auto const &attachment_ref = subpass.pResolveAttachments[j];
+            auto const& attachment_ref = subpass.pResolveAttachments[j];
             if (attachment_ref.attachment == VK_ATTACHMENT_UNUSED) {
                 continue;
             }
@@ -1642,14 +1645,14 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             const VkImageLayout attachment_layout = attachment_ref.layout;
             if (IsValueIn(attachment_layout,
                           {VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL})) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06914" : "VUID-VkSubpassDescription-attachment-06914";
                 skip |= LogError(vuid, device, resolve_loc.dot(Field::layout), "(%s) is invalid.",
                                  string_VkImageLayout(attachment_layout));
             }
             if (IsValueIn(attachment_layout, {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
                                               VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL})) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06917" : "VUID-VkSubpassDescription-attachment-06917";
                 skip |= LogError(vuid, device, resolve_loc.dot(Field::layout), "(%s) is invalid.",
                                  string_VkImageLayout(attachment_layout));
@@ -1657,20 +1660,20 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             if (IsValueIn(attachment_layout,
                           {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL,
                            VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL})) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06920" : "VUID-VkSubpassDescription-attachment-06920";
                 skip |= LogError(vuid, device, resolve_loc.dot(Field::layout), "(%s) is invalid.",
                                  string_VkImageLayout(attachment_layout));
             }
             if (attachment_layout == VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06923" : "VUID-VkSubpassDescription-attachment-06923";
                 skip |= LogError(vuid, device, resolve_loc.dot(Field::layout), "(%s) is invalid.",
                                  string_VkImageLayout(attachment_layout));
             }
 
             if (fragment_density_map_info) {
-                const auto &fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
+                const auto& fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
                 if ((fdm_attachment_index != VK_ATTACHMENT_UNUSED) && (attachment_ref.attachment == fdm_attachment_index)) {
                     skip |= LogError("VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548", device,
                                      resolve_loc,
@@ -1689,7 +1692,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                 subpass_performs_resolve = true;
 
                 if (create_info.pAttachments[attachment_ref.attachment].samples != VK_SAMPLE_COUNT_1_BIT) {
-                    const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03067"
+                    const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03067"
                                                : "VUID-VkSubpassDescription-pResolveAttachments-00849";
                     skip |= LogError(vuid, device, attachment_loc.dot(Field::samples), "is %s (referenced by %s).",
                                      string_VkSampleCountFlagBits(create_info.pAttachments[attachment_ref.attachment].samples),
@@ -1700,7 +1703,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                 // Can be VK_FORMAT_UNDEFINED with VK_ANDROID_external_format_resolve
                 if ((format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT) == 0 && attachment_format != VK_FORMAT_UNDEFINED) {
                     if (!enabled_features.linearColorAttachment) {
-                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-09343"
+                        const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-09343"
                                                    : "VUID-VkSubpassDescription-pResolveAttachments-02649";
 
                         skip |= LogError(vuid, device, attachment_loc.dot(Field::format),
@@ -1709,7 +1712,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                                          string_VkFormat(attachment_format), resolve_loc.Fields().c_str(),
                                          string_VkFormatFeatureFlags2(format_features).c_str());
                     } else if ((format_features & VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV) == 0) {
-                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06501"
+                        const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06501"
                                                    : "VUID-VkSubpassDescription-linearColorAttachment-06498";
                         skip |= LogError(vuid, device, attachment_loc.dot(Field::format),
                                          "%s (referenced by %s) doesn't support "
@@ -1720,7 +1723,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                 }
 
                 if ((subpass.flags & VK_SUBPASS_DESCRIPTION_CUSTOM_RESOLVE_BIT_EXT) != 0) {
-                    const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-flags-04907" : "VUID-VkSubpassDescription-flags-03341";
+                    const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-flags-04907" : "VUID-VkSubpassDescription-flags-03341";
                     skip |= LogError(vuid, device, resolve_loc,
                                      "contains a reference to attachment %" PRIu32 " instead of being VK_ATTACHMENT_UNUSED.",
                                      attachment_ref.attachment);
@@ -1741,7 +1744,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             const VkImageLayout attachment_layout = subpass.pDepthStencilAttachment->layout;
             if (IsValueIn(attachment_layout,
                           {VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL})) {
-                const char *vuid =
+                const char* vuid =
                     use_rp2 ? "VUID-VkSubpassDescription2-attachment-06915" : "VUID-VkSubpassDescription-attachment-06915";
                 skip |=
                     LogError(vuid, device, ds_loc.dot(Field::layout), "(%s) is invalid.", string_VkImageLayout(attachment_layout));
@@ -1750,14 +1753,14 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
             if (use_rp2 && IsValueIn(attachment_layout,
                                      {VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL})) {
                 if (vku::FindStructInPNextChain<VkAttachmentReferenceStencilLayout>(subpass.pDepthStencilAttachment->pNext)) {
-                    const char *vuid = "VUID-VkSubpassDescription2-attachment-06251";
+                    const char* vuid = "VUID-VkSubpassDescription2-attachment-06251";
                     skip |= LogError(vuid, device, ds_loc.dot(Field::layout), "(%s) is invalid.",
                                      string_VkImageLayout(attachment_layout));
                 }
             }
 
             if (fragment_density_map_info) {
-                const auto &fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
+                const auto& fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
                 if ((fdm_attachment_index != VK_ATTACHMENT_UNUSED) && (attachment == fdm_attachment_index)) {
                     skip |= LogError("VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548", device,
                                      ds_loc,
@@ -1780,7 +1783,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
                 const VkFormatFeatureFlags2 format_features = GetPotentialFormatFeatures(attachment_format);
                 if ((format_features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-                    const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pDepthStencilAttachment-02900"
+                    const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-pDepthStencilAttachment-02900"
                                                : "VUID-VkSubpassDescription-pDepthStencilAttachment-02650";
                     skip |= LogError(vuid, device, attachment_loc.dot(Field::format),
                                      "%s (referenced by %s) doesn't support "
@@ -1916,7 +1919,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
         uint32_t last_sample_count_attachment = VK_ATTACHMENT_UNUSED;
         for (uint32_t j = 0; j < subpass.colorAttachmentCount; ++j) {
-            auto const &attachment_ref = subpass.pColorAttachments[j];
+            auto const& attachment_ref = subpass.pColorAttachments[j];
             const uint32_t attachment_index = attachment_ref.attachment;
             const Location color_loc = subpass_loc.dot(Field::pColorAttachments, j);
             if (attachment_index != VK_ATTACHMENT_UNUSED) {
@@ -1926,14 +1929,14 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                 const VkImageLayout attachment_layout = attachment_ref.layout;
                 if (IsValueIn(attachment_layout,
                               {VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL})) {
-                    const char *vuid =
+                    const char* vuid =
                         use_rp2 ? "VUID-VkSubpassDescription2-attachment-06913" : "VUID-VkSubpassDescription-attachment-06913";
                     skip |= LogError(vuid, device, color_loc.dot(Field::layout), "(%s) is invalid.",
                                      string_VkImageLayout(attachment_layout));
                 }
                 if (IsValueIn(attachment_layout, {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
                                                   VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL})) {
-                    const char *vuid =
+                    const char* vuid =
                         use_rp2 ? "VUID-VkSubpassDescription2-attachment-06916" : "VUID-VkSubpassDescription-attachment-06916";
                     skip |= LogError(vuid, device, color_loc.dot(Field::layout), "(%s) is invalid.",
                                      string_VkImageLayout(attachment_layout));
@@ -1941,20 +1944,20 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                 if (IsValueIn(attachment_layout,
                               {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL,
                                VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL})) {
-                    const char *vuid =
+                    const char* vuid =
                         use_rp2 ? "VUID-VkSubpassDescription2-attachment-06919" : "VUID-VkSubpassDescription-attachment-06919";
                     skip |= LogError(vuid, device, color_loc.dot(Field::layout), "(%s) is invalid.",
                                      string_VkImageLayout(attachment_layout));
                 }
                 if (attachment_layout == VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL) {
-                    const char *vuid =
+                    const char* vuid =
                         use_rp2 ? "VUID-VkSubpassDescription2-attachment-06922" : "VUID-VkSubpassDescription-attachment-06922";
                     skip |= LogError(vuid, device, color_loc.dot(Field::layout), "(%s) is invalid.",
                                      string_VkImageLayout(attachment_layout));
                 }
 
                 if (fragment_density_map_info) {
-                    const auto &fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
+                    const auto& fdm_attachment_index = fragment_density_map_info->fragmentDensityMapAttachment.attachment;
                     if ((fdm_attachment_index != VK_ATTACHMENT_UNUSED) && (attachment_index == fdm_attachment_index)) {
                         skip |= LogError("VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548",
                                          device, color_loc,
@@ -1965,7 +1968,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
                 // safe to dereference pCreateInfo->pAttachments[]
                 if (attachment_index < create_info.attachmentCount) {
-                    const VkAttachmentDescription2 &attachment_description = create_info.pAttachments[attachment_index];
+                    const VkAttachmentDescription2& attachment_description = create_info.pAttachments[attachment_index];
                     const VkFormat attachment_format = attachment_description.format;
                     skip |= ValidateAttachmentReference(attachment_ref, attachment_format, false, color_loc);
                     skip |= AddAttachmentUse(attachment_uses, attachment_layouts, attachment_index, ATTACHMENT_COLOR,
@@ -1991,7 +1994,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                                 create_info.pAttachments[subpass.pColorAttachments[last_sample_count_attachment].attachment]
                                     .samples;
                             if (current_sample_count != last_sample_count) {
-                                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
+                                const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
                                                            : "VUID-VkSubpassDescription-pColorAttachments-09430";
                                 skip |= LogError(vuid, device, attachment_loc.dot(Field::samples),
                                                  "is %s, but the pColorAttachments[%" PRIu32 "] has sample count %s.",
@@ -2004,7 +2007,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
                     if (subpass_performs_resolve && current_sample_count == VK_SAMPLE_COUNT_1_BIT &&
                         !enabled_features.externalFormatResolve) {
-                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-externalFormatResolve-09338"
+                        const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-externalFormatResolve-09338"
                                                    : "VUID-VkSubpassDescription-pResolveAttachments-00848";
                         skip |= LogError(vuid, device, attachment_loc.dot(Field::samples), "is VK_SAMPLE_COUNT_1_BIT.");
                     }
@@ -2016,7 +2019,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
                         if (IsExtEnabled(extensions.vk_amd_mixed_attachment_samples)) {
                             if (current_sample_count > depth_stencil_sample_count) {
-                                const char *vuid =
+                                const char* vuid =
                                     use_rp2 ? "VUID-VkSubpassDescription2-None-09456" : "VUID-VkSubpassDescription-None-09431";
                                 skip |= LogError(vuid, device, attachment_loc.dot(Field::samples),
                                                  "%s) (referenced by %s) is larger than from pCreateInfo->pAttachments[%" PRIu32
@@ -2031,7 +2034,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                         }
 
                         if (!IsMixSamplingSupported() && current_sample_count != depth_stencil_sample_count) {
-                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
+                            const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
                                                        : "VUID-VkSubpassDescription-pDepthStencilAttachment-01418";
                             skip |= LogError(vuid, device, attachment_loc.dot(Field::samples),
                                              "%s) (referenced by %s) is different from pCreateInfo->pAttachments[%" PRIu32
@@ -2049,7 +2052,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                     if ((format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT) == 0 &&
                         attachment_format != VK_FORMAT_UNDEFINED) {
                         if (!enabled_features.linearColorAttachment) {
-                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pColorAttachments-02898"
+                            const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-pColorAttachments-02898"
                                                        : "VUID-VkSubpassDescription-pColorAttachments-02648";
                             skip |= LogError(vuid, device, attachment_loc.dot(Field::format),
                                              "(%s) (referenced by %s) doesn't support "
@@ -2057,7 +2060,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                                              string_VkFormat(attachment_format), color_loc.Fields().c_str(),
                                              string_VkFormatFeatureFlags2(format_features).c_str());
                         } else if ((format_features & VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV) == 0) {
-                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06500"
+                            const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06500"
                                                        : "VUID-VkSubpassDescription-linearColorAttachment-06497";
                             skip |= LogError(vuid, device, attachment_loc.dot(Field::format),
                                              "(%s) (referenced by %s) doesn't support "
@@ -2077,10 +2080,10 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
 
             if (subpass_performs_resolve && subpass.pResolveAttachments[j].attachment != VK_ATTACHMENT_UNUSED &&
                 subpass.pResolveAttachments[j].attachment < create_info.attachmentCount) {
-                auto const &resolve_attachment_ref = subpass.pResolveAttachments[j];
+                auto const& resolve_attachment_ref = subpass.pResolveAttachments[j];
                 const uint32_t resolve_attachment_index = resolve_attachment_ref.attachment;
-                const auto &resolve_desc = create_info.pAttachments[resolve_attachment_index];
-                const Location &resolve_loc = subpass_loc.dot(Field::pResolveAttachments, j);
+                const auto& resolve_desc = create_info.pAttachments[resolve_attachment_index];
+                const Location& resolve_loc = subpass_loc.dot(Field::pResolveAttachments, j);
                 if (enabled_features.externalFormatResolve && resolve_desc.format == VK_FORMAT_UNDEFINED) {
                     if (attachment_index == VK_ATTACHMENT_UNUSED) {
                         if (!device_state->android_external_format_resolve_null_color_attachment_prop) {
@@ -2104,7 +2107,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                                              color_loc.dot(Field::attachment).Fields().c_str(), attachment_index);
                         }
 
-                        const auto &color_desc = create_info.pAttachments[attachment_index];
+                        const auto& color_desc = create_info.pAttachments[attachment_index];
                         if (color_desc.samples != VK_SAMPLE_COUNT_1_BIT) {
                             skip |= LogError("VUID-VkSubpassDescription2-externalFormatResolve-09345", device,
                                              create_info_loc.dot(Field::pAttachments, attachment_index).dot(Field::samples),
@@ -2152,7 +2155,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                         }
                     }
 
-                    const auto *fragment_shading_rate_info =
+                    const auto* fragment_shading_rate_info =
                         vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(create_info.pNext);
                     if (fragment_shading_rate_info && fragment_shading_rate_info->pFragmentShadingRateAttachment &&
                         fragment_shading_rate_info->pFragmentShadingRateAttachment->attachment != VK_ATTACHMENT_UNUSED) {
@@ -2178,15 +2181,15 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                             fragment_density_map_info->fragmentDensityMapAttachment.attachment);
                     }
                 } else if (attachment_index == VK_ATTACHMENT_UNUSED) {
-                    const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-externalFormatResolve-09335"
+                    const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-externalFormatResolve-09335"
                                                : "VUID-VkSubpassDescription-pResolveAttachments-00847";
                     skip |= LogError(vuid, device, resolve_loc.dot(Field::attachment),
                                      "is %" PRIu32 ", but %s is VK_ATTACHMENT_UNUSED.", resolve_attachment_index,
                                      color_loc.dot(Field::attachment).Fields().c_str());
                 } else {
-                    const auto &color_desc = create_info.pAttachments[attachment_index];
+                    const auto& color_desc = create_info.pAttachments[attachment_index];
                     if (color_desc.format != resolve_desc.format) {
-                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-externalFormatResolve-09339"
+                        const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-externalFormatResolve-09339"
                                                    : "VUID-VkSubpassDescription-pResolveAttachments-00850";
                         skip |= LogError(
                             vuid, device, create_info_loc.dot(Field::pAttachments, attachment_index).dot(Field::format),
@@ -2210,14 +2213,14 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
     return skip;
 }
 
-bool CoreChecks::ValidateRenderPassDAG(const VkRenderPassCreateInfo2 &create_info, const Location &create_info_loc) const {
+bool CoreChecks::ValidateRenderPassDAG(const VkRenderPassCreateInfo2& create_info, const Location& create_info_loc) const {
     bool skip = false;
-    const char *vuid;
+    const char* vuid;
     const bool use_rp2 = create_info_loc.function != Func::vkCreateRenderPass;
 
     for (uint32_t i = 0; i < create_info.dependencyCount; ++i) {
         const Location dependencies_loc = create_info_loc.dot(Field::pDependencies, i);
-        const VkSubpassDependency2 &dependency = create_info.pDependencies[i];
+        const VkSubpassDependency2& dependency = create_info.pDependencies[i];
 
         // The first subpass here serves as a good proxy for "is multiview enabled" - since all view masks need to be non-zero if
         // any are, which enables multiview.
@@ -2301,7 +2304,7 @@ bool CoreChecks::ValidateRenderPassDAG(const VkRenderPassCreateInfo2 &create_inf
     return skip;
 }
 
-bool CoreChecks::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_info, const Location &loc) const {
+bool CoreChecks::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info, const Location& loc) const {
     bool skip = false;
     const bool use_rp2 = loc.function != Func::vkCreateRenderPass;
     const Location create_info_loc = loc.dot(Field::pCreateInfo);
@@ -2317,7 +2320,7 @@ bool CoreChecks::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_
 
     for (uint32_t i = 0; i < create_info.subpassCount; ++i) {
         const Location subpass_loc = create_info_loc.dot(Field::pSubpasses, i);
-        const VkSubpassDescription2 &subpass = create_info.pSubpasses[i];
+        const VkSubpassDescription2& subpass = create_info.pSubpasses[i];
 
         skip |= ValidateDepthStencilResolve(create_info, subpass, subpass_loc);
 
@@ -2375,20 +2378,20 @@ bool CoreChecks::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_
     auto func_name = use_rp2 ? Func::vkCreateRenderPass2 : Func::vkCreateRenderPass;
     auto structure = use_rp2 ? Struct::VkSubpassDependency2 : Struct::VkSubpassDependency;
     for (uint32_t i = 0; i < create_info.dependencyCount; ++i) {
-        auto const &dependency = create_info.pDependencies[i];
+        auto const& dependency = create_info.pDependencies[i];
         Location loc(func_name, structure, Field::pDependencies, i);
         skip |= ValidateSubpassDependency(loc, dependency);
     }
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     // Handle extension structs from KHR_multiview and KHR_maintenance2 that can only be validated for RP1 (indices out of bounds)
-    const VkRenderPassMultiviewCreateInfo *multiview_info =
+    const VkRenderPassMultiviewCreateInfo* multiview_info =
         vku::FindStructInPNextChain<VkRenderPassMultiviewCreateInfo>(pCreateInfo->pNext);
     if (multiview_info) {
         if (multiview_info->subpassCount && multiview_info->subpassCount != pCreateInfo->subpassCount) {
@@ -2445,7 +2448,7 @@ bool CoreChecks::PreCallValidateCreateRenderPass(VkDevice device, const VkRender
             }
         }
     }
-    const VkRenderPassInputAttachmentAspectCreateInfo *input_attachment_aspect_info =
+    const VkRenderPassInputAttachmentAspectCreateInfo* input_attachment_aspect_info =
         vku::FindStructInPNextChain<VkRenderPassInputAttachmentAspectCreateInfo>(pCreateInfo->pNext);
     if (input_attachment_aspect_info) {
         for (uint32_t i = 0; i < input_attachment_aspect_info->aspectReferenceCount; ++i) {
@@ -2666,17 +2669,17 @@ bool CoreChecks::ValidateDepthStencilResolve(const VkRenderPassCreateInfo2& crea
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     skip |= ValidateCreateRenderPass(*pCreateInfo, error_obj.location);
     return skip;
 }
 
-bool CoreChecks::ValidateFragmentShadingRateAttachments(const VkRenderPassCreateInfo2 &create_info,
-                                                        const Location &create_info_loc) const {
+bool CoreChecks::ValidateFragmentShadingRateAttachments(const VkRenderPassCreateInfo2& create_info,
+                                                        const Location& create_info_loc) const {
     bool skip = false;
 
     if (!enabled_features.attachmentFragmentShadingRate) {
@@ -2706,7 +2709,7 @@ bool CoreChecks::ValidateFragmentShadingRateAttachments(const VkRenderPassCreate
 
         // Prepass to find any use as a fragment shading rate attachment structures and validate them independently
         for (uint32_t subpass = 0; subpass < create_info.subpassCount; ++subpass) {
-            const auto *fragment_shading_rate_attachment =
+            const auto* fragment_shading_rate_attachment =
                 vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(create_info.pSubpasses[subpass].pNext);
             if (!fragment_shading_rate_attachment || !fragment_shading_rate_attachment->pFragmentShadingRateAttachment) {
                 continue;
@@ -2715,7 +2718,7 @@ bool CoreChecks::ValidateFragmentShadingRateAttachments(const VkRenderPassCreate
             const Location subpass_loc = create_info_loc.dot(Field::pSubpasses, subpass);
             const Location fragment_loc =
                 subpass_loc.pNext(Struct::VkFragmentShadingRateAttachmentInfoKHR, Field::pFragmentShadingRateAttachment);
-            const VkAttachmentReference2 &attachment_reference =
+            const VkAttachmentReference2& attachment_reference =
                 *(fragment_shading_rate_attachment->pFragmentShadingRateAttachment);
             if (attachment_reference.attachment == attachment_description) {
                 used_as_fragment_shading_rate_attachment.push_back(subpass);
@@ -2837,7 +2840,7 @@ bool CoreChecks::ValidateFragmentShadingRateAttachments(const VkRenderPassCreate
         if (!used_as_fragment_shading_rate_attachment.empty()) {
             for (uint32_t subpass = 0; subpass < create_info.subpassCount; ++subpass) {
                 const Location subpass_loc = create_info_loc.dot(Field::pSubpasses, subpass);
-                const VkSubpassDescription2 &subpass_info = create_info.pSubpasses[subpass];
+                const VkSubpassDescription2& subpass_info = create_info.pSubpasses[subpass];
 
                 std::string fsr_attachment_subpasses_string = vector_to_string(used_as_fragment_shading_rate_attachment);
 
@@ -2878,7 +2881,7 @@ bool CoreChecks::ValidateFragmentShadingRateAttachments(const VkRenderPassCreate
                                          attachment_description, fsr_attachment_subpasses_string.c_str());
                     }
                 }
-                const auto *depth_stencil_resolve_attachment =
+                const auto* depth_stencil_resolve_attachment =
                     vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass_info.pNext);
                 if (depth_stencil_resolve_attachment && depth_stencil_resolve_attachment->pDepthStencilResolveAttachment) {
                     if (depth_stencil_resolve_attachment->pDepthStencilResolveAttachment->attachment == attachment_description) {
@@ -2957,14 +2960,14 @@ bool CoreChecks::ValidateFragmentDensityMapAttachments(const VkRenderPassCreateI
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, error_obj);
 }
 
-bool CoreChecks::ValidateRenderingInfoAttachmentDeviceGroup(const vvl::Image &image_state, const VkRenderingInfo &rendering_info,
-                                                            const LogObjectList &objlist, const Location &loc) const {
+bool CoreChecks::ValidateRenderingInfoAttachmentDeviceGroup(const vvl::Image& image_state, const VkRenderingInfo& rendering_info,
+                                                            const LogObjectList& objlist, const Location& loc) const {
     bool skip = false;
 
     auto device_group_render_pass_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
@@ -2996,9 +2999,9 @@ bool CoreChecks::ValidateRenderingInfoAttachmentDeviceGroup(const vvl::Image &im
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                 const VkRenderingAttachmentInfo &attachment_info,
-                                                 const Location &attachment_loc) const {
+bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                 const VkRenderingAttachmentInfo& attachment_info,
+                                                 const Location& attachment_loc) const {
     bool skip = false;
 
     // "If imageView is VK_NULL_HANDLE, and resolveMode is not VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID, other members
@@ -3019,10 +3022,10 @@ bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                            const VkRenderingAttachmentInfo &attachment_info,
-                                                            const vvl::ImageView &image_view_state,
-                                                            const Location &attachment_loc) const {
+bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                            const VkRenderingAttachmentInfo& attachment_info,
+                                                            const vvl::ImageView& image_view_state,
+                                                            const Location& attachment_loc) const {
     bool skip = false;
 
     // First validate things when resolve mode can be NONE
@@ -3069,7 +3072,7 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
         }
 
         if (enabled_features.tileMemoryHeap && !resolve_view_state->image_state->GetBoundMemoryStates().empty()) {
-            for (const auto &bound_memory : resolve_view_state->image_state->GetBoundMemoryStates()) {
+            for (const auto& bound_memory : resolve_view_state->image_state->GetBoundMemoryStates()) {
                 if (bound_memory && HasTileMemoryType(bound_memory->allocate_info.memoryTypeIndex)) {
                     const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView, bound_memory->VkHandle());
                     skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveImageView-10728", objlist, attachment_loc,
@@ -3091,7 +3094,7 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
 
     if (attachment_info.resolveImageLayout == VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR) {
         const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-        const char *vuid = IsExtEnabled(extensions.vk_khr_fragment_shading_rate) ? "VUID-VkRenderingAttachmentInfo-imageView-06144"
+        const char* vuid = IsExtEnabled(extensions.vk_khr_fragment_shading_rate) ? "VUID-VkRenderingAttachmentInfo-imageView-06144"
                                                                                  : "VUID-VkRenderingAttachmentInfo-imageView-06139";
         skip |= LogError(vuid, objlist, attachment_loc.dot(Field::resolveImageLayout),
                          "must not be VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR "
@@ -3180,9 +3183,9 @@ bool CoreChecks::ValidateRenderingAttachmentInfoMultisampledResolveMode(VkComman
 }
 
 bool CoreChecks::ValidateRenderingAttachmentInfoFeedbackLoop(VkCommandBuffer commandBuffer,
-                                                             const VkRenderingAttachmentInfo &attachment_info,
-                                                             const vvl::ImageView &image_view_state,
-                                                             const Location &attachment_loc) const {
+                                                             const VkRenderingAttachmentInfo& attachment_info,
+                                                             const vvl::ImageView& image_view_state,
+                                                             const Location& attachment_loc) const {
     bool skip = false;
     const auto attachment_feedback_loop_info = vku::FindStructInPNextChain<VkAttachmentFeedbackLoopInfoEXT>(attachment_info.pNext);
     bool explicit_enabled = attachment_feedback_loop_info && attachment_feedback_loop_info->feedbackLoopEnable;
@@ -3212,9 +3215,9 @@ bool CoreChecks::ValidateRenderingAttachmentInfoFeedbackLoop(VkCommandBuffer com
 }
 
 bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuffer,
-                                                      const VkRenderingAttachmentInfo &attachment_info,
-                                                      const vvl::ImageView &image_view_state,
-                                                      const Location &attachment_loc) const {
+                                                      const VkRenderingAttachmentInfo& attachment_info,
+                                                      const vvl::ImageView& image_view_state,
+                                                      const Location& attachment_loc) const {
     bool skip = false;
     const auto attachment_flags = vku::FindStructInPNextChain<VkRenderingAttachmentFlagsInfoKHR>(attachment_info.pNext);
     if (!attachment_flags) {
@@ -3276,8 +3279,8 @@ bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuf
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                          const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                          const Location& rendering_info_loc) const {
     bool skip = false;
 
     const auto* fdm_attachment_info =
@@ -3376,7 +3379,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         const bool non_zero_device_render_area = device_group_begin_info && device_group_begin_info->deviceRenderAreaCount != 0;
         if (!non_zero_device_render_area) {
             // Upcasting to handle overflow
-            const VkRect2D &render_area = rendering_info.renderArea;
+            const VkRect2D& render_area = rendering_info.renderArea;
             const int64_t x_adjusted_extent =
                 static_cast<int64_t>(render_area.offset.x) + static_cast<int64_t>(render_area.extent.width);
             const int64_t y_adjusted_extent =
@@ -3416,10 +3419,10 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                           const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                           const Location& rendering_info_loc) const {
     bool skip = false;
-    const auto *rendering_fragment_shading_rate_attachment_info =
+    const auto* rendering_fragment_shading_rate_attachment_info =
         vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(rendering_info.pNext);
     if (!rendering_fragment_shading_rate_attachment_info ||
         rendering_fragment_shading_rate_attachment_info->imageView == VK_NULL_HANDLE) {
@@ -3472,9 +3475,9 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer comma
 }
 
 bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
-    VkCommandBuffer commandBuffer, const vvl::ImageView &view_state,
-    const VkRenderingFragmentShadingRateAttachmentInfoKHR &fsr_attachment_info, const VkRenderingInfo &rendering_info,
-    const Location &rendering_info_loc) const {
+    VkCommandBuffer commandBuffer, const vvl::ImageView& view_state,
+    const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info, const VkRenderingInfo& rendering_info,
+    const Location& rendering_info_loc) const {
     bool skip = false;
 
     // All these VUs can be skipped if all conditions are met
@@ -3484,10 +3487,10 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
     }
 
     const LogObjectList objlist(commandBuffer, view_state.Handle());
-    const auto *device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
+    const auto* device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
     const bool non_zero_device_render_area = device_group_begin_info && device_group_begin_info->deviceRenderAreaCount != 0;
     if (!non_zero_device_render_area) {
-        const VkRect2D &render_area = rendering_info.renderArea;
+        const VkRect2D& render_area = rendering_info.renderArea;
         // Upcasting to handle overflow
         const int64_t x_adjusted_extent =
             static_cast<int64_t>(render_area.offset.x) + static_cast<int64_t>(render_area.extent.width);
@@ -3526,7 +3529,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
                 const int32_t offset_y = device_group_begin_info->pDeviceRenderAreas[deviceRenderAreaIndex].offset.y;
                 const uint32_t height = device_group_begin_info->pDeviceRenderAreas[deviceRenderAreaIndex].extent.height;
 
-                vvl::Image *image_state = view_state.image_state.get();
+                vvl::Image* image_state = view_state.image_state.get();
                 if (image_state->create_info.extent.width <
                     vvl::GetQuotientCeil(offset_x + width, fsr_attachment_info.shadingRateAttachmentTexelSize.width)) {
                     skip |= LogError(
@@ -3558,8 +3561,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                   const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                   const Location& rendering_info_loc) const {
     bool skip = false;
     const VkSampleCountFlagBits unused = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
 
@@ -3568,7 +3571,7 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
         VkSampleCountFlagBits color_sample_count = unused;
         uint32_t first_color_index = 0;
         for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
-            const VkRenderingAttachmentInfo &color_attachment = rendering_info.pColorAttachments[i];
+            const VkRenderingAttachmentInfo& color_attachment = rendering_info.pColorAttachments[i];
             if (color_attachment.imageView == VK_NULL_HANDLE) {
                 continue;
             }
@@ -3632,7 +3635,7 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
         // If all things are disabled, everything must match
         VkSampleCountFlagBits first_sample_count = unused;
         for (uint32_t j = 0; j < rendering_info.colorAttachmentCount; ++j) {
-            const VkRenderingAttachmentInfo &color_attachment = rendering_info.pColorAttachments[j];
+            const VkRenderingAttachmentInfo& color_attachment = rendering_info.pColorAttachments[j];
             if (color_attachment.imageView == VK_NULL_HANDLE) {
                 continue;
             }
@@ -3656,15 +3659,15 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                   const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                   const Location& rendering_info_loc) const {
     bool skip = false;
 
-    const auto *device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
+    const auto* device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
 
     const bool non_zero_device_render_area = device_group_begin_info && device_group_begin_info->deviceRenderAreaCount != 0;
     if (!non_zero_device_render_area) {
-        const VkRect2D &render_area = rendering_info.renderArea;
+        const VkRect2D& render_area = rendering_info.renderArea;
         // if the renderArea was set with garbage, only want to report 1 error
         if (render_area.offset.x < 0) {
             skip |= LogError("VUID-VkRenderingInfo-pNext-06077", commandBuffer,
@@ -3743,7 +3746,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             if (rendering_info.pColorAttachments[j].imageView == VK_NULL_HANDLE) continue;
             auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[j].imageView);
             ASSERT_AND_CONTINUE(image_view_state);
-            vvl::Image *image_state = image_view_state->image_state.get();
+            vvl::Image* image_state = image_view_state->image_state.get();
             if (image_state->create_info.extent.width < offset_x + width) {
                 const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
@@ -3767,7 +3770,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         if (rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
             auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
             ASSERT_AND_RETURN_SKIP(depth_view_state);
-            vvl::Image *image_state = depth_view_state->image_state.get();
+            vvl::Image* image_state = depth_view_state->image_state.get();
             if (image_state->create_info.extent.width < offset_x + width) {
                 const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
@@ -3791,7 +3794,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         if (rendering_info.pStencilAttachment && rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
             auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
             ASSERT_AND_RETURN_SKIP(stencil_view_state);
-            vvl::Image *image_state = stencil_view_state->image_state.get();
+            vvl::Image* image_state = stencil_view_state->image_state.get();
             if (image_state->create_info.extent.width < offset_x + width) {
                 const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
@@ -3812,12 +3815,12 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             }
         }
 
-        const auto *fragment_density_map_attachment_info =
+        const auto* fragment_density_map_attachment_info =
             vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext);
         if (fragment_density_map_attachment_info && fragment_density_map_attachment_info->imageView != VK_NULL_HANDLE) {
             auto view_state = Get<vvl::ImageView>(fragment_density_map_attachment_info->imageView);
             ASSERT_AND_RETURN_SKIP(view_state);
-            vvl::Image *image_state = view_state->image_state.get();
+            vvl::Image* image_state = view_state->image_state.get();
             ASSERT_AND_RETURN_SKIP(image_state);
             if (image_state->create_info.extent.width <
                 vvl::GetQuotientCeil(offset_x + width,
@@ -3854,11 +3857,11 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
 }
 
 bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkCommandBuffer commandBuffer,
-                                                                         const VkRenderingInfo &rendering_info,
-                                                                         const Location &rendering_info_loc) const {
+                                                                         const VkRenderingInfo& rendering_info,
+                                                                         const Location& rendering_info_loc) const {
     bool skip = false;
 
-    const auto *msrtss_info = vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(rendering_info.pNext);
+    const auto* msrtss_info = vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(rendering_info.pNext);
     if (!msrtss_info) {
         return false;
     }
@@ -3893,8 +3896,8 @@ bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkComma
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
+                                                  const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -3940,10 +3943,10 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     return skip;
 }
 
-static bool CheckAttachmentNullMismatch(const CoreChecks &validator, const char *vuid, const LogObjectList &objlist,
-                                        const VkRenderingAttachmentInfo *resume_attachment,
-                                        const VkRenderingAttachmentInfo *suspend_attachment,
-                                        const Location &resume_attachment_loc) {
+static bool CheckAttachmentNullMismatch(const CoreChecks& validator, const char* vuid, const LogObjectList& objlist,
+                                        const VkRenderingAttachmentInfo* resume_attachment,
+                                        const VkRenderingAttachmentInfo* suspend_attachment,
+                                        const Location& resume_attachment_loc) {
     bool skip = false;
     if ((resume_attachment != nullptr) != (suspend_attachment != nullptr)) {
         if (resume_attachment == nullptr) {
@@ -3957,12 +3960,12 @@ static bool CheckAttachmentNullMismatch(const CoreChecks &validator, const char 
     return skip;
 }
 
-static bool CheckAttachmentInfoMismatch(const CoreChecks &validator, const char *vuid, const LogObjectList &objlist,
-                                        const VkRenderingAttachmentInfo &resume_attachment,
-                                        const VkRenderingAttachmentInfo &suspend_attachment,
-                                        const Location &resume_attachment_loc) {
+static bool CheckAttachmentInfoMismatch(const CoreChecks& validator, const char* vuid, const LogObjectList& objlist,
+                                        const VkRenderingAttachmentInfo& resume_attachment,
+                                        const VkRenderingAttachmentInfo& suspend_attachment,
+                                        const Location& resume_attachment_loc) {
     bool skip = false;
-    const char *message = "(%s) does not match %s used by the suspended rendering instance.";
+    const char* message = "(%s) does not match %s used by the suspended rendering instance.";
     if (resume_attachment.imageView != suspend_attachment.imageView) {
         const Location loc = resume_attachment_loc.dot(vvl::Field::imageView);
         const std::string resume_handle = validator.FormatHandle(resume_attachment.imageView);
@@ -4028,9 +4031,9 @@ static bool CheckAttachmentInfoMismatch(const CoreChecks &validator, const char 
     return skip;
 }
 
-bool CoreChecks::ValidateSuspendResumeMismatch(const char *vuid, const LogObjectList &objlist,
-                                               const VkRenderingInfo &rendering_info, const VkRenderingInfo &last_rendering_info,
-                                               const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateSuspendResumeMismatch(const char* vuid, const LogObjectList& objlist,
+                                               const VkRenderingInfo& rendering_info, const VkRenderingInfo& last_rendering_info,
+                                               const Location& rendering_info_loc) const {
     bool skip = false;
 
     const bool is_suspend_resume =
@@ -4039,12 +4042,12 @@ bool CoreChecks::ValidateSuspendResumeMismatch(const char *vuid, const LogObject
     if (!is_suspend_resume) {
         return skip;
     }
-    const VkRenderingInfo &resume_info = rendering_info;
-    const VkRenderingInfo &suspend_info = last_rendering_info;
-    const Location &resume_info_loc = rendering_info_loc;
+    const VkRenderingInfo& resume_info = rendering_info;
+    const VkRenderingInfo& suspend_info = last_rendering_info;
+    const Location& resume_info_loc = rendering_info_loc;
 
-    const char *message_str = "(%s) does not match %s used by the suspended rendering instance.";
-    const char *message_uint = "(%" PRIu32 ") does not match %" PRIu32 " used by the suspended rendering instance.";
+    const char* message_str = "(%s) does not match %s used by the suspended rendering instance.";
+    const char* message_uint = "(%" PRIu32 ") does not match %" PRIu32 " used by the suspended rendering instance.";
 
     // Flags to ignore mentioned by the spec
     const VkRenderingFlags ignore_flags =
@@ -4105,8 +4108,8 @@ bool CoreChecks::ValidateSuspendResumeMismatch(const char *vuid, const LogObject
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingResume(const vvl::CommandBuffer &cb_state, const VkRenderingInfo &rendering_info,
-                                              const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingResume(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                              const Location& rendering_info_loc) const {
     bool skip = false;
     if (!cb_state.last_rendering_info.has_value()) {
         return skip;
@@ -4117,13 +4120,12 @@ bool CoreChecks::ValidateBeginRenderingResume(const vvl::CommandBuffer &cb_state
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer &cb_state,
-                                                       const VkRenderingInfo &rendering_info,
-                                                       const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                       const Location& rendering_info_loc) const {
     bool skip = false;
     const VkCommandBuffer commandBuffer = cb_state.VkHandle();
     for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
-        const VkRenderingAttachmentInfo &color_attachment = rendering_info.pColorAttachments[i];
+        const VkRenderingAttachmentInfo& color_attachment = rendering_info.pColorAttachments[i];
         const Location color_attachment_loc = rendering_info_loc.dot(Field::pColorAttachments, i);
         skip |= ValidateRenderingAttachmentInfo(commandBuffer, rendering_info, color_attachment, color_attachment_loc);
         skip |= ValidateRenderingAttachmentCurrentLayout(cb_state, color_attachment, VK_IMAGE_ASPECT_COLOR_BIT,
@@ -4132,7 +4134,7 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer 
         if (color_attachment.imageView != VK_NULL_HANDLE) {
             auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView);
             ASSERT_AND_CONTINUE(image_view_state);
-            const vvl::Image &image_state = *image_view_state->image_state;
+            const vvl::Image& image_state = *image_view_state->image_state;
             const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state.Handle());
             const Location color_image_view = color_attachment_loc.dot(Field::imageView);
 
@@ -4172,14 +4174,14 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer 
                     rendering_info.colorAttachmentCount);
                 break;  // only print first index with error
             }
-            const auto *fragment_density_info_ext =
+            const auto* fragment_density_info_ext =
                 vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext);
             if (fragment_density_info_ext && fragment_density_info_ext->imageView != VK_NULL_HANDLE) {
                 skip |= LogError("VUID-VkRenderingInfo-resolveMode-09321", commandBuffer,
                                  rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                                  "is not null (%s).", FormatHandle(fragment_density_info_ext->imageView).c_str());
             }
-            const auto *fragment_shading_rate_info_khr =
+            const auto* fragment_shading_rate_info_khr =
                 vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(rendering_info.pNext);
             if (fragment_shading_rate_info_khr && fragment_shading_rate_info_khr->imageView != VK_NULL_HANDLE) {
                 skip |=
@@ -4279,13 +4281,13 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer 
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer &cb_state, const VkRenderingInfo &rendering_info,
-                                                       const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                       const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pDepthAttachment) return skip;
 
     const VkCommandBuffer commandBuffer = cb_state.VkHandle();
-    const VkRenderingAttachmentInfo &depth_attachment = *rendering_info.pDepthAttachment;
+    const VkRenderingAttachmentInfo& depth_attachment = *rendering_info.pDepthAttachment;
     const Location depth_attachment_loc = rendering_info_loc.dot(Field::pDepthAttachment);
     skip |= ValidateRenderingAttachmentInfo(commandBuffer, rendering_info, depth_attachment, depth_attachment_loc);
     skip |= ValidateRenderingAttachmentCurrentLayout(cb_state, depth_attachment, VK_IMAGE_ASPECT_DEPTH_BIT, depth_attachment_loc,
@@ -4294,7 +4296,7 @@ bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer 
     if (depth_attachment.imageView != VK_NULL_HANDLE) {
         auto depth_view_state = Get<vvl::ImageView>(depth_attachment.imageView);
         ASSERT_AND_RETURN_SKIP(depth_view_state);
-        const vvl::Image &image_state = *depth_view_state->image_state;
+        const vvl::Image& image_state = *depth_view_state->image_state;
         const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state.Handle());
         const Location depth_image_view = depth_attachment_loc.dot(Field::imageView);
 
@@ -4367,13 +4369,13 @@ bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer 
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffer &cb_state, const VkRenderingInfo &rendering_info,
-                                                         const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                         const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pStencilAttachment) return skip;
 
     const VkCommandBuffer commandBuffer = cb_state.VkHandle();
-    const VkRenderingAttachmentInfo &stencil_attachment = *rendering_info.pStencilAttachment;
+    const VkRenderingAttachmentInfo& stencil_attachment = *rendering_info.pStencilAttachment;
     const Location stencil_attachment_loc = rendering_info_loc.dot(Field::pStencilAttachment);
     skip |= ValidateRenderingAttachmentInfo(commandBuffer, rendering_info, stencil_attachment, stencil_attachment_loc);
     skip |= ValidateRenderingAttachmentCurrentLayout(cb_state, stencil_attachment, VK_IMAGE_ASPECT_STENCIL_BIT,
@@ -4382,7 +4384,7 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffe
     if (stencil_attachment.imageView != VK_NULL_HANDLE) {
         auto stencil_view_state = Get<vvl::ImageView>(stencil_attachment.imageView);
         ASSERT_AND_RETURN_SKIP(stencil_view_state);
-        const vvl::Image &image_state = *stencil_view_state->image_state;
+        const vvl::Image& image_state = *stencil_view_state->image_state;
         const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state.Handle());
         const Location stencil_image_view = stencil_attachment_loc.dot(Field::imageView);
 
@@ -4457,13 +4459,13 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffe
 }
 
 bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer commandBuffer,
-                                                                 const VkRenderingInfo &rendering_info,
-                                                                 const Location &rendering_info_loc) const {
+                                                                 const VkRenderingInfo& rendering_info,
+                                                                 const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pDepthAttachment || !rendering_info.pStencilAttachment) return skip;
 
-    const auto &depth_attachment = *rendering_info.pDepthAttachment;
-    const auto &stencil_attachment = *rendering_info.pStencilAttachment;
+    const auto& depth_attachment = *rendering_info.pDepthAttachment;
+    const auto& stencil_attachment = *rendering_info.pStencilAttachment;
 
     if (depth_attachment.imageView != VK_NULL_HANDLE && stencil_attachment.imageView != VK_NULL_HANDLE) {
         if (depth_attachment.imageView != stencil_attachment.imageView) {
@@ -4509,7 +4511,7 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer
 
 // Flags validation error if the associated call is made inside a render pass. The apiName routine should ONLY be called outside a
 // render pass.
-bool CoreChecks::InsideRenderPass(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
+bool CoreChecks::InsideRenderPass(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
     bool skip = false;
     if (!cb_state.active_render_pass) {
         return skip;
@@ -4553,7 +4555,7 @@ bool CoreChecks::InsideRenderPass(const vvl::CommandBuffer &cb_state, const Loca
 
 // Flags validation error if the associated call is made outside a render pass. The apiName
 // routine should ONLY be called inside a render pass.
-bool CoreChecks::OutsideRenderPass(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
+bool CoreChecks::OutsideRenderPass(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
     bool outside = false;
     if ((cb_state.IsPrimary() && (!cb_state.active_render_pass)) ||
         (cb_state.IsSecondary() && (!cb_state.active_render_pass) &&
@@ -4563,7 +4565,7 @@ bool CoreChecks::OutsideRenderPass(const vvl::CommandBuffer &cb_state, const Loc
     return outside;
 }
 
-bool CoreChecks::ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidateCmd(cb_state, error_obj.location);
@@ -4575,23 +4577,23 @@ bool CoreChecks::ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, con
         error_obj.location.function != Func::vkCmdEndRendering && error_obj.location.function != Func::vkCmdEndRenderingKHR;
 
     if (!cb_state.active_render_pass->UsesDynamicRendering()) {
-        const char *vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-None-10610" : "VUID-vkCmdEndRendering-None-06161";
+        const char* vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-None-10610" : "VUID-vkCmdEndRendering-None-06161";
         skip |= LogError(vuid, cb_state.Handle(), error_obj.location,
                          "in a render pass instance that was not begun with vkCmdBeginRendering().");
     }
     if (cb_state.active_render_pass->use_dynamic_rendering_inherited) {
-        const char *vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-commandBuffer-10611" : "VUID-vkCmdEndRendering-commandBuffer-06162";
+        const char* vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-commandBuffer-10611" : "VUID-vkCmdEndRendering-commandBuffer-06162";
         skip |= LogError(vuid, cb_state.Handle(), error_obj.location,
                          "in a render pass instance that was not begun in this command buffer.");
     }
     if (cb_state.transform_feedback_active) {
-        const char *vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-None-10612" : "VUID-vkCmdEndRendering-None-06781";
+        const char* vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-None-10612" : "VUID-vkCmdEndRendering-None-06781";
         skip |= LogError(vuid, cb_state.Handle(), error_obj.location,
                          "in a render pass instance that was not begun in this command buffer.");
     }
-    for (const auto &query : cb_state.render_pass_queries) {
+    for (const auto& query : cb_state.render_pass_queries) {
         const LogObjectList objlist(cb_state.Handle(), query.pool);
-        const char *vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-None-10613" : "VUID-vkCmdEndRendering-None-06999";
+        const char* vuid = is_2 ? "VUID-vkCmdEndRendering2KHR-None-10613" : "VUID-vkCmdEndRendering-None-06999";
         skip |=
             LogError(vuid, objlist, error_obj.location, "query %" PRIu32 " from %s was began in the render pass, but never ended.",
                      query.slot, FormatHandle(query.pool).c_str());
@@ -4600,24 +4602,24 @@ bool CoreChecks::ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, con
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     return ValidateCmdEndRendering(cb_state, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdEndRendering2KHR(VkCommandBuffer commandBuffer, const VkRenderingEndInfoKHR *pRenderingEndInfo,
-                                                    const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndRendering2KHR(VkCommandBuffer commandBuffer, const VkRenderingEndInfoKHR* pRenderingEndInfo,
+                                                    const ErrorObject& error_obj) const {
     bool skip = false;
 
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmdEndRendering(cb_state, error_obj);
 
-    const auto *rp_state_ptr = cb_state.active_render_pass.get();
+    const auto* rp_state_ptr = cb_state.active_render_pass.get();
     if (!rp_state_ptr || !pRenderingEndInfo) {
         return skip;
     }
 
-    if (const auto *fdm_offset_end_info =
+    if (const auto* fdm_offset_end_info =
             vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapOffsetEndInfoEXT>(pRenderingEndInfo->pNext)) {
         if (fdm_offset_end_info->fragmentDensityOffsetCount != 0) {
             skip |= ValidateFragmentDensityMapOffsetEnd(
@@ -4625,7 +4627,7 @@ bool CoreChecks::PreCallValidateCmdEndRendering2KHR(VkCommandBuffer commandBuffe
                 error_obj.location.dot(Field::pRenderingEndInfo).pNext(Struct::VkRenderPassFragmentDensityMapOffsetEndInfoEXT));
         }
 
-        const auto &cb_sub_state = core::SubState(cb_state);
+        const auto& cb_sub_state = core::SubState(cb_state);
         const uint32_t previous_count = static_cast<uint32_t>(cb_sub_state.fragment_density_offsets.size());
         if (previous_count > 0) {
             if (fdm_offset_end_info->fragmentDensityOffsetCount != previous_count) {
@@ -4657,19 +4659,19 @@ bool CoreChecks::PreCallValidateCmdEndRendering2KHR(VkCommandBuffer commandBuffe
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdEndRendering2EXT(VkCommandBuffer commandBuffer, const VkRenderingEndInfoEXT *pRenderingEndInfo,
-                                                    const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndRendering2EXT(VkCommandBuffer commandBuffer, const VkRenderingEndInfoEXT* pRenderingEndInfo,
+                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCmdEndRendering2KHR(commandBuffer, pRenderingEndInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     return PreCallValidateCmdEndRendering(commandBuffer, error_obj);
 }
 
-bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView &image_view_state,
-                                                              const VkMultisampledRenderToSingleSampledInfoEXT &msrtss_info,
-                                                              const Location &attachment_loc,
-                                                              const Location &rendering_info_loc) const {
+bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
+                                                              const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
+                                                              const Location& attachment_loc,
+                                                              const Location& rendering_info_loc) const {
     bool skip = false;
     if (!msrtss_info.multisampledRenderToSingleSampledEnable) {
         return false;
@@ -4683,7 +4685,7 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
                          string_VkSampleCountFlagBits(msrtss_info.rasterizationSamples), attachment_loc.Fields().c_str(),
                          string_VkSampleCountFlagBits(image_view_state.samples));
     }
-    vvl::Image *image_state = image_view_state.image_state.get();
+    vvl::Image* image_state = image_view_state.image_state.get();
     if ((image_view_state.samples == VK_SAMPLE_COUNT_1_BIT) &&
         !(image_state->create_info.flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT)) {
         const LogObjectList objlist(commandBuffer, image_view_state.Handle());
@@ -4715,13 +4717,13 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR *pRenderingInfo,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCmdBeginRendering(commandBuffer, pRenderingInfo, error_obj);
 }
 
 // If a renderpass is active, verify that the given command type is appropriate for current subpass state
-bool CoreChecks::ValidateCmdSubpassState(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
+bool CoreChecks::ValidateCmdSubpassState(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
     if (!cb_state.active_render_pass || cb_state.active_render_pass->UsesDynamicRendering()) return false;
     bool skip = false;
     if (cb_state.IsPrimary() && cb_state.active_subpass_contents == VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS &&
@@ -4737,11 +4739,11 @@ bool CoreChecks::ValidateCmdSubpassState(const vvl::CommandBuffer &cb_state, con
     return skip;
 }
 
-bool CoreChecks::ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool CoreChecks::ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     const bool use_rp2 = error_obj.location.function != Func::vkCmdNextSubpass;
-    const char *vuid;
+    const char* vuid;
 
     skip |= ValidateCmd(*cb_state, error_obj.location);
     if (!cb_state->active_render_pass) {
@@ -4761,22 +4763,22 @@ bool CoreChecks::ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const Err
 }
 
 bool CoreChecks::PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
-                                               const ErrorObject &error_obj) const {
+                                               const ErrorObject& error_obj) const {
     return ValidateCmdNextSubpass(commandBuffer, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                   const VkSubpassEndInfo *pSubpassEndInfo, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                   const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
     return PreCallValidateCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                const VkSubpassEndInfo *pSubpassEndInfo, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
     return ValidateCmdNextSubpass(commandBuffer, error_obj);
 }
 
-bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attachments, const VkFramebufferCreateInfo &fbci,
-                            VkImageUsageFlagBits usage_flag, const char *vuid, const Location &create_info_loc) const {
+bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2* attachments, const VkFramebufferCreateInfo& fbci,
+                            VkImageUsageFlagBits usage_flag, const char* vuid, const Location& create_info_loc) const {
     bool skip = false;
 
     if (!attachments) {
@@ -4789,7 +4791,7 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attach
             continue;
         }
         if ((fbci.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
-            const VkImageView *image_view = &fbci.pAttachments[fb_attachment];
+            const VkImageView* image_view = &fbci.pAttachments[fb_attachment];
             if (auto view_state = Get<vvl::ImageView>(*image_view)) {
                 if ((view_state->inherited_usage & usage_flag) == 0) {
                     const LogObjectList objlist(*image_view, view_state->create_info.image);
@@ -4799,7 +4801,7 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attach
                 }
             }
         } else {
-            const VkFramebufferAttachmentsCreateInfo *fbaci =
+            const VkFramebufferAttachmentsCreateInfo* fbaci =
                 vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(fbci.pNext);
             if (fbaci != nullptr && fbaci->pAttachmentImageInfos != nullptr && fbaci->attachmentImageInfoCount > fb_attachment) {
                 uint32_t image_usage = fbaci->pAttachmentImageInfos[fb_attachment].usage;
@@ -4816,11 +4818,11 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attach
     return skip;
 }
 
-bool CoreChecks::MsRenderedToSingleSampledValidateFBAttachments(uint32_t count, const VkAttachmentReference2 *attachments,
-                                                                const VkFramebufferCreateInfo &fbci,
-                                                                const VkRenderPassCreateInfo2 &rpci, uint32_t subpass,
+bool CoreChecks::MsRenderedToSingleSampledValidateFBAttachments(uint32_t count, const VkAttachmentReference2* attachments,
+                                                                const VkFramebufferCreateInfo& fbci,
+                                                                const VkRenderPassCreateInfo2& rpci, uint32_t subpass,
                                                                 VkSampleCountFlagBits sample_count,
-                                                                const Location &create_info_loc) const {
+                                                                const Location& create_info_loc) const {
     bool skip = false;
 
     for (uint32_t attach = 0; attach < count; attach++) {
@@ -4831,7 +4833,7 @@ bool CoreChecks::MsRenderedToSingleSampledValidateFBAttachments(uint32_t count, 
 
         const auto renderpass_samples = rpci.pAttachments[fb_attachment].samples;
         if (renderpass_samples == VK_SAMPLE_COUNT_1_BIT) {
-            const VkImageView *image_view = &fbci.pAttachments[fb_attachment];
+            const VkImageView* image_view = &fbci.pAttachments[fb_attachment];
             auto view_state = Get<vvl::ImageView>(*image_view);
             ASSERT_AND_CONTINUE(view_state);
             auto image_state = view_state->image_state;
@@ -4867,9 +4869,9 @@ bool CoreChecks::MsRenderedToSingleSampledValidateFBAttachments(uint32_t count, 
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkFramebuffer *pFramebuffer,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
+                                                  const ErrorObject& error_obj) const {
     // TODO : Verify that renderPass FB is created with is compatible with FB
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
@@ -4878,7 +4880,7 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
     auto rp_state = Get<vvl::RenderPass>(pCreateInfo->renderPass);
     ASSERT_AND_RETURN_SKIP(rp_state);
 
-    const VkRenderPassCreateInfo2 *rpci = rp_state->create_info.ptr();
+    const VkRenderPassCreateInfo2* rpci = rp_state->create_info.ptr();
 
     if (rpci->attachmentCount != pCreateInfo->attachmentCount) {
         skip |= LogError("VUID-VkFramebufferCreateInfo-attachmentCount-00876", pCreateInfo->renderPass,
@@ -4888,7 +4890,7 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
         return skip;  // nothing else to validate
     }
 
-    const auto *framebuffer_attachments_create_info =
+    const auto* framebuffer_attachments_create_info =
         vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(pCreateInfo->pNext);
     if (framebuffer_attachments_create_info) {
         for (const auto [i, attachment_image_info] :
@@ -4940,17 +4942,17 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
     return skip;
 }
 
-bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &create_info, const Location &create_info_loc,
-                                                const vvl::RenderPass &rp_state, const VkRenderPassCreateInfo2 &rpci) const {
+bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo& create_info, const Location& create_info_loc,
+                                                const vvl::RenderPass& rp_state, const VkRenderPassCreateInfo2& rpci) const {
     bool skip = false;
 
-    const VkImageView *image_views = create_info.pAttachments;
+    const VkImageView* image_views = create_info.pAttachments;
     for (uint32_t i = 0; i < create_info.attachmentCount; ++i) {
         const Location attachment_loc = create_info_loc.dot(Field::pAttachments, i);
         auto view_state = Get<vvl::ImageView>(image_views[i]);
         ASSERT_AND_CONTINUE(view_state);
-        auto &ivci = view_state->create_info;
-        auto &subresource_range = view_state->normalized_subresource_range;
+        auto& ivci = view_state->create_info;
+        auto& subresource_range = view_state->normalized_subresource_range;
         if (ivci.format != rpci.pAttachments[i].format) {
             LogObjectList objlist(create_info.renderPass, image_views[i]);
             skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00880", objlist, attachment_loc,
@@ -4970,7 +4972,7 @@ bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &c
             }
         }
 
-        const auto &ici = view_state->image_state->create_info;
+        const auto& ici = view_state->image_state->create_info;
         if (ici.samples != rpci.pAttachments[i].samples) {
             LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
             skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00881", objlist, attachment_loc,
@@ -5002,7 +5004,7 @@ bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &c
         bool fsr_non_zero_viewmasks = false;
 
         for (uint32_t j = 0; j < rpci.subpassCount; ++j) {
-            const VkSubpassDescription2 &subpass = rpci.pSubpasses[j];
+            const VkSubpassDescription2& subpass = rpci.pSubpasses[j];
 
             // if viewmask is zero, will return -1 (so layerCount is always lower)
             int highest_view_bit = MostSignificantBit(subpass.viewMask);
@@ -5037,7 +5039,7 @@ bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &c
             }
 
             if (enabled_features.attachmentFragmentShadingRate) {
-                const auto *fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
+                const auto* fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
                 if (fsr_attachment && fsr_attachment->pFragmentShadingRateAttachment &&
                     fsr_attachment->pFragmentShadingRateAttachment->attachment == i) {
                     used_as_fragment_shading_rate_attachment = true;
@@ -5091,7 +5093,7 @@ bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &c
             }
 
             if (enabled_features.fragmentDensityMap && api_version >= VK_API_VERSION_1_1) {
-                const auto *fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
+                const auto* fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
 
                 if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
                     int32_t layer_count = view_state->normalized_subresource_range.layerCount;
@@ -5138,7 +5140,7 @@ bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &c
         }
 
         if (enabled_features.fragmentDensityMap) {
-            const auto *fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
+            const auto* fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
             if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED) {
                 if (fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
                     uint32_t ceiling_width = vvl::GetQuotientCeil(
@@ -5266,8 +5268,8 @@ bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &c
     return skip;
 }
 
-bool CoreChecks::ValidateTileMemoryAttachments(const VkImageView *image_views, const Location &loc, const vvl::RenderPass &rp_state,
-                                               const VkRenderPassCreateInfo2 &rpci) const {
+bool CoreChecks::ValidateTileMemoryAttachments(const VkImageView* image_views, const Location& loc, const vvl::RenderPass& rp_state,
+                                               const VkRenderPassCreateInfo2& rpci) const {
     bool skip = false;
     if (!enabled_features.tileMemoryHeap) {
         return skip;
@@ -5296,10 +5298,10 @@ bool CoreChecks::ValidateTileMemoryAttachments(const VkImageView *image_views, c
         ASSERT_AND_CONTINUE(image_view_state);
 
         auto bound_memory_states = image_view_state->image_state->GetBoundMemoryStates();
-        for (const auto &bound_memory : bound_memory_states) {
+        for (const auto& bound_memory : bound_memory_states) {
             if (bound_memory && HasTileMemoryType(bound_memory->allocate_info.memoryTypeIndex)) {
                 const bool is_imageless = loc.function != Func::vkCreateFramebuffer;
-                const char *vuid = is_imageless ? "VUID-VkRenderPassBeginInfo-framebuffer-12328"
+                const char* vuid = is_imageless ? "VUID-VkRenderPassBeginInfo-framebuffer-12328"
                                                 : "VUID-VkFramebufferCreateInfo-pAttachments-12327";
                 LogObjectList objlist(rp_state.VkHandle(), image_views[i], bound_memory->VkHandle());
                 skip |=
@@ -5316,13 +5318,13 @@ bool CoreChecks::ValidateTileMemoryAttachments(const VkImageView *image_views, c
 }
 
 bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
-    const VkFramebufferCreateInfo &create_info, const Location &create_info_loc, const VkRenderPassCreateInfo2 &rpci,
-    const VkFramebufferAttachmentsCreateInfo &framebuffer_attachments_create_info) const {
+    const VkFramebufferCreateInfo& create_info, const Location& create_info_loc, const VkRenderPassCreateInfo2& rpci,
+    const VkFramebufferAttachmentsCreateInfo& framebuffer_attachments_create_info) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < create_info.attachmentCount; ++i) {
         const Location attachment_loc = create_info_loc.dot(Field::pAttachments, i);
-        auto &aii = framebuffer_attachments_create_info.pAttachmentImageInfos[i];
+        auto& aii = framebuffer_attachments_create_info.pAttachmentImageInfos[i];
         bool format_found = false;
         for (uint32_t j = 0; j < aii.viewFormatCount; ++j) {
             if (aii.pViewFormats[j] == rpci.pAttachments[i].format) {
@@ -5342,7 +5344,7 @@ bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
         bool fsr_non_zero_viewmasks = false;
 
         for (uint32_t j = 0; j < rpci.subpassCount; ++j) {
-            const VkSubpassDescription2 &subpass = rpci.pSubpasses[j];
+            const VkSubpassDescription2& subpass = rpci.pSubpasses[j];
 
             int highest_view_bit = MostSignificantBit(subpass.viewMask);
 
@@ -5366,7 +5368,7 @@ bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
             }
 
             if (enabled_features.attachmentFragmentShadingRate) {
-                const auto *fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
+                const auto* fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
                 if (fsr_attachment && fsr_attachment->pFragmentShadingRateAttachment->attachment == i) {
                     used_as_fragment_shading_rate_attachment = true;
                     const bool validate_render_area =
@@ -5409,10 +5411,10 @@ bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
             }
 
             if (enabled_features.fragmentDensityMap) {
-                const auto *fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
+                const auto* fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
 
                 if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
-                    const auto &maxFragmentDensityTexelSize =
+                    const auto& maxFragmentDensityTexelSize =
                         phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize;
                     const uint32_t ceiling_width = vvl::GetQuotientCeil(create_info.width, maxFragmentDensityTexelSize.width);
                     if (aii.width < ceiling_width) {
@@ -5475,7 +5477,7 @@ bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
     // Validate image usage
     uint32_t attachment_index = VK_ATTACHMENT_UNUSED;
     for (uint32_t i = 0; i < rpci.subpassCount; ++i) {
-        const VkSubpassDescription2 &subpass = rpci.pSubpasses[i];
+        const VkSubpassDescription2& subpass = rpci.pSubpasses[i];
 
         skip |= MatchUsage(subpass.colorAttachmentCount, subpass.pColorAttachments, create_info,
                            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03201", create_info_loc);
@@ -5486,14 +5488,14 @@ bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
         skip |= MatchUsage(subpass.inputAttachmentCount, subpass.pInputAttachments, create_info,
                            VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03204", create_info_loc);
 
-        const auto *depth_stencil_resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass.pNext);
+        const auto* depth_stencil_resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass.pNext);
         if (depth_stencil_resolve != nullptr) {
             skip |= MatchUsage(1, depth_stencil_resolve->pDepthStencilResolveAttachment, create_info,
                                VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03203",
                                create_info_loc);
         }
 
-        const auto *fragment_shading_rate_attachment_info =
+        const auto* fragment_shading_rate_attachment_info =
             vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
         if (enabled_features.attachmentFragmentShadingRate && fragment_shading_rate_attachment_info != nullptr) {
             skip |= MatchUsage(1, fragment_shading_rate_attachment_info->pFragmentShadingRateAttachment, create_info,
@@ -5505,8 +5507,8 @@ bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
     // VUID-VkSubpassDescription2-multiview-06558 forces viewMask to be zero if not using multiView
     if ((rpci.subpassCount > 0) && (rpci.pSubpasses[0].viewMask != 0)) {
         for (uint32_t i = 0; i < rpci.subpassCount; ++i) {
-            const VkSubpassDescription2 &subpass = rpci.pSubpasses[i];
-            const auto *depth_stencil_resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass.pNext);
+            const VkSubpassDescription2& subpass = rpci.pSubpasses[i];
+            const auto* depth_stencil_resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass.pNext);
             uint32_t view_bits = subpass.viewMask;
             int highest_view_bit = MostSignificantBit(view_bits);
 
@@ -5608,8 +5610,8 @@ bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
     return skip;
 }
 
-bool CoreChecks::ValidateFrameBufferSubpasses(const VkFramebufferCreateInfo &create_info, const Location &create_info_loc,
-                                              const VkRenderPassCreateInfo2 &rpci) const {
+bool CoreChecks::ValidateFrameBufferSubpasses(const VkFramebufferCreateInfo& create_info, const Location& create_info_loc,
+                                              const VkRenderPassCreateInfo2& rpci) const {
     bool skip = false;
     for (uint32_t subpass = 0; subpass < rpci.subpassCount; subpass++) {
         const VkSubpassDescription2& subpass_description = rpci.pSubpasses[subpass];
@@ -5623,7 +5625,7 @@ bool CoreChecks::ValidateFrameBufferSubpasses(const VkFramebufferCreateInfo &cre
         skip |= MatchUsage(1, subpass_description.pDepthStencilAttachment, create_info, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
                            "VUID-VkFramebufferCreateInfo-pAttachments-02633", create_info_loc);
         // Verify depth/stecnil resolve
-        if (const auto *ds_resolve =
+        if (const auto* ds_resolve =
                 vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass_description.pNext)) {
             skip |=
                 MatchUsage(1, ds_resolve->pDepthStencilResolveAttachment, create_info, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
@@ -5659,7 +5661,7 @@ bool CoreChecks::ValidateFrameBufferSubpasses(const VkFramebufferCreateInfo &cre
 }
 
 bool CoreChecks::PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
-                                                   const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
+                                                   const VkAllocationCallbacks* pAllocator, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto framebuffer_state = Get<vvl::Framebuffer>(framebuffer)) {
         skip |= ValidateObjectNotInUse(framebuffer_state.get(), error_obj.location, "VUID-vkDestroyFramebuffer-framebuffer-00892");
@@ -5667,10 +5669,10 @@ bool CoreChecks::PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffe
     return skip;
 }
 
-bool CoreChecks::ValidateInheritanceInfoFramebuffer(const vvl::CommandBuffer &cb_state,
-                                                    const vvl::CommandBuffer &secondary_cb_state,
-                                                    const VkCommandBufferInheritanceInfo &secondary_inheritance_info,
-                                                    const Location &loc) const {
+bool CoreChecks::ValidateInheritanceInfoFramebuffer(const vvl::CommandBuffer& cb_state,
+                                                    const vvl::CommandBuffer& secondary_cb_state,
+                                                    const VkCommandBufferInheritanceInfo& secondary_inheritance_info,
+                                                    const Location& loc) const {
     bool skip = false;
     VkFramebuffer primary_fb = cb_state.active_framebuffer ? cb_state.active_framebuffer->VkHandle() : VK_NULL_HANDLE;
     VkFramebuffer secondary_fb = secondary_inheritance_info.framebuffer;
@@ -5686,8 +5688,8 @@ bool CoreChecks::ValidateInheritanceInfoFramebuffer(const vvl::CommandBuffer &cb
 }
 
 // TODO - loc_info makes no sense coming from a secondary command buffer
-bool CoreChecks::ValidateRenderingAttachmentLocations(const VkRenderingAttachmentLocationInfo &location_info,
-                                                      const LogObjectList objlist, const Location &loc_info) const {
+bool CoreChecks::ValidateRenderingAttachmentLocations(const VkRenderingAttachmentLocationInfo& location_info,
+                                                      const LogObjectList objlist, const Location& loc_info) const {
     bool skip = false;
 
     if (location_info.pColorAttachmentLocations) {
@@ -5734,9 +5736,9 @@ bool CoreChecks::ValidateRenderingAttachmentLocations(const VkRenderingAttachmen
 }
 
 bool CoreChecks::PreCallValidateCmdSetRenderingAttachmentLocations(VkCommandBuffer commandBuffer,
-                                                                   const VkRenderingAttachmentLocationInfo *pLocationInfo,
-                                                                   const ErrorObject &error_obj) const {
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+                                                                   const VkRenderingAttachmentLocationInfo* pLocationInfo,
+                                                                   const ErrorObject& error_obj) const {
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
 
     if (!enabled_features.dynamicRenderingLocalRead) {
@@ -5746,12 +5748,12 @@ bool CoreChecks::PreCallValidateCmdSetRenderingAttachmentLocations(VkCommandBuff
 
     skip |= ValidateCmd(cb_state, error_obj.location);
 
-    const auto *rp_state_ptr = cb_state.active_render_pass.get();
+    const auto* rp_state_ptr = cb_state.active_render_pass.get();
     if (!rp_state_ptr) {
         return skip;  // called outside a render pass (validated elsewhere)
     }
 
-    const auto &rp_state = *rp_state_ptr;
+    const auto& rp_state = *rp_state_ptr;
     if (!rp_state.use_dynamic_rendering) {
         const LogObjectList objlist(commandBuffer, rp_state.VkHandle());
         if (!rp_state.use_dynamic_rendering_inherited) {
@@ -5781,14 +5783,14 @@ bool CoreChecks::PreCallValidateCmdSetRenderingAttachmentLocations(VkCommandBuff
 }
 
 bool CoreChecks::PreCallValidateCmdSetRenderingAttachmentLocationsKHR(VkCommandBuffer commandBuffer,
-                                                                      const VkRenderingAttachmentLocationInfoKHR *pLocationInfo,
-                                                                      const ErrorObject &error_obj) const {
+                                                                      const VkRenderingAttachmentLocationInfoKHR* pLocationInfo,
+                                                                      const ErrorObject& error_obj) const {
     return PreCallValidateCmdSetRenderingAttachmentLocations(commandBuffer, pLocationInfo, error_obj);
 }
 
 // TODO - loc_info makes no sense coming from a secondary command buffer
-bool CoreChecks::ValidateRenderingInputAttachmentIndices(const VkRenderingInputAttachmentIndexInfo &index_info,
-                                                         const LogObjectList objlist, const Location &loc_info) const {
+bool CoreChecks::ValidateRenderingInputAttachmentIndices(const VkRenderingInputAttachmentIndexInfo& index_info,
+                                                         const LogObjectList objlist, const Location& loc_info) const {
     bool skip = false;
 
     vvl::unordered_map<uint32_t, uint32_t> unique;
@@ -5878,9 +5880,9 @@ bool CoreChecks::ValidateRenderingInputAttachmentIndices(const VkRenderingInputA
 }
 
 bool CoreChecks::PreCallValidateCmdSetRenderingInputAttachmentIndices(VkCommandBuffer commandBuffer,
-                                                                      const VkRenderingInputAttachmentIndexInfo *pLocationInfo,
-                                                                      const ErrorObject &error_obj) const {
-    const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
+                                                                      const VkRenderingInputAttachmentIndexInfo* pLocationInfo,
+                                                                      const ErrorObject& error_obj) const {
+    const auto& cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
 
     if (!enabled_features.dynamicRenderingLocalRead) {
@@ -5890,12 +5892,12 @@ bool CoreChecks::PreCallValidateCmdSetRenderingInputAttachmentIndices(VkCommandB
 
     skip |= ValidateCmd(cb_state, error_obj.location);
 
-    const auto *rp_state_ptr = cb_state.active_render_pass.get();
+    const auto* rp_state_ptr = cb_state.active_render_pass.get();
     if (!rp_state_ptr) {
         return skip;  // called outside a render pass (validated elsewhere)
     }
 
-    const auto &rp_state = *rp_state_ptr;
+    const auto& rp_state = *rp_state_ptr;
     if (!rp_state.use_dynamic_rendering) {
         const LogObjectList objlist(commandBuffer, rp_state.VkHandle());
         if (!rp_state.use_dynamic_rendering_inherited) {
@@ -5926,12 +5928,12 @@ bool CoreChecks::PreCallValidateCmdSetRenderingInputAttachmentIndices(VkCommandB
 }
 
 bool CoreChecks::PreCallValidateCmdSetRenderingInputAttachmentIndicesKHR(
-    VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR *pLocationInfo,
-    const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR* pLocationInfo,
+    const ErrorObject& error_obj) const {
     return PreCallValidateCmdSetRenderingInputAttachmentIndices(commandBuffer, pLocationInfo, error_obj);
 }
 
-bool CoreChecks::ValidateCustomResolveCreateInfoEXT(const VkCustomResolveCreateInfoEXT &create_info, const Location &loc) const {
+bool CoreChecks::ValidateCustomResolveCreateInfoEXT(const VkCustomResolveCreateInfoEXT& create_info, const Location& loc) const {
     bool skip = false;
     if (create_info.colorAttachmentCount > phys_dev_props.limits.maxColorAttachments) {
         skip |= LogError("VUID-VkCustomResolveCreateInfoEXT-colorAttachmentCount-11507", device,

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -41,14 +41,14 @@
 #include "utils/vk_api_utils.h"
 #include "utils/image_utils.h"
 
-bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, const spirv::Module &module_state,
-                                              const spirv::EntryPoint &entrypoint, const Location &create_info_loc) const {
+bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline& pipeline, const spirv::Module& module_state,
+                                              const spirv::EntryPoint& entrypoint, const Location& create_info_loc) const {
     bool skip = false;
     const Location vi_loc = create_info_loc.dot(Field::pVertexInputState);
 
     struct AttribInputPair {
-        const VkFormat *attribute_input = nullptr;
-        const spirv::Instruction *shader_input = nullptr;
+        const VkFormat* attribute_input = nullptr;
+        const spirv::Instruction* shader_input = nullptr;
         const spirv::StageInterfaceVariable* variable_ptr = nullptr;
         uint32_t attribute_index = 0;
     };
@@ -57,7 +57,7 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
     // or have 2 variables in a location
     std::map<uint32_t, AttribInputPair> location_map;
 
-    vku::safe_VkPipelineVertexInputStateCreateInfo const *input_state = pipeline.InputState();
+    vku::safe_VkPipelineVertexInputStateCreateInfo const* input_state = pipeline.InputState();
     if (!input_state) {
         // if using vertex and mesh, will hit an error, but still might get here
         return skip;
@@ -76,8 +76,8 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
         }
     }
 
-    for (const auto *variable_ptr : entrypoint.user_defined_interface_variables) {
-        const auto &variable = *variable_ptr;
+    for (const auto* variable_ptr : entrypoint.user_defined_interface_variables) {
+        const auto& variable = *variable_ptr;
         if ((variable.storage_class != spv::StorageClassInput)) {
             continue;  // not an input interface
         }
@@ -85,7 +85,7 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
         // All members of struct must all have Locations or none of them will.
         // If the interface variable doesn't have the Locations, find them inside the struct members
         if (!variable.type_struct_info) {
-            for (const auto &slot : variable.interface_slots) {
+            for (const auto& slot : variable.interface_slots) {
                 const uint32_t location = slot.Location();
                 location_map[location].shader_input = &variable.base_type;
                 location_map[location].variable_ptr = variable_ptr;
@@ -94,7 +94,7 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
             // Variable is decorated with Location
             uint32_t location = variable.decorations.location;
             for (uint32_t i = 0; i < variable.type_struct_info->members.size(); i++) {
-                const auto &member = variable.type_struct_info->members[i];
+                const auto& member = variable.type_struct_info->members[i];
                 // can be 64-bit formats in the struct
                 const spirv::Instruction* member_type = module_state.FindDef(member.id);
                 const uint32_t num_locations = module_state.GetLocationsConsumedByType(member_type);
@@ -106,7 +106,7 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
             }
         } else {
             // Can't be nested so only need to look at first level of members
-            for (const auto &member : variable.type_struct_info->members) {
+            for (const auto& member : variable.type_struct_info->members) {
                 const uint32_t location = member.decorations->location;
                 location_map[location].shader_input = member.insn;
                 location_map[location].variable_ptr = variable_ptr;
@@ -114,7 +114,7 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
         }
     }
 
-    for (const auto &[location, attribute_info] : location_map) {
+    for (const auto& [location, attribute_info] : location_map) {
         const auto attribute_input = attribute_info.attribute_input;
         const auto shader_input = attribute_info.shader_input;
 
@@ -185,10 +185,10 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
     return skip;
 }
 
-bool CoreChecks::ValidateInterfaceFragmentOutput(const vvl::Pipeline &pipeline, const spirv::Module &module_state,
-                                                 const spirv::EntryPoint &entrypoint, const Location &create_info_loc) const {
+bool CoreChecks::ValidateInterfaceFragmentOutput(const vvl::Pipeline& pipeline, const spirv::Module& module_state,
+                                                 const spirv::EntryPoint& entrypoint, const Location& create_info_loc) const {
     bool skip = false;
-    const auto *ms_state = pipeline.MultisampleState();
+    const auto* ms_state = pipeline.MultisampleState();
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT) && ms_state && ms_state->alphaToCoverageEnable) {
         if (!entrypoint.has_alpha_to_coverage_variable) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891", module_state.handle(),
@@ -201,8 +201,8 @@ bool CoreChecks::ValidateInterfaceFragmentOutput(const vvl::Pipeline &pipeline, 
     return skip;
 }
 
-bool CoreChecks::ValidateBuiltInLimits(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                       const vvl::Pipeline *pipeline, const Location &loc) const {
+bool CoreChecks::ValidateBuiltInLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                       const vvl::Pipeline* pipeline, const Location& loc) const {
     bool skip = false;
 
     // Currently all builtin tested are only found in fragment shaders
@@ -210,12 +210,12 @@ bool CoreChecks::ValidateBuiltInLimits(const spirv::Module &module_state, const 
         return skip;
     }
 
-    for (const auto *variable : entrypoint.built_in_variables) {
+    for (const auto* variable : entrypoint.built_in_variables) {
         // Currently don't need to search in structs
         // Handles both the input and output sampleMask
         if (variable->decorations.built_in == spv::BuiltInSampleMask &&
             variable->array_size > phys_dev_props.limits.maxSampleMaskWords) {
-            const char *vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-maxSampleMaskWords-00711"
+            const char* vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-maxSampleMaskWords-00711"
                                         : "VUID-VkShaderCreateInfoEXT-pCode-08451";
             const bool glsl_name = module_state.static_data_.source_language != spv::SourceLanguageHLSL &&
                                    module_state.static_data_.source_language != spv::SourceLanguageSlang;
@@ -232,8 +232,8 @@ bool CoreChecks::ValidateBuiltInLimits(const spirv::Module &module_state, const 
     return skip;
 }
 
-bool CoreChecks::ValidatePrimitiveTopology(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                           const vvl::Pipeline &pipeline, const Location &loc) const {
+bool CoreChecks::ValidatePrimitiveTopology(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                           const vvl::Pipeline& pipeline, const Location& loc) const {
     bool skip = false;
 
     if (!pipeline.pre_raster_state || !pipeline.InputAssemblyState() || entrypoint.stage != VK_SHADER_STAGE_GEOMETRY_BIT ||
@@ -299,18 +299,18 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const ShaderStageState& producer
 
     // build up a mapping of which slots are used and then go through it and look for gaps
     struct ComponentInfo {
-        const spirv::StageInterfaceVariable *output = nullptr;
+        const spirv::StageInterfaceVariable* output = nullptr;
         uint32_t output_type = 0;
         uint32_t output_width = 0;
-        const spirv::StageInterfaceVariable *input = nullptr;
+        const spirv::StageInterfaceVariable* input = nullptr;
         uint32_t input_type = 0;
         uint32_t input_width = 0;
     };
     // <Location, Components[4]> (only 4 components in a Location)
     vvl::unordered_map<uint32_t, std::array<ComponentInfo, 4>> slot_map;
 
-    for (const auto &[interface_slot, stage_variable] : producer_entrypoint.output_interface_slots) {
-        auto &slot = slot_map[interface_slot.Location()][interface_slot.Component()];
+    for (const auto& [interface_slot, stage_variable] : producer_entrypoint.output_interface_slots) {
+        auto& slot = slot_map[interface_slot.Location()][interface_slot.Component()];
         if (stage_variable->nested_struct) {
             return skip;  // TODO workaround
         }
@@ -319,8 +319,8 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const ShaderStageState& producer
         slot.output_width = interface_slot.bit_width;
     }
 
-    for (const auto &[interface_slot, stage_variable] : consumer_entrypoint.input_interface_slots) {
-        auto &slot = slot_map[interface_slot.Location()][interface_slot.Component()];
+    for (const auto& [interface_slot, stage_variable] : consumer_entrypoint.input_interface_slots) {
+        auto& slot = slot_map[interface_slot.Location()][interface_slot.Component()];
         if (stage_variable->nested_struct) {
             return skip;  // TODO workaround
         }
@@ -329,14 +329,14 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const ShaderStageState& producer
         slot.input_width = interface_slot.bit_width;
     }
 
-    for (const auto &[location, components] : slot_map) {
+    for (const auto& [location, components] : slot_map) {
         // Found that sometimes there is a big mismatch and printing out EVERY slot adds a lot of noise
         if (skip) break;
 
         for (uint32_t component = 0; component < 4; component++) {
-            const auto &component_info = components[component];
-            const auto *input_var = component_info.input;
-            const auto *output_var = component_info.output;
+            const auto& component_info = components[component];
+            const auto* input_var = component_info.input;
+            const auto* output_var = component_info.output;
 
             if ((input_var == nullptr) && (output_var == nullptr)) {
                 continue;  // both empty
@@ -458,13 +458,13 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const ShaderStageState& producer
 
     std::vector<spv::BuiltIn> input_built_in_block;
     std::vector<spv::BuiltIn> output_built_in_block;
-    for (const auto *variable : producer_entrypoint.built_in_variables) {
+    for (const auto* variable : producer_entrypoint.built_in_variables) {
         if (variable->storage_class == spv::StorageClassOutput && !variable->built_in_block.empty()) {
             output_built_in_block = variable->built_in_block;
             break;
         }
     }
-    for (const auto *variable : consumer_entrypoint.built_in_variables) {
+    for (const auto* variable : consumer_entrypoint.built_in_variables) {
         if (variable->storage_class == spv::StorageClassInput && !variable->built_in_block.empty()) {
             input_built_in_block = variable->built_in_block;
             break;
@@ -510,9 +510,9 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const ShaderStageState& producer
 
 // Note - This is missing a variation check for ShaderObjects, but there is one for Dynamic Rendering and likely people using
 // ShaderObject are not using Render Passes
-bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                    const vvl::Pipeline &pipeline, uint32_t subpass_index,
-                                                    const Location &create_info_loc) const {
+bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                    const vvl::Pipeline& pipeline, uint32_t subpass_index,
+                                                    const Location& create_info_loc) const {
     bool skip = false;
     // To match with the dynamic rendering case
     if (global_settings.only_report_errors) {
@@ -520,20 +520,20 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
     }
 
     struct Attachment {
-        const VkAttachmentReference2 *reference = nullptr;
-        const VkAttachmentDescription2 *attachment = nullptr;
-        const spirv::StageInterfaceVariable *output = nullptr;
+        const VkAttachmentReference2* reference = nullptr;
+        const VkAttachmentDescription2* attachment = nullptr;
+        const spirv::StageInterfaceVariable* output = nullptr;
     };
     std::map<uint32_t, Attachment> location_map;
 
-    const auto &rp_state = pipeline.RenderPassState();
+    const auto& rp_state = pipeline.RenderPassState();
     ASSERT_AND_RETURN_SKIP(rp_state);
     const auto rpci = rp_state->create_info.ptr();
     if (subpass_index >= rpci->subpassCount) return skip;
 
     const auto subpass = rpci->pSubpasses[subpass_index];
     for (uint32_t i = 0; i < subpass.colorAttachmentCount; ++i) {
-        auto const &reference = subpass.pColorAttachments[i];
+        auto const& reference = subpass.pColorAttachments[i];
         location_map[i].reference = &reference;
         if (reference.attachment != VK_ATTACHMENT_UNUSED &&
             rpci->pAttachments[reference.attachment].format != VK_FORMAT_UNDEFINED) {
@@ -542,7 +542,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
     }
 
     // TODO: dual source blend index (spv::DecIndex, zero if not provided)
-    for (const auto *variable : entrypoint.user_defined_interface_variables) {
+    for (const auto* variable : entrypoint.user_defined_interface_variables) {
         if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
             continue;  // not an output interface
         }
@@ -557,17 +557,17 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
         location_map[variable->interface_slots[0].Location()].output = variable;
     }
 
-    const auto *ms_state = pipeline.MultisampleState();
+    const auto* ms_state = pipeline.MultisampleState();
     const bool alpha_to_coverage_enabled = ms_state && (ms_state->alphaToCoverageEnable == VK_TRUE);
 
-    for (const auto &[location, attachment_info] : location_map) {
+    for (const auto& [location, attachment_info] : location_map) {
         const auto reference = attachment_info.reference;
         if (reference != nullptr && reference->attachment == VK_ATTACHMENT_UNUSED) {
             continue;
         }
 
-        const VkAttachmentDescription2 *attachment = attachment_info.attachment;
-        const spirv::StageInterfaceVariable *output = attachment_info.output;
+        const VkAttachmentDescription2* attachment = attachment_info.attachment;
+        const spirv::StageInterfaceVariable* output = attachment_info.output;
         if (attachment && !output) {
             // See https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9616
             // If there is no output variable declared, the attachment is unaffected
@@ -625,8 +625,8 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
 }
 
 // This is validated at draw time unlike the VkRenderPass version
-bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bound_state, const vvl::CommandBuffer &cb_state,
-                                                       const Location &loc) const {
+bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound& last_bound_state, const vvl::CommandBuffer& cb_state,
+                                                       const Location& loc) const {
     bool skip = false;
     // Some apps do 100k draws a frame and found this function is a bottleneck if an app is violating these warnings
     if (global_settings.only_report_errors) {
@@ -635,19 +635,19 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
     if (last_bound_state.IsRasterizationDisabled()) {
         return skip;
     }
-    const spirv::EntryPoint *entrypoint = last_bound_state.GetFragmentEntryPoint();
+    const spirv::EntryPoint* entrypoint = last_bound_state.GetFragmentEntryPoint();
     if (!entrypoint) {
         return skip;
     }
-    const vvl::RenderPass &rp_state = *cb_state.active_render_pass;
+    const vvl::RenderPass& rp_state = *cb_state.active_render_pass;
     if (rp_state.use_dynamic_rendering_inherited) {
         return skip;
     }
-    vvl::Pipeline *pipeline = last_bound_state.pipeline_state;
+    vvl::Pipeline* pipeline = last_bound_state.pipeline_state;
 
     struct Attachment {
-        const VkRenderingAttachmentInfo *rendering_attachment_info = nullptr;
-        const spirv::StageInterfaceVariable *output = nullptr;
+        const VkRenderingAttachmentInfo* rendering_attachment_info = nullptr;
+        const spirv::StageInterfaceVariable* output = nullptr;
         std::optional<uint32_t> mapped_location = std::nullopt;
     };
     std::map<uint32_t, Attachment> location_map;
@@ -656,13 +656,14 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
     for (size_t i = 0; i < color_attachment_count; ++i) {
         uint32_t color_location = cb_state.rendering_attachments.color_locations[i];
         if (color_location != VK_ATTACHMENT_UNUSED) {
-            location_map[color_location].rendering_attachment_info = rp_state.dynamic_rendering_begin_rendering_info.pColorAttachments[i].ptr();
+            location_map[color_location].rendering_attachment_info =
+                rp_state.dynamic_rendering_begin_rendering_info.pColorAttachments[i].ptr();
             location_map[color_location].mapped_location = static_cast<uint32_t>(i);
         }
     }
 
     // TODO: dual source blend index (spv::DecIndex, zero if not provided)
-    for (const auto *variable : entrypoint->user_defined_interface_variables) {
+    for (const auto* variable : entrypoint->user_defined_interface_variables) {
         if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
             continue;  // not an output interface
         }
@@ -677,10 +678,10 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
         location_map[variable->interface_slots[0].Location()].output = variable;
     }
 
-    for (const auto &[location, attachment_info] : location_map) {
+    for (const auto& [location, attachment_info] : location_map) {
         const bool has_attachment =
             attachment_info.rendering_attachment_info && attachment_info.rendering_attachment_info->imageView != VK_NULL_HANDLE;
-        const spirv::StageInterfaceVariable *output = attachment_info.output;
+        const spirv::StageInterfaceVariable* output = attachment_info.output;
         uint32_t mapped_loc = attachment_info.mapped_location.value_or(location);
 
         if (has_attachment && !output) {
@@ -705,7 +706,7 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
                     }
                 } else {
                     ss << "none of the attachments were mapped to that location (mapping was [";
-                    for (const uint32_t &mapping : cb_state.rendering_attachments.color_locations) {
+                    for (const uint32_t& mapping : cb_state.rendering_attachments.color_locations) {
                         if (&mapping != &cb_state.rendering_attachments.color_locations[0]) {
                             ss << ", ";
                         }
@@ -723,12 +724,12 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
             const auto image_view_state = Get<vvl::ImageView>(attachment_info.rendering_attachment_info->imageView);
 
             // TODO - This create helper to do this via LastBound (and find other places doing similar thing)
-            const spirv::Module *module_state = nullptr;
+            const spirv::Module* module_state = nullptr;
             if (pipeline && pipeline->fragment_shader_state && pipeline->fragment_shader_state->fragment_shader &&
                 pipeline->fragment_shader_state->fragment_shader->spirv) {
                 module_state = pipeline->fragment_shader_state->fragment_shader->spirv.get();
             } else if (!pipeline) {
-                const vvl::ShaderObject *shader_object = last_bound_state.GetShaderObjectStateIfValid(ShaderObjectStage::FRAGMENT);
+                const vvl::ShaderObject* shader_object = last_bound_state.GetShaderObjectStateIfValid(ShaderObjectStage::FRAGMENT);
                 if (shader_object && shader_object->stage.spirv_state) {
                     module_state = shader_object->stage.spirv_state.get();
                 }
@@ -760,7 +761,8 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
                                "attachments "
                                "have different colorWriteMask)";
                     }
-                    msg << ".\nIf you have the output variable, but are not using it on purpose, removing it from being declared in the shader will "
+                    msg << ".\nIf you have the output variable, but are not using it on purpose, removing it from being declared "
+                           "in the shader will "
                            "remove the undefined value warning";
                     const LogObjectList objlist = last_bound_state.cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
                     skip |= LogUndefinedValue("Undefined-Value-OutputNotWritten-DynamicRendering", objlist, loc, "%s",
@@ -808,7 +810,7 @@ bool CoreChecks::ValidateDrawRenderingTileMemoryOutputs(const LastBound& last_bo
     }
 
     for (uint32_t i = 0; i < cb_state.active_attachments.size(); ++i) {
-        const auto &attachment_info = cb_state.active_attachments[i];
+        const auto& attachment_info = cb_state.active_attachments[i];
         const auto image_view_state = attachment_info.image_view;
         // Resolve is banned with a separate VU and checked elsewhere
         if (image_view_state && !attachment_info.IsResolve()) {
@@ -863,7 +865,7 @@ bool CoreChecks::ValidatePipelineTessellationStages(const ShaderStageState& tesc
 
 // Validate that the shaders used by the given pipeline and store the active_slots
 //  that are actually used by the pipeline into pPipeline->active_slots
-bool CoreChecks::ValidateGraphicsPipelineShaderState(const vvl::Pipeline &pipeline, const Location &create_info_loc) const {
+bool CoreChecks::ValidateGraphicsPipelineShaderState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const {
     bool skip = false;
 
     if (!(pipeline.pre_raster_state || pipeline.fragment_shader_state)) {
@@ -877,7 +879,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const vvl::Pipeline &pipeli
     const ShaderStageState* fragment_stage = nullptr;
 
     for (uint32_t i = 0; i < pipeline.stage_states.size(); i++) {
-        auto &stage_state = pipeline.stage_states[i];
+        auto& stage_state = pipeline.stage_states[i];
         const VkShaderStageFlagBits stage = stage_state.GetStage();
         // Only validate the shader state once when added, not again when linked
         if ((stage & pipeline.linking_shaders) == 0) {
@@ -962,7 +964,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const vvl::Pipeline &pipeli
 
     // Don't check any color attachments if rasterization is disabled
     if (fragment_stage && fragment_stage->entrypoint && fragment_stage->spirv_state && !pipeline.RasterizationDisabled()) {
-        const auto &rp_state = pipeline.RenderPassState();
+        const auto& rp_state = pipeline.RenderPassState();
         // Dynamic Rendering is done at draw time incase the user has VK_EXT_dynamic_rendering_unused_attachments we can't do all
         // the checks at this time
         if (rp_state && !rp_state->UsesDynamicRendering()) {

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -62,7 +62,7 @@ bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module& module_state
     bool skip = false;
     assert(variable.is_input_attachment);
 
-    const auto &rp_state = pipeline.RenderPassState();
+    const auto& rp_state = pipeline.RenderPassState();
     if (!rp_state) {
         return skip;
     }
@@ -136,9 +136,9 @@ bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module& module_state
     return skip;
 }
 
-bool CoreChecks::ValidatePushConstantUsage(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                           const vvl::Pipeline *pipeline, const ShaderStageState &stage_state,
-                                           const Location &loc) const {
+bool CoreChecks::ValidatePushConstantUsage(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                           const vvl::Pipeline* pipeline, const ShaderStageState& stage_state,
+                                           const Location& loc) const {
     bool skip = false;
 
     if (stage_state.descriptor_heap_mode) {
@@ -155,7 +155,7 @@ bool CoreChecks::ValidatePushConstantUsage(const spirv::Module &module_state, co
     }
 
     PushConstantRangesId shader_object_push_constant_ranges_id;
-    std::vector<VkPushConstantRange> const *push_constant_ranges;
+    std::vector<VkPushConstantRange> const* push_constant_ranges;
     if (pipeline) {
         push_constant_ranges = pipeline->PipelineLayoutState()->push_constant_ranges_layout.get();
     } else {
@@ -180,7 +180,7 @@ bool CoreChecks::ValidatePushConstantUsage(const spirv::Module &module_state, co
     }
 
     bool found_stage = false;
-    for (auto const &range : *push_constant_ranges) {
+    for (auto const& range : *push_constant_ranges) {
         if (range.stageFlags & stage) {
             found_stage = true;
             const uint32_t range_end = range.offset + range.size;
@@ -213,7 +213,7 @@ bool CoreChecks::ValidatePushConstantUsage(const spirv::Module &module_state, co
             ss << "VkShaderCreateInfoEXT::pPushConstantRanges";
         }
         ss << " doesn't set any with " << string_VkShaderStageFlags(stage) << "\nCurrent VkPushConstantRange:";
-        for (auto const &range : *push_constant_ranges) {
+        for (auto const& range : *push_constant_ranges) {
             ss << "\n - " << string_VkPushConstantRange(range);
         }
         skip |= LogError(GetSpirvInterfaceVariableVUID(loc, vvl::SpirvInterfaceVariableError::PushConstantStage_07987), objlist,
@@ -301,9 +301,9 @@ struct ShaderResourceType {
 // This function is matching the VkDescriptorType to the SPIR-V.
 // We return back a set, because things like a Uniform in SPIR-V could be one of many possible matching VkDescriptorType.
 // https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-storage-class-correspondence
-static void TypeToDescriptorTypeSet(const spirv::Module &module_state, uint32_t type_id, uint32_t data_type_id,
-                                    ShaderResourceType &out_data) {
-    const spirv::Instruction *type = module_state.FindDef(type_id);
+static void TypeToDescriptorTypeSet(const spirv::Module& module_state, uint32_t type_id, uint32_t data_type_id,
+                                    ShaderResourceType& out_data) {
+    const spirv::Instruction* type = module_state.FindDef(type_id);
     assert(type->Opcode() == spv::OpTypePointer || type->Opcode() == spv::OpTypeUntypedPointerKHR);
     bool is_storage_buffer = type->StorageClass() == spv::StorageClassStorageBuffer;
 
@@ -327,7 +327,7 @@ static void TypeToDescriptorTypeSet(const spirv::Module &module_state, uint32_t 
 
     switch (type->Opcode()) {
         case spv::OpTypeStruct: {
-            for (const spirv::Instruction *insn : module_state.static_data_.decoration_inst) {
+            for (const spirv::Instruction* insn : module_state.static_data_.decoration_inst) {
                 if (insn->Word(1) == type->ResultId()) {
                     if (insn->Word(2) == spv::DecorationBlock) {
                         if (is_storage_buffer) {
@@ -357,7 +357,7 @@ static void TypeToDescriptorTypeSet(const spirv::Module &module_state, uint32_t 
         case spv::OpTypeSampledImage: {
             // Slight relaxation for some GLSL historical madness: samplerBuffer doesn't really have a sampler, and a texel
             // buffer descriptor doesn't really provide one. Allow this slight mismatch.
-            const spirv::Instruction *image_type = module_state.FindDef(type->Word(2));
+            const spirv::Instruction* image_type = module_state.FindDef(type->Word(2));
             auto dim = image_type->Word(3);
             auto sampled = image_type->Word(7);
             if (dim == spv::DimBuffer && sampled == 1) {
@@ -415,7 +415,7 @@ static void TypeToDescriptorTypeSet(const spirv::Module &module_state, uint32_t 
 }
 
 // Map SPIR-V type to VK_COMPONENT_TYPE enum
-VkComponentTypeKHR GetComponentType(const spirv::Instruction *insn, bool is_signed_int) {
+VkComponentTypeKHR GetComponentType(const spirv::Instruction* insn, bool is_signed_int) {
     if (insn->Opcode() == spv::OpTypeInt) {
         switch (insn->Word(2)) {
             case 8:
@@ -479,20 +479,20 @@ static bool IsSignedIntEnum(const VkComponentTypeKHR component_type) {
 
 // Validate SPV_KHR_cooperative_matrix (and SPV_NV_cooperative_matrix) behavior that can't be statically validated in SPIRV-Tools
 // (e.g. due to specialization constant usage).
-bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                           const ShaderStageState &stage_state, const spirv::LocalSize &local_size,
-                                           const Location &loc) const {
+bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                           const ShaderStageState& stage_state, const spirv::LocalSize& local_size,
+                                           const Location& loc) const {
     bool skip = false;
     const uint64_t workgroup_size = local_size.x * local_size.y * local_size.z;
 
     uint32_t effective_subgroup_size = phys_dev_props_core11.subgroupSize;
-    if (const auto *required_subgroup_size_ci =
+    if (const auto* required_subgroup_size_ci =
             vku::FindStructInPNextChain<VkPipelineShaderStageRequiredSubgroupSizeCreateInfo>(stage_state.GetPNext())) {
         effective_subgroup_size = required_subgroup_size_ci->requiredSubgroupSize;
     }
 
-    const auto &IsSignedIntType = [&module_state](const uint32_t type_id) {
-        const spirv::Instruction *type = module_state.FindDef(type_id);
+    const auto& IsSignedIntType = [&module_state](const uint32_t type_id) {
+        const spirv::Instruction* type = module_state.FindDef(type_id);
         if (type->Opcode() == spv::OpTypeCooperativeMatrixKHR || type->Opcode() == spv::OpTypeCooperativeMatrixNV) {
             type = module_state.FindDef(type->Word(2));
         }
@@ -507,12 +507,12 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
         uint32_t use;
         bool all_constant;
 
-        CoopMatType(uint32_t id, const spirv::Module &module_state, bool is_signed_int) {
-            const spirv::Instruction *insn = module_state.FindDef(id);
-            const spirv::Instruction *component_type_insn = module_state.FindDef(insn->Word(2));
-            const spirv::Instruction *scope_insn = module_state.FindDef(insn->Word(3));
-            const spirv::Instruction *rows_insn = module_state.FindDef(insn->Word(4));
-            const spirv::Instruction *cols_insn = module_state.FindDef(insn->Word(5));
+        CoopMatType(uint32_t id, const spirv::Module& module_state, bool is_signed_int) {
+            const spirv::Instruction* insn = module_state.FindDef(id);
+            const spirv::Instruction* component_type_insn = module_state.FindDef(insn->Word(2));
+            const spirv::Instruction* scope_insn = module_state.FindDef(insn->Word(3));
+            const spirv::Instruction* rows_insn = module_state.FindDef(insn->Word(4));
+            const spirv::Instruction* cols_insn = module_state.FindDef(insn->Word(5));
 
             all_constant = true;
             uint32_t tmp_scope = 0;
@@ -529,7 +529,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
             component_type = GetComponentType(component_type_insn, is_signed_int);
 
             if (insn->Opcode() == spv::OpTypeCooperativeMatrixKHR) {
-                const spirv::Instruction *use_insn = module_state.FindDef(insn->Word(6));
+                const spirv::Instruction* use_insn = module_state.FindDef(insn->Word(6));
                 if (!module_state.GetInt32IfConstant(*use_insn, &use)) {
                     all_constant = false;
                 }
@@ -577,7 +577,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
         }
 
         if (!has_full_subgroups) {
-            const char *vuid = stage_state.HasPipeline() ? "VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-10770"
+            const char* vuid = stage_state.HasPipeline() ? "VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-10770"
                                                          : "VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-10771";
             skip |= LogError(vuid, module_state.handle(), loc,
                              "shader %s contains SPV_KHR_cooperative_matrix which requires SPIR-V 1.6 (Vulkan 1.3). In order to "
@@ -591,7 +591,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
     // Map SPIR-V result ID to the ID of its type.
     // TODO - Should have more robust way in ModuleState to find the type
     vvl::unordered_map<uint32_t, uint32_t> id_to_type_id;
-    for (const spirv::Instruction &insn : module_state.GetInstructions()) {
+    for (const spirv::Instruction& insn : module_state.GetInstructions()) {
         if (OpcodeHasType(insn.Opcode()) && OpcodeHasResult(insn.Opcode())) {
             id_to_type_id[insn.Word(2)] = insn.Word(1);
         }
@@ -600,7 +600,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
     auto print_properties = [this]() {
         std::ostringstream ss;
         for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_khr.size(); ++i) {
-            const auto &prop = device_state->cooperative_matrix_properties_khr[i];
+            const auto& prop = device_state->cooperative_matrix_properties_khr[i];
             ss << "[" << i << "] MSize = " << prop.MSize << " | NSize = " << prop.NSize << " | KSize = " << prop.KSize
                << " | AType = " << string_VkComponentTypeKHR(prop.AType) << " | BType = " << string_VkComponentTypeKHR(prop.BType)
                << " | CType = " << string_VkComponentTypeKHR(prop.CType)
@@ -613,7 +613,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
     auto print_flexible_properties = [this]() {
         std::ostringstream ss;
         for (uint32_t i = 0; i < device_state->cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
-            const auto &prop = device_state->cooperative_matrix_flexible_dimensions_properties[i];
+            const auto& prop = device_state->cooperative_matrix_flexible_dimensions_properties[i];
             ss << "[" << i << "] MGranularity = " << prop.MGranularity << " | NGranularity = " << prop.NGranularity
                << " | KGranularity = " << prop.KGranularity << " | AType = " << string_VkComponentTypeKHR(prop.AType)
                << " | BType = " << string_VkComponentTypeKHR(prop.BType) << " | CType = " << string_VkComponentTypeKHR(prop.CType)
@@ -623,8 +623,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
         return ss.str();
     };
 
-    for (const spirv::Instruction *cooperative_matrix_inst : module_state.static_data_.cooperative_matrix_inst) {
-        const spirv::Instruction &insn = *cooperative_matrix_inst;
+    for (const spirv::Instruction* cooperative_matrix_inst : module_state.static_data_.cooperative_matrix_inst) {
+        const spirv::Instruction& insn = *cooperative_matrix_inst;
         switch (insn.Opcode()) {
             case spv::OpTypeCooperativeMatrixKHR: {
                 CoopMatType m(insn.ResultId(), module_state, IsSignedIntType(insn.Word(2)));
@@ -667,7 +667,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                 // operands of a cooperative matrix khr property.
                 bool valid = false;
                 for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_khr.size(); ++i) {
-                    const auto &property = device_state->cooperative_matrix_properties_khr[i];
+                    const auto& property = device_state->cooperative_matrix_properties_khr[i];
                     if (property.AType == m.component_type && property.MSize == m.rows && property.KSize == m.cols &&
                         property.scope == m.scope && m.use == spv::CooperativeMatrixUseMatrixAKHR) {
                         valid = true;
@@ -691,7 +691,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                 }
                 if (enabled_features.cooperativeMatrixFlexibleDimensions) {
                     for (uint32_t i = 0; i < device_state->cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
-                        const auto &property = device_state->cooperative_matrix_flexible_dimensions_properties[i];
+                        const auto& property = device_state->cooperative_matrix_flexible_dimensions_properties[i];
 
                         if (property.scope == VK_SCOPE_WORKGROUP_KHR && workgroup_size != property.workgroupInvocations) {
                             continue;
@@ -766,7 +766,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                     // cooperative matrix property.
                     bool found_matching_prop = false;
                     for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_khr.size(); ++i) {
-                        const auto &property = device_state->cooperative_matrix_properties_khr[i];
+                        const auto& property = device_state->cooperative_matrix_properties_khr[i];
 
                         bool valid = true;
                         valid &= property.AType == a.component_type && property.MSize == a.rows && property.KSize == a.cols &&
@@ -798,7 +798,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                     bool found_matching_flexible_prop = false;
                     if (enabled_features.cooperativeMatrixFlexibleDimensions) {
                         for (uint32_t i = 0; i < device_state->cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
-                            const auto &property = device_state->cooperative_matrix_flexible_dimensions_properties[i];
+                            const auto& property = device_state->cooperative_matrix_flexible_dimensions_properties[i];
 
                             bool valid = true;
                             valid &= property.AType == a.component_type && IsIntegerMultipleOf(a.rows, property.MGranularity) &&
@@ -867,7 +867,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                 // operands of a cooperative matrix property.
                 bool valid = false;
                 for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_nv.size(); ++i) {
-                    const auto &property = device_state->cooperative_matrix_properties_nv[i];
+                    const auto& property = device_state->cooperative_matrix_properties_nv[i];
                     if (property.AType == m.component_type && property.MSize == m.rows && property.KSize == m.cols &&
                         property.scope == m.scope) {
                         valid = true;
@@ -911,7 +911,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                     bool valid_c = false;
                     bool valid_d = false;
                     for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_nv.size(); ++i) {
-                        const auto &property = device_state->cooperative_matrix_properties_nv[i];
+                        const auto& property = device_state->cooperative_matrix_properties_nv[i];
                         valid_a |= property.AType == a.component_type && property.MSize == a.rows && property.KSize == a.cols &&
                                    property.scope == a.scope;
                         valid_b |= property.BType == b.component_type && property.KSize == b.rows && property.NSize == b.cols &&
@@ -960,8 +960,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
     return skip;
 }
 
-bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                           const Location &loc) const {
+bool CoreChecks::ValidateCooperativeVector(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                           const Location& loc) const {
     bool skip = false;
 
     struct CoopVecType {
@@ -969,10 +969,10 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
         uint32_t component_count;
         bool all_constant;
 
-        CoopVecType(uint32_t id, const spirv::Module &module_state, bool is_signed) {
-            const spirv::Instruction *insn = module_state.FindDef(id);
-            const spirv::Instruction *component_type_insn = module_state.FindDef(insn->Word(2));
-            const spirv::Instruction *component_count_insn = module_state.FindDef(insn->Word(3));
+        CoopVecType(uint32_t id, const spirv::Module& module_state, bool is_signed) {
+            const spirv::Instruction* insn = module_state.FindDef(id);
+            const spirv::Instruction* component_type_insn = module_state.FindDef(insn->Word(2));
+            const spirv::Instruction* component_count_insn = module_state.FindDef(insn->Word(3));
 
             all_constant = true;
             if (!module_state.GetInt32IfConstant(*component_count_insn, &component_count)) {
@@ -1003,13 +1003,13 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
     }
 
     vvl::unordered_map<uint32_t, uint32_t> id_to_type_id;
-    for (const spirv::Instruction &insn : module_state.GetInstructions()) {
+    for (const spirv::Instruction& insn : module_state.GetInstructions()) {
         if (OpcodeHasType(insn.Opcode()) && OpcodeHasResult(insn.Opcode())) {
             id_to_type_id[insn.Word(2)] = insn.Word(1);
         }
     }
-    for (const spirv::Instruction *cooperative_vector_inst : module_state.static_data_.cooperative_vector_inst) {
-        const spirv::Instruction &insn = *cooperative_vector_inst;
+    for (const spirv::Instruction* cooperative_vector_inst : module_state.static_data_.cooperative_vector_inst) {
+        const spirv::Instruction& insn = *cooperative_vector_inst;
         switch (insn.Opcode()) {
             case spv::OpTypeCooperativeVectorNV: {
                 // SPIR-V integer types are not strictly signed or unsigned. Allow this type to
@@ -1031,7 +1031,7 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
 
                 bool found = false;
                 for (uint32_t i = 0; i < device_state->cooperative_vector_properties_nv.size(); ++i) {
-                    const auto &property = device_state->cooperative_vector_properties_nv[i];
+                    const auto& property = device_state->cooperative_vector_properties_nv[i];
                     if (m_signed.component_type == property.inputType || m_signed.component_type == property.resultType ||
                         m_unsigned.component_type == property.inputType || m_unsigned.component_type == property.resultType) {
                         found = true;
@@ -1102,7 +1102,7 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
 
                 bool found = false;
                 for (uint32_t i = 0; i < device_state->cooperative_vector_properties_nv.size(); ++i) {
-                    const auto &property = device_state->cooperative_vector_properties_nv[i];
+                    const auto& property = device_state->cooperative_vector_properties_nv[i];
                     if (property.inputType == input_type && property.inputInterpretation == input_interpretation &&
                         property.matrixInterpretation == matrix_interpretation &&
                         (insn.Opcode() == spv::OpCooperativeVectorMatrixMulNV ||
@@ -1173,7 +1173,7 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
                         break;
                 }
 
-                const spirv::Instruction *ptr_type = module_state.FindDef(id_to_type_id[insn.Word(1)]);
+                const spirv::Instruction* ptr_type = module_state.FindDef(id_to_type_id[insn.Word(1)]);
                 if (ptr_type->StorageClass() != spv::StorageClassStorageBuffer &&
                     ptr_type->StorageClass() != spv::StorageClassPhysicalStorageBuffer) {
                     skip |= LogError("VUID-RuntimeSpirv-OpCooperativeVectorReduceSumAccumulateNV-10092", module_state.handle(), loc,
@@ -1241,7 +1241,7 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
                     }
                 }
 
-                const spirv::Instruction *ptr_type = module_state.FindDef(id_to_type_id[insn.Word(1)]);
+                const spirv::Instruction* ptr_type = module_state.FindDef(id_to_type_id[insn.Word(1)]);
                 if (ptr_type->StorageClass() != spv::StorageClassStorageBuffer &&
                     ptr_type->StorageClass() != spv::StorageClassPhysicalStorageBuffer) {
                     skip |= LogError("VUID-RuntimeSpirv-OpCooperativeVectorOuterProductAccumulateNV-10093", module_state.handle(),
@@ -1260,9 +1260,9 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
     return skip;
 }
 
-bool CoreChecks::ValidateShader64BitIndexing(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                             const ShaderStageState &stage_state, const vvl::Pipeline *pipeline,
-                                             const Location &loc) const {
+bool CoreChecks::ValidateShader64BitIndexing(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                             const ShaderStageState& stage_state, const vvl::Pipeline* pipeline,
+                                             const Location& loc) const {
     bool skip = false;
 
     if (pipeline && (pipeline->create_flags & VK_PIPELINE_CREATE_2_64_BIT_INDEXING_BIT_EXT)) {
@@ -1276,14 +1276,14 @@ bool CoreChecks::ValidateShader64BitIndexing(const spirv::Module &module_state, 
         return skip;
     }
 
-    auto const &check = [&](uint32_t value_id) -> bool {
+    auto const& check = [&](uint32_t value_id) -> bool {
         auto value_insn = module_state.FindDef(value_id);
         auto type_insn = module_state.FindDef(value_insn->Word(1));
         return type_insn->Word(2) != 32;
     };
 
-    for (const spirv::Instruction *cooperative_vector_inst : module_state.static_data_.cooperative_vector_inst) {
-        const spirv::Instruction &insn = *cooperative_vector_inst;
+    for (const spirv::Instruction* cooperative_vector_inst : module_state.static_data_.cooperative_vector_inst) {
+        const spirv::Instruction& insn = *cooperative_vector_inst;
         switch (insn.Opcode()) {
             case spv::OpCooperativeVectorMatrixMulNV:
             case spv::OpCooperativeVectorMatrixMulAddNV: {
@@ -1340,16 +1340,16 @@ bool CoreChecks::ValidateShader64BitIndexing(const spirv::Module &module_state, 
                 break;
         }
     }
-    for (const spirv::Instruction *array_length_inst : module_state.static_data_.array_length_inst) {
-        const spirv::Instruction &insn = *array_length_inst;
+    for (const spirv::Instruction* array_length_inst : module_state.static_data_.array_length_inst) {
+        const spirv::Instruction& insn = *array_length_inst;
         if (check(insn.TypeId())) {
             skip |= LogError("VUID-RuntimeSpirv-OpArrayLength-11807", module_state.handle(), loc,
                              "shader %s contains 64-bit array length return type\n%s\n", entrypoint.Describe().c_str(),
                              module_state.DescribeInstruction(insn).c_str());
         }
     }
-    for (const spirv::Instruction *constant_size_of_inst : module_state.static_data_.constant_size_of_inst) {
-        const spirv::Instruction &insn = *constant_size_of_inst;
+    for (const spirv::Instruction* constant_size_of_inst : module_state.static_data_.constant_size_of_inst) {
+        const spirv::Instruction& insn = *constant_size_of_inst;
         if (check(insn.TypeId())) {
             skip |= LogError("VUID-RuntimeSpirv-OpConstantSizeOfEXT-11475", module_state.handle(), loc,
                              "shader %s contains 64-bit OpConstantSizeOfEXT return type\n%s\n", entrypoint.Describe().c_str(),
@@ -1390,7 +1390,7 @@ bool CoreChecks::ValidateSubpassCustomeResolve(const spirv::Module& module_state
     // If the pipeline's subpass description contains flag VK_SUBPASS_DESCRIPTION_FRAGMENT_REGION_BIT_EXT,
     // then the fragment shader must not enable the SPIRV SampleRateShading capability.
     if (stage == VK_SHADER_STAGE_FRAGMENT_BIT && module_state.HasCapability(spv::CapabilitySampleRateShading)) {
-        const auto &rp_state = pipeline.RenderPassState();
+        const auto& rp_state = pipeline.RenderPassState();
         if (!rp_state || rp_state->UsesDynamicRendering()) {
             return skip;
         }
@@ -1407,9 +1407,9 @@ bool CoreChecks::ValidateSubpassCustomeResolve(const spirv::Module& module_state
     return skip;
 }
 
-bool CoreChecks::ValidateShaderExecutionModes(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                              VkShaderStageFlagBits stage, const vvl::Pipeline *pipeline,
-                                              const Location &loc) const {
+bool CoreChecks::ValidateShaderExecutionModes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                              VkShaderStageFlagBits stage, const vvl::Pipeline* pipeline,
+                                              const Location& loc) const {
     bool skip = false;
 
     if (entrypoint.stage == VK_SHADER_STAGE_GEOMETRY_BIT) {
@@ -1417,7 +1417,7 @@ bool CoreChecks::ValidateShaderExecutionModes(const spirv::Module &module_state,
         const uint32_t invocations = entrypoint.execution_mode.invocations;
         if (vertices_out != spirv::kInvalidValue &&
             (vertices_out == 0 || vertices_out > phys_dev_props.limits.maxGeometryOutputVertices)) {
-            const char *vuid =
+            const char* vuid =
                 pipeline ? "VUID-VkPipelineShaderStageCreateInfo-stage-00714" : "VUID-VkShaderCreateInfoEXT-pCode-08454";
             skip |= LogError(vuid, module_state.handle(), loc,
                              "shader %s entry point must have an OpExecutionMode instruction that "
@@ -1428,7 +1428,7 @@ bool CoreChecks::ValidateShaderExecutionModes(const spirv::Module &module_state,
         }
 
         if (invocations == 0 || invocations > phys_dev_props.limits.maxGeometryShaderInvocations) {
-            const char *vuid =
+            const char* vuid =
                 pipeline ? "VUID-VkPipelineShaderStageCreateInfo-stage-00715" : "VUID-VkShaderCreateInfoEXT-pCode-08455";
             skip |= LogError(vuid, module_state.handle(), loc,
                              "shader %s entry point must have an OpExecutionMode instruction that "
@@ -1440,7 +1440,7 @@ bool CoreChecks::ValidateShaderExecutionModes(const spirv::Module &module_state,
     } else if (entrypoint.stage == VK_SHADER_STAGE_FRAGMENT_BIT &&
                entrypoint.execution_mode.Has(spirv::ExecutionModeSet::early_fragment_test_bit)) {
         if (pipeline) {
-            const auto *ds_state = pipeline->DepthStencilState();
+            const auto* ds_state = pipeline->DepthStencilState();
             if ((ds_state &&
                  (ds_state->flags &
                   (VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_BIT_EXT |
@@ -1457,9 +1457,9 @@ bool CoreChecks::ValidateShaderExecutionModes(const spirv::Module &module_state,
     return skip;
 }
 
-bool CoreChecks::ValidatePointSizeShaderState(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                              const vvl::Pipeline &pipeline, VkShaderStageFlagBits stage,
-                                              const Location &loc) const {
+bool CoreChecks::ValidatePointSizeShaderState(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                              const vvl::Pipeline& pipeline, VkShaderStageFlagBits stage,
+                                              const Location& loc) const {
     bool skip = false;
     // vkspec.html#primsrast-points describes which is the final stage that needs to check for points
     //
@@ -1515,9 +1515,9 @@ bool CoreChecks::ValidatePointSizeShaderState(const spirv::Module &module_state,
     return skip;
 }
 
-bool CoreChecks::ValidatePrimitiveRateShaderState(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                  const vvl::Pipeline &pipeline, VkShaderStageFlagBits stage,
-                                                  const Location &loc) const {
+bool CoreChecks::ValidatePrimitiveRateShaderState(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                  const vvl::Pipeline& pipeline, VkShaderStageFlagBits stage,
+                                                  const Location& loc) const {
     bool skip = false;
 
     const auto viewport_state = pipeline.ViewportState();
@@ -1554,8 +1554,8 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const spirv::Module &module_st
     return skip;
 }
 
-bool CoreChecks::ValidateWorkgroupSharedMemory(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                               VkShaderStageFlagBits stage, const Location &loc) const {
+bool CoreChecks::ValidateWorkgroupSharedMemory(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                               VkShaderStageFlagBits stage, const Location& loc) const {
     bool skip = false;
 
     const uint32_t total_workgroup_shared_memory = module_state.CalculateWorkgroupSharedMemory();
@@ -1569,7 +1569,7 @@ bool CoreChecks::ValidateWorkgroupSharedMemory(const spirv::Module &module_state
         }
 
         if (enabled_features.cooperativeMatrixWorkgroupScope) {
-            for (auto &cooperative_matrix_inst : module_state.static_data_.cooperative_matrix_inst) {
+            for (auto& cooperative_matrix_inst : module_state.static_data_.cooperative_matrix_inst) {
                 if (cooperative_matrix_inst->Opcode() != spv::OpTypeCooperativeMatrixKHR) {
                     continue;
                 }
@@ -1603,9 +1603,9 @@ bool CoreChecks::ValidateWorkgroupSharedMemory(const spirv::Module &module_state
     return skip;
 }
 
-bool CoreChecks::ValidateShaderInterfaceVariable(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                 const ShaderStageState &stage_state,
-                                                 const spirv::ResourceInterfaceVariable &variable, const Location &loc) const {
+bool CoreChecks::ValidateShaderInterfaceVariable(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                 const ShaderStageState& stage_state,
+                                                 const spirv::ResourceInterfaceVariable& variable, const Location& loc) const {
     bool skip = false;
 
     if (stage_state.descriptor_set_layouts) {
@@ -1687,9 +1687,9 @@ bool CoreChecks::ValidateShaderInterfaceVariable(const spirv::Module &module_sta
     return skip;
 }
 
-bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                    const ShaderStageState &stage_state,
-                                                    const spirv::ResourceInterfaceVariable &variable, const Location &loc) const {
+bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                    const ShaderStageState& stage_state,
+                                                    const spirv::ResourceInterfaceVariable& variable, const Location& loc) const {
     bool skip = false;
     if (!stage_state.descriptor_set_layouts) {
         return skip;
@@ -1699,9 +1699,9 @@ bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module &module_
 
     LogObjectList objlist(module_state.handle());
 
-    const VkDescriptorSetLayoutBinding *binding = nullptr;
+    const VkDescriptorSetLayoutBinding* binding = nullptr;
 
-    const vvl::DescriptorSetLayout *descriptor_set_layout = stage_state.descriptor_set_layouts->FindFromVariable(variable);
+    const vvl::DescriptorSetLayout* descriptor_set_layout = stage_state.descriptor_set_layouts->FindFromVariable(variable);
     if (descriptor_set_layout) {
         objlist.add(descriptor_set_layout->Handle());
         binding = descriptor_set_layout->GetDescriptorSetLayoutBindingPtrFromBinding(variable.decorations.binding);
@@ -1782,11 +1782,11 @@ bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module &module_
 }
 
 // "friends don't let friends validate YCbCr in SPIR-V" ~Spencer
-bool CoreChecks::ValidateShaderYcbcrSampler(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                            const vvl::DescriptorSetLayout &descriptor_set_layout,
-                                            const VkDescriptorSetLayoutBinding &binding,
-                                            const spirv::ResourceInterfaceVariable &variable, const LogObjectList &objlist,
-                                            const Location &loc) const {
+bool CoreChecks::ValidateShaderYcbcrSampler(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                            const vvl::DescriptorSetLayout& descriptor_set_layout,
+                                            const VkDescriptorSetLayoutBinding& binding,
+                                            const spirv::ResourceInterfaceVariable& variable, const LogObjectList& objlist,
+                                            const Location& loc) const {
     bool skip = false;
 
     // pImmutableSamplers can have non-YCbCr samplers (but can't mix between YCbCr/Non-YCbCr)
@@ -1807,10 +1807,10 @@ bool CoreChecks::ValidateShaderYcbcrSampler(const spirv::Module &module_state, c
 
     // The sampler state might have been destroyed, we need to get the safe struct we saved
     const uint32_t index = descriptor_set_layout.GetIndexFromBinding(binding.binding);
-    const std::vector<vku::safe_VkSamplerCreateInfo> &sampler_create_infos =
+    const std::vector<vku::safe_VkSamplerCreateInfo>& sampler_create_infos =
         descriptor_set_layout.GetImmutableSamplerCreateInfosFromIndex(index);
     for (uint32_t i = 0; i < sampler_create_infos.size(); i++) {
-        auto *conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(sampler_create_infos[i].pNext);
+        auto* conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(sampler_create_infos[i].pNext);
         if (!conversion_info || conversion_info->conversion == VK_NULL_HANDLE) {
             continue;
         }
@@ -1854,8 +1854,8 @@ bool CoreChecks::ValidateShaderYcbcrSampler(const spirv::Module &module_state, c
     return skip;
 }
 
-bool CoreChecks::ValidateTransformFeedbackPipeline(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                   const vvl::Pipeline &pipeline, const Location &loc) const {
+bool CoreChecks::ValidateTransformFeedbackPipeline(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                   const vvl::Pipeline& pipeline, const Location& loc) const {
     bool skip = false;
 
     const bool is_xfb_execution_mode = entrypoint.execution_mode.Has(spirv::ExecutionModeSet::xfb_bit);
@@ -1896,10 +1896,10 @@ bool CoreChecks::ValidateTransformFeedbackPipeline(const spirv::Module &module_s
 bool CoreChecks::ValidateImageWrite(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                     const Location& loc) const {
     bool skip = false;
-    for (const auto &[insn, load_id] : module_state.static_data_.image_write_load_id_map) {
+    for (const auto& [insn, load_id] : module_state.static_data_.image_write_load_id_map) {
         // guaranteed by spirv-val to be an OpTypeImage
         const uint32_t image = module_state.GetTypeId(load_id);
-        const spirv::Instruction *image_def = module_state.FindDef(image);
+        const spirv::Instruction* image_def = module_state.FindDef(image);
         const uint32_t image_format = image_def->Word(8);
         // If format is 'Unknown' then need to wait until a descriptor is bound to it
         if (image_format != spv::ImageFormatUnknown) {
@@ -1921,7 +1921,7 @@ bool CoreChecks::ValidateImageWrite(const spirv::Module& module_state, const spi
     return skip;
 }
 
-static const std::string GetShaderTileImageCapabilitiesString(const spirv::Module &module_state) {
+static const std::string GetShaderTileImageCapabilitiesString(const spirv::Module& module_state) {
     struct SpvCapabilityWithString {
         const spv::Capability cap;
         const std::string cap_string;
@@ -1944,8 +1944,8 @@ static const std::string GetShaderTileImageCapabilitiesString(const spirv::Modul
     return ss_capabilities.str();
 }
 
-bool CoreChecks::ValidateShaderTileImage(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                         const vvl::Pipeline &pipeline, const Location &loc) const {
+bool CoreChecks::ValidateShaderTileImage(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                         const vvl::Pipeline& pipeline, const Location& loc) const {
     bool skip = false;
 
     const bool using_tile_image_capability = module_state.HasCapability(spv::CapabilityTileImageColorReadAccessEXT) ||
@@ -1967,7 +1967,7 @@ bool CoreChecks::ValidateShaderTileImage(const spirv::Module &module_state, cons
 
     const bool mode_early_fragment_test = entrypoint.execution_mode.Has(spirv::ExecutionModeSet::early_fragment_test_bit);
     if (module_state.static_data_.has_shader_tile_image_depth_read) {
-        const auto *ds_state = pipeline.DepthStencilState();
+        const auto* ds_state = pipeline.DepthStencilState();
         const bool write_enabled =
             !pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE) && (ds_state && ds_state->depthWriteEnable);
         if (mode_early_fragment_test && write_enabled) {
@@ -1978,7 +1978,7 @@ bool CoreChecks::ValidateShaderTileImage(const spirv::Module &module_state, cons
     }
 
     if (module_state.static_data_.has_shader_tile_image_stencil_read) {
-        const auto *ds_state = pipeline.DepthStencilState();
+        const auto* ds_state = pipeline.DepthStencilState();
         const bool is_write_mask_set = !pipeline.IsDynamic(CB_DYNAMIC_STATE_STENCIL_WRITE_MASK) &&
                                        (ds_state && (ds_state->front.writeMask != 0 || ds_state->back.writeMask != 0));
         if (mode_early_fragment_test && is_write_mask_set) {
@@ -1992,7 +1992,7 @@ bool CoreChecks::ValidateShaderTileImage(const spirv::Module &module_state, cons
     bool using_tile_image_op = module_state.static_data_.has_shader_tile_image_depth_read ||
                                module_state.static_data_.has_shader_tile_image_stencil_read ||
                                module_state.static_data_.has_shader_tile_image_color_read;
-    const auto *ms_state = pipeline.MultisampleState();
+    const auto* ms_state = pipeline.MultisampleState();
     if (using_tile_image_op && ms_state && ms_state->sampleShadingEnable && (ms_state->minSampleShading != 1.0)) {
         skip |= LogError("VUID-RuntimeSpirv-minSampleShading-08732", module_state.handle(), loc,
                          "shader %s is using tile attachment reads, but minSampleShading (%f) is not equal to 1.0.",
@@ -2003,8 +2003,8 @@ bool CoreChecks::ValidateShaderTileImage(const spirv::Module &module_state, cons
 }
 
 // Validate the VkPipelineShaderStageCreateInfo from the various pipeline types or a Shader Object
-bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const vvl::Pipeline *pipeline,
-                                     const Location &loc) const {
+bool CoreChecks::ValidateShaderStage(const ShaderStageState& stage_state, const vvl::Pipeline* pipeline,
+                                     const Location& loc) const {
     bool skip = false;
     const VkShaderStageFlagBits stage = stage_state.GetStage();
 
@@ -2013,7 +2013,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
     skip |= ValidateSpecializations(stage_state.GetSpecializationInfo(), loc.dot(Field::pSpecializationInfo));
     if (pipeline) {
         skip |= ValidateShaderStageMaxResources(stage, *pipeline, loc);
-        if (const auto *pipeline_robustness_info =
+        if (const auto* pipeline_robustness_info =
                 vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(stage_state.GetPNext())) {
             skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, *pipeline_robustness_info, loc);
         }
@@ -2035,7 +2035,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
     }
 
     if (!stage_state.entrypoint) {
-        const char *vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pName-00707" : "VUID-VkShaderCreateInfoEXT-pName-08440";
+        const char* vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pName-00707" : "VUID-VkShaderCreateInfoEXT-pName-08440";
         std::ostringstream err;
         err << "\"" << stage_state.GetPName() << "\" entry point not found for stage " << string_VkShaderStageFlagBits(stage)
             << ".";
@@ -2058,7 +2058,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
             }
         } else {
             err << " The following entry points were found in the SPIR-V module:\n";
-            for (const auto &entry_point : stage_state.spirv_state->static_data_.entry_points) {
+            for (const auto& entry_point : stage_state.spirv_state->static_data_.entry_points) {
                 if (!entry_point) continue;
                 err << "\"" << entry_point->name << "\"\t(" << string_VkShaderStageFlagBits(entry_point->stage) << ")\n";
             }
@@ -2075,8 +2075,8 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
         // setup the call back if the optimizer fails
         spvtools::Optimizer optimizer(spirv_environment);
         spvtools::MessageConsumer consumer = [&skip, &module_state_ptr, &stage, loc, this](
-                                                 spv_message_level_t level, const char *source, const spv_position_t &position,
-                                                 const char *message) {
+                                                 spv_message_level_t level, const char* source, const spv_position_t& position,
+                                                 const char* message) {
             skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-module-parameter", device, loc,
                              "%s failed in spirv-opt because it does not contain valid spirv for stage %s. %s",
                              FormatHandle(module_state_ptr->handle()).c_str(), string_VkShaderStageFlagBits(stage), message);
@@ -2085,16 +2085,16 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
 
         // The app might be using the default spec constant values, but if they pass values at runtime to the pipeline then need to
         // use those values to apply to the spec constants
-        auto const &specialization_info = stage_state.GetSpecializationInfo();
+        auto const& specialization_info = stage_state.GetSpecializationInfo();
         if (specialization_info != nullptr && specialization_info->mapEntryCount > 0 &&
             specialization_info->pMapEntries != nullptr) {
             // Gather the specialization-constant values.
-            auto const &specialization_data = reinterpret_cast<uint8_t const *>(specialization_info->pData);
+            auto const& specialization_data = reinterpret_cast<uint8_t const*>(specialization_info->pData);
             std::unordered_map<uint32_t, std::vector<uint32_t>> id_value_map;  // note: this must be std:: to work with spvtools
             id_value_map.reserve(specialization_info->mapEntryCount);
 
             // spirv-val makes sure every OpSpecConstant has a OpDecoration.
-            for (const auto &[result_id, spec_id] : module_state_ptr->static_data_.id_to_spec_id) {
+            for (const auto& [result_id, spec_id] : module_state_ptr->static_data_.id_to_spec_id) {
                 VkSpecializationMapEntry map_entry = {spirv::kInvalidValue, 0, 0};
                 for (uint32_t i = 0; i < specialization_info->mapEntryCount; i++) {
                     if (specialization_info->pMapEntries[i].constantID == spec_id) {
@@ -2110,8 +2110,8 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
                 }
 
                 uint32_t spec_const_size = spirv::kInvalidValue;
-                const spirv::Instruction *def_insn = module_state_ptr->FindDef(result_id);
-                const spirv::Instruction *type_insn = module_state_ptr->FindDef(def_insn->Word(1));
+                const spirv::Instruction* def_insn = module_state_ptr->FindDef(result_id);
+                const spirv::Instruction* type_insn = module_state_ptr->FindDef(def_insn->Word(1));
 
                 // Specialization constants can only be of type bool, scalar integer, or scalar floating point
                 switch (type_insn->Opcode()) {
@@ -2147,9 +2147,9 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
                 if ((map_entry.offset + map_entry.size) <= specialization_info->dataSize) {
                     // Allocate enough room for ceil(map_entry.size / 4) to store entries
                     std::vector<uint32_t> entry_data((map_entry.size + 4 - 1) / 4, 0);
-                    uint8_t *out_p = reinterpret_cast<uint8_t *>(entry_data.data());
-                    const uint8_t *const start_in_p = specialization_data + map_entry.offset;
-                    const uint8_t *const end_in_p = start_in_p + map_entry.size;
+                    uint8_t* out_p = reinterpret_cast<uint8_t*>(entry_data.data());
+                    const uint8_t* const start_in_p = specialization_data + map_entry.offset;
+                    const uint8_t* const end_in_p = start_in_p + map_entry.size;
 
                     std::copy(start_in_p, end_in_p, out_p);
                     id_value_map.emplace(map_entry.constantID, std::move(entry_data));
@@ -2186,7 +2186,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
             spv_diagnostic diag = nullptr;
             auto const spv_valid = spvValidateWithOptions(ctx, spirv_val_options, &binary, &diag);
             if (spv_valid != SPV_SUCCESS) {
-                const char *vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06849"
+                const char* vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06849"
                                             : "VUID-VkShaderCreateInfoEXT-pCode-08460";
                 std::string name = pipeline ? FormatHandle(module_state_ptr->handle()) : "shader object";
                 skip |= LogError(vuid, device, loc,
@@ -2221,7 +2221,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
             spvContextDestroy(ctx);
         } else {
             // Should never get here, but better then asserting
-            const char *vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06849"
+            const char* vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06849"
                                         : "VUID-VkShaderCreateInfoEXT-pCode-08460";
             skip |= LogError(vuid, device, loc,
                              "%s shader (stage %s) attempted to apply specialization constants with spirv-opt but failed.",
@@ -2234,8 +2234,8 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
         }
     }
 
-    const spirv::Module &module_state = *module_state_ptr;
-    const spirv::EntryPoint &entrypoint = *entrypoint_ptr;
+    const spirv::Module& module_state = *module_state_ptr;
+    const spirv::EntryPoint& entrypoint = *entrypoint_ptr;
 
     spirv::LocalSize local_size = module_state.FindLocalSize(entrypoint);
 
@@ -2317,7 +2317,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
         }
     }
 
-    for (const auto &variable : entrypoint.resource_interface_variables) {
+    for (const auto& variable : entrypoint.resource_interface_variables) {
         skip |= ValidateShaderInterfaceVariable(module_state, entrypoint, stage_state, variable, loc);
         if (pipeline) {
             if (variable.decorations.Has(spirv::DecorationSet::input_attachment_bit)) {
@@ -2329,9 +2329,9 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
     return skip;
 }
 
-uint32_t CoreChecks::CalcShaderStageCount(const vvl::Pipeline &pipeline, VkShaderStageFlagBits stageBit) const {
+uint32_t CoreChecks::CalcShaderStageCount(const vvl::Pipeline& pipeline, VkShaderStageFlagBits stageBit) const {
     uint32_t total = 0;
-    for (const auto &stage_ci : pipeline.shader_stages_ci) {
+    for (const auto& stage_ci : pipeline.shader_stages_ci) {
         if (stage_ci.stage == stageBit) {
             total++;
         }
@@ -2350,25 +2350,25 @@ uint32_t CoreChecks::CalcShaderStageCount(const vvl::Pipeline &pipeline, VkShade
 
 // This is done in PreCallRecord to help with the interaction with GPU-AV
 // See diagram on https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6230
-void CoreChecks::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                                 const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) {
+void CoreChecks::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
+                                                 const RecordObject& record_obj, chassis::CreateShaderModule& chassis_state) {
     // Normally would validate in PreCallValidate, but need a non-const function to update chassis_state
     // This is on the stack, we don't have to worry about threading hazards and this could be moved and used const_cast
     chassis_state.skip |=
         stateless_spirv_validator.Validate(*chassis_state.module_state, chassis_state.stateless_data, record_obj.location);
 }
 
-void CoreChecks::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
-                                               const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
-                                               const RecordObject &record_obj, chassis::ShaderObject &chassis_state) {
+void CoreChecks::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
+                                               const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
+                                               const RecordObject& record_obj, chassis::ShaderObject& chassis_state) {
     // For ShaderObjects, to validate most things we need to first parse the SPIR-V.
     // We use to parse both at PreCallValidate and PreCallRecord which was wasteful.
     // We now parse it at PreCallRecord (so we can store it) and then just do the validation here
     chassis_state.skip = ValidateCreateShadersSpirv(createInfoCount, pCreateInfos, record_obj.location, chassis_state);
 }
 
-bool CoreChecks::RunSpirvValidation(spv_const_binary_t &binary, const Location &loc, ValidationCache *cache) const {
+bool CoreChecks::RunSpirvValidation(spv_const_binary_t& binary, const Location& loc, ValidationCache* cache) const {
     bool skip = false;
 
     if (global_settings.debug_disable_spirv_val) {
@@ -2377,7 +2377,7 @@ bool CoreChecks::RunSpirvValidation(spv_const_binary_t &binary, const Location &
 
     uint32_t hash = 0;
     if (cache) {
-        hash = hash_util::Hash32((void *)binary.code, binary.wordCount * sizeof(uint32_t));
+        hash = hash_util::Hash32((void*)binary.code, binary.wordCount * sizeof(uint32_t));
         if (cache->Contains(hash)) {
             return skip;
         }
@@ -2389,19 +2389,19 @@ bool CoreChecks::RunSpirvValidation(spv_const_binary_t &binary, const Location &
     spv_diagnostic diag = nullptr;
     const spv_result_t spv_valid = spvValidateWithOptions(ctx, spirv_val_options, &binary, &diag);
     if (spv_valid != SPV_SUCCESS) {
-        const char *error_message = diag && diag->error ? diag->error : "(no error text)";
+        const char* error_message = diag && diag->error ? diag->error : "(no error text)";
 
         // Umbrella VUID if we can't find one in spirv-val
-        const char *vuid = loc.function == Func::vkCreateShadersEXT ? "VUID-VkShaderCreateInfoEXT-pCode-08737"
+        const char* vuid = loc.function == Func::vkCreateShadersEXT ? "VUID-VkShaderCreateInfoEXT-pCode-08737"
                                                                     : "VUID-VkShaderModuleCreateInfo-pCode-08737";
 
         // We want to search inside the spirv-val error message to see if there is VUID in it as it allows people to silence just
         // that VUID and not the whole spirv-val check
-        char *spirv_val_vuid = nullptr;
+        char* spirv_val_vuid = nullptr;
         if (diag && diag->error) {
             // Note: Will always start with "[VUID-xxx-00000]" if there is one
             if (std::strncmp(error_message, "[VUID", 5) == 0) {
-                const char *bracket_end = std::strchr(error_message, ']');
+                const char* bracket_end = std::strchr(error_message, ']');
                 if (bracket_end) {
                     const size_t vuid_len = bracket_end - error_message - 1;
                     spirv_val_vuid = new char[vuid_len + 1];  // +1 for null-terminator
@@ -2439,8 +2439,8 @@ bool CoreChecks::RunSpirvValidation(spv_const_binary_t &binary, const Location &
     return skip;
 }
 
-bool CoreChecks::ValidateShaderModuleCreateInfo(const VkShaderModuleCreateInfo &create_info,
-                                                const Location &create_info_loc) const {
+bool CoreChecks::ValidateShaderModuleCreateInfo(const VkShaderModuleCreateInfo& create_info,
+                                                const Location& create_info_loc) const {
     bool skip = false;
 
     if (disabled[shader_validation]) {
@@ -2451,7 +2451,7 @@ bool CoreChecks::ValidateShaderModuleCreateInfo(const VkShaderModuleCreateInfo &
 
     // This extension is meant for tooling, but still valid to be used, if used, we need to detect if GLSL
     if (IsExtEnabled(extensions.vk_nv_glsl_shader)) {
-        if (strncmp((char *)create_info.pCode, "#version", 8) == 0) {
+        if (strncmp((char*)create_info.pCode, "#version", 8) == 0) {
             return skip;  // incoming GLSL
         }
     }
@@ -2470,11 +2470,11 @@ bool CoreChecks::ValidateShaderModuleCreateInfo(const VkShaderModuleCreateInfo &
         // if pCode is garbage, don't pass along to spirv-val
 
         const auto validation_cache_ci = vku::FindStructInPNextChain<VkShaderModuleValidationCacheCreateInfoEXT>(create_info.pNext);
-        ValidationCache *cache =
-            validation_cache_ci ? CastFromHandle<ValidationCache *>(validation_cache_ci->validationCache) : nullptr;
+        ValidationCache* cache =
+            validation_cache_ci ? CastFromHandle<ValidationCache*>(validation_cache_ci->validationCache) : nullptr;
         // If app isn't using a shader validation cache, use the default one from CoreChecks
         if (!cache) {
-            cache = CastFromHandle<ValidationCache *>(core_validation_cache);
+            cache = CastFromHandle<ValidationCache*>(core_validation_cache);
         }
 
         spv_const_binary_t binary{create_info.pCode, create_info.codeSize / sizeof(uint32_t)};
@@ -2484,15 +2484,15 @@ bool CoreChecks::ValidateShaderModuleCreateInfo(const VkShaderModuleCreateInfo &
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                                   const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
+                                                   const ErrorObject& error_obj) const {
     return ValidateShaderModuleCreateInfo(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
 }
 
 bool CoreChecks::PreCallValidateGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
-                                                             VkShaderModuleIdentifierEXT *pIdentifier,
-                                                             const ErrorObject &error_obj) const {
+                                                             VkShaderModuleIdentifierEXT* pIdentifier,
+                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     if (!(enabled_features.shaderModuleIdentifier)) {
         skip |= LogError("VUID-vkGetShaderModuleIdentifierEXT-shaderModuleIdentifier-06884", shaderModule, error_obj.location,
@@ -2501,9 +2501,9 @@ bool CoreChecks::PreCallValidateGetShaderModuleIdentifierEXT(VkDevice device, Vk
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetShaderModuleCreateInfoIdentifierEXT(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                                       VkShaderModuleIdentifierEXT *pIdentifier,
-                                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetShaderModuleCreateInfoIdentifierEXT(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                                       VkShaderModuleIdentifierEXT* pIdentifier,
+                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     if (!(enabled_features.shaderModuleIdentifier)) {
         skip |= LogError("VUID-vkGetShaderModuleCreateInfoIdentifierEXT-shaderModuleIdentifier-06885", device, error_obj.location,
@@ -2517,7 +2517,7 @@ bool CoreChecks::ValidateRequiredSubgroupSize(const spirv::Module& module_state,
                                               const spirv::LocalSize& local_size, const Location& loc) const {
     bool skip = false;
 
-    const auto *required_subgroup_size_ci =
+    const auto* required_subgroup_size_ci =
         vku::FindStructInPNextChain<VkPipelineShaderStageRequiredSubgroupSizeCreateInfo>(stage_state.GetPNext());
     if (!required_subgroup_size_ci) return skip;
 
@@ -2572,9 +2572,9 @@ bool CoreChecks::ValidateRequiredSubgroupSize(const spirv::Module& module_state,
     return skip;
 }
 
-bool CoreChecks::ValidateComputeWorkGroupSizes(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                               const ShaderStageState &stage_state, const spirv::LocalSize &local_size,
-                                               const Location &loc) const {
+bool CoreChecks::ValidateComputeWorkGroupSizes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                               const ShaderStageState& stage_state, const spirv::LocalSize& local_size,
+                                               const Location& loc) const {
     bool skip = false;
 
     if (local_size.x == 0) {
@@ -2626,7 +2626,7 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const spirv::Module &module_state
     } else {
         const bool varying = stage_state.shader_object_create_info->flags & VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT;
         const bool full = stage_state.shader_object_create_info->flags & VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
-        const auto *required_subgroup_size =
+        const auto* required_subgroup_size =
             vku::FindStructInPNextChain<VkShaderRequiredSubgroupSizeCreateInfoEXT>(stage_state.GetPNext());
         if (varying && full) {
             if (!IsIntegerMultipleOf(local_size.x, phys_dev_props_core13.maxSubgroupSize)) {
@@ -2650,8 +2650,8 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const spirv::Module &module_state
     return skip;
 }
 
-bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                const spirv::LocalSize &local_size, const Location &loc) const {
+bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                const spirv::LocalSize& local_size, const Location& loc) const {
     bool skip = false;
 
     if (local_size.x == 0) {
@@ -2674,7 +2674,7 @@ bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const spirv::Module &module_stat
     }
 
     if (local_size.x > max_local_size.x) {
-        const char *vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07291" : "VUID-RuntimeSpirv-MeshEXT-07295";
+        const char* vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07291" : "VUID-RuntimeSpirv-MeshEXT-07295";
         skip |= LogError(vuid, module_state.handle(), loc,
                          "shader %s local workgroup size X dimension (%" PRIu32
                          ") must be less than or equal to the max workgroup size (%" PRIu32 ").",
@@ -2682,7 +2682,7 @@ bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const spirv::Module &module_stat
     }
 
     if (local_size.y > max_local_size.y) {
-        const char *vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07292" : "VUID-RuntimeSpirv-MeshEXT-07296";
+        const char* vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07292" : "VUID-RuntimeSpirv-MeshEXT-07296";
         skip |= LogError(vuid, module_state.handle(), loc,
                          "shader %s local workgroup size Y dimension (%" PRIu32
                          ") must be less than or equal to the max workgroup size (%" PRIu32 ").",
@@ -2690,7 +2690,7 @@ bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const spirv::Module &module_stat
     }
 
     if (local_size.z > max_local_size.z) {
-        const char *vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07293" : "VUID-RuntimeSpirv-MeshEXT-07297";
+        const char* vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07293" : "VUID-RuntimeSpirv-MeshEXT-07297";
         skip |= LogError(vuid, module_state.handle(), loc,
                          "shader %s local workgroup size Z dimension (%" PRIu32
                          ") must be less than or equal to the max workgroup size (%" PRIu32 ").",
@@ -2712,7 +2712,7 @@ bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const spirv::Module &module_stat
         }
     }
     if (fail) {
-        const char *vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07294" : "VUID-RuntimeSpirv-MeshEXT-07298";
+        const char* vuid = is_task ? "VUID-RuntimeSpirv-TaskEXT-07294" : "VUID-RuntimeSpirv-MeshEXT-07298";
         skip |= LogError(vuid, module_state.handle(), loc,
                          "shader %s total invocation size of %" PRIu64
                          " (%s) must be less than or equal to max workgroup invocations (%" PRIu32 ").",
@@ -2721,11 +2721,11 @@ bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const spirv::Module &module_stat
     return skip;
 }
 
-bool CoreChecks::ValidateTaskShaderLimits(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                          uint32_t total_workgroup_shared_memory, const Location &loc) const {
+bool CoreChecks::ValidateTaskShaderLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                          uint32_t total_workgroup_shared_memory, const Location& loc) const {
     bool skip = false;
 
-    for (const spirv::Instruction *insn : module_state.static_data_.emit_mesh_tasks_inst) {
+    for (const spirv::Instruction* insn : module_state.static_data_.emit_mesh_tasks_inst) {
         uint32_t x, y, z;
         bool found_x = module_state.GetInt32IfConstant(*module_state.FindDef(insn->Word(1)), &x);
         bool found_y = module_state.GetInt32IfConstant(*module_state.FindDef(insn->Word(2)), &y);
@@ -2806,8 +2806,8 @@ bool CoreChecks::ValidateTaskShaderLimits(const spirv::Module &module_state, con
     return skip;
 }
 
-bool CoreChecks::ValidateMeshShaderLimits(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                          uint32_t total_workgroup_shared_memory, const Location &loc) const {
+bool CoreChecks::ValidateMeshShaderLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                          uint32_t total_workgroup_shared_memory, const Location& loc) const {
     bool skip = false;
 
     if (total_workgroup_shared_memory > phys_dev_ext_props.mesh_shader_props_ext.maxMeshSharedMemorySize) {
@@ -2876,7 +2876,7 @@ bool CoreChecks::ValidateDataGraphPipelineShaderModuleSpirv(VkDevice device, con
     }
 
     std::shared_ptr<spirv::EntryPoint> entry_point = nullptr;
-    for (auto &ep : module_spirv.static_data_.entry_points) {
+    for (auto& ep : module_spirv.static_data_.entry_points) {
         if (!ep->is_data_graph) {
             continue;
         }
@@ -2889,7 +2889,7 @@ bool CoreChecks::ValidateDataGraphPipelineShaderModuleSpirv(VkDevice device, con
 
     if (!entry_point) {
         std::ostringstream wrong_names;
-        for (const auto &ep : module_spirv.static_data_.entry_points) {
+        for (const auto& ep : module_spirv.static_data_.entry_points) {
             if (!wrong_names.str().empty()) {
                 wrong_names << ", ";
             }
@@ -2910,15 +2910,15 @@ bool CoreChecks::ValidateDataGraphPipelineShaderModuleSpirv(VkDevice device, con
 }
 
 // Check consistency of datagraph variables between spirv and vulkan. First we match spirv -> vulkan, then vulkan -> spirv
-bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_spirv, const spirv::EntryPoint &entry_point,
-                                                    const ShaderStageState &stage_state,
-                                                    const VkDataGraphPipelineCreateInfoARM &create_info,
-                                                    const Location &create_info_loc, const Location &module_loc) const {
+bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module& module_spirv, const spirv::EntryPoint& entry_point,
+                                                    const ShaderStageState& stage_state,
+                                                    const VkDataGraphPipelineCreateInfoARM& create_info,
+                                                    const Location& create_info_loc, const Location& module_loc) const {
     bool skip = false;
 
     // loop over spirv resource definitions
     std::vector<bool> pResource_matched(create_info.resourceInfoCount, false);
-    for (const spirv::ResourceInterfaceVariable &variable : entry_point.resource_interface_variables) {
+    for (const spirv::ResourceInterfaceVariable& variable : entry_point.resource_interface_variables) {
         // layout checks are the same as for shader resources
         skip |= ValidateShaderInterfaceVariableDSL(module_spirv, entry_point, stage_state, variable, module_loc);
 
@@ -2926,7 +2926,7 @@ bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_
             continue;
         }
 
-        const spirv::Instruction &tensor_type_instr = variable.base_type;
+        const spirv::Instruction& tensor_type_instr = variable.base_type;
 
         // input/output tensors must have rank and shape, i.e. exactly 5 words
         if (tensor_type_instr.Length() < 5) {
@@ -2937,7 +2937,7 @@ bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_
         // MUST match 1 and only 1 element of pResourceInfos in the pipeline create_info
         std::vector<uint32_t> vk_indexes;
         for (uint32_t j = 0; j < create_info.resourceInfoCount; j++) {
-            const VkDataGraphPipelineResourceInfoARM &resource = create_info.pResourceInfos[j];
+            const VkDataGraphPipelineResourceInfoARM& resource = create_info.pResourceInfos[j];
             if ((resource.descriptorSet == variable.decorations.set) && (resource.binding == variable.decorations.binding)) {
                 vk_indexes.push_back(j);
             }
@@ -2961,7 +2961,7 @@ bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_
         // vk_indexes
         for (auto vk_index : vk_indexes) {
             pResource_matched[vk_index] = true;
-            const VkDataGraphPipelineResourceInfoARM &resource = create_info.pResourceInfos[vk_index];
+            const VkDataGraphPipelineResourceInfoARM& resource = create_info.pResourceInfos[vk_index];
             const Location resource_loc = create_info_loc.dot(Field::pResourceInfos, vk_index);
 
             // part of VU 9923, this is the specific text in the specs:
@@ -2972,7 +2972,7 @@ bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_
                          "(%" PRIu32 ") is not zero.\n%s", resource.arrayElement, variable.DescribeDescriptor().c_str());
             }
 
-            if (auto *tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(resource.pNext)) {
+            if (auto* tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(resource.pNext)) {
                 const spirv::Instruction& element_type_instr = *module_spirv.FindDef(tensor_type_instr.Word(2));
                 if (!module_spirv.IsTensorFormatCompatible(tensor_desc->format, element_type_instr)) {
                     skip |= LogError("VUID-RuntimeSpirv-pNext-09923", device,
@@ -3020,7 +3020,7 @@ bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_
 
     // loop over Vulkan resource declarations
     for (uint32_t j = 0; j < create_info.resourceInfoCount; j++) {
-        const VkDataGraphPipelineResourceInfoARM &resource = create_info.pResourceInfos[j];
+        const VkDataGraphPipelineResourceInfoARM& resource = create_info.pResourceInfos[j];
         const Location resource_loc = create_info_loc.dot(Field::pResourceInfos, j);
 
         if (!pResource_matched[j]) {
@@ -3028,7 +3028,7 @@ bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_
                 LogError("VUID-RuntimeSpirv-pNext-09923", device, resource_loc, "%s has no matching OpVariable in the module spirv",
                          string_VkDataGraphPipelineResourceInfoARM(resource).c_str());
         } else {
-            if (auto *tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(resource.pNext)) {
+            if (auto* tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(resource.pNext)) {
                 if ((tensor_desc->usage & VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM) == 0) {
                     skip |=
                         LogError("VUID-VkDataGraphPipelineResourceInfoARM-descriptorSet-09851", device,
@@ -3044,15 +3044,15 @@ bool CoreChecks::ValidateDataGraphResourceVariables(const spirv::Module &module_
 }
 
 // Check consistency of datagraph constants between spirv and vulkan. First we match spirv -> vulkan, then vulkan -> spirv
-bool CoreChecks::ValidateDataGraphConstants(const spirv::Module &module_spirv, const spirv::EntryPoint &entry_point,
-                                            const VkDataGraphPipelineShaderModuleCreateInfoARM &dg_shader_ci,
-                                            const Location &dg_shader_ci_loc, const Location &module_loc) const {
+bool CoreChecks::ValidateDataGraphConstants(const spirv::Module& module_spirv, const spirv::EntryPoint& entry_point,
+                                            const VkDataGraphPipelineShaderModuleCreateInfoARM& dg_shader_ci,
+                                            const Location& dg_shader_ci_loc, const Location& module_loc) const {
     bool skip = false;
 
     // loop over spirv constant definitions
     std::vector<bool> pConstant_matched(dg_shader_ci.constantCount, false);
     for (auto constant_instr : entry_point.datagraph_constants) {
-        const spirv::Instruction &tensor_type_instr = *module_spirv.FindDef(constant_instr->TypeId());
+        const spirv::Instruction& tensor_type_instr = *module_spirv.FindDef(constant_instr->TypeId());
 
         // the following checks are only for tensors. Any type other than tensor will throw an error executing spirv-val, which
         // results in VU 8737 in the VVL
@@ -3071,7 +3071,7 @@ bool CoreChecks::ValidateDataGraphConstants(const spirv::Module &module_spirv, c
         const uint32_t graph_constant_id = constant_instr->Word(3);
         std::vector<uint32_t> vk_indexes;
         for (uint32_t j = 0; j < dg_shader_ci.constantCount; j++) {
-            const VkDataGraphPipelineConstantARM &vk_constant = dg_shader_ci.pConstants[j];
+            const VkDataGraphPipelineConstantARM& vk_constant = dg_shader_ci.pConstants[j];
             if (vk_constant.id == graph_constant_id) {
                 vk_indexes.push_back(j);
             }
@@ -3092,9 +3092,9 @@ bool CoreChecks::ValidateDataGraphConstants(const spirv::Module &module_spirv, c
             // found the one and only match
             uint32_t vk_index = vk_indexes[0];
             pConstant_matched[vk_index] = true;
-            const VkDataGraphPipelineConstantARM &vk_constant = dg_shader_ci.pConstants[vk_index];
+            const VkDataGraphPipelineConstantARM& vk_constant = dg_shader_ci.pConstants[vk_index];
             const Location vk_constant_loc = dg_shader_ci_loc.dot(Field::pConstants, vk_index);
-            if (auto *tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(vk_constant.pNext)) {
+            if (auto* tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(vk_constant.pNext)) {
                 const spirv::Instruction& element_type_instr = *module_spirv.FindDef(tensor_type_instr.Word(2));
                 const VkFormat spirv_vk_format = module_spirv.GetTensorFormat(element_type_instr);
                 if (tensor_desc->format != spirv_vk_format) {
@@ -3117,7 +3117,7 @@ bool CoreChecks::ValidateDataGraphConstants(const spirv::Module &module_spirv, c
 
                 // nothing to check here if the tensor has no shape, and we have already failed VU 9920 anyway.
                 if (tensor_type_instr.Length() > 4) {
-                    const spirv::Instruction *shape_instr = module_spirv.FindDef(tensor_type_instr.Word(4));
+                    const spirv::Instruction* shape_instr = module_spirv.FindDef(tensor_type_instr.Word(4));
                     const uint32_t max_dim = std::min(tensor_desc->dimensionCount, spirv_rank);
                     for (uint32_t i = 0; i < max_dim; i++) {
                         const uint32_t spirv_dim_i = module_spirv.GetConstantValueById(shape_instr->Word(3 + i));
@@ -3140,14 +3140,14 @@ bool CoreChecks::ValidateDataGraphConstants(const spirv::Module &module_spirv, c
 
     // loop over Vulkan constant declarations
     for (uint32_t i = 0; i < dg_shader_ci.constantCount; i++) {
-        const VkDataGraphPipelineConstantARM &constant = dg_shader_ci.pConstants[i];
+        const VkDataGraphPipelineConstantARM& constant = dg_shader_ci.pConstants[i];
         const Location constant_loc = dg_shader_ci_loc.dot(Field::pConstants, i);
         if (!pConstant_matched[i]) {
             skip |= LogError("VUID-RuntimeSpirv-pNext-09921", device, constant_loc.dot(Field::id),
                              "(%" PRIu32 ") does not match the id of any of the OpGraphConstantARM instructions in module",
                              constant.id);
         } else {
-            if (auto *tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(constant.pNext)) {
+            if (auto* tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(constant.pNext)) {
                 if ((tensor_desc->usage & VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM) == 0) {
                     skip |= LogError(
                         "VUID-VkDataGraphPipelineConstantARM-id-09850", device, constant_loc.dot(Field::id),
@@ -3171,21 +3171,20 @@ bool CoreChecks::ValidateDataGraphConstants(const spirv::Module &module_spirv, c
 
 // It is not listed in the spec, but each vendor decides which engine/operations are required.
 // TOSA 1.0 is the current valid instruction set for the ARM engine
-const VkQueueFamilyDataGraphPropertiesARM tosa_1_0_property {
+const VkQueueFamilyDataGraphPropertiesARM tosa_1_0_property{
     VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM,
     nullptr,
     {VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM, false},
-    {VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM, "TOSA.001000.1", 0}
-};
+    {VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM, "TOSA.001000.1", 0}};
 
 bool CoreChecks::ValidateDataGraphOperations(const vvl::Pipeline& pipeline, uint32_t queueFamilyIndex, const Location& loc) const {
     bool skip = false;
 
-    const ShaderStageState *stage_state_ptr = GetDataGraphShaderStage(pipeline);
+    const ShaderStageState* stage_state_ptr = GetDataGraphShaderStage(pipeline);
     if (!stage_state_ptr) {
         return skip;
     }
-    const spirv::EntryPoint *entry_point = stage_state_ptr->entrypoint.get();
+    const spirv::EntryPoint* entry_point = stage_state_ptr->entrypoint.get();
     if (!entry_point) {
         return skip;
     }
@@ -3229,19 +3228,19 @@ bool CoreChecks::ValidateDataGraphOperations(const vvl::Pipeline& pipeline, uint
     return skip;
 }
 
-bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::Module &module_state,
-                                                                  const spirv::EntryPoint &entrypoint,
-                                                                  const vvl::Pipeline *pipeline,
-                                                                  const ShaderStageState &stage_state, const Location &loc) const {
+bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::Module& module_state,
+                                                                  const spirv::EntryPoint& entrypoint,
+                                                                  const vvl::Pipeline* pipeline,
+                                                                  const ShaderStageState& stage_state, const Location& loc) const {
     bool skip = false;
-    const auto *mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(stage_state.GetPNext());
+    const auto* mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(stage_state.GetPNext());
 
     // If there is no VkShaderDescriptorSetAndBindingMappingInfoEXT, but the heap flags is used, we need to still ensure all the
     // resource variables are untyped (not using set/binding)
     if (!mapping_info) {
         // If not flag, this is just a "normal" vulkan 1.0 situtation
         if (stage_state.descriptor_heap_mode) {
-            for (const spirv::ResourceInterfaceVariable &resource_variable : entrypoint.resource_interface_variables) {
+            for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
                 if (resource_variable.decorations.IsDescriptorSet()) {
                     skip |= LogError(
                         vvl::GetSpirvInterfaceVariableVUID(loc, vvl::SpirvInterfaceVariableError::DescriptorHeapMapping_11312),
@@ -3270,9 +3269,9 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
     }
 
     std::vector<bool> used_mapping_set(mapping_info->mappingCount, false);
-    std::unordered_set<const spirv::ResourceInterfaceVariable *> unmapped_variables;
+    std::unordered_set<const spirv::ResourceInterfaceVariable*> unmapped_variables;
 
-    for (const spirv::ResourceInterfaceVariable &resource_variable : entrypoint.resource_interface_variables) {
+    for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
         if (!resource_variable.decorations.IsDescriptorSet()) {
             continue;
         }
@@ -3281,7 +3280,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
 
         bool found_mapping = false;
         for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
-            const auto &mapping = mapping_info->pMappings[i];
+            const auto& mapping = mapping_info->pMappings[i];
             if (mapping.descriptorSet != descriptor_set || descriptor_binding < mapping.firstBinding ||
                 descriptor_binding >= mapping.firstBinding + uint64_t(mapping.bindingCount) ||
                 !ResourceTypeMatchesBinding(mapping.resourceMask, resource_variable)) {
@@ -3295,14 +3294,14 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT,
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT})) {
-                const spirv::Instruction &base_type = resource_variable.base_type;
+                const spirv::Instruction& base_type = resource_variable.base_type;
                 const uint32_t base_opcode = base_type.Opcode();
                 const bool is_sampler = (base_opcode == spv::OpTypeSampledImage) || resource_variable.is_type_sampled_image;
 
                 struct MappingSourceInfo {
                     uint32_t offset = 0;
                     uint32_t array_stride = 0;
-                    const char *vuid = nullptr;
+                    const char* vuid = nullptr;
                     VkDeviceSize align = 0;
                     Field align_field = Field::Empty;
                 } info;
@@ -3332,22 +3331,22 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                 }
 
                 if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
-                    const auto &source_data = mapping.sourceData.constantOffset;
+                    const auto& source_data = mapping.sourceData.constantOffset;
                     info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
                     info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
-                    const auto &source_data = mapping.sourceData.pushIndex;
+                    const auto& source_data = mapping.sourceData.pushIndex;
                     info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
                     info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
-                    const auto &source_data = mapping.sourceData.indirectIndex;
+                    const auto& source_data = mapping.sourceData.indirectIndex;
                     info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
                     info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
-                    const auto &source_data = mapping.sourceData.indirectIndexArray;
+                    const auto& source_data = mapping.sourceData.indirectIndexArray;
                     info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT) {
-                    const auto &source_data = mapping.sourceData.shaderRecordIndex;
+                    const auto& source_data = mapping.sourceData.shaderRecordIndex;
                     info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
                     info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
                 }
@@ -3378,7 +3377,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                 const bool block = resource_variable.type_struct_info &&
                                    resource_variable.type_struct_info->decorations.Has(spirv::DecorationSet::block_bit);
                 if (!block || resource_variable.storage_class != spv::StorageClassUniform) {
-                    const char *vuid =
+                    const char* vuid =
                         pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pNext-11315" : "VUID-VkShaderCreateInfoEXT-pNext-11315";
                     const bool is_uniform = resource_variable.storage_class == spv::StorageClassUniform;
                     skip |= LogError(
@@ -3392,7 +3391,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                                     : "is not decorated with Block");
                 } else if (resource_variable.storage_class == spv::StorageClassUniform && resource_variable.IsArray()) {
                     // Additional VU because we currently mark array of Block Structs the same in |resource_variable|
-                    const char *vuid =
+                    const char* vuid =
                         pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pNext-11315" : "VUID-VkShaderCreateInfoEXT-pNext-11315";
                     skip |= LogError(
                         vuid, module_state.handle(),
@@ -3409,7 +3408,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                     const uint64_t struct_size = (uint64_t)resource_variable.type_struct_info->GetSize(module_state).size;
                     if (struct_size >
                         (uint64_t)(mapping.sourceData.pushDataOffset + phys_dev_ext_props.descriptor_heap_props.maxPushDataSize)) {
-                        const char *vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pNext-11316"
+                        const char* vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pNext-11316"
                                                     : "VUID-VkShaderCreateInfoEXT-pNext-11316";
                         skip |=
                             LogError(vuid, module_state.handle(),
@@ -3428,7 +3427,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                     resource_variable.type_struct_info ? resource_variable.type_struct_info->GetSize(module_state).size : 0;
                 if (mapping.sourceData.shaderRecordDataOffset + struct_size >
                     phys_dev_ext_props.ray_tracing_props_khr.maxShaderGroupStride) {
-                    const char *vuid =
+                    const char* vuid =
                         pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pNext-11317" : "VUID-VkShaderCreateInfoEXT-pNext-11317";
                     skip |= LogError(
                         vuid, module_state.handle(),
@@ -3443,11 +3442,11 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
             }
             if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT ||
                 mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT) {
-                const auto *type_struct_info = resource_variable.type_struct_info.get();
+                const auto* type_struct_info = resource_variable.type_struct_info.get();
                 const bool block_bit = type_struct_info && type_struct_info->decorations.Has(spirv::DecorationSet::block_bit);
                 const bool buffer_block_bit =
                     type_struct_info && type_struct_info->decorations.Has(spirv::DecorationSet::buffer_block_bit);
-                const spirv::Instruction *type = module_state.FindDef(resource_variable.type_id);
+                const spirv::Instruction* type = module_state.FindDef(resource_variable.type_id);
                 uint32_t opcode = type ? type->Opcode() : vvl::kNoIndex32;
                 if (opcode == spv::OpTypePointer) {
                     opcode = module_state.FindDef(type->Word(3))->Opcode();
@@ -3477,7 +3476,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT,
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT})) {
-                const VkSamplerCreateInfo *embedded_sampler = GetEmbeddedSampler(mapping);
+                const VkSamplerCreateInfo* embedded_sampler = GetEmbeddedSampler(mapping);
                 if (resource_variable.IsArray() && embedded_sampler != nullptr) {
                     skip |= LogError(
                         pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pNext-11399" : "VUID-VkShaderCreateInfoEXT-pNext-11399",
@@ -3493,17 +3492,17 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
             if (IsValueIn(mapping.source,
                           {VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT, VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT,
                            VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT})) {
-                const spirv::Instruction *found_inst = nullptr;
+                const spirv::Instruction* found_inst = nullptr;
                 const uint32_t desc_type = module_state.FindDef(resource_variable.type_id)->ResultId();
-                for (const spirv::Instruction *array_length_inst : module_state.static_data_.array_length_inst) {
-                    const spirv::Instruction *type = module_state.FindDef(array_length_inst->Word(3));
+                for (const spirv::Instruction* array_length_inst : module_state.static_data_.array_length_inst) {
+                    const spirv::Instruction* type = module_state.FindDef(array_length_inst->Word(3));
                     if (type->Opcode() == spv::OpVariable && type->Word(1) == desc_type) {
                         found_inst = array_length_inst;
                         break;
                     }
                 }
                 if (found_inst) {
-                    const char *vuid =
+                    const char* vuid =
                         pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pNext-11378" : "VUID-VkShaderCreateInfoEXT-pNext-11378";
                     skip |= LogError(
                         vuid, module_state.handle(),
@@ -3523,10 +3522,10 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                     std::stringstream msg;
                     if (resource_variable.non_constant_id != 0) {
                         // We know this is a OpAccessChain, because of how all_constant_integral_expressions is determined
-                        const spirv::Instruction *pointer = module_state.FindDef(resource_variable.non_constant_id);
-                        const spirv::Instruction *base = module_state.FindDef(pointer->Word(3));
+                        const spirv::Instruction* pointer = module_state.FindDef(resource_variable.non_constant_id);
+                        const spirv::Instruction* base = module_state.FindDef(pointer->Word(3));
                         for (uint32_t j = 4; j < pointer->Length(); ++j) {
-                            const spirv::Instruction *access_op = module_state.FindDef(pointer->Word(j));
+                            const spirv::Instruction* access_op = module_state.FindDef(pointer->Word(j));
                             if (!IsValueIn((spv::Op)access_op->Opcode(),
                                            {spv::OpConstant, spv::OpSpecConstant, spv::OpConstantComposite})) {
                                 // TODO - Currently a bit aimed towards GLSL and need a general util to help with this
@@ -3559,7 +3558,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
     // to why their mappings are invalid
     if (!unmapped_variables.empty()) {
         // Currently only report the first variable, likely will be spam if trying to print them all
-        const spirv::ResourceInterfaceVariable &resource_variable = **unmapped_variables.begin();
+        const spirv::ResourceInterfaceVariable& resource_variable = **unmapped_variables.begin();
         std::stringstream ss;
         ss << "has no mapping for " << resource_variable.DescribeDescriptor() << " in " << entrypoint.Describe() << " but "
            << (pipeline ? "VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT" : "VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT")
@@ -3589,7 +3588,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                 if (used_mapping_set[i]) {
                     continue;
                 }
-                const auto &mapping = mapping_info->pMappings[i];
+                const auto& mapping = mapping_info->pMappings[i];
                 ss << " - pMappings[" << i << "]: descriptorSet (" << mapping.descriptorSet << "), firstBinding ("
                    << mapping.firstBinding << "), bindingCount (" << mapping.bindingCount << "), resourceMask ("
                    << string_VkSpirvResourceTypeFlagsEXT(mapping.resourceMask) << ")\n\t| not valid because ";
@@ -3629,14 +3628,14 @@ bool CoreChecks::ValidateDescriptorHeapStructs(const spirv::Module& module_state
     // There are to ways to set the offset with decorations
     //  - classic Offset
     //  - using new OffsetIdEXT, which is designed to be used with a spec constant
-    for (const auto &type_struct : module_state.static_data_.type_structs) {
+    for (const auto& type_struct : module_state.static_data_.type_structs) {
         if (!type_struct->has_descriptor_type) {
             continue;  // way to skip skip majority of structs
         }
         // Even if there is a struct inside member, we don't need to go into it, it will be it's own iteration inside
         // |static_data_.type_structs|
         for (uint32_t i = 0; i < type_struct->members.size(); i++) {
-            const auto &member = type_struct->members[i];
+            const auto& member = type_struct->members[i];
 
             const uint32_t opcode = member.insn->Opcode();
             if (opcode == spv::OpTypeSampler) {

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -664,7 +664,6 @@ void CommandBufferSubState::RecordBarriers2(const VkDependencyInfo& dep_info, co
             base.tensor_barriers.emplace_back(barrier);
         }
     }
-
 }
 
 static void SetQueryState(const QueryObject& object, QueryState value, QueryMap* local_query_to_state_map) {

--- a/layers/core_checks/cc_sync_vuid_maps.cpp
+++ b/layers/core_checks/cc_sync_vuid_maps.cpp
@@ -24,7 +24,7 @@
 namespace vvl {
 
 // IMPORTANT: this map should be in sync with features enumerated in DisabledPipelineStages()
-const vvl::unordered_map<VkPipelineStageFlags2, std::string> &GetFeatureNameMap() {
+const vvl::unordered_map<VkPipelineStageFlags2, std::string>& GetFeatureNameMap() {
     static const vvl::unordered_map<VkPipelineStageFlags2, std::string> feature_name_map{
         {VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT, "geometryShader"},
         {VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT, "tessellationShader"},
@@ -46,7 +46,7 @@ const vvl::unordered_map<VkPipelineStageFlags2, std::string> &GetFeatureNameMap(
 // commonvalidity/pipeline_stage_common.txt
 // commonvalidity/stage_mask_2_common.txt
 // commonvalidity/stage_mask_common.txt
-static const vvl::unordered_map<VkPipelineStageFlags2, std::vector<Entry>> &GetStageMaskErrorsMap() {
+static const vvl::unordered_map<VkPipelineStageFlags2, std::vector<Entry>>& GetStageMaskErrorsMap() {
     static const vvl::unordered_map<VkPipelineStageFlags2, std::vector<Entry>> stage_mask_errors{
         {VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT,
          std::vector<Entry>{
@@ -301,7 +301,7 @@ static const vvl::unordered_map<VkPipelineStageFlags2, std::vector<Entry>> &GetS
     return stage_mask_errors;
 }
 
-const auto &GetStageMaskErrorsNone() {
+const auto& GetStageMaskErrorsNone() {
     static const std::array<Entry, 12> kStageMaskErrorsNone{{
         {Key(Func::vkCmdPipelineBarrier, Field::srcStageMask), "VUID-vkCmdPipelineBarrier-srcStageMask-03937"},
         {Key(Func::vkCmdPipelineBarrier, Field::dstStageMask), "VUID-vkCmdPipelineBarrier-dstStageMask-03937"},
@@ -319,7 +319,7 @@ const auto &GetStageMaskErrorsNone() {
     return kStageMaskErrorsNone;
 }
 
-const auto &GetStageMaskErrorsShadingRate() {
+const auto& GetStageMaskErrorsShadingRate() {
     static const std::array<Entry, 24> kStageMaskErrorsShadingRate{{
         {Key(Struct::VkBufferMemoryBarrier2, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2-dstStageMask-07316"},
         {Key(Struct::VkBufferMemoryBarrier2, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2-srcStageMask-07316"},
@@ -349,7 +349,7 @@ const auto &GetStageMaskErrorsShadingRate() {
     return kStageMaskErrorsShadingRate;
 }
 
-const auto &GetStageMaskErrorsSubpassShader() {
+const auto& GetStageMaskErrorsSubpassShader() {
     static const std::array<Entry, 12> kStageMaskErrorsSubpassShader{{
         {Key(Struct::VkBufferMemoryBarrier2, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2-dstStageMask-04957"},
         {Key(Struct::VkBufferMemoryBarrier2, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2-srcStageMask-04957"},
@@ -367,7 +367,7 @@ const auto &GetStageMaskErrorsSubpassShader() {
     return kStageMaskErrorsSubpassShader;
 }
 
-const auto &GetStageMaskErrorsInvocationMask() {
+const auto& GetStageMaskErrorsInvocationMask() {
     static const std::array<Entry, 12> kStageMaskErrorsInvocationMask{{
         {Key(Struct::VkBufferMemoryBarrier2, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2-dstStageMask-04995"},
         {Key(Struct::VkBufferMemoryBarrier2, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2-srcStageMask-04995"},
@@ -385,7 +385,7 @@ const auto &GetStageMaskErrorsInvocationMask() {
     return kStageMaskErrorsInvocationMask;
 }
 
-const auto &GetStageMaskErrorsAccelerationStructureBuild() {
+const auto& GetStageMaskErrorsAccelerationStructureBuild() {
     static const std::array<Entry, 23> kStageMaskErrorsAccelerationStructureBuild{{
         {Key(Struct::VkBufferMemoryBarrier2, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2-dstStageMask-10751"},
         {Key(Struct::VkBufferMemoryBarrier2, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2-srcStageMask-10751"},
@@ -414,7 +414,7 @@ const auto &GetStageMaskErrorsAccelerationStructureBuild() {
     return kStageMaskErrorsAccelerationStructureBuild;
 }
 
-const auto &GetStageMaskErrorsAccelerationStructurCopy() {
+const auto& GetStageMaskErrorsAccelerationStructurCopy() {
     static const std::array<Entry, 12> kStageMaskErrorsAccelerationStructureCopy{{
         {Key(Struct::VkBufferMemoryBarrier2, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2-dstStageMask-10752"},
         {Key(Struct::VkBufferMemoryBarrier2, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2-srcStageMask-10752"},
@@ -432,7 +432,7 @@ const auto &GetStageMaskErrorsAccelerationStructurCopy() {
     return kStageMaskErrorsAccelerationStructureCopy;
 }
 
-const auto &GetStageMaskErrorsMicromapBuild() {
+const auto& GetStageMaskErrorsMicromapBuild() {
     static const std::array<Entry, 12> kStageMaskErrorsMicromapBuild{{
         {Key(Struct::VkBufferMemoryBarrier2, Field::dstStageMask), "VUID-VkBufferMemoryBarrier2-dstStageMask-10753"},
         {Key(Struct::VkBufferMemoryBarrier2, Field::srcStageMask), "VUID-VkBufferMemoryBarrier2-srcStageMask-10753"},
@@ -450,7 +450,7 @@ const auto &GetStageMaskErrorsMicromapBuild() {
     return kStageMaskErrorsMicromapBuild;
 }
 
-const std::string &GetBadFeatureVUID(const Location &loc, VkPipelineStageFlags2 bit, const DeviceExtensions &device_extensions) {
+const std::string& GetBadFeatureVUID(const Location& loc, VkPipelineStageFlags2 bit, const DeviceExtensions& device_extensions) {
     // special case for stages that require an extension or feature bit,
     // this is checked in DisabledPipelineStages
     if (bit == VK_PIPELINE_STAGE_2_NONE) {
@@ -469,7 +469,7 @@ const std::string &GetBadFeatureVUID(const Location &loc, VkPipelineStageFlags2 
         return FindVUID(loc, GetStageMaskErrorsMicromapBuild());
     }
 
-    const auto &result = FindVUID(bit, loc, GetStageMaskErrorsMap());
+    const auto& result = FindVUID(bit, loc, GetStageMaskErrorsMap());
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandle-pipeline-stage-feature");
@@ -1003,7 +1003,7 @@ static const vvl::unordered_map<VkAccessFlags2, std::array<Entry, 8>>& GetAccess
     return access_mask2_common;
 }
 // commonvalidity/fine_sync_commands_common.txt
-const std::vector<Entry> &GetFineSyncCommon() {
+const std::vector<Entry>& GetFineSyncCommon() {
     static const std::vector<Entry> kFineSyncCommon = {
         {Key(Func::vkCmdPipelineBarrier, Struct::VkMemoryBarrier, Field::srcAccessMask),
          "VUID-vkCmdPipelineBarrier-srcAccessMask-02815"},
@@ -1034,12 +1034,12 @@ const std::vector<Entry> &GetFineSyncCommon() {
     };
     return kFineSyncCommon;
 }
-const std::string &GetBadAccessFlagsVUID(const Location &loc, VkAccessFlags2 bit) {
-    const auto &result = FindVUID(bit, loc, GetAccessMask2CommonMap());
+const std::string& GetBadAccessFlagsVUID(const Location& loc, VkAccessFlags2 bit) {
+    const auto& result = FindVUID(bit, loc, GetAccessMask2CommonMap());
     if (!result.empty()) {
         return result;
     }
-    const auto &result2 = FindVUID(loc, GetFineSyncCommon());
+    const auto& result2 = FindVUID(loc, GetFineSyncCommon());
     assert(!result2.empty());
     if (result2.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-bad-access-flags");
@@ -1049,7 +1049,7 @@ const std::string &GetBadAccessFlagsVUID(const Location &loc, VkAccessFlags2 bit
 }
 
 // commonvalidity/access_mask_common.adoc/access_mask_2_common.adoc
-static const auto &GetLocation2VUIDMap() {
+static const auto& GetLocation2VUIDMap() {
     static const vvl::unordered_map<Key, std::string, Key::hash> Location2VUID{
         // Sync2 barriers. This can match different functions that work with VkDependencyInfo
         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "VUID-VkMemoryBarrier2-srcAccessMask-06256"},
@@ -1090,7 +1090,7 @@ static const auto &GetLocation2VUIDMap() {
     return Location2VUID;
 }
 
-const std::string &GetAccessMaskRayQueryVUIDSelector(const Location &loc, const DeviceExtensions &device_extensions) {
+const std::string& GetAccessMaskRayQueryVUIDSelector(const Location& loc, const DeviceExtensions& device_extensions) {
     // At first try exact match: VUID for specific parameter (struct + field) of specific function
     const Key key_full(loc.function, loc.structure, loc.field);
     if (auto it = GetLocation2VUIDMap().find(key_full); it != GetLocation2VUIDMap().end()) {
@@ -1105,7 +1105,7 @@ const std::string &GetAccessMaskRayQueryVUIDSelector(const Location &loc, const 
     return unhandled;
 }
 
-const std::vector<Entry> &GetQueueCapErrors() {
+const std::vector<Entry>& GetQueueCapErrors() {
     static const std::vector<Entry> kQueueCapErrors{
         {Key(Struct::VkSubmitInfo, Field::pWaitDstStageMask), "VUID-vkQueueSubmit-pWaitDstStageMask-00066"},
         {Key(Struct::VkSubpassDependency, Field::srcStageMask), "VUID-vkCmdBeginRenderPass-srcStageMask-06451"},
@@ -1143,9 +1143,9 @@ const std::vector<Entry> &GetQueueCapErrors() {
     return kQueueCapErrors;
 }
 
-const std::string &GetStageQueueCapVUID(const Location &loc, VkPipelineStageFlags2 bit) {
+const std::string& GetStageQueueCapVUID(const Location& loc, VkPipelineStageFlags2 bit) {
     // no per-bit lookups needed
-    const auto &result = FindVUID(loc, GetQueueCapErrors());
+    const auto& result = FindVUID(loc, GetQueueCapErrors());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-queue-capabilities");
         return unhandled;
@@ -1153,7 +1153,7 @@ const std::string &GetStageQueueCapVUID(const Location &loc, VkPipelineStageFlag
     return result;
 }
 
-static const vvl::unordered_map<QueueError, std::vector<Entry>> &GetBarrierQueueErrors() {
+static const vvl::unordered_map<QueueError, std::vector<Entry>>& GetBarrierQueueErrors() {
     static const vvl::unordered_map<QueueError, std::vector<Entry>> kBarrierQueueErrors{
         {QueueError::kSrcNoExternalExt,
          {
@@ -1237,7 +1237,7 @@ static const vvl::unordered_map<QueueError, std::vector<Entry>> &GetBarrierQueue
     return kBarrierQueueErrors;
 }
 
-const vvl::unordered_map<QueueError, std::string> &GetQueueErrorSummaryMap() {
+const vvl::unordered_map<QueueError, std::string>& GetQueueErrorSummaryMap() {
     static const vvl::unordered_map<QueueError, std::string> kQueueErrorSummary{
         {QueueError::kSrcNoExternalExt, "Source queue family must not be VK_QUEUE_FAMILY_EXTERNAL."},
         {QueueError::kDstNoExternalExt, "Destination queue family must not be VK_QUEUE_FAMILY_EXTERNAL."},
@@ -1251,8 +1251,8 @@ const vvl::unordered_map<QueueError, std::string> &GetQueueErrorSummaryMap() {
     return kQueueErrorSummary;
 }
 
-const std::string &GetBarrierQueueVUID(const Location &loc, QueueError error) {
-    const auto &result = FindVUID(error, loc, GetBarrierQueueErrors());
+const std::string& GetBarrierQueueVUID(const Location& loc, QueueError error) {
+    const auto& result = FindVUID(error, loc, GetBarrierQueueErrors());
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-queue-error");
@@ -1261,7 +1261,7 @@ const std::string &GetBarrierQueueVUID(const Location &loc, QueueError error) {
     return result;
 }
 
-const vvl::unordered_map<VkImageLayout, std::array<Entry, 3>> &GetImageLayoutErrorsMap() {
+const vvl::unordered_map<VkImageLayout, std::array<Entry, 3>>& GetImageLayoutErrorsMap() {
     using ValueType = std::array<Entry, 3>;
     static const vvl::unordered_map<VkImageLayout, std::array<Entry, 3>> kImageLayoutErrors{
         {VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
@@ -1412,8 +1412,8 @@ const vvl::unordered_map<VkImageLayout, std::array<Entry, 3>> &GetImageLayoutErr
     return kImageLayoutErrors;
 }
 
-const std::string &GetBadImageLayoutVUID(const Location &loc, VkImageLayout layout) {
-    const auto &result = FindVUID(layout, loc, GetImageLayoutErrorsMap());
+const std::string& GetBadImageLayoutVUID(const Location& loc, VkImageLayout layout) {
+    const auto& result = FindVUID(layout, loc, GetImageLayoutErrorsMap());
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-bad-image-layout");
@@ -1422,7 +1422,7 @@ const std::string &GetBadImageLayoutVUID(const Location &loc, VkImageLayout layo
     return result;
 }
 
-static const vvl::unordered_map<BufferError, std::array<Entry, 2>> &GetBufferErrorsMap() {
+static const vvl::unordered_map<BufferError, std::array<Entry, 2>>& GetBufferErrorsMap() {
     static const vvl::unordered_map<BufferError, std::array<Entry, 2>> kBufferErrors{
         {BufferError::kNoMemory,
          {{
@@ -1448,8 +1448,8 @@ static const vvl::unordered_map<BufferError, std::array<Entry, 2>> &GetBufferErr
     return kBufferErrors;
 }
 
-const std::string &GetBufferBarrierVUID(const Location &loc, BufferError error) {
-    const auto &result = FindVUID(error, loc, GetBufferErrorsMap());
+const std::string& GetBufferBarrierVUID(const Location& loc, BufferError error) {
+    const auto& result = FindVUID(error, loc, GetBufferErrorsMap());
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-buffer-barrier-error");
@@ -1458,7 +1458,7 @@ const std::string &GetBufferBarrierVUID(const Location &loc, BufferError error) 
     return result;
 }
 
-const vvl::unordered_map<ImageError, std::vector<Entry>> &GetImageErrorsMap() {
+const vvl::unordered_map<ImageError, std::vector<Entry>>& GetImageErrorsMap() {
     static const vvl::unordered_map<ImageError, std::vector<Entry>> kImageErrors{
         {ImageError::kNoMemory,
          {
@@ -1575,8 +1575,8 @@ const vvl::unordered_map<ImageError, std::vector<Entry>> &GetImageErrorsMap() {
     return kImageErrors;
 }
 
-const std::string &GetImageBarrierVUID(const Location &loc, ImageError error) {
-    const auto &result = FindVUID(error, loc, GetImageErrorsMap());
+const std::string& GetImageBarrierVUID(const Location& loc, ImageError error) {
+    const auto& result = FindVUID(error, loc, GetImageErrorsMap());
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-image-barrier-error");
@@ -1585,7 +1585,7 @@ const std::string &GetImageBarrierVUID(const Location &loc, ImageError error) {
     return result;
 }
 
-static const vvl::unordered_map<SubmitError, std::vector<Entry>> &GetSubmitErrorsMap() {
+static const vvl::unordered_map<SubmitError, std::vector<Entry>>& GetSubmitErrorsMap() {
     static const vvl::unordered_map<SubmitError, std::vector<Entry>> kSubmitErrors{
         {SubmitError::kTimelineSemSmallValue,
          {
@@ -1675,8 +1675,8 @@ static const vvl::unordered_map<SubmitError, std::vector<Entry>> &GetSubmitError
     return kSubmitErrors;
 }
 
-const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {
-    const auto &result = FindVUID(error, loc, GetSubmitErrorsMap());
+const std::string& GetQueueSubmitVUID(const Location& loc, SubmitError error) {
+    const auto& result = FindVUID(error, loc, GetSubmitErrorsMap());
     if (result.empty()) {
         // TODO - Handle better way then Key::recursive to find certain VUs
         // Can reproduce with NegativeSyncObject.Sync2QueueSubmitTimelineSemaphoreValue
@@ -1692,7 +1692,7 @@ const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {
     return result;
 }
 
-const std::string &GetDynamicRenderingBarrierVUID(const Location &loc, DynamicRenderingBarrierError error) {
+const std::string& GetDynamicRenderingBarrierVUID(const Location& loc, DynamicRenderingBarrierError error) {
     static const vvl::unordered_map<DynamicRenderingBarrierError, std::vector<Entry>> kDynamicRenderingBarrierErrors{
         {DynamicRenderingBarrierError::kFeatureError,
          {
@@ -1721,7 +1721,7 @@ const std::string &GetDynamicRenderingBarrierVUID(const Location &loc, DynamicRe
          }},
     };
 
-    const auto &result = FindVUID(error, loc, kDynamicRenderingBarrierErrors);
+    const auto& result = FindVUID(error, loc, kDynamicRenderingBarrierErrors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-barrier-error");

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -71,10 +71,10 @@ WriteLockGuard CoreChecks::WriteLock() {
     }
 }
 
-bool SemaphoreSubmitState::CanWaitBinary(const vvl::Semaphore &semaphore_state) const {
+bool SemaphoreSubmitState::CanWaitBinary(const vvl::Semaphore& semaphore_state) const {
     assert(semaphore_state.type == VK_SEMAPHORE_TYPE_BINARY);
     // Check if current submission has signaled or unsignaled the semaphore
-    if (const bool *signaling_state = vvl::Find(binary_signaling_state, semaphore_state.VkHandle())) {
+    if (const bool* signaling_state = vvl::Find(binary_signaling_state, semaphore_state.VkHandle())) {
         const bool signaled = *signaling_state;
         return signaled;  // signaled => can wait
     }
@@ -82,11 +82,11 @@ bool SemaphoreSubmitState::CanWaitBinary(const vvl::Semaphore &semaphore_state) 
     return semaphore_state.CanBinaryBeWaited();
 }
 
-bool SemaphoreSubmitState::CanSignalBinary(const vvl::Semaphore &semaphore_state, VkQueue &other_queue,
-                                           vvl::Func &other_acquire_command) const {
+bool SemaphoreSubmitState::CanSignalBinary(const vvl::Semaphore& semaphore_state, VkQueue& other_queue,
+                                           vvl::Func& other_acquire_command) const {
     assert(semaphore_state.type == VK_SEMAPHORE_TYPE_BINARY);
     // Check if current submission has signaled or unsignaled the semaphore
-    if (const bool *signaling_state = vvl::Find(binary_signaling_state, semaphore_state.VkHandle())) {
+    if (const bool* signaling_state = vvl::Find(binary_signaling_state, semaphore_state.VkHandle())) {
         const bool signaled = *signaling_state;
         if (!signaled) {
             return true;  // not signaled => can signal
@@ -103,7 +103,7 @@ bool SemaphoreSubmitState::CanSignalBinary(const vvl::Semaphore &semaphore_state
     return false;
 }
 
-VkQueue SemaphoreSubmitState::AnotherQueueWaits(const vvl::Semaphore &semaphore_state) const {
+VkQueue SemaphoreSubmitState::AnotherQueueWaits(const vvl::Semaphore& semaphore_state) const {
     // VUID-vkQueueSubmit-pWaitSemaphores-00068 (and similar VUs):
     // "When a semaphore wait operation referring to a binary semaphore defined
     //  by any element of the pWaitSemaphores member of any element of pSubmits
@@ -115,8 +115,8 @@ VkQueue SemaphoreSubmitState::AnotherQueueWaits(const vvl::Semaphore &semaphore_
     return VK_NULL_HANDLE;
 }
 
-std::optional<uint64_t> SemaphoreSubmitState::CheckTimelineMaxDiff(const vvl::Semaphore &semaphore_state, uint64_t value,
-                                                                   const char *&payload_type) {
+std::optional<uint64_t> SemaphoreSubmitState::CheckTimelineMaxDiff(const vvl::Semaphore& semaphore_state, uint64_t value,
+                                                                   const char*& payload_type) {
     const uint64_t max_diff = core.phys_dev_props_core12.maxTimelineSemaphoreValueDifference;
     auto current_signal = timeline_signals.find(semaphore_state.VkHandle());
     if (current_signal != timeline_signals.end()) {
@@ -135,8 +135,8 @@ std::optional<uint64_t> SemaphoreSubmitState::CheckTimelineMaxDiff(const vvl::Se
     return semaphore_state.CheckMaxDiffThreshold(value, payload_type);
 }
 
-std::optional<uint64_t> SemaphoreSubmitState::CheckTimelineSignalTooSmall(const vvl::Semaphore &semaphore_state, uint64_t value,
-                                                                          const char *&payload_type) {
+std::optional<uint64_t> SemaphoreSubmitState::CheckTimelineSignalTooSmall(const vvl::Semaphore& semaphore_state, uint64_t value,
+                                                                          const char*& payload_type) {
     if (auto it = timeline_signals.find(semaphore_state.VkHandle()); it != timeline_signals.end()) {
         const uint64_t current_submit_signal = it->second;
         if (value <= current_submit_signal) {
@@ -159,22 +159,22 @@ std::optional<uint64_t> SemaphoreSubmitState::CheckTimelineSignalTooSmall(const 
     return {};
 }
 
-bool SemaphoreSubmitState::ValidateBinaryWait(const Location &loc, const vvl::Semaphore &semaphore_state) {
+bool SemaphoreSubmitState::ValidateBinaryWait(const Location& loc, const vvl::Semaphore& semaphore_state) {
     bool skip = false;
     auto semaphore = semaphore_state.VkHandle();
     if ((semaphore_state.Scope() == vvl::Semaphore::kInternal || internal_semaphores.count(semaphore))) {
         if (VkQueue other_queue = AnotherQueueWaits(semaphore_state)) {
-            const auto &vuid = vvl::GetQueueSubmitVUID(loc, vvl::SubmitError::kOtherQueueWaiting);
+            const auto& vuid = vvl::GetQueueSubmitVUID(loc, vvl::SubmitError::kOtherQueueWaiting);
             const LogObjectList objlist(semaphore, queue, other_queue);
             skip |= core.LogError(vuid, objlist, loc, "queue (%s) is already waiting on semaphore (%s).",
                                   core.FormatHandle(other_queue).c_str(), core.FormatHandle(semaphore).c_str());
         } else if (!CanWaitBinary(semaphore_state)) {
-            const auto &vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kBinaryCannotBeSignalled);
+            const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kBinaryCannotBeSignalled);
             const LogObjectList objlist(semaphore, queue);
             skip |= core.LogError(vuid, objlist, loc, "queue (%s) is waiting on semaphore (%s) that has no way to be signaled.",
                                   core.FormatHandle(queue).c_str(), core.FormatHandle(semaphore).c_str());
         } else if (auto timeline_wait_info = semaphore_state.GetPendingBinarySignalTimelineDependency()) {
-            const auto &vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kBinaryCannotBeSignalled);
+            const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kBinaryCannotBeSignalled);
             const LogObjectList objlist(semaphore_state.Handle(), timeline_wait_info->semaphore->Handle(), queue);
             skip |= core.LogError(
                 vuid, objlist, loc,
@@ -191,12 +191,12 @@ bool SemaphoreSubmitState::ValidateBinaryWait(const Location &loc, const vvl::Se
     return skip;
 }
 
-bool SemaphoreSubmitState::ValidateTimelineWait(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state,
+bool SemaphoreSubmitState::ValidateTimelineWait(const Location& semaphore_loc, const vvl::Semaphore& semaphore_state,
                                                 uint64_t value) {
     bool skip = false;
-    const char *payload_type = nullptr;
+    const char* payload_type = nullptr;
     if (std::optional<uint64_t> far_away_payload = CheckTimelineMaxDiff(semaphore_state, value, payload_type)) {
-        const auto &vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kTimelineSemMaxDiff);
+        const auto& vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kTimelineSemMaxDiff);
         skip |= core.LogError(vuid, semaphore_state.Handle(), semaphore_loc,
                               "value (%" PRIu64 ") exceeds limit regarding %s semaphore %s value (%" PRIu64 ").", value,
                               payload_type, core.FormatHandle(semaphore_state.Handle()).c_str(), *far_away_payload);
@@ -206,7 +206,7 @@ bool SemaphoreSubmitState::ValidateTimelineWait(const Location &semaphore_loc, c
     return skip;
 }
 
-bool SemaphoreSubmitState::ValidateWaitSemaphore(const Location &wait_semaphore_loc, const vvl::Semaphore &semaphore_state,
+bool SemaphoreSubmitState::ValidateWaitSemaphore(const Location& wait_semaphore_loc, const vvl::Semaphore& semaphore_state,
                                                  uint64_t value) {
     bool skip = false;
     if (semaphore_state.type == VK_SEMAPHORE_TYPE_BINARY) {
@@ -218,16 +218,16 @@ bool SemaphoreSubmitState::ValidateWaitSemaphore(const Location &wait_semaphore_
     return skip;
 }
 
-static std::string GetSemaphoreInUseBySwapchainMessage(const vvl::Semaphore::SwapchainWaitInfo &swapchain_info,
-                                                       const vvl::Semaphore &semaphore_state, VkQueue queue,
-                                                       bool swapchain_fence_supported, const Logger &logger) {
+static std::string GetSemaphoreInUseBySwapchainMessage(const vvl::Semaphore::SwapchainWaitInfo& swapchain_info,
+                                                       const vvl::Semaphore& semaphore_state, VkQueue queue,
+                                                       bool swapchain_fence_supported, const Logger& logger) {
     std::ostringstream ss;
 
     const std::string semaphore_str = logger.FormatHandle(semaphore_state.Handle());
     const std::string queue_str = logger.FormatHandle(queue);
 
     if (swapchain_info.swapchain) {
-        const vvl::Swapchain &swapchain = *swapchain_info.swapchain;
+        const vvl::Swapchain& swapchain = *swapchain_info.swapchain;
 
         ss << "(" << semaphore_str << ") is being signaled by " << queue_str << ", but it may still be in use by "
            << logger.FormatHandle(swapchain.Handle()) << ".\n";
@@ -292,11 +292,11 @@ static std::string GetSemaphoreInUseBySwapchainMessage(const vvl::Semaphore::Swa
     return ss.str();
 }
 
-bool SemaphoreSubmitState::ValidateBinarySignal(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state) {
+bool SemaphoreSubmitState::ValidateBinarySignal(const Location& semaphore_loc, const vvl::Semaphore& semaphore_state) {
     bool skip = false;
 
     // Detect use case when to disable present semaphore in-use check
-    auto is_shared_present_pre_maintenance1 = [this](const vvl::Semaphore::SwapchainWaitInfo &swapchain_wait_info) {
+    auto is_shared_present_pre_maintenance1 = [this](const vvl::Semaphore::SwapchainWaitInfo& swapchain_wait_info) {
         // Null swapchain is only in the case of multiple swapchains.
         // Assume it's not a shared present mode and proceed with reporting semaphore in-use error
         if (!swapchain_wait_info.swapchain) {
@@ -339,7 +339,7 @@ bool SemaphoreSubmitState::ValidateBinarySignal(const Location &semaphore_loc, c
             initiator << core.FormatHandle(other_queue);
             objlist.add(other_queue);
         }
-        const auto &vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kSemAlreadySignalled);
+        const auto& vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kSemAlreadySignalled);
         skip |= core.LogError(vuid, objlist, semaphore_loc,
                               "(%s) is being signaled by %s, but it was previously signaled by %s and has not since been waited on",
                               core.FormatHandle(semaphore).c_str(), core.FormatHandle(queue).c_str(), initiator.str().c_str());
@@ -349,7 +349,7 @@ bool SemaphoreSubmitState::ValidateBinarySignal(const Location &semaphore_loc, c
                                              IsExtEnabled(core.extensions.vk_ext_swapchain_maintenance1);
         const std::string error_message =
             GetSemaphoreInUseBySwapchainMessage(*swapchain_info, semaphore_state, queue, present_fence_supported, core);
-        const std::string &vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kSemAlreadySignalled);
+        const std::string& vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kSemAlreadySignalled);
         skip |= core.LogError(vuid, objlist, semaphore_loc, "%s", error_message.c_str());
     } else {
         binary_signaling_state[semaphore] = true;
@@ -357,20 +357,20 @@ bool SemaphoreSubmitState::ValidateBinarySignal(const Location &semaphore_loc, c
     return skip;
 }
 
-bool SemaphoreSubmitState::ValidateTimelineSignal(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state,
+bool SemaphoreSubmitState::ValidateTimelineSignal(const Location& semaphore_loc, const vvl::Semaphore& semaphore_state,
                                                   uint64_t value) {
     bool skip = false;
-    const char *where = nullptr;
+    const char* where = nullptr;
 
     if (std::optional<uint64_t> larger_or_equal_payload = CheckTimelineSignalTooSmall(semaphore_state, value, where)) {
-        const auto &vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kTimelineSemSmallValue);
+        const auto& vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kTimelineSemSmallValue);
         LogObjectList objlist(semaphore_state.Handle(), queue);
         skip |= core.LogError(vuid, objlist, semaphore_loc,
                               "signal value (%" PRIu64 ") in %s must be greater than %s timeline semaphore %s value (%" PRIu64 ")",
                               value, core.FormatHandle(queue).c_str(), where, core.FormatHandle(semaphore_state.Handle()).c_str(),
                               *larger_or_equal_payload);
     } else if (std::optional<uint64_t> far_away_payload = CheckTimelineMaxDiff(semaphore_state, value, where)) {
-        const auto &vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kTimelineSemMaxDiff);
+        const auto& vuid = GetQueueSubmitVUID(semaphore_loc, vvl::SubmitError::kTimelineSemMaxDiff);
         LogObjectList objlist(semaphore_state.Handle(), queue);
         skip |= core.LogError(vuid, objlist, semaphore_loc,
                               "value (%" PRIu64 ") exceeds limit regarding %s semaphore %s value (%" PRIu64 ").", value, where,
@@ -381,7 +381,7 @@ bool SemaphoreSubmitState::ValidateTimelineSignal(const Location &semaphore_loc,
     return skip;
 }
 
-bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &signal_semaphore_loc, const vvl::Semaphore &semaphore_state,
+bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location& signal_semaphore_loc, const vvl::Semaphore& semaphore_state,
                                                    uint64_t value) {
     bool skip = false;
     if (semaphore_state.type == VK_SEMAPHORE_TYPE_BINARY) {
@@ -393,19 +393,19 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &signal_semaph
     return skip;
 }
 
-bool CoreChecks::ValidateStageMaskHost(const LogObjectList &objlist, const Location &stage_mask_loc,
+bool CoreChecks::ValidateStageMaskHost(const LogObjectList& objlist, const Location& stage_mask_loc,
                                        VkPipelineStageFlags2KHR stageMask) const {
     bool skip = false;
     if ((stageMask & VK_PIPELINE_STAGE_HOST_BIT) != 0) {
-        const auto &vuid = GetQueueSubmitVUID(stage_mask_loc, vvl::SubmitError::kHostStageMask);
+        const auto& vuid = GetQueueSubmitVUID(stage_mask_loc, vvl::SubmitError::kHostStageMask);
         skip |= LogError(vuid, objlist, stage_mask_loc,
                          "must not include VK_PIPELINE_STAGE_HOST_BIT as the stage can't be invoked inside a command buffer.");
     }
     return skip;
 }
 
-bool CoreChecks::ValidateFenceForSubmit(const vvl::Fence &fence_state, const char *inflight_vuid, const char *retired_vuid,
-                                        const LogObjectList &objlist, const Location &loc) const {
+bool CoreChecks::ValidateFenceForSubmit(const vvl::Fence& fence_state, const char* inflight_vuid, const char* retired_vuid,
+                                        const LogObjectList& objlist, const Location& loc) const {
     bool skip = false;
 
     if (fence_state.Scope() == vvl::Fence::kInternal) {
@@ -427,8 +427,8 @@ bool CoreChecks::ValidateFenceForSubmit(const vvl::Fence &fence_state, const cha
     return skip;
 }
 
-bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const VkSubmitInfo &submit,
-                                             const Location &submit_loc) const {
+bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState& state, const VkSubmitInfo& submit,
+                                             const Location& submit_loc) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     if (const auto d3d12_fence_submit_info = vku::FindStructInPNextChain<VkD3D12FenceSubmitInfoKHR>(submit.pNext)) {
@@ -448,7 +448,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
         }
     }
 #endif
-    auto *timeline_semaphore_submit_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(submit.pNext);
+    auto* timeline_semaphore_submit_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(submit.pNext);
     for (uint32_t i = 0; i < submit.waitSemaphoreCount; ++i) {
         uint64_t value = 0;
         VkSemaphore semaphore = submit.pWaitSemaphores[i];
@@ -519,11 +519,11 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
     return skip;
 }
 
-bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const VkSubmitInfo2 &submit,
-                                             const Location &submit_loc) const {
+bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState& state, const VkSubmitInfo2& submit,
+                                             const Location& submit_loc) const {
     bool skip = false;
     for (uint32_t i = 0; i < submit.waitSemaphoreInfoCount; ++i) {
-        const auto &wait_info = submit.pWaitSemaphoreInfos[i];
+        const auto& wait_info = submit.pWaitSemaphoreInfos[i];
         Location wait_info_loc = submit_loc.dot(Field::pWaitSemaphoreInfos, i);
         const LogObjectList objlist(wait_info.semaphore, state.queue);
         skip |= ValidatePipelineStage(objlist, wait_info_loc.dot(Field::stageMask), state.queue_flags, wait_info.stageMask);
@@ -535,7 +535,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
         skip |= state.ValidateWaitSemaphore(wait_info_loc.dot(Field::semaphore), *semaphore_state, wait_info.value);
         if (semaphore_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
             for (uint32_t sig_index = 0; sig_index < submit.signalSemaphoreInfoCount; sig_index++) {
-                const auto &sig_info = submit.pSignalSemaphoreInfos[sig_index];
+                const auto& sig_info = submit.pSignalSemaphoreInfos[sig_index];
                 if (wait_info.semaphore == sig_info.semaphore && wait_info.value >= sig_info.value) {
                     Location sig_loc = submit_loc.dot(Field::pSignalSemaphoreInfos, sig_index);
                     skip |= LogError("VUID-VkSubmitInfo2-semaphore-03881", objlist, wait_info_loc.dot(Field::value),
@@ -546,7 +546,7 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
         }
     }
     for (uint32_t i = 0; i < submit.signalSemaphoreInfoCount; ++i) {
-        const auto &sem_info = submit.pSignalSemaphoreInfos[i];
+        const auto& sem_info = submit.pSignalSemaphoreInfos[i];
         auto signal_info_loc = submit_loc.dot(Field::pSignalSemaphoreInfos, i);
         const LogObjectList objlist(sem_info.semaphore, state.queue);
         skip |= ValidatePipelineStage(objlist, signal_info_loc.dot(Field::stageMask), state.queue_flags, sem_info.stageMask);
@@ -558,10 +558,10 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
     return skip;
 }
 
-bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const VkBindSparseInfo &submit,
-                                             const Location &submit_loc) const {
+bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState& state, const VkBindSparseInfo& submit,
+                                             const Location& submit_loc) const {
     bool skip = false;
-    auto *timeline_semaphore_submit_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(submit.pNext);
+    auto* timeline_semaphore_submit_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(submit.pNext);
     for (uint32_t i = 0; i < submit.waitSemaphoreCount; ++i) {
         uint64_t value = 0;
         VkSemaphore semaphore = submit.pWaitSemaphores[i];
@@ -628,9 +628,9 @@ bool CoreChecks::ValidateSemaphoresForSubmit(SemaphoreSubmitState &state, const 
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo,
-                                            const VkAllocationCallbacks *pAllocator, VkFence *pFence,
-                                            const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkFence* pFence,
+                                            const ErrorObject& error_obj) const {
     bool skip = false;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     auto fence_export_info = vku::FindStructInPNextChain<VkExportFenceCreateInfo>(pCreateInfo->pNext);
@@ -665,9 +665,9 @@ bool CoreChecks::PreCallValidateCreateFence(VkDevice device, const VkFenceCreate
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
     auto sem_type_create_info = vku::FindStructInPNextChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -719,13 +719,13 @@ bool CoreChecks::PreCallValidateCreateSemaphore(VkDevice device, const VkSemapho
     return skip;
 }
 
-bool CoreChecks::PreCallValidateWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                                  const ErrorObject& error_obj) const {
     return PreCallValidateWaitSemaphores(device, pWaitInfo, timeout, error_obj);
 }
 
-bool CoreChecks::PreCallValidateWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
@@ -741,8 +741,8 @@ bool CoreChecks::PreCallValidateWaitSemaphores(VkDevice device, const VkSemaphor
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks *pAllocator,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks* pAllocator,
+                                             const ErrorObject& error_obj) const {
     bool skip = false;
     auto fence_state = Get<vvl::Fence>(fence);
     if (fence_state && fence_state->Scope() == vvl::Fence::kInternal && fence_state->State() == vvl::Fence::kInflight) {
@@ -751,8 +751,8 @@ bool CoreChecks::PreCallValidateDestroyFence(VkDevice device, VkFence fence, con
     return skip;
 }
 
-bool CoreChecks::PreCallValidateResetFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences,
-                                            const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateResetFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences,
+                                            const ErrorObject& error_obj) const {
     bool skip = false;
     for (uint32_t i = 0; i < fenceCount; ++i) {
         auto fence_state = Get<vvl::Fence>(pFences[i]);
@@ -765,8 +765,8 @@ bool CoreChecks::PreCallValidateResetFences(VkDevice device, uint32_t fenceCount
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks *pAllocator,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto sema_node = Get<vvl::Semaphore>(semaphore)) {
         skip |= ValidateObjectNotInUse(sema_node.get(), error_obj.location, "VUID-vkDestroySemaphore-semaphore-05149");
@@ -774,8 +774,8 @@ bool CoreChecks::PreCallValidateDestroySemaphore(VkDevice device, VkSemaphore se
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator,
+                                             const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto event_state = Get<vvl::Event>(event)) {
         skip |= ValidateObjectNotInUse(event_state.get(), error_obj.location.dot(Field::event), "VUID-vkDestroyEvent-event-01145");
@@ -783,8 +783,8 @@ bool CoreChecks::PreCallValidateDestroyEvent(VkDevice device, VkEvent event, con
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks *pAllocator,
-                                               const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks* pAllocator,
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto sampler_state = Get<vvl::Sampler>(sampler)) {
         skip |= ValidateObjectNotInUse(sampler_state.get(), error_obj.location.dot(Field::sampler),
@@ -794,7 +794,7 @@ bool CoreChecks::PreCallValidateDestroySampler(VkDevice device, VkSampler sample
 }
 
 bool CoreChecks::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                            const ErrorObject &error_obj) const {
+                                            const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -805,8 +805,8 @@ bool CoreChecks::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEve
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo *pDependencyInfo,
-                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
+                                             const ErrorObject& error_obj) const {
     const LogObjectList objlist(commandBuffer, event);
 
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
@@ -853,12 +853,12 @@ bool CoreChecks::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEv
 }
 
 bool CoreChecks::PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                                const VkDependencyInfoKHR *pDependencyInfo, const ErrorObject &error_obj) const {
+                                                const VkDependencyInfoKHR* pDependencyInfo, const ErrorObject& error_obj) const {
     return PreCallValidateCmdSetEvent2(commandBuffer, event, pDependencyInfo, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                              const ErrorObject &error_obj) const {
+                                              const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     const LogObjectList objlist(commandBuffer);
     const Location stage_mask_loc = error_obj.location.dot(Field::stageMask);
@@ -871,7 +871,7 @@ bool CoreChecks::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkE
 }
 
 bool CoreChecks::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
-                                               const ErrorObject &error_obj) const {
+                                               const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     const LogObjectList objlist(commandBuffer);
     const Location stage_mask_loc = error_obj.location.dot(Field::stageMask);
@@ -888,24 +888,24 @@ bool CoreChecks::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, Vk
 }
 
 bool CoreChecks::PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
-                                                  const ErrorObject &error_obj) const {
+                                                  const ErrorObject& error_obj) const {
     return PreCallValidateCmdResetEvent2(commandBuffer, event, stageMask, error_obj);
 }
 
 struct RenderPassDepState {
     using Field = vvl::Field;
 
-    const CoreChecks &core;
+    const CoreChecks& core;
     const std::string vuid;
     uint32_t active_subpass;
     const VkRenderPass rp_handle;
     const VkPipelineStageFlags2KHR disabled_features;
-    const std::vector<uint32_t> &self_dependencies;
-    const vku::safe_VkSubpassDependency2 *dependencies;
+    const std::vector<uint32_t>& self_dependencies;
+    const vku::safe_VkSubpassDependency2* dependencies;
 
-    RenderPassDepState(const CoreChecks &c, const std::string &v, uint32_t subpass, const VkRenderPass handle,
-                       const DeviceFeatures &features, const DeviceExtensions &device_extensions,
-                       const std::vector<uint32_t> &self_deps, const vku::safe_VkSubpassDependency2 *deps)
+    RenderPassDepState(const CoreChecks& c, const std::string& v, uint32_t subpass, const VkRenderPass handle,
+                       const DeviceFeatures& features, const DeviceExtensions& device_extensions,
+                       const std::vector<uint32_t>& self_deps, const vku::safe_VkSubpassDependency2* deps)
         : core(c),
           vuid(v),
           active_subpass(subpass),
@@ -914,7 +914,7 @@ struct RenderPassDepState {
           self_dependencies(self_deps),
           dependencies(deps) {}
 
-    VkMemoryBarrier2 GetSubPassDepBarrier(const vku::safe_VkSubpassDependency2 &dep) const {
+    VkMemoryBarrier2 GetSubPassDepBarrier(const vku::safe_VkSubpassDependency2& dep) const {
         // "If a VkMemoryBarrier2 is included in the pNext chain, srcStageMask, dstStageMask,
         // srcAccessMask, and dstAccessMask parameters are ignored. The synchronization and
         // access scopes instead are defined by the parameters of VkMemoryBarrier2."
@@ -930,7 +930,7 @@ struct RenderPassDepState {
         return barrier;
     }
 
-    bool ValidateStage(const Location &barrier_loc, VkPipelineStageFlags2 src_stage_mask,
+    bool ValidateStage(const Location& barrier_loc, VkPipelineStageFlags2 src_stage_mask,
                        VkPipelineStageFlags2 dst_stage_mask) const {
         // Look for srcStageMask + dstStageMask superset in any self-dependency
         for (const auto self_dep_index : self_dependencies) {
@@ -956,7 +956,7 @@ struct RenderPassDepState {
                              core.FormatHandle(rp_handle).c_str());
     }
 
-    bool ValidateAccess(const Location &barrier_loc, VkAccessFlags2 src_access_mask, VkAccessFlags2 dst_access_mask) const {
+    bool ValidateAccess(const Location& barrier_loc, VkAccessFlags2 src_access_mask, VkAccessFlags2 dst_access_mask) const {
         // Look for srcAccessMask + dstAccessMask superset in any self-dependency
         for (const auto self_dep_index : self_dependencies) {
             const auto subpass_dep = GetSubPassDepBarrier(dependencies[self_dep_index]);
@@ -971,9 +971,9 @@ struct RenderPassDepState {
                              active_subpass, core.FormatHandle(rp_handle).c_str());
     }
 
-    bool ValidateDependencyFlag(const Location &dep_flags_loc, VkDependencyFlags dependency_flags) const {
+    bool ValidateDependencyFlag(const Location& dep_flags_loc, VkDependencyFlags dependency_flags) const {
         for (const auto self_dep_index : self_dependencies) {
-            const auto &subpass_dep = dependencies[self_dep_index];
+            const auto& subpass_dep = dependencies[self_dep_index];
             const bool match = subpass_dep.dependencyFlags == dependency_flags;
             if (match) return false;  // match is found, return skip value (false)
         }
@@ -986,7 +986,7 @@ struct RenderPassDepState {
 };
 
 // If inside a renderpass, validate
-bool CoreChecks::ValidateRenderPassPipelineStage(VkRenderPass render_pass, const Location &loc,
+bool CoreChecks::ValidateRenderPassPipelineStage(VkRenderPass render_pass, const Location& loc,
                                                  VkPipelineStageFlags2 src_stage_mask, VkPipelineStageFlags2 dst_stage_mask) const {
     bool skip = false;
     const VkPipelineStageFlags2 graphics_stages = syncAllCommandStagesByQueueFlags().at(VK_QUEUE_GRAPHICS_BIT);
@@ -995,13 +995,13 @@ bool CoreChecks::ValidateRenderPassPipelineStage(VkRenderPass render_pass, const
     const VkPipelineStageFlags2 dst_diff =
         sync_utils::ExpandPipelineStages(dst_stage_mask, VK_QUEUE_GRAPHICS_BIT) & ~graphics_stages;
     if (src_diff != 0) {
-        const char *vuid = loc.function == Func::vkCmdPipelineBarrier ? "VUID-vkCmdPipelineBarrier-None-07892"
+        const char* vuid = loc.function == Func::vkCmdPipelineBarrier ? "VUID-vkCmdPipelineBarrier-None-07892"
                                                                       : "VUID-vkCmdPipelineBarrier2-None-07892";
         skip |= LogError(vuid, render_pass, loc.dot(Field::srcStageMask), "contains non graphics stage %s.",
                          string_VkPipelineStageFlags2(src_diff).c_str());
     }
     if (dst_diff != 0) {
-        const char *vuid = loc.function == Func::vkCmdPipelineBarrier ? "VUID-vkCmdPipelineBarrier-None-07892"
+        const char* vuid = loc.function == Func::vkCmdPipelineBarrier ? "VUID-vkCmdPipelineBarrier-None-07892"
                                                                       : "VUID-vkCmdPipelineBarrier2-None-07892";
         skip |= LogError(vuid, render_pass, loc.dot(Field::dstStageMask), "contains non graphics stage %s.",
                          string_VkPipelineStageFlags2(dst_diff).c_str());
@@ -1009,11 +1009,11 @@ bool CoreChecks::ValidateRenderPassPipelineStage(VkRenderPass render_pass, const
     return skip;
 }
 
-bool CoreChecks::ValidateRenderPassInstanceNoLayoutChange(const LogObjectList &objlist, const Location &barrier_loc,
+bool CoreChecks::ValidateRenderPassInstanceNoLayoutChange(const LogObjectList& objlist, const Location& barrier_loc,
                                                           VkImageLayout old_layout, VkImageLayout new_layout) const {
     bool skip = false;
     if (old_layout != new_layout) {
-        const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassInstanceLayoutChange);
+        const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassInstanceLayoutChange);
         skip |= LogError(
             vuid, objlist, barrier_loc,
             "defines image layout transition (oldLayout = %s, newLayout = %s) within a render pass instance, which is not allowed.",
@@ -1024,14 +1024,14 @@ bool CoreChecks::ValidateRenderPassInstanceNoLayoutChange(const LogObjectList &o
 
 // Validate VUs for Pipeline Barriers that are within a renderPass
 // Pre: cb_state->active_render_pass must be a pointer to valid renderPass state
-bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl::CommandBuffer &cb_state,
+bool CoreChecks::ValidateRenderPassBarriers(const Location& outer_loc, const vvl::CommandBuffer& cb_state,
                                             VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
                                             VkDependencyFlags dependency_flags, uint32_t mem_barrier_count,
-                                            const VkMemoryBarrier *mem_barriers, uint32_t buffer_mem_barrier_count,
-                                            const VkBufferMemoryBarrier *buffer_mem_barriers, uint32_t image_mem_barrier_count,
-                                            const VkImageMemoryBarrier *image_barriers) const {
+                                            const VkMemoryBarrier* mem_barriers, uint32_t buffer_mem_barrier_count,
+                                            const VkBufferMemoryBarrier* buffer_mem_barriers, uint32_t image_mem_barrier_count,
+                                            const VkImageMemoryBarrier* image_barriers) const {
     bool skip = false;
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
     ASSERT_AND_RETURN_SKIP(rp_state);
     RenderPassDepState state(*this, "VUID-vkCmdPipelineBarrier-None-07889", cb_state.GetActiveSubpass(), rp_state->VkHandle(),
                              enabled_features, extensions, rp_state->self_dependencies[cb_state.GetActiveSubpass()],
@@ -1044,7 +1044,7 @@ bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl
         return skip;
     }
     // Grab ref to current subpassDescription up-front for use below
-    const auto &sub_desc = rp_state->create_info.pSubpasses[state.active_subpass];
+    const auto& sub_desc = rp_state->create_info.pSubpasses[state.active_subpass];
     skip |= state.ValidateStage(outer_loc, src_stage_mask, dst_stage_mask);
     skip |= ValidateRenderPassPipelineStage(state.rp_handle, outer_loc, src_stage_mask, dst_stage_mask);
 
@@ -1055,7 +1055,7 @@ bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl
                          buffer_mem_barrier_count, state.active_subpass, FormatHandle(rp_state->Handle()).c_str());
     }
     for (uint32_t i = 0; i < mem_barrier_count; ++i) {
-        const auto &mem_barrier = mem_barriers[i];
+        const auto& mem_barrier = mem_barriers[i];
         const Location barrier_loc = outer_loc.dot(Struct::VkMemoryBarrier, Field::pMemoryBarriers, i);
         skip |= state.ValidateAccess(barrier_loc, mem_barrier.srcAccessMask, mem_barrier.dstAccessMask);
     }
@@ -1091,10 +1091,10 @@ bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl
     return skip;
 }
 
-bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl::CommandBuffer &cb_state,
-                                            const VkDependencyInfo &dep_info) const {
+bool CoreChecks::ValidateRenderPassBarriers(const Location& outer_loc, const vvl::CommandBuffer& cb_state,
+                                            const VkDependencyInfo& dep_info) const {
     bool skip = false;
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
     if (!rp_state || rp_state->UsesDynamicRendering()) {
         return skip;
     }
@@ -1110,9 +1110,9 @@ bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl
         return skip;
     }
     // Grab ref to current subpassDescription up-front for use below
-    const auto &sub_desc = rp_state->create_info.pSubpasses[state.active_subpass];
+    const auto& sub_desc = rp_state->create_info.pSubpasses[state.active_subpass];
     for (uint32_t i = 0; i < dep_info.memoryBarrierCount; ++i) {
-        const auto &mem_barrier = dep_info.pMemoryBarriers[i];
+        const auto& mem_barrier = dep_info.pMemoryBarriers[i];
         const Location barrier_loc = outer_loc.dot(Struct::VkMemoryBarrier2, Field::pMemoryBarriers, i);
         skip |= state.ValidateStage(barrier_loc, mem_barrier.srcStageMask, mem_barrier.dstStageMask);
         skip |= state.ValidateAccess(barrier_loc, mem_barrier.srcAccessMask, mem_barrier.dstAccessMask);
@@ -1159,7 +1159,7 @@ bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl
     return skip;
 }
 
-bool CoreChecks::ValidateStageMasksAgainstQueueCapabilities(const LogObjectList &objlist, const Location &stage_mask_loc,
+bool CoreChecks::ValidateStageMasksAgainstQueueCapabilities(const LogObjectList& objlist, const Location& stage_mask_loc,
                                                             VkQueueFlags queue_flags, VkPipelineStageFlags2KHR stage_mask) const {
     bool skip = false;
     // these are always allowed by queues, calls that restrict them have dedicated VUs.
@@ -1176,9 +1176,9 @@ bool CoreChecks::ValidateStageMasksAgainstQueueCapabilities(const LogObjectList 
          {VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT, VK_QUEUE_GRAPHICS_BIT},
          {VK_PIPELINE_STAGE_2_DATA_GRAPH_BIT_ARM, VK_QUEUE_DATA_GRAPH_BIT_ARM}}};
 
-    for (const auto &entry : metaFlags) {
+    for (const auto& entry : metaFlags) {
         if (((entry.first & stage_mask) != 0) && ((entry.second & queue_flags) == 0)) {
-            const auto &vuid = vvl::GetStageQueueCapVUID(stage_mask_loc, entry.first);
+            const auto& vuid = vvl::GetStageQueueCapVUID(stage_mask_loc, entry.first);
             skip |= LogError(vuid, objlist, stage_mask_loc,
                              "(%s) is not compatible with the queue family properties (%s) of this command buffer.",
                              sync_utils::StringPipelineStageFlags(entry.first).c_str(), string_VkQueueFlags(queue_flags).c_str());
@@ -1197,7 +1197,7 @@ bool CoreChecks::ValidateStageMasksAgainstQueueCapabilities(const LogObjectList 
     for (size_t i = 0; i < sizeof(bad_flags) * 8; i++) {
         VkPipelineStageFlags2KHR bit = (1ULL << i) & bad_flags;
         if (bit) {
-            const auto &vuid = vvl::GetStageQueueCapVUID(stage_mask_loc, bit);
+            const auto& vuid = vvl::GetStageQueueCapVUID(stage_mask_loc, bit);
             skip |= LogError(vuid, objlist, stage_mask_loc,
                              "(%s) is not compatible with the queue family properties (%s) of this command buffer.",
                              sync_utils::StringPipelineStageFlags(bit).c_str(), string_VkQueueFlags(queue_flags).c_str());
@@ -1206,11 +1206,11 @@ bool CoreChecks::ValidateStageMasksAgainstQueueCapabilities(const LogObjectList 
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineStageFeatureEnables(const LogObjectList &objlist, const Location &stage_mask_loc,
+bool CoreChecks::ValidatePipelineStageFeatureEnables(const LogObjectList& objlist, const Location& stage_mask_loc,
                                                      VkPipelineStageFlags2 stage_mask) const {
     bool skip = false;
     if (!enabled_features.synchronization2 && stage_mask == VK_PIPELINE_STAGE_2_NONE) {
-        const auto &vuid = vvl::GetBadFeatureVUID(stage_mask_loc, 0, extensions);
+        const auto& vuid = vvl::GetBadFeatureVUID(stage_mask_loc, 0, extensions);
         skip |= LogError(vuid, objlist, stage_mask_loc, "must not be 0 unless synchronization2 is enabled.");
     }
 
@@ -1222,8 +1222,8 @@ bool CoreChecks::ValidatePipelineStageFeatureEnables(const LogObjectList &objlis
     for (size_t i = 0; i < sizeof(bad_bits) * 8; i++) {
         VkPipelineStageFlags2 bit = 1ULL << i;
         if (bit & bad_bits) {
-            const auto &vuid = vvl::GetBadFeatureVUID(stage_mask_loc, bit, extensions);
-            const auto &feature_names = vvl::GetFeatureNameMap();
+            const auto& vuid = vvl::GetBadFeatureVUID(stage_mask_loc, bit, extensions);
+            const auto& feature_names = vvl::GetFeatureNameMap();
             auto feature_it = feature_names.find(bit);
 
             // If hit this assert just ensure that features in DisabledPipelineStages() match features in GetFeatureNameMap()
@@ -1238,7 +1238,7 @@ bool CoreChecks::ValidatePipelineStageFeatureEnables(const LogObjectList &objlis
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineStage(const LogObjectList &objlist, const Location &stage_mask_loc, VkQueueFlags queue_flags,
+bool CoreChecks::ValidatePipelineStage(const LogObjectList& objlist, const Location& stage_mask_loc, VkQueueFlags queue_flags,
                                        VkPipelineStageFlags2KHR stage_mask) const {
     bool skip = false;
     skip |= ValidateStageMasksAgainstQueueCapabilities(objlist, stage_mask_loc, queue_flags, stage_mask);
@@ -1246,7 +1246,7 @@ bool CoreChecks::ValidatePipelineStage(const LogObjectList &objlist, const Locat
     return skip;
 }
 
-bool CoreChecks::ValidateAccessMask(const LogObjectList &objlist, const Location &access_mask_loc, const Location &stage_mask_loc,
+bool CoreChecks::ValidateAccessMask(const LogObjectList& objlist, const Location& access_mask_loc, const Location& stage_mask_loc,
                                     VkQueueFlags queue_flags, VkAccessFlags2 access_mask, VkPipelineStageFlags2 stage_mask) const {
     bool skip = false;
 
@@ -1257,7 +1257,7 @@ bool CoreChecks::ValidateAccessMask(const LogObjectList &objlist, const Location
             AllVkPipelineShaderStageBits2 & ~VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR;
         if (stage_mask & illegal_pipeline_stages) {
             // Select right vuid based on enabled extensions
-            const auto &vuid = vvl::GetAccessMaskRayQueryVUIDSelector(access_mask_loc, extensions);
+            const auto& vuid = vvl::GetAccessMaskRayQueryVUIDSelector(access_mask_loc, extensions);
             skip |= LogError(vuid, objlist, stage_mask_loc, "contains pipeline stages %s.",
                              sync_utils::StringPipelineStageFlags(stage_mask).c_str());
         }
@@ -1278,7 +1278,7 @@ bool CoreChecks::ValidateAccessMask(const LogObjectList &objlist, const Location
     for (size_t i = 0; i < sizeof(bad_accesses) * 8; i++) {
         VkAccessFlags2 bit = (1ULL << i);
         if (bad_accesses & bit) {
-            const auto &vuid = vvl::GetBadAccessFlagsVUID(access_mask_loc, bit);
+            const auto& vuid = vvl::GetBadAccessFlagsVUID(access_mask_loc, bit);
 
             std::ostringstream ss;
             ss << "(" << sync_utils::StringAccessFlags(bit) << ") is not supported by stage mask ("
@@ -1296,11 +1296,11 @@ bool CoreChecks::ValidateAccessMask(const LogObjectList &objlist, const Location
     return skip;
 }
 
-bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer &cb_state, size_t eventCount, size_t firstEventIndex,
+bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer& cb_state, size_t eventCount, size_t firstEventIndex,
                                             VkPipelineStageFlags2 sourceStageMask, vku::safe_VkDependencyInfo dependency_info,
-                                            const EventMap &local_event_signal_info, VkQueue waiting_queue, const Location &loc) {
+                                            const EventMap& local_event_signal_info, VkQueue waiting_queue, const Location& loc) {
     bool skip = false;
-    const vvl::DeviceState &state_data = cb_state.dev_data;
+    const vvl::DeviceState& state_data = cb_state.dev_data;
     VkPipelineStageFlags2KHR stage_mask = 0;
     const auto max_event = std::min((firstEventIndex + eventCount), cb_state.events.size());
     bool any_event2 = false;
@@ -1315,7 +1315,7 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer &cb_state, 
         // submit, vvl::CommandBuffer::Submit() updates vvl::Event, so it contains
         // the last src_stage from that submission).
         vku::safe_VkDependencyInfo set_dependency_info = {};
-        if (const auto *event_info = vvl::Find(local_event_signal_info, event)) {
+        if (const auto* event_info = vvl::Find(local_event_signal_info, event)) {
             stage_mask |= event_info->src_stage_mask;
             set_dependency_info = event_info->dependency_info;
             // The "set event" is found in the current submission (the same queue); there can't be inter-queue usage errors
@@ -1389,12 +1389,12 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer &cb_state, 
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                               VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-                                              uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-                                              uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
-                                              uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
-                                              const ErrorObject &error_obj) const {
+                                              uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                              uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                              uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -1431,8 +1431,8 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                               const VkDependencyInfo *pDependencyInfos, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                               const VkDependencyInfo* pDependencyInfos, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
     bool skip = false;
@@ -1459,9 +1459,9 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
                                      : "");
             } else if (!is_transfer_use_all_only) {
                 skip |= LogError("VUID-vkCmdWaitEvents2-maintenance8-10205", objlist, dep_info_loc.dot(Field::dependencyFlags),
-                                "(%s) but only VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR and "
-                                "VK_DEPENDENCY_ASYMMETRIC_EVENT_BIT_KHR are allowed.",
-                                string_VkDependencyFlags(pDependencyInfos[i].dependencyFlags).c_str());
+                                 "(%s) but only VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR and "
+                                 "VK_DEPENDENCY_ASYMMETRIC_EVENT_BIT_KHR are allowed.",
+                                 string_VkDependencyFlags(pDependencyInfos[i].dependencyFlags).c_str());
             }
         } else if ((pDependencyInfos[i].dependencyFlags & ~allowed_flags) != 0) {
             skip |= LogError("VUID-vkCmdWaitEvents2-dependencyFlags-10394", objlist, dep_info_loc.dot(Field::dependencyFlags),
@@ -1473,16 +1473,16 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                  const VkDependencyInfoKHR *pDependencyInfos, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                  const VkDependencyInfoKHR* pDependencyInfos, const ErrorObject& error_obj) const {
     return PreCallValidateCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdPipelineBarrier(
     VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-    const VkImageMemoryBarrier *pImageMemoryBarriers, const ErrorObject &error_obj) const {
+    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+    const VkImageMemoryBarrier* pImageMemoryBarriers, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     const LogObjectList objlist(commandBuffer);
@@ -1491,8 +1491,8 @@ bool CoreChecks::PreCallValidateCmdPipelineBarrier(
     if (!enabled_features.maintenance8 &&
         (dependencyFlags & VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR)) {
         skip |= LogError("VUID-vkCmdPipelineBarrier-maintenance8-10206", objlist, error_obj.location.dot(Field::dependencyFlags),
-                        "VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR is used, but maintenance8 feature "
-                        "was not enabled.");
+                         "VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR is used, but maintenance8 feature "
+                         "was not enabled.");
     }
 
     skip |= ValidatePipelineStage(objlist, error_obj.location.dot(Field::srcStageMask), queue_flags, srcStageMask);
@@ -1520,8 +1520,8 @@ bool CoreChecks::PreCallValidateCmdPipelineBarrier(
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,
-                                                    const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
+                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     const LogObjectList objlist(commandBuffer);
@@ -1548,12 +1548,12 @@ bool CoreChecks::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffe
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR *pDependencyInfo,
-                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR* pDependencyInfo,
+                                                       const ErrorObject& error_obj) const {
     return PreCallValidateCmdPipelineBarrier2(commandBuffer, pDependencyInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateSetEvent(VkDevice device, VkEvent event, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateSetEvent(VkDevice device, VkEvent event, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto event_state = Get<vvl::Event>(event)) {
         if (event_state->InUse()) {
@@ -1568,7 +1568,7 @@ bool CoreChecks::PreCallValidateSetEvent(VkDevice device, VkEvent event, const E
     return skip;
 }
 
-bool CoreChecks::PreCallValidateResetEvent(VkDevice device, VkEvent event, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateResetEvent(VkDevice device, VkEvent event, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto event_state = Get<vvl::Event>(event)) {
         if (event_state->flags & VK_EVENT_CREATE_DEVICE_ONLY_BIT) {
@@ -1579,7 +1579,7 @@ bool CoreChecks::PreCallValidateResetEvent(VkDevice device, VkEvent event, const
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetEventStatus(VkDevice device, VkEvent event, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetEventStatus(VkDevice device, VkEvent event, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto event_state = Get<vvl::Event>(event)) {
         if (event_state->flags & VK_EVENT_CREATE_DEVICE_ONLY_BIT) {
@@ -1589,8 +1589,8 @@ bool CoreChecks::PreCallValidateGetEventStatus(VkDevice device, VkEvent event, c
     }
     return skip;
 }
-bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
     const Location signal_loc = error_obj.location.dot(Field::pSignalInfo);
     auto semaphore_state = Get<vvl::Semaphore>(pSignalInfo->semaphore);
@@ -1619,10 +1619,10 @@ bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemapho
         return skip;
     }
 
-    const char *payload_type = nullptr;
+    const char* payload_type = nullptr;
     if (auto far_away_payload = semaphore_state->CheckMaxDiffThreshold(pSignalInfo->value, payload_type)) {
         const Location loc = error_obj.location.dot(Struct::VkSemaphoreSignalInfo, Field::value);
-        const auto &vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kTimelineSemMaxDiff);
+        const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kTimelineSemMaxDiff);
         skip |= LogError(vuid, semaphore_state->Handle(), loc,
                          "(%" PRIu64 ") exceeds limit regarding %s semaphore %s payload (%" PRIu64 ").", pSignalInfo->value,
                          FormatHandle(*semaphore_state).c_str(), payload_type, *far_away_payload);
@@ -1630,13 +1630,13 @@ bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemapho
     return skip;
 }
 
-bool CoreChecks::PreCallValidateSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                                   const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                                   const ErrorObject& error_obj) const {
     return PreCallValidateSignalSemaphore(device, pSignalInfo, error_obj);
 }
 
-bool CoreChecks::PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
-                                                         const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
+                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     auto semaphore_state = Get<vvl::Semaphore>(semaphore);
     ASSERT_AND_RETURN_SKIP(semaphore_state);
@@ -1647,8 +1647,8 @@ bool CoreChecks::PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSema
     return skip;
 }
 
-bool CoreChecks::PreCallValidateGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
-                                                            const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
+                                                            const ErrorObject& error_obj) const {
     return PreCallValidateGetSemaphoreCounterValue(device, semaphore, pValue, error_obj);
 }
 
@@ -1659,7 +1659,7 @@ static inline VkQueueFlags SubpassToQueueFlags(uint32_t subpass) {
     return subpass == VK_SUBPASS_EXTERNAL ? kAllQueueTypes : static_cast<VkQueueFlags>(VK_QUEUE_GRAPHICS_BIT);
 }
 
-bool CoreChecks::ValidateSubpassDependency(const Location &loc, const VkSubpassDependency2 &dependency) const {
+bool CoreChecks::ValidateSubpassDependency(const Location& loc, const VkSubpassDependency2& dependency) const {
     bool skip = false;
 
     if (dependency.dependencyFlags & VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR) {
@@ -1670,7 +1670,7 @@ bool CoreChecks::ValidateSubpassDependency(const Location &loc, const VkSubpassD
     }
 
     VkMemoryBarrier2 converted_barrier;
-    const auto *mem_barrier = vku::FindStructInPNextChain<VkMemoryBarrier2>(dependency.pNext);
+    const auto* mem_barrier = vku::FindStructInPNextChain<VkMemoryBarrier2>(dependency.pNext);
     const Location barrier_loc = mem_barrier ? loc.dot(Field::pNext) : loc;
 
     if (mem_barrier) {
@@ -1696,7 +1696,7 @@ bool CoreChecks::ValidateSubpassDependency(const Location &loc, const VkSubpassD
 }
 
 // Verify an image barrier's old/new layouts are compatible with the image's usage flags.
-bool CoreChecks::ValidateImageLayoutAgainstImageUsage(const Location &layout_loc, VkImage image, VkImageLayout layout,
+bool CoreChecks::ValidateImageLayoutAgainstImageUsage(const Location& layout_loc, VkImage image, VkImageLayout layout,
                                                       VkImageUsageFlags usage_flags) const {
     bool skip = false;
     bool is_error = false;
@@ -1787,7 +1787,7 @@ bool CoreChecks::ValidateImageLayoutAgainstImageUsage(const Location &layout_loc
     }
 
     if (is_error) {
-        const auto &vuid = vvl::GetBadImageLayoutVUID(layout_loc, layout);
+        const auto& vuid = vvl::GetBadImageLayoutVUID(layout_loc, layout);
         skip |= LogError(vuid, image, layout_loc, "(%s) is not compatible with %s usage flags %s.", string_VkImageLayout(layout),
                          FormatHandle(image).c_str(), string_VkImageUsageFlags(usage_flags).c_str());
     }
@@ -1795,15 +1795,15 @@ bool CoreChecks::ValidateImageLayoutAgainstImageUsage(const Location &layout_loc
 }
 
 // Verify image barrier is compatible with the image it references.
-bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer &cb_state, const ImageBarrier &barrier,
-                                                  const Location &barrier_loc, const vvl::Image &image_state,
-                                                  ImageLayoutRegistry &local_layout_registry) const {
+bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
+                                                  const Location& barrier_loc, const vvl::Image& image_state,
+                                                  ImageLayoutRegistry& local_layout_registry) const {
     bool skip = false;
 
     const VkImage image = image_state.VkHandle();
     assert(image == barrier.image);
 
-    const VkImageCreateInfo &image_ci = image_state.create_info;
+    const VkImageCreateInfo& image_ci = image_state.create_info;
     const Location image_loc = barrier_loc.dot(Field::image);
     const VkFormat image_format = image_ci.format;
     const VkImageLayout old_layout = barrier.oldLayout;
@@ -1815,7 +1815,7 @@ bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer &cb_s
 
     skip |= ValidateBarrierQueueFamilies(cb_state.Handle(), barrier_loc, image_loc, barrier, image_state.Handle(),
                                          image_ci.sharingMode, cb_state.command_pool->queueFamilyIndex);
-    const auto &vuid_aspect = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kAspectMask);
+    const auto& vuid_aspect = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kAspectMask);
     skip |= ValidateImageAspectMask(image_state.VkHandle(), image_ci.format, barrier.subresourceRange.aspectMask,
                                     image_state.disjoint, image_loc, vuid_aspect.c_str());
     skip |= ValidateImageBarrierSubresourceRange(image_ci, barrier.subresourceRange, image_state, cb_state.Handle(),
@@ -1904,7 +1904,7 @@ bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer &cb_s
         skip |= ValidateImageBarrierLayouts(cb_state, image_state, image_loc, barrier, local_layout_registry);
     }
 
-    const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
+    const vvl::RenderPass* rp_state = cb_state.active_render_pass.get();
     if (rp_state && rp_state->UsesDynamicRendering()) {
         skip |= VerifyDynamicRenderingImageBarrierLayouts(cb_state, image_state,
                                                           *rp_state->dynamic_rendering_begin_rendering_info.ptr(), barrier_loc);
@@ -1915,13 +1915,13 @@ bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer &cb_s
     if (vkuFormatIsColor(image_format) && (barrier_aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT)) {
         if (!vkuFormatIsMultiplane(image_format)) {
             const LogObjectList objlist(cb_state.Handle(), image);
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kNotColorAspectSinglePlane);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kNotColorAspectSinglePlane);
             skip |= LogError(vuid, objlist, image_loc, "(%s) has color format %s, but its aspectMask is %s.",
                              FormatHandle(image).c_str(), string_VkFormat(image_format),
                              string_VkImageAspectFlags(barrier_aspect_mask).c_str());
         } else if (!image_state.disjoint) {
             const LogObjectList objlist(cb_state.Handle(), image);
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kNotColorAspectNonDisjoint);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kNotColorAspectNonDisjoint);
             skip |= LogError(vuid, objlist, image_loc, "(%s) has color format %s, but its aspectMask is %s.",
                              FormatHandle(image).c_str(), string_VkFormat(image_format),
                              string_VkImageAspectFlags(barrier_aspect_mask).c_str());
@@ -1930,7 +1930,7 @@ bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer &cb_s
     if ((vkuFormatIsMultiplane(image_format)) && (image_state.disjoint == true)) {
         if (!IsValidPlaneAspect(image_format, barrier_aspect_mask) && ((barrier_aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) == 0)) {
             const LogObjectList objlist(cb_state.Handle(), image);
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadMultiplanarAspect);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadMultiplanarAspect);
             skip |= LogError(vuid, objlist, image_loc, "(%s) has Multiplane format %s, but its aspectMask is %s.",
                              FormatHandle(image).c_str(), string_VkFormat(image_format),
                              string_VkImageAspectFlags(barrier_aspect_mask).c_str());
@@ -1940,11 +1940,11 @@ bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer &cb_s
     return skip;
 }
 
-bool CoreChecks::ValidateImageBarrierZeroInitializedSubresourceRange(const VkImageSubresourceRange &subresource_range,
-                                                                     const vvl::Image &image_state, const LogObjectList &objlist,
-                                                                     const Location &barrier_or_transition_loc) const {
+bool CoreChecks::ValidateImageBarrierZeroInitializedSubresourceRange(const VkImageSubresourceRange& subresource_range,
+                                                                     const vvl::Image& image_state, const LogObjectList& objlist,
+                                                                     const Location& barrier_or_transition_loc) const {
     bool skip = false;
-    const auto &vuid = GetImageBarrierVUID(barrier_or_transition_loc, vvl::ImageError::kZeroInitializeSubresource);
+    const auto& vuid = GetImageBarrierVUID(barrier_or_transition_loc, vvl::ImageError::kZeroInitializeSubresource);
     const Location subresource_range_loc = barrier_or_transition_loc.dot(Field::subresourceRange);
 
     if (subresource_range.baseArrayLayer != 0) {
@@ -1973,10 +1973,10 @@ bool CoreChecks::ValidateImageBarrierZeroInitializedSubresourceRange(const VkIma
 }
 
 // Verify image barrier image state and that the image is consistent with FB image
-bool CoreChecks::ValidateImageBarrierAttachment(const Location &barrier_loc, const vvl::CommandBuffer &cb_state,
-                                                const vvl::Framebuffer &fb_state, uint32_t active_subpass,
-                                                const vku::safe_VkSubpassDescription2 &sub_desc, const VkRenderPass rp_handle,
-                                                const ImageBarrier &img_barrier, const vvl::CommandBuffer *primary_cb_state) const {
+bool CoreChecks::ValidateImageBarrierAttachment(const Location& barrier_loc, const vvl::CommandBuffer& cb_state,
+                                                const vvl::Framebuffer& fb_state, uint32_t active_subpass,
+                                                const vku::safe_VkSubpassDescription2& sub_desc, const VkRenderPass rp_handle,
+                                                const ImageBarrier& img_barrier, const vvl::CommandBuffer* primary_cb_state) const {
     bool skip = false;
     const auto img_bar_image = img_barrier.image;
     bool image_match = false;
@@ -2003,7 +2003,7 @@ bool CoreChecks::ValidateImageBarrierAttachment(const Location &barrier_loc, con
             sub_image_found = true;
         }
         if (!sub_image_found) {
-            const auto *resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(sub_desc.pNext);
+            const auto* resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(sub_desc.pNext);
             if (resolve && resolve->pDepthStencilResolveAttachment &&
                 resolve->pDepthStencilResolveAttachment->attachment == attach_index) {
                 sub_image_layout = resolve->pDepthStencilResolveAttachment->layout;
@@ -2024,13 +2024,13 @@ bool CoreChecks::ValidateImageBarrierAttachment(const Location &barrier_loc, con
                     sub_image_found = true;
                     if (image_ahb_format == 0) {
                         const LogObjectList objlist(cb_state.Handle(), rp_handle, fb_state.Handle(), img_bar_image);
-                        const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatchAhbZero);
+                        const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatchAhbZero);
                         skip |= LogError(vuid, objlist, image_loc,
                                          "(%s) for subpass %" PRIu32 " was not created with an externalFormat.",
                                          FormatHandle(img_bar_image).c_str(), active_subpass);
                     } else if (sub_desc.pColorAttachments && sub_desc.pColorAttachments[0].attachment != VK_ATTACHMENT_UNUSED) {
                         const LogObjectList objlist(cb_state.Handle(), rp_handle, fb_state.Handle(), img_bar_image);
-                        const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatchColorUnused);
+                        const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatchColorUnused);
                         skip |=
                             LogError(vuid, objlist, image_loc,
                                      "(%s) for subpass %" PRIu32 " the pColorAttachments[0].attachment is %" PRIu32
@@ -2042,7 +2042,7 @@ bool CoreChecks::ValidateImageBarrierAttachment(const Location &barrier_loc, con
             }
         }
         if (!sub_image_found) {
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatch);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatch);
             const LogObjectList objlist(cb_state.Handle(), rp_handle, fb_state.Handle(), img_bar_image);
             skip |= LogError(vuid, objlist, image_loc,
                              "(%s) is not referenced by the VkSubpassDescription for active subpass (%" PRIu32 ") of current %s.",
@@ -2051,7 +2051,7 @@ bool CoreChecks::ValidateImageBarrierAttachment(const Location &barrier_loc, con
 
     } else {  // !image_match
         const LogObjectList objlist(cb_state.Handle(), rp_handle, fb_state.Handle(), img_bar_image);
-        const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatch);
+        const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kRenderPassMismatch);
         skip |= LogError(vuid, objlist, image_loc, "(%s) does not match an image from the current %s.",
                          FormatHandle(img_bar_image).c_str(), FormatHandle(fb_state.Handle()).c_str());
     }
@@ -2070,21 +2070,21 @@ bool CoreChecks::ValidateImageBarrierAttachment(const Location &barrier_loc, con
     return skip;
 }
 
-void CoreChecks::EnqueueValidateImageBarrierAttachment(const Location &loc, core::CommandBufferSubState &cb_sub_state,
-                                                       const ImageBarrier &barrier) {
+void CoreChecks::EnqueueValidateImageBarrierAttachment(const Location& loc, core::CommandBufferSubState& cb_sub_state,
+                                                       const ImageBarrier& barrier) {
     // Secondary CBs can have null framebuffer so queue up validation in that case 'til FB is known
-    const vvl::RenderPass *rp_state = cb_sub_state.base.active_render_pass.get();
+    const vvl::RenderPass* rp_state = cb_sub_state.base.active_render_pass.get();
     if (rp_state && (VK_NULL_HANDLE == cb_sub_state.base.active_framebuffer) && cb_sub_state.base.IsSecondary()) {
         const auto active_subpass = cb_sub_state.base.GetActiveSubpass();
         if (active_subpass < rp_state->create_info.subpassCount) {
-            const auto &sub_desc = rp_state->create_info.pSubpasses[active_subpass];
+            const auto& sub_desc = rp_state->create_info.pSubpasses[active_subpass];
             // Secondary CB case w/o FB specified delay validation
-            auto *this_ptr = this;  // Required for older compilers with c++20 compatibility
+            auto* this_ptr = this;  // Required for older compilers with c++20 compatibility
             vvl::LocationCapture loc_capture(loc);
             const VkRenderPass render_pass = rp_state->VkHandle();
             cb_sub_state.cmd_execute_commands_functions.emplace_back(
                 [this_ptr, loc_capture, active_subpass, sub_desc, render_pass, barrier](
-                    const vvl::CommandBuffer &secondary_cb, const vvl::CommandBuffer *primary_cb, const vvl::Framebuffer *fb) {
+                    const vvl::CommandBuffer& secondary_cb, const vvl::CommandBuffer* primary_cb, const vvl::Framebuffer* fb) {
                     if (!fb) return false;
                     return this_ptr->ValidateImageBarrierAttachment(loc_capture.Get(), secondary_cb, *fb, active_subpass, sub_desc,
                                                                     render_pass, barrier, primary_cb);
@@ -2093,7 +2093,7 @@ void CoreChecks::EnqueueValidateImageBarrierAttachment(const Location &loc, core
     }
 }
 
-static bool IsQueueFamilyValid(const vvl::DeviceState &device_data, uint32_t queue_family) {
+static bool IsQueueFamilyValid(const vvl::DeviceState& device_data, uint32_t queue_family) {
     return (queue_family < static_cast<uint32_t>(device_data.physical_device_state->queue_family_properties.size()));
 }
 
@@ -2101,7 +2101,7 @@ static bool IsQueueFamilySpecial(uint32_t queue_family) {
     return IsQueueFamilyExternal(queue_family) || (queue_family == VK_QUEUE_FAMILY_IGNORED);
 }
 
-static const char *GetFamilyAnnotation(const vvl::DeviceState &device_data, uint32_t family) {
+static const char* GetFamilyAnnotation(const vvl::DeviceState& device_data, uint32_t family) {
     switch (family) {
         case VK_QUEUE_FAMILY_EXTERNAL:
             return " (VK_QUEUE_FAMILY_EXTERNAL)";
@@ -2117,8 +2117,8 @@ static const char *GetFamilyAnnotation(const vvl::DeviceState &device_data, uint
     }
 }
 
-bool CoreChecks::ValidateHostStage(const LogObjectList &objlist, const Location &barrier_loc,
-                                   const OwnershipTransferBarrier &barrier) const {
+bool CoreChecks::ValidateHostStage(const LogObjectList& objlist, const Location& barrier_loc,
+                                   const OwnershipTransferBarrier& barrier) const {
     bool skip = false;
     // src/dst queue families should be equal if HOST_BIT is used
     if (barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex) {
@@ -2131,7 +2131,7 @@ bool CoreChecks::ValidateHostStage(const LogObjectList &objlist, const Location 
             stage_field = vvl::Field::dstStageMask;
         }
         if (stage_field != vvl::Field::Empty) {
-            const auto &vuid = GetBarrierQueueVUID(barrier_loc, vvl::QueueError::kHostStage);
+            const auto& vuid = GetBarrierQueueVUID(barrier_loc, vvl::QueueError::kHostStage);
             const Location stage_loc = is_sync2 ? barrier_loc.dot(stage_field) : Location(barrier_loc.function, stage_field);
             skip |= LogError(vuid, objlist, stage_loc,
                              "is %s but srcQueueFamilyIndex (%" PRIu32 ") != dstQueueFamilyIndex (%" PRIu32 ").",
@@ -2142,9 +2142,9 @@ bool CoreChecks::ValidateHostStage(const LogObjectList &objlist, const Location 
     return skip;
 }
 
-void CoreChecks::RecordBarrierValidationInfo(const Location &barrier_loc, vvl::CommandBuffer &cb_state,
-                                             const BufferBarrier &barrier,
-                                             QFOTransferBarrierSets<QFOBufferTransferBarrier> &barrier_sets) {
+void CoreChecks::RecordBarrierValidationInfo(const Location& barrier_loc, vvl::CommandBuffer& cb_state,
+                                             const BufferBarrier& barrier,
+                                             QFOTransferBarrierSets<QFOBufferTransferBarrier>& barrier_sets) {
     if (IsOwnershipTransfer(barrier)) {
         if (cb_state.IsReleaseOp(barrier) && !IsQueueFamilyExternal(barrier.dstQueueFamilyIndex)) {
             barrier_sets.release.emplace(barrier);
@@ -2154,9 +2154,9 @@ void CoreChecks::RecordBarrierValidationInfo(const Location &barrier_loc, vvl::C
     }
 }
 
-void CoreChecks::RecordBarrierValidationInfo(const Location &barrier_loc, vvl::CommandBuffer &cb_state, const ImageBarrier &barrier,
-                                             const vvl::Image &image_state,
-                                             QFOTransferBarrierSets<QFOImageTransferBarrier> &barrier_sets) {
+void CoreChecks::RecordBarrierValidationInfo(const Location& barrier_loc, vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
+                                             const vvl::Image& image_state,
+                                             QFOTransferBarrierSets<QFOImageTransferBarrier>& barrier_sets) {
     if (IsOwnershipTransfer(barrier)) {
         ImageBarrier adjusted_barrier = barrier;
         adjusted_barrier.subresourceRange = image_state.NormalizeSubresourceRange(barrier.subresourceRange);
@@ -2170,23 +2170,23 @@ void CoreChecks::RecordBarrierValidationInfo(const Location &barrier_loc, vvl::C
 }
 
 template <typename TransferBarrier>
-bool CoreChecks::ValidateQueuedQFOTransferBarriers(const core::CommandBufferSubState &cb_sub_state,
-                                                   QFOTransferCBScoreboards<TransferBarrier> *scoreboards,
-                                                   const GlobalQFOTransferBarrierMap<TransferBarrier> &global_release_barriers,
-                                                   const Location &loc) const {
+bool CoreChecks::ValidateQueuedQFOTransferBarriers(const core::CommandBufferSubState& cb_sub_state,
+                                                   QFOTransferCBScoreboards<TransferBarrier>* scoreboards,
+                                                   const GlobalQFOTransferBarrierMap<TransferBarrier>& global_release_barriers,
+                                                   const Location& loc) const {
     bool skip = false;
-    const auto &cb_barriers = cb_sub_state.GetQFOBarrierSets(TransferBarrier());
+    const auto& cb_barriers = cb_sub_state.GetQFOBarrierSets(TransferBarrier());
 
     // Each acquire must have a matching release (ERROR)
-    for (const auto &acquire : cb_barriers.acquire) {
+    for (const auto& acquire : cb_barriers.acquire) {
         const auto set_it = global_release_barriers.find(acquire.handle);
         bool matching_release_found = false;
         if (set_it != global_release_barriers.cend()) {
-            const QFOTransferBarrierSet<TransferBarrier> &set_for_handle = set_it->second;
+            const QFOTransferBarrierSet<TransferBarrier>& set_for_handle = set_it->second;
             matching_release_found = set_for_handle.find(acquire) != set_for_handle.cend();
         }
         if (!matching_release_found) {
-            const char *vuid = (loc.function == vvl::Func::vkQueueSubmit) ? "VUID-vkQueueSubmit-pSubmits-02207"
+            const char* vuid = (loc.function == vvl::Func::vkQueueSubmit) ? "VUID-vkQueueSubmit-pSubmits-02207"
                                                                           : "VUID-vkQueueSubmit2-commandBuffer-03879";
             skip |= LogError(vuid, cb_sub_state.Handle(), loc,
                              "contains a %s that acquires ownership of %s for destination queue family %" PRIu32
@@ -2198,12 +2198,12 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(const core::CommandBufferSubS
     return skip;
 }
 
-bool CoreChecks::ValidateQueuedQFOTransfers(const vvl::CommandBuffer &cb_state,
-                                            QFOTransferCBScoreboards<QFOImageTransferBarrier> *qfo_image_scoreboards,
-                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier> *qfo_buffer_scoreboards,
-                                            const Location &loc) const {
+bool CoreChecks::ValidateQueuedQFOTransfers(const vvl::CommandBuffer& cb_state,
+                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
+                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards,
+                                            const Location& loc) const {
     bool skip = false;
-    auto &cb_sub_state = core::SubState(cb_state);
+    auto& cb_sub_state = core::SubState(cb_state);
     skip |= ValidateQueuedQFOTransferBarriers<QFOImageTransferBarrier>(cb_sub_state, qfo_image_scoreboards,
                                                                        qfo_release_image_barrier_map, loc);
     skip |= ValidateQueuedQFOTransferBarriers<QFOBufferTransferBarrier>(cb_sub_state, qfo_buffer_scoreboards,
@@ -2212,10 +2212,10 @@ bool CoreChecks::ValidateQueuedQFOTransfers(const vvl::CommandBuffer &cb_state,
 }
 
 template <typename TransferBarrier>
-void RecordQueuedQFOTransferBarriers(QFOTransferBarrierSets<TransferBarrier> &cb_barriers,
-                                     GlobalQFOTransferBarrierMap<TransferBarrier> &global_release_barriers) {
+void RecordQueuedQFOTransferBarriers(QFOTransferBarrierSets<TransferBarrier>& cb_barriers,
+                                     GlobalQFOTransferBarrierMap<TransferBarrier>& global_release_barriers) {
     // Add release barriers from this submit to the global map
-    for (const auto &release : cb_barriers.release) {
+    for (const auto& release : cb_barriers.release) {
         // the global barrier list is mapped by resource handle to allow cleanup on resource destruction
         // NOTE: vvl::concurrent_ordered_map::find() makes a thread safe copy of the result, so we must
         // copy back after updating.
@@ -2225,11 +2225,11 @@ void RecordQueuedQFOTransferBarriers(QFOTransferBarrierSets<TransferBarrier> &cb
     }
 
     // Erase acquired barriers from this submit from the global map -- essentially marking releases as consumed
-    for (const auto &acquire : cb_barriers.acquire) {
+    for (const auto& acquire : cb_barriers.acquire) {
         // NOTE: We're not using [] because we don't want to create entries for missing releases
         auto set_it = global_release_barriers.find(acquire.handle);
         if (set_it != global_release_barriers.end()) {
-            QFOTransferBarrierSet<TransferBarrier> &set_for_handle = set_it->second;
+            QFOTransferBarrierSet<TransferBarrier>& set_for_handle = set_it->second;
             set_for_handle.erase(acquire);
             if (set_for_handle.empty()) {  // Clean up empty sets
                 global_release_barriers.erase(acquire.handle);
@@ -2242,23 +2242,23 @@ void RecordQueuedQFOTransferBarriers(QFOTransferBarrierSets<TransferBarrier> &cb
     }
 }
 
-void CoreChecks::RecordQueuedQFOTransfers(vvl::CommandBuffer &cb_state) {
-    auto &cb_sub_state = core::SubState(cb_state);
+void CoreChecks::RecordQueuedQFOTransfers(vvl::CommandBuffer& cb_state) {
+    auto& cb_sub_state = core::SubState(cb_state);
     RecordQueuedQFOTransferBarriers<QFOImageTransferBarrier>(cb_sub_state.qfo_transfer_image_barriers,
                                                              qfo_release_image_barrier_map);
     RecordQueuedQFOTransferBarriers<QFOBufferTransferBarrier>(cb_sub_state.qfo_transfer_buffer_barriers,
                                                               qfo_release_buffer_barrier_map);
 }
 
-bool CoreChecks::ValidateBarrierQueueFamilies(const LogObjectList &objects, const Location &barrier_loc, const Location &field_loc,
-                                              const OwnershipTransferBarrier &barrier, const VulkanTypedHandle &resource_handle,
+bool CoreChecks::ValidateBarrierQueueFamilies(const LogObjectList& objects, const Location& barrier_loc, const Location& field_loc,
+                                              const OwnershipTransferBarrier& barrier, const VulkanTypedHandle& resource_handle,
                                               VkSharingMode sharing_mode, uint32_t command_pool_queue_family) const {
     bool skip = false;
 
     auto log_queue_family_error = [sharing_mode, resource_handle, &barrier_loc, &field_loc, device_data_ = device_state,
-                                   objects_ = objects](vvl::QueueError vu_index, uint32_t family, const char *param_name) -> bool {
-        const std::string &vuid = GetBarrierQueueVUID(field_loc, vu_index);
-        const char *annotation = GetFamilyAnnotation(*device_data_, family);
+                                   objects_ = objects](vvl::QueueError vu_index, uint32_t family, const char* param_name) -> bool {
+        const std::string& vuid = GetBarrierQueueVUID(field_loc, vu_index);
+        const char* annotation = GetFamilyAnnotation(*device_data_, family);
         return device_data_->LogError(vuid, objects_, barrier_loc,
                                       "barrier using %s created with sharingMode %s, has %s %" PRIu32 "%s. %s",
                                       device_data_->FormatHandle(resource_handle).c_str(), string_VkSharingMode(sharing_mode),
@@ -2307,9 +2307,9 @@ bool CoreChecks::ValidateBarrierQueueFamilies(const LogObjectList &objects, cons
         } else if (dst_queue_family != VK_QUEUE_FAMILY_IGNORED && dst_queue_family != VK_QUEUE_FAMILY_EXTERNAL) {
             skip |= log_queue_family_error(vvl::QueueError::kSync1ConcurrentDst, dst_queue_family, "dstQueueFamilyIndex");
         } else if (src_queue_family != VK_QUEUE_FAMILY_IGNORED && dst_queue_family != VK_QUEUE_FAMILY_IGNORED) {
-            const std::string &vuid = GetBarrierQueueVUID(field_loc, vvl::QueueError::kSync1ConcurrentNoIgnored);
-            const char *src_annotation = GetFamilyAnnotation(*device_state, src_queue_family);
-            const char *dst_annotation = GetFamilyAnnotation(*device_state, dst_queue_family);
+            const std::string& vuid = GetBarrierQueueVUID(field_loc, vvl::QueueError::kSync1ConcurrentNoIgnored);
+            const char* src_annotation = GetFamilyAnnotation(*device_state, src_queue_family);
+            const char* dst_annotation = GetFamilyAnnotation(*device_state, dst_queue_family);
             // Log both src and dst queue families
             skip |= LogError(vuid, objects, barrier_loc,
                              "barrier using %s created with sharingMode %s, has srcQueueFamilyIndex %" PRIu32
@@ -2323,8 +2323,8 @@ bool CoreChecks::ValidateBarrierQueueFamilies(const LogObjectList &objects, cons
     if (sharing_mode == VK_SHARING_MODE_EXCLUSIVE && IsOwnershipTransfer(barrier)) {
         if (src_queue_family != command_pool_queue_family && dst_queue_family != command_pool_queue_family) {
             const std::string vuid = GetBarrierQueueVUID(barrier_loc, vvl::QueueError::kSubmitQueueMustMatchSrcOrDst);
-            const char *src_annotation = GetFamilyAnnotation(*device_state, src_queue_family);
-            const char *dst_annotation = GetFamilyAnnotation(*device_state, dst_queue_family);
+            const char* src_annotation = GetFamilyAnnotation(*device_state, src_queue_family);
+            const char* dst_annotation = GetFamilyAnnotation(*device_state, dst_queue_family);
             skip |= LogError(
                 vuid, objects, barrier_loc,
                 "has srcQueueFamilyIndex %" PRIu32 "%s and dstQueueFamilyIndex %" PRIu32
@@ -2338,8 +2338,8 @@ bool CoreChecks::ValidateBarrierQueueFamilies(const LogObjectList &objects, cons
     return skip;
 }
 
-bool CoreChecks::ValidateBufferBarrier(const LogObjectList &objects, const Location &barrier_loc,
-                                       const vvl::CommandBuffer &cb_state, const BufferBarrier &mem_barrier) const {
+bool CoreChecks::ValidateBufferBarrier(const LogObjectList& objects, const Location& barrier_loc,
+                                       const vvl::CommandBuffer& cb_state, const BufferBarrier& mem_barrier) const {
     bool skip = false;
 
     const bool is_memory_range = barrier_loc.structure == vvl::Struct::VkMemoryRangeBarrierKHR;
@@ -2358,13 +2358,13 @@ bool CoreChecks::ValidateBufferBarrier(const LogObjectList &objects, const Locat
         auto buffer_size = buffer_state->create_info.size;
         if (mem_barrier.offset >= buffer_size) {
             auto offset_loc = barrier_loc.dot(Field::offset);
-            const auto &vuid = GetBufferBarrierVUID(offset_loc, vvl::BufferError::kOffsetTooBig);
+            const auto& vuid = GetBufferBarrierVUID(offset_loc, vvl::BufferError::kOffsetTooBig);
             skip |=
                 LogError(vuid, objects, offset_loc, "%s has offset 0x%" PRIx64 " which is not less than total size 0x%" PRIx64 ".",
                          FormatHandle(mem_barrier.buffer).c_str(), HandleToUint64(mem_barrier.offset), HandleToUint64(buffer_size));
         } else if (!is_memory_range && mem_barrier.size != VK_WHOLE_SIZE && (mem_barrier.offset + mem_barrier.size > buffer_size)) {
             auto size_loc = barrier_loc.dot(Field::size);
-            const auto &vuid = GetBufferBarrierVUID(size_loc, vvl::BufferError::kSizeOutOfRange);
+            const auto& vuid = GetBufferBarrierVUID(size_loc, vvl::BufferError::kSizeOutOfRange);
             skip |=
                 LogError(vuid, objects, size_loc,
                          "%s has offset 0x%" PRIx64 " and size 0x%" PRIx64 " whose sum is greater than total size 0x%" PRIx64 ".",
@@ -2373,15 +2373,15 @@ bool CoreChecks::ValidateBufferBarrier(const LogObjectList &objects, const Locat
         }
         if (mem_barrier.size == 0) {
             auto size_loc = barrier_loc.dot(Field::size);
-            const auto &vuid = GetBufferBarrierVUID(size_loc, vvl::BufferError::kSizeZero);
+            const auto& vuid = GetBufferBarrierVUID(size_loc, vvl::BufferError::kSizeZero);
             skip |= LogError(vuid, objects, barrier_loc, "%s has a size of 0.", FormatHandle(mem_barrier.buffer).c_str());
         }
     }
     return skip;
 }
 
-bool CoreChecks::ValidateImageBarrier(const LogObjectList &objlist, const vvl::CommandBuffer &cb_state, const ImageBarrier &barrier,
-                                      const Location &barrier_loc, ImageLayoutRegistry &local_layout_registry) const {
+bool CoreChecks::ValidateImageBarrier(const LogObjectList& objlist, const vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
+                                      const Location& barrier_loc, ImageLayoutRegistry& local_layout_registry) const {
     bool skip = false;
 
     const VkImageLayout old_layout = barrier.oldLayout;
@@ -2392,12 +2392,12 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objlist, const vvl::C
         is_image_layout_transition = old_layout != new_layout;
     } else {
         if (IsValueIn(old_layout, {VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL})) {
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadSync2OldLayout);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadSync2OldLayout);
             skip |= LogError(vuid, objlist, barrier_loc.dot(Field::oldLayout),
                              "is %s, but the synchronization2 feature was not enabled.", string_VkImageLayout(old_layout));
         }
         if (IsValueIn(new_layout, {VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL})) {
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadSync2NewLayout);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadSync2NewLayout);
             skip |= LogError(vuid, objlist, barrier_loc.dot(Field::newLayout),
                              "is %s, but the synchronization2 feature was not enabled.", string_VkImageLayout(new_layout));
         }
@@ -2406,20 +2406,20 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objlist, const vvl::C
     if (is_image_layout_transition) {
         if (IsValueIn(new_layout,
                       {VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PREINITIALIZED, VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT})) {
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadLayout);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadLayout);
             skip |= LogError(vuid, objlist, barrier_loc.dot(Field::newLayout), "is %s.", string_VkImageLayout(new_layout));
         }
     }
 
     if (old_layout == VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT && !enabled_features.zeroInitializeDeviceMemory) {
-        const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadZeroInitializeOldLayout);
+        const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadZeroInitializeOldLayout);
         skip |= LogError(vuid, objlist, barrier_loc.dot(Field::oldLayout),
                          "is %s, but the zeroInitializeDeviceMemory feature was not enabled.", string_VkImageLayout(old_layout));
     }
 
     if (new_layout == VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT) {
         if (!enabled_features.attachmentFeedbackLoopLayout) {
-            const auto &vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadAttFeedbackLoopLayout);
+            const auto& vuid = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kBadAttFeedbackLoopLayout);
             skip |= LogError(vuid, objlist, barrier_loc.dot(Field::newLayout),
                              "is VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT, but the attachmentFeedbackLoopLayout "
                              "feature was not enabled.");
@@ -2427,7 +2427,7 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objlist, const vvl::C
     }
 
     if (auto image_state = Get<vvl::Image>(barrier.image)) {
-        const auto &vuid_no_memory = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kNoMemory);
+        const auto& vuid_no_memory = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kNoMemory);
         skip |=
             ValidateMemoryIsBoundToImage(cb_state.Handle(), *image_state, barrier_loc.dot(Field::image), vuid_no_memory.c_str());
         skip |= ValidateImageBarrierAgainstImage(cb_state, barrier, barrier_loc, *image_state, local_layout_registry);
@@ -2441,11 +2441,11 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objlist, const vvl::C
     return skip;
 }
 
-bool CoreChecks::ValidateBarriers(const Location &outer_loc, const vvl::CommandBuffer &cb_state,
+bool CoreChecks::ValidateBarriers(const Location& outer_loc, const vvl::CommandBuffer& cb_state,
                                   VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
-                                  uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferBarrierCount,
-                                  const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-                                  const VkImageMemoryBarrier *pImageMemoryBarriers) const {
+                                  uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers, uint32_t bufferBarrierCount,
+                                  const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+                                  const VkImageMemoryBarrier* pImageMemoryBarriers) const {
     bool skip = false;
     LogObjectList objects(cb_state.Handle());
 
@@ -2475,8 +2475,8 @@ bool CoreChecks::ValidateBarriers(const Location &outer_loc, const vvl::CommandB
     return skip;
 }
 
-bool CoreChecks::ValidateDependencyInfo(const LogObjectList &objects, const Location &dep_info_loc,
-                                        const vvl::CommandBuffer &cb_state, const VkDependencyInfo &dep_info) const {
+bool CoreChecks::ValidateDependencyInfo(const LogObjectList& objects, const Location& dep_info_loc,
+                                        const vvl::CommandBuffer& cb_state, const VkDependencyInfo& dep_info) const {
     bool skip = false;
 
     // Tracks duplicate layout transition for image barriers.
@@ -2536,11 +2536,11 @@ bool CoreChecks::ValidateDependencyInfo(const LogObjectList &objects, const Loca
     return skip;
 }
 
-bool CoreChecks::ValidateDynamicRenderingPipelineStage(const LogObjectList &objlist, const Location &loc,
+bool CoreChecks::ValidateDynamicRenderingPipelineStage(const LogObjectList& objlist, const Location& loc,
                                                        VkPipelineStageFlags2 stage_mask, VkDependencyFlags dependency_flags) const {
     bool skip = false;
     if (HasNonFramebufferStagePipelineStageFlags(stage_mask)) {
-        const auto &vuid = GetDynamicRenderingBarrierVUID(loc, vvl::DynamicRenderingBarrierError::kFramebufferSpace);
+        const auto& vuid = GetDynamicRenderingBarrierVUID(loc, vvl::DynamicRenderingBarrierError::kFramebufferSpace);
 
         skip |= LogError(vuid, objlist, loc, "(%s) is restricted to framebuffer space stages (%s).",
                          sync_utils::StringPipelineStageFlags(stage_mask).c_str(),
@@ -2548,19 +2548,19 @@ bool CoreChecks::ValidateDynamicRenderingPipelineStage(const LogObjectList &objl
     }
     if (HasFramebufferStagePipelineStageFlags(stage_mask) && loc.field == Field::srcStageMask &&
         (dependency_flags & VK_DEPENDENCY_BY_REGION_BIT) != VK_DEPENDENCY_BY_REGION_BIT) {
-        const auto &vuid = GetDynamicRenderingBarrierVUID(loc, vvl::DynamicRenderingBarrierError::kDependencyFlags);
+        const auto& vuid = GetDynamicRenderingBarrierVUID(loc, vvl::DynamicRenderingBarrierError::kDependencyFlags);
         skip |= LogError(vuid, objlist, loc.prev->dot(Field::dependencyFlags), "must contain VK_DEPENDENCY_BY_REGION_BIT.");
     }
     return skip;
 }
 
-bool CoreChecks::ValidateDynamicRenderingImageBarrierLayoutMismatch(const vvl::CommandBuffer &cb_state,
-                                                                    const VkImageMemoryBarrier &image_barrier,
-                                                                    const Location &image_loc) const {
+bool CoreChecks::ValidateDynamicRenderingImageBarrierLayoutMismatch(const vvl::CommandBuffer& cb_state,
+                                                                    const VkImageMemoryBarrier& image_barrier,
+                                                                    const Location& image_loc) const {
     bool skip = false;
-    const VkRenderingInfo &rendering_info = *cb_state.active_render_pass->dynamic_rendering_begin_rendering_info.ptr();
+    const VkRenderingInfo& rendering_info = *cb_state.active_render_pass->dynamic_rendering_begin_rendering_info.ptr();
     for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; i++) {
-        const AttachmentInfo &attachment = cb_state.active_attachments[cb_state.GetDynamicRenderingColorAttachmentIndex(i)];
+        const AttachmentInfo& attachment = cb_state.active_attachments[cb_state.GetDynamicRenderingColorAttachmentIndex(i)];
         if (attachment.image_view && attachment.image_view->image_state->VkHandle() == image_barrier.image) {
             if (rendering_info.pColorAttachments[i].imageLayout != image_barrier.oldLayout) {
                 const LogObjectList objlist(cb_state.Handle(), attachment.image_view->image_state->Handle());
@@ -2574,7 +2574,7 @@ bool CoreChecks::ValidateDynamicRenderingImageBarrierLayoutMismatch(const vvl::C
         }
     }
     if (rendering_info.pDepthAttachment) {
-        const AttachmentInfo &attachment =
+        const AttachmentInfo& attachment =
             cb_state.active_attachments[cb_state.GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Depth)];
         if (attachment.image_view && attachment.image_view->image_state->VkHandle() == image_barrier.image) {
             if (rendering_info.pDepthAttachment->imageLayout != image_barrier.oldLayout) {
@@ -2589,7 +2589,7 @@ bool CoreChecks::ValidateDynamicRenderingImageBarrierLayoutMismatch(const vvl::C
         }
     }
     if (rendering_info.pStencilAttachment) {
-        const AttachmentInfo &attachment =
+        const AttachmentInfo& attachment =
             cb_state.active_attachments[cb_state.GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Stencil)];
         if (attachment.image_view && attachment.image_view->image_state->VkHandle() == image_barrier.image) {
             if (rendering_info.pStencilAttachment->imageLayout != image_barrier.oldLayout) {
@@ -2616,15 +2616,15 @@ bool CoreChecks::IsDynamicRenderingImageUsageValid(VkImageUsageFlags image_usage
     return valid;
 }
 
-bool CoreChecks::ValidateDynamicRenderingBarriers(const LogObjectList &objlist, const Location &outer_loc,
-                                                  const VkDependencyInfo &dep_info) const {
+bool CoreChecks::ValidateDynamicRenderingBarriers(const LogObjectList& objlist, const Location& outer_loc,
+                                                  const VkDependencyInfo& dep_info) const {
     bool skip = false;
     skip |= ValidateDynamicRenderingBarriersCommon(objlist, outer_loc, dep_info.dependencyFlags, dep_info.bufferMemoryBarrierCount,
                                                    dep_info.imageMemoryBarrierCount);
 
     for (uint32_t i = 0; i < dep_info.memoryBarrierCount; ++i) {
         const Location loc = outer_loc.dot(Struct::VkMemoryBarrier2, Field::pMemoryBarriers, i);
-        const auto &mem_barrier = dep_info.pMemoryBarriers[i];
+        const auto& mem_barrier = dep_info.pMemoryBarriers[i];
         skip |= ValidateDynamicRenderingPipelineStage(objlist, loc.dot(Field::srcStageMask), mem_barrier.srcStageMask,
                                                       dep_info.dependencyFlags);
         skip |= ValidateDynamicRenderingPipelineStage(objlist, loc.dot(Field::dstStageMask), mem_barrier.dstStageMask,
@@ -2640,11 +2640,11 @@ bool CoreChecks::ValidateDynamicRenderingBarriers(const LogObjectList &objlist, 
     return skip;
 }
 
-bool CoreChecks::ValidateDynamicRenderingBarriers(const LogObjectList &objlist, const Location &outer_loc,
-                                                  const vvl::CommandBuffer &cb_state, VkDependencyFlags dependency_flags,
-                                                  uint32_t memory_barrier_count, const VkMemoryBarrier *memory_barriers,
+bool CoreChecks::ValidateDynamicRenderingBarriers(const LogObjectList& objlist, const Location& outer_loc,
+                                                  const vvl::CommandBuffer& cb_state, VkDependencyFlags dependency_flags,
+                                                  uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers,
                                                   uint32_t buffer_barrier_count, uint32_t image_barrier_count,
-                                                  const VkImageMemoryBarrier *image_barriers, VkPipelineStageFlags src_stage_mask,
+                                                  const VkImageMemoryBarrier* image_barriers, VkPipelineStageFlags src_stage_mask,
                                                   VkPipelineStageFlags dst_stage_mask) const {
     bool skip = false;
     skip |= ValidateDynamicRenderingBarriersCommon(objlist, outer_loc, dependency_flags, buffer_barrier_count, image_barrier_count);
@@ -2665,7 +2665,7 @@ bool CoreChecks::ValidateDynamicRenderingBarriers(const LogObjectList &objlist, 
     return skip;
 }
 
-bool CoreChecks::ValidateDynamicRenderingBarriersCommon(const LogObjectList &objlist, const Location &outer_loc,
+bool CoreChecks::ValidateDynamicRenderingBarriersCommon(const LogObjectList& objlist, const Location& outer_loc,
                                                         VkDependencyFlags dependency_flags, uint32_t buffer_barrier_count,
                                                         uint32_t image_barrier_count) const {
     bool skip = false;
@@ -2674,7 +2674,7 @@ bool CoreChecks::ValidateDynamicRenderingBarriersCommon(const LogObjectList &obj
     const bool features_enabled = enabled_features.shaderTileImageColorReadAccess ||
                                   enabled_features.shaderTileImageDepthReadAccess || enabled_features.dynamicRenderingLocalRead;
     if (!features_enabled) {
-        const auto &feature_error_vuid =
+        const auto& feature_error_vuid =
             GetDynamicRenderingBarrierVUID(outer_loc, vvl::DynamicRenderingBarrierError::kFeatureError);
         skip |= LogError(feature_error_vuid, objlist, outer_loc,
                          "can not be called inside a dynamic rendering instance. This can be fixed by enabling the "
@@ -2683,7 +2683,7 @@ bool CoreChecks::ValidateDynamicRenderingBarriersCommon(const LogObjectList &obj
 
     if (!enabled_features.dynamicRenderingLocalRead) {
         if (buffer_barrier_count != 0 || image_barrier_count != 0) {
-            const auto &buf_img_vuid =
+            const auto& buf_img_vuid =
                 GetDynamicRenderingBarrierVUID(outer_loc, vvl::DynamicRenderingBarrierError::kNoBuffersOrImages);
             skip |= LogError(buf_img_vuid, objlist, outer_loc,
                              "can only include memory barriers, while application specify image barrier count %" PRIu32
@@ -2695,8 +2695,8 @@ bool CoreChecks::ValidateDynamicRenderingBarriersCommon(const LogObjectList &obj
     return skip;
 }
 
-bool CoreChecks::ValidateMemoryBarrier(const LogObjectList &objects, const Location &barrier_loc,
-                                       const vvl::CommandBuffer &cb_state, const SyncMemoryBarrier &barrier,
+bool CoreChecks::ValidateMemoryBarrier(const LogObjectList& objects, const Location& barrier_loc,
+                                       const vvl::CommandBuffer& cb_state, const SyncMemoryBarrier& barrier,
                                        OwnershipTransferOp ownership_transfer_op, VkDependencyFlags dependency_flags) const {
     bool skip = false;
     const VkQueueFlags queue_flags = cb_state.GetQueueFlags();
@@ -2746,8 +2746,8 @@ bool CoreChecks::ValidateMemoryBarrier(const LogObjectList &objects, const Locat
     return skip;
 }
 
-bool CoreChecks::ValidateTensorQueueFamilyIndex(uint32_t src_q, uint32_t dst_q, const LogObjectList &objlist,
-                                                const vvl::Tensor &tensor_state, const Location &loc) const {
+bool CoreChecks::ValidateTensorQueueFamilyIndex(uint32_t src_q, uint32_t dst_q, const LogObjectList& objlist,
+                                                const vvl::Tensor& tensor_state, const Location& loc) const {
     bool skip = false;
     if (VK_SHARING_MODE_EXCLUSIVE == tensor_state.create_info.sharingMode) {
         if (VK_QUEUE_FAMILY_IGNORED != src_q) {
@@ -2769,12 +2769,12 @@ bool CoreChecks::ValidateTensorQueueFamilyIndex(uint32_t src_q, uint32_t dst_q, 
     return skip;
 }
 
-bool CoreChecks::ValidateTensorBarrier(const LogObjectList &objlist, const Location &barrier_loc,
-                                       const vvl::CommandBuffer &cb_state, const TensorBarrier &barrier) const {
+bool CoreChecks::ValidateTensorBarrier(const LogObjectList& objlist, const Location& barrier_loc,
+                                       const vvl::CommandBuffer& cb_state, const TensorBarrier& barrier) const {
     bool skip = false;
     auto tensor_state_ptr = Get<vvl::Tensor>(barrier.tensor);
     ASSERT_AND_RETURN_SKIP(tensor_state_ptr);
-    const auto &tensor_state = *tensor_state_ptr;
+    const auto& tensor_state = *tensor_state_ptr;
     skip |= ValidateMemoryIsBoundToTensor(objlist, tensor_state, barrier_loc, "VUID-VkTensorMemoryBarrierARM-tensor-09758");
     skip |= ValidateTensorQueueFamilyIndex(barrier.srcQueueFamilyIndex, barrier.dstQueueFamilyIndex, objlist, tensor_state,
                                            barrier_loc);

--- a/layers/core_checks/cc_tensor.cpp
+++ b/layers/core_checks/cc_tensor.cpp
@@ -23,8 +23,8 @@
 #include "state_tracker/tensor_state.h"
 #include "state_tracker/cmd_buffer_state.h"
 
-bool CoreChecks::ValidateTensorFormatUsage(VkFormat format, VkTensorUsageFlagsARM usage, VkTensorTilingARM tiling, const char *vuid,
-                                           const Location &loc) const {
+bool CoreChecks::ValidateTensorFormatUsage(VkFormat format, VkTensorUsageFlagsARM usage, VkTensorTilingARM tiling, const char* vuid,
+                                           const Location& loc) const {
     bool skip = false;
     VkTensorFormatPropertiesARM tensor_fmt_props = vku::InitStructHelper();
     VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&tensor_fmt_props);
@@ -37,29 +37,31 @@ bool CoreChecks::ValidateTensorFormatUsage(VkFormat format, VkTensorUsageFlagsAR
     }
 
     const std::vector<std::pair<VkTensorUsageFlagBitsARM, VkFormatFeatureFlagBits2>> usage_to_feature_map = {
-        { VK_TENSOR_USAGE_TRANSFER_SRC_BIT_ARM, VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT },
-        { VK_TENSOR_USAGE_TRANSFER_DST_BIT_ARM, VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT },
-        { VK_TENSOR_USAGE_IMAGE_ALIASING_BIT_ARM, VK_FORMAT_FEATURE_2_TENSOR_IMAGE_ALIASING_BIT_ARM },
-        { VK_TENSOR_USAGE_SHADER_BIT_ARM, VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM },
-        { VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM, VK_FORMAT_FEATURE_2_TENSOR_DATA_GRAPH_BIT_ARM },
+        {VK_TENSOR_USAGE_TRANSFER_SRC_BIT_ARM, VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT},
+        {VK_TENSOR_USAGE_TRANSFER_DST_BIT_ARM, VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT},
+        {VK_TENSOR_USAGE_IMAGE_ALIASING_BIT_ARM, VK_FORMAT_FEATURE_2_TENSOR_IMAGE_ALIASING_BIT_ARM},
+        {VK_TENSOR_USAGE_SHADER_BIT_ARM, VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM},
+        {VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM, VK_FORMAT_FEATURE_2_TENSOR_DATA_GRAPH_BIT_ARM},
     };
 
     for (auto element : usage_to_feature_map) {
         auto usage_bit = element.first;
         auto feature_bit = element.second;
         if (usage & usage_bit && !(tensor_feature_flags & feature_bit)) {
-            skip |= LogError(vuid, device, loc.dot(Field::usage), "(%s) has bit (%s) set but format features (%s) does not include matching required bit (%s)",
+            skip |= LogError(vuid, device, loc.dot(Field::usage),
+                             "(%s) has bit (%s) set but format features (%s) does not include matching required bit (%s)",
                              string_VkTensorUsageFlagsARM(usage).c_str(), string_VkTensorUsageFlagsARM(usage_bit).c_str(),
-                             string_VkTensorUsageFlagsARM(tensor_feature_flags).c_str(), string_VkTensorUsageFlagsARM(feature_bit).c_str());
+                             string_VkTensorUsageFlagsARM(tensor_feature_flags).c_str(),
+                             string_VkTensorUsageFlagsARM(feature_bit).c_str());
         }
     }
 
     return skip;
 }
 
-bool CoreChecks::ValidateTensorCreateInfo(const VkTensorCreateInfoARM &create_info, const Location &create_info_loc) const {
+bool CoreChecks::ValidateTensorCreateInfo(const VkTensorCreateInfoARM& create_info, const Location& create_info_loc) const {
     bool skip = false;
-    const VkTensorDescriptionARM &description = *create_info.pDescription;
+    const VkTensorDescriptionARM& description = *create_info.pDescription;
     if (create_info.sharingMode == VK_SHARING_MODE_CONCURRENT && create_info.pQueueFamilyIndices) {
         skip |= ValidatePhysicalDeviceQueueFamilies(create_info.queueFamilyIndexCount, create_info.pQueueFamilyIndices,
                                                     create_info_loc, "VUID-VkTensorCreateInfoARM-sharingMode-09725");
@@ -101,22 +103,22 @@ bool CoreChecks::ValidateTensorCreateInfo(const VkTensorCreateInfoARM &create_in
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateTensorARM(VkDevice device, const VkTensorCreateInfoARM *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkTensorARM *pTensor,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateTensorARM(VkDevice device, const VkTensorCreateInfoARM* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkTensorARM* pTensor,
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     skip |= ValidateTensorCreateInfo(*pCreateInfo, create_info_loc);
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateTensorViewARM(VkDevice device, const VkTensorViewCreateInfoARM *pCreateInfo,
-                                                    const VkAllocationCallbacks *pAllocator, VkTensorViewARM *pView,
-                                                    const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateTensorViewARM(VkDevice device, const VkTensorViewCreateInfoARM* pCreateInfo,
+                                                    const VkAllocationCallbacks* pAllocator, VkTensorViewARM* pView,
+                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     auto tensor_state_ptr = Get<vvl::Tensor>(pCreateInfo->tensor);
     ASSERT_AND_RETURN_SKIP(tensor_state_ptr);
-    const auto &tensor_state = *tensor_state_ptr;
+    const auto& tensor_state = *tensor_state_ptr;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
 
     auto valid_usage_flags = VK_TENSOR_USAGE_SHADER_BIT_ARM | VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM;
@@ -164,8 +166,8 @@ bool CoreChecks::PreCallValidateCreateTensorViewARM(VkDevice device, const VkTen
     return skip;
 }
 
-bool CoreChecks::ValidateTensorUsageFlags(VkCommandBuffer commandBuffer, vvl::Tensor const &tensor_state,
-                                          VkTensorUsageFlagsARM desired, const char *vuid, const Location &tensor_loc) const {
+bool CoreChecks::ValidateTensorUsageFlags(VkCommandBuffer commandBuffer, vvl::Tensor const& tensor_state,
+                                          VkTensorUsageFlagsARM desired, const char* vuid, const Location& tensor_loc) const {
     bool skip = false;
     LogObjectList objlist(commandBuffer, tensor_state.Handle());
     if ((tensor_state.create_info.pDescription->usage & desired) == 0) {
@@ -176,16 +178,16 @@ bool CoreChecks::ValidateTensorUsageFlags(VkCommandBuffer commandBuffer, vvl::Te
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdCopyTensorARM(VkCommandBuffer commandBuffer, const VkCopyTensorInfoARM *pCopyTensorInfo,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdCopyTensorARM(VkCommandBuffer commandBuffer, const VkCopyTensorInfoARM* pCopyTensorInfo,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_tensor_state_ptr = Get<vvl::Tensor>(pCopyTensorInfo->srcTensor);
     auto dst_tensor_state_ptr = Get<vvl::Tensor>(pCopyTensorInfo->dstTensor);
     ASSERT_AND_RETURN_SKIP(src_tensor_state_ptr && dst_tensor_state_ptr);
-    const auto &src_tensor_state = *src_tensor_state_ptr;
-    const auto &dst_tensor_state = *dst_tensor_state_ptr;
-    const auto &cb_state = *cb_state_ptr;
+    const auto& src_tensor_state = *src_tensor_state_ptr;
+    const auto& dst_tensor_state = *dst_tensor_state_ptr;
+    const auto& cb_state = *cb_state_ptr;
 
     const Location copy_info_loc = error_obj.location.dot(Field::pCopyTensorInfo);
     LogObjectList src_objlist(commandBuffer, src_tensor_state.Handle());
@@ -201,7 +203,7 @@ bool CoreChecks::PreCallValidateCmdCopyTensorARM(VkCommandBuffer commandBuffer, 
 
     // currently there can only be 1 region (VUID 09686 above), but this way the code is future-proof
     for (uint32_t j = 0; j < pCopyTensorInfo->regionCount; j++) {
-        const auto &region = pCopyTensorInfo->pRegions[j];
+        const auto& region = pCopyTensorInfo->pRegions[j];
 
         if (src_tensor_state.description.dimensionCount != dst_tensor_state.description.dimensionCount) {
             skip |= LogError("VUID-VkCopyTensorInfoARM-dimensionCount-09684", tensors_objlist, copy_info_loc,
@@ -286,8 +288,8 @@ bool CoreChecks::PreCallValidateCmdCopyTensorARM(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
-bool CoreChecks::PreCallValidateDestroyTensorARM(VkDevice device, VkTensorARM tensor, const VkAllocationCallbacks *pAllocator,
-                                                 const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateDestroyTensorARM(VkDevice device, VkTensorARM tensor, const VkAllocationCallbacks* pAllocator,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     auto tensor_state = Get<vvl::Tensor>(tensor);
     ASSERT_AND_RETURN_SKIP(tensor_state);
@@ -296,7 +298,7 @@ bool CoreChecks::PreCallValidateDestroyTensorARM(VkDevice device, VkTensorARM te
 }
 
 bool CoreChecks::PreCallValidateDestroyTensorViewARM(VkDevice device, VkTensorViewARM tensorView,
-                                                     const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
+                                                     const VkAllocationCallbacks* pAllocator, const ErrorObject& error_obj) const {
     bool skip = false;
     auto tensor_view_state = Get<vvl::TensorView>(tensorView);
     ASSERT_AND_RETURN_SKIP(tensor_view_state);
@@ -305,8 +307,8 @@ bool CoreChecks::PreCallValidateDestroyTensorViewARM(VkDevice device, VkTensorVi
 }
 
 bool CoreChecks::PreCallValidateGetTensorOpaqueCaptureDescriptorDataARM(VkDevice device,
-                                                                        const VkTensorCaptureDescriptorDataInfoARM *pInfo,
-                                                                        void *pData, const ErrorObject &error_obj) const {
+                                                                        const VkTensorCaptureDescriptorDataInfoARM* pInfo,
+                                                                        void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
     if (!enabled_features.descriptorBufferCaptureReplay) {
         skip |= LogError("VUID-vkGetTensorOpaqueCaptureDescriptorDataARM-descriptorBufferCaptureReplay-09702", pInfo->tensor,
@@ -319,8 +321,8 @@ bool CoreChecks::PreCallValidateGetTensorOpaqueCaptureDescriptorDataARM(VkDevice
         ASSERT_AND_RETURN_SKIP(tensor_state);
         if (!(tensor_state->create_info.flags & VK_TENSOR_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_ARM)) {
             skip |= LogError("VUID-VkTensorCaptureDescriptorDataInfoARM-tensor-09705", pInfo->tensor,
-                                error_obj.location.dot(Field::pInfo).dot(Field::tensor), "was created with %s.",
-                                string_VkTensorCreateFlagsARM(tensor_state->create_info.flags).c_str());
+                             error_obj.location.dot(Field::pInfo).dot(Field::tensor), "was created with %s.",
+                             string_VkTensorCreateFlagsARM(tensor_state->create_info.flags).c_str());
         }
     }
     if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
@@ -335,8 +337,8 @@ bool CoreChecks::PreCallValidateGetTensorOpaqueCaptureDescriptorDataARM(VkDevice
 }
 
 bool CoreChecks::PreCallValidateGetTensorViewOpaqueCaptureDescriptorDataARM(VkDevice device,
-                                                                            const VkTensorViewCaptureDescriptorDataInfoARM *pInfo,
-                                                                            void *pData, const ErrorObject &error_obj) const {
+                                                                            const VkTensorViewCaptureDescriptorDataInfoARM* pInfo,
+                                                                            void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
     if (!enabled_features.descriptorBufferCaptureReplay) {
         skip |= LogError("VUID-vkGetTensorViewOpaqueCaptureDescriptorDataARM-descriptorBufferCaptureReplay-09706",
@@ -349,8 +351,8 @@ bool CoreChecks::PreCallValidateGetTensorViewOpaqueCaptureDescriptorDataARM(VkDe
         ASSERT_AND_RETURN_SKIP(tensor_view_state);
         if (!(tensor_view_state->create_info.flags & VK_TENSOR_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_ARM)) {
             skip |= LogError("VUID-VkTensorViewCaptureDescriptorDataInfoARM-tensorView-09709", pInfo->tensorView,
-                                error_obj.location.dot(Field::pInfo).dot(Field::tensor), "was created with %s.",
-                                string_VkTensorViewCreateFlagsARM(tensor_view_state->create_info.flags).c_str());
+                             error_obj.location.dot(Field::pInfo).dot(Field::tensor), "was created with %s.",
+                             string_VkTensorViewCreateFlagsARM(tensor_view_state->create_info.flags).c_str());
         }
     }
     if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
@@ -365,8 +367,8 @@ bool CoreChecks::PreCallValidateGetTensorViewOpaqueCaptureDescriptorDataARM(VkDe
 }
 
 // Validates the buffer is allowed to be protected
-bool CoreChecks::ValidateProtectedTensor(const vvl::CommandBuffer &cb_state, const vvl::Tensor &tensor_state,
-                                         const Location &tensor_loc, const char *vuid, const char *more_message) const {
+bool CoreChecks::ValidateProtectedTensor(const vvl::CommandBuffer& cb_state, const vvl::Tensor& tensor_state,
+                                         const Location& tensor_loc, const char* vuid, const char* more_message) const {
     // don't use on an unprotected tensor
     assert(tensor_state.unprotected == false);
 
@@ -382,8 +384,8 @@ bool CoreChecks::ValidateProtectedTensor(const vvl::CommandBuffer &cb_state, con
 }
 
 // Validates the buffer is allowed to be unprotected
-bool CoreChecks::ValidateUnprotectedTensor(const vvl::CommandBuffer &cb_state, const vvl::Tensor &tensor_state,
-                                           const Location &tensor_loc, const char *vuid, const char *more_message) const {
+bool CoreChecks::ValidateUnprotectedTensor(const vvl::CommandBuffer& cb_state, const vvl::Tensor& tensor_state,
+                                           const Location& tensor_loc, const char* vuid, const char* more_message) const {
     // don't use on a protected tensor
     assert(tensor_state.unprotected == true);
 
@@ -399,9 +401,9 @@ bool CoreChecks::ValidateUnprotectedTensor(const vvl::CommandBuffer &cb_state, c
 }
 
 bool CoreChecks::PreCallValidateGetDeviceTensorMemoryRequirementsARM(VkDevice device,
-                                                                     const VkDeviceTensorMemoryRequirementsARM *pInfo,
-                                                                     VkMemoryRequirements2 *pMemoryRequirements,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     const VkDeviceTensorMemoryRequirementsARM* pInfo,
+                                                                     VkMemoryRequirements2* pMemoryRequirements,
+                                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     const Location loc = error_obj.location.dot(Field::tensors);
     if (!enabled_features.tensors) {

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -32,7 +32,7 @@
 
 // Flags validation error if the associated call is made inside a video coding block.
 // The apiName routine should ONLY be called outside a video coding block.
-bool CoreChecks::InsideVideoCodingScope(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
+bool CoreChecks::InsideVideoCodingScope(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
     bool inside = false;
     if (cb_state.bound_video_session) {
         inside = LogError(vuid, cb_state.Handle(), loc, "It is invalid to issue this call inside a video coding block.");
@@ -42,7 +42,7 @@ bool CoreChecks::InsideVideoCodingScope(const vvl::CommandBuffer &cb_state, cons
 
 // Flags validation error if the associated call is made outside a video coding block.
 // The apiName routine should ONLY be called inside a video coding block.
-bool CoreChecks::OutsideVideoCodingScope(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
+bool CoreChecks::OutsideVideoCodingScope(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
     bool outside = false;
     if (!cb_state.bound_video_session) {
         outside = LogError(vuid, cb_state.Handle(), loc, "This call must be issued inside a video coding block.");
@@ -51,7 +51,7 @@ bool CoreChecks::OutsideVideoCodingScope(const vvl::CommandBuffer &cb_state, con
 }
 
 std::vector<VkVideoFormatPropertiesKHR> CoreChecks::GetVideoFormatProperties(VkImageUsageFlags image_usage,
-                                                                             const VkVideoProfileListInfoKHR *profile_list) const {
+                                                                             const VkVideoProfileListInfoKHR* profile_list) const {
     // NOTE: We have to mask out any usage that is not video related
     const VkImageUsageFlags video_usage_mask = VK_IMAGE_USAGE_VIDEO_DECODE_SRC_BIT_KHR | VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR |
                                                VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR |
@@ -72,7 +72,7 @@ std::vector<VkVideoFormatPropertiesKHR> CoreChecks::GetVideoFormatProperties(VkI
 }
 
 std::vector<VkVideoFormatPropertiesKHR> CoreChecks::GetVideoFormatProperties(VkImageUsageFlags image_usage,
-                                                                             const VkVideoProfileInfoKHR *profile) const {
+                                                                             const VkVideoProfileInfoKHR* profile) const {
     VkVideoProfileListInfoKHR profile_list = vku::InitStructHelper();
     profile_list.profileCount = 1;
     profile_list.pProfiles = profile;
@@ -80,10 +80,10 @@ std::vector<VkVideoFormatPropertiesKHR> CoreChecks::GetVideoFormatProperties(VkI
     return GetVideoFormatProperties(image_usage, &profile_list);
 }
 
-bool CoreChecks::IsSupportedVideoFormat(const VkImageCreateInfo &image_ci, const VkVideoProfileListInfoKHR *profile_list) const {
+bool CoreChecks::IsSupportedVideoFormat(const VkImageCreateInfo& image_ci, const VkVideoProfileListInfoKHR* profile_list) const {
     auto format_props_list = GetVideoFormatProperties(image_ci.usage, profile_list);
 
-    for (auto &format_props : format_props_list) {
+    for (auto& format_props : format_props_list) {
         const VkImageCreateFlags allowed_flags = format_props.imageCreateFlags | VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR;
         const bool compatible_usage = (image_ci.flags & VK_IMAGE_CREATE_EXTENDED_USAGE_BIT) ||
                                       ((image_ci.usage & format_props.imageUsageFlags) == image_ci.usage);
@@ -96,7 +96,7 @@ bool CoreChecks::IsSupportedVideoFormat(const VkImageCreateInfo &image_ci, const
     return false;
 }
 
-bool CoreChecks::IsSupportedVideoFormat(const VkImageCreateInfo &image_ci, const VkVideoProfileInfoKHR *profile) const {
+bool CoreChecks::IsSupportedVideoFormat(const VkImageCreateInfo& image_ci, const VkVideoProfileInfoKHR* profile) const {
     VkVideoProfileListInfoKHR profile_list = vku::InitStructHelper();
     profile_list.profileCount = 1;
     profile_list.pProfiles = profile;
@@ -105,20 +105,20 @@ bool CoreChecks::IsSupportedVideoFormat(const VkImageCreateInfo &image_ci, const
 }
 
 bool CoreChecks::IsVideoFormatSupported(VkFormat format, VkImageUsageFlags image_usage,
-                                        const VkVideoProfileInfoKHR *profile) const {
+                                        const VkVideoProfileInfoKHR* profile) const {
     auto format_props_list = GetVideoFormatProperties(image_usage, profile);
-    for (const auto &format_props : format_props_list) {
+    for (const auto& format_props : format_props_list) {
         if (format_props.format == format) return true;
     }
     return false;
 }
 
-bool CoreChecks::IsBufferCompatibleWithVideoSession(const vvl::Buffer &buffer_state, const vvl::VideoSession &vs_state) const {
+bool CoreChecks::IsBufferCompatibleWithVideoSession(const vvl::Buffer& buffer_state, const vvl::VideoSession& vs_state) const {
     return (buffer_state.create_info.flags & VK_BUFFER_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) ||
            buffer_state.supported_video_profiles.find(vs_state.profile) != buffer_state.supported_video_profiles.end();
 }
 
-bool CoreChecks::IsImageCompatibleWithVideoSession(const vvl::Image &image_state, const vvl::VideoSession &vs_state) const {
+bool CoreChecks::IsImageCompatibleWithVideoSession(const vvl::Image& image_state, const vvl::VideoSession& vs_state) const {
     if (image_state.create_info.flags & VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) {
         return IsSupportedVideoFormat(image_state.create_info, vs_state.create_info.pVideoProfile);
     } else {
@@ -126,8 +126,8 @@ bool CoreChecks::IsImageCompatibleWithVideoSession(const vvl::Image &image_state
     }
 }
 
-bool CoreChecks::ValidateVideoInlineQueryInfo(const vvl::QueryPool &query_pool_state, const VkVideoInlineQueryInfoKHR &query_info,
-                                              const Location &loc) const {
+bool CoreChecks::ValidateVideoInlineQueryInfo(const vvl::QueryPool& query_pool_state, const VkVideoInlineQueryInfoKHR& query_info,
+                                              const Location& loc) const {
     bool skip = false;
 
     if (query_info.firstQuery >= query_pool_state.create_info.queryCount) {
@@ -146,12 +146,12 @@ bool CoreChecks::ValidateVideoInlineQueryInfo(const vvl::QueryPool &query_pool_s
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeIntraRefreshInfo(const vvl::CommandBuffer &cb_state, const vvl::VideoSession &vs_state,
-                                                     const VkVideoEncodeInfoKHR &encode_info,
-                                                     const Location &encode_info_loc) const {
+bool CoreChecks::ValidateVideoEncodeIntraRefreshInfo(const vvl::CommandBuffer& cb_state, const vvl::VideoSession& vs_state,
+                                                     const VkVideoEncodeInfoKHR& encode_info,
+                                                     const Location& encode_info_loc) const {
     bool skip = false;
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     const auto intra_refresh_mode = vs_state.GetIntraRefreshMode();
     const auto intra_refresh_info = vku::FindStructInPNextChain<VkVideoEncodeIntraRefreshInfoKHR>(encode_info.pNext);
@@ -240,14 +240,14 @@ bool CoreChecks::ValidateVideoEncodeIntraRefreshInfo(const vvl::CommandBuffer &c
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlInfo(const VkVideoEncodeRateControlInfoKHR &rc_info, const void *pNext,
-                                                    VkCommandBuffer cmdbuf, const vvl::VideoSession &vs_state,
-                                                    const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlInfo(const VkVideoEncodeRateControlInfoKHR& rc_info, const void* pNext,
+                                                    VkCommandBuffer cmdbuf, const vvl::VideoSession& vs_state,
+                                                    const Location& loc) const {
     bool skip = false;
 
     const Location rc_info_loc = loc.pNext(Struct::VkVideoEncodeRateControlInfoKHR);
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if (rc_info.layerCount > profile_caps.encode.maxRateControlLayers) {
         const LogObjectList objlist(cmdbuf, vs_state.Handle());
@@ -329,9 +329,9 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfo(const VkVideoEncodeRateContr
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlInfoH264(const VkVideoEncodeRateControlInfoKHR &rc_info, const void *pNext,
-                                                        VkCommandBuffer cmdbuf, const vvl::VideoSession &vs_state,
-                                                        const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlInfoH264(const VkVideoEncodeRateControlInfoKHR& rc_info, const void* pNext,
+                                                        VkCommandBuffer cmdbuf, const vvl::VideoSession& vs_state,
+                                                        const Location& loc) const {
     bool skip = false;
 
     const auto rc_info_h264 = vku::FindStructInPNextChain<VkVideoEncodeH264RateControlInfoKHR>(pNext);
@@ -339,7 +339,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfoH264(const VkVideoEncodeRateC
 
     const auto rc_info_h264_loc = loc.pNext(Struct::VkVideoEncodeH264RateControlInfoKHR);
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if (rc_info_h264->flags & VK_VIDEO_ENCODE_H264_RATE_CONTROL_ATTEMPT_HRD_COMPLIANCE_BIT_KHR &&
         (profile_caps.encode_h264.flags & VK_VIDEO_ENCODE_H264_CAPABILITY_HRD_COMPLIANCE_BIT_KHR) == 0) {
@@ -398,9 +398,9 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfoH264(const VkVideoEncodeRateC
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlInfoH265(const VkVideoEncodeRateControlInfoKHR &rc_info, const void *pNext,
-                                                        VkCommandBuffer cmdbuf, const vvl::VideoSession &vs_state,
-                                                        const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlInfoH265(const VkVideoEncodeRateControlInfoKHR& rc_info, const void* pNext,
+                                                        VkCommandBuffer cmdbuf, const vvl::VideoSession& vs_state,
+                                                        const Location& loc) const {
     bool skip = false;
 
     const auto rc_info_h265 = vku::FindStructInPNextChain<VkVideoEncodeH265RateControlInfoKHR>(pNext);
@@ -408,7 +408,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfoH265(const VkVideoEncodeRateC
 
     const auto rc_info_h265_loc = loc.pNext(Struct::VkVideoEncodeH265RateControlInfoKHR);
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if (rc_info_h265->flags & VK_VIDEO_ENCODE_H265_RATE_CONTROL_ATTEMPT_HRD_COMPLIANCE_BIT_KHR &&
         (profile_caps.encode_h265.flags & VK_VIDEO_ENCODE_H265_CAPABILITY_HRD_COMPLIANCE_BIT_KHR) == 0) {
@@ -466,9 +466,9 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfoH265(const VkVideoEncodeRateC
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlInfoAV1(const VkVideoEncodeRateControlInfoKHR &rc_info, const void *pNext,
-                                                       VkCommandBuffer cmdbuf, const vvl::VideoSession &vs_state,
-                                                       const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlInfoAV1(const VkVideoEncodeRateControlInfoKHR& rc_info, const void* pNext,
+                                                       VkCommandBuffer cmdbuf, const vvl::VideoSession& vs_state,
+                                                       const Location& loc) const {
     bool skip = false;
 
     const auto rc_info_av1 = vku::FindStructInPNextChain<VkVideoEncodeAV1RateControlInfoKHR>(pNext);
@@ -476,7 +476,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfoAV1(const VkVideoEncodeRateCo
 
     const auto rc_info_av1_loc = loc.pNext(Struct::VkVideoEncodeAV1RateControlInfoKHR);
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if ((rc_info_av1->flags & VK_VIDEO_ENCODE_AV1_RATE_CONTROL_REFERENCE_PATTERN_FLAT_BIT_KHR ||
          rc_info_av1->flags & VK_VIDEO_ENCODE_AV1_RATE_CONTROL_REFERENCE_PATTERN_DYADIC_BIT_KHR) &&
@@ -537,13 +537,13 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfoAV1(const VkVideoEncodeRateCo
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlLayerInfo(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR &rc_info,
-                                                         const void *pNext, VkCommandBuffer cmdbuf,
-                                                         const vvl::VideoSession &vs_state, const Location &rc_info_loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlLayerInfo(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR& rc_info,
+                                                         const void* pNext, VkCommandBuffer cmdbuf,
+                                                         const vvl::VideoSession& vs_state, const Location& rc_info_loc) const {
     bool skip = false;
 
-    const auto &rc_layer_info = rc_info.pLayers[layer_index];
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& rc_layer_info = rc_info.pLayers[layer_index];
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     const Location rc_layer_info_loc = rc_info_loc.dot(Field::pLayers, layer_index);
 
@@ -616,22 +616,22 @@ bool CoreChecks::ValidateVideoEncodeRateControlLayerInfo(uint32_t layer_index, c
 }
 
 template <typename RateControlLayerInfo>
-bool CoreChecks::ValidateVideoEncodeRateControlH26xQp(VkCommandBuffer cmdbuf, const vvl::VideoSession &vs_state,
-                                                      const RateControlLayerInfo &rc_layer_info, const char *min_qp_range_vuid,
-                                                      const char *max_qp_range_vuid, int32_t min_qp, int32_t max_qp,
-                                                      const char *min_qp_per_pic_type_vuid, const char *max_qp_per_pic_type_vuid,
-                                                      bool qp_per_picture_type, const char *min_max_qp_compare_vuid,
-                                                      const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlH26xQp(VkCommandBuffer cmdbuf, const vvl::VideoSession& vs_state,
+                                                      const RateControlLayerInfo& rc_layer_info, const char* min_qp_range_vuid,
+                                                      const char* max_qp_range_vuid, int32_t min_qp, int32_t max_qp,
+                                                      const char* min_qp_per_pic_type_vuid, const char* max_qp_per_pic_type_vuid,
+                                                      bool qp_per_picture_type, const char* min_max_qp_compare_vuid,
+                                                      const Location& loc) const {
     bool skip = false;
 
-    auto qp_range_error = [&](const char *vuid, const Location &field_loc, int32_t value) {
+    auto qp_range_error = [&](const char* vuid, const Location& field_loc, int32_t value) {
         const LogObjectList objlist(cmdbuf, vs_state.Handle());
         return LogError(vuid, objlist, field_loc,
                         "(%d) is outside of the range [%d, %d] supported by the video profile (%s) %s was created with.", value,
                         min_qp, max_qp, string_VideoProfileDesc(*vs_state.profile).c_str(), FormatHandle(vs_state).c_str());
     };
 
-    auto qp_per_pic_type_error = [&](const char *vuid, const Location &struct_loc, int32_t qp_i, int32_t qp_p, int32_t qp_b) {
+    auto qp_per_pic_type_error = [&](const char* vuid, const Location& struct_loc, int32_t qp_i, int32_t qp_p, int32_t qp_b) {
         const LogObjectList objlist(cmdbuf, vs_state.Handle());
         return LogError(vuid, objlist, struct_loc,
                         "contains non-matching QP values (qpI = %d, qpP = %d, qpB = %d) but different QP values per "
@@ -639,7 +639,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlH26xQp(VkCommandBuffer cmdbuf, co
                         qp_i, qp_p, qp_b, string_VideoProfileDesc(*vs_state.profile).c_str(), FormatHandle(vs_state).c_str());
     };
 
-    auto min_max_qp_compare_error = [&](const char *which, int32_t min_value, int32_t max_value) {
+    auto min_max_qp_compare_error = [&](const char* which, int32_t min_value, int32_t max_value) {
         return LogError(min_max_qp_compare_vuid, cmdbuf, loc, "minQp.%s (%d) is greater than maxQp.%s (%d).", which, min_value,
                         which, max_value);
     };
@@ -701,16 +701,16 @@ bool CoreChecks::ValidateVideoEncodeRateControlH26xQp(VkCommandBuffer cmdbuf, co
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlAV1QIndex(VkCommandBuffer cmdbuf, const vvl::VideoSession &vs_state,
-                                                         const VkVideoEncodeAV1RateControlLayerInfoKHR &rc_layer_info,
-                                                         const char *min_q_index_range_vuid, const char *max_q_index_range_vuid,
+bool CoreChecks::ValidateVideoEncodeRateControlAV1QIndex(VkCommandBuffer cmdbuf, const vvl::VideoSession& vs_state,
+                                                         const VkVideoEncodeAV1RateControlLayerInfoKHR& rc_layer_info,
+                                                         const char* min_q_index_range_vuid, const char* max_q_index_range_vuid,
                                                          uint32_t min_q_index, uint32_t max_q_index,
-                                                         const char *min_q_index_per_rc_group_vuid,
-                                                         const char *max_q_index_per_rc_group_vuid, bool q_index_per_rc_group,
-                                                         const char *min_max_q_index_compare_vuid, const Location &loc) const {
+                                                         const char* min_q_index_per_rc_group_vuid,
+                                                         const char* max_q_index_per_rc_group_vuid, bool q_index_per_rc_group,
+                                                         const char* min_max_q_index_compare_vuid, const Location& loc) const {
     bool skip = false;
 
-    auto q_index_range_error = [&](const char *vuid, const Location &field_loc, uint32_t value) {
+    auto q_index_range_error = [&](const char* vuid, const Location& field_loc, uint32_t value) {
         const LogObjectList objlist(cmdbuf, vs_state.Handle());
         return LogError(vuid, objlist, field_loc,
                         "(%" PRIu32 ") is outside of the range [%" PRIu32 ", %" PRIu32
@@ -719,7 +719,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlAV1QIndex(VkCommandBuffer cmdbuf,
                         FormatHandle(vs_state).c_str());
     };
 
-    auto q_index_per_rc_group_error = [&](const char *vuid, const Location &struct_loc, uint32_t qi_i, uint32_t qi_p,
+    auto q_index_per_rc_group_error = [&](const char* vuid, const Location& struct_loc, uint32_t qi_i, uint32_t qi_p,
                                           uint32_t qi_b) {
         const LogObjectList objlist(cmdbuf, vs_state.Handle());
         return LogError(vuid, objlist, struct_loc,
@@ -731,7 +731,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlAV1QIndex(VkCommandBuffer cmdbuf,
                         qi_i, qi_p, qi_b, string_VideoProfileDesc(*vs_state.profile).c_str(), FormatHandle(vs_state).c_str());
     };
 
-    auto min_max_q_index_compare_error = [&](const char *which, uint32_t min_value, uint32_t max_value) {
+    auto min_max_q_index_compare_error = [&](const char* which, uint32_t min_value, uint32_t max_value) {
         return LogError(min_max_q_index_compare_vuid, cmdbuf, loc,
                         "minQIndex.%s (%" PRIu32 ") is greater than maxQIndex.%s (%" PRIu32 ").", which, min_value, which,
                         max_value);
@@ -807,10 +807,10 @@ bool CoreChecks::ValidateVideoEncodeRateControlAV1QIndex(VkCommandBuffer cmdbuf,
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH264(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR &rc_info,
-                                                             const void *pNext, VkCommandBuffer cmdbuf,
-                                                             const vvl::VideoSession &vs_state,
-                                                             const Location &rc_layer_info_loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH264(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR& rc_info,
+                                                             const void* pNext, VkCommandBuffer cmdbuf,
+                                                             const vvl::VideoSession& vs_state,
+                                                             const Location& rc_layer_info_loc) const {
     bool skip = false;
 
     const auto rc_layer_info_h264 =
@@ -819,7 +819,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH264(uint32_t layer_inde
 
     const Location rc_layer_info_h264_loc = rc_layer_info_loc.pNext(Struct::VkVideoEncodeH264RateControlLayerInfoKHR);
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     skip |= ValidateVideoEncodeRateControlH26xQp(
         cmdbuf, vs_state, *rc_layer_info_h264, "VUID-VkVideoEncodeH264RateControlLayerInfoKHR-useMinQp-08286",
@@ -832,10 +832,10 @@ bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH264(uint32_t layer_inde
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH265(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR &rc_info,
-                                                             const void *pNext, VkCommandBuffer cmdbuf,
-                                                             const vvl::VideoSession &vs_state,
-                                                             const Location &rc_layer_info_loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH265(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR& rc_info,
+                                                             const void* pNext, VkCommandBuffer cmdbuf,
+                                                             const vvl::VideoSession& vs_state,
+                                                             const Location& rc_layer_info_loc) const {
     bool skip = false;
 
     const auto rc_layer_info_h265 =
@@ -844,7 +844,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH265(uint32_t layer_inde
 
     const Location rc_layer_info_h265_loc = rc_layer_info_loc.pNext(Struct::VkVideoEncodeH265RateControlLayerInfoKHR);
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     skip |= ValidateVideoEncodeRateControlH26xQp(
         cmdbuf, vs_state, *rc_layer_info_h265, "VUID-VkVideoEncodeH265RateControlLayerInfoKHR-useMinQp-08297",
@@ -857,10 +857,10 @@ bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoH265(uint32_t layer_inde
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoAV1(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR &rc_info,
-                                                            const void *pNext, VkCommandBuffer cmdbuf,
-                                                            const vvl::VideoSession &vs_state,
-                                                            const Location &rc_layer_info_loc) const {
+bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoAV1(uint32_t layer_index, const VkVideoEncodeRateControlInfoKHR& rc_info,
+                                                            const void* pNext, VkCommandBuffer cmdbuf,
+                                                            const vvl::VideoSession& vs_state,
+                                                            const Location& rc_layer_info_loc) const {
     bool skip = false;
 
     const auto rc_layer_info_av1 =
@@ -869,7 +869,7 @@ bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoAV1(uint32_t layer_index
 
     const Location rc_layer_info_av1_loc = rc_layer_info_loc.pNext(Struct::VkVideoEncodeAV1RateControlLayerInfoKHR);
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     skip |= ValidateVideoEncodeRateControlAV1QIndex(
         cmdbuf, vs_state, *rc_layer_info_av1, "VUID-VkVideoEncodeAV1RateControlLayerInfoKHR-useMinQIndex-10300",
@@ -882,12 +882,12 @@ bool CoreChecks::ValidateVideoEncodeRateControlLayerInfoAV1(uint32_t layer_index
     return skip;
 }
 
-bool CoreChecks::ValidateVideoPictureResource(const vvl::VideoPictureResource &picture_resource, VkCommandBuffer cmdbuf,
-                                              const vvl::VideoSession &vs_state, const Location &loc, const char *coded_offset_vuid,
-                                              const char *coded_extent_vuid) const {
+bool CoreChecks::ValidateVideoPictureResource(const vvl::VideoPictureResource& picture_resource, VkCommandBuffer cmdbuf,
+                                              const vvl::VideoSession& vs_state, const Location& loc, const char* coded_offset_vuid,
+                                              const char* coded_extent_vuid) const {
     bool skip = false;
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if (coded_offset_vuid) {
         VkOffset2D offset_granularity{0, 0};
@@ -930,14 +930,14 @@ bool CoreChecks::ValidateVideoPictureResource(const vvl::VideoPictureResource &p
 }
 
 template <typename StateObject>
-bool core::ValidateVideoProfileInfo(const StateObject &state, const VkVideoProfileInfoKHR *profile, const ErrorObject &error_obj,
-                                    const Location &loc) {
+bool core::ValidateVideoProfileInfo(const StateObject& state, const VkVideoProfileInfoKHR* profile, const ErrorObject& error_obj,
+                                    const Location& loc) {
     using Field = vvl::Field;
 
     bool skip = false;
 
-    const char *profile_pnext_msg = "chain does not contain a %s structure.";
-    const char *codec_feature_not_enabled_msg = "is %s but the %s device feature is not enabled.";
+    const char* profile_pnext_msg = "chain does not contain a %s structure.";
+    const char* codec_feature_not_enabled_msg = "is %s but the %s device feature is not enabled.";
     (void)codec_feature_not_enabled_msg;
 
     if (CountSetBits(profile->chromaSubsampling) != 1) {
@@ -989,7 +989,7 @@ bool core::ValidateVideoProfileInfo(const StateObject &state, const VkVideoProfi
             if constexpr (std::is_same_v<StateObject, CoreChecks>) {
                 using Func = vvl::Func;
                 if (!state.enabled_features.videoDecodeVP9) {
-                    const char *vuid = kVUIDUndefined;
+                    const char* vuid = kVUIDUndefined;
                     switch (loc.function) {
                         case Func::vkCreateVideoSessionKHR:
                             vuid = "VUID-VkVideoSessionCreateInfoKHR-pVideoProfile-10793";
@@ -1044,7 +1044,7 @@ bool core::ValidateVideoProfileInfo(const StateObject &state, const VkVideoProfi
             if constexpr (std::is_same_v<StateObject, CoreChecks>) {
                 using Func = vvl::Func;
                 if (!state.enabled_features.videoEncodeAV1) {
-                    const char *vuid = kVUIDUndefined;
+                    const char* vuid = kVUIDUndefined;
                     switch (loc.function) {
                         case Func::vkCreateVideoSessionKHR:
                             vuid = "VUID-VkVideoSessionCreateInfoKHR-pVideoProfile-10269";
@@ -1085,16 +1085,16 @@ bool core::ValidateVideoProfileInfo(const StateObject &state, const VkVideoProfi
 
     return skip;
 }
-template bool core::ValidateVideoProfileInfo<core::Instance>(const core::Instance &state, const VkVideoProfileInfoKHR *profile,
-                                                             const ErrorObject &error_obj, const Location &loc);
-template bool core::ValidateVideoProfileInfo<CoreChecks>(const CoreChecks &state, const VkVideoProfileInfoKHR *profile,
-                                                         const ErrorObject &error_obj, const Location &loc);
+template bool core::ValidateVideoProfileInfo<core::Instance>(const core::Instance& state, const VkVideoProfileInfoKHR* profile,
+                                                             const ErrorObject& error_obj, const Location& loc);
+template bool core::ValidateVideoProfileInfo<CoreChecks>(const CoreChecks& state, const VkVideoProfileInfoKHR* profile,
+                                                         const ErrorObject& error_obj, const Location& loc);
 
 template <typename StateObject>
-bool core::ValidateVideoProfileListInfo(const StateObject &state, const VkVideoProfileListInfoKHR *profile_list,
-                                        const ErrorObject &error_obj, const Location &loc, bool expect_decode_profile,
-                                        const char *missing_decode_profile_msg_code, bool expect_encode_profile,
-                                        const char *missing_encode_profile_msg_code) {
+bool core::ValidateVideoProfileListInfo(const StateObject& state, const VkVideoProfileListInfoKHR* profile_list,
+                                        const ErrorObject& error_obj, const Location& loc, bool expect_decode_profile,
+                                        const char* missing_decode_profile_msg_code, bool expect_encode_profile,
+                                        const char* missing_encode_profile_msg_code) {
     bool skip = false;
 
     bool has_decode_profile = false;
@@ -1143,21 +1143,21 @@ bool core::ValidateVideoProfileListInfo(const StateObject &state, const VkVideoP
     return skip;
 }
 template bool core::ValidateVideoProfileListInfo<core::Instance>(
-    const core::Instance &state, const VkVideoProfileListInfoKHR *profile_list, const ErrorObject &error_obj, const Location &loc,
-    bool expect_decode_profile, const char *missing_decode_profile_msg_code, bool expect_encode_profile,
-    const char *missing_encode_profile_msg_code);
-template bool core::ValidateVideoProfileListInfo<CoreChecks>(const CoreChecks &state, const VkVideoProfileListInfoKHR *profile_list,
-                                                             const ErrorObject &error_obj, const Location &loc,
+    const core::Instance& state, const VkVideoProfileListInfoKHR* profile_list, const ErrorObject& error_obj, const Location& loc,
+    bool expect_decode_profile, const char* missing_decode_profile_msg_code, bool expect_encode_profile,
+    const char* missing_encode_profile_msg_code);
+template bool core::ValidateVideoProfileListInfo<CoreChecks>(const CoreChecks& state, const VkVideoProfileListInfoKHR* profile_list,
+                                                             const ErrorObject& error_obj, const Location& loc,
                                                              bool expect_decode_profile,
-                                                             const char *missing_decode_profile_msg_code,
+                                                             const char* missing_decode_profile_msg_code,
                                                              bool expect_encode_profile,
-                                                             const char *missing_encode_profile_msg_code);
+                                                             const char* missing_encode_profile_msg_code);
 
-bool CoreChecks::ValidateDecodeH264ParametersAddInfo(const vvl::VideoSession &vs_state,
-                                                     const VkVideoDecodeH264SessionParametersAddInfoKHR *add_info, VkDevice device,
-                                                     const Location &loc,
-                                                     const VkVideoDecodeH264SessionParametersCreateInfoKHR *create_info,
-                                                     const vvl::VideoSessionParameters *template_state) const {
+bool CoreChecks::ValidateDecodeH264ParametersAddInfo(const vvl::VideoSession& vs_state,
+                                                     const VkVideoDecodeH264SessionParametersAddInfoKHR* add_info, VkDevice device,
+                                                     const Location& loc,
+                                                     const VkVideoDecodeH264SessionParametersCreateInfoKHR* create_info,
+                                                     const vvl::VideoSessionParameters* template_state) const {
     bool skip = false;
 
     vvl::unordered_set<vvl::VideoSessionParameters::ParameterKey> keys;
@@ -1178,7 +1178,7 @@ bool CoreChecks::ValidateDecodeH264ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify SPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h264.sps) {
+            for (const auto& it : template_data->h264.sps) {
                 keys.emplace(it.first);
             }
         }
@@ -1207,7 +1207,7 @@ bool CoreChecks::ValidateDecodeH264ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify PPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h264.pps) {
+            for (const auto& it : template_data->h264.pps) {
                 keys.emplace(it.first);
             }
         }
@@ -1222,11 +1222,11 @@ bool CoreChecks::ValidateDecodeH264ParametersAddInfo(const vvl::VideoSession &vs
     return skip;
 }
 
-bool CoreChecks::ValidateDecodeH265ParametersAddInfo(const vvl::VideoSession &vs_state,
-                                                     const VkVideoDecodeH265SessionParametersAddInfoKHR *add_info, VkDevice device,
-                                                     const Location &loc,
-                                                     const VkVideoDecodeH265SessionParametersCreateInfoKHR *create_info,
-                                                     const vvl::VideoSessionParameters *template_state) const {
+bool CoreChecks::ValidateDecodeH265ParametersAddInfo(const vvl::VideoSession& vs_state,
+                                                     const VkVideoDecodeH265SessionParametersAddInfoKHR* add_info, VkDevice device,
+                                                     const Location& loc,
+                                                     const VkVideoDecodeH265SessionParametersCreateInfoKHR* create_info,
+                                                     const vvl::VideoSessionParameters* template_state) const {
     bool skip = false;
 
     vvl::unordered_set<vvl::VideoSessionParameters::ParameterKey> keys;
@@ -1247,7 +1247,7 @@ bool CoreChecks::ValidateDecodeH265ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify VPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h265.vps) {
+            for (const auto& it : template_data->h265.vps) {
                 keys.emplace(it.first);
             }
         }
@@ -1276,7 +1276,7 @@ bool CoreChecks::ValidateDecodeH265ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify SPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h265.sps) {
+            for (const auto& it : template_data->h265.sps) {
                 keys.emplace(it.first);
             }
         }
@@ -1305,7 +1305,7 @@ bool CoreChecks::ValidateDecodeH265ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify PPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h265.pps) {
+            for (const auto& it : template_data->h265.pps) {
                 keys.emplace(it.first);
             }
         }
@@ -1320,11 +1320,11 @@ bool CoreChecks::ValidateDecodeH265ParametersAddInfo(const vvl::VideoSession &vs
     return skip;
 }
 
-bool CoreChecks::ValidateEncodeH264ParametersAddInfo(const vvl::VideoSession &vs_state,
-                                                     const VkVideoEncodeH264SessionParametersAddInfoKHR *add_info, VkDevice device,
-                                                     const Location &loc,
-                                                     const VkVideoEncodeH264SessionParametersCreateInfoKHR *create_info,
-                                                     const vvl::VideoSessionParameters *template_state) const {
+bool CoreChecks::ValidateEncodeH264ParametersAddInfo(const vvl::VideoSession& vs_state,
+                                                     const VkVideoEncodeH264SessionParametersAddInfoKHR* add_info, VkDevice device,
+                                                     const Location& loc,
+                                                     const VkVideoEncodeH264SessionParametersCreateInfoKHR* create_info,
+                                                     const vvl::VideoSessionParameters* template_state) const {
     bool skip = false;
 
     vvl::unordered_set<vvl::VideoSessionParameters::ParameterKey> keys;
@@ -1345,7 +1345,7 @@ bool CoreChecks::ValidateEncodeH264ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify SPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h264.sps) {
+            for (const auto& it : template_data->h264.sps) {
                 keys.emplace(it.first);
             }
         }
@@ -1374,7 +1374,7 @@ bool CoreChecks::ValidateEncodeH264ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify PPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h264.pps) {
+            for (const auto& it : template_data->h264.pps) {
                 keys.emplace(it.first);
             }
         }
@@ -1389,11 +1389,11 @@ bool CoreChecks::ValidateEncodeH264ParametersAddInfo(const vvl::VideoSession &vs
     return skip;
 }
 
-bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession &vs_state,
-                                                     const VkVideoEncodeH265SessionParametersAddInfoKHR *add_info, VkDevice device,
-                                                     const Location &loc,
-                                                     const VkVideoEncodeH265SessionParametersCreateInfoKHR *create_info,
-                                                     const vvl::VideoSessionParameters *template_state) const {
+bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession& vs_state,
+                                                     const VkVideoEncodeH265SessionParametersAddInfoKHR* add_info, VkDevice device,
+                                                     const Location& loc,
+                                                     const VkVideoEncodeH265SessionParametersCreateInfoKHR* create_info,
+                                                     const vvl::VideoSessionParameters* template_state) const {
     bool skip = false;
 
     vvl::unordered_set<vvl::VideoSessionParameters::ParameterKey> keys;
@@ -1414,7 +1414,7 @@ bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify VPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h265.vps) {
+            for (const auto& it : template_data->h265.vps) {
                 keys.emplace(it.first);
             }
         }
@@ -1443,7 +1443,7 @@ bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify SPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h265.sps) {
+            for (const auto& it : template_data->h265.sps) {
                 keys.emplace(it.first);
             }
         }
@@ -1472,7 +1472,7 @@ bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession &vs
     if (create_info) {
         // Verify PPS capacity
         if (template_data) {
-            for (const auto &it : template_data->h265.pps) {
+            for (const auto& it : template_data->h265.pps) {
                 keys.emplace(it.first);
             }
         }
@@ -1485,12 +1485,12 @@ bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession &vs
     }
 
     if (add_info) {
-        const auto &profile_caps = vs_state.profile->GetCapabilities();
+        const auto& profile_caps = vs_state.profile->GetCapabilities();
 
         // Verify PPS contents
         for (uint32_t i = 0; i < add_info->stdPPSCount; ++i) {
             if (add_info->pStdPPSs[i].num_tile_columns_minus1 >= profile_caps.encode_h265.maxTiles.width) {
-                const char *vuid = nullptr;
+                const char* vuid = nullptr;
                 if (create_info) {
                     assert(loc.function == Func::vkCreateVideoSessionParametersKHR);
                     vuid = "VUID-VkVideoSessionParametersCreateInfoKHR-videoSession-08319";
@@ -1507,7 +1507,7 @@ bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession &vs
                                  FormatHandle(vs_state).c_str());
             }
             if (add_info->pStdPPSs[i].num_tile_rows_minus1 >= profile_caps.encode_h265.maxTiles.height) {
-                const char *vuid = nullptr;
+                const char* vuid = nullptr;
                 if (create_info) {
                     assert(loc.function == Func::vkCreateVideoSessionParametersKHR);
                     vuid = "VUID-VkVideoSessionParametersCreateInfoKHR-videoSession-08320";
@@ -1530,13 +1530,13 @@ bool CoreChecks::ValidateEncodeH265ParametersAddInfo(const vvl::VideoSession &vs
 }
 
 bool CoreChecks::ValidateEncodeQuantizationMapParametersCreateInfo(
-    const vvl::VideoSession &vs_state, const VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR &quantization_map_info,
-    VkDevice device, const Location &loc, const vvl::VideoSessionParameters *template_state) const {
+    const vvl::VideoSession& vs_state, const VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR& quantization_map_info,
+    VkDevice device, const Location& loc, const vvl::VideoSessionParameters* template_state) const {
     bool skip = false;
 
-    const char *quant_map_type_name = nullptr;
-    const char *texel_size_vuid = nullptr;
-    const vvl::SupportedQuantizationMapTexelSizes *supported_texel_sizes = nullptr;
+    const char* quant_map_type_name = nullptr;
+    const char* texel_size_vuid = nullptr;
+    const vvl::SupportedQuantizationMapTexelSizes* supported_texel_sizes = nullptr;
 
     if (vs_state.create_info.flags & VK_VIDEO_SESSION_CREATE_ALLOW_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR) {
         quant_map_type_name = "quantization delta map";
@@ -1575,13 +1575,13 @@ bool CoreChecks::ValidateEncodeQuantizationMapParametersCreateInfo(
     return skip;
 }
 
-bool CoreChecks::ValidateDecodeDistinctOutput(const vvl::CommandBuffer &cb_state, const VkVideoDecodeInfoKHR &decode_info,
-                                              const Location &loc) const {
+bool CoreChecks::ValidateDecodeDistinctOutput(const vvl::CommandBuffer& cb_state, const VkVideoDecodeInfoKHR& decode_info,
+                                              const Location& loc) const {
     bool skip = false;
     auto cmd_loc = Location(loc.function);
 
-    const auto &vs_state = *cb_state.bound_video_session;
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& vs_state = *cb_state.bound_video_session;
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if ((profile_caps.decode.flags & VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR) == 0) {
         const LogObjectList objlist(cb_state.Handle(), vs_state.Handle());
@@ -1625,13 +1625,13 @@ bool CoreChecks::ValidateDecodeDistinctOutput(const vvl::CommandBuffer &cb_state
     return skip;
 }
 
-bool CoreChecks::ValidateVideoDecodeInfoH264(const vvl::CommandBuffer &cb_state, const VkVideoDecodeInfoKHR &decode_info,
-                                             const Location &loc) const {
+bool CoreChecks::ValidateVideoDecodeInfoH264(const vvl::CommandBuffer& cb_state, const VkVideoDecodeInfoKHR& decode_info,
+                                             const Location& loc) const {
     bool skip = false;
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
+    const char* pnext_msg = "chain does not contain a %s structure.";
 
-    const auto &vs_state = *cb_state.bound_video_session;
+    const auto& vs_state = *cb_state.bound_video_session;
 
     const bool inline_session_params_enabled =
         vs_state.create_info.flags & VK_VIDEO_SESSION_CREATE_INLINE_SESSION_PARAMETERS_BIT_KHR;
@@ -1710,11 +1710,11 @@ bool CoreChecks::ValidateVideoDecodeInfoH264(const vvl::CommandBuffer &cb_state,
         }
 
         if (needs_bound_session_params && has_bound_session_params) {
-            const auto &vsp_state = *cb_state.bound_video_session_parameters;
+            const auto& vsp_state = *cb_state.bound_video_session_parameters;
             auto session_params = vsp_state.Lock();
             if (!has_inline_sps && session_params.GetH264SPS(std_picture_info->seq_parameter_set_id) == nullptr) {
                 const LogObjectList objlist(cb_state.Handle(), vsp_state.Handle());
-                const char *additional_info =
+                const char* additional_info =
                     inline_session_params_enabled
                         ? "nor is inline SPS provided by including a VkVideoDecodeH264InlineSessionParametersInfoKHR "
                           "structure in the pNext chain of pDecodeInfo with a non-null pStdSPS"
@@ -1730,7 +1730,7 @@ bool CoreChecks::ValidateVideoDecodeInfoH264(const vvl::CommandBuffer &cb_state,
             if (!has_inline_pps && session_params.GetH264PPS(std_picture_info->seq_parameter_set_id,
                                                              std_picture_info->pic_parameter_set_id) == nullptr) {
                 const LogObjectList objlist(cb_state.Handle(), vsp_state.Handle());
-                const char *additional_info =
+                const char* additional_info =
                     inline_session_params_enabled
                         ? "nor is inline PPS provided by including a VkVideoDecodeH264InlineSessionParametersInfoKHR "
                           "structure in the pNext chain of pDecodeInfo with a non-null pStdPPS"
@@ -1812,13 +1812,13 @@ bool CoreChecks::ValidateVideoDecodeInfoH264(const vvl::CommandBuffer &cb_state,
     return skip;
 }
 
-bool CoreChecks::ValidateVideoDecodeInfoH265(const vvl::CommandBuffer &cb_state, const VkVideoDecodeInfoKHR &decode_info,
-                                             const Location &loc) const {
+bool CoreChecks::ValidateVideoDecodeInfoH265(const vvl::CommandBuffer& cb_state, const VkVideoDecodeInfoKHR& decode_info,
+                                             const Location& loc) const {
     bool skip = false;
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
+    const char* pnext_msg = "chain does not contain a %s structure.";
 
-    const auto &vs_state = *cb_state.bound_video_session;
+    const auto& vs_state = *cb_state.bound_video_session;
 
     const bool inline_session_params_enabled =
         vs_state.create_info.flags & VK_VIDEO_SESSION_CREATE_INLINE_SESSION_PARAMETERS_BIT_KHR;
@@ -1911,12 +1911,12 @@ bool CoreChecks::ValidateVideoDecodeInfoH265(const vvl::CommandBuffer &cb_state,
         }
 
         if (needs_bound_session_params && has_bound_session_params) {
-            const auto &vsp_state = *cb_state.bound_video_session_parameters;
+            const auto& vsp_state = *cb_state.bound_video_session_parameters;
             const auto session_params = vsp_state.Lock();
 
             if (!has_inline_vps && session_params.GetH265VPS(std_picture_info->sps_video_parameter_set_id) == nullptr) {
                 const LogObjectList objlist(cb_state.Handle(), vsp_state.Handle());
-                const char *additional_info =
+                const char* additional_info =
                     inline_session_params_enabled
                         ? "nor is inline VPS provided by including a VkVideoDecodeH265InlineSessionParametersInfoKHR "
                           "structure in the pNext chain of pDecodeInfo with a non-null pStdVPS"
@@ -1932,7 +1932,7 @@ bool CoreChecks::ValidateVideoDecodeInfoH265(const vvl::CommandBuffer &cb_state,
             if (!has_inline_sps && session_params.GetH265SPS(std_picture_info->sps_video_parameter_set_id,
                                                              std_picture_info->pps_seq_parameter_set_id) == nullptr) {
                 const LogObjectList objlist(cb_state.Handle(), vsp_state.Handle());
-                const char *additional_info =
+                const char* additional_info =
                     inline_session_params_enabled
                         ? "nor is inline SPS provided by including a VkVideoDecodeH265InlineSessionParametersInfoKHR "
                           "structure in the pNext chain of pDecodeInfo with a non-null pStdSPS"
@@ -1952,7 +1952,7 @@ bool CoreChecks::ValidateVideoDecodeInfoH265(const vvl::CommandBuffer &cb_state,
                 session_params.GetH265PPS(std_picture_info->sps_video_parameter_set_id, std_picture_info->pps_seq_parameter_set_id,
                                           std_picture_info->pps_pic_parameter_set_id) == nullptr) {
                 const LogObjectList objlist(cb_state.Handle(), vsp_state.Handle());
-                const char *additional_info =
+                const char* additional_info =
                     inline_session_params_enabled
                         ? "nor is inline PPS provided by including a VkVideoDecodeH265InlineSessionParametersInfoKHR "
                           "structure in the pNext chain of pDecodeInfo with a non-null pStdPPS"
@@ -1992,14 +1992,14 @@ bool CoreChecks::ValidateVideoDecodeInfoH265(const vvl::CommandBuffer &cb_state,
     return skip;
 }
 
-bool CoreChecks::ValidateVideoDecodeInfoAV1(const vvl::CommandBuffer &cb_state, const VkVideoDecodeInfoKHR &decode_info,
-                                            const Location &loc) const {
+bool CoreChecks::ValidateVideoDecodeInfoAV1(const vvl::CommandBuffer& cb_state, const VkVideoDecodeInfoKHR& decode_info,
+                                            const Location& loc) const {
     bool skip = false;
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
-    const char *src_buffer_range_msg = "(%" PRIu32 ") is greater than or equal to pDecodeInfo->srcBufferRange (%" PRIu64 ").";
+    const char* pnext_msg = "chain does not contain a %s structure.";
+    const char* src_buffer_range_msg = "(%" PRIu32 ") is greater than or equal to pDecodeInfo->srcBufferRange (%" PRIu64 ").";
 
-    const auto &vs_state = *cb_state.bound_video_session;
+    const auto& vs_state = *cb_state.bound_video_session;
 
     const bool inline_session_params_enabled =
         vs_state.create_info.flags & VK_VIDEO_SESSION_CREATE_INLINE_SESSION_PARAMETERS_BIT_KHR;
@@ -2084,8 +2084,7 @@ bool CoreChecks::ValidateVideoDecodeInfoAV1(const vvl::CommandBuffer &cb_state, 
 
         for (uint32_t i = 0; i < decode_info.referenceSlotCount; ++i) {
             if (reference_name_slot_indices.find(decode_info.pReferenceSlots[i].slotIndex) == reference_name_slot_indices.end()) {
-                skip |= LogError("VUID-vkCmdDecodeVideoKHR-slotIndex-09263", cb_state.Handle(),
-                                 loc.dot(Field::pReferenceSlots, i),
+                skip |= LogError("VUID-vkCmdDecodeVideoKHR-slotIndex-09263", cb_state.Handle(), loc.dot(Field::pReferenceSlots, i),
                                  "(%d) does not match any of the elements of "
                                  "VkVideoDecodeAV1PictureInfoKHR::referenceNameSlotIndices.",
                                  decode_info.pReferenceSlots[i].slotIndex);
@@ -2121,12 +2120,12 @@ bool CoreChecks::ValidateVideoDecodeInfoAV1(const vvl::CommandBuffer &cb_state, 
     return skip;
 }
 
-bool CoreChecks::ValidateVideoDecodeInfoVP9(const vvl::CommandBuffer &cb_state, const VkVideoDecodeInfoKHR &decode_info,
-                                            const Location &loc) const {
+bool CoreChecks::ValidateVideoDecodeInfoVP9(const vvl::CommandBuffer& cb_state, const VkVideoDecodeInfoKHR& decode_info,
+                                            const Location& loc) const {
     bool skip = false;
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
-    const char *src_buffer_range_msg = "(%" PRIu32 ") is greater than or equal to pDecodeInfo->srcBufferRange (%" PRIu64 ").";
+    const char* pnext_msg = "chain does not contain a %s structure.";
+    const char* src_buffer_range_msg = "(%" PRIu32 ") is greater than or equal to pDecodeInfo->srcBufferRange (%" PRIu64 ").";
 
     vvl::unordered_set<int32_t> reference_slot_indices{};
     for (uint32_t i = 0; i < decode_info.referenceSlotCount; ++i) {
@@ -2183,11 +2182,11 @@ bool CoreChecks::ValidateVideoDecodeInfoVP9(const vvl::CommandBuffer &cb_state, 
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeH264PicType(const vvl::VideoSession &vs_state, StdVideoH264PictureType pic_type,
-                                                const Location &loc, const char *where) const {
+bool CoreChecks::ValidateVideoEncodeH264PicType(const vvl::VideoSession& vs_state, StdVideoH264PictureType pic_type,
+                                                const Location& loc, const char* where) const {
     bool skip = false;
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if (profile_caps.encode_h264.maxPPictureL0ReferenceCount == 0 && pic_type == STD_VIDEO_H264_PICTURE_TYPE_P) {
         skip |= LogError("VUID-vkCmdEncodeVideoKHR-maxPPictureL0ReferenceCount-08340", vs_state.Handle(), loc,
@@ -2207,18 +2206,18 @@ bool CoreChecks::ValidateVideoEncodeH264PicType(const vvl::VideoSession &vs_stat
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer &cb_state, const VkVideoEncodeInfoKHR &encode_info,
-                                             const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer& cb_state, const VkVideoEncodeInfoKHR& encode_info,
+                                             const Location& loc) const {
     bool skip = false;
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
+    const char* pnext_msg = "chain does not contain a %s structure.";
 
-    const auto &vs_state = *cb_state.bound_video_session;
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& vs_state = *cb_state.bound_video_session;
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
-    const auto &rc_state = cb_state.video_encode_rate_control_state;
+    const auto& rc_state = cb_state.video_encode_rate_control_state;
 
-    const auto &vsp_state = *cb_state.bound_video_session_parameters;
+    const auto& vsp_state = *cb_state.bound_video_session_parameters;
     const auto session_params = vsp_state.Lock();
 
     if (encode_info.pSetupReferenceSlot) {
@@ -2229,7 +2228,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer &cb_state,
         }
     }
 
-    vvl::unordered_map<int32_t, const VkVideoEncodeH264DpbSlotInfoKHR *> reference_slots{};
+    vvl::unordered_map<int32_t, const VkVideoEncodeH264DpbSlotInfoKHR*> reference_slots{};
     for (uint32_t i = 0; i < encode_info.referenceSlotCount; ++i) {
         auto dpb_slot_info = vku::FindStructInPNextChain<VkVideoEncodeH264DpbSlotInfoKHR>(encode_info.pReferenceSlots[i].pNext);
         if (!dpb_slot_info) {
@@ -2317,8 +2316,8 @@ bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer &cb_state,
         // Either match all slice types to 0th index, or if that happened to be intra refreshed, then the 1st index
         const uint32_t slice_type_compare_idx = (intra_refresh_h264_slice_idx == 0) ? 1 : 0;
         for (uint32_t slice_idx = 0; slice_idx < picture_info->naluSliceEntryCount; ++slice_idx) {
-            const auto &slice_info = picture_info->pNaluSliceEntries[slice_idx];
-            const auto *std_slice_header = slice_info.pStdSliceHeader;
+            const auto& slice_info = picture_info->pNaluSliceEntries[slice_idx];
+            const auto* std_slice_header = slice_info.pStdSliceHeader;
             const Location slice_info_loc = loc.pNext(Struct::VkVideoEncodeH264PictureInfoKHR, Field::pNaluSliceEntries, slice_idx);
 
             if (slice_idx != intra_refresh_h264_slice_idx &&
@@ -2354,7 +2353,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer &cb_state,
 
             if (std_pps != nullptr &&
                 (profile_caps.encode_h264.flags & VK_VIDEO_ENCODE_H264_CAPABILITY_PREDICTION_WEIGHT_TABLE_GENERATED_BIT_KHR) == 0) {
-                const char *weighted_pred_error_msg = nullptr;
+                const char* weighted_pred_error_msg = nullptr;
 
                 if (std_slice_header->slice_type == STD_VIDEO_H264_SLICE_TYPE_P && std_pps->flags.weighted_pred_flag) {
                     weighted_pred_error_msg =
@@ -2412,7 +2411,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer &cb_state,
                     continue;
                 }
 
-                const auto &ref_slot = reference_slots.find((int32_t)ref_list_entry);
+                const auto& ref_slot = reference_slots.find((int32_t)ref_list_entry);
                 if (ref_slot != reference_slots.end()) {
                     if (ref_slot->second != nullptr) {
                         auto std_reference_info = ref_slot->second->pStdReferenceInfo;
@@ -2447,7 +2446,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer &cb_state,
                     continue;
                 }
 
-                const auto &ref_slot = reference_slots.find((int32_t)ref_list_entry);
+                const auto& ref_slot = reference_slots.find((int32_t)ref_list_entry);
                 if (ref_slot != reference_slots.end()) {
                     if (ref_slot->second != nullptr) {
                         auto std_reference_info = ref_slot->second->pStdReferenceInfo;
@@ -2579,11 +2578,11 @@ bool CoreChecks::ValidateVideoEncodeInfoH264(const vvl::CommandBuffer &cb_state,
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeH265PicType(const vvl::VideoSession &vs_state, StdVideoH265PictureType pic_type,
-                                                const Location &loc, const char *where) const {
+bool CoreChecks::ValidateVideoEncodeH265PicType(const vvl::VideoSession& vs_state, StdVideoH265PictureType pic_type,
+                                                const Location& loc, const char* where) const {
     bool skip = false;
 
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
     if (profile_caps.encode_h265.maxPPictureL0ReferenceCount == 0 && pic_type == STD_VIDEO_H265_PICTURE_TYPE_P) {
         skip |= LogError("VUID-vkCmdEncodeVideoKHR-maxPPictureL0ReferenceCount-08345", vs_state.Handle(), loc,
@@ -2603,18 +2602,18 @@ bool CoreChecks::ValidateVideoEncodeH265PicType(const vvl::VideoSession &vs_stat
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer &cb_state, const VkVideoEncodeInfoKHR &encode_info,
-                                             const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer& cb_state, const VkVideoEncodeInfoKHR& encode_info,
+                                             const Location& loc) const {
     bool skip = false;
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
+    const char* pnext_msg = "chain does not contain a %s structure.";
 
-    const auto &vs_state = *cb_state.bound_video_session;
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& vs_state = *cb_state.bound_video_session;
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
-    const auto &rc_state = cb_state.video_encode_rate_control_state;
+    const auto& rc_state = cb_state.video_encode_rate_control_state;
 
-    const auto &vsp_state = *cb_state.bound_video_session_parameters;
+    const auto& vsp_state = *cb_state.bound_video_session_parameters;
     const auto session_params = vsp_state.Lock();
 
     if (encode_info.pSetupReferenceSlot) {
@@ -2625,7 +2624,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer &cb_state,
         }
     }
 
-    vvl::unordered_map<int32_t, const VkVideoEncodeH265DpbSlotInfoKHR *> reference_slots{};
+    vvl::unordered_map<int32_t, const VkVideoEncodeH265DpbSlotInfoKHR*> reference_slots{};
     for (uint32_t i = 0; i < encode_info.referenceSlotCount; ++i) {
         auto dpb_slot_info = vku::FindStructInPNextChain<VkVideoEncodeH265DpbSlotInfoKHR>(encode_info.pReferenceSlots[i].pNext);
         if (!dpb_slot_info) {
@@ -2773,8 +2772,8 @@ bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer &cb_state,
         // Either match all slice types to 0th index, or if that happened to be intra refreshed, then the 1st index
         const uint32_t slice_type_compare_idx = (intra_refresh_h265_slice_seg_idx == 0) ? 1 : 0;
         for (uint32_t slice_seg_idx = 0; slice_seg_idx < picture_info->naluSliceSegmentEntryCount; ++slice_seg_idx) {
-            const auto &slice_segment_info = picture_info->pNaluSliceSegmentEntries[slice_seg_idx];
-            const auto *std_slice_segment_header = slice_segment_info.pStdSliceSegmentHeader;
+            const auto& slice_segment_info = picture_info->pNaluSliceSegmentEntries[slice_seg_idx];
+            const auto* std_slice_segment_header = slice_segment_info.pStdSliceSegmentHeader;
             const Location slice_seg_info_loc =
                 loc.pNext(Struct::VkVideoEncodeH265PictureInfoKHR, Field::pNaluSliceSegmentEntries, slice_seg_idx);
 
@@ -2813,7 +2812,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer &cb_state,
 
             if (std_pps != nullptr &&
                 (profile_caps.encode_h265.flags & VK_VIDEO_ENCODE_H265_CAPABILITY_PREDICTION_WEIGHT_TABLE_GENERATED_BIT_KHR) == 0) {
-                const char *weighted_pred_error_msg = nullptr;
+                const char* weighted_pred_error_msg = nullptr;
 
                 if (std_slice_segment_header->slice_type == STD_VIDEO_H265_SLICE_TYPE_P && std_pps->flags.weighted_pred_flag) {
                     weighted_pred_error_msg =
@@ -2871,7 +2870,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer &cb_state,
                     continue;
                 }
 
-                const auto &ref_slot = reference_slots.find((int32_t)ref_list_entry);
+                const auto& ref_slot = reference_slots.find((int32_t)ref_list_entry);
                 if (ref_slot != reference_slots.end()) {
                     if (ref_slot->second != nullptr) {
                         auto std_reference_info = ref_slot->second->pStdReferenceInfo;
@@ -2906,7 +2905,7 @@ bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer &cb_state,
                     continue;
                 }
 
-                const auto &ref_slot = reference_slots.find((int32_t)ref_list_entry);
+                const auto& ref_slot = reference_slots.find((int32_t)ref_list_entry);
                 if (ref_slot != reference_slots.end()) {
                     if (ref_slot->second != nullptr) {
                         auto std_reference_info = ref_slot->second->pStdReferenceInfo;
@@ -3029,22 +3028,22 @@ bool CoreChecks::ValidateVideoEncodeInfoH265(const vvl::CommandBuffer &cb_state,
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeInfoAV1(const vvl::CommandBuffer &cb_state, const VkVideoEncodeInfoKHR &encode_info,
-                                            const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeInfoAV1(const vvl::CommandBuffer& cb_state, const VkVideoEncodeInfoKHR& encode_info,
+                                            const Location& loc) const {
     bool skip = false;
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
+    const char* pnext_msg = "chain does not contain a %s structure.";
 
-    const auto &vs_state = *cb_state.bound_video_session;
-    const auto &profile_caps = vs_state.profile->GetCapabilities();
+    const auto& vs_state = *cb_state.bound_video_session;
+    const auto& profile_caps = vs_state.profile->GetCapabilities();
 
-    const auto &rc_state = cb_state.video_encode_rate_control_state;
+    const auto& rc_state = cb_state.video_encode_rate_control_state;
 
-    const auto &vsp_state = *cb_state.bound_video_session_parameters;
+    const auto& vsp_state = *cb_state.bound_video_session_parameters;
     const auto session_params = vsp_state.Lock();
     const auto std_seq_header = session_params.GetAV1SequenceHeader();
 
-    const VkVideoEncodeAV1DpbSlotInfoKHR *setup_dpb_slot_info = nullptr;
+    const VkVideoEncodeAV1DpbSlotInfoKHR* setup_dpb_slot_info = nullptr;
     if (encode_info.pSetupReferenceSlot) {
         setup_dpb_slot_info = vku::FindStructInPNextChain<VkVideoEncodeAV1DpbSlotInfoKHR>(encode_info.pSetupReferenceSlot->pNext);
         if (!setup_dpb_slot_info) {
@@ -3053,7 +3052,7 @@ bool CoreChecks::ValidateVideoEncodeInfoAV1(const vvl::CommandBuffer &cb_state, 
         }
     }
 
-    vvl::unordered_map<int32_t, const VkVideoEncodeAV1DpbSlotInfoKHR *> reference_slots{};
+    vvl::unordered_map<int32_t, const VkVideoEncodeAV1DpbSlotInfoKHR*> reference_slots{};
     for (uint32_t i = 0; i < encode_info.referenceSlotCount; ++i) {
         auto dpb_slot_info = vku::FindStructInPNextChain<VkVideoEncodeAV1DpbSlotInfoKHR>(encode_info.pReferenceSlots[i].pNext);
         if (dpb_slot_info) {
@@ -3554,9 +3553,9 @@ bool CoreChecks::ValidateVideoEncodeInfoAV1(const vvl::CommandBuffer &cb_state, 
     return skip;
 }
 
-bool CoreChecks::ValidateVideoEncodeQuantizationMapInfo(const vvl::CommandBuffer &cb_state, const VkExtent2D &coded_extent,
-                                                        const VkVideoEncodeQuantizationMapInfoKHR &quantization_map_info,
-                                                        const Location &loc) const {
+bool CoreChecks::ValidateVideoEncodeQuantizationMapInfo(const vvl::CommandBuffer& cb_state, const VkExtent2D& coded_extent,
+                                                        const VkVideoEncodeQuantizationMapInfoKHR& quantization_map_info,
+                                                        const Location& loc) const {
     bool skip = false;
 
     const auto vs_state = cb_state.bound_video_session.get();
@@ -3635,11 +3634,11 @@ bool CoreChecks::ValidateVideoEncodeQuantizationMapInfo(const vvl::CommandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateActiveReferencePictureCount(const vvl::CommandBuffer &cb_state, const VkVideoDecodeInfoKHR &decode_info,
-                                                     const Location &loc) const {
+bool CoreChecks::ValidateActiveReferencePictureCount(const vvl::CommandBuffer& cb_state, const VkVideoDecodeInfoKHR& decode_info,
+                                                     const Location& loc) const {
     bool skip = false;
 
-    const auto &vs_state = *cb_state.bound_video_session;
+    const auto& vs_state = *cb_state.bound_video_session;
 
     uint32_t active_reference_picture_count = decode_info.referenceSlotCount;
 
@@ -3670,11 +3669,11 @@ bool CoreChecks::ValidateActiveReferencePictureCount(const vvl::CommandBuffer &c
     return skip;
 }
 
-bool CoreChecks::ValidateActiveReferencePictureCount(const vvl::CommandBuffer &cb_state, const VkVideoEncodeInfoKHR &encode_info,
-                                                     const Location &loc) const {
+bool CoreChecks::ValidateActiveReferencePictureCount(const vvl::CommandBuffer& cb_state, const VkVideoEncodeInfoKHR& encode_info,
+                                                     const Location& loc) const {
     bool skip = false;
 
-    const auto &vs_state = *cb_state.bound_video_session;
+    const auto& vs_state = *cb_state.bound_video_session;
 
     uint32_t active_reference_picture_count = encode_info.referenceSlotCount;
 
@@ -3691,11 +3690,11 @@ bool CoreChecks::ValidateActiveReferencePictureCount(const vvl::CommandBuffer &c
     return skip;
 }
 
-bool CoreChecks::ValidateReferencePictureUseCount(const vvl::CommandBuffer &cb_state, const VkVideoDecodeInfoKHR &decode_info,
-                                                  const Location &loc) const {
+bool CoreChecks::ValidateReferencePictureUseCount(const vvl::CommandBuffer& cb_state, const VkVideoDecodeInfoKHR& decode_info,
+                                                  const Location& loc) const {
     bool skip = false;
 
-    const auto &vs_state = *cb_state.bound_video_session;
+    const auto& vs_state = *cb_state.bound_video_session;
 
     std::vector<uint32_t> dpb_frame_use_count(vs_state.create_info.maxDpbSlots, 0);
 
@@ -3713,7 +3712,7 @@ bool CoreChecks::ValidateReferencePictureUseCount(const vvl::CommandBuffer &cb_s
 
     // Collect use count for each DPB across the elements pReferenceSlots and pSetupReferenceSlot
     for (uint32_t i = 0; i <= decode_info.referenceSlotCount; ++i) {
-        const VkVideoReferenceSlotInfoKHR *slot =
+        const VkVideoReferenceSlotInfoKHR* slot =
             (i == decode_info.referenceSlotCount) ? decode_info.pSetupReferenceSlot : &decode_info.pReferenceSlots[i];
 
         if (slot == nullptr) continue;
@@ -3773,17 +3772,17 @@ bool CoreChecks::ValidateReferencePictureUseCount(const vvl::CommandBuffer &cb_s
     return skip;
 }
 
-bool CoreChecks::ValidateReferencePictureUseCount(const vvl::CommandBuffer &cb_state, const VkVideoEncodeInfoKHR &encode_info,
-                                                  const Location &loc) const {
+bool CoreChecks::ValidateReferencePictureUseCount(const vvl::CommandBuffer& cb_state, const VkVideoEncodeInfoKHR& encode_info,
+                                                  const Location& loc) const {
     bool skip = false;
 
-    const auto &vs_state = *cb_state.bound_video_session;
+    const auto& vs_state = *cb_state.bound_video_session;
 
     std::vector<uint32_t> dpb_frame_use_count(vs_state.create_info.maxDpbSlots, 0);
 
     // Collect use count for each DPB across the elements pReferenceSlots and pSetupReferenceSlot
     for (uint32_t i = 0; i <= encode_info.referenceSlotCount; ++i) {
-        const VkVideoReferenceSlotInfoKHR *slot =
+        const VkVideoReferenceSlotInfoKHR* slot =
             (i == encode_info.referenceSlotCount) ? encode_info.pSetupReferenceSlot : &encode_info.pReferenceSlots[i];
 
         if (slot == nullptr) continue;
@@ -3806,14 +3805,14 @@ bool CoreChecks::ValidateReferencePictureUseCount(const vvl::CommandBuffer &cb_s
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceVideoCapabilitiesKHR(VkPhysicalDevice physicalDevice,
-                                                                          const VkVideoProfileInfoKHR *pVideoProfile,
-                                                                          VkVideoCapabilitiesKHR *pCapabilities,
-                                                                          const ErrorObject &error_obj) const {
+                                                                          const VkVideoProfileInfoKHR* pVideoProfile,
+                                                                          VkVideoCapabilitiesKHR* pCapabilities,
+                                                                          const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidateVideoProfileInfo(*this, pVideoProfile, error_obj, error_obj.location.dot(Field::pVideoProfile));
 
-    const char *caps_pnext_msg = "chain does not contain a %s structure.";
+    const char* caps_pnext_msg = "chain does not contain a %s structure.";
 
     const Location caps_loc = error_obj.location.dot(Field::pCapabilities);
 
@@ -3895,18 +3894,18 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceVideoCapabilitiesKHR(VkPhys
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceVideoFormatPropertiesKHR(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceVideoFormatInfoKHR *pVideoFormatInfo,
-    uint32_t *pVideoFormatPropertyCount, VkVideoFormatPropertiesKHR *pVideoFormatProperties, const ErrorObject &error_obj) const {
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceVideoFormatInfoKHR* pVideoFormatInfo,
+    uint32_t* pVideoFormatPropertyCount, VkVideoFormatPropertiesKHR* pVideoFormatProperties, const ErrorObject& error_obj) const {
     bool skip = false;
 
-    const auto *video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pVideoFormatInfo->pNext);
+    const auto* video_profiles = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pVideoFormatInfo->pNext);
     if (video_profiles && video_profiles->profileCount != 0) {
         skip |=
             ValidateVideoProfileListInfo(*this, video_profiles, error_obj,
                                          error_obj.location.dot(Field::pVideoFormatInfo).pNext(Struct::VkVideoProfileListInfoKHR),
                                          false, nullptr, false, nullptr);
     } else {
-        const char *msg = video_profiles ? "no VkVideoProfileListInfoKHR structure found in the pNext chain of pVideoFormatInfo."
+        const char* msg = video_profiles ? "no VkVideoProfileListInfoKHR structure found in the pNext chain of pVideoFormatInfo."
                                          : "profileCount is zero in the VkVideoProfileListInfoKHR structure included in the "
                                            "pNext chain of pVideoFormatInfo.";
         skip |=
@@ -3917,20 +3916,20 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceVideoFormatPropertiesKHR(
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR *pQualityLevelInfo,
-    VkVideoEncodeQualityLevelPropertiesKHR *pQualityLevelProperties, const ErrorObject &error_obj) const {
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR* pQualityLevelInfo,
+    VkVideoEncodeQualityLevelPropertiesKHR* pQualityLevelProperties, const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location quality_level_info_loc = error_obj.location.dot(Field::pQualityLevelInfo);
     const Location quality_level_props_loc = error_obj.location.dot(Field::pQualityLevelProperties);
 
-    const char *props_pnext_msg = "chain does not contain a %s structure.";
+    const char* props_pnext_msg = "chain does not contain a %s structure.";
 
     skip |= core::ValidateVideoProfileInfo(*this, pQualityLevelInfo->pVideoProfile, error_obj,
                                            quality_level_info_loc.dot(Field::pVideoProfile));
 
     vvl::VideoProfileDesc profile_desc(physicalDevice, pQualityLevelInfo->pVideoProfile);
-    const auto &profile_caps = profile_desc.GetCapabilities();
+    const auto& profile_caps = profile_desc.GetCapabilities();
 
     if (!profile_desc.IsEncode()) {
         skip |= LogError("VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pVideoProfile-08260", physicalDevice,
@@ -3984,9 +3983,9 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceVideoEncodeQualityLevelProp
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkVideoSessionKHR *pVideoSession,
-                                                      const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession,
+                                                      const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -3994,7 +3993,7 @@ bool CoreChecks::PreCallValidateCreateVideoSessionKHR(VkDevice device, const VkV
     skip |= core::ValidateVideoProfileInfo(*this, pCreateInfo->pVideoProfile, error_obj, create_info_loc.dot(Field::pVideoProfile));
 
     vvl::VideoProfileDesc profile_desc(physical_device, pCreateInfo->pVideoProfile);
-    const auto &profile_caps = profile_desc.GetCapabilities();
+    const auto& profile_caps = profile_desc.GetCapabilities();
 
     if (profile_caps.supported) {
         if (pCreateInfo->flags & VK_VIDEO_SESSION_CREATE_PROTECTED_CONTENT_BIT_KHR) {
@@ -4247,8 +4246,8 @@ bool CoreChecks::PreCallValidateCreateVideoSessionKHR(VkDevice device, const VkV
 }
 
 bool CoreChecks::PreCallValidateDestroyVideoSessionKHR(VkDevice device, VkVideoSessionKHR videoSession,
-                                                       const VkAllocationCallbacks *pAllocator,
-                                                       const ErrorObject &error_obj) const {
+                                                       const VkAllocationCallbacks* pAllocator,
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto video_session_state = Get<vvl::VideoSession>(videoSession)) {
         skip |= ValidateObjectNotInUse(video_session_state.get(), error_obj.location,
@@ -4259,8 +4258,8 @@ bool CoreChecks::PreCallValidateDestroyVideoSessionKHR(VkDevice device, VkVideoS
 
 bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVideoSessionKHR videoSession,
                                                           uint32_t bindSessionMemoryInfoCount,
-                                                          const VkBindVideoSessionMemoryInfoKHR *pBindSessionMemoryInfos,
-                                                          const ErrorObject &error_obj) const {
+                                                          const VkBindVideoSessionMemoryInfoKHR* pBindSessionMemoryInfos,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto vs_state = Get<vvl::VideoSession>(videoSession);
@@ -4282,8 +4281,8 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
         }
 
         for (uint32_t i = 0; i < bindSessionMemoryInfoCount; ++i) {
-            const auto &bind_info = pBindSessionMemoryInfos[i];
-            const auto &mem_binding_info = vs_state->GetMemoryBindingInfo(bind_info.memoryBindIndex);
+            const auto& bind_info = pBindSessionMemoryInfos[i];
+            const auto& mem_binding_info = vs_state->GetMemoryBindingInfo(bind_info.memoryBindIndex);
             if (mem_binding_info != nullptr) {
                 if (auto memory_state = Get<vvl::DeviceMemory>(bind_info.memory)) {
                     if (((1 << memory_state->allocate_info.memoryTypeIndex) & mem_binding_info->requirements.memoryTypeBits) == 0) {
@@ -4355,10 +4354,10 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
 }
 
 bool CoreChecks::PreCallValidateCreateVideoSessionParametersKHR(VkDevice device,
-                                                                const VkVideoSessionParametersCreateInfoKHR *pCreateInfo,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                VkVideoSessionParametersKHR *pVideoSessionParameters,
-                                                                const ErrorObject &error_obj) const {
+                                                                const VkVideoSessionParametersCreateInfoKHR* pCreateInfo,
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                VkVideoSessionParametersKHR* pVideoSessionParameters,
+                                                                const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -4379,7 +4378,7 @@ bool CoreChecks::PreCallValidateCreateVideoSessionParametersKHR(VkDevice device,
     auto vs_state = Get<vvl::VideoSession>(pCreateInfo->videoSession);
     if (!vs_state) return skip;
 
-    const char *pnext_chain_msg = "does not contain a %s structure.";
+    const char* pnext_chain_msg = "does not contain a %s structure.";
     switch (vs_state->GetCodecOp()) {
         case VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR: {
             auto codec_info = vku::FindStructInPNextChain<VkVideoDecodeH264SessionParametersCreateInfoKHR>(pCreateInfo->pNext);
@@ -4550,7 +4549,7 @@ bool CoreChecks::PreCallValidateCreateVideoSessionParametersKHR(VkDevice device,
                              "VK_VIDEO_SESSION_CREATE_ALLOW_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR or "
                              "VK_VIDEO_SESSION_CREATE_ALLOW_ENCODE_EMPHASIS_MAP_BIT_KHR.");
             } else {
-                const auto *quantization_map_info =
+                const auto* quantization_map_info =
                     vku::FindStructInPNextChain<VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR>(pCreateInfo->pNext);
                 if (quantization_map_info) {
                     skip |= ValidateEncodeQuantizationMapParametersCreateInfo(
@@ -4583,8 +4582,8 @@ bool CoreChecks::PreCallValidateCreateVideoSessionParametersKHR(VkDevice device,
 }
 
 bool CoreChecks::PreCallValidateUpdateVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters,
-                                                                const VkVideoSessionParametersUpdateInfoKHR *pUpdateInfo,
-                                                                const ErrorObject &error_obj) const {
+                                                                const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo,
+                                                                const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto vsp_state = Get<vvl::VideoSessionParameters>(videoSessionParameters);
@@ -4898,8 +4897,8 @@ bool CoreChecks::PreCallValidateUpdateVideoSessionParametersKHR(VkDevice device,
 
 bool CoreChecks::PreCallValidateDestroyVideoSessionParametersKHR(VkDevice device,
                                                                  VkVideoSessionParametersKHR videoSessionParameters,
-                                                                 const VkAllocationCallbacks *pAllocator,
-                                                                 const ErrorObject &error_obj) const {
+                                                                 const VkAllocationCallbacks* pAllocator,
+                                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto video_session_parameters_state = Get<vvl::VideoSessionParameters>(videoSessionParameters)) {
         skip |= ValidateObjectNotInUse(video_session_parameters_state.get(), error_obj.location,
@@ -4909,9 +4908,9 @@ bool CoreChecks::PreCallValidateDestroyVideoSessionParametersKHR(VkDevice device
 }
 
 bool CoreChecks::PreCallValidateGetEncodedVideoSessionParametersKHR(
-    VkDevice device, const VkVideoEncodeSessionParametersGetInfoKHR *pVideoSessionParametersInfo,
-    VkVideoEncodeSessionParametersFeedbackInfoKHR *pFeedbackInfo, size_t *pDataSize, void *pData,
-    const ErrorObject &error_obj) const {
+    VkDevice device, const VkVideoEncodeSessionParametersGetInfoKHR* pVideoSessionParametersInfo,
+    VkVideoEncodeSessionParametersFeedbackInfoKHR* pFeedbackInfo, size_t* pDataSize, void* pData,
+    const ErrorObject& error_obj) const {
     bool skip = false;
 
     const auto vsp_state = Get<vvl::VideoSessionParameters>(pVideoSessionParametersInfo->videoSessionParameters);
@@ -4921,7 +4920,7 @@ bool CoreChecks::PreCallValidateGetEncodedVideoSessionParametersKHR(
 
     auto vsp_data = vsp_state->Lock();
 
-    const char *pnext_msg = "chain does not contain a %s structure.";
+    const char* pnext_msg = "chain does not contain a %s structure.";
 
     if (vsp_state->IsEncode()) {
         switch (vsp_state->GetCodecOp()) {
@@ -5027,8 +5026,8 @@ bool CoreChecks::PreCallValidateGetEncodedVideoSessionParametersKHR(
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR *pBeginInfo,
-                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo,
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -5084,10 +5083,10 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
         vvl::VideoPictureResources unique_resources{};
         bool resources_unique = true;
         bool has_separate_images = false;
-        const vvl::Image *last_dpb_image = nullptr;
+        const vvl::Image* last_dpb_image = nullptr;
 
         for (uint32_t i = 0; i < pBeginInfo->referenceSlotCount; ++i) {
-            const auto &slot = pBeginInfo->pReferenceSlots[i];
+            const auto& slot = pBeginInfo->pReferenceSlots[i];
             const Location reference_slot_loc = begin_info_loc.dot(Field::pReferenceSlots, i);
 
             if (slot.slotIndex >= 0 && (uint32_t)slot.slotIndex >= vs_state->create_info.maxDpbSlots) {
@@ -5219,7 +5218,7 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
                          FormatHandle(pBeginInfo->videoSessionParameters).c_str(), FormatHandle(pBeginInfo->videoSession).c_str());
     }
 
-    const char *codec_op_requires_params_vuid = nullptr;
+    const char* codec_op_requires_params_vuid = nullptr;
     switch (vs_state->GetCodecOp()) {
         case VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR:
             if (!enabled_features.videoMaintenance2) {
@@ -5281,7 +5280,7 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
                             vku::FindStructInPNextChain<VkVideoEncodeH264GopRemainingFrameInfoKHR>(pBeginInfo->pNext);
                         if (vs_state->profile->GetCapabilities().encode_h264.requiresGopRemainingFrames &&
                             (gop_info_h264 == nullptr || gop_info_h264->useGopRemainingFrames == VK_FALSE)) {
-                            const char *why = gop_info_h264 == nullptr
+                            const char* why = gop_info_h264 == nullptr
                                                   ? "there is no VkVideoEncodeH264GopRemainingFrameInfoKHR structure"
                                                   : "VkVideoEncodeH264GopRemainingFrameInfoKHR::useGopRemainingFrames is VK_FALSE";
                             const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession);
@@ -5300,7 +5299,7 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
                             vku::FindStructInPNextChain<VkVideoEncodeH265GopRemainingFrameInfoKHR>(pBeginInfo->pNext);
                         if (vs_state->profile->GetCapabilities().encode_h265.requiresGopRemainingFrames &&
                             (gop_info_h265 == nullptr || gop_info_h265->useGopRemainingFrames == VK_FALSE)) {
-                            const char *why = gop_info_h265 == nullptr
+                            const char* why = gop_info_h265 == nullptr
                                                   ? "there is no VkVideoEncodeH265GopRemainingFrameInfoKHR structure"
                                                   : "VkVideoEncodeH265GopRemainingFrameInfoKHR::useGopRemainingFrames is VK_FALSE";
                             const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession);
@@ -5319,7 +5318,7 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
                             vku::FindStructInPNextChain<VkVideoEncodeAV1GopRemainingFrameInfoKHR>(pBeginInfo->pNext);
                         if (vs_state->profile->GetCapabilities().encode_av1.requiresGopRemainingFrames &&
                             (gop_info_av1 == nullptr || gop_info_av1->useGopRemainingFrames == VK_FALSE)) {
-                            const char *why = gop_info_av1 == nullptr
+                            const char* why = gop_info_av1 == nullptr
                                                   ? "there is no VkVideoEncodeAV1GopRemainingFrameInfoKHR structure"
                                                   : "VkVideoEncodeAV1GopRemainingFrameInfoKHR::useGopRemainingFrames is VK_FALSE";
                             const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession);
@@ -5343,8 +5342,8 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR *pEndCodingInfo,
-                                                     const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo,
+                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -5359,8 +5358,8 @@ bool CoreChecks::PreCallValidateCmdEndVideoCodingKHR(VkCommandBuffer commandBuff
 }
 
 bool CoreChecks::PreCallValidateCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                         const VkVideoCodingControlInfoKHR *pCodingControlInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkVideoCodingControlInfoKHR* pCodingControlInfo,
+                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -5371,10 +5370,10 @@ bool CoreChecks::PreCallValidateCmdControlVideoCodingKHR(VkCommandBuffer command
 
     const Location control_info_loc = error_obj.location.dot(Field::pCodingControlInfo);
 
-    const auto &profile_caps = vs_state->profile->GetCapabilities();
+    const auto& profile_caps = vs_state->profile->GetCapabilities();
 
-    const char *flags_pnext_msg = "has %s set but missing %s from the pNext chain of pCodingControlInfo.";
-    const char *flags_require_encode_msg = "has %s set but %s is not a video encode session.";
+    const char* flags_pnext_msg = "has %s set but missing %s from the pNext chain of pCodingControlInfo.";
+    const char* flags_require_encode_msg = "has %s set but %s is not a video encode session.";
 
     if (pCodingControlInfo->flags & VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR) {
         if (vs_state->IsEncode()) {
@@ -5426,8 +5425,8 @@ bool CoreChecks::PreCallValidateCmdControlVideoCodingKHR(VkCommandBuffer command
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR *pDecodeInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -5447,9 +5446,9 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
         return skip;
     }
 
-    const auto &bound_resources = cb_state->bound_video_picture_resources;
+    const auto& bound_resources = cb_state->bound_video_picture_resources;
 
-    const auto &profile_caps = vs_state->profile->GetCapabilities();
+    const auto& profile_caps = vs_state->profile->GetCapabilities();
 
     if (auto buffer_state = Get<vvl::Buffer>(pDecodeInfo->srcBuffer)) {
         skip |= ValidateProtectedBuffer(*cb_state, *buffer_state, decode_info_loc.dot(Field::srcBuffer),
@@ -5577,8 +5576,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                                  "the bound video session %s was created with.",
                                  FormatHandle(pDecodeInfo->dstPictureResource.imageViewBinding).c_str(),
                                  FormatHandle(dst_resource.image_state->Handle()).c_str(),
-                                 string_VideoProfileDesc(*vs_state->profile).c_str(),
-                                 FormatHandle(*vs_state).c_str());
+                                 string_VideoProfileDesc(*vs_state->profile).c_str(), FormatHandle(*vs_state).c_str());
             } else {
                 skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07142", objlist, dst_image_view_loc,
                                  "(%s created from %s) is not compatible with the video profile (%s) "
@@ -5620,7 +5618,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
         VkImageLayout expected_layout =
             dst_same_as_setup ? VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR : VK_IMAGE_LAYOUT_VIDEO_DECODE_DST_KHR;
 
-        const char *vuid =
+        const char* vuid =
             dst_same_as_setup ? "VUID-vkCmdDecodeVideoKHR-pDecodeInfo-10802" : "VUID-vkCmdDecodeVideoKHR-pDecodeInfo-10801";
 
         skip |= ValidateVideoImageLayout(*cb_state, *dst_resource.image_state, dst_resource.range, expected_layout,
@@ -5675,7 +5673,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                         resources_unique = false;
                     }
 
-                    const auto &it = bound_resources.find(reference_resource);
+                    const auto& it = bound_resources.find(reference_resource);
                     if (it == bound_resources.end()) {
                         skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07151", commandBuffer, error_obj.location,
                                          "the video picture resource specified in "
@@ -5717,7 +5715,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
     }
 
     uint32_t op_count = vs_state->GetVideoDecodeOperationCount(pDecodeInfo);
-    for (const auto &query : cb_state->active_queries) {
+    for (const auto& query : cb_state->active_queries) {
         if (query.active_query_index + op_count > query.last_activatable_query_index + 1) {
             auto query_pool_state = Get<vvl::QueryPool>(query.pool);
             skip |=
@@ -5769,7 +5767,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                     }
                 }
 
-                const auto &qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool->queueFamilyIndex];
+                const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool->queueFamilyIndex];
                 if (!qf_ext_props.query_result_status_props.queryResultStatusSupport) {
                     const LogObjectList objlist(commandBuffer, inline_query_info->queryPool);
                     skip |= LogError("VUID-vkCmdDecodeVideoKHR-queryType-08369", objlist, error_obj.location,
@@ -5806,8 +5804,8 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR *pEncodeInfo,
-                                                  const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
@@ -5843,14 +5841,14 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
         }
     }
 
-    const auto *quantization_map_info = vku::FindStructInPNextChain<VkVideoEncodeQuantizationMapInfoKHR>(pEncodeInfo->pNext);
+    const auto* quantization_map_info = vku::FindStructInPNextChain<VkVideoEncodeQuantizationMapInfoKHR>(pEncodeInfo->pNext);
 
     struct QuantizationMapInfoValidUsages {
         VkVideoEncodeFlagBitsKHR encode_flag;
         VkVideoSessionCreateFlagBitsKHR session_flag;
         VkImageUsageFlagBits image_usage_flag;
-        const char *session_mismatch_vuid;
-        const char *image_view_mismatch_vuid;
+        const char* session_mismatch_vuid;
+        const char* image_view_mismatch_vuid;
     };
     QuantizationMapInfoValidUsages quantization_map_info_valid_usages[] = {
         {
@@ -5869,7 +5867,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
         },
     };
 
-    for (auto &valid_usage : quantization_map_info_valid_usages) {
+    for (auto& valid_usage : quantization_map_info_valid_usages) {
         if ((pEncodeInfo->flags & valid_usage.encode_flag) == 0) continue;
 
         if ((vs_state->create_info.flags & valid_usage.session_flag) == 0) {
@@ -5933,9 +5931,9 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
         }
     }
 
-    const auto &bound_resources = cb_state->bound_video_picture_resources;
+    const auto& bound_resources = cb_state->bound_video_picture_resources;
 
-    const auto &profile_caps = vs_state->profile->GetCapabilities();
+    const auto& profile_caps = vs_state->profile->GetCapabilities();
 
     skip |= ValidateVideoEncodeIntraRefreshInfo(*cb_state, *vs_state, *pEncodeInfo, encode_info_loc);
 
@@ -6142,7 +6140,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                         resources_unique = false;
                     }
 
-                    const auto &it = bound_resources.find(reference_resource);
+                    const auto& it = bound_resources.find(reference_resource);
                     if (it == bound_resources.end()) {
                         skip |= LogError("VUID-vkCmdEncodeVideoKHR-pPictureResource-08219", commandBuffer, error_obj.location,
                                          "the video picture resource specified in "
@@ -6185,7 +6183,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
 
     uint32_t op_count = vs_state->GetVideoEncodeOperationCount(pEncodeInfo);
 
-    for (const auto &query : cb_state->active_queries) {
+    for (const auto& query : cb_state->active_queries) {
         if (query.active_query_index + op_count > query.last_activatable_query_index + 1) {
             auto query_pool_state = Get<vvl::QueryPool>(query.pool);
             skip |=
@@ -6239,7 +6237,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                     }
                 }
 
-                const auto &qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool->queueFamilyIndex];
+                const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool->queueFamilyIndex];
                 if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
                     !qf_ext_props.query_result_status_props.queryResultStatusSupport) {
                     const LogObjectList objlist(commandBuffer, inline_query_info->queryPool);

--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -25,7 +25,7 @@
 
 namespace vvl {
 
-const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError error) {
+const std::string& GetCopyBufferImageDeviceVUID(const Location& loc, CopyError error) {
     static const std::map<CopyError, std::array<Entry, 5>> errors{
         {CopyError::TexelBlockSize_07975,
          {{
@@ -152,7 +152,7 @@ const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError e
     }
     const Location updated_loc(f, s, loc.field, loc.index);
 
-    const auto &result = FindVUID(error, updated_loc, errors);
+    const auto& result = FindVUID(error, updated_loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-copy-buffer");
@@ -161,7 +161,7 @@ const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError e
     return result;
 }
 
-const std::string &GetCopyBufferImageVUID(const Location &loc, CopyError error) {
+const std::string& GetCopyBufferImageVUID(const Location& loc, CopyError error) {
     static const std::map<CopyError, std::array<Entry, 8>> errors{
         {CopyError::ImageOffset_07971,
          {{
@@ -367,7 +367,7 @@ const std::string &GetCopyBufferImageVUID(const Location &loc, CopyError error) 
     }
     const Location updated_loc(f, s, loc.field, loc.index);
 
-    const auto &result = FindVUID(error, updated_loc, errors);
+    const auto& result = FindVUID(error, updated_loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-copy-buffer-image");
@@ -376,7 +376,7 @@ const std::string &GetCopyBufferImageVUID(const Location &loc, CopyError error) 
     return result;
 }
 
-const std::string &GetCopyImageVUID(const Location &loc, CopyError error) {
+const std::string& GetCopyImageVUID(const Location& loc, CopyError error) {
     static const std::map<CopyError, std::array<Entry, 3>> errors{
         {CopyError::SrcImage1D_00146,
          {{
@@ -554,7 +554,7 @@ const std::string &GetCopyImageVUID(const Location &loc, CopyError error) {
          }}},
     };
 
-    const auto &result = FindVUID(error, loc, errors);
+    const auto& result = FindVUID(error, loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-copy-buffer");
@@ -563,7 +563,7 @@ const std::string &GetCopyImageVUID(const Location &loc, CopyError error) {
     return result;
 }
 
-const std::string &GetImageMipLevelVUID(const Location &loc) {
+const std::string& GetImageMipLevelVUID(const Location& loc) {
     static const std::array<Entry, 22> errors{{
         {Key(Func::vkCmdCopyImage, Field::srcSubresource), "VUID-vkCmdCopyImage-srcSubresource-07967"},
         {Key(Func::vkCmdCopyImage, Field::dstSubresource), "VUID-vkCmdCopyImage-dstSubresource-07967"},
@@ -589,7 +589,7 @@ const std::string &GetImageMipLevelVUID(const Location &loc) {
         {Key(Func::vkCmdCopyImageToMemoryKHR), "VUID-VkCopyDeviceMemoryImageInfoKHR-imageSubresource-07967"},
     }};
 
-    const auto &result = FindVUID(loc, errors);
+    const auto& result = FindVUID(loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-mip-level");
@@ -598,7 +598,7 @@ const std::string &GetImageMipLevelVUID(const Location &loc) {
     return result;
 }
 
-const std::string &GetImageArrayLayerRangeVUID(const Location &loc) {
+const std::string& GetImageArrayLayerRangeVUID(const Location& loc) {
     static const std::array<Entry, 22> errors{{
         {Key(Func::vkCmdCopyImage, Field::srcSubresource), "VUID-vkCmdCopyImage-srcSubresource-07968"},
         {Key(Func::vkCmdCopyImage, Field::dstSubresource), "VUID-vkCmdCopyImage-dstSubresource-07968"},
@@ -624,7 +624,7 @@ const std::string &GetImageArrayLayerRangeVUID(const Location &loc) {
         {Key(Func::vkCmdCopyImageToMemoryKHR), "VUID-VkCopyDeviceMemoryImageInfoKHR-imageSubresource-07968"},
     }};
 
-    const auto &result = FindVUID(loc, errors);
+    const auto& result = FindVUID(loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-array-layer-range");
@@ -633,7 +633,7 @@ const std::string &GetImageArrayLayerRangeVUID(const Location &loc) {
     return result;
 }
 
-const std::string &GetImageImageLayoutVUID(const Location &loc) {
+const std::string& GetImageImageLayoutVUID(const Location& loc) {
     static const std::array<Entry, 5> errors{{
         {Key(Func::vkTransitionImageLayout), "VUID-VkHostImageLayoutTransitionInfo-oldLayout-09229"},
         {Key(Func::vkCopyImageToMemory, Field::srcImageLayout), "VUID-VkCopyImageToMemoryInfo-srcImageLayout-09064"},
@@ -642,7 +642,7 @@ const std::string &GetImageImageLayoutVUID(const Location &loc) {
         {Key(Func::vkCopyImageToImage, Field::dstImageLayout), "VUID-VkCopyImageToImageInfo-dstImageLayout-09071"},
     }};
 
-    const auto &result = FindVUID(loc, errors);
+    const auto& result = FindVUID(loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-image-layout");
@@ -839,7 +839,7 @@ const char* GetBuildASVUID(const Location& loc, BuildASError error) {
     // clang-format on
 }
 
-const std::string &GetSubresourceRangeVUID(const Location &loc, SubresourceRangeError error) {
+const std::string& GetSubresourceRangeVUID(const Location& loc, SubresourceRangeError error) {
     static const std::map<SubresourceRangeError, std::array<Entry, 6>> errors{
         {SubresourceRangeError::BaseMip_01486,
          {{
@@ -906,7 +906,7 @@ const std::string &GetSubresourceRangeVUID(const Location &loc, SubresourceRange
          }}},
     };
 
-    const auto &result = FindVUID(error, loc, errors);
+    const auto& result = FindVUID(error, loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-subresource-range");
@@ -915,7 +915,7 @@ const std::string &GetSubresourceRangeVUID(const Location &loc, SubresourceRange
     return result;
 }
 
-const char *GetSpirvInterfaceVariableVUID(const Location &loc, SpirvInterfaceVariableError error) {
+const char* GetSpirvInterfaceVariableVUID(const Location& loc, SpirvInterfaceVariableError error) {
     // clang-format off
     switch (error) {
         case SpirvInterfaceVariableError::ShaderStage_07988:

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -46,7 +46,7 @@ static bool IsExtentInsideBounds(VkExtent2D extent, VkExtent2D min, VkExtent2D m
     return true;
 }
 
-static VkImageCreateInfo GetSwapchainImpliedImageCreateInfo(const VkSwapchainCreateInfoKHR &create_info) {
+static VkImageCreateInfo GetSwapchainImpliedImageCreateInfo(const VkSwapchainCreateInfoKHR& create_info) {
     VkImageCreateInfo result = vku::InitStructHelper();
 
     if (create_info.flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) {
@@ -75,9 +75,9 @@ static VkImageCreateInfo GetSwapchainImpliedImageCreateInfo(const VkSwapchainCre
     return result;
 }
 
-bool CoreChecks::ValidateSwapchainImageExtent(const VkSwapchainCreateInfoKHR &create_info,
-                                              const VkSurfaceCapabilitiesKHR &surface_caps, const Location &create_info_loc,
-                                              const vvl::Surface *surface_state) const {
+bool CoreChecks::ValidateSwapchainImageExtent(const VkSwapchainCreateInfoKHR& create_info,
+                                              const VkSurfaceCapabilitiesKHR& surface_caps, const Location& create_info_loc,
+                                              const vvl::Surface* surface_state) const {
     bool skip = false;
 
     if (create_info.imageExtent.width == 0 || create_info.imageExtent.height == 0) {
@@ -128,10 +128,10 @@ bool CoreChecks::ValidateSwapchainImageExtent(const VkSwapchainCreateInfoKHR &cr
 }
 
 // Validate VkSwapchainPresentModesCreateInfoKHR data
-bool CoreChecks::ValidateSwapchainPresentModesCreateInfo(VkPresentModeKHR present_mode, const Location &create_info_loc,
-                                                         const VkSwapchainCreateInfoKHR &create_info,
-                                                         const std::vector<VkPresentModeKHR> &present_modes,
-                                                         const vvl::Surface *surface_state) const {
+bool CoreChecks::ValidateSwapchainPresentModesCreateInfo(VkPresentModeKHR present_mode, const Location& create_info_loc,
+                                                         const VkSwapchainCreateInfoKHR& create_info,
+                                                         const std::vector<VkPresentModeKHR>& present_modes,
+                                                         const vvl::Surface* surface_state) const {
     bool skip = false;
     auto swapchain_present_modes_ci = vku::FindStructInPNextChain<VkSwapchainPresentModesCreateInfoKHR>(create_info.pNext);
     if (!swapchain_present_modes_ci) {
@@ -175,10 +175,10 @@ bool CoreChecks::ValidateSwapchainPresentModesCreateInfo(VkPresentModeKHR presen
     return skip;
 }
 
-bool CoreChecks::ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR present_mode, const Location &create_info_loc,
-                                                           const VkSurfaceCapabilitiesKHR &capabilities,
-                                                           const VkSwapchainCreateInfoKHR &create_info,
-                                                           const vvl::Surface *surface_state) const {
+bool CoreChecks::ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR present_mode, const Location& create_info_loc,
+                                                           const VkSurfaceCapabilitiesKHR& capabilities,
+                                                           const VkSwapchainCreateInfoKHR& create_info,
+                                                           const vvl::Surface* surface_state) const {
     bool skip = false;
     auto pres_scale_ci = vku::FindStructInPNextChain<VkSwapchainPresentScalingCreateInfoKHR>(create_info.pNext);
     if (pres_scale_ci) {
@@ -268,7 +268,7 @@ bool CoreChecks::ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR pres
         }
 
         // Further validation for when a VkSwapchainPresentModesCreateInfoKHR struct is *also* in the pNext chain
-        const auto *present_modes_ci = vku::FindStructInPNextChain<VkSwapchainPresentModesCreateInfoKHR>(create_info.pNext);
+        const auto* present_modes_ci = vku::FindStructInPNextChain<VkSwapchainPresentModesCreateInfoKHR>(create_info.pNext);
         if (present_modes_ci) {
             for (uint32_t i = 0; i < present_modes_ci->presentModeCount; i++) {
                 const Location present_mode_loc =
@@ -333,15 +333,15 @@ bool CoreChecks::IsSameNativeWindow(const VkSurfaceKHR surface_a, const VkSurfac
     return true;
 }
 
-bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_info, const vvl::Surface *surface_state,
-                                         const vvl::Swapchain *old_swapchain_state, const Location &create_info_loc) const {
+bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR& create_info, const vvl::Surface* surface_state,
+                                         const vvl::Swapchain* old_swapchain_state, const Location& create_info_loc) const {
     bool skip = false;  // TODO: update this file to use conventional skipage (needs more testing, swapchain is fragile)
 
     // All physical devices and queue families are required to be able to present to any native window on Android; require the
     // application to have established support on any other platform.
     if (!IsExtEnabled(extensions.vk_khr_android_surface)) {
         // restrict search only to queue families of VkDeviceQueueCreateInfos, not the whole physical device
-        const bool is_supported = AnyOf<vvl::Queue>([this, surface_state](const vvl::Queue &queue_state) {
+        const bool is_supported = AnyOf<vvl::Queue>([this, surface_state](const vvl::Queue& queue_state) {
             return surface_state->GetQueueSupport(physical_device, queue_state.queue_family_index);
         });
 
@@ -376,18 +376,18 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
         }
     }
 
-    void *surface_info_pnext = nullptr;
+    void* surface_info_pnext = nullptr;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     VkSurfaceFullScreenExclusiveInfoEXT full_screen_info_copy = vku::InitStructHelper();
     VkSurfaceFullScreenExclusiveWin32InfoEXT win32_full_screen_info_copy = vku::InitStructHelper();
-    const auto *full_screen_info = vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveInfoEXT>(create_info.pNext);
+    const auto* full_screen_info = vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveInfoEXT>(create_info.pNext);
     if (full_screen_info && full_screen_info->fullScreenExclusive == VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT) {
         full_screen_info_copy = *full_screen_info;
         full_screen_info_copy.pNext = surface_info_pnext;
         surface_info_pnext = &full_screen_info_copy;
 
         if (IsExtEnabled(extensions.vk_khr_win32_surface)) {
-            const auto *win32_full_screen_info =
+            const auto* win32_full_screen_info =
                 vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveWin32InfoEXT>(create_info.pNext);
             if (!win32_full_screen_info) {
                 const LogObjectList objlist(device, create_info.surface);
@@ -512,7 +512,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
         } else if (IsExtEnabled(extensions.vk_google_surfaceless_query)) {
             formats = physical_device_state->surfaceless_query_state.formats;
         }
-        for (const auto &format : formats) {
+        for (const auto& format : formats) {
             if (create_info.imageFormat == format.surfaceFormat.format) {
                 // Validate pCreateInfo->imageColorSpace against VkSurfaceFormatKHR::colorSpace:
                 found_format = true;
@@ -706,7 +706,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
                          PrintPNextChain(Struct::VkSwapchainCreateInfoKHR, create_info.pNext).c_str());
     }
 
-    const auto *swapchain_counter = vku::FindStructInPNextChain<VkSwapchainCounterCreateInfoEXT>(create_info.pNext);
+    const auto* swapchain_counter = vku::FindStructInPNextChain<VkSwapchainCounterCreateInfoEXT>(create_info.pNext);
     if (swapchain_counter) {
         VkSurfaceCapabilities2EXT surface_capabilities = vku::InitStructHelper();
         const VkResult result =
@@ -732,9 +732,9 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain,
-                                                   const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
+                                                   const ErrorObject& error_obj) const {
     auto surface_state = instance_state->Get<vvl::Surface>(pCreateInfo->surface);
     auto old_swapchain_state = Get<vvl::Swapchain>(pCreateInfo->oldSwapchain);
     return ValidateCreateSwapchain(*pCreateInfo, surface_state.get(), old_swapchain_state.get(),
@@ -742,7 +742,7 @@ bool CoreChecks::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwap
 }
 
 void CoreChecks::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
-                                                  const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                  const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     if (auto swapchain_state = Get<vvl::Swapchain>(swapchain)) {
         for (const auto& swapchain_image : swapchain_state->images) {
             ASSERT_AND_CONTINUE(swapchain_image.image_state);
@@ -751,12 +751,12 @@ void CoreChecks::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKH
     }
 }
 
-bool CoreChecks::ValidateImageAcquireWait(const vvl::SwapchainImage &swapchain_image, uint32_t image_index,
-                                          const VkPresentInfoKHR &present_info, const Location present_info_loc) const {
+bool CoreChecks::ValidateImageAcquireWait(const vvl::SwapchainImage& swapchain_image, uint32_t image_index,
+                                          const VkPresentInfoKHR& present_info, const Location present_info_loc) const {
     bool skip = false;
 
-    const auto &semaphore = swapchain_image.acquire_semaphore;
-    const auto &fence = swapchain_image.acquire_fence;
+    const auto& semaphore = swapchain_image.acquire_semaphore;
+    const auto& fence = swapchain_image.acquire_fence;
 
     // The specification requires that either a semaphore or fence is specified (or both).
     // If neither is specified the error is reported by the stateless validation.
@@ -784,7 +784,7 @@ bool CoreChecks::ValidateImageAcquireWait(const vvl::SwapchainImage &swapchain_i
     // Either semaphore or fence should be waited on (or both)
     if (!semaphore_was_waited_on && !fence_was_waited_on) {
         // TODO: Replace UNASSIGNED with official VUID when ready: https://gitlab.khronos.org/vulkan/vulkan/-/issues/3616
-        static const char *missing_acquire_wait_vuid = "UNASSIGNED-VkPresentInfoKHR-pImageIndices-MissingAcquireWait";
+        static const char* missing_acquire_wait_vuid = "UNASSIGNED-VkPresentInfoKHR-pImageIndices-MissingAcquireWait";
 
         const Location image_index_loc = present_info_loc.dot(Field::pImageIndices, image_index);
         if (semaphore && fence) {
@@ -1131,8 +1131,8 @@ bool CoreChecks::ValidateDisplayPresentInfo(VkQueue queue, VkSwapchainKHR swapch
     return skip;
 }
 
-bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
-                                                const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
     auto queue_state = Get<vvl::Queue>(queue);
 
@@ -1260,8 +1260,8 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
     return skip;
 }
 
-bool CoreChecks::PreCallValidateReleaseSwapchainImagesKHR(VkDevice device, const VkReleaseSwapchainImagesInfoKHR *pReleaseInfo,
-                                                          const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateReleaseSwapchainImagesKHR(VkDevice device, const VkReleaseSwapchainImagesInfoKHR* pReleaseInfo,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     bool image_in_use = false;
     auto swapchain_state = Get<vvl::Swapchain>(pReleaseInfo->swapchain);
@@ -1295,15 +1295,15 @@ bool CoreChecks::PreCallValidateReleaseSwapchainImagesKHR(VkDevice device, const
     return skip;
 }
 
-bool CoreChecks::PreCallValidateReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT *pReleaseInfo,
-                                                          const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo,
+                                                          const ErrorObject& error_obj) const {
     return PreCallValidateReleaseSwapchainImagesKHR(device, pReleaseInfo, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
-                                                          const VkSwapchainCreateInfoKHR *pCreateInfos,
-                                                          const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchains,
-                                                          const ErrorObject &error_obj) const {
+                                                          const VkSwapchainCreateInfoKHR* pCreateInfos,
+                                                          const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     if (pCreateInfos) {
         for (uint32_t i = 0; i < swapchainCount; i++) {
@@ -1317,7 +1317,7 @@ bool CoreChecks::PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint3
 }
 
 bool CoreChecks::PreCallValidateSetSwapchainPresentTimingQueueSizeEXT(VkDevice device, VkSwapchainKHR swapchain, uint32_t size,
-                                                                      const ErrorObject &error_obj) const {
+                                                                      const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto swapchain_state = Get<vvl::Swapchain>(swapchain);
@@ -1330,15 +1330,15 @@ bool CoreChecks::PreCallValidateSetSwapchainPresentTimingQueueSizeEXT(VkDevice d
 }
 
 bool CoreChecks::PreCallValidateGetPastPresentationTimingEXT(
-    VkDevice device, const VkPastPresentationTimingInfoEXT *pPastPresentationTimingInfo,
-    VkPastPresentationTimingPropertiesEXT *pPastPresentationTimingProperties, const ErrorObject &error_obj) const {
+    VkDevice device, const VkPastPresentationTimingInfoEXT* pPastPresentationTimingInfo,
+    VkPastPresentationTimingPropertiesEXT* pPastPresentationTimingProperties, const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto swapchain_state = Get<vvl::Swapchain>(pPastPresentationTimingInfo->swapchain);
     if (!swapchain_state->present_timing_stage_queries.empty()) {
         if ((pPastPresentationTimingInfo->flags & VK_PAST_PRESENTATION_TIMING_ALLOW_OUT_OF_ORDER_RESULTS_BIT_EXT) != 0) {
             uint32_t max = 0;
-            for (const auto &query : swapchain_state->present_timing_stage_queries) {
+            for (const auto& query : swapchain_state->present_timing_stage_queries) {
                 if (query.second.num_present_stage_queries > max) {
                     max = query.second.num_present_stage_queries;
                 }
@@ -1357,7 +1357,7 @@ bool CoreChecks::PreCallValidateGetPastPresentationTimingEXT(
         } else {
             for (uint32_t i = 0; i < pPastPresentationTimingProperties->presentationTimingCount; ++i) {
                 uint32_t max = 0;
-                for (const auto &query : swapchain_state->present_timing_stage_queries) {
+                for (const auto& query : swapchain_state->present_timing_stage_queries) {
                     if (query.first == pPastPresentationTimingProperties->pPresentationTimings[i].presentId &&
                         query.second.num_present_stage_queries > max) {
                         max = query.second.num_present_stage_queries;
@@ -1380,7 +1380,7 @@ bool CoreChecks::PreCallValidateGetPastPresentationTimingEXT(
 }
 
 bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
-                                          VkFence fence, const Location &loc, const char *semaphore_type_vuid) const {
+                                          VkFence fence, const Location& loc, const char* semaphore_type_vuid) const {
     bool skip = false;
     const bool version_2 = loc.function != Func::vkAcquireNextImageKHR;
     if (auto semaphore_state = Get<vvl::Semaphore>(semaphore)) {
@@ -1394,12 +1394,12 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
             // acquire / wait / acquire and the first acquire (and thus the wait) have completed, but our state
             // isn't aware of it yet. This results in MANY false positives.
             if (!semaphore_state->CanBinaryBeSignaled()) {
-                const char *vuid =
+                const char* vuid =
                     version_2 ? "VUID-VkAcquireNextImageInfoKHR-semaphore-01288" : "VUID-vkAcquireNextImageKHR-semaphore-01286";
                 skip |= LogError(vuid, semaphore, loc, "Semaphore must not be currently signaled.");
             }
             if (semaphore_state->InUse()) {
-                const char *vuid =
+                const char* vuid =
                     version_2 ? "VUID-VkAcquireNextImageInfoKHR-semaphore-01781" : "VUID-vkAcquireNextImageKHR-semaphore-01779";
                 skip |= LogError(vuid, semaphore, loc, "Semaphore must not have any pending operations.");
             }
@@ -1408,16 +1408,16 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
 
     if (auto fence_state = Get<vvl::Fence>(fence)) {
         const LogObjectList objlist(device, fence);
-        const char *inflight_vuid =
+        const char* inflight_vuid =
             version_2 ? "VUID-VkAcquireNextImageInfoKHR-fence-10067" : "VUID-vkAcquireNextImageKHR-fence-10066";
-        const char *retired_vuid =
+        const char* retired_vuid =
             version_2 ? "VUID-VkAcquireNextImageInfoKHR-fence-01289" : "VUID-vkAcquireNextImageKHR-fence-01287";
         skip |= ValidateFenceForSubmit(*fence_state, inflight_vuid, retired_vuid, objlist, loc);
     }
 
     if (auto swapchain_state = Get<vvl::Swapchain>(swapchain)) {
         if (swapchain_state->retired) {
-            const char *vuid =
+            const char* vuid =
                 version_2 ? "VUID-VkAcquireNextImageInfoKHR-swapchain-01675" : "VUID-vkAcquireNextImageKHR-swapchain-01285";
             skip |= LogError(vuid, swapchain, loc,
                              "This swapchain has been retired. The application can still present any images it "
@@ -1454,7 +1454,7 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
         }
         const bool too_many_already_acquired = acquired_images > swapchain_image_count - min_image_count;
         if (timeout == vvl::kU64Max && too_many_already_acquired) {
-            const char *vuid = version_2 ? "VUID-vkAcquireNextImage2KHR-surface-07784" : "VUID-vkAcquireNextImageKHR-surface-07783";
+            const char* vuid = version_2 ? "VUID-vkAcquireNextImage2KHR-surface-07784" : "VUID-vkAcquireNextImageKHR-surface-07783";
             const uint32_t acquirable = swapchain_image_count - min_image_count + 1;
             skip |= LogError(vuid, swapchain, loc,
                              "Application has already previously acquired %" PRIu32 " image%s from swapchain. Only %" PRIu32
@@ -1468,14 +1468,14 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
 }
 
 bool CoreChecks::PreCallValidateAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
-                                                    VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
-                                                    const ErrorObject &error_obj) const {
+                                                    VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
+                                                    const ErrorObject& error_obj) const {
     return ValidateAcquireNextImage(device, swapchain, timeout, semaphore, fence, error_obj.location,
                                     "VUID-vkAcquireNextImageKHR-semaphore-03265");
 }
 
-bool CoreChecks::PreCallValidateAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
-                                                     uint32_t *pImageIndex, const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
+                                                     uint32_t* pImageIndex, const ErrorObject& error_obj) const {
     bool skip = false;
     const LogObjectList objlist(pAcquireInfo->swapchain);
     const Location acquire_info_loc = error_obj.location.dot(Field::pAcquireInfo);
@@ -1489,7 +1489,7 @@ bool CoreChecks::PreCallValidateAcquireNextImage2KHR(VkDevice device, const VkAc
 }
 
 bool CoreChecks::PreCallValidateWaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout,
-                                                  const ErrorObject &error_obj) const {
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     if (!enabled_features.presentWait) {
         skip |= LogError("VUID-vkWaitForPresentKHR-presentWait-06234", swapchain, error_obj.location,
@@ -1506,8 +1506,8 @@ bool CoreChecks::PreCallValidateWaitForPresentKHR(VkDevice device, VkSwapchainKH
 }
 
 bool CoreChecks::PreCallValidateWaitForPresent2KHR(VkDevice device, VkSwapchainKHR swapchain,
-                                                   const VkPresentWait2InfoKHR *pPresentWait2Info,
-                                                   const ErrorObject &error_obj) const {
+                                                   const VkPresentWait2InfoKHR* pPresentWait2Info,
+                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     if (!enabled_features.presentWait2) {
         skip |= LogError("VUID-vkWaitForPresent2KHR-presentWait2-10814", swapchain, error_obj.location,
@@ -1543,7 +1543,7 @@ bool CoreChecks::PreCallValidateWaitForPresent2KHR(VkDevice device, VkSwapchainK
 }
 
 bool core::Instance::PreCallValidateDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
-                                                      const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
+                                                      const VkAllocationCallbacks* pAllocator, const ErrorObject& error_obj) const {
     bool skip = false;
     auto surface_state = Get<vvl::Surface>(surface);
     if (surface_state && surface_state->swapchain) {
@@ -1556,8 +1556,8 @@ bool core::Instance::PreCallValidateDestroySurfaceKHR(VkInstance instance, VkSur
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 bool core::Instance::PreCallValidateGetPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                                    uint32_t queueFamilyIndex,
-                                                                                   struct wl_display *display,
-                                                                                   const ErrorObject &error_obj) const {
+                                                                                   struct wl_display* display,
+                                                                                   const ErrorObject& error_obj) const {
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(*pd_state, queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceWaylandPresentationSupportKHR-queueFamilyIndex-01306",
@@ -1568,9 +1568,9 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceWaylandPresentationSupportK
 #ifdef VK_USE_PLATFORM_XCB_KHR
 bool core::Instance::PreCallValidateGetPhysicalDeviceXcbPresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                                uint32_t queueFamilyIndex,
-                                                                               xcb_connection_t *connection,
+                                                                               xcb_connection_t* connection,
                                                                                xcb_visualid_t visual_id,
-                                                                               const ErrorObject &error_obj) const {
+                                                                               const ErrorObject& error_obj) const {
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(*pd_state, queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceXcbPresentationSupportKHR-queueFamilyIndex-01312",
@@ -1580,9 +1580,9 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceXcbPresentationSupportKHR(V
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
 bool core::Instance::PreCallValidateGetPhysicalDeviceXlibPresentationSupportKHR(VkPhysicalDevice physicalDevice,
-                                                                                uint32_t queueFamilyIndex, Display *dpy,
+                                                                                uint32_t queueFamilyIndex, Display* dpy,
                                                                                 VisualID visualID,
-                                                                                const ErrorObject &error_obj) const {
+                                                                                const ErrorObject& error_obj) const {
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(*pd_state, queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceXlibPresentationSupportKHR-queueFamilyIndex-01315",
@@ -1593,8 +1593,8 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceXlibPresentationSupportKHR(
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
 bool core::Instance::PreCallValidateGetPhysicalDeviceScreenPresentationSupportQNX(VkPhysicalDevice physicalDevice,
                                                                                   uint32_t queueFamilyIndex,
-                                                                                  struct _screen_window *window,
-                                                                                  const ErrorObject &error_obj) const {
+                                                                                  struct _screen_window* window,
+                                                                                  const ErrorObject& error_obj) const {
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(*pd_state, queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceScreenPresentationSupportQNX-queueFamilyIndex-04743",
@@ -1604,8 +1604,8 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceScreenPresentationSupportQN
 
 #ifdef VK_USE_PLATFORM_DIRECTFB_EXT
 bool core::Instance::PreCallValidateGetPhysicalDeviceDirectFBPresentationSupportEXT(VkPhysicalDevice physicalDevice,
-                                                                                    uint32_t queueFamilyIndex, IDirectFB *dfb,
-                                                                                    const ErrorObject &error_obj) const {
+                                                                                    uint32_t queueFamilyIndex, IDirectFB* dfb,
+                                                                                    const ErrorObject& error_obj) const {
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(*pd_state, queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceDirectFBPresentationSupportEXT-queueFamilyIndex-04119",
@@ -1614,16 +1614,16 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceDirectFBPresentationSupport
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
-                                                                       VkSurfaceKHR surface, VkBool32 *pSupported,
-                                                                       const ErrorObject &error_obj) const {
+                                                                       VkSurfaceKHR surface, VkBool32* pSupported,
+                                                                       const ErrorObject& error_obj) const {
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(*pd_state, queueFamilyIndex, "VUID-vkGetPhysicalDeviceSurfaceSupportKHR-queueFamilyIndex-01269",
                                     error_obj.location.dot(Field::queueFamilyIndex));
 }
 
 bool core::Instance::PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
-                                                                        uint32_t *pDisplayCount, VkDisplayKHR *pDisplays,
-                                                                        const ErrorObject &error_obj) const {
+                                                                        uint32_t* pDisplayCount, VkDisplayKHR* pDisplays,
+                                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateGetPhysicalDeviceDisplayPlaneProperties(physicalDevice, planeIndex, error_obj.location.dot(Field::planeIndex));
     return skip;
@@ -1631,17 +1631,17 @@ bool core::Instance::PreCallValidateGetDisplayPlaneSupportedDisplaysKHR(VkPhysic
 
 bool core::Instance::PreCallValidateGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode,
                                                                    uint32_t planeIndex,
-                                                                   VkDisplayPlaneCapabilitiesKHR *pCapabilities,
-                                                                   const ErrorObject &error_obj) const {
+                                                                   VkDisplayPlaneCapabilitiesKHR* pCapabilities,
+                                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateGetPhysicalDeviceDisplayPlaneProperties(physicalDevice, planeIndex, error_obj.location.dot(Field::planeIndex));
     return skip;
 }
 
 bool core::Instance::PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
-                                                                    const VkDisplayPlaneInfo2KHR *pDisplayPlaneInfo,
-                                                                    VkDisplayPlaneCapabilities2KHR *pCapabilities,
-                                                                    const ErrorObject &error_obj) const {
+                                                                    const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
+                                                                    VkDisplayPlaneCapabilities2KHR* pCapabilities,
+                                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     skip |= ValidateGetPhysicalDeviceDisplayPlaneProperties(
         physicalDevice, pDisplayPlaneInfo->planeIndex, error_obj.location.dot(Field::pDisplayPlaneInfo).dot(Field::planeIndex));
@@ -1649,9 +1649,9 @@ bool core::Instance::PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysicalDe
 }
 
 bool core::Instance::PreCallValidateCreateDisplayPlaneSurfaceKHR(VkInstance instance,
-                                                                 const VkDisplaySurfaceCreateInfoKHR *pCreateInfo,
-                                                                 const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                                 const ErrorObject &error_obj) const {
+                                                                 const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
+                                                                 const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     const VkDisplayModeKHR display_mode = pCreateInfo->displayMode;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -1789,7 +1789,7 @@ bool core::Instance::PreCallValidateCreateDisplayPlaneSurfaceKHR(VkInstance inst
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 bool core::Instance::PreCallValidateGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                                  uint32_t queueFamilyIndex,
-                                                                                 const ErrorObject &error_obj) const {
+                                                                                 const ErrorObject& error_obj) const {
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(*pd_state, queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceWin32PresentationSupportKHR-queueFamilyIndex-01309",
@@ -1797,7 +1797,7 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceWin32PresentationSupportKHR
 }
 
 bool CoreChecks::PreCallValidateAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
-                                                                  const ErrorObject &error_obj) const {
+                                                                  const ErrorObject& error_obj) const {
     bool skip = false;
 
     auto swapchain_state = Get<vvl::Swapchain>(swapchain);
@@ -1807,7 +1807,7 @@ bool CoreChecks::PreCallValidateAcquireFullScreenExclusiveModeEXT(VkDevice devic
         skip |= LogError("VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-02674", device, error_obj.location,
                          "swapchain %s is retired.", FormatHandle(swapchain).c_str());
     }
-    const auto *surface_full_screen_exclusive_info =
+    const auto* surface_full_screen_exclusive_info =
         vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveInfoEXT>(swapchain_state->create_info.pNext);
     if (!surface_full_screen_exclusive_info ||
         surface_full_screen_exclusive_info->fullScreenExclusive != VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT) {
@@ -1825,7 +1825,7 @@ bool CoreChecks::PreCallValidateAcquireFullScreenExclusiveModeEXT(VkDevice devic
 }
 
 bool CoreChecks::PreCallValidateReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
-                                                                  const ErrorObject &error_obj) const {
+                                                                  const ErrorObject& error_obj) const {
     bool skip = false;
 
     const auto swapchain_state = Get<vvl::Swapchain>(swapchain);
@@ -1835,7 +1835,7 @@ bool CoreChecks::PreCallValidateReleaseFullScreenExclusiveModeEXT(VkDevice devic
         skip |= LogError("VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-02677", device, error_obj.location,
                          "swapchain %s is retired.", FormatHandle(swapchain).c_str());
     }
-    const auto *surface_full_screen_exclusive_info =
+    const auto* surface_full_screen_exclusive_info =
         vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveInfoEXT>(swapchain_state->create_info.pNext);
     if (!surface_full_screen_exclusive_info ||
         surface_full_screen_exclusive_info->fullScreenExclusive != VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT) {
@@ -1849,12 +1849,12 @@ bool CoreChecks::PreCallValidateReleaseFullScreenExclusiveModeEXT(VkDevice devic
 }
 
 bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(VkDevice device,
-                                                                      const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                      VkDeviceGroupPresentModeFlagsKHR *pModes,
-                                                                      const ErrorObject &error_obj) const {
+                                                                      const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                      VkDeviceGroupPresentModeFlagsKHR* pModes,
+                                                                      const ErrorObject& error_obj) const {
     bool skip = false;
 
-    const auto *core_instance = reinterpret_cast<core::Instance *>(instance_proxy);
+    const auto* core_instance = reinterpret_cast<core::Instance*>(instance_proxy);
     const Location info_loc = error_obj.location.dot(Field::pSurfaceInfo);
     const Location surface_loc = info_loc.dot(Field::surface);
     if (device_state->physical_device_count == 1) {
@@ -1870,10 +1870,10 @@ bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(VkDevice d
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfacePresentModes2EXT(VkPhysicalDevice physicalDevice,
-                                                                             const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                             uint32_t *pPresentModeCount,
-                                                                             VkPresentModeKHR *pPresentModes,
-                                                                             const ErrorObject &error_obj) const {
+                                                                             const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                             uint32_t* pPresentModeCount,
+                                                                             VkPresentModeKHR* pPresentModes,
+                                                                             const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location info_loc = error_obj.location.dot(Field::pSurfaceInfo);
@@ -1911,10 +1911,10 @@ bool core::Instance::ValidatePhysicalDeviceSurfaceSupport(VkPhysicalDevice physi
 }
 
 bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface,
-                                                                     VkDeviceGroupPresentModeFlagsKHR *pModes,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     VkDeviceGroupPresentModeFlagsKHR* pModes,
+                                                                     const ErrorObject& error_obj) const {
     bool skip = false;
-    const auto *core_instance = static_cast<core::Instance *>(instance_proxy);
+    const auto* core_instance = static_cast<core::Instance*>(instance_proxy);
     const Location surface_loc = error_obj.location.dot(Field::surface);
     if (device_state->physical_device_count == 1) {
         skip |= core_instance->ValidatePhysicalDeviceSurfaceSupport(physical_device, surface, surface_loc);
@@ -1929,8 +1929,8 @@ bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModesKHR(VkDevice de
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDevicePresentRectanglesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                          uint32_t *pRectCount, VkRect2D *pRects,
-                                                                          const ErrorObject &error_obj) const {
+                                                                          uint32_t* pRectCount, VkRect2D* pRects,
+                                                                          const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidatePhysicalDeviceSurfaceSupport(physicalDevice, surface, error_obj.location.dot(Field::surface));
@@ -1939,8 +1939,8 @@ bool core::Instance::PreCallValidateGetPhysicalDevicePresentRectanglesKHR(VkPhys
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                             VkSurfaceCapabilities2EXT *pSurfaceCapabilities,
-                                                                             const ErrorObject &error_obj) const {
+                                                                             VkSurfaceCapabilities2EXT* pSurfaceCapabilities,
+                                                                             const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidatePhysicalDeviceSurfaceSupport(physicalDevice, surface, error_obj.location.dot(Field::surface));
@@ -1949,9 +1949,9 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2EXT(VkP
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice,
-                                                                             const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                             VkSurfaceCapabilities2KHR *pSurfaceCapabilities,
-                                                                             const ErrorObject &error_obj) const {
+                                                                             const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                             VkSurfaceCapabilities2KHR* pSurfaceCapabilities,
+                                                                             const ErrorObject& error_obj) const {
     bool skip = false;
 
     const Location info_loc = error_obj.location.dot(Field::pSurfaceInfo);
@@ -1962,7 +1962,7 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(VkP
     ASSERT_AND_RETURN_SKIP(surface_state);
 
     if (IsExtEnabled(extensions.vk_khr_surface_maintenance1) || IsExtEnabled(extensions.vk_ext_surface_maintenance1)) {
-        const auto *surface_present_mode = vku::FindStructInPNextChain<VkSurfacePresentModeKHR>(pSurfaceInfo->pNext);
+        const auto* surface_present_mode = vku::FindStructInPNextChain<VkSurfacePresentModeKHR>(pSurfaceInfo->pNext);
         if (surface_present_mode) {
             VkPresentModeKHR present_mode = surface_present_mode->presentMode;
             std::vector<VkPresentModeKHR> present_modes{};
@@ -1982,9 +1982,9 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(VkP
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     if (IsExtEnabled(extensions.vk_khr_win32_surface) && IsExtEnabled(extensions.vk_ext_full_screen_exclusive)) {
-        if (const auto *full_screen_info = vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveInfoEXT>(pSurfaceInfo->pNext);
+        if (const auto* full_screen_info = vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveInfoEXT>(pSurfaceInfo->pNext);
             full_screen_info && full_screen_info->fullScreenExclusive == VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT) {
-            if (const auto *win32_full_screen_info =
+            if (const auto* win32_full_screen_info =
                     vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveWin32InfoEXT>(pSurfaceInfo->pNext);
                 !win32_full_screen_info) {
                 const LogObjectList objlist(physicalDevice, pSurfaceInfo->surface);
@@ -2001,8 +2001,8 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(VkP
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                            VkSurfaceCapabilitiesKHR *pSurfaceCapabilities,
-                                                                            const ErrorObject &error_obj) const {
+                                                                            VkSurfaceCapabilitiesKHR* pSurfaceCapabilities,
+                                                                            const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidatePhysicalDeviceSurfaceSupport(physicalDevice, surface, error_obj.location.dot(Field::surface));
@@ -2011,10 +2011,10 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPh
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice,
-                                                                        const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                        uint32_t *pSurfaceFormatCount,
-                                                                        VkSurfaceFormat2KHR *pSurfaceFormats,
-                                                                        const ErrorObject &error_obj) const {
+                                                                        const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                        uint32_t* pSurfaceFormatCount,
+                                                                        VkSurfaceFormat2KHR* pSurfaceFormats,
+                                                                        const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidatePhysicalDeviceSurfaceSupport(physicalDevice, pSurfaceInfo->surface,
@@ -2024,9 +2024,9 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(VkPhysic
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                       uint32_t *pSurfaceFormatCount,
-                                                                       VkSurfaceFormatKHR *pSurfaceFormats,
-                                                                       const ErrorObject &error_obj) const {
+                                                                       uint32_t* pSurfaceFormatCount,
+                                                                       VkSurfaceFormatKHR* pSurfaceFormats,
+                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidatePhysicalDeviceSurfaceSupport(physicalDevice, surface, error_obj.location.dot(Field::surface));
@@ -2035,9 +2035,9 @@ bool core::Instance::PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(VkPhysica
 }
 
 bool core::Instance::PreCallValidateGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                            uint32_t *pPresentModeCount,
-                                                                            VkPresentModeKHR *pPresentModes,
-                                                                            const ErrorObject &error_obj) const {
+                                                                            uint32_t* pPresentModeCount,
+                                                                            VkPresentModeKHR* pPresentModes,
+                                                                            const ErrorObject& error_obj) const {
     bool skip = false;
 
     skip |= ValidatePhysicalDeviceSurfaceSupport(physicalDevice, surface, error_obj.location.dot(Field::surface));

--- a/layers/core_checks/cc_ycbcr.cpp
+++ b/layers/core_checks/cc_ycbcr.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
@@ -34,10 +34,10 @@ bool CoreChecks::FormatRequiresYcbcrConversionExplicitly(const VkFormat format) 
     return vkuFormatRequiresYcbcrConversion(format);
 }
 
-bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator,
-                                                             VkSamplerYcbcrConversion *pYcbcrConversion,
-                                                             const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator,
+                                                             VkSamplerYcbcrConversion* pYcbcrConversion,
+                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     const VkFormat conversion_format = pCreateInfo->format;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -136,9 +136,9 @@ bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, co
 }
 
 bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversionKHR(VkDevice device,
-                                                                const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                VkSamplerYcbcrConversion *pYcbcrConversion,
-                                                                const ErrorObject &error_obj) const {
+                                                                const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                VkSamplerYcbcrConversion* pYcbcrConversion,
+                                                                const ErrorObject& error_obj) const {
     return PreCallValidateCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, error_obj);
 }

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -42,7 +42,7 @@
 namespace vvl {
 
 // This seems like it could be useful elsewhere, but until find another spot, just keep here.
-static const char *GetActionType(Func command) {
+static const char* GetActionType(Func command) {
     if (IsCommandDispatch(command)) {
         return "dispatch";
     } else if (IsCommandTraceRays(command)) {
@@ -52,7 +52,7 @@ static const char *GetActionType(Func command) {
     }
 }
 
-std::string DescriptorValidator::DescribeDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, uint32_t index,
+std::string DescriptorValidator::DescribeDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, uint32_t index,
                                                     VkDescriptorType type) const {
     std::ostringstream ss;
     switch (type) {
@@ -133,9 +133,9 @@ std::string DescriptorValidator::DescribeInstruction() const {
     return ss.str();
 }
 
-DescriptorValidator::DescriptorValidator(vvl::DeviceProxy &dev, CommandBuffer &cb_state, DescriptorSet &descriptor_set,
-                                         uint32_t set_index, VkFramebuffer framebuffer, const LogObjectList *objlist,
-                                         const Location &loc)
+DescriptorValidator::DescriptorValidator(vvl::DeviceProxy& dev, CommandBuffer& cb_state, DescriptorSet& descriptor_set,
+                                         uint32_t set_index, VkFramebuffer framebuffer, const LogObjectList* objlist,
+                                         const Location& loc)
     : Logger(dev.debug_report),
       dev_proxy(dev),
       is_gpu_av(dev.container_type == LayerObjectTypeGpuAssisted),
@@ -149,14 +149,14 @@ DescriptorValidator::DescriptorValidator(vvl::DeviceProxy &dev, CommandBuffer &c
       set_index(set_index),
       objlist(objlist) {}
 
-void DescriptorValidator::SetLocationForGpuAv(const Location &gpuav_loc) {
+void DescriptorValidator::SetLocationForGpuAv(const Location& gpuav_loc) {
     loc = LocationCapture(gpuav_loc);
     vuids = &GetDrawDispatchVuid(gpuav_loc.function);
 }
 
 template <typename T>
-bool DescriptorValidator::ValidateDescriptorsStatic(const spirv::ResourceInterfaceVariable &resource_variable,
-                                                    const T &binding) const {
+bool DescriptorValidator::ValidateDescriptorsStatic(const spirv::ResourceInterfaceVariable& resource_variable,
+                                                    const T& binding) const {
     bool skip = false;
 
     // If there is a descriptor array, we care about the size of the array statically used in the shader, not what was declared in
@@ -168,7 +168,7 @@ bool DescriptorValidator::ValidateDescriptorsStatic(const spirv::ResourceInterfa
     }
 
     for (uint32_t index = 0; !skip && index < count; index++) {
-        const auto &descriptor = binding.descriptors[index];
+        const auto& descriptor = binding.descriptors[index];
 
         if (!binding.updated[index]) {
             const LogObjectList objlist(this->objlist, descriptor_set.Handle());
@@ -184,30 +184,30 @@ bool DescriptorValidator::ValidateDescriptorsStatic(const spirv::ResourceInterfa
     return skip;
 }
 
-bool DescriptorValidator::ValidateBindingStatic(const spirv::ResourceInterfaceVariable &resource_variable,
-                                                const DescriptorBinding &binding) const {
+bool DescriptorValidator::ValidateBindingStatic(const spirv::ResourceInterfaceVariable& resource_variable,
+                                                const DescriptorBinding& binding) const {
     bool skip = false;
     switch (binding.descriptor_class) {
         case DescriptorClass::GeneralBuffer:
-            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const BufferBinding &>(binding));
+            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const BufferBinding&>(binding));
             break;
         case DescriptorClass::ImageSampler:
-            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const ImageSamplerBinding &>(binding));
+            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const ImageSamplerBinding&>(binding));
             break;
         case DescriptorClass::Image:
-            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const ImageBinding &>(binding));
+            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const ImageBinding&>(binding));
             break;
         case DescriptorClass::PlainSampler:
-            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const SamplerBinding &>(binding));
+            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const SamplerBinding&>(binding));
             break;
         case DescriptorClass::TexelBuffer:
-            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const TexelBinding &>(binding));
+            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const TexelBinding&>(binding));
             break;
         case DescriptorClass::AccelerationStructure:
-            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const AccelerationStructureBinding &>(binding));
+            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const AccelerationStructureBinding&>(binding));
             break;
         case DescriptorClass::Tensor:
-            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const TensorBinding &>(binding));
+            skip |= ValidateDescriptorsStatic(resource_variable, static_cast<const TensorBinding&>(binding));
             break;
         case DescriptorClass::InlineUniform:
             break;  // Can't validate the descriptor because it may not have been updated.
@@ -221,10 +221,10 @@ bool DescriptorValidator::ValidateBindingStatic(const spirv::ResourceInterfaceVa
 }
 
 template <typename T>
-bool DescriptorValidator::ValidateDescriptorsDynamic(const spirv::ResourceInterfaceVariable &resource_variable, const T &binding,
+bool DescriptorValidator::ValidateDescriptorsDynamic(const spirv::ResourceInterfaceVariable& resource_variable, const T& binding,
                                                      const uint32_t index) {
     bool skip = false;
-    const auto &descriptor = binding.descriptors[index];
+    const auto& descriptor = binding.descriptors[index];
 
     if (!binding.updated[index]) {
         const LogObjectList objlist(this->objlist, descriptor_set.Handle());
@@ -238,44 +238,43 @@ bool DescriptorValidator::ValidateDescriptorsDynamic(const spirv::ResourceInterf
     return skip;
 }
 
-bool DescriptorValidator::ValidateBindingDynamic(const spirv::ResourceInterfaceVariable &resource_variable,
-                                                 DescriptorBinding &binding, const uint32_t index) {
+bool DescriptorValidator::ValidateBindingDynamic(const spirv::ResourceInterfaceVariable& resource_variable,
+                                                 DescriptorBinding& binding, const uint32_t index) {
     bool skip = false;
 
     switch (binding.descriptor_class) {
         case DescriptorClass::GeneralBuffer:
-            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const BufferBinding &>(binding), index);
+            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const BufferBinding&>(binding), index);
             break;
         case DescriptorClass::ImageSampler: {
-            auto &img_sampler_binding = static_cast<ImageSamplerBinding &>(binding);
+            auto& img_sampler_binding = static_cast<ImageSamplerBinding&>(binding);
             if (dev_proxy.gpuav_settings.validate_image_layout) {
-                auto &descriptor = img_sampler_binding.descriptors[index];
+                auto& descriptor = img_sampler_binding.descriptors[index];
                 descriptor.UpdateImageLayoutDrawState(cb_state);
             }
             skip |= ValidateDescriptorsDynamic(resource_variable, img_sampler_binding, index);
             break;
         }
         case DescriptorClass::Image: {
-            auto &img_binding = static_cast<ImageBinding &>(binding);
+            auto& img_binding = static_cast<ImageBinding&>(binding);
             if (dev_proxy.gpuav_settings.validate_image_layout) {
-                auto &descriptor = img_binding.descriptors[index];
+                auto& descriptor = img_binding.descriptors[index];
                 descriptor.UpdateImageLayoutDrawState(cb_state);
             }
             skip |= ValidateDescriptorsDynamic(resource_variable, img_binding, index);
             break;
         }
         case DescriptorClass::PlainSampler:
-            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const SamplerBinding &>(binding), index);
+            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const SamplerBinding&>(binding), index);
             break;
         case DescriptorClass::TexelBuffer:
-            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const TexelBinding &>(binding), index);
+            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const TexelBinding&>(binding), index);
             break;
         case DescriptorClass::AccelerationStructure:
-            skip |=
-                ValidateDescriptorsDynamic(resource_variable, static_cast<const AccelerationStructureBinding &>(binding), index);
+            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const AccelerationStructureBinding&>(binding), index);
             break;
         case DescriptorClass::Tensor:
-            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const TensorBinding &>(binding), index);
+            skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const TensorBinding&>(binding), index);
             break;
         case DescriptorClass::InlineUniform:
             break;  // TODO - Can give warning if reading uninitialized data
@@ -288,8 +287,8 @@ bool DescriptorValidator::ValidateBindingDynamic(const spirv::ResourceInterfaceV
     return skip;
 }
 
-bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, const uint32_t index,
-                                             VkDescriptorType descriptor_type, const BufferDescriptor &descriptor) const {
+bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, const uint32_t index,
+                                             VkDescriptorType descriptor_type, const BufferDescriptor& descriptor) const {
     bool skip = false;
     // Verify that buffers are valid
     const VkBuffer buffer = descriptor.GetBuffer();
@@ -309,7 +308,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
         return skip;
     }
     if (buffer_node /* && !buffer_node->sparse*/) {
-        for (const auto &binding : buffer_node->GetInvalidMemory()) {
+        for (const auto& binding : buffer_node->GetInvalidMemory()) {
             const LogObjectList objlist(this->objlist, descriptor_set.Handle());
             skip |= LogError(vuids->descriptor_buffer_bit_set_08114, objlist, loc.Get(),
                              "the %s is using buffer %s that references invalid memory %s.%s",
@@ -331,7 +330,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     return skip;
 }
 
-static const char *SuggestImageViewType(spv::Dim dim, bool is_image_array) {
+static const char* SuggestImageViewType(spv::Dim dim, bool is_image_array) {
     VkImageViewType suggest = VK_IMAGE_VIEW_TYPE_MAX_ENUM;
     if (dim == spv::Dim1D) {
         suggest = is_image_array ? VK_IMAGE_VIEW_TYPE_1D_ARRAY : VK_IMAGE_VIEW_TYPE_1D;
@@ -349,30 +348,30 @@ static const char *SuggestImageViewType(spv::Dim dim, bool is_image_array) {
 }
 
 // 'index' is the index into the descriptor
-bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, const uint32_t index,
-                                             VkDescriptorType descriptor_type, const ImageDescriptor &image_descriptor) const {
+bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, const uint32_t index,
+                                             VkDescriptorType descriptor_type, const ImageDescriptor& image_descriptor) const {
     // We skip various parts of checks for core check to prevent false positive when we don't know the index
     bool skip = false;
-    std::vector<const Sampler *> sampler_states;
+    std::vector<const Sampler*> sampler_states;
     const VkImageView image_view = image_descriptor.GetImageView();
-    const ImageView *image_view_state = image_descriptor.GetImageViewState();
+    const ImageView* image_view_state = image_descriptor.GetImageViewState();
 
     if (image_descriptor.GetClass() == DescriptorClass::ImageSampler) {
-        sampler_states.emplace_back(static_cast<const ImageSamplerDescriptor &>(image_descriptor).GetSamplerState());
+        sampler_states.emplace_back(static_cast<const ImageSamplerDescriptor&>(image_descriptor).GetSamplerState());
     } else if (is_gpu_av) {
         // TODO - This will skip for GPU-AV because we don't currently capture array of samplers with array of sampled images
         // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8922
         // To not give false positve, we will skip all Sampler related checks since sampler_states will be empty
     } else {
         if (index < resource_variable.samplers_used_by_image.size()) {
-            for (const auto &sampler_used : resource_variable.samplers_used_by_image[index]) {
-                const auto *descriptor =
+            for (const auto& sampler_used : resource_variable.samplers_used_by_image[index]) {
+                const auto* descriptor =
                     descriptor_set.GetDescriptorFromBinding(sampler_used.sampler_slot.binding, sampler_used.sampler_index);
                 // TODO: This check _shouldn't_ be necessary due to the checks made in ResourceInterfaceVariable() in
                 //       shader_validation.cpp. However, without this check some traces still crash.
                 // The issue is we set dynamic image index to zero in samplers_used_by_image so will fail GPU-AV case
                 if (descriptor && (descriptor->GetClass() == DescriptorClass::PlainSampler)) {
-                    const auto *sampler_state = static_cast<const SamplerDescriptor *>(descriptor)->GetSamplerState();
+                    const auto* sampler_state = static_cast<const SamplerDescriptor*>(descriptor)->GetSamplerState();
                     if (sampler_state) sampler_states.emplace_back(sampler_state);
                 }
             }
@@ -400,7 +399,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     const auto image_state = image_view_state->image_state.get();
     ASSERT_AND_RETURN_SKIP(image_state);
 
-    const auto &image_view_ci = image_view_state->create_info;
+    const auto& image_view_ci = image_view_state->create_info;
 
     const spv::Dim dim = resource_variable.info.image_dim;
     const bool is_image_array = resource_variable.info.is_image_array;
@@ -494,7 +493,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                     msg << "1. Set your ImageView to " << string_VkFormat(resource_variable.info.vk_format)
                         << " and swizzle the values in the shader to match the desired results.\n";
                 } else {
-                    const char *suggested_format = string_SpirvImageFormat(image_view_ci.format);
+                    const char* suggested_format = string_SpirvImageFormat(image_view_ci.format);
                     if (strncmp(suggested_format, "Unknown", 7) != 0) {
                         msg << "1. Change your shader to use " << suggested_format << " instead as that matches "
                             << string_VkFormat(image_view_ci.format) << "\n";
@@ -639,8 +638,8 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     if (!cb_state.active_attachments.empty() && !cb_state.active_subpasses.empty() &&
         (descriptor_type != VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
         for (uint32_t att_index = 0; att_index < cb_state.active_attachments.size(); ++att_index) {
-            const auto &attachment_info = cb_state.active_attachments[att_index];
-            const auto *view_state = attachment_info.image_view;
+            const auto& attachment_info = cb_state.active_attachments[att_index];
+            const auto* view_state = attachment_info.image_view;
             if (!view_state || view_state->Destroyed()) {
                 continue;
             }
@@ -656,7 +655,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                 if (!stage.HasSpirv()) {
                     continue;
                 }
-                for (const auto &interface_variable : stage.entrypoint->resource_interface_variables) {
+                for (const auto& interface_variable : stage.entrypoint->resource_interface_variables) {
                     if (interface_variable.decorations.set == set_index &&
                         interface_variable.decorations.binding == binding_index) {
                         descriptor_written_to |= interface_variable.IsWrittenTo();
@@ -665,7 +664,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                 }
             }
 
-            const SubpassInfo &subpass = cb_state.active_subpasses[att_index];
+            const SubpassInfo& subpass = cb_state.active_subpasses[att_index];
             const bool layout_read_only = IsImageLayoutReadOnly(attachment_info.layout);
             const bool read_attachment = (subpass.usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) != 0;
             if (read_attachment && descriptor_written_to) {
@@ -729,7 +728,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     if (skip) return skip;
 
     const VkFormat image_view_format = image_view_state->create_info.format;
-    for (const auto *sampler_state : sampler_states) {
+    for (const auto* sampler_state : sampler_states) {
         if (!sampler_state || sampler_state->Destroyed()) {
             continue;
         }
@@ -900,7 +899,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
         // UnnormalizedCoordinates sampler validations
         // only check if sampled as could have a texelFetch on a combined image sampler
         if (sampler_state->create_info.unnormalizedCoordinates && image_insn.is_sampler_sampled) {
-            const auto &subresource_range = image_view_state->normalized_subresource_range;
+            const auto& subresource_range = image_view_state->normalized_subresource_range;
 
             // If ImageView is used by a unnormalizedCoordinates sampler, it needs to check ImageView type
             if (image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_3D || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
@@ -978,10 +977,10 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     return skip;
 }
 
-bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, const uint32_t index,
-                                             VkDescriptorType descriptor_type, const ImageSamplerDescriptor &descriptor) const {
+bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, const uint32_t index,
+                                             VkDescriptorType descriptor_type, const ImageSamplerDescriptor& descriptor) const {
     bool skip = false;
-    skip |= ValidateDescriptor(resource_variable, index, descriptor_type, static_cast<const ImageDescriptor &>(descriptor));
+    skip |= ValidateDescriptor(resource_variable, index, descriptor_type, static_cast<const ImageDescriptor&>(descriptor));
     if (skip) {
         return skip;
     }
@@ -990,8 +989,8 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     return skip;
 }
 
-bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, const uint32_t index,
-                                             VkDescriptorType descriptor_type, const TexelDescriptor &texel_descriptor) const {
+bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, const uint32_t index,
+                                             VkDescriptorType descriptor_type, const TexelDescriptor& texel_descriptor) const {
     bool skip = false;
     const VkBufferView buffer_view = texel_descriptor.GetBufferView();
     auto buffer_view_state = texel_descriptor.GetBufferViewState();
@@ -1012,7 +1011,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     if (!resource_variable.IsAccessed()) return skip;
 
     auto buffer = buffer_view_state->create_info.buffer;
-    const auto *buffer_state = buffer_view_state->buffer_state.get();
+    const auto* buffer_state = buffer_view_state->buffer_state.get();
     if (!buffer_state || buffer_state->Destroyed()) {
         const LogObjectList objlist(this->objlist, descriptor_set.Handle());
         skip |= LogError(vuids->descriptor_buffer_bit_set_08114, objlist, loc.Get(),
@@ -1062,7 +1061,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                 msg << "1. Set your BuffereView to " << string_VkFormat(resource_variable.info.vk_format)
                     << " and swizzle the values in the shader to match the desired results.\n";
             } else {
-                const char *suggested_format = string_SpirvImageFormat(buffer_view_format);
+                const char* suggested_format = string_SpirvImageFormat(buffer_view_format);
                 if (strncmp(suggested_format, "Unknown", 7) != 0) {
                     msg << "1. Change your shader to use " << suggested_format << " instead as that matches "
                         << string_VkFormat(buffer_view_format) << "\n";
@@ -1168,9 +1167,9 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     return skip;
 }
 
-bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, const uint32_t index,
+bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, const uint32_t index,
                                              VkDescriptorType descriptor_type,
-                                             const AccelerationStructureDescriptor &descriptor) const {
+                                             const AccelerationStructureDescriptor& descriptor) const {
     bool skip = false;
     // Verify that acceleration structures are valid
     if (descriptor.IsKHR()) {
@@ -1186,7 +1185,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                                  DescribeInstruction().c_str());
             }
         } else if (acc_node->buffer_state) {
-            for (const auto &mem_binding : acc_node->buffer_state->GetInvalidMemory()) {
+            for (const auto& mem_binding : acc_node->buffer_state->GetInvalidMemory()) {
                 const LogObjectList objlist(this->objlist, descriptor_set.Handle());
                 skip |= LogError(vuids->descriptor_buffer_bit_set_08114, objlist, loc.Get(),
                                  "the %s is using acceleration structure %s that references invalid memory %s.%s",
@@ -1207,7 +1206,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                                  DescribeInstruction().c_str());
             }
         } else {
-            for (const auto &mem_binding : acc_node->GetInvalidMemory()) {
+            for (const auto& mem_binding : acc_node->GetInvalidMemory()) {
                 const LogObjectList objlist(this->objlist, descriptor_set.Handle());
                 skip |= LogError(vuids->descriptor_buffer_bit_set_08114, objlist, loc.Get(),
                                  "the %s is using acceleration structure %s that references invalid memory %s.%s",
@@ -1222,8 +1221,8 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
 // If the validation is related to both of image and sampler,
 // please leave it in (descriptor_class == DescriptorClass::ImageSampler || descriptor_class ==
 // DescriptorClass::Image) Here is to validate for only sampler.
-bool DescriptorValidator::ValidateSamplerDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, uint32_t index,
-                                                    VkSampler sampler, bool is_immutable, const Sampler *sampler_state) const {
+bool DescriptorValidator::ValidateSamplerDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, uint32_t index,
+                                                    VkSampler sampler, bool is_immutable, const Sampler* sampler_state) const {
     bool skip = false;
 
     // maintenance4 specifies that pipeline layout and its children (set layout, immutable samplers)
@@ -1249,17 +1248,17 @@ bool DescriptorValidator::ValidateSamplerDescriptor(const spirv::ResourceInterfa
     return skip;
 }
 
-bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, const uint32_t index,
-                                             VkDescriptorType descriptor_type, const SamplerDescriptor &descriptor) const {
+bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, const uint32_t index,
+                                             VkDescriptorType descriptor_type, const SamplerDescriptor& descriptor) const {
     return ValidateSamplerDescriptor(resource_variable, index, descriptor.GetSampler(), descriptor.IsImmutableSampler(),
                                      descriptor.GetSamplerState());
 }
 
-bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, uint32_t index,
-                                             VkDescriptorType descriptor_type, const vvl::TensorDescriptor &descriptor) const {
+bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVariable& resource_variable, uint32_t index,
+                                             VkDescriptorType descriptor_type, const vvl::TensorDescriptor& descriptor) const {
     bool skip = false;
 
-    const vvl::TensorView *tensor_view_state = descriptor.GetTensorViewState();
+    const vvl::TensorView* tensor_view_state = descriptor.GetTensorViewState();
     ASSERT_AND_RETURN_SKIP(tensor_view_state);
     if (tensor_view_state->Destroyed()) {
         const LogObjectList objlist(this->objlist, descriptor_set.Handle());
@@ -1269,7 +1268,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                          FormatHandle(tensor_view_state->Handle()).c_str(), DescribeInstruction().c_str());
         return skip;
     }
-    const vvl::Tensor *tensor_state = descriptor.GetTensorState();
+    const vvl::Tensor* tensor_state = descriptor.GetTensorState();
     ASSERT_AND_RETURN_SKIP(tensor_state);
     if (tensor_state->Destroyed()) {
         const LogObjectList objlist(this->objlist, descriptor_set.Handle());
@@ -1291,11 +1290,12 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     if (loc.Get().function != Func::vkCmdDispatchDataGraphARM) {
         if (resource_variable.info.tensor_rank != tensor_state->create_info.pDescription->dimensionCount) {
             const LogObjectList objlist(cb_state.Handle(), this->objlist, descriptor_set.Handle(), tensor_state->Handle());
-            skip |= LogError(
-                vuids->tensorARM_dimensionCount_09905, objlist, loc.Get(),
-                "the %s is using tensor %s created with dimensionCount %" PRIu32 ", but the corresponding OpTypeTensorARM has rank %" PRIu32 ".%s",
-                DescribeDescriptor(resource_variable, index, descriptor_type).c_str(), FormatHandle(tensor_state->Handle()).c_str(),
-                tensor_state->create_info.pDescription->dimensionCount, resource_variable.info.tensor_rank, DescribeInstruction().c_str());
+            skip |= LogError(vuids->tensorARM_dimensionCount_09905, objlist, loc.Get(),
+                             "the %s is using tensor %s created with dimensionCount %" PRIu32
+                             ", but the corresponding OpTypeTensorARM has rank %" PRIu32 ".%s",
+                             DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
+                             FormatHandle(tensor_state->Handle()).c_str(), tensor_state->create_info.pDescription->dimensionCount,
+                             resource_variable.info.tensor_rank, DescribeInstruction().c_str());
         }
         if (resource_variable.info.vk_format != tensor_view_state->create_info.format) {
             const LogObjectList objlist(cb_state.Handle(), this->objlist, descriptor_set.Handle(), tensor_view_state->Handle());

--- a/layers/error_message/error_location.cpp
+++ b/layers/error_message/error_location.cpp
@@ -108,8 +108,7 @@ std::string PrintPNextChain(vvl::Struct in_struct, const void* in_pNext) {
 namespace vvl {
 LocationCapture::LocationCapture(const Location& loc) { Capture(loc, 1); }
 
-LocationCapture::LocationCapture(const LocationCapture& other)
-    : capture(other.capture) {
+LocationCapture::LocationCapture(const LocationCapture& other) : capture(other.capture) {
     if (capture.empty()) {
         return;
     }
@@ -119,8 +118,7 @@ LocationCapture::LocationCapture(const LocationCapture& other)
     }
 }
 
-LocationCapture::LocationCapture(LocationCapture&& other)
-    : capture(std::move(other.capture)) {
+LocationCapture::LocationCapture(LocationCapture&& other) : capture(std::move(other.capture)) {
     if (capture.empty()) {
         return;
     }
@@ -209,7 +207,7 @@ bool operator==(const Key& key, const Location& loc) {
         return true;
     }
     if (key.recurse_field) {
-        const Location *prev = loc.prev;
+        const Location* prev = loc.prev;
         while (prev != nullptr) {
             if (key.field == prev->field) {
                 return true;

--- a/layers/error_message/error_strings.cpp
+++ b/layers/error_message/error_strings.cpp
@@ -24,7 +24,7 @@
 
 #include <sstream>
 
-constexpr const char *indent = "    ";
+constexpr const char* indent = "    ";
 
 std::string string_VkDependencyInfo(const Logger& logger, VkDependencyInfo set_dependency_info, VkDependencyInfo dependency_info) {
     std::ostringstream set;
@@ -220,10 +220,10 @@ std::string string_VkDependencyInfo(const Logger& logger, VkDependencyInfo set_d
     return "event was set with " + set.str() + " and is being waited on with " + wait.str();
 }
 
-static std::string BuffersFromAddressStr(const vvl::DeviceProxy &validator, VkDeviceAddress address) {
+static std::string BuffersFromAddressStr(const vvl::DeviceProxy& validator, VkDeviceAddress address) {
     std::string buffers_str;
-    vvl::span<vvl::Buffer *const> buffers = validator.GetBuffersByAddress(address);
-    for (vvl::Buffer *const buffer : buffers) {
+    vvl::span<vvl::Buffer* const> buffers = validator.GetBuffersByAddress(address);
+    for (vvl::Buffer* const buffer : buffers) {
         if (!buffers_str.empty()) {
             buffers_str += '\n';
         }
@@ -234,8 +234,8 @@ static std::string BuffersFromAddressStr(const vvl::DeviceProxy &validator, VkDe
     return buffers_str;
 }
 
-std::string string_VkAccelerationStructureBuildGeometryInfoKHR(const Logger &logger,
-                                                               const VkAccelerationStructureBuildGeometryInfoKHR &info) {
+std::string string_VkAccelerationStructureBuildGeometryInfoKHR(const Logger& logger,
+                                                               const VkAccelerationStructureBuildGeometryInfoKHR& info) {
     std::stringstream ss;
 
     ss << indent << "type: " << string_VkAccelerationStructureTypeKHR(info.type) << '\n';
@@ -253,7 +253,7 @@ std::string string_VkAccelerationStructureBuildGeometryInfoKHR(const Logger &log
 }
 
 std::string string_VkAccelerationStructureGeometryTrianglesDataKHR(
-    const vvl::DeviceProxy &validator, const VkAccelerationStructureGeometryTrianglesDataKHR &triangles) {
+    const vvl::DeviceProxy& validator, const VkAccelerationStructureGeometryTrianglesDataKHR& triangles) {
     std::string pertains = indent;
     pertains += indent;
     pertains += "Pertains to the following buffer(s):\n";
@@ -293,7 +293,7 @@ std::string string_VkAccelerationStructureGeometryTrianglesDataKHR(
     return ss_str;
 }
 
-std::string string_VkAccelerationStructureGeometryAabbsDataKHR(const vvl::DeviceProxy &validator,
+std::string string_VkAccelerationStructureGeometryAabbsDataKHR(const vvl::DeviceProxy& validator,
                                                                const VkAccelerationStructureGeometryAabbsDataKHR aabb) {
     std::string pertains = indent;
     pertains += indent;
@@ -314,7 +314,7 @@ std::string string_VkAccelerationStructureGeometryAabbsDataKHR(const vvl::Device
     return ss_str;
 }
 
-std::string string_VkAccelerationStructureBuildRangeInfoKHR(const VkAccelerationStructureBuildRangeInfoKHR &bri) {
+std::string string_VkAccelerationStructureBuildRangeInfoKHR(const VkAccelerationStructureBuildRangeInfoKHR& bri) {
     std::stringstream ss;
     ss << indent << "primitiveCount: " << bri.primitiveCount << '\n';
     ss << indent << "primitiveOffset: " << bri.primitiveOffset << '\n';

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -34,10 +34,10 @@
 #include "utils/text_utils.h"
 #include "error_message/log_message_type.h"
 
-[[maybe_unused]] const char *kVUIDUndefined = "VUID_Undefined";
+[[maybe_unused]] const char* kVUIDUndefined = "VUID_Undefined";
 
-static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, VkDebugUtilsMessageSeverityFlagsEXT *da_severity,
-                                                VkDebugUtilsMessageTypeFlagsEXT *da_type) {
+static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, VkDebugUtilsMessageSeverityFlagsEXT* da_severity,
+                                                VkDebugUtilsMessageTypeFlagsEXT* da_type) {
     *da_severity = 0;
     *da_type = 0;
     // If it's explicitly listed as a performance warning, treat it as a performance message. Otherwise, treat it as a validation
@@ -64,9 +64,9 @@ static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, 
     }
 }
 
-void DebugReport::SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks) {
+void DebugReport::SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState>& callbacks) {
     // For all callback in list, return their complete set of severities and modes
-    for (const auto &item : callbacks) {
+    for (const auto& item : callbacks) {
         if (item.IsUtils()) {
             active_msg_severities |= item.debug_utils_msg_flags;
             active_msg_types |= item.debug_utils_msg_type;
@@ -81,7 +81,7 @@ void DebugReport::SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState
 }
 
 void DebugReport::RemoveDebugUtilsCallback(uint64_t callback) {
-    std::vector<VkLayerDbgFunctionState> &callbacks = debug_callback_list;
+    std::vector<VkLayerDbgFunctionState>& callbacks = debug_callback_list;
     auto item = callbacks.begin();
     for (item = callbacks.begin(); item != callbacks.end(); item++) {
         if (item->IsUtils()) {
@@ -97,8 +97,8 @@ void DebugReport::RemoveDebugUtilsCallback(uint64_t callback) {
 }
 
 // We try to return as early as we can if we know we don't need to spend time logging the message
-bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, const LogObjectList &objects, const Location &loc,
-                             const std::string &main_message) {
+bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, const LogObjectList& objects, const Location& loc,
+                             const std::string& main_message) {
     // Convert the info to the VK_EXT_debug_utils format
     VkDebugUtilsMessageSeverityFlagsEXT msg_severity;
     VkDebugUtilsMessageTypeFlagsEXT msg_type;
@@ -155,7 +155,7 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
     std::vector<VkDebugUtilsObjectNameInfoEXT> object_name_infos;
     object_name_infos.reserve(objects.object_list.size());
     for (uint32_t i = 0; i < objects.object_list.size(); i++) {
-        const VulkanTypedHandle &current_object = objects.object_list[i];
+        const VulkanTypedHandle& current_object = objects.object_list[i];
         // If only one VkDevice was created, it is just noise to print it out in the error message.
         // Also avoid printing unknown objects, likely if new function is calling error with null LogObjectList
         if ((current_object.type == kVulkanObjectTypeDevice && device_created <= 1) ||
@@ -217,7 +217,7 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
     const auto callback_list = &debug_callback_list;
     // We only output to default callbacks if there are no non-default callbacks
     bool use_default_callbacks = true;
-    for (const auto &current_callback : *callback_list) {
+    for (const auto& current_callback : *callback_list) {
         use_default_callbacks &= current_callback.IsDefault();
     }
 
@@ -227,9 +227,9 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
     }
 #endif
 
-    const char *layer_prefix = "Validation";
+    const char* layer_prefix = "Validation";
     bool bail = false;
-    for (const auto &current_callback : *callback_list) {
+    for (const auto& current_callback : *callback_list) {
         // Skip callback if it's a default callback and there are non-default callbacks present
         if (current_callback.IsDefault() && !use_default_callbacks) continue;
 
@@ -261,7 +261,7 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
     return bail;
 }
 
-std::string DebugReport::CreateMessageText(const Location &loc, std::string_view vuid_text, const std::string &main_message,
+std::string DebugReport::CreateMessageText(const Location& loc, std::string_view vuid_text, const std::string& main_message,
                                            bool at_message_limit) {
     std::ostringstream oss;
 
@@ -282,9 +282,9 @@ std::string DebugReport::CreateMessageText(const Location &loc, std::string_view
 
     // Append the spec error text to the error message, unless it contains a word treated as special
     if ((vuid_text.find("VUID-") != std::string::npos)) {
-        const char *spec_text = nullptr;
+        const char* spec_text = nullptr;
         // Only the Antora site will make use of the sections
-        const char *spec_url_section = nullptr;
+        const char* spec_url_section = nullptr;
         const auto found_vuid = GetVuidMap().find(vuid_text);
         if (found_vuid != GetVuidMap().end()) {
             spec_text = found_vuid->second.spec_text.data();
@@ -294,9 +294,9 @@ std::string DebugReport::CreateMessageText(const Location &loc, std::string_view
         // Construct and append the specification text and link to the appropriate version of the spec
         if (spec_text && spec_url_section) {
 #ifdef ANNOTATED_SPEC_LINK
-            const char *spec_url_base = ANNOTATED_SPEC_LINK;
+            const char* spec_url_base = ANNOTATED_SPEC_LINK;
 #else
-            const char *spec_url_base = "https://docs.vulkan.org/spec/latest/";
+            const char* spec_url_base = "https://docs.vulkan.org/spec/latest/";
 #endif
 
             const auto last_char = main_message.back();
@@ -319,9 +319,9 @@ std::string DebugReport::CreateMessageText(const Location &loc, std::string_view
     return oss.str();
 }
 
-std::string DebugReport::CreateMessageJson(VkFlags msg_flags, const Location &loc,
-                                           const std::vector<VkDebugUtilsObjectNameInfoEXT> &object_name_infos,
-                                           const uint32_t vuid_hash, std::string_view vuid_text, const std::string &main_message,
+std::string DebugReport::CreateMessageJson(VkFlags msg_flags, const Location& loc,
+                                           const std::vector<VkDebugUtilsObjectNameInfoEXT>& object_name_infos,
+                                           const uint32_t vuid_hash, std::string_view vuid_text, const std::string& main_message,
                                            bool at_message_limit) {
     std::ostringstream oss;
     // For now we just list each JSON field as a new line as it is "pretty-print enough".
@@ -356,12 +356,14 @@ std::string DebugReport::CreateMessageJson(VkFlags msg_flags, const Location &lo
         oss << "\"," << new_line;
     }
 
-    { oss << line_start << "\"VUID\" : \"" << vuid_text << "\"," << new_line; }
+    {
+        oss << line_start << "\"VUID\" : \"" << vuid_text << "\"," << new_line;
+    }
 
     {
         oss << line_start << "\"Objects\" : [" << new_line;
         for (uint32_t i = 0; i < object_name_infos.size(); i++) {
-            const VkDebugUtilsObjectNameInfoEXT &src_object = object_name_infos[i];
+            const VkDebugUtilsObjectNameInfoEXT& src_object = object_name_infos[i];
 
             oss << line_start << line_start;
             oss << "{\"type\" : \"" << string_VkObjectTypeHandleName(src_object.objectType) << "\", \"handle\" : \"";
@@ -383,9 +385,15 @@ std::string DebugReport::CreateMessageJson(VkFlags msg_flags, const Location &lo
         oss << line_start << "]," << new_line;
     }
 
-    { oss << line_start << "\"MessageID\" : \"0x" << std::hex << vuid_hash << "\"," << new_line; }
-    { oss << line_start << "\"Function\" : \"" << loc.StringFunc() << "\"," << new_line; }
-    { oss << line_start << "\"Location\" : \"" << loc.Fields() << "\"," << new_line; }
+    {
+        oss << line_start << "\"MessageID\" : \"0x" << std::hex << vuid_hash << "\"," << new_line;
+    }
+    {
+        oss << line_start << "\"Function\" : \"" << loc.StringFunc() << "\"," << new_line;
+    }
+    {
+        oss << line_start << "\"Location\" : \"" << loc.Fields() << "\"," << new_line;
+    }
     {
         oss << line_start << "\"MainMessage\" : \"";
 
@@ -414,9 +422,9 @@ std::string DebugReport::CreateMessageJson(VkFlags msg_flags, const Location &lo
     }
 
     if ((vuid_text.find("VUID-") != std::string::npos)) {
-        const char *spec_text = nullptr;
+        const char* spec_text = nullptr;
         // Only the Antora site will make use of the sections
-        const char *spec_url_section = nullptr;
+        const char* spec_url_section = nullptr;
         const auto found_vuid = GetVuidMap().find(vuid_text);
         if (found_vuid != GetVuidMap().end()) {
             spec_text = found_vuid->second.spec_text.data();
@@ -448,7 +456,7 @@ std::string DebugReport::CreateMessageJson(VkFlags msg_flags, const Location &lo
     return oss.str();
 }
 
-void DebugReport::SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+void DebugReport::SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT* pNameInfo) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
     if (pNameInfo->pObjectName) {
         debug_utils_object_name_map[pNameInfo->objectHandle] = pNameInfo->pObjectName;
@@ -457,7 +465,7 @@ void DebugReport::SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameI
     }
 }
 
-void DebugReport::SetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+void DebugReport::SetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT* pNameInfo) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
     if (pNameInfo->pObjectName) {
         debug_object_name_map[pNameInfo->object] = pNameInfo->pObjectName;
@@ -488,7 +496,7 @@ std::string DebugReport::GetMarkerObjectNameNoLock(const uint64_t object) const 
     return label;
 }
 
-std::string DebugReport::FormatHandle(const char *handle_type_name, uint64_t handle) const {
+std::string DebugReport::FormatHandle(const char* handle_type_name, uint64_t handle) const {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
     std::string handle_name = GetUtilsObjectNameNoLock(handle);
     if (handle_name.empty()) {
@@ -513,9 +521,9 @@ LoggingLabel::LoggingLabel(const VkDebugUtilsLabelEXT* label_info) {
 }
 
 template <typename Map>
-static LoggingLabelState *GetLoggingLabelState(Map *map, typename Map::key_type key, bool insert) {
+static LoggingLabelState* GetLoggingLabelState(Map* map, typename Map::key_type key, bool insert) {
     auto iter = map->find(key);
-    LoggingLabelState *label_state = nullptr;
+    LoggingLabelState* label_state = nullptr;
     if (iter == map->end()) {
         if (insert) {
             // Add a label state if not present
@@ -530,10 +538,10 @@ static LoggingLabelState *GetLoggingLabelState(Map *map, typename Map::key_type 
     return label_state;
 }
 
-void DebugReport::BeginQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT *label_info) {
+void DebugReport::BeginQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT* label_info) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
     if (nullptr != label_info && nullptr != label_info->pLabelName) {
-        auto *label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ true);
+        auto* label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ true);
         assert(label_state);
         label_state->labels.push_back(label_info);
 
@@ -544,7 +552,7 @@ void DebugReport::BeginQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLab
 
 void DebugReport::EndQueueDebugUtilsLabel(VkQueue queue) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ false);
+    auto* label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ false);
     if (label_state) {
         // Pop the normal item
         if (!label_state->labels.empty()) {
@@ -556,18 +564,18 @@ void DebugReport::EndQueueDebugUtilsLabel(VkQueue queue) {
     }
 }
 
-void DebugReport::InsertQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT *label_info) {
+void DebugReport::InsertQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT* label_info) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ true);
+    auto* label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ true);
 
     // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
     label_state->insert_label = LoggingLabel(label_info);
 }
 
-void DebugReport::BeginCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT *label_info) {
+void DebugReport::BeginCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT* label_info) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
     if (nullptr != label_info && nullptr != label_info->pLabelName) {
-        auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ true);
+        auto* label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ true);
         assert(label_state);
         label_state->labels.push_back(label_info);
 
@@ -578,7 +586,7 @@ void DebugReport::BeginCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const 
 
 void DebugReport::EndCmdDebugUtilsLabel(VkCommandBuffer command_buffer) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ false);
+    auto* label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ false);
     if (label_state) {
         // Pop the normal item
         if (!label_state->labels.empty()) {
@@ -590,9 +598,9 @@ void DebugReport::EndCmdDebugUtilsLabel(VkCommandBuffer command_buffer) {
     }
 }
 
-void DebugReport::InsertCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT *label_info) {
+void DebugReport::InsertCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT* label_info) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ true);
+    auto* label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ true);
     assert(label_state);
 
     // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
@@ -602,7 +610,7 @@ void DebugReport::InsertCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const
 // Current tracking beyond a single command buffer scope is incorrect, and even when it is we need to be able to clean up
 void DebugReport::ResetCmdDebugUtilsLabel(VkCommandBuffer command_buffer) {
     std::unique_lock<std::mutex> lock(debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ false);
+    auto* label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ false);
     if (label_state) {
         label_state->labels.clear();
         label_state->insert_label.Reset();
@@ -615,18 +623,18 @@ void DebugReport::EraseCmdDebugUtilsLabel(VkCommandBuffer command_buffer) {
 }
 
 template <typename TCreateInfo, typename TCallback>
-static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, DebugReport *debug_report, const TCreateInfo *create_info,
-                                TCallback *callback) {
+static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, DebugReport* debug_report, const TCreateInfo* create_info,
+                                TCallback* callback) {
     std::unique_lock<std::mutex> lock(debug_report->debug_output_mutex);
 
     debug_report->debug_callback_list.emplace_back(VkLayerDbgFunctionState());
-    auto &callback_state = debug_report->debug_callback_list.back();
+    auto& callback_state = debug_report->debug_callback_list.back();
     callback_state.callback_status = callback_status;
     callback_state.pUserData = create_info->pUserData;
 
     if (callback_state.IsUtils()) {
-        auto utils_create_info = reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT *>(create_info);
-        auto utils_callback = reinterpret_cast<VkDebugUtilsMessengerEXT *>(callback);
+        auto utils_create_info = reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(create_info);
+        auto utils_callback = reinterpret_cast<VkDebugUtilsMessengerEXT*>(callback);
         if (!(*utils_callback)) {
             // callback constructed default callbacks have no handle -- so use struct address as unique handle
             *utils_callback = reinterpret_cast<VkDebugUtilsMessengerEXT>(&callback_state);
@@ -636,8 +644,8 @@ static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, DebugR
         callback_state.debug_utils_msg_flags = utils_create_info->messageSeverity;
         callback_state.debug_utils_msg_type = utils_create_info->messageType;
     } else {  // Debug report callback
-        auto report_create_info = reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT *>(create_info);
-        auto report_callback = reinterpret_cast<VkDebugReportCallbackEXT *>(callback);
+        auto report_create_info = reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT*>(create_info);
+        auto report_callback = reinterpret_cast<VkDebugReportCallbackEXT*>(callback);
         if (!(*report_callback)) {
             // Internally constructed default callbacks have no handle -- so use struct address as unique handle
             *report_callback = reinterpret_cast<VkDebugReportCallbackEXT>(&callback_state);
@@ -659,22 +667,22 @@ static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, DebugR
     debug_report->SetDebugUtilsSeverityFlags(debug_report->debug_callback_list);
 }
 
-VKAPI_ATTR VkResult LayerCreateMessengerCallback(DebugReport *debug_report, bool default_callback,
-                                                 const VkDebugUtilsMessengerCreateInfoEXT *create_info,
-                                                 VkDebugUtilsMessengerEXT *messenger) {
+VKAPI_ATTR VkResult LayerCreateMessengerCallback(DebugReport* debug_report, bool default_callback,
+                                                 const VkDebugUtilsMessengerCreateInfoEXT* create_info,
+                                                 VkDebugUtilsMessengerEXT* messenger) {
     LayerCreateCallback((DEBUG_CALLBACK_UTILS | (default_callback ? DEBUG_CALLBACK_DEFAULT : 0)), debug_report, create_info,
                         messenger);
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR VkResult LayerCreateReportCallback(DebugReport *debug_report, bool default_callback,
-                                              const VkDebugReportCallbackCreateInfoEXT *create_info,
-                                              VkDebugReportCallbackEXT *callback) {
+VKAPI_ATTR VkResult LayerCreateReportCallback(DebugReport* debug_report, bool default_callback,
+                                              const VkDebugReportCallbackCreateInfoEXT* create_info,
+                                              VkDebugReportCallbackEXT* callback) {
     LayerCreateCallback((default_callback ? DEBUG_CALLBACK_DEFAULT : 0), debug_report, create_info, callback);
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void ActivateInstanceDebugCallbacks(DebugReport *debug_report) {
+VKAPI_ATTR void ActivateInstanceDebugCallbacks(DebugReport* debug_report) {
     auto current = debug_report->instance_pnext_chain;
     for (;;) {
         auto create_info = vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(current);
@@ -692,13 +700,13 @@ VKAPI_ATTR void ActivateInstanceDebugCallbacks(DebugReport *debug_report) {
     }
 }
 
-VKAPI_ATTR void DeactivateInstanceDebugCallbacks(DebugReport *debug_report) {
+VKAPI_ATTR void DeactivateInstanceDebugCallbacks(DebugReport* debug_report) {
     if (!vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(debug_report->instance_pnext_chain) &&
         !vku::FindStructInPNextChain<VkDebugReportCallbackCreateInfoEXT>(debug_report->instance_pnext_chain))
         return;
     std::vector<VkDebugUtilsMessengerEXT> instance_utils_callback_handles{};
     std::vector<VkDebugReportCallbackEXT> instance_report_callback_handles{};
-    for (const auto &item : debug_report->debug_callback_list) {
+    for (const auto& item : debug_report->debug_callback_list) {
         if (item.IsInstance()) {
             if (item.IsUtils()) {
                 instance_utils_callback_handles.push_back(item.debug_utils_callback_object);
@@ -707,24 +715,24 @@ VKAPI_ATTR void DeactivateInstanceDebugCallbacks(DebugReport *debug_report) {
             }
         }
     }
-    for (const auto &item : instance_utils_callback_handles) {
+    for (const auto& item : instance_utils_callback_handles) {
         LayerDestroyCallback(debug_report, item);
     }
-    for (const auto &item : instance_report_callback_handles) {
+    for (const auto& item : instance_report_callback_handles) {
         LayerDestroyCallback(debug_report, item);
     }
 }
 
-bool DebugReport::LogMessageVaList(VkFlags msg_flags, std::string_view vuid_text, const LogObjectList &objects, const Location &loc,
-                                   const char *format, va_list argptr) {
+bool DebugReport::LogMessageVaList(VkFlags msg_flags, std::string_view vuid_text, const LogObjectList& objects, const Location& loc,
+                                   const char* format, va_list argptr) {
     const std::string main_message = text::VFormat(format, argptr);
     return LogMessage(msg_flags, vuid_text, objects, loc, main_message);
 }
 
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback([[maybe_unused]] VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                       [[maybe_unused]] VkDebugUtilsMessageTypeFlagsEXT message_type,
-                                                      [[maybe_unused]] const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
-                                                      [[maybe_unused]] void *user_data) {
+                                                      [[maybe_unused]] const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
+                                                      [[maybe_unused]] void* user_data) {
     // TODO: Consider to use https://github.com/scottt/debugbreak
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     DebugBreak();
@@ -737,7 +745,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback([[maybe_unused]] VkDebugUt
 
 static std::string CreateDefaultCallbackMessage(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                 VkDebugUtilsMessageTypeFlagsEXT message_type,
-                                                const VkDebugUtilsMessengerCallbackDataEXT &callback_data) {
+                                                const VkDebugUtilsMessengerCallbackDataEXT& callback_data) {
     std::ostringstream oss;
 
     // The callback is in JSON (this is the only way the first char is '{')
@@ -768,7 +776,7 @@ static std::string CreateDefaultCallbackMessage(VkDebugUtilsMessageSeverityFlagB
     if (callback_data.objectCount > 0) {
         oss << "Objects: " << callback_data.objectCount << '\n';
         for (uint32_t i = 0; i < callback_data.objectCount; i++) {
-            const auto &debug_object = callback_data.pObjects[i];
+            const auto& debug_object = callback_data.pObjects[i];
             oss << "    [" << i << "] " << string_VkObjectTypeHandleName(debug_object.objectType);
             if (debug_object.objectHandle) {
                 oss << " 0x" << std::hex << debug_object.objectHandle;
@@ -791,14 +799,14 @@ static std::string CreateDefaultCallbackMessage(VkDebugUtilsMessageSeverityFlagB
 
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                     VkDebugUtilsMessageTypeFlagsEXT message_type,
-                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data) {
+                                                    const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data) {
     const std::string msg_buffer_str = CreateDefaultCallbackMessage(message_severity, message_type, *callback_data);
 
     // By default we are really just printing to stdout
     // Even if this is stdout, we still want to print for android
     // VVL testing (and probably other systems now) call freopen() to map stdout to dedicated file
-    fprintf((FILE *)user_data, "%s", msg_buffer_str.c_str());
-    fflush((FILE *)user_data);
+    fprintf((FILE*)user_data, "%s", msg_buffer_str.c_str());
+    fflush((FILE*)user_data);
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     // If the user uses there own callback, we can let them fix the formatting, but as a default, some error messages will be way to
@@ -820,10 +828,10 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityF
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                             VkDebugUtilsMessageTypeFlagsEXT message_type,
-                                                            const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
-                                                            [[maybe_unused]] void *user_data) {
+                                                            const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
+                                                            [[maybe_unused]] void* user_data) {
     const std::string msg_buffer_str = CreateDefaultCallbackMessage(message_severity, message_type, *callback_data);
-    const char *cstr = msg_buffer_str.c_str();
+    const char* cstr = msg_buffer_str.c_str();
     OutputDebugStringA(cstr);
     return false;
 }

--- a/layers/error_message/spirv_logging.cpp
+++ b/layers/error_message/spirv_logging.cpp
@@ -52,8 +52,8 @@ struct SpirvLoggingInfo {
 
 // Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
 // Split the single string into a vector of strings, one for each line, for easier processing.
-static void ReadOpSource(const std::vector<uint32_t> &instructions, const uint32_t reported_file_id,
-                         std::vector<std::string> &out_source_lines) {
+static void ReadOpSource(const std::vector<uint32_t>& instructions, const uint32_t reported_file_id,
+                         std::vector<std::string>& out_source_lines) {
     uint32_t offset = kModuleStartingOffset;
     while (offset < instructions.size()) {
         const uint32_t instruction = instructions[offset];
@@ -67,7 +67,7 @@ static void ReadOpSource(const std::vector<uint32_t> &instructions, const uint32
         // OpSource has been found
         std::istringstream in_stream;
         std::string current_line;
-        const char *str = reinterpret_cast<const char *>(&instructions[offset + 4]);
+        const char* str = reinterpret_cast<const char*>(&instructions[offset + 4]);
         in_stream.str(str);
         while (std::getline(in_stream, current_line)) {
             out_source_lines.emplace_back(current_line);
@@ -88,7 +88,7 @@ static void ReadOpSource(const std::vector<uint32_t> &instructions, const uint32
 
         std::istringstream in_stream;
         std::string current_line;
-        const char *str = reinterpret_cast<const char *>(&instructions[offset + 1]);
+        const char* str = reinterpret_cast<const char*>(&instructions[offset + 1]);
         in_stream.str(str);
         while (std::getline(in_stream, current_line)) {
             out_source_lines.emplace_back(current_line);
@@ -97,8 +97,8 @@ static void ReadOpSource(const std::vector<uint32_t> &instructions, const uint32
     }
 }
 
-static void ReadDebugSource(const std::vector<uint32_t> &instructions, const uint32_t debug_source_id, uint32_t &out_file_string_id,
-                            std::vector<std::string> &out_source_lines) {
+static void ReadDebugSource(const std::vector<uint32_t>& instructions, const uint32_t debug_source_id, uint32_t& out_file_string_id,
+                            std::vector<std::string>& out_source_lines) {
     uint32_t offset = kModuleStartingOffset;
     while (offset < instructions.size()) {
         const uint32_t instruction = instructions[offset];
@@ -119,7 +119,7 @@ static void ReadDebugSource(const std::vector<uint32_t> &instructions, const uin
         }
 
         const uint32_t string_id = instructions[offset + 6];
-        const char *source_text = spirv::GetOpString(instructions, string_id);
+        const char* source_text = spirv::GetOpString(instructions, string_id);
         if (!source_text) {
             return;  // error should be caught in spirv-val, but don't crash here
         }
@@ -146,7 +146,7 @@ static void ReadDebugSource(const std::vector<uint32_t> &instructions, const uin
         }
 
         const uint32_t string_id = instructions[offset + 5];
-        const char *continue_text = spirv::GetOpString(instructions, string_id);
+        const char* continue_text = spirv::GetOpString(instructions, string_id);
         if (!continue_text) {
             return;  // error should be caught in spirv-val, but don't crash here
         }
@@ -179,7 +179,7 @@ static void ReadDebugSource(const std::vector<uint32_t> &instructions, const uin
 //   is why we need to examine the entire contents of the source, instead of leaving early
 //   when finding a #line line number larger than the reported error line number.
 //
-static bool GetLineFromDirective(const std::string &string, uint32_t *linenumber, std::string &filename) {
+static bool GetLineFromDirective(const std::string& string, uint32_t* linenumber, std::string& filename) {
     static const std::regex line_regex(  // matches #line directives
         "^"                              // beginning of line
         "\\s*"                           // optional whitespace
@@ -207,7 +207,7 @@ static bool GetLineFromDirective(const std::string &string, uint32_t *linenumber
 }
 
 // Return false if any error arise
-static bool GetLineAndFilename(std::ostringstream &ss, const std::vector<uint32_t> &instructions, SpirvLoggingInfo &logging_info) {
+static bool GetLineAndFilename(std::ostringstream& ss, const std::vector<uint32_t>& instructions, SpirvLoggingInfo& logging_info) {
     const std::string debug_info_type = (logging_info.using_shader_debug_info) ? "DebugSource" : "OpLine";
     if (logging_info.file_string_id == 0) {
         // This error should be caught in spirv-val
@@ -215,7 +215,7 @@ static bool GetLineAndFilename(std::ostringstream &ss, const std::vector<uint32_
         return false;
     }
 
-    const char *file_string_insn = spirv::GetOpString(instructions, logging_info.file_string_id);
+    const char* file_string_insn = spirv::GetOpString(instructions, logging_info.file_string_id);
     if (!file_string_insn) {
         // This error should be caught in spirv-val
         ss << "(Unable to find SPIR-V OpString " << logging_info.file_string_id << " from " << debug_info_type << " instruction)\n";
@@ -241,8 +241,8 @@ static bool GetLineAndFilename(std::ostringstream &ss, const std::vector<uint32_
     return true;
 }
 
-static void GetSourceLines(std::ostringstream &ss, const std::vector<std::string> &source_lines,
-                           const SpirvLoggingInfo &logging_info) {
+static void GetSourceLines(std::ostringstream& ss, const std::vector<std::string>& source_lines,
+                           const SpirvLoggingInfo& logging_info) {
     if (source_lines.empty()) {
         if (logging_info.using_shader_debug_info) {
             ss << "No Text operand found in DebugSource\n";
@@ -325,7 +325,7 @@ static void GetSourceLines(std::ostringstream &ss, const std::vector<std::string
     }
 }
 
-void GetShaderSourceInfo(std::ostringstream &ss, const std::vector<uint32_t> &instructions, const Instruction &last_line_insn) {
+void GetShaderSourceInfo(std::ostringstream& ss, const std::vector<uint32_t>& instructions, const Instruction& last_line_insn) {
     // Read the source code and split it up into separate lines.
     //
     // 1. OpLine will point to a OpSource/OpSourceContinued which have the string built-in
@@ -363,7 +363,7 @@ void GetShaderSourceInfo(std::ostringstream &ss, const std::vector<uint32_t> &in
     GetSourceLines(ss, source_lines, logging_info);
 }
 
-const char *GetOpString(const std::vector<uint32_t> &instructions, uint32_t string_id) {
+const char* GetOpString(const std::vector<uint32_t>& instructions, uint32_t string_id) {
     uint32_t offset = kModuleStartingOffset;
     while (offset < instructions.size()) {
         const uint32_t instruction = instructions[offset];
@@ -376,7 +376,7 @@ const char *GetOpString(const std::vector<uint32_t> &instructions, uint32_t stri
         if (opcode == spv::OpString) {
             const uint32_t result_id = instructions[offset + 1];
             if (result_id == string_id) {
-                return reinterpret_cast<const char *>(&instructions[offset + 2]);
+                return reinterpret_cast<const char*>(&instructions[offset + 2]);
             }
         }
         offset += length;
@@ -384,7 +384,7 @@ const char *GetOpString(const std::vector<uint32_t> &instructions, uint32_t stri
     return nullptr;
 }
 
-uint32_t GetConstantValue(const std::vector<uint32_t> &instructions, uint32_t constant_id) {
+uint32_t GetConstantValue(const std::vector<uint32_t>& instructions, uint32_t constant_id) {
     uint32_t offset = kModuleStartingOffset;
     while (offset < instructions.size()) {
         const uint32_t instruction = instructions[offset];
@@ -406,7 +406,7 @@ uint32_t GetConstantValue(const std::vector<uint32_t> &instructions, uint32_t co
     return 0;
 }
 
-void GetExecutionModelNames(const std::vector<uint32_t> &instructions, std::ostringstream &ss) {
+void GetExecutionModelNames(const std::vector<uint32_t>& instructions, std::ostringstream& ss) {
     bool first_stage = true;
 
     uint32_t offset = kModuleStartingOffset;
@@ -434,7 +434,7 @@ void GetExecutionModelNames(const std::vector<uint32_t> &instructions, std::ostr
 
 // Find the OpLine/DebugLine just before the failing instruction indicated by the debug info.
 // Return the offset into the instructions array
-static uint32_t GetDebugLineOffset(const std::vector<uint32_t> &instructions, uint32_t instruction_position_offset) {
+static uint32_t GetDebugLineOffset(const std::vector<uint32_t>& instructions, uint32_t instruction_position_offset) {
     uint32_t shader_debug_info_set_id = 0;
     uint32_t last_line_inst_offset = 0;
 
@@ -445,7 +445,7 @@ static uint32_t GetDebugLineOffset(const std::vector<uint32_t> &instructions, ui
         const uint32_t opcode = Opcode(instruction);
 
         if (opcode == spv::OpExtInstImport) {
-            const char *str = reinterpret_cast<const char *>(&instructions[offset + 2]);
+            const char* str = reinterpret_cast<const char*>(&instructions[offset + 2]);
             if (strcmp(str, "NonSemantic.Shader.DebugInfo.100") == 0) {
                 shader_debug_info_set_id = instructions[offset + 1];
             }
@@ -473,7 +473,7 @@ static uint32_t GetDebugLineOffset(const std::vector<uint32_t> &instructions, ui
 // There are 2 ways to inject source into a shader:
 // 1. The "old" way using OpLine/OpSource
 // 2. The "new" way using NonSemantic Shader DebugInfo
-void FindShaderSource(std::ostringstream &ss, const std::vector<uint32_t> &instructions, uint32_t instruction_position_offset,
+void FindShaderSource(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t instruction_position_offset,
                       bool debug_printf_only) {
     const uint32_t last_line_offset = GetDebugLineOffset(instructions, instruction_position_offset);
     if (last_line_offset != 0) {

--- a/layers/gpuav/core/gpuav_features.cpp
+++ b/layers/gpuav/core/gpuav_features.cpp
@@ -38,8 +38,8 @@ static std::vector<VkExtensionProperties> GetAvailableExtensions(VkPhysicalDevic
     }
 }
 
-static bool IsExtensionAvailable(const char *extension_name, const std::vector<VkExtensionProperties> &available_extensions) {
-    for (const VkExtensionProperties &ext : available_extensions) {
+static bool IsExtensionAvailable(const char* extension_name, const std::vector<VkExtensionProperties>& available_extensions) {
+    for (const VkExtensionProperties& ext : available_extensions) {
         if (strncmp(extension_name, ext.extensionName, VK_MAX_EXTENSION_NAME_SIZE) == 0) {
             return true;
         }
@@ -54,8 +54,8 @@ static const VulkanTypedHandle kNoObjects;
 
 // In PreCallRecord we try to turn on as many features as possible on behalf of the app (and warn the user if we are doing it).
 // Later after device creation, we can decide if the required Vulkan feature for each GPU-AV setting is found and report errors
-void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceCreateInfo *modified_create_info,
-                           const Location &loc) {
+void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceCreateInfo* modified_create_info,
+                           const Location& loc) {
     // Query things here to make sure we don't attempt to add a feature this is just not supported
     VkPhysicalDeviceCooperativeMatrixFeaturesKHR supported_coop_mat_feature = vku::InitStructHelper();
     VkPhysicalDeviceRobustness2FeaturesKHR supported_robustness2_feature = vku::InitStructHelper(&supported_coop_mat_feature);
@@ -74,12 +74,11 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
 
     // First core features
     {
-        const VkPhysicalDeviceFeatures &supported_features = features_2.features;
+        const VkPhysicalDeviceFeatures& supported_features = features_2.features;
 
-        VkPhysicalDeviceFeatures *modified_features =
-            const_cast<VkPhysicalDeviceFeatures *>(modified_create_info->pEnabledFeatures);
+        VkPhysicalDeviceFeatures* modified_features = const_cast<VkPhysicalDeviceFeatures*>(modified_create_info->pEnabledFeatures);
         if (!modified_features) {
-            if (auto *modified_features_2 = const_cast<VkPhysicalDeviceFeatures2 *>(
+            if (auto* modified_features_2 = const_cast<VkPhysicalDeviceFeatures2*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(modified_create_info->pNext))) {
                 modified_features = &modified_features_2->features;
             } else {
@@ -120,7 +119,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
 
     if (supported_timeline_feature.timelineSemaphore) {
         auto add_timeline_semaphore = [modified_create_info, &adjustment_warnings]() {
-            if (auto *ts_features = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures *>(
+            if (auto* ts_features = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceTimelineSemaphoreFeatures>(modified_create_info))) {
                 if (ts_features->timelineSemaphore == VK_FALSE) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore to VK_TRUE\n";
@@ -136,7 +135,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
         };
 
         if (api_version > VK_API_VERSION_1_1) {
-            if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            if (auto* features12 = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (features12->timelineSemaphore == VK_FALSE) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkan12Features::timelineSemaphore to VK_TRUE\n";
@@ -155,7 +154,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
 
     if (supported_memory_model_feature.vulkanMemoryModel) {
         auto add_memory_model = [modified_create_info, &adjustment_warnings]() {
-            if (auto *mm_features = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+            if (auto* mm_features = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(modified_create_info))) {
                 if (mm_features->vulkanMemoryModel == VK_FALSE) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModel to VK_TRUE\n";
@@ -178,7 +177,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
         };
 
         if (api_version > VK_API_VERSION_1_1) {
-            if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            if (auto* features12 = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (features12->vulkanMemoryModel == VK_FALSE) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModel to VK_TRUE\n";
@@ -201,7 +200,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
     if (supported_bda_feature.bufferDeviceAddress) {
         auto add_bda = [modified_create_info, &adjustment_warnings]() {
             // Add buffer device address feature
-            if (auto *bda_features = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+            if (auto* bda_features = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(modified_create_info))) {
                 if (!bda_features->bufferDeviceAddress) {
                     adjustment_warnings +=
@@ -218,7 +217,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
         };
 
         if (api_version >= VK_API_VERSION_1_2) {
-            if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            if (auto* features12 = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->bufferDeviceAddress) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkan12Features::bufferDeviceAddress to VK_TRUE\n";
@@ -236,7 +235,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
 
     if (supported_scalar_feature.scalarBlockLayout) {
         auto add_scalar = [modified_create_info, &adjustment_warnings]() {
-            if (auto *bda_features = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures *>(
+            if (auto* bda_features = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceScalarBlockLayoutFeatures>(modified_create_info))) {
                 if (!bda_features->scalarBlockLayout) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout to VK_TRUE\n";
@@ -252,7 +251,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
         };
 
         if (api_version >= VK_API_VERSION_1_2) {
-            if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            if (auto* features12 = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->scalarBlockLayout) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkan12Features::scalarBlockLayout to VK_TRUE\n";
@@ -271,7 +270,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
     if (supported_8bit_feature.storageBuffer8BitAccess) {
         auto add_8bit_access = [modified_create_info, &adjustment_warnings]() {
             // Add storageBuffer8BitAccess feature
-            if (auto *eight_bit_access_feature = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+            if (auto* eight_bit_access_feature = const_cast<VkPhysicalDevice8BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(modified_create_info))) {
                 if (!eight_bit_access_feature->storageBuffer8BitAccess) {
                     adjustment_warnings += "\tForcing VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess to VK_TRUE\n";
@@ -288,7 +287,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
         };
 
         if (api_version >= VK_API_VERSION_1_2) {
-            if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            if (auto* features12 = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->storageBuffer8BitAccess) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess to VK_TRUE\n";
@@ -307,7 +306,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
     if (supported_shader_float16_int8_feature.shaderInt8) {
         auto add_int8 = [modified_create_info, &adjustment_warnings]() {
             // Add shaderInt8 feature
-            if (auto *sixteen_bit_access_feature = const_cast<VkPhysicalDeviceShaderFloat16Int8Features *>(
+            if (auto* sixteen_bit_access_feature = const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat16Int8Features>(modified_create_info))) {
                 if (!sixteen_bit_access_feature->shaderInt8) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceShaderFloat16Int8Features::shaderInt8 to VK_TRUE\n";
@@ -324,7 +323,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
         };
 
         if (api_version >= VK_API_VERSION_1_2) {
-            if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            if (auto* features12 = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->shaderInt8) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkan12Features::shaderInt8 to VK_TRUE\n";
@@ -343,7 +342,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
     if (supported_16bit_feature.storageBuffer16BitAccess) {
         auto add_16bit_access = [modified_create_info, &adjustment_warnings]() {
             // Add storageBuffer16BitAccess feature
-            if (auto *sixteen_bit_access_feature = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+            if (auto* sixteen_bit_access_feature = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(modified_create_info))) {
                 if (!sixteen_bit_access_feature->storageBuffer16BitAccess) {
                     adjustment_warnings += "\tForcing VkPhysicalDevice16BitStorageFeatures::storageBuffer16BitAccess to VK_TRUE\n";
@@ -360,7 +359,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
         };
 
         if (api_version >= VK_API_VERSION_1_1) {
-            if (auto *features11 = const_cast<VkPhysicalDeviceVulkan11Features *>(
+            if (auto* features11 = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(modified_create_info->pNext))) {
                 if (!features11->storageBuffer16BitAccess) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceVulkan11Features::storageBuffer16BitAccess to VK_TRUE\n";
@@ -398,7 +397,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
                 vku::AddExtension(*modified_create_info, VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
             }
 
-            if (auto *robust_buffer_2_feature = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
+            if (auto* robust_buffer_2_feature = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(modified_create_info))) {
                 if (!robust_buffer_2_feature->robustBufferAccess2 && supported_robustness2_feature.robustBufferAccess2) {
                     adjustment_warnings += "\tForcing VkPhysicalDeviceRobustness2FeaturesKHR::robustBufferAccess2 to VK_TRUE\n";
@@ -428,7 +427,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
     if (gpuav_settings.force_on_robustness && supported_coop_mat_feature.cooperativeMatrixRobustBufferAccess) {
         // Because they need to have VkPhysicalDeviceCooperativeMatrixFeaturesKHR::cooperativeMatrix to even use this extensions, we
         // don't add it, we only need to update the other feature bit for them
-        if (auto *coop_mat_feature = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(
+        if (auto* coop_mat_feature = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(modified_create_info))) {
             if (!coop_mat_feature->cooperativeMatrixRobustBufferAccess) {
                 adjustment_warnings +=

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -37,13 +37,13 @@
 
 namespace gpuav {
 
-void Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
-                                          const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
-                                          const RecordObject &record_obj, chassis::CreateBuffer &chassis_state) {
+void Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+                                          const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
+                                          const RecordObject& record_obj, chassis::CreateBuffer& chassis_state) {
     // init here so if using just CoreCheck we don't waste time
     chassis_state.modified_create_info.initialize(pCreateInfo);
 
-    const auto *flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(chassis_state.modified_create_info.pNext);
+    const auto* flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(chassis_state.modified_create_info.pNext);
     const VkBufferUsageFlags2 in_usage = flags2 ? flags2->usage : chassis_state.modified_create_info.usage;
 
     // Ray tracing acceleration structure instance buffers also need the storage buffer usage as
@@ -51,7 +51,7 @@ void Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateI
     // handles inside of a compute shader.
     if (in_usage & VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR) {
         if (flags2) {
-            const_cast<VkBufferUsageFlags2CreateInfo *>(flags2)->usage |= VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT;
+            const_cast<VkBufferUsageFlags2CreateInfo*>(flags2)->usage |= VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT;
         } else {
             chassis_state.modified_create_info.usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         }
@@ -61,7 +61,7 @@ void Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateI
     if (gpuav_settings.IsBufferValidationEnabled() &&
         (in_usage & (VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT))) {
         if (flags2) {
-            const_cast<VkBufferUsageFlags2CreateInfo *>(flags2)->usage |= VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT;
+            const_cast<VkBufferUsageFlags2CreateInfo*>(flags2)->usage |= VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT;
         } else {
             chassis_state.modified_create_info.usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         }
@@ -70,7 +70,7 @@ void Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateI
     if (gpuav_settings.validate_acceleration_structures_builds &&
         (in_usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR)) {
         if (flags2) {
-            const_cast<VkBufferUsageFlags2CreateInfo *>(flags2)->usage |= VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT;
+            const_cast<VkBufferUsageFlags2CreateInfo*>(flags2)->usage |= VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT;
         } else {
             chassis_state.modified_create_info.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
         }
@@ -84,10 +84,10 @@ void Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateI
     chassis_state.create_info_copy = chassis_state.modified_create_info.ptr();
 }
 
-void Validator::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
-                                           const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
-                                           const RecordObject &record_obj) {
-    const auto *flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pCreateInfo->pNext);
+void Validator::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
+                                           const RecordObject& record_obj) {
+    const auto* flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pCreateInfo->pNext);
     const VkBufferUsageFlags2 in_usage = flags2 ? flags2->usage : pCreateInfo->usage;
 
     if (in_usage & VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) {
@@ -95,13 +95,13 @@ void Validator::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreate
     }
 }
 
-void Validator::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
-                                           const RecordObject &record_obj) {
+void Validator::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
+                                           const RecordObject& record_obj) {
     descriptor_buffer.resource_handles_.erase(buffer);
 }
 
-void Validator::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator,
-                                        const RecordObject &record_obj) {
+void Validator::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator,
+                                        const RecordObject& record_obj) {
     if (descriptor_buffer.resource_memory_handles_.find(memory) != descriptor_buffer.resource_memory_handles_.end()) {
         descriptor_buffer.resource_memory_handles_.erase(memory);
     }
@@ -114,50 +114,50 @@ void Validator::BindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, VkDevic
 }
 
 void Validator::PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                               const RecordObject &record_obj) {
+                                               const RecordObject& record_obj) {
     BindBufferMemory(buffer, memory, memoryOffset);
 }
 
-void Validator::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos,
-                                                const RecordObject &record_obj) {
+void Validator::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos,
+                                                const RecordObject& record_obj) {
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         BindBufferMemory(pBindInfos->buffer, pBindInfos->memory, pBindInfos->memoryOffset);
     }
 }
 
 void Validator::PostCallRecordBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount,
-                                                   const VkBindBufferMemoryInfo *pBindInfos, const RecordObject &record_obj) {
+                                                   const VkBindBufferMemoryInfo* pBindInfos, const RecordObject& record_obj) {
     PostCallRecordBindBufferMemory2(device, bindInfoCount, pBindInfos, record_obj);
 }
 
 void Validator::PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                                         const VkDescriptorBufferBindingInfoEXT *pBindingInfos,
-                                                         const RecordObject &record_obj,
-                                                         chassis::CmdBindDescriptorBuffers &chassis_state) {
+                                                         const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
+                                                         const RecordObject& record_obj,
+                                                         chassis::CmdBindDescriptorBuffers& chassis_state) {
     // Resize here so if using just CoreCheck we don't waste time allocating this
     chassis_state.modified_binding_infos.resize(bufferCount + 1);
     for (uint32_t i = 0; i < bufferCount; ++i) {
-        vku::safe_VkDescriptorBufferBindingInfoEXT &new_bind_info = chassis_state.modified_binding_infos[i];
+        vku::safe_VkDescriptorBufferBindingInfoEXT& new_bind_info = chassis_state.modified_binding_infos[i];
         new_bind_info.initialize(&pBindingInfos[i]);
     }
 
-    vku::safe_VkDescriptorBufferBindingInfoEXT &modified_binding_info = chassis_state.modified_binding_infos[bufferCount];
+    vku::safe_VkDescriptorBufferBindingInfoEXT& modified_binding_info = chassis_state.modified_binding_infos[bufferCount];
     modified_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
     modified_binding_info.address = GetGlobalDescriptorBuffer().Address();
 
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    CommandBufferSubState &gpuav_cb_state = SubState(*cb_state);
+    CommandBufferSubState& gpuav_cb_state = SubState(*cb_state);
     gpuav_cb_state.resource_descriptor_buffer_index_ = bufferCount;
 
     // Set the pointer the chassis will use
-    chassis_state.pBindInfos = reinterpret_cast<VkDescriptorBufferBindingInfoEXT *>(chassis_state.modified_binding_infos.data());
+    chassis_state.pBindInfos = reinterpret_cast<VkDescriptorBufferBindingInfoEXT*>(chassis_state.modified_binding_infos.data());
 }
 
-void Validator::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *pBeginInfo,
-                                                const RecordObject &record_obj) {
+void Validator::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
+                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    CommandBufferSubState &gpuav_cb_state = SubState(*cb_state);
+    CommandBufferSubState& gpuav_cb_state = SubState(*cb_state);
     RegisterDescriptorChecksValidation(*this, gpuav_cb_state);
     RegisterPostProcessingValidation(*this, gpuav_cb_state);
     RegisterBufferDeviceAddressValidation(*this, gpuav_cb_state);
@@ -172,17 +172,17 @@ void Validator::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, c
 
 // Dedicated warning VUID that likely can be ignored.
 // We want to always warn the user when adjusting settings/limits/features/etc on them
-void Instance::AdjustmentWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
+void Instance::AdjustmentWarning(LogObjectList objlist, const Location& loc, const char* const specific_message) const {
     LogWarning("WARNING-Setting-Limit-Adjusted", objlist, loc, "Warning that validation is adjusting settings:\n%s",
                specific_message);
 }
 
-void Instance::InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
-    const char *vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
+void Instance::InternalWarning(LogObjectList objlist, const Location& loc, const char* const specific_message) const {
+    const char* vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
     LogWarning(vuid, objlist, loc, "Internal Warning: %s", specific_message);
 }
 
-void Instance::ReserveBindingSlot(VkPhysicalDevice physicalDevice, VkPhysicalDeviceLimits &limits, const Location &loc) {
+void Instance::ReserveBindingSlot(VkPhysicalDevice physicalDevice, VkPhysicalDeviceLimits& limits, const Location& loc) {
     // There is an implicit layer that can cause this call to return 0 for maxBoundDescriptorSets - Ignore such calls
     if (limits.maxBoundDescriptorSets == 0) return;
 
@@ -203,18 +203,18 @@ void Instance::ReserveBindingSlot(VkPhysicalDevice physicalDevice, VkPhysicalDev
     }
 }
 
-void Instance::PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties *device_props,
-                                                         const RecordObject &record_obj) {
+void Instance::PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties* device_props,
+                                                         const RecordObject& record_obj) {
     ReserveBindingSlot(physicalDevice, device_props->limits, record_obj.location);
 }
 
 void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
-                                                          VkPhysicalDeviceProperties2 *device_props2,
-                                                          const RecordObject &record_obj) {
+                                                          VkPhysicalDeviceProperties2* device_props2,
+                                                          const RecordObject& record_obj) {
     std::string adjustment_warnings;
 
     // override all possible places maxUpdateAfterBindDescriptorsInAllPools can be set
-    auto *desc_indexing_props = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingProperties>(device_props2->pNext);
+    auto* desc_indexing_props = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingProperties>(device_props2->pNext);
     if (desc_indexing_props &&
         desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescriptors) {
         std::ostringstream ss;
@@ -225,7 +225,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
         desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescriptors;
     }
 
-    auto *vk12_props = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Properties>(device_props2->pNext);
+    auto* vk12_props = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Properties>(device_props2->pNext);
     if (vk12_props && vk12_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescriptors) {
         std::ostringstream ss;
         ss << "\tSetting VkPhysicalDeviceVulkan12Properties::maxUpdateAfterBindDescriptorsInAllPools to "
@@ -235,7 +235,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
         vk12_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescriptors;
     }
 
-    if (auto *desc_buffer_props =
+    if (auto* desc_buffer_props =
             vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferPropertiesEXT>(device_props2->pNext)) {
         if (desc_buffer_props->maxResourceDescriptorBufferBindings > 1) {
             desc_buffer_props->maxResourceDescriptorBufferBindings -= 1;
@@ -270,7 +270,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
         AdjustmentWarning(physicalDevice, record_obj.location, adjustment_warnings.c_str());
     }
 
-    if (auto *desc_heap_props = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorHeapPropertiesEXT>(device_props2->pNext)) {
+    if (auto* desc_heap_props = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorHeapPropertiesEXT>(device_props2->pNext)) {
         VkDeviceSize bytes_to_reserve =
             Align(desc_heap_props->bufferDescriptorSize * glsl::kTotalBindings, desc_heap_props->bufferDescriptorAlignment);
         bytes_to_reserve = Align(bytes_to_reserve, desc_heap_props->resourceHeapAlignment);
@@ -289,8 +289,8 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
 }
 
 // Clean up device-related resources
-void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
-                                           const RecordObject &record_obj) {
+void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
+                                           const RecordObject& record_obj) {
     // Need to destroy substate before memory backed in things like shared_resources_cache are cleared
     DestroySubstate();
 
@@ -312,54 +312,54 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
 }
 
 // Common logic before any draw/dispatch/traceRays
-void Validator::PreCallActionCommand(Validator &gpuav, CommandBufferSubState &cb_state, const LastBound &last_bound,
-                                     const Location &loc) {
+void Validator::PreCallActionCommand(Validator& gpuav, CommandBufferSubState& cb_state, const LastBound& last_bound,
+                                     const Location& loc) {
     PreCallSetupShaderInstrumentationResources(gpuav, cb_state, last_bound, loc);
 }
 
 void Validator::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                     uint32_t firstVertex, uint32_t firstInstance, const RecordObject &record_obj) {
+                                     uint32_t firstVertex, uint32_t firstInstance, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
+    auto& sub_state = SubState(*cb_state);
 
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                             const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount, uint32_t firstInstance,
-                                             uint32_t stride, const RecordObject &record_obj) {
+                                             const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount, uint32_t firstInstance,
+                                             uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                             uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
-                                            const RecordObject &record_obj) {
+                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                    const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
-                                                    uint32_t firstInstance, uint32_t stride, const int32_t *pVertexOffset,
-                                                    const RecordObject &record_obj) {
+                                                    const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
+                                                    uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset,
+                                                    const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
-                                             uint32_t stride, const RecordObject &record_obj) {
+                                             uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     auto indirect_buffer_state = Get<vvl::Buffer>(buffer);
@@ -367,21 +367,21 @@ void Validator::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBu
         InternalError(commandBuffer, record_obj.location, "buffer must be a valid VkBuffer handle");
         return;
     }
-    auto &sub_state = SubState(*cb_state);
+    auto& sub_state = SubState(*cb_state);
 
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     valcmd::FirstInstance<VkDrawIndirectCommand>(*this, sub_state, record_obj.location, last_bound, buffer, offset, count,
                                                  VK_NULL_HANDLE, 0);
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                    uint32_t count, uint32_t stride, const RecordObject &record_obj) {
+                                                    uint32_t count, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
+    auto& sub_state = SubState(*cb_state);
 
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     valcmd::DrawIndexedIndirectIndexBuffer(*this, sub_state, record_obj.location, last_bound, buffer, offset, stride, count,
                                            VK_NULL_HANDLE, 0, "VUID-VkDrawIndexedIndirectCommand-robustBufferAccess2-08798");
 
@@ -392,14 +392,14 @@ void Validator::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffe
 
 void Validator::PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                     uint32_t stride, const RecordObject &record_obj) {
+                                                     uint32_t stride, const RecordObject& record_obj) {
     PreCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                       record_obj);
 }
 
 void Validator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                   VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                  uint32_t stride, const RecordObject &record_obj) {
+                                                  uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     auto indirect_buffer_state = Get<vvl::Buffer>(buffer);
@@ -407,9 +407,9 @@ void Validator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer,
         InternalError(commandBuffer, record_obj.location, "buffer must be a valid VkBuffer handle");
         return;
     }
-    auto &sub_state = SubState(*cb_state);
+    auto& sub_state = SubState(*cb_state);
 
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     const char* vuid = (record_obj.location.function == vvl::Func::vkCmdDrawIndirectCount2KHR ||
                         record_obj.location.function == vvl::Func::vkCmdDrawIndexedIndirectCount2KHR ||
                         record_obj.location.function == vvl::Func::vkCmdDrawMeshTasksIndirectCount2EXT)
@@ -423,7 +423,7 @@ void Validator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer,
 }
 
 void Validator::PreCallRecordCmdDrawIndirect2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR* pInfo,
-                                                 const RecordObject &record_obj) {
+                                                 const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     const auto buffer_states = GetBuffersByAddress(pInfo->addressRange.address);
@@ -445,7 +445,7 @@ void Validator::PreCallRecordCmdDrawIndirect2KHR(VkCommandBuffer commandBuffer, 
 }
 
 void Validator::PreCallRecordCmdDrawIndexedIndirect2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR* pInfo,
-                                                        const RecordObject &record_obj) {
+                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     const auto buffer_states = GetBuffersByAddress(pInfo->addressRange.address);
@@ -513,29 +513,29 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectCount2EXT(VkCommandBuffer c
 void Validator::PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
                                                          uint32_t firstInstance, VkBuffer counterBuffer,
                                                          VkDeviceSize counterBufferOffset, uint32_t counterOffset,
-                                                         uint32_t vertexStride, const RecordObject &record_obj) {
+                                                         uint32_t vertexStride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                             VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                             uint32_t maxDrawCount, uint32_t stride,
-                                                            const RecordObject &record_obj) {
+                                                            const RecordObject& record_obj) {
     PreCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                              record_obj);
 }
 
 void Validator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                         uint32_t maxDrawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                         uint32_t maxDrawCount, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     valcmd::CountBuffer(*this, sub_state, record_obj.location, last_bound, buffer, offset, sizeof(VkDrawIndexedIndirectCommand),
                         vvl::Struct::VkDrawIndexedIndirectCommand, stride, countBuffer, countBufferOffset,
                         "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717");
@@ -550,27 +550,27 @@ void Validator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer command
 }
 
 void Validator::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
-                                                const RecordObject &record_obj) {
+                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                        uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                        uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                              uint32_t maxDrawCount, uint32_t stride,
-                                                             const RecordObject &record_obj) {
+                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     auto indirect_buffer_state = Get<vvl::Buffer>(buffer);
@@ -579,8 +579,8 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer com
         return;
     }
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     valcmd::CountBuffer(*this, sub_state, record_obj.location, last_bound, buffer, offset, sizeof(VkDrawMeshTasksIndirectCommandNV),
                         vvl::Struct::VkDrawMeshTasksIndirectCommandNV, stride, countBuffer, countBufferOffset,
                         "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02717");
@@ -589,20 +589,20 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer com
 }
 
 void Validator::PreCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                                 uint32_t groupCountZ, const RecordObject &record_obj) {
+                                                 uint32_t groupCountZ, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                         uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                         uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     valcmd::DrawMeshIndirect(*this, sub_state, record_obj.location, last_bound, buffer, offset, stride, VK_NULL_HANDLE, 0,
                              drawCount);
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
@@ -611,7 +611,7 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer command
 void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride,
-                                                              const RecordObject &record_obj) {
+                                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     auto indirect_buffer_state = Get<vvl::Buffer>(buffer);
@@ -620,8 +620,8 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer co
         return;
     }
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundGraphics();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundGraphics();
     valcmd::DrawMeshIndirect(*this, sub_state, record_obj.location, last_bound, buffer, offset, stride, countBuffer,
                              countBufferOffset, maxDrawCount);
 
@@ -632,48 +632,48 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer co
 }
 
 void Validator::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
-                                         const RecordObject &record_obj) {
+                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundCompute();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundCompute();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                 const RecordObject &record_obj) {
+                                                 const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundCompute();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundCompute();
     valcmd::DispatchIndirect(*this, record_obj.location, sub_state, last_bound, buffer, offset);
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                              uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ,
-                                             const RecordObject &record_obj) {
+                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundCompute();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundCompute();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                 uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                uint32_t groupCountZ, const RecordObject &record_obj) {
+                                                uint32_t groupCountZ, const RecordObject& record_obj) {
     PreCallRecordCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ,
                                  record_obj);
 }
 
 void Validator::PreCallRecordCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &cb_sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundRayTracing();
+    auto& cb_sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundRayTracing();
     valcmd::TLAS(*this, record_obj.location, cb_sub_state, last_bound, infoCount, pInfos, ppBuildRangeInfos);
     valcmd::BLAS(*this, record_obj.location, cb_sub_state, last_bound, infoCount, pInfos, ppBuildRangeInfos);
 }
@@ -684,66 +684,66 @@ void Validator::PreCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuf
                                             VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset,
                                             VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                             VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
-                                            uint32_t width, uint32_t height, uint32_t depth, const RecordObject &record_obj) {
+                                            uint32_t width, uint32_t height, uint32_t depth, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundRayTracing();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundRayTracing();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                             const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                             const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                             const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                             const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable, uint32_t width,
-                                             uint32_t height, uint32_t depth, const RecordObject &record_obj) {
+                                             const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                             const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                             const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                             const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width,
+                                             uint32_t height, uint32_t depth, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundRayTracing();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundRayTracing();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                     const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                     const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                     const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                     const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                     VkDeviceAddress indirectDeviceAddress, const RecordObject &record_obj) {
+                                                     const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                     const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                     const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                     const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                     VkDeviceAddress indirectDeviceAddress, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundRayTracing();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundRayTracing();
     valcmd::TraceRaysIndirect(*this, record_obj.location, sub_state, last_bound, indirectDeviceAddress);
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
-                                                      const RecordObject &record_obj) {
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
-    const LastBound &last_bound = cb_state->GetLastBoundRayTracing();
+    auto& sub_state = SubState(*cb_state);
+    const LastBound& last_bound = cb_state->GetLastBoundRayTracing();
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdExecuteGeneratedCommandsEXT(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
-                                                            const VkGeneratedCommandsInfoEXT *pGeneratedCommandsInfo,
-                                                            const RecordObject &record_obj) {
+                                                            const VkGeneratedCommandsInfoEXT* pGeneratedCommandsInfo,
+                                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
-    auto &sub_state = SubState(*cb_state);
+    auto& sub_state = SubState(*cb_state);
 
     const VkPipelineBindPoint bind_point = ConvertStageToBindPoint(pGeneratedCommandsInfo->shaderStages);
     const vvl::BindPoint vvl_bind_point = ConvertToVvlBindPoint(bind_point);
-    const LastBound &last_bound = cb_state->lastBound[vvl_bind_point];
+    const LastBound& last_bound = cb_state->lastBound[vvl_bind_point];
     PreCallActionCommand(*this, sub_state, last_bound, record_obj.location);
 };
 
 void Validator::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                   VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                  const VkBufferImageCopy *pRegions, const RecordObject &record_obj) {
+                                                  const VkBufferImageCopy* pRegions, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     std::vector<VkBufferImageCopy2> regions_2(regionCount);
@@ -767,21 +767,21 @@ void Validator::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer,
 }
 
 void Validator::PreCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                                      const VkCopyBufferToImageInfo2KHR *pCopyBufferToImageInfo2KHR,
-                                                      const RecordObject &record_obj) {
+                                                      const VkCopyBufferToImageInfo2KHR* pCopyBufferToImageInfo2KHR,
+                                                      const RecordObject& record_obj) {
     PreCallRecordCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo2KHR, record_obj);
 }
 
 void Validator::PreCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
-                                                   const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
-                                                   const RecordObject &record_obj) {
+                                                   const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
+                                                   const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     valcmd::CopyBufferToImage(*this, record_obj.location, SubState(*cb_state), pCopyBufferToImageInfo);
 }
 
 void Validator::PreCallRecordCmdCopyMemoryIndirectKHR(VkCommandBuffer commandBuffer,
-                                                      const VkCopyMemoryIndirectInfoKHR *pCopyMemoryIndirectInfo,
-                                                      const RecordObject &record_obj) {
+                                                      const VkCopyMemoryIndirectInfoKHR* pCopyMemoryIndirectInfo,
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     const valcmd::CopyMemoryIndirectCommon copy_info = {pCopyMemoryIndirectInfo->copyCount,
                                                         pCopyMemoryIndirectInfo->copyAddressRange};
@@ -789,8 +789,8 @@ void Validator::PreCallRecordCmdCopyMemoryIndirectKHR(VkCommandBuffer commandBuf
 }
 
 void Validator::PreCallRecordCmdCopyMemoryToImageIndirectKHR(
-    VkCommandBuffer commandBuffer, const VkCopyMemoryToImageIndirectInfoKHR *pCopyMemoryToImageIndirectInfo,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkCopyMemoryToImageIndirectInfoKHR* pCopyMemoryToImageIndirectInfo,
+    const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     const valcmd::CopyMemoryIndirectCommon copy_info = {pCopyMemoryToImageIndirectInfo->copyCount,
                                                         pCopyMemoryToImageIndirectInfo->copyAddressRange};
@@ -798,8 +798,8 @@ void Validator::PreCallRecordCmdCopyMemoryToImageIndirectKHR(
 }
 
 void Validator::PreCallRecordCmdCopyMemoryToImageKHR(VkCommandBuffer commandBuffer,
-                                                     const VkCopyDeviceMemoryImageInfoKHR *pCopyMemoryInfo,
-                                                     const RecordObject &record_obj) {
+                                                     const VkCopyDeviceMemoryImageInfoKHR* pCopyMemoryInfo,
+                                                     const RecordObject& record_obj) {
     for (uint32_t i = 0; i < pCopyMemoryInfo->regionCount; ++i) {
         // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11879
         const auto buffer_states = GetBuffersByAddress(pCopyMemoryInfo->pRegions[i].addressRange.address);
@@ -826,8 +826,8 @@ void Validator::PreCallRecordCmdCopyMemoryToImageKHR(VkCommandBuffer commandBuff
     }
 }
 
-bool Validator::PreCallValidateCmdPushDataEXT(VkCommandBuffer commandBuffer, const VkPushDataInfoEXT *pPushDataInfo,
-                                              const ErrorObject &error_obj) const {
+bool Validator::PreCallValidateCmdPushDataEXT(VkCommandBuffer commandBuffer, const VkPushDataInfoEXT* pPushDataInfo,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
     if (pPushDataInfo->offset + pPushDataInfo->data.size > push_data_offset_) {
         skip |=
@@ -841,8 +841,8 @@ bool Validator::PreCallValidateCmdPushDataEXT(VkCommandBuffer commandBuffer, con
 }
 
 // Validates the buffer is allowed to be protected
-bool Validator::ValidateProtectedBuffer(const vvl::CommandBuffer &cb_state, const vvl::Buffer &buffer_state,
-                                        const Location &buffer_loc, const char *vuid, const char *more_message) const {
+bool Validator::ValidateProtectedBuffer(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state,
+                                        const Location& buffer_loc, const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values
@@ -855,8 +855,8 @@ bool Validator::ValidateProtectedBuffer(const vvl::CommandBuffer &cb_state, cons
 }
 
 // Validates the buffer is allowed to be unprotected
-bool Validator::ValidateUnprotectedBuffer(const vvl::CommandBuffer &cb_state, const vvl::Buffer &buffer_state,
-                                          const Location &buffer_loc, const char *vuid, const char *more_message) const {
+bool Validator::ValidateUnprotectedBuffer(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state,
+                                          const Location& buffer_loc, const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values
@@ -869,8 +869,8 @@ bool Validator::ValidateUnprotectedBuffer(const vvl::CommandBuffer &cb_state, co
 }
 
 // Validates the image is allowed to be protected
-bool Validator::ValidateProtectedImage(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state, const Location &loc,
-                                       const char *vuid, const char *more_message) const {
+bool Validator::ValidateProtectedImage(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, const Location& loc,
+                                       const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values
@@ -883,8 +883,8 @@ bool Validator::ValidateProtectedImage(const vvl::CommandBuffer &cb_state, const
 }
 
 // Validates the image is allowed to be unprotected
-bool Validator::ValidateUnprotectedImage(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state, const Location &loc,
-                                         const char *vuid, const char *more_message) const {
+bool Validator::ValidateUnprotectedImage(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, const Location& loc,
+                                         const char* vuid, const char* more_message) const {
     bool skip = false;
 
     // if driver supports protectedNoFault the operation is valid, just has undefined values
@@ -897,8 +897,8 @@ bool Validator::ValidateUnprotectedImage(const vvl::CommandBuffer &cb_state, con
 }
 
 // Validates the buffer is allowed to be protected
-bool Validator::ValidateProtectedTensor(const vvl::CommandBuffer &cb_state, const vvl::Tensor &tensor_state,
-                                        const Location &tensor_loc, const char *vuid, const char *more_message) const {
+bool Validator::ValidateProtectedTensor(const vvl::CommandBuffer& cb_state, const vvl::Tensor& tensor_state,
+                                        const Location& tensor_loc, const char* vuid, const char* more_message) const {
     /* don't use on an unprotected tensor */
     assert(tensor_state.unprotected == false);
 
@@ -914,8 +914,8 @@ bool Validator::ValidateProtectedTensor(const vvl::CommandBuffer &cb_state, cons
 }
 
 // Validates the buffer is allowed to be unprotected
-bool Validator::ValidateUnprotectedTensor(const vvl::CommandBuffer &cb_state, const vvl::Tensor &tensor_state,
-                                          const Location &tensor_loc, const char *vuid, const char *more_message) const {
+bool Validator::ValidateUnprotectedTensor(const vvl::CommandBuffer& cb_state, const vvl::Tensor& tensor_state,
+                                          const Location& tensor_loc, const char* vuid, const char* more_message) const {
     /* don't use on a protected tensor */
     assert(tensor_state.unprotected == true);
 

--- a/layers/gpuav/core/gpuav_settings.cpp
+++ b/layers/gpuav/core/gpuav_settings.cpp
@@ -65,15 +65,15 @@ void GpuAVSettings::SetBufferValidationEnabled(bool enabled) {
     validate_acceleration_structures_builds = enabled;
 }
 
-void GpuAVSettings::SetShaderSelectionRegexes(std::vector<std::string> &&shader_selection_regexes) {
+void GpuAVSettings::SetShaderSelectionRegexes(std::vector<std::string>&& shader_selection_regexes) {
     this->shader_selection_regexes = std::move(shader_selection_regexes);
 }
 
-bool GpuAVSettings::MatchesAnyShaderSelectionRegex(const std::string &debug_name) {
+bool GpuAVSettings::MatchesAnyShaderSelectionRegex(const std::string& debug_name) {
     if (debug_name.empty()) {
         return false;
     }
-    for (const std::string &shader_selection_regex_str : shader_selection_regexes) {
+    for (const std::string& shader_selection_regex_str : shader_selection_regexes) {
         std::regex regex(shader_selection_regex_str, std::regex_constants::ECMAScript);
         if (std::regex_match(debug_name, regex)) {
             return true;

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -36,89 +36,89 @@ namespace gpuav {
 // Location to add per-queue submit debug info if built with -D DEBUG_CAPTURE_KEYBOARD=ON
 void Validator::DebugCapture() {}
 
-void Validator::Created(vvl::DescriptorSet &set) {
+void Validator::Created(vvl::DescriptorSet& set) {
     set.SetSubState(container_type, std::make_unique<DescriptorSetSubState>(set, *this));
 }
 
-void Validator::Created(vvl::CommandBuffer &cb_state) {
+void Validator::Created(vvl::CommandBuffer& cb_state) {
     cb_state.SetSubState(container_type, std::make_unique<CommandBufferSubState>(*this, cb_state));
 }
 
-void Validator::Created(vvl::Queue &queue) { queue.SetSubState(container_type, std::make_unique<QueueSubState>(*this, queue)); }
+void Validator::Created(vvl::Queue& queue) { queue.SetSubState(container_type, std::make_unique<QueueSubState>(*this, queue)); }
 
-void Validator::Created(vvl::Image &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::Image& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<ImageSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::ImageView &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::ImageView& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<ImageViewSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::Buffer &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::Buffer& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<BufferSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::BufferView &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::BufferView& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<BufferViewSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::Sampler &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::Sampler& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<SamplerSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::AccelerationStructureNV &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::AccelerationStructureNV& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<AccelerationStructureNVSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::AccelerationStructureKHR &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::AccelerationStructureKHR& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<AccelerationStructureKHRSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::Tensor &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::Tensor& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<TensorSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::TensorView &obj) {
-    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
+void Validator::Created(vvl::TensorView& obj) {
+    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<TensorViewSubState>(obj, desc_heap));
 }
-void Validator::Created(vvl::ShaderObject &obj) { obj.SetSubState(container_type, std::make_unique<ShaderObjectSubState>(obj)); }
+void Validator::Created(vvl::ShaderObject& obj) { obj.SetSubState(container_type, std::make_unique<ShaderObjectSubState>(obj)); }
 
-void Validator::Created(vvl::Pipeline &obj) { obj.SetSubState(container_type, std::make_unique<PipelineSubState>(*this, obj)); }
+void Validator::Created(vvl::Pipeline& obj) { obj.SetSubState(container_type, std::make_unique<PipelineSubState>(*this, obj)); }
 
 // Trampolines to make VMA call Dispatch for Vulkan calls
-static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetInstanceProcAddr(VkInstance inst, const char *name) {
+static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetInstanceProcAddr(VkInstance inst, const char* name) {
     return DispatchGetInstanceProcAddr(inst, name);
 }
-static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetDeviceProcAddr(VkDevice dev, const char *name) {
+static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetDeviceProcAddr(VkDevice dev, const char* name) {
     return DispatchGetDeviceProcAddr(dev, name);
 }
 static VKAPI_ATTR void VKAPI_CALL gpuVkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
-                                                                   VkPhysicalDeviceProperties *pProperties) {
+                                                                   VkPhysicalDeviceProperties* pProperties) {
     DispatchGetPhysicalDeviceProperties(physicalDevice, pProperties);
 }
 static VKAPI_ATTR void VKAPI_CALL gpuVkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice,
-                                                                         VkPhysicalDeviceMemoryProperties *pMemoryProperties) {
+                                                                         VkPhysicalDeviceMemoryProperties* pMemoryProperties) {
     DispatchGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties);
 }
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
-                                                          const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory) {
+static VKAPI_ATTR VkResult VKAPI_CALL gpuVkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory) {
     return DispatchAllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
 }
-static VKAPI_ATTR void VKAPI_CALL gpuVkFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator) {
+static VKAPI_ATTR void VKAPI_CALL gpuVkFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator) {
     DispatchFreeMemory(device, memory, pAllocator);
 }
 static VKAPI_ATTR VkResult VKAPI_CALL gpuVkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size,
-                                                     VkMemoryMapFlags flags, void **ppData) {
+                                                     VkMemoryMapFlags flags, void** ppData) {
     return DispatchMapMemory(device, memory, offset, size, flags, ppData);
 }
 static VKAPI_ATTR void VKAPI_CALL gpuVkUnmapMemory(VkDevice device, VkDeviceMemory memory) { DispatchUnmapMemory(device, memory); }
 static VKAPI_ATTR VkResult VKAPI_CALL gpuVkFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
-                                                                   const VkMappedMemoryRange *pMemoryRanges) {
+                                                                   const VkMappedMemoryRange* pMemoryRanges) {
     return DispatchFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
 }
 static VKAPI_ATTR VkResult VKAPI_CALL gpuVkInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
-                                                                        const VkMappedMemoryRange *pMemoryRanges) {
+                                                                        const VkMappedMemoryRange* pMemoryRanges) {
     return DispatchInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
 }
 static VKAPI_ATTR VkResult VKAPI_CALL gpuVkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
@@ -130,34 +130,34 @@ static VKAPI_ATTR VkResult VKAPI_CALL gpuVkBindImageMemory(VkDevice device, VkIm
     return DispatchBindImageMemory(device, image, memory, memoryOffset);
 }
 static VKAPI_ATTR void VKAPI_CALL gpuVkGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer,
-                                                                   VkMemoryRequirements *pMemoryRequirements) {
+                                                                   VkMemoryRequirements* pMemoryRequirements) {
     DispatchGetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
 }
 static VKAPI_ATTR void VKAPI_CALL gpuVkGetImageMemoryRequirements(VkDevice device, VkImage image,
-                                                                  VkMemoryRequirements *pMemoryRequirements) {
+                                                                  VkMemoryRequirements* pMemoryRequirements) {
     DispatchGetImageMemoryRequirements(device, image, pMemoryRequirements);
 }
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
-                                                        const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer) {
+static VKAPI_ATTR VkResult VKAPI_CALL gpuVkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer) {
     return DispatchCreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
 }
-static VKAPI_ATTR void VKAPI_CALL gpuVkDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {
+static VKAPI_ATTR void VKAPI_CALL gpuVkDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator) {
     return DispatchDestroyBuffer(device, buffer, pAllocator);
 }
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
-                                                       const VkAllocationCallbacks *pAllocator, VkImage *pImage) {
+static VKAPI_ATTR VkResult VKAPI_CALL gpuVkCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkImage* pImage) {
     return DispatchCreateImage(device, pCreateInfo, pAllocator, pImage);
 }
-static VKAPI_ATTR void VKAPI_CALL gpuVkDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
+static VKAPI_ATTR void VKAPI_CALL gpuVkDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator) {
     DispatchDestroyImage(device, image, pAllocator);
 }
 static VKAPI_ATTR void VKAPI_CALL gpuVkCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                                     uint32_t regionCount, const VkBufferCopy *pRegions) {
+                                                     uint32_t regionCount, const VkBufferCopy* pRegions) {
     DispatchCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 }
 
 static VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device,
-                                  VmaAllocator *pAllocator) {
+                                  VmaAllocator* pAllocator) {
     VmaVulkanFunctions functions;
     VmaAllocatorCreateInfo allocator_info = {};
     allocator_info.instance = instance;
@@ -191,9 +191,9 @@ static VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical
     return vmaCreateAllocator(&allocator_info, pAllocator);
 }
 
-void Instance::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                         const VkAllocationCallbacks *pAllocator, VkDevice *pDevice, const RecordObject &record_obj,
-                                         vku::safe_VkDeviceCreateInfo *modified_create_info) {
+void Instance::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                         const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,
+                                         vku::safe_VkDeviceCreateInfo* modified_create_info) {
     BaseClass::PreCallRecordCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, record_obj, modified_create_info);
 
     // GPU-AV requirements not met, exit early or future Vulkan calls may be invalid
@@ -205,7 +205,7 @@ void Instance::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const 
 }
 
 // Perform initializations that can be done at Create Device time.
-void Validator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void Validator::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) {
     // GPU-AV not supported, exit early to prevent errors inside Validator::PostCallRecordCreateDevice
     if (api_version < VK_API_VERSION_1_1) {
         InternalError(device, loc, "GPU Shader Instrumentation requires Vulkan 1.1 or later.");
@@ -302,7 +302,7 @@ void Validator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const L
         }
 
         uint32_t stride = indices_buffer_alignment_ / sizeof(uint32_t);
-        uint32_t *indices_ptr = (uint32_t *)global_indices_buffer_.GetMappedPtr();
+        uint32_t* indices_ptr = (uint32_t*)global_indices_buffer_.GetMappedPtr();
         for (uint32_t i = 0; i < gpuav_settings.indices_buffer_count; ++i) {
             const uint32_t offset = i * stride;
             indices_ptr[offset] = i;
@@ -346,16 +346,16 @@ namespace setting {
 
 // Each setting in GPU-AV has a common interface to make adding a new setting easier
 struct Setting {
-    virtual bool IsEnabled(const GpuAVSettings &settings) = 0;
-    virtual bool HasRequiredFeatures(const DeviceFeatures &features) = 0;
-    virtual void Disable(GpuAVSettings &settings) = 0;
+    virtual bool IsEnabled(const GpuAVSettings& settings) = 0;
+    virtual bool HasRequiredFeatures(const DeviceFeatures& features) = 0;
+    virtual void Disable(GpuAVSettings& settings) = 0;
     virtual std::string DisableMessage() = 0;
 };
 
 struct BufferDeviceAddress : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.shader_instrumentation.buffer_device_address; }
-    bool HasRequiredFeatures(const DeviceFeatures &features) { return features.shaderInt64; }
-    void Disable(GpuAVSettings &settings) { settings.shader_instrumentation.buffer_device_address = false; }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.shader_instrumentation.buffer_device_address; }
+    bool HasRequiredFeatures(const DeviceFeatures& features) { return features.shaderInt64; }
+    void Disable(GpuAVSettings& settings) { settings.shader_instrumentation.buffer_device_address = false; }
     std::string DisableMessage() {
         return "\tBuffer Device Address validation option was enabled, but the shaderInt64 feature is not supported. [Disabling "
                "gpuav_buffer_address_oob]\n";
@@ -363,46 +363,47 @@ struct BufferDeviceAddress : public Setting {
 };
 
 struct RayQuery : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.shader_instrumentation.ray_query; }
-    bool HasRequiredFeatures(const DeviceFeatures &features) { return features.rayQuery; }
-    void Disable(GpuAVSettings &settings) { settings.shader_instrumentation.ray_query = false; }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.shader_instrumentation.ray_query; }
+    bool HasRequiredFeatures(const DeviceFeatures& features) { return features.rayQuery; }
+    void Disable(GpuAVSettings& settings) { settings.shader_instrumentation.ray_query = false; }
     std::string DisableMessage() {
         return "\tRay Query validation option was enabled, but the rayQuery feature is not supported. [Disabling "
                "gpuav_validate_ray_query]\n";
     }
 };
 struct RayHitObject : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.shader_instrumentation.ray_hit_object; }
-    bool HasRequiredFeatures(const DeviceFeatures &features) { return features.rayTracingInvocationReorder; }
-    void Disable(GpuAVSettings &settings) { settings.shader_instrumentation.ray_hit_object = false; }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.shader_instrumentation.ray_hit_object; }
+    bool HasRequiredFeatures(const DeviceFeatures& features) { return features.rayTracingInvocationReorder; }
+    void Disable(GpuAVSettings& settings) { settings.shader_instrumentation.ray_hit_object = false; }
     std::string DisableMessage() {
-        return "\tRay Hit Object validation option was enabled, but the rayTracingInvocationReorder feature is not supported. [Disabling "
+        return "\tRay Hit Object validation option was enabled, but the rayTracingInvocationReorder feature is not supported. "
+               "[Disabling "
                "gpuav_validate_ray_hit_object]\n";
     }
 };
 struct MeshShading : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.shader_instrumentation.mesh_shading; }
-    bool HasRequiredFeatures(const DeviceFeatures &features) { return features.meshShader; }
-    void Disable(GpuAVSettings &settings) { settings.shader_instrumentation.mesh_shading = false; }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.shader_instrumentation.mesh_shading; }
+    bool HasRequiredFeatures(const DeviceFeatures& features) { return features.meshShader; }
+    void Disable(GpuAVSettings& settings) { settings.shader_instrumentation.mesh_shading = false; }
     std::string DisableMessage() {
         return "\tMesh Shading validation option was enabled, but the meshShader feature is not supported. [Disabling "
                "gpuav_mesh_shading]\n";
     }
 };
 struct BufferCopies : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.validate_buffer_copies; }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.validate_buffer_copies; }
     // copy_buffer_to_image.comp relies on uint8_t buffers to perform validation
-    bool HasRequiredFeatures(const DeviceFeatures &features) { return features.storageBuffer8BitAccess; }
-    void Disable(GpuAVSettings &settings) { settings.validate_buffer_copies = false; }
+    bool HasRequiredFeatures(const DeviceFeatures& features) { return features.storageBuffer8BitAccess; }
+    void Disable(GpuAVSettings& settings) { settings.validate_buffer_copies = false; }
     std::string DisableMessage() {
         return "\tBuffer copies option was enabled, but the storageBuffer8BitAccess feature is not supported. [Disabling "
                "gpuav_buffer_copies]\n";
     }
 };
 struct BufferContent : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.IsBufferValidationEnabled(); }
-    bool HasRequiredFeatures(const DeviceFeatures &features) { return features.shaderInt64; }
-    void Disable(GpuAVSettings &settings) { settings.SetBufferValidationEnabled(false); }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.IsBufferValidationEnabled(); }
+    bool HasRequiredFeatures(const DeviceFeatures& features) { return features.shaderInt64; }
+    void Disable(GpuAVSettings& settings) { settings.SetBufferValidationEnabled(false); }
     std::string DisableMessage() {
         return "\tBuffer content validation option was enabled, but the shaderInt64 feature is not supported. [Disabling "
                "gpuav_buffers_validation]\n";
@@ -410,12 +411,12 @@ struct BufferContent : public Setting {
 };
 
 struct AccelerationStructuresBuild : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.validate_acceleration_structures_builds; }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.validate_acceleration_structures_builds; }
     // Validation shader branches on a push constant value to fetch different descriptors
-    bool HasRequiredFeatures(const DeviceFeatures &features) {
+    bool HasRequiredFeatures(const DeviceFeatures& features) {
         return features.shaderInt64 && features.storageBuffer8BitAccess && features.storageBuffer16BitAccess;
     }
-    void Disable(GpuAVSettings &settings) { settings.validate_acceleration_structures_builds = false; }
+    void Disable(GpuAVSettings& settings) { settings.validate_acceleration_structures_builds = false; }
     std::string DisableMessage() {
         return "\tAcceleration structure builds validation option was enabled, but the shaderInt64 or storageBuffer8BitAccess or "
                "storageBuffer16BitAccess features are not "
@@ -425,12 +426,12 @@ struct AccelerationStructuresBuild : public Setting {
 };
 
 struct RayTracingBuffersConsistency : public Setting {
-    bool IsEnabled(const GpuAVSettings &settings) { return settings.ray_tracing_buffers_consistency; }
+    bool IsEnabled(const GpuAVSettings& settings) { return settings.ray_tracing_buffers_consistency; }
     // Validation shader branches on a push constant value to fetch different descriptors
-    bool HasRequiredFeatures(const DeviceFeatures &features) {
+    bool HasRequiredFeatures(const DeviceFeatures& features) {
         return features.shaderInt64 && features.shaderInt16 && features.shaderInt8;
     }
-    void Disable(GpuAVSettings &settings) { settings.ray_tracing_buffers_consistency = false; }
+    void Disable(GpuAVSettings& settings) { settings.ray_tracing_buffers_consistency = false; }
     std::string DisableMessage() {
         return "\tRay tracing buffers consistency option was enabled, but the shaderInt64 or shaderInt16 or shaderInt8 "
                "features are not "
@@ -442,7 +443,7 @@ struct RayTracingBuffersConsistency : public Setting {
 
 // At this point extensions/features may have been turned on by us in PreCallRecord.
 // Now that we have all the information, here is where we might disable GPU-AV settings that are missing requirements
-void Validator::InitSettings(const Location &loc) {
+void Validator::InitSettings(const Location& loc) {
     setting::BufferDeviceAddress buffer_device_address;
     setting::RayQuery ray_query;
     setting::RayHitObject ray_hit_object;
@@ -451,12 +452,12 @@ void Validator::InitSettings(const Location &loc) {
     setting::BufferContent buffer_content;
     setting::AccelerationStructuresBuild as_builds;
     setting::RayTracingBuffersConsistency rt_buffers_consistency;
-    std::array<setting::Setting *, 8> all_settings = {
+    std::array<setting::Setting*, 8> all_settings = {
         &buffer_device_address, &ray_query,      &ray_hit_object, &mesh_shading,
         &buffer_copies,         &buffer_content, &as_builds,      &rt_buffers_consistency};
 
     std::string adjustment_warnings;
-    for (auto &setting_object : all_settings) {
+    for (auto& setting_object : all_settings) {
         if (setting_object->IsEnabled(gpuav_settings) && !setting_object->HasRequiredFeatures(modified_features)) {
             setting_object->Disable(gpuav_settings);
             adjustment_warnings += setting_object->DisableMessage();
@@ -497,18 +498,18 @@ void Validator::InitSettings(const Location &loc) {
     gpuav_settings.TracyLogSettings();
 }
 
-void Validator::InternalVmaError(LogObjectList objlist, VkResult result, const char *const specific_message) const {
+void Validator::InternalVmaError(LogObjectList objlist, VkResult result, const char* const specific_message) const {
     aborted_ = true;
     std::string error_message = specific_message;
 
-    char *stats_string;
+    char* stats_string;
     vmaBuildStatsString(vma_allocator_, &stats_string, false);
     error_message += " VMA statistics = ";
     error_message += stats_string;
     vmaFreeStatsString(vma_allocator_, stats_string);
 
-    const char *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
-    const char *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
+    const char* layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
+    const char* vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
 
     LogError(vuid, objlist, Location(vvl::Func::Empty), "Internal VMA Error (%s), %s is being disabled. Details:\n%s",
              string_VkResult(result), layer_name, error_message.c_str());
@@ -549,7 +550,7 @@ void Validator::DestroySubstate() {
     for (auto object_it = dispatch_device_->object_dispatch.begin(); object_it != dispatch_device_->object_dispatch.end();
          object_it++) {
         if ((*object_it)->container_type == LayerObjectTypeStateTracker) {
-            auto &state_tracker = dynamic_cast<vvl::DeviceState &>(**object_it);
+            auto& state_tracker = dynamic_cast<vvl::DeviceState&>(**object_it);
             state_tracker.RemoveSubState(LayerObjectTypeGpuAssisted);
         }
     }

--- a/layers/gpuav/core/gpuav_validation_pipeline.cpp
+++ b/layers/gpuav/core/gpuav_validation_pipeline.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2025 The Khronos Group Inc.
- * Copyright (c) 2018-2025 Valve Corporation
- * Copyright (c) 2018-2025 LunarG, Inc.
+/* Copyright (c) 2018-2026 The Khronos Group Inc.
+ * Copyright (c) 2018-2026 Valve Corporation
+ * Copyright (c) 2018-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,12 @@ namespace gpuav {
 namespace valpipe {
 namespace internal {
 
-bool CreateComputePipelineHelper(Validator &gpuav, const Location &loc,
+bool CreateComputePipelineHelper(Validator& gpuav, const Location& loc,
                                  const std::vector<VkDescriptorSetLayoutBinding> specific_bindings,
                                  VkDescriptorSetLayout additional_desc_set_layout, uint32_t push_constants_byte_size,
-                                 uint32_t spirv_size, const uint32_t *spirv, VkDevice &out_device,
-                                 VkDescriptorSetLayout &out_specific_descriptor_set_layout, VkPipelineLayout &out_pipeline_layout,
-                                 VkShaderModule &out_shader_module, VkPipeline &out_pipeline) {
+                                 uint32_t spirv_size, const uint32_t* spirv, VkDevice& out_device,
+                                 VkDescriptorSetLayout& out_specific_descriptor_set_layout, VkPipelineLayout& out_pipeline_layout,
+                                 VkShaderModule& out_shader_module, VkPipeline& out_pipeline) {
     out_device = gpuav.device;
     VkPushConstantRange push_constant_range = {};
     push_constant_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
@@ -113,13 +113,13 @@ void DestroyComputePipelineHelper(VkDevice device, VkDescriptorSetLayout specifi
     }
 }
 
-VkDescriptorSet GetDescriptorSetHelper(CommandBufferSubState &cb_state, VkDescriptorSetLayout desc_set_layout) {
+VkDescriptorSet GetDescriptorSetHelper(CommandBufferSubState& cb_state, VkDescriptorSetLayout desc_set_layout) {
     return cb_state.gpu_resources_manager.GetManagedDescriptorSet(desc_set_layout);
 }
 
-void BindShaderResourcesHelper(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineLayout pipeline_layout,
-                               VkDescriptorSet desc_set, const std::vector<VkWriteDescriptorSet> &descriptor_writes,
-                               const uint32_t push_constants_byte_size, const void *push_constants) {
+void BindShaderResourcesHelper(Validator& gpuav, CommandBufferSubState& cb_state, VkPipelineLayout pipeline_layout,
+                               VkDescriptorSet desc_set, const std::vector<VkWriteDescriptorSet>& descriptor_writes,
+                               const uint32_t push_constants_byte_size, const void* push_constants) {
     // Any push constants byte size below 4 is illegal. Can come from empty push constant struct
     if (push_constants_byte_size >= 4) {
         DispatchCmdPushConstants(cb_state.VkHandle(), pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, push_constants_byte_size,
@@ -137,11 +137,11 @@ void BindShaderResourcesHelper(Validator &gpuav, CommandBufferSubState &cb_state
 
 }  // namespace internal
 
-void RestorablePipelineState::Create(CommandBufferSubState &cb_state, VkPipelineBindPoint bind_point) {
+void RestorablePipelineState::Create(CommandBufferSubState& cb_state, VkPipelineBindPoint bind_point) {
     pipeline_bind_point_ = bind_point;
     const vvl::BindPoint vvl_bind_point = ConvertToVvlBindPoint(bind_point);
 
-    LastBound &last_bound = cb_state.base.lastBound[vvl_bind_point];
+    LastBound& last_bound = cb_state.base.lastBound[vvl_bind_point];
     if (last_bound.pipeline_state) {
         pipeline_ = last_bound.pipeline_state->VkHandle();
 
@@ -164,7 +164,7 @@ void RestorablePipelineState::Create(CommandBufferSubState &cb_state, VkPipeline
 
     descriptor_sets_.reserve(last_bound.ds_slots.size());
     for (std::size_t set_i = 0; set_i < last_bound.ds_slots.size(); set_i++) {
-        const auto &bound_descriptor_set = last_bound.ds_slots[set_i].ds_state;
+        const auto& bound_descriptor_set = last_bound.ds_slots[set_i].ds_state;
         if (bound_descriptor_set) {
             descriptor_sets_.emplace_back(bound_descriptor_set->VkHandle(), static_cast<uint32_t>(set_i));
             if (bound_descriptor_set->IsPushDescriptor()) {
@@ -205,7 +205,7 @@ void RestorablePipelineState::Restore() const {
     if (!shader_objects_.empty()) {
         std::vector<VkShaderStageFlagBits> stages;
         std::vector<VkShaderEXT> shaders;
-        for (const vvl::ShaderObject *shader_obj : shader_objects_) {
+        for (const vvl::ShaderObject* shader_obj : shader_objects_) {
             stages.emplace_back(shader_obj->create_info.stage);
             shaders.emplace_back(shader_obj->VkHandle());
         }
@@ -225,10 +225,10 @@ void RestorablePipelineState::Restore() const {
     if (!push_descriptor_set_writes_.empty()) {
         DispatchCmdPushDescriptorSetKHR(cb_state_.VkHandle(), pipeline_bind_point_, desc_set_pipeline_layout_,
                                         push_descriptor_set_index_, static_cast<uint32_t>(push_descriptor_set_writes_.size()),
-                                        reinterpret_cast<const VkWriteDescriptorSet *>(push_descriptor_set_writes_.data()));
+                                        reinterpret_cast<const VkWriteDescriptorSet*>(push_descriptor_set_writes_.data()));
     }
 
-    for (const auto &push_constant_range : push_constants_data_) {
+    for (const auto& push_constant_range : push_constants_data_) {
         DispatchCmdPushConstants(cb_state_.VkHandle(), push_constant_range.layout, push_constant_range.stage_flags,
                                  push_constant_range.offset, static_cast<uint32_t>(push_constant_range.values.size()),
                                  push_constant_range.values.data());

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -71,7 +71,7 @@ struct Substring {
     bool is_pointer = false;
 };
 
-static std::vector<Substring> ParseFormatString(const std::string &format_string) {
+static std::vector<Substring> ParseFormatString(const std::string& format_string) {
     const char types[] = {'d', 'i', 'o', 'u', 'x', 'X', 'a', 'A', 'e', 'E', 'f', 'F', 'g', 'G', 'v', 'p', '\0'};
     std::vector<Substring> parsed_strings;
     size_t pos = 0;
@@ -175,14 +175,14 @@ struct OutputRecord {
     uint32_t size;                  // kHeader_ErrorRecordSizeOffset
     uint32_t shader_id;             // kHeader_ShaderIdErrorOffset
     uint32_t stage_instruction_id;  // kHeader_StageInstructionIdOffset
-    uint32_t stage_info_0;  // kHeader_StageInfoOffset_0
-    uint32_t stage_info_1;  // kHeader_StageInfoOffset_1
-    uint32_t stage_info_2;  // kHeader_StageInfoOffset_2
+    uint32_t stage_info_0;          // kHeader_StageInfoOffset_0
+    uint32_t stage_info_1;          // kHeader_StageInfoOffset_1
+    uint32_t stage_info_2;          // kHeader_StageInfoOffset_2
     uint32_t format_string_id;
     uint32_t double_bitmask;     // used to distinguish if float is 1 or 2 dwords
     uint32_t signed_8_bitmask;   // used to distinguish if signed int is a int8_t
     uint32_t signed_16_bitmask;  // used to distinguish if signed int is a int16_t
-    uint32_t values;  // place holder to be casted to get rest of items in record
+    uint32_t values;             // place holder to be casted to get rest of items in record
 };
 
 struct DebugPrintfBufferInfo {
@@ -195,11 +195,11 @@ struct DebugPrintfBufferInfo {
     LogObjectList objlist;
 
     DebugPrintfBufferInfo(vko::BufferRange output_mem_buffer, VkPipelineBindPoint pipeline_bind_point,
-                          uint32_t action_command_index, const LogObjectList &objlist)
+                          uint32_t action_command_index, const LogObjectList& objlist)
         : output_mem_buffer(output_mem_buffer),
           pipeline_bind_point(pipeline_bind_point),
           action_command_index(action_command_index),
-          objlist(objlist){};
+          objlist(objlist) {};
 };
 
 struct DebugPrintfCbState {
@@ -218,7 +218,7 @@ void AnalyzeAndGenerateMessage(Validator& gpuav, VkCommandBuffer command_buffer,
         const OutputRecord* debug_record = reinterpret_cast<const OutputRecord*>(&debug_output_buffer[output_record_i]);
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
         // by the instrumented shader.
-        const gpuav::InstrumentedShader *instrumented_shader = nullptr;
+        const gpuav::InstrumentedShader* instrumented_shader = nullptr;
         auto it = gpuav.instrumented_shaders_map_.find(debug_record->shader_id);
         if (it != gpuav.instrumented_shaders_map_.end()) {
             instrumented_shader = &it->second;
@@ -232,7 +232,7 @@ void AnalyzeAndGenerateMessage(Validator& gpuav, VkCommandBuffer command_buffer,
 
         // Search through the shader source for the printf format string for this invocation
         std::string format_string;
-        const char *op_string = ::spirv::GetOpString(instrumented_shader->original_spirv, debug_record->format_string_id);
+        const char* op_string = ::spirv::GetOpString(instrumented_shader->original_spirv, debug_record->format_string_id);
         if (op_string) {
             format_string = std::string(op_string);
         } else {
@@ -251,7 +251,7 @@ void AnalyzeAndGenerateMessage(Validator& gpuav, VkCommandBuffer command_buffer,
         const void* current_value = static_cast<const void*>(&debug_record->values);
         // Sprintf each format substring into a temporary string then add that to the message
         for (size_t substring_i = 0; substring_i < format_substrings.size(); substring_i++) {
-            auto &substring = format_substrings[substring_i];
+            auto& substring = format_substrings[substring_i];
             std::string temp_string;
             size_t needed = 0;
 
@@ -259,7 +259,7 @@ void AnalyzeAndGenerateMessage(Validator& gpuav, VkCommandBuffer command_buffer,
                 if (substring.is_64_bit) {
                     if (substring.type == NumericTypeUint) {
                         std::array<std::string_view, 3> format_strings = {{"%ul", "%lu", "%lx"}};
-                        for (const auto &ul_string : format_strings) {
+                        for (const auto& ul_string : format_strings) {
                             size_t ul_pos = substring.string.find(ul_string);
                             if (ul_pos == std::string::npos) continue;
                             if (ul_string != "%lu") {
@@ -403,15 +403,15 @@ void AnalyzeAndGenerateMessage(Validator& gpuav, VkCommandBuffer command_buffer,
 #pragma GCC diagnostic pop
 #endif
 
-void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
+void RegisterDebugPrintf(Validator& gpuav, CommandBufferSubState& cb_state) {
     if (!gpuav.gpuav_settings.debug_printf_enabled) {
         return;
     }
 
     cb_state.on_instrumentation_desc_set_update_functions.emplace_back(
         [debug_printf_buffer_size = gpuav.gpuav_settings.debug_printf_buffer_size](
-            CommandBufferSubState &cb, VkPipelineBindPoint bind_point, const Location &, VkDescriptorBufferInfo &out_buffer_info,
-            uint32_t &out_dst_binding) {
+            CommandBufferSubState& cb, VkPipelineBindPoint bind_point, const Location&, VkDescriptorBufferInfo& out_buffer_info,
+            uint32_t& out_dst_binding) {
             vko::BufferRange debug_printf_output_buffer =
                 cb.gpu_resources_manager.GetHostCoherentBufferRange(debug_printf_buffer_size);
             std::memset(debug_printf_output_buffer.offset_mapped_ptr, 0, (size_t)debug_printf_buffer_size);
@@ -422,15 +422,15 @@ void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
 
             out_dst_binding = glsl::kBindingInstDebugPrintf;
 
-            DebugPrintfCbState &debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
+            DebugPrintfCbState& debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
             debug_printf_cb_state.buffer_infos.emplace_back(
                 debug_printf_output_buffer, bind_point, cb.GetActionCommandIndex(bind_point), cb.base.GetObjectList(bind_point));
         });
 
     cb_state.on_instrumentation_desc_buffer_update_functions.emplace_back(
         [debug_printf_buffer_size = gpuav.gpuav_settings.debug_printf_buffer_size](
-            CommandBufferSubState &cb, VkPipelineBindPoint bind_point, VkDescriptorAddressInfoEXT &out_address_info,
-            uint32_t &out_dst_binding) {
+            CommandBufferSubState& cb, VkPipelineBindPoint bind_point, VkDescriptorAddressInfoEXT& out_address_info,
+            uint32_t& out_dst_binding) {
             vko::BufferRange debug_printf_output_buffer =
                 cb.gpu_resources_manager.GetHostCoherentBufferRange(debug_printf_buffer_size);
             std::memset(debug_printf_output_buffer.offset_mapped_ptr, 0, (size_t)debug_printf_buffer_size);
@@ -440,15 +440,15 @@ void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
 
             out_dst_binding = glsl::kBindingInstDebugPrintf;
 
-            DebugPrintfCbState &debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
+            DebugPrintfCbState& debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
             debug_printf_cb_state.buffer_infos.emplace_back(
                 debug_printf_output_buffer, bind_point, cb.GetActionCommandIndex(bind_point), cb.base.GetObjectList(bind_point));
         });
 
     cb_state.on_instrumentation_desc_heap_update_functions.emplace_back(
         [debug_printf_buffer_size = gpuav.gpuav_settings.debug_printf_buffer_size](
-            CommandBufferSubState &cb, VkPipelineBindPoint bind_point, const Location &loc, VkDeviceAddress &out_address,
-            uint32_t &out_dst_binding) {
+            CommandBufferSubState& cb, VkPipelineBindPoint bind_point, const Location& loc, VkDeviceAddress& out_address,
+            uint32_t& out_dst_binding) {
             vko::BufferRange debug_printf_output_buffer =
                 cb.gpu_resources_manager.GetHostCoherentBufferRange(debug_printf_buffer_size);
             std::memset(debug_printf_output_buffer.offset_mapped_ptr, 0, (size_t)debug_printf_buffer_size);
@@ -457,21 +457,21 @@ void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
 
             out_dst_binding = glsl::kBindingInstDebugPrintf;
 
-            DebugPrintfCbState &debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
+            DebugPrintfCbState& debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
             debug_printf_cb_state.buffer_infos.emplace_back(
                 debug_printf_output_buffer, bind_point, cb.GetActionCommandIndex(bind_point), cb.base.GetObjectList(bind_point));
         });
 
-    cb_state.on_cb_completion_functions.emplace_back([](Validator &gpuav, CommandBufferSubState &cb,
-                                                        const CommandBufferSubState::LabelLogging &label_logging,
-                                                        const Location &loc) {
-        DebugPrintfCbState *debug_printf_cb_state = cb.shared_resources_cache.TryGet<DebugPrintfCbState>();
+    cb_state.on_cb_completion_functions.emplace_back([](Validator& gpuav, CommandBufferSubState& cb,
+                                                        const CommandBufferSubState::LabelLogging& label_logging,
+                                                        const Location& loc) {
+        DebugPrintfCbState* debug_printf_cb_state = cb.shared_resources_cache.TryGet<DebugPrintfCbState>();
         if (!debug_printf_cb_state) {
             return true;
         }
-        for (DebugPrintfBufferInfo &printf_buffer_info : debug_printf_cb_state->buffer_infos) {
-            auto printf_output_ptr = (char *)printf_buffer_info.output_mem_buffer.offset_mapped_ptr;
-            debug_printf::AnalyzeAndGenerateMessage(gpuav, cb.VkHandle(), printf_buffer_info, (uint32_t *)printf_output_ptr, loc);
+        for (DebugPrintfBufferInfo& printf_buffer_info : debug_printf_cb_state->buffer_infos) {
+            auto printf_output_ptr = (char*)printf_buffer_info.output_mem_buffer.offset_mapped_ptr;
+            debug_printf::AnalyzeAndGenerateMessage(gpuav, cb.VkHandle(), printf_buffer_info, (uint32_t*)printf_output_ptr, loc);
         }
         return true;
     });

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -32,7 +32,7 @@ using vvl::DescriptorClass;
 
 namespace gpuav {
 
-DescriptorSetSubState::DescriptorSetSubState(const vvl::DescriptorSet &set, Validator &state_data)
+DescriptorSetSubState::DescriptorSetSubState(const vvl::DescriptorSet& set, Validator& state_data)
     : vvl::DescriptorSetSubState(set), input_buffer_(state_data) {
     BuildBindingLayouts();
 }
@@ -44,7 +44,7 @@ void DescriptorSetSubState::BuildBindingLayouts() {
 
     binding_layouts_.resize(binding_count);
     uint32_t start = 0;
-    for (const auto &binding : base) {
+    for (const auto& binding : base) {
         if (binding->type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) {
             binding_layouts_[binding->binding] = {start, 1};
             start++;
@@ -56,21 +56,21 @@ void DescriptorSetSubState::BuildBindingLayouts() {
 }
 
 template <typename StateObject>
-DescriptorId GetId(const StateObject *obj, bool allow_null = true) {
+DescriptorId GetId(const StateObject* obj, bool allow_null = true) {
     if (!obj) {
         return allow_null ? glsl::kNullDescriptor : 0;
     }
-    auto &sub_state = SubState(*obj);
+    auto& sub_state = SubState(*obj);
     return sub_state.Id();
 }
 
-static glsl::DescriptorState GetInData(const vvl::BufferDescriptor &desc) {
+static glsl::DescriptorState GetInData(const vvl::BufferDescriptor& desc) {
     return glsl::DescriptorState(DescriptorClass::GeneralBuffer, GetId(desc.GetBufferState()),
                                  static_cast<uint32_t>(desc.GetEffectiveRange()));
 }
 
-static glsl::DescriptorState GetInData(const vvl::TexelDescriptor &desc) {
-    auto *buffer_view_state = desc.GetBufferViewState();
+static glsl::DescriptorState GetInData(const vvl::TexelDescriptor& desc) {
+    auto* buffer_view_state = desc.GetBufferViewState();
     uint32_t res_size = vvl::kNoIndex32;
     if (buffer_view_state) {
         auto view_size = buffer_view_state->Size();
@@ -79,31 +79,31 @@ static glsl::DescriptorState GetInData(const vvl::TexelDescriptor &desc) {
     return glsl::DescriptorState(DescriptorClass::TexelBuffer, GetId(buffer_view_state), res_size);
 }
 
-static glsl::DescriptorState GetInData(const vvl::ImageDescriptor &desc) {
+static glsl::DescriptorState GetInData(const vvl::ImageDescriptor& desc) {
     return glsl::DescriptorState(DescriptorClass::Image, GetId(desc.GetImageViewState()));
 }
 
-static glsl::DescriptorState GetInData(const vvl::TensorDescriptor &desc) {
-    auto tensor_view_state = static_cast<const vvl::TensorView *>(desc.GetTensorViewState());
+static glsl::DescriptorState GetInData(const vvl::TensorDescriptor& desc) {
+    auto tensor_view_state = static_cast<const vvl::TensorView*>(desc.GetTensorViewState());
     return glsl::DescriptorState(DescriptorClass::Tensor, tensor_view_state ? tensor_view_state->GetId() : glsl::kNullDescriptor);
 }
 
-static glsl::DescriptorState GetInData(const vvl::SamplerDescriptor &desc) {
+static glsl::DescriptorState GetInData(const vvl::SamplerDescriptor& desc) {
     return glsl::DescriptorState(DescriptorClass::PlainSampler, GetId(desc.GetSamplerState()));
 }
 
-static glsl::DescriptorState GetInData(const vvl::ImageSamplerDescriptor &desc) {
+static glsl::DescriptorState GetInData(const vvl::ImageSamplerDescriptor& desc) {
     // image can be null in some cases, but the sampler can't
     return glsl::DescriptorState(DescriptorClass::ImageSampler, GetId(desc.GetImageViewState()),
                                  GetId(desc.GetSamplerState(), false));
 }
 
-static glsl::DescriptorState GetInData(const vvl::AccelerationStructureDescriptor &ac) {
+static glsl::DescriptorState GetInData(const vvl::AccelerationStructureDescriptor& ac) {
     uint32_t id = ac.IsKHR() ? GetId(ac.GetAccelerationStructureStateKHR()) : GetId(ac.GetAccelerationStructureStateNV());
     return glsl::DescriptorState(DescriptorClass::AccelerationStructure, id);
 }
 
-static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
+static glsl::DescriptorState GetInData(const vvl::MutableDescriptor& desc) {
     auto desc_class = desc.ActiveClass();
     switch (desc_class) {
         case DescriptorClass::GeneralBuffer: {
@@ -151,7 +151,7 @@ static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
 }
 
 template <typename Binding>
-void FillBindingInData(const Binding &binding, glsl::DescriptorState *data, uint32_t &index) {
+void FillBindingInData(const Binding& binding, glsl::DescriptorState* data, uint32_t& index) {
     for (uint32_t di = 0; di < binding.count; di++) {
         if (!binding.updated[di]) {
             data[index++] = glsl::DescriptorState();
@@ -163,12 +163,12 @@ void FillBindingInData(const Binding &binding, glsl::DescriptorState *data, uint
 
 // Inline Uniforms are currently treated as a single descriptor. Writes to any offsets cause the whole range to be valid.
 template <>
-void FillBindingInData(const vvl::InlineUniformBinding &binding, glsl::DescriptorState *data, uint32_t &index) {
+void FillBindingInData(const vvl::InlineUniformBinding& binding, glsl::DescriptorState* data, uint32_t& index) {
     // While not techincally a "null descriptor" we want to skip it as if it is one
     data[index++] = glsl::DescriptorState(DescriptorClass::InlineUniform, glsl::kNullDescriptor, vvl::kNoIndex32);
 }
 
-VkDeviceAddress DescriptorSetSubState::GetTypeAddress(Validator &gpuav) {
+VkDeviceAddress DescriptorSetSubState::GetTypeAddress(Validator& gpuav) {
     std::lock_guard guard(state_lock_);
     const uint32_t current_version = current_version_.load();
 
@@ -202,37 +202,37 @@ VkDeviceAddress DescriptorSetSubState::GetTypeAddress(Validator &gpuav) {
         return 0;
     }
 
-    auto data = (glsl::DescriptorState *)input_buffer_.GetMappedPtr();
+    auto data = (glsl::DescriptorState*)input_buffer_.GetMappedPtr();
 
     uint32_t index = 0;
-    for (const auto &binding : base) {
+    for (const auto& binding : base) {
         switch (binding->descriptor_class) {
             case DescriptorClass::InlineUniform:
-                FillBindingInData(static_cast<const vvl::InlineUniformBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::InlineUniformBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::GeneralBuffer:
-                FillBindingInData(static_cast<const vvl::BufferBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::BufferBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::TexelBuffer:
-                FillBindingInData(static_cast<const vvl::TexelBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::TexelBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::Mutable:
-                FillBindingInData(static_cast<const vvl::MutableBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::MutableBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::PlainSampler:
-                FillBindingInData(static_cast<const vvl::SamplerBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::SamplerBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::ImageSampler:
-                FillBindingInData(static_cast<const vvl::ImageSamplerBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::ImageSamplerBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::Image:
-                FillBindingInData(static_cast<const vvl::ImageBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::ImageBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::AccelerationStructure:
-                FillBindingInData(static_cast<const vvl::AccelerationStructureBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::AccelerationStructureBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::Tensor:
-                FillBindingInData(static_cast<const vvl::TensorBinding &>(*binding), data, index);
+                FillBindingInData(static_cast<const vvl::TensorBinding&>(*binding), data, index);
                 break;
             case DescriptorClass::Invalid:
                 gpuav.InternalError(gpuav.device, Location(vvl::Func::Empty), "Unknown DescriptorClass");

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
+/* Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,16 +26,16 @@
 namespace gpuav {
 namespace descriptor {
 
-void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineBindPoint pipeline_bind_point,
-                            const Location &loc) {
+void UpdateBoundDescriptors(Validator& gpuav, CommandBufferSubState& cb_state, VkPipelineBindPoint pipeline_bind_point,
+                            const Location& loc) {
     // If DescriptorSetBindings has not been created at this point, then no validation needs it,
     // so skip updating it.
-    DescriptorSetBindings *desc_set_bindings = cb_state.shared_resources_cache.TryGet<DescriptorSetBindings>();
+    DescriptorSetBindings* desc_set_bindings = cb_state.shared_resources_cache.TryGet<DescriptorSetBindings>();
     if (!desc_set_bindings) {
         return;
     }
 
-    auto const &last_bound = cb_state.base.lastBound[ConvertToVvlBindPoint(pipeline_bind_point)];
+    auto const& last_bound = cb_state.base.lastBound[ConvertToVvlBindPoint(pipeline_bind_point)];
 
     const size_t number_of_sets = last_bound.ds_slots.size();
     if (number_of_sets == 0) {
@@ -50,11 +50,11 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, V
     // Currently we loop through the sets multiple times to reduce complexity and seperate the various parts, can revisit if we find
     // this is actually a perf bottleneck (assume number of sets are low as people we will then to have a single large set)
     for (uint32_t i = 0; i < number_of_sets; i++) {
-        const auto &ds_slot = last_bound.ds_slots[i];
+        const auto& ds_slot = last_bound.ds_slots[i];
         descriptor_binding_cmd.bound_descriptor_sets.emplace_back(ds_slot.ds_state);
     }
 
-    for (auto &descriptor_binding_func : desc_set_bindings->on_update_bound_descriptor_sets) {
+    for (auto& descriptor_binding_func : desc_set_bindings->on_update_bound_descriptor_sets) {
         descriptor_binding_func(gpuav, cb_state, descriptor_binding_cmd);
     }
     desc_set_bindings->descriptor_set_binding_commands.emplace_back(std::move(descriptor_binding_cmd));

--- a/layers/gpuav/instrumentation/buffer_device_address.cpp
+++ b/layers/gpuav/instrumentation/buffer_device_address.cpp
@@ -38,61 +38,59 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
 
     cb.on_instrumentation_error_logger_register_functions.emplace_back([](Validator& gpuav, CommandBufferSubState& cb,
                                                                           const LastBound& last_bound) {
-        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator& gpuav, const Location&,
-                                                                                 const uint32_t* error_record,
-                                                                                 const InstrumentedShader* instrumented_shader,
-                                                                                 std::string& out_error_msg,
-                                                                                 std::string& out_vuid_msg) {
-            using namespace glsl;
-            bool error_found = false;
-            if (GetErrorGroup(error_record) != kErrorGroup_InstBufferDeviceAddress) {
+        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger =
+            [](Validator& gpuav, const Location&, const uint32_t* error_record, const InstrumentedShader* instrumented_shader,
+               std::string& out_error_msg, std::string& out_vuid_msg) {
+                using namespace glsl;
+                bool error_found = false;
+                if (GetErrorGroup(error_record) != kErrorGroup_InstBufferDeviceAddress) {
+                    return error_found;
+                }
+                error_found = true;
+
+                std::ostringstream strm;
+
+                const uint32_t payload = error_record[kInst_LogError_ParameterOffset_2];
+                const bool is_write = ((payload >> kInst_BuffAddrAccess_PayloadShiftIsWrite) & 1) != 0;
+                const bool is_struct = ((payload >> kInst_BuffAddrAccess_PayloadShiftIsStruct) & 1) != 0;
+
+                const uint64_t address = *reinterpret_cast<const uint64_t*>(error_record + kInst_LogError_ParameterOffset_0);
+
+                const uint32_t error_sub_code = GetSubError(error_record);
+                switch (error_sub_code) {
+                    case kErrorSubCode_BufferDeviceAddress_UnallocRef: {
+                        const char* access_type = is_write ? "written" : "read";
+                        const uint32_t byte_size = payload & kInst_BuffAddrAccess_PayloadMaskAccessInfo;
+                        strm << "Out of bounds access: " << byte_size << " bytes " << access_type << " at buffer device address 0x"
+                             << std::hex << address << '.';
+                        if (is_struct) {
+                            // Added because glslang currently has no way to seperate out the struct (Slang does as of 2025.6.2)
+                            strm << " This " << (is_write ? "write" : "read") << " corresponds to a full OpTypeStruct load";
+                            const uint32_t instruction_position_offset =
+                                error_record[kHeader_StageInstructionIdOffset] & kInstructionId_Mask;
+                            ::spirv::FindOpStructFromBDA(strm, instrumented_shader->original_spirv, instruction_position_offset);
+                            strm << ". While not all members of the struct might be accessed, "
+                                    "it is up "
+                                    "to the source language or tooling to detect that and reflect it in the SPIR-V.";
+                        }
+                        out_vuid_msg = "VUID-RuntimeSpirv-PhysicalStorageBuffer64-11819";
+
+                    } break;
+                    case kErrorSubCode_BufferDeviceAddress_Alignment: {
+                        const char* access_type = is_write ? "OpStore" : "OpLoad";
+                        const uint32_t alignment = (payload & kInst_BuffAddrAccess_PayloadMaskAccessInfo);
+                        strm << "Unaligned pointer access: The " << access_type << " at buffer device address 0x" << std::hex
+                             << address << " is not aligned to the instruction Aligned operand of " << std::dec << alignment << '.';
+                        out_vuid_msg = "VUID-RuntimeSpirv-PhysicalStorageBuffer64-06315";
+
+                    } break;
+                    default:
+                        error_found = false;
+                        break;
+                }
+                out_error_msg += strm.str();
                 return error_found;
-            }
-            error_found = true;
-
-            std::ostringstream strm;
-
-            const uint32_t payload = error_record[kInst_LogError_ParameterOffset_2];
-            const bool is_write = ((payload >> kInst_BuffAddrAccess_PayloadShiftIsWrite) & 1) != 0;
-            const bool is_struct = ((payload >> kInst_BuffAddrAccess_PayloadShiftIsStruct) & 1) != 0;
-
-            const uint64_t address = *reinterpret_cast<const uint64_t*>(error_record + kInst_LogError_ParameterOffset_0);
-
-            const uint32_t error_sub_code = GetSubError(error_record);
-            switch (error_sub_code) {
-                case kErrorSubCode_BufferDeviceAddress_UnallocRef: {
-                    const char* access_type = is_write ? "written" : "read";
-                    const uint32_t byte_size = payload & kInst_BuffAddrAccess_PayloadMaskAccessInfo;
-                    strm << "Out of bounds access: " << byte_size << " bytes " << access_type << " at buffer device address 0x"
-                         << std::hex << address << '.';
-                    if (is_struct) {
-                        // Added because glslang currently has no way to seperate out the struct (Slang does as of 2025.6.2)
-                        strm << " This " << (is_write ? "write" : "read") << " corresponds to a full OpTypeStruct load";
-                        const uint32_t instruction_position_offset =
-                            error_record[kHeader_StageInstructionIdOffset] & kInstructionId_Mask;
-                        ::spirv::FindOpStructFromBDA(strm, instrumented_shader->original_spirv, instruction_position_offset);
-                        strm << ". While not all members of the struct might be accessed, "
-                                "it is up "
-                                "to the source language or tooling to detect that and reflect it in the SPIR-V.";
-                    }
-                    out_vuid_msg = "VUID-RuntimeSpirv-PhysicalStorageBuffer64-11819";
-
-                } break;
-                case kErrorSubCode_BufferDeviceAddress_Alignment: {
-                    const char* access_type = is_write ? "OpStore" : "OpLoad";
-                    const uint32_t alignment = (payload & kInst_BuffAddrAccess_PayloadMaskAccessInfo);
-                    strm << "Unaligned pointer access: The " << access_type << " at buffer device address 0x" << std::hex << address
-                         << " is not aligned to the instruction Aligned operand of " << std::dec << alignment << '.';
-                    out_vuid_msg = "VUID-RuntimeSpirv-PhysicalStorageBuffer64-06315";
-
-                } break;
-                default:
-                    error_found = false;
-                    break;
-            }
-            out_error_msg += strm.str();
-            return error_found;
-        };
+            };
 
         return inst_error_logger;
     });
@@ -117,32 +115,32 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
         out_dst_binding = glsl::kBindingInstBufferDeviceAddress;
     });
 
-    cb.on_pre_cb_submission_functions.emplace_back([](Validator& gpuav, CommandBufferSubState& cb,
-                                                      VkCommandBuffer per_submission_cb) {
-        BufferDeviceAddressCbState* bda_cb_state = cb.shared_resources_cache.TryGet<BufferDeviceAddressCbState>();
-        // Can happen if command buffer did not record any action command
-        if (!bda_cb_state) {
-            return;
-        }
+    cb.on_pre_cb_submission_functions.emplace_back(
+        [](Validator& gpuav, CommandBufferSubState& cb, VkCommandBuffer per_submission_cb) {
+            BufferDeviceAddressCbState* bda_cb_state = cb.shared_resources_cache.TryGet<BufferDeviceAddressCbState>();
+            // Can happen if command buffer did not record any action command
+            if (!bda_cb_state) {
+                return;
+            }
 
-        // Update buffer device address (BDA) table
-        // One snapshot update per CB submission, to prevent concurrent submissions of the same CB to write and read
-        // to the same snapshot.
-        const size_t bda_ranges_count = gpuav.device_state->GetBufferAddressRangesCount();
-        const VkDeviceSize bda_table_byte_size = 2 * sizeof(uint32_t) + 2 * sizeof(VkDeviceAddress) * bda_ranges_count;
-        vko::BufferRange bda_table = cb.gpu_resources_manager.GetHostCachedBufferRange(bda_table_byte_size);
+            // Update buffer device address (BDA) table
+            // One snapshot update per CB submission, to prevent concurrent submissions of the same CB to write and read
+            // to the same snapshot.
+            const size_t bda_ranges_count = gpuav.device_state->GetBufferAddressRangesCount();
+            const VkDeviceSize bda_table_byte_size = 2 * sizeof(uint32_t) + 2 * sizeof(VkDeviceAddress) * bda_ranges_count;
+            vko::BufferRange bda_table = cb.gpu_resources_manager.GetHostCachedBufferRange(bda_table_byte_size);
 
-        auto bda_table_ranges_u32_ptr = (uint32_t*)bda_table.offset_mapped_ptr;
-        *bda_table_ranges_u32_ptr = (uint32_t)bda_ranges_count;
-        gpuav.device_state->GetBufferAddressRanges((vvl::DeviceState::BufferAddressRange*)(bda_table_ranges_u32_ptr + 2));
-        cb.gpu_resources_manager.FlushAllocation(bda_table);
+            auto bda_table_ranges_u32_ptr = (uint32_t*)bda_table.offset_mapped_ptr;
+            *bda_table_ranges_u32_ptr = (uint32_t)bda_ranges_count;
+            gpuav.device_state->GetBufferAddressRanges((vvl::DeviceState::BufferAddressRange*)(bda_table_ranges_u32_ptr + 2));
+            cb.gpu_resources_manager.FlushAllocation(bda_table);
 
-        // Fill a GPU buffer with a pointer to the BDA table
-        vko::BufferRange bda_table_ptr = cb.gpu_resources_manager.GetHostCoherentBufferRange(sizeof(VkDeviceAddress));
-        *(VkDeviceAddress*)bda_table_ptr.offset_mapped_ptr = bda_table.offset_address;
+            // Fill a GPU buffer with a pointer to the BDA table
+            vko::BufferRange bda_table_ptr = cb.gpu_resources_manager.GetHostCoherentBufferRange(sizeof(VkDeviceAddress));
+            *(VkDeviceAddress*)bda_table_ptr.offset_mapped_ptr = bda_table.offset_address;
 
-        vko::CmdSynchronizedCopyBufferRange(per_submission_cb, bda_cb_state->bda_ranges_snapshot_ptr, bda_table_ptr);
-    });
+            vko::CmdSynchronizedCopyBufferRange(per_submission_cb, bda_cb_state->bda_ranges_snapshot_ptr, bda_table_ptr);
+        });
 }
 
 }  // namespace gpuav

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -56,14 +56,14 @@ struct CommonInstrumentationErrorInfo {
 };
 
 // If application is using shader objects, bindings count will be computed from bound shaders
-static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(const LastBound &last_bound) {
+static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(const LastBound& last_bound) {
     // App uses pipeline or graphics pipeline libraries
     if (last_bound.pipeline_state && last_bound.pipeline_state->PipelineLayoutState()) {
         return uint32_t(last_bound.pipeline_state->PipelineLayoutState()->set_layouts.list.size());
     }
 
     // App uses shader objects
-    if (const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader()) {
+    if (const vvl::ShaderObject* main_bound_shader = last_bound.GetFirstShader()) {
         return static_cast<uint32_t>(main_bound_shader->set_layouts.list.size());
     }
 
@@ -73,13 +73,13 @@ static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(const LastBound &l
 }
 
 // If application is using shader objects, bindings count will be computed from bound shaders
-static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(const LastBound &last_bound) {
+static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(const LastBound& last_bound) {
     if (last_bound.pipeline_state && last_bound.pipeline_state->PreRasterPipelineLayoutState()) {
         return static_cast<uint32_t>(
             last_bound.pipeline_state->PreRasterPipelineLayoutState()->push_constant_ranges_layout->size());
     }
 
-    if (const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader()) {
+    if (const vvl::ShaderObject* main_bound_shader = last_bound.GetFirstShader()) {
         return static_cast<uint32_t>(main_bound_shader->push_constant_ranges->size());
     }
 
@@ -88,7 +88,7 @@ static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(const LastBoun
     return 0;
 }
 
-static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, const Location &loc, const LastBound &last_bound,
+static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator& gpuav, const Location& loc, const LastBound& last_bound,
                                                             VkDescriptorSetLayout dummy_desc_set_layout,
                                                             VkDescriptorSetLayout instrumentation_desc_set_layout,
                                                             uint32_t inst_desc_set_binding) {
@@ -105,7 +105,7 @@ static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, co
         std::vector<VkPushConstantRange> ranges;
         if (last_bound_pipeline_pipe_layout->push_constant_ranges_layout) {
             ranges.reserve(last_bound_pipeline_pipe_layout->push_constant_ranges_layout->size());
-            for (const VkPushConstantRange &range : *last_bound_pipeline_pipe_layout->push_constant_ranges_layout) {
+            for (const VkPushConstantRange& range : *last_bound_pipeline_pipe_layout->push_constant_ranges_layout) {
                 ranges.push_back(range);
             }
         }
@@ -113,7 +113,7 @@ static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, co
         pipe_layout_ci.pPushConstantRanges = ranges.data();
         std::vector<VkDescriptorSetLayout> set_layouts;
         set_layouts.reserve(inst_desc_set_binding + 1);
-        for (const auto &set_layout : last_bound_pipeline_pipe_layout->set_layouts.list) {
+        for (const auto& set_layout : last_bound_pipeline_pipe_layout->set_layouts.list) {
             set_layouts.push_back(set_layout->VkHandle());
         }
         for (uint32_t set_i = static_cast<uint32_t>(last_bound_pipeline_pipe_layout->set_layouts.list.size());
@@ -135,7 +135,7 @@ static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, co
         // Application is using shader objects, compose a pipeline layout from bound shaders
         // ---
 
-        const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader();
+        const vvl::ShaderObject* main_bound_shader = last_bound.GetFirstShader();
         if (!main_bound_shader) {
             // Should not get there, it would mean no pipeline nor shader object was bound
             gpuav.InternalError(gpuav.device, loc, "Could not retrieve last bound computer/vertex/mesh shader");
@@ -150,7 +150,7 @@ static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, co
         // layouts
         // => To compose a VkPipelineLayout, only need to get compute or vertex/mesh shader and look at their bindings,
         // no need to check other shaders.
-        const vvl::DescriptorSetLayoutList &set_layouts = main_bound_shader->set_layouts;
+        const vvl::DescriptorSetLayoutList& set_layouts = main_bound_shader->set_layouts;
         PushConstantRangesId push_constants_layouts = main_bound_shader->push_constant_ranges;
 
         if (last_bound.desc_set_pipeline_layout) {
@@ -159,7 +159,7 @@ static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, co
         std::vector<VkDescriptorSetLayout> set_layout_handles;
         {
             set_layout_handles.reserve(inst_desc_set_binding + 1);
-            for (const auto &set_layout : set_layouts.list) {
+            for (const auto& set_layout : set_layouts.list) {
                 set_layout_handles.push_back(set_layout->VkHandle());
             }
             for (uint32_t set_i = static_cast<uint32_t>(set_layouts.list.size()); set_i < inst_desc_set_binding; ++set_i) {
@@ -185,11 +185,11 @@ static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, co
     }
 }
 
-void UpdateInstrumentationDescBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const LastBound &last_bound,
-                                     const Location &loc, CommonInstrumentationErrorInfo &out_error_info) {
+void UpdateInstrumentationDescBuffer(Validator& gpuav, CommandBufferSubState& cb_state, const LastBound& last_bound,
+                                     const Location& loc, CommonInstrumentationErrorInfo& out_error_info) {
     void* descriptor_start = gpuav.GetGlobalDescriptorBuffer().GetMappedPtr();
 
-    for (const auto &func : vvl::make_span(cb_state.on_instrumentation_desc_buffer_update_functions)) {
+    for (const auto& func : vvl::make_span(cb_state.on_instrumentation_desc_buffer_update_functions)) {
         VkDescriptorGetInfoEXT get_info = vku::InitStructHelper();
         get_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 
@@ -200,16 +200,16 @@ void UpdateInstrumentationDescBuffer(Validator &gpuav, CommandBufferSubState &cb
         get_info.data.pStorageBuffer = &address_info;
 
         const VkDeviceSize binding_offset = gpuav.resource_descriptor_buffer_offsets_[binding];
-        uint8_t *descriptor_offset = (uint8_t *)descriptor_start + binding_offset;
+        uint8_t* descriptor_offset = (uint8_t*)descriptor_start + binding_offset;
         DispatchGetDescriptorEXT(gpuav.device, &get_info,
                                  gpuav.phys_dev_ext_props.descriptor_buffer_props.storageBufferDescriptorSize, descriptor_offset);
     }
 }
 
-void UpdateInstrumentationDescHeap(Validator &gpuav, CommandBufferSubState &cb_state, VkDeviceAddress *indirect_memory,
+void UpdateInstrumentationDescHeap(Validator& gpuav, CommandBufferSubState& cb_state, VkDeviceAddress* indirect_memory,
                                    uint32_t action_command_index_offset, uint32_t resource_index_offset,
-                                   const LastBound &last_bound, const Location &loc,
-                                   CommonInstrumentationErrorInfo &out_error_info) {
+                                   const LastBound& last_bound, const Location& loc,
+                                   CommonInstrumentationErrorInfo& out_error_info) {
     if (gpuav.gpuav_settings.IsShaderInstrumentationEnabled()) {
         // Error output buffer
         indirect_memory[glsl::kBindingInstErrorBuffer] = cb_state.GetErrorOutputBufferRange().offset_address;
@@ -233,9 +233,9 @@ void UpdateInstrumentationDescHeap(Validator &gpuav, CommandBufferSubState &cb_s
     }
 }
 
-void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineBindPoint bind_point,
-                                  VkDescriptorSet instrumentation_desc_set, const Location &loc,
-                                  CommonInstrumentationErrorInfo &out_error_info) {
+void UpdateInstrumentationDescSet(Validator& gpuav, CommandBufferSubState& cb_state, VkPipelineBindPoint bind_point,
+                                  VkDescriptorSet instrumentation_desc_set, const Location& loc,
+                                  CommonInstrumentationErrorInfo& out_error_info) {
     small_vector<VkWriteDescriptorSet, 8> desc_writes = {};
 
     VkDescriptorBufferInfo error_output_desc_buffer_info = {};
@@ -321,7 +321,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
     DispatchUpdateDescriptorSets(gpuav.device, static_cast<uint32_t>(desc_writes.size()), desc_writes.data(), 0, nullptr);
 }
 
-static bool WasInstrumented(const LastBound &last_bound) {
+static bool WasInstrumented(const LastBound& last_bound) {
     if (last_bound.pipeline_state) {
         return last_bound.pipeline_state->instrumentation_data.was_instrumented;
     }
@@ -330,8 +330,8 @@ static bool WasInstrumented(const LastBound &last_bound) {
         if (!last_bound.IsValidShaderObjectBound(stage)) {
             continue;
         }
-        if (const vvl::ShaderObject *shader_object_state = last_bound.GetShaderObjectState(stage)) {
-            auto &sub_state = SubState(*shader_object_state);
+        if (const vvl::ShaderObject* shader_object_state = last_bound.GetShaderObjectState(stage)) {
+            auto& sub_state = SubState(*shader_object_state);
             if (sub_state.was_instrumented) {
                 return true;
             }
@@ -374,7 +374,7 @@ bool LogInstrumentationError(Validator& gpuav, const VkCommandBuffer cb_handle, 
         instrumented_shader = &it->second;
     }
 
-    for (const CommandBufferSubState::InstrumentationErrorLogger &error_logger : error_loggers) {
+    for (const CommandBufferSubState::InstrumentationErrorLogger& error_logger : error_loggers) {
         error_found = error_logger(gpuav, loc_with_debug_region, error_record, instrumented_shader, error_msg, vuid_msg);
         if (error_found) {
             break;
@@ -393,9 +393,9 @@ bool LogInstrumentationError(Validator& gpuav, const VkCommandBuffer cb_handle, 
     return error_found;
 }
 
-void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, CommandBufferSubState &cb_state,
-                                                       const LastBound &last_bound,
-                                                       const InstBindingPipeLayout &inst_binding_pipe_layout, const Location &loc) {
+void PreCallSetupShaderInstrumentationResourcesClassic(Validator& gpuav, CommandBufferSubState& cb_state,
+                                                       const LastBound& last_bound,
+                                                       const InstBindingPipeLayout& inst_binding_pipe_layout, const Location& loc) {
     const VkCommandBuffer cb_handle = cb_state.VkHandle();
     VkDescriptorSet instrumentation_desc_set =
         cb_state.gpu_resources_manager.GetManagedDescriptorSet(cb_state.GetInstrumentationDescriptorSetLayout());
@@ -490,7 +490,7 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
     }
 
     std::vector<CommandBufferSubState::InstrumentationErrorLogger> error_loggers = {};
-    for (const auto &func : vvl::make_span(cb_state.on_instrumentation_error_logger_register_functions)) {
+    for (const auto& func : vvl::make_span(cb_state.on_instrumentation_error_logger_register_functions)) {
         error_loggers.emplace_back(func(gpuav, cb_state, last_bound));
     }
 
@@ -506,10 +506,10 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
     cb_state.AddCommandErrorLogger(loc, &last_bound, std::move(error_logger));
 }
 
-void PreCallSetupShaderInstrumentationResourcesDescriptorHeap(Validator &gpuav, CommandBufferSubState &cb_state,
-                                                              const LastBound &last_bound, const Location &loc) {
-    const auto &heap_buffer = gpuav.GetGlobalDescriptorHeap();
-    VkDeviceAddress *indirect_memory = static_cast<VkDeviceAddress *>(heap_buffer.GetMappedPtr());
+void PreCallSetupShaderInstrumentationResourcesDescriptorHeap(Validator& gpuav, CommandBufferSubState& cb_state,
+                                                              const LastBound& last_bound, const Location& loc) {
+    const auto& heap_buffer = gpuav.GetGlobalDescriptorHeap();
+    VkDeviceAddress* indirect_memory = static_cast<VkDeviceAddress*>(heap_buffer.GetMappedPtr());
 
     CommonInstrumentationErrorInfo error_info;
     error_info.action_command_index = cb_state.GetActionCommandIndex(last_bound.bind_point);
@@ -527,7 +527,7 @@ void PreCallSetupShaderInstrumentationResourcesDescriptorHeap(Validator &gpuav, 
 
     std::vector<CommandBufferSubState::InstrumentationErrorLogger> error_loggers = {};
     for (size_t i = 0; i < cb_state.on_instrumentation_error_logger_register_functions.size(); ++i) {
-        const CommandBufferSubState::OnInstrumentationErrorLoggerRegister &error_logger_register =
+        const CommandBufferSubState::OnInstrumentationErrorLoggerRegister& error_logger_register =
             cb_state.on_instrumentation_error_logger_register_functions[i];
 
         error_loggers.emplace_back(error_logger_register(gpuav, cb_state, last_bound));
@@ -553,10 +553,10 @@ void PreCallSetupShaderInstrumentationResourcesDescriptorHeap(Validator &gpuav, 
     DispatchCmdPushDataEXT(cb_state.VkHandle(), &push_data_info);
 }
 
-void PreCallSetupShaderInstrumentationResourcesDescriptorBuffer(Validator &gpuav, CommandBufferSubState &cb_state,
-                                                                const LastBound &last_bound,
-                                                                const InstBindingPipeLayout &inst_binding_pipe_layout,
-                                                                const Location &loc) {
+void PreCallSetupShaderInstrumentationResourcesDescriptorBuffer(Validator& gpuav, CommandBufferSubState& cb_state,
+                                                                const LastBound& last_bound,
+                                                                const InstBindingPipeLayout& inst_binding_pipe_layout,
+                                                                const Location& loc) {
     if (!gpuav.gpuav_settings.debug_printf_enabled) {
         return;  // currently only thing enabled
     }
@@ -598,8 +598,8 @@ void PreCallSetupShaderInstrumentationResourcesDescriptorBuffer(Validator &gpuav
     (void)error_info;
 }
 
-void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferSubState &cb_state, const LastBound &last_bound,
-                                                const Location &loc) {
+void PreCallSetupShaderInstrumentationResources(Validator& gpuav, CommandBufferSubState& cb_state, const LastBound& last_bound,
+                                                const Location& loc) {
     if (!gpuav.gpuav_settings.IsSpirvModified()) {
         return;
     }
@@ -620,7 +620,7 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
     const vvl::DescriptorMode mode = last_bound.GetActionDescriptorMode();
     if (last_bound.pipeline_state) {
         if (mode != vvl::DescriptorMode::DescriptorModeHeap) {
-            const PipelineSubState &pipeline_sub_state = SubState(*last_bound.pipeline_state);
+            const PipelineSubState& pipeline_sub_state = SubState(*last_bound.pipeline_state);
 
             inst_binding_pipe_layout.handle = pipeline_sub_state.GetPipelineLayoutUnion(loc, mode);
             assert(inst_binding_pipe_layout.handle != VK_NULL_HANDLE);
@@ -654,8 +654,8 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
     }
 }
 
-void PostCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, CommandBufferSubState &cb_state,
-                                                        const LastBound &last_bound) {
+void PostCallSetupShaderInstrumentationResourcesClassic(Validator& gpuav, CommandBufferSubState& cb_state,
+                                                        const LastBound& last_bound) {
     // Only need to rebind application desc sets if they have been disturbed by GPU-AV binding its instrumentation desc set.
     // - Can happen if the pipeline layout used to bind instrumentation descriptor set is not compatible with the one used by the
     // app to bind the last/all the last desc set.
@@ -675,13 +675,13 @@ void PostCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Comman
 
             for (uint32_t set_i = 0; set_i < disturbed_bindings_count; ++set_i) {
                 const uint32_t last_bound_set_i = set_i + first_disturbed_set;
-                const auto &last_bound_set_state = last_bound.ds_slots[last_bound_set_i].ds_state;
+                const auto& last_bound_set_state = last_bound.ds_slots[last_bound_set_i].ds_state;
                 // last_bound.ds_slot is a LUT, and descriptor sets before the last one could be unbound.
                 if (!last_bound_set_state) {
                     continue;
                 }
                 VkDescriptorSet last_bound_set = last_bound_set_state->VkHandle();
-                const std::vector<uint32_t> &dynamic_offset = last_bound.ds_slots[last_bound_set_i].dynamic_offsets;
+                const std::vector<uint32_t>& dynamic_offset = last_bound.ds_slots[last_bound_set_i].dynamic_offsets;
                 const uint32_t dynamic_offset_count = static_cast<uint32_t>(dynamic_offset.size());
                 DispatchCmdBindDescriptorSets(cb_state.VkHandle(), last_bound.bind_point,
                                               last_bound.desc_set_pipeline_layout->VkHandle(), last_bound_set_i, 1, &last_bound_set,
@@ -691,7 +691,7 @@ void PostCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Comman
     }
 }
 
-void PostCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferSubState &cb_state, const LastBound &last_bound) {
+void PostCallSetupShaderInstrumentationResources(Validator& gpuav, CommandBufferSubState& cb_state, const LastBound& last_bound) {
     if (!gpuav.gpuav_settings.IsSpirvModified()) {
         return;
     }

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -80,7 +80,7 @@ WriteLockGuard GpuShaderInstrumentor::WriteLock() {
     }
 }
 
-void GpuShaderInstrumentor::SetupClassicDescriptor(const Location &loc) {
+void GpuShaderInstrumentor::SetupClassicDescriptor(const Location& loc) {
     const VkDescriptorSetLayoutCreateInfo debug_desc_layout_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0,
                                                                     static_cast<uint32_t>(instrumentation_bindings_.size()),
                                                                     instrumentation_bindings_.data()};
@@ -125,7 +125,7 @@ void GpuShaderInstrumentor::SetupClassicDescriptor(const Location &loc) {
     }
 }
 
-void GpuShaderInstrumentor::SetupDescriptorBuffers(const Location &loc) {
+void GpuShaderInstrumentor::SetupDescriptorBuffers(const Location& loc) {
     if (!IsExtEnabled(extensions.vk_ext_descriptor_buffer)) {
         return;
     }
@@ -194,7 +194,7 @@ void GpuShaderInstrumentor::SetupDescriptorBuffers(const Location &loc) {
     instrumentation_bindings_[glsl::kBindingInstCmdResourceIndex].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
 }
 
-void GpuShaderInstrumentor::SetupDescriptorHeap(const Location &loc) {
+void GpuShaderInstrumentor::SetupDescriptorHeap(const Location& loc) {
     if (!IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         return;
     }
@@ -209,7 +209,7 @@ void GpuShaderInstrumentor::SetupDescriptorHeap(const Location &loc) {
 }
 
 // In charge of getting things for shader instrumentation that both GPU-AV and DebugPrintF will need
-void GpuShaderInstrumentor::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void GpuShaderInstrumentor::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) {
     BaseClass::FinishDeviceSetup(pCreateInfo, loc);
 
     // Update feature and extension state based on changes made to the create info.
@@ -297,15 +297,15 @@ void GpuShaderInstrumentor::Cleanup() {
     }
 }
 
-void GpuShaderInstrumentor::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
-                                                       const RecordObject &record_obj) {
+void GpuShaderInstrumentor::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
+                                                       const RecordObject& record_obj) {
     Cleanup();
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
 }
 
 // Just gives a warning about a possible deadlock.
 bool GpuShaderInstrumentor::ValidateCmdWaitEvents(VkCommandBuffer command_buffer, VkPipelineStageFlags2 src_stage_mask,
-                                                  const Location &loc) const {
+                                                  const Location& loc) const {
     if (src_stage_mask & VK_PIPELINE_STAGE_2_HOST_BIT) {
         std::ostringstream error_msg;
         error_msg << loc.Message()
@@ -317,22 +317,22 @@ bool GpuShaderInstrumentor::ValidateCmdWaitEvents(VkCommandBuffer command_buffer
 }
 
 bool GpuShaderInstrumentor::PreCallValidateCmdWaitEvents(
-    VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags srcStageMask,
-    VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-    const VkImageMemoryBarrier *pImageMemoryBarriers, const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents, VkPipelineStageFlags srcStageMask,
+    VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+    const VkImageMemoryBarrier* pImageMemoryBarriers, const ErrorObject& error_obj) const {
     return ValidateCmdWaitEvents(commandBuffer, static_cast<VkPipelineStageFlags2>(srcStageMask), error_obj.location);
 }
 
 bool GpuShaderInstrumentor::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount,
-                                                             const VkEvent *pEvents, const VkDependencyInfoKHR *pDependencyInfos,
-                                                             const ErrorObject &error_obj) const {
+                                                             const VkEvent* pEvents, const VkDependencyInfoKHR* pDependencyInfos,
+                                                             const ErrorObject& error_obj) const {
     return PreCallValidateCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, error_obj);
 }
 
 bool GpuShaderInstrumentor::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount,
-                                                          const VkEvent *pEvents, const VkDependencyInfo *pDependencyInfos,
-                                                          const ErrorObject &error_obj) const {
+                                                          const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfos,
+                                                          const ErrorObject& error_obj) const {
     VkPipelineStageFlags2 src_stage_mask = 0;
 
     for (uint32_t i = 0; i < eventCount; i++) {
@@ -344,7 +344,7 @@ bool GpuShaderInstrumentor::PreCallValidateCmdWaitEvents2(VkCommandBuffer comman
 }
 
 vvl::DescriptorMode GpuShaderInstrumentor::SelectDescriptorModeFromDSL(uint32_t set_layout_count,
-                                                                       const VkDescriptorSetLayout *set_layouts) const {
+                                                                       const VkDescriptorSetLayout* set_layouts) const {
     vvl::DescriptorMode mode = vvl::DescriptorModeClassic;
     if (IsExtEnabled(extensions.vk_ext_descriptor_buffer)) {
         if (set_layout_count > 0) {
@@ -370,10 +370,10 @@ vvl::DescriptorMode GpuShaderInstrumentor::SelectDescriptorModeFromDSL(uint32_t 
     return mode;
 }
 
-void GpuShaderInstrumentor::PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
-                                                              const VkAllocationCallbacks *pAllocator,
-                                                              VkPipelineLayout *pPipelineLayout, const RecordObject &record_obj,
-                                                              chassis::CreatePipelineLayout &chassis_state) {
+void GpuShaderInstrumentor::PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                                              const VkAllocationCallbacks* pAllocator,
+                                                              VkPipelineLayout* pPipelineLayout, const RecordObject& record_obj,
+                                                              chassis::CreatePipelineLayout& chassis_state) {
     if (gpuav_settings.IsSpirvModified()) {
         if (chassis_state.modified_create_info.setLayoutCount > instrumentation_desc_set_bind_index_) {
             std::ostringstream strm;
@@ -402,10 +402,10 @@ void GpuShaderInstrumentor::PreCallRecordCreatePipelineLayout(VkDevice device, c
     }
 }
 
-void GpuShaderInstrumentor::PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                                             const RecordObject &record_obj,
-                                                             chassis::CreateShaderModule &chassis_state) {
+void GpuShaderInstrumentor::PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
+                                                             const RecordObject& record_obj,
+                                                             chassis::CreateShaderModule& chassis_state) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -421,12 +421,12 @@ void GpuShaderInstrumentor::PostCallRecordCreateShaderModule(VkDevice device, co
 // We on the spot create a VkShaderEXT without instrumentation to return to the user
 // We assume people are not trying to use GPU-AV while calling vkGetShaderBinaryDataEXT
 // But this is needed for things like CTS that are using this to mock a fake Binary Shader Object
-void GpuShaderInstrumentor::PreCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t *pDataSize, void *pData,
-                                                                const RecordObject &record_obj,
-                                                                chassis::ShaderBinaryData &chassis_state) {
-    const auto &shader_object_state = Get<vvl::ShaderObject>(shader);
+void GpuShaderInstrumentor::PreCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData,
+                                                                const RecordObject& record_obj,
+                                                                chassis::ShaderBinaryData& chassis_state) {
+    const auto& shader_object_state = Get<vvl::ShaderObject>(shader);
     ASSERT_AND_RETURN(shader_object_state);
-    auto &sub_state = SubState(*shader_object_state);
+    auto& sub_state = SubState(*shader_object_state);
 
     VkShaderEXT original_handle = VK_NULL_HANDLE;
 
@@ -439,7 +439,7 @@ void GpuShaderInstrumentor::PreCallRecordGetShaderBinaryDataEXT(VkDevice device,
     // The original pCode might be gone, so need to make a shallow copy and put original SPIR-V inside
     VkShaderCreateInfoEXT create_info_copy = *sub_state.original_create_info.ptr();
     // The pCode doesn't live in the safe struct, we need to grab it from our other map
-    const gpuav::InstrumentedShader *instrumented_shader = &it->second;
+    const gpuav::InstrumentedShader* instrumented_shader = &it->second;
     create_info_copy.pCode = instrumented_shader->original_spirv.data();
     create_info_copy.codeSize = instrumented_shader->original_spirv.size() * sizeof(uint32_t);
 
@@ -470,7 +470,7 @@ bool GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(
 
     const uint32_t unique_shader_id = unique_shader_module_id_++;
 
-    std::vector<uint32_t> &instrumented_spirv = instrumentation_data.instrumented_spirv;
+    std::vector<uint32_t>& instrumented_spirv = instrumentation_data.instrumented_spirv;
     spirv::InstrumentationInterface interface(create_info_loc);
     interface.unique_shader_id = unique_shader_id;
     interface.entry_point_name = modified_create_info.pName;
@@ -492,9 +492,9 @@ bool GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(
 }
 
 void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
-                                                          const VkShaderCreateInfoEXT *pCreateInfos,
-                                                          const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
-                                                          const RecordObject &record_obj, chassis::ShaderObject &chassis_state) {
+                                                          const VkShaderCreateInfoEXT* pCreateInfos,
+                                                          const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
+                                                          const RecordObject& record_obj, chassis::ShaderObject& chassis_state) {
     if (!gpuav_settings.IsSpirvModified()) return;
 
     // Resize here so if using just CoreCheck we don't waste time allocating this
@@ -503,7 +503,7 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
 
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         // Need deep copy as there might be pNext items
-        vku::safe_VkShaderCreateInfoEXT &new_create_info = chassis_state.modified_create_infos[i];
+        vku::safe_VkShaderCreateInfoEXT& new_create_info = chassis_state.modified_create_infos[i];
         new_create_info.initialize(&pCreateInfos[i]);
 
         if (new_create_info.codeType != VK_SHADER_CODE_TYPE_SPIRV_EXT) {
@@ -536,7 +536,7 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
             // 1. Copying the caller's descriptor set desc_layouts
             // 2. Fill in dummy descriptor layouts up to the max binding
             // 3. Fill in with the debug descriptor layout at the max binding slot
-            const VkShaderCreateInfoEXT &original_create_info = pCreateInfos[i];
+            const VkShaderCreateInfoEXT& original_create_info = pCreateInfos[i];
 
             const vvl::DescriptorMode mode =
                 (original_create_info.flags & VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT)
@@ -546,7 +546,7 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
                 if (gpuav_settings.select_instrumented_shaders && !IsSelectiveInstrumentationEnabled(new_create_info.pNext)) {
                     continue;
                 }
-                AddDescriptorHeapMappings(reinterpret_cast<VkBaseOutStructure *>(&new_create_info));
+                AddDescriptorHeapMappings(reinterpret_cast<VkBaseOutStructure*>(&new_create_info));
                 chassis_state.is_modified |=
                     PreCallRecordShaderObjectInstrumentation(new_create_info, create_info_loc, instrumentation_data);
             } else {
@@ -571,13 +571,13 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
         }
     }
 
-    chassis_state.pCreateInfos = reinterpret_cast<VkShaderCreateInfoEXT *>(chassis_state.modified_create_infos.data());
+    chassis_state.pCreateInfos = reinterpret_cast<VkShaderCreateInfoEXT*>(chassis_state.modified_create_infos.data());
 }
 
 void GpuShaderInstrumentor::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
-                                                           const VkShaderCreateInfoEXT *pCreateInfos,
-                                                           const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
-                                                           const RecordObject &record_obj, chassis::ShaderObject &chassis_state) {
+                                                           const VkShaderCreateInfoEXT* pCreateInfos,
+                                                           const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
+                                                           const RecordObject& record_obj, chassis::ShaderObject& chassis_state) {
     if (!gpuav_settings.IsSpirvModified()) {
         return;
     }
@@ -593,16 +593,16 @@ void GpuShaderInstrumentor::PostCallRecordCreateShadersEXT(VkDevice device, uint
             continue;
         }
 
-        auto &instrumentation_data = chassis_state.instrumentations_data[i];
+        auto& instrumentation_data = chassis_state.instrumentations_data[i];
 
         // if the shader for some reason was not instrumented, there is nothing to save
         // (like not using VK_SHADER_CODE_TYPE_SPIRV_EXT)
         if (!instrumentation_data.IsInstrumented()) {
             continue;
         }
-        const auto &shader_object_state = Get<vvl::ShaderObject>(shader_handle);
+        const auto& shader_object_state = Get<vvl::ShaderObject>(shader_handle);
         ASSERT_AND_CONTINUE(shader_object_state);
-        auto &sub_state = SubState(*shader_object_state);
+        auto& sub_state = SubState(*shader_object_state);
 
         sub_state.was_instrumented = true;
         sub_state.unique_shader_id = instrumentation_data.unique_shader_id;
@@ -621,9 +621,9 @@ void GpuShaderInstrumentor::PostCallRecordCreateShadersEXT(VkDevice device, uint
 }
 
 void GpuShaderInstrumentor::PreCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT shader,
-                                                          const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                          const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     if (auto shader_object_state = Get<vvl::ShaderObject>(shader)) {
-        auto &sub_state = SubState(*shader_object_state);
+        auto& sub_state = SubState(*shader_object_state);
         instrumented_shaders_map_.pop(sub_state.unique_shader_id);
 
         if (sub_state.original_handle != VK_NULL_HANDLE) {
@@ -633,28 +633,28 @@ void GpuShaderInstrumentor::PreCallRecordDestroyShaderEXT(VkDevice device, VkSha
 }
 
 void GpuShaderInstrumentor::PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                                 const VkGraphicsPipelineCreateInfo *pCreateInfos,
-                                                                 const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                                 const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                                 chassis::CreateGraphicsPipelines &chassis_state) {
+                                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                                 const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                                 chassis::CreateGraphicsPipelines& chassis_state) {
     if (!gpuav_settings.IsSpirvModified()) return;
 
     chassis_state.shader_instrumentations_metadata.resize(count);
     chassis_state.modified_create_infos.resize(count);
 
     for (uint32_t i = 0; i < count; ++i) {
-        const auto &pipeline_state = pipeline_states[i];
+        const auto& pipeline_state = pipeline_states[i];
         const Location create_info_loc = record_obj.location.dot(vvl::Field::pCreateInfos, i);
 
         // Need to make a deep copy so if SPIR-V is inlined, user doesn't see it after the call
-        auto &new_pipeline_ci = chassis_state.modified_create_infos[i];
+        auto& new_pipeline_ci = chassis_state.modified_create_infos[i];
         new_pipeline_ci.initialize(&pipeline_state->GraphicsCreateInfo());
 
         if (!NeedPipelineCreationShaderInstrumentation(*pipeline_state, create_info_loc)) {
             continue;
         }
 
-        auto &shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
+        auto& shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
 
         bool success = false;
         if (pipeline_state->linking_shaders != 0) {
@@ -671,32 +671,32 @@ void GpuShaderInstrumentor::PreCallRecordCreateGraphicsPipelines(VkDevice device
     }
 
     chassis_state.is_modified = true;
-    chassis_state.pCreateInfos = reinterpret_cast<VkGraphicsPipelineCreateInfo *>(chassis_state.modified_create_infos.data());
+    chassis_state.pCreateInfos = reinterpret_cast<VkGraphicsPipelineCreateInfo*>(chassis_state.modified_create_infos.data());
 }
 
 void GpuShaderInstrumentor::PreCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                                const VkComputePipelineCreateInfo *pCreateInfos,
-                                                                const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                                const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                                chassis::CreateComputePipelines &chassis_state) {
+                                                                const VkComputePipelineCreateInfo* pCreateInfos,
+                                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                                const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                                chassis::CreateComputePipelines& chassis_state) {
     if (!gpuav_settings.IsSpirvModified()) return;
 
     chassis_state.shader_instrumentations_metadata.resize(count);
     chassis_state.modified_create_infos.resize(count);
 
     for (uint32_t i = 0; i < count; ++i) {
-        const auto &pipeline_state = pipeline_states[i];
+        const auto& pipeline_state = pipeline_states[i];
         const Location create_info_loc = record_obj.location.dot(vvl::Field::pCreateInfos, i);
 
         // Need to make a deep copy so if SPIR-V is inlined, user doesn't see it after the call
-        auto &new_pipeline_ci = chassis_state.modified_create_infos[i];
+        auto& new_pipeline_ci = chassis_state.modified_create_infos[i];
         new_pipeline_ci.initialize(&pipeline_state->ComputeCreateInfo());
 
         if (!NeedPipelineCreationShaderInstrumentation(*pipeline_state, create_info_loc)) {
             continue;
         }
 
-        auto &shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
+        auto& shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
 
         bool success = PreCallRecordPipelineCreationShaderInstrumentation(pAllocator, *pipeline_state, new_pipeline_ci, 1,
                                                                           create_info_loc, shader_instrumentation_metadata);
@@ -706,13 +706,13 @@ void GpuShaderInstrumentor::PreCallRecordCreateComputePipelines(VkDevice device,
     }
 
     chassis_state.is_modified = true;
-    chassis_state.pCreateInfos = reinterpret_cast<VkComputePipelineCreateInfo *>(chassis_state.modified_create_infos.data());
+    chassis_state.pCreateInfos = reinterpret_cast<VkComputePipelineCreateInfo*>(chassis_state.modified_create_infos.data());
 }
 
 void GpuShaderInstrumentor::PreCallRecordCreateRayTracingPipelinesKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, VkPipelineCache pipelineCache, uint32_t count,
-    const VkRayTracingPipelineCreateInfoKHR *pCreateInfos, const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-    const RecordObject &record_obj, PipelineStates &pipeline_states, chassis::CreateRayTracingPipelinesKHR &chassis_state) {
+    const VkRayTracingPipelineCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+    const RecordObject& record_obj, PipelineStates& pipeline_states, chassis::CreateRayTracingPipelinesKHR& chassis_state) {
     if (!gpuav_settings.IsSpirvModified()) {
         return;
     }
@@ -721,18 +721,18 @@ void GpuShaderInstrumentor::PreCallRecordCreateRayTracingPipelinesKHR(
     chassis_state.modified_create_infos.resize(count);
 
     for (uint32_t i = 0; i < count; ++i) {
-        const auto &pipeline_state = pipeline_states[i];
+        const auto& pipeline_state = pipeline_states[i];
         const Location create_info_loc = record_obj.location.dot(vvl::Field::pCreateInfos, i);
 
         // Need to make a deep copy so if SPIR-V is inlined, user doesn't see it after the call
-        auto &new_pipeline_ci = chassis_state.modified_create_infos[i];
+        auto& new_pipeline_ci = chassis_state.modified_create_infos[i];
         new_pipeline_ci.initialize(&pipeline_state->RayTracingCreateInfo());
 
         if (!NeedPipelineCreationShaderInstrumentation(*pipeline_state, create_info_loc)) {
             continue;
         }
 
-        auto &shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
+        auto& shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
 
         // Ray tracing pipelines can be made of libraries, but contrary to GPL instrumentation is not postponed
         // to final link time, and done at ray tracing library creation time.
@@ -749,14 +749,14 @@ void GpuShaderInstrumentor::PreCallRecordCreateRayTracingPipelinesKHR(
     }
 
     chassis_state.is_modified = true;
-    chassis_state.pCreateInfos = reinterpret_cast<VkRayTracingPipelineCreateInfoKHR *>(chassis_state.modified_create_infos.data());
+    chassis_state.pCreateInfos = reinterpret_cast<VkRayTracingPipelineCreateInfoKHR*>(chassis_state.modified_create_infos.data());
 }
 
 template <typename CreateInfos, typename SafeCreateInfos>
-static void UtilCopyCreatePipelineFeedbackData(CreateInfos &create_info, SafeCreateInfos &safe_create_info) {
+static void UtilCopyCreatePipelineFeedbackData(CreateInfos& create_info, SafeCreateInfos& safe_create_info) {
     auto src_feedback_struct = vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfo>(safe_create_info.pNext);
     if (!src_feedback_struct) return;
-    auto dst_feedback_struct = const_cast<VkPipelineCreationFeedbackCreateInfo *>(
+    auto dst_feedback_struct = const_cast<VkPipelineCreationFeedbackCreateInfo*>(
         vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfo>(create_info.pNext));
     *dst_feedback_struct->pPipelineCreationFeedback = *src_feedback_struct->pPipelineCreationFeedback;
     for (uint32_t j = 0; j < src_feedback_struct->pipelineStageCreationFeedbackCount; j++) {
@@ -765,10 +765,10 @@ static void UtilCopyCreatePipelineFeedbackData(CreateInfos &create_info, SafeCre
 }
 
 void GpuShaderInstrumentor::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                                  const VkGraphicsPipelineCreateInfo *pCreateInfos,
-                                                                  const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                                  const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                                  chassis::CreateGraphicsPipelines &chassis_state) {
+                                                                  const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                                  const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                                  const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                                  chassis::CreateGraphicsPipelines& chassis_state) {
     if (!gpuav_settings.IsSpirvModified()) return;
     // VK_PIPELINE_COMPILE_REQUIRED means that the current pipeline creation call was used to poke the driver cache,
     // no pipeline is created in this case
@@ -789,7 +789,7 @@ void GpuShaderInstrumentor::PostCallRecordCreateGraphicsPipelines(VkDevice devic
         // Move all instrumentation until the final linking time
         if (pipeline_state->create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) continue;
 
-        auto &shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
+        auto& shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
         if (pipeline_state->linking_shaders != 0) {
             PostCallRecordPipelineCreationShaderInstrumentationGPL(*pipeline_state, shader_instrumentation_metadata);
         } else {
@@ -800,10 +800,10 @@ void GpuShaderInstrumentor::PostCallRecordCreateGraphicsPipelines(VkDevice devic
 }
 
 void GpuShaderInstrumentor::PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                                 const VkComputePipelineCreateInfo *pCreateInfos,
-                                                                 const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                                 const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                                 chassis::CreateComputePipelines &chassis_state) {
+                                                                 const VkComputePipelineCreateInfo* pCreateInfos,
+                                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                                 const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                                 chassis::CreateComputePipelines& chassis_state) {
     if (!gpuav_settings.IsSpirvModified()) return;
     // VK_PIPELINE_COMPILE_REQUIRED means that the current pipeline creation call was used to poke the driver cache,
     // no pipeline is created in this case
@@ -821,15 +821,15 @@ void GpuShaderInstrumentor::PostCallRecordCreateComputePipelines(VkDevice device
 
         auto pipeline_state = Get<vvl::Pipeline>(pipeline_handle);
         ASSERT_AND_CONTINUE(pipeline_state);
-        auto &shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
+        auto& shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
         PostCallRecordPipelineCreationShaderInstrumentation(*pipeline_state, 1, shader_instrumentation_metadata);
     }
 }
 
 void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, VkPipelineCache pipelineCache, uint32_t count,
-    const VkRayTracingPipelineCreateInfoKHR *pCreateInfos, const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-    const RecordObject &record_obj, PipelineStates &pipeline_states,
+    const VkRayTracingPipelineCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+    const RecordObject& record_obj, PipelineStates& pipeline_states,
     std::shared_ptr<chassis::CreateRayTracingPipelinesKHR> chassis_state) {
     // This can occur if the driver failed to compile the instrumented shader or if a PreCall step failed
     if (!chassis_state->is_modified) {
@@ -857,7 +857,7 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
         }
 
         auto found = dispatch_device_->deferred_operation_post_check.pop(deferredOperation);
-        std::vector<std::function<void(std::pair<uint32_t, VkPipeline *>)>> deferred_op_post_checks;
+        std::vector<std::function<void(std::pair<uint32_t, VkPipeline*>)>> deferred_op_post_checks;
         if (found->first) {
             deferred_op_post_checks = std::move(found->second);
         } else {
@@ -873,19 +873,19 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
         }
 
         deferred_op_post_checks.emplace_back([this, held_chassis_state =
-                                                        chassis_state](std::pair<uint32_t, VkPipeline *> pipelines) mutable {
+                                                        chassis_state](std::pair<uint32_t, VkPipeline*> pipelines) mutable {
             for (const auto [pipe_i, pipe] : vvl::enumerate(pipelines.second, pipelines.first)) {
-                std::shared_ptr<vvl::Pipeline> pipeline_state = ((GpuShaderInstrumentor *)this)->Get<vvl::Pipeline>(pipe);
+                std::shared_ptr<vvl::Pipeline> pipeline_state = ((GpuShaderInstrumentor*)this)->Get<vvl::Pipeline>(pipe);
                 ASSERT_AND_CONTINUE(pipeline_state);
                 if (pipeline_state->ray_tracing_library_ci) {
                     for (VkPipeline lib : vvl::make_span(pipeline_state->ray_tracing_library_ci->pLibraries,
                                                          pipeline_state->ray_tracing_library_ci->libraryCount)) {
-                        auto lib_state = ((GpuShaderInstrumentor *)this)->Get<vvl::Pipeline>(lib);
+                        auto lib_state = ((GpuShaderInstrumentor*)this)->Get<vvl::Pipeline>(lib);
                         ASSERT_AND_CONTINUE(lib_state);
                         pipeline_state->instrumentation_data.was_instrumented |= lib_state->instrumentation_data.was_instrumented;
                     }
                 }
-                auto &shader_instrumentation_metadata = held_chassis_state->shader_instrumentations_metadata[pipe_i];
+                auto& shader_instrumentation_metadata = held_chassis_state->shader_instrumentations_metadata[pipe_i];
                 // Ray tracing pipelines can be made of libraries, but contrary to GPL instrumentation is not postponed
                 // to final link time, and done at ray tracing library creation time.
                 // => No need to iterate over shader stages coming from libraries,
@@ -917,7 +917,7 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
                 }
             }
 
-            auto &shader_instrumentation_metadata = chassis_state->shader_instrumentations_metadata[i];
+            auto& shader_instrumentation_metadata = chassis_state->shader_instrumentations_metadata[i];
             // Ray tracing pipelines can be made of libraries, but contrary to GPL instrumentation is not postponed
             // to final link time, and done at ray tracing library creation time.
             // => No need to iterate over shader stages coming from libraries,
@@ -932,7 +932,7 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
 
 // Remove all the shader trackers associated with this destroyed pipeline.
 void GpuShaderInstrumentor::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline,
-                                                         const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                         const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     if (auto pipeline_state = Get<vvl::Pipeline>(pipeline)) {
         for (auto shader_module_handle : pipeline_state->instrumentation_data.shader_modules) {
             DispatchDestroyShaderModule(device, shader_module_handle, pAllocator);
@@ -944,7 +944,7 @@ void GpuShaderInstrumentor::PreCallRecordDestroyPipeline(VkDevice device, VkPipe
 }
 
 template <typename CreateInfo>
-VkShaderModule GetShaderModule(const CreateInfo &create_info, VkShaderStageFlagBits stage) {
+VkShaderModule GetShaderModule(const CreateInfo& create_info, VkShaderStageFlagBits stage) {
     for (uint32_t i = 0; i < create_info.stageCount; ++i) {
         if (create_info.pStages[i].stage == stage) {
             return create_info.pStages[i].module;
@@ -954,20 +954,20 @@ VkShaderModule GetShaderModule(const CreateInfo &create_info, VkShaderStageFlagB
 }
 
 template <>
-VkShaderModule GetShaderModule(const VkComputePipelineCreateInfo &create_info, VkShaderStageFlagBits) {
+VkShaderModule GetShaderModule(const VkComputePipelineCreateInfo& create_info, VkShaderStageFlagBits) {
     return create_info.stage.module;
 }
 
 template <typename SafeType>
-void SetShaderModule(SafeType &create_info, const vku::safe_VkPipelineShaderStageCreateInfo &stage_info,
+void SetShaderModule(SafeType& create_info, const vku::safe_VkPipelineShaderStageCreateInfo& stage_info,
                      VkShaderModule shader_module, uint32_t stage_ci_index) {
     create_info.pStages[stage_ci_index] = stage_info;
     create_info.pStages[stage_ci_index].module = shader_module;
 }
 
 template <>
-void SetShaderModule(vku::safe_VkComputePipelineCreateInfo &create_info,
-                     const vku::safe_VkPipelineShaderStageCreateInfo &stage_info, VkShaderModule shader_module,
+void SetShaderModule(vku::safe_VkComputePipelineCreateInfo& create_info,
+                     const vku::safe_VkPipelineShaderStageCreateInfo& stage_info, VkShaderModule shader_module,
                      uint32_t stage_ci_index) {
     assert(stage_ci_index == 0);
     create_info.stage = stage_info;
@@ -975,7 +975,7 @@ void SetShaderModule(vku::safe_VkComputePipelineCreateInfo &create_info,
 }
 
 template <typename CreateInfo, typename StageInfo>
-StageInfo &GetShaderStageCI(CreateInfo &ci, VkShaderStageFlagBits stage) {
+StageInfo& GetShaderStageCI(CreateInfo& ci, VkShaderStageFlagBits stage) {
     static StageInfo null_stage{};
     for (uint32_t i = 0; i < ci.stageCount; ++i) {
         if (ci.pStages[i].stage == stage) {
@@ -986,11 +986,11 @@ StageInfo &GetShaderStageCI(CreateInfo &ci, VkShaderStageFlagBits stage) {
 }
 
 template <>
-vku::safe_VkPipelineShaderStageCreateInfo &GetShaderStageCI(vku::safe_VkComputePipelineCreateInfo &ci, VkShaderStageFlagBits) {
+vku::safe_VkPipelineShaderStageCreateInfo& GetShaderStageCI(vku::safe_VkComputePipelineCreateInfo& ci, VkShaderStageFlagBits) {
     return ci.stage;
 }
 
-bool GpuShaderInstrumentor::IsSelectiveInstrumentationEnabled(const void *pNext) {
+bool GpuShaderInstrumentor::IsSelectiveInstrumentationEnabled(const void* pNext) {
     if (auto features = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(pNext)) {
         for (uint32_t i = 0; i < features->enabledValidationFeatureCount; i++) {
             if (features->pEnabledValidationFeatures[i] == VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT) {
@@ -1001,7 +1001,7 @@ bool GpuShaderInstrumentor::IsSelectiveInstrumentationEnabled(const void *pNext)
     return false;
 }
 
-bool GpuShaderInstrumentor::NeedPipelineCreationShaderInstrumentation(vvl::Pipeline &pipeline_state, const Location &loc) {
+bool GpuShaderInstrumentor::NeedPipelineCreationShaderInstrumentation(vvl::Pipeline& pipeline_state, const Location& loc) {
     // Currently there is a VU (VUID-VkIndirectExecutionSetPipelineInfoEXT-initialPipeline-11019) that prevents
     // VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC in the pipeline layout, but we need it currently for GPU-AV.
     // As a temporary solution, we will just not support people using DGC with IES
@@ -1080,13 +1080,13 @@ void GpuShaderInstrumentor::BuildDescriptorSetLayoutInfo(const vvl::DescriptorSe
     if (set_layout_state.GetBindingCount() == 0) return;
     const uint32_t binding_count = set_layout_state.GetMaxBinding() + 1;
 
-    auto &binding_layouts = out_instrumentation_dsl.set_index_to_bindings_layout_lut[set_layout_index];
+    auto& binding_layouts = out_instrumentation_dsl.set_index_to_bindings_layout_lut[set_layout_index];
     binding_layouts.resize(binding_count);
 
     uint32_t start = 0;
     auto dsl_bindings = set_layout_state.GetBindings();
     for (uint32_t binding_index = 0; binding_index < dsl_bindings.size(); binding_index++) {
-        auto &dsl_binding = dsl_bindings[binding_index];
+        auto& dsl_binding = dsl_bindings[binding_index];
         if (dsl_binding.descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) {
             binding_layouts[dsl_binding.binding] = {start, 1};
             start += 1;
@@ -1102,7 +1102,7 @@ void GpuShaderInstrumentor::BuildDescriptorSetLayoutInfo(const vvl::DescriptorSe
     }
 }
 
-bool GpuShaderInstrumentor::IsPipelineSelectedForInstrumentation(VkPipeline pipeline, const Location &loc) {
+bool GpuShaderInstrumentor::IsPipelineSelectedForInstrumentation(VkPipeline pipeline, const Location& loc) {
     if (!gpuav_settings.select_instrumented_shaders) {
         return true;
     }
@@ -1124,8 +1124,8 @@ bool GpuShaderInstrumentor::IsPipelineSelectedForInstrumentation(VkPipeline pipe
     return should_instrument_pipeline;
 }
 
-bool GpuShaderInstrumentor::IsShaderSelectedForInstrumentation(vku::safe_VkShaderModuleCreateInfo *modified_shader_module_ci,
-                                                               VkShaderModule modified_shader, const Location &loc) {
+bool GpuShaderInstrumentor::IsShaderSelectedForInstrumentation(vku::safe_VkShaderModuleCreateInfo* modified_shader_module_ci,
+                                                               VkShaderModule modified_shader, const Location& loc) {
     if (!gpuav_settings.select_instrumented_shaders) {
         return true;
     }
@@ -1152,9 +1152,9 @@ bool GpuShaderInstrumentor::IsShaderSelectedForInstrumentation(vku::safe_VkShade
     return should_instrument_shader;
 }
 
-void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure *create_info) {
-    const vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT *mapping_info =
-        reinterpret_cast<const vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT *>(
+void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure* create_info) {
+    const vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT* mapping_info =
+        reinterpret_cast<const vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT*>(
             vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(create_info->pNext));
 
     uint32_t mapping_count = glsl::kTotalBindings;
@@ -1163,7 +1163,7 @@ void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure *create
         app_mapping_count = mapping_info->mappingCount;
         mapping_count += app_mapping_count;
     }
-    vku::safe_VkDescriptorSetAndBindingMappingEXT *new_mappings = new vku::safe_VkDescriptorSetAndBindingMappingEXT[mapping_count];
+    vku::safe_VkDescriptorSetAndBindingMappingEXT* new_mappings = new vku::safe_VkDescriptorSetAndBindingMappingEXT[mapping_count];
 
     if (mapping_info) {
         for (uint32_t i = 0; i < app_mapping_count; i++) {
@@ -1172,7 +1172,7 @@ void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure *create
     }
 
     for (uint32_t i = 0; i < glsl::kTotalBindings; i++) {
-        vku::safe_VkDescriptorSetAndBindingMappingEXT &mapping = new_mappings[app_mapping_count + i];
+        vku::safe_VkDescriptorSetAndBindingMappingEXT& mapping = new_mappings[app_mapping_count + i];
         mapping = vku::safe_VkDescriptorSetAndBindingMappingEXT();
         mapping.descriptorSet = instrumentation_desc_set_bind_index_;
         mapping.firstBinding = i;
@@ -1184,18 +1184,18 @@ void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure *create
     }
 
     if (mapping_info) {
-        vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT *modified_mapping_info =
-            const_cast<vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT *>(mapping_info);
+        vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT* modified_mapping_info =
+            const_cast<vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT*>(mapping_info);
         modified_mapping_info->mappingCount = mapping_count;
         delete[] modified_mapping_info->pMappings;
         modified_mapping_info->pMappings = new_mappings;
     } else {
-        vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT *new_mapping_info =
+        vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT* new_mapping_info =
             new vku::safe_VkShaderDescriptorSetAndBindingMappingInfoEXT();
         new_mapping_info->mappingCount = mapping_count;
         new_mapping_info->pMappings = new_mappings;
         new_mapping_info->pNext = create_info->pNext;
-        create_info->pNext = reinterpret_cast<VkBaseOutStructure *>(new_mapping_info);
+        create_info->pNext = reinterpret_cast<VkBaseOutStructure*>(new_mapping_info);
     }
 }
 
@@ -1212,9 +1212,9 @@ void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure *create
 // Note: Shader Objects are handled in their own path as they don't use pipelines
 template <typename SafeCreateInfo>
 bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
-    const VkAllocationCallbacks *pAllocator, vvl::Pipeline &pipeline_state, SafeCreateInfo &modified_pipeline_ci,
-    uint32_t stages_count, const Location &loc,
-    std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata) {
+    const VkAllocationCallbacks* pAllocator, vvl::Pipeline& pipeline_state, SafeCreateInfo& modified_pipeline_ci,
+    uint32_t stages_count, const Location& loc,
+    std::vector<chassis::ShaderInstrumentationMetadata>& shader_instrumentation_metadata) {
     // Init here instead of in chassis so we don't pay cost when GPU-AV is not used
     shader_instrumentation_metadata.resize(stages_count);
 
@@ -1223,7 +1223,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
     BuildDescriptorSetLayoutInfo(pipeline_state, interface.instrumentation_dsl);
 
     for (uint32_t stage_state_i = 0; stage_state_i < stages_count; ++stage_state_i) {
-        const auto &stage_state = pipeline_state.stage_states[stage_state_i];
+        const auto& stage_state = pipeline_state.stage_states[stage_state_i];
         auto modified_module_state = std::const_pointer_cast<vvl::ShaderModule>(stage_state.module_state);
         ASSERT_AND_CONTINUE(modified_module_state);
         if (!modified_module_state->spirv) {
@@ -1231,17 +1231,17 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
         }
         std::unique_lock<std::mutex> module_lock(modified_module_state->module_mutex_);
 
-        auto &instrumentation_metadata = shader_instrumentation_metadata[stage_state_i];
+        auto& instrumentation_metadata = shader_instrumentation_metadata[stage_state_i];
 
         // Check pNext for inlined SPIR-V
         // ---
-        vku::safe_VkShaderModuleCreateInfo *modified_shader_module_ci = nullptr;
+        vku::safe_VkShaderModuleCreateInfo* modified_shader_module_ci = nullptr;
         {
             const VkShaderStageFlagBits stage = stage_state.GetStage();
-            auto &stage_ci =
+            auto& stage_ci =
                 GetShaderStageCI<SafeCreateInfo, vku::safe_VkPipelineShaderStageCreateInfo>(modified_pipeline_ci, stage);
             modified_shader_module_ci =
-                const_cast<vku::safe_VkShaderModuleCreateInfo *>(reinterpret_cast<const vku::safe_VkShaderModuleCreateInfo *>(
+                const_cast<vku::safe_VkShaderModuleCreateInfo*>(reinterpret_cast<const vku::safe_VkShaderModuleCreateInfo*>(
                     vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(stage_ci.pNext)));
 
             if (!IsShaderSelectedForInstrumentation(modified_shader_module_ci, modified_module_state->VkHandle(),
@@ -1296,9 +1296,9 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
 
         if (stage_state.descriptor_heap_mode) {
             const VkShaderStageFlagBits stage = stage_state.GetStage();
-            auto &stage_ci =
+            auto& stage_ci =
                 GetShaderStageCI<SafeCreateInfo, vku::safe_VkPipelineShaderStageCreateInfo>(modified_pipeline_ci, stage);
-            AddDescriptorHeapMappings(reinterpret_cast<VkBaseOutStructure *>(&stage_ci));
+            AddDescriptorHeapMappings(reinterpret_cast<VkBaseOutStructure*>(&stage_ci));
         }
     }
     return true;
@@ -1306,13 +1306,13 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
 
 // Now that we have created the pipeline (and have its handle) build up the shader map for each shader we instrumented
 void GpuShaderInstrumentor::PostCallRecordPipelineCreationShaderInstrumentation(
-    vvl::Pipeline &pipeline_state, uint32_t stages_count,
-    std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata) {
+    vvl::Pipeline& pipeline_state, uint32_t stages_count,
+    std::vector<chassis::ShaderInstrumentationMetadata>& shader_instrumentation_metadata) {
     // if we return early from NeedPipelineCreationShaderInstrumentation, will need to skip at this point in PostCall
     if (shader_instrumentation_metadata.empty()) return;
 
     for (uint32_t stage_state_i = 0; stage_state_i < stages_count; ++stage_state_i) {
-        auto &instrumentation_metadata = shader_instrumentation_metadata[stage_state_i];
+        auto& instrumentation_metadata = shader_instrumentation_metadata[stage_state_i];
 
         // if the shader for some reason was not instrumented, there is nothing to save
         if (!instrumentation_metadata.IsInstrumented()) {
@@ -1320,8 +1320,8 @@ void GpuShaderInstrumentor::PostCallRecordPipelineCreationShaderInstrumentation(
         }
         pipeline_state.instrumentation_data.was_instrumented = true;
 
-        const auto &stage_state = pipeline_state.stage_states[stage_state_i];
-        auto &module_state = stage_state.module_state;
+        const auto& stage_state = pipeline_state.stage_states[stage_state_i];
+        auto& module_state = stage_state.module_state;
 
         // We currently need to store a copy of the original, non-instrumented shader so if there is debug information,
         // we can reference it by the instruction number printed out in the shader. Since the application can destroy the
@@ -1345,9 +1345,9 @@ void GpuShaderInstrumentor::PostCallRecordPipelineCreationShaderInstrumentation(
 // Graphics, Compute, and Ray Tracing. GPL is only for graphics, so we end up needing this "side code path" for graphics only and it
 // doesn't fit in the "all pipeline" templated flow.
 bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGPL(
-    const VkAllocationCallbacks *pAllocator, vvl::Pipeline &linked_pipeline_state,
-    vku::safe_VkGraphicsPipelineCreateInfo &modified_pipeline_ci, const Location &loc,
-    std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata) {
+    const VkAllocationCallbacks* pAllocator, vvl::Pipeline& linked_pipeline_state,
+    vku::safe_VkGraphicsPipelineCreateInfo& modified_pipeline_ci, const Location& loc,
+    std::vector<chassis::ShaderInstrumentationMetadata>& shader_instrumentation_metadata) {
     // Init here instead of in chassis so we don't pay cost when GPU-AV is not used
     const size_t total_stages = linked_pipeline_state.stage_states.size();
     shader_instrumentation_metadata.resize(total_stages);
@@ -1356,7 +1356,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
     // Can set this once for all shaders in the pipeline
     BuildDescriptorSetLayoutInfo(linked_pipeline_state, interface.instrumentation_dsl);
 
-    auto modified_library_ci = const_cast<VkPipelineLibraryCreateInfoKHR *>(
+    auto modified_library_ci = const_cast<VkPipelineLibraryCreateInfoKHR*>(
         vku::FindStructInPNextChain<VkPipelineLibraryCreateInfoKHR>(modified_pipeline_ci.pNext));
 
     // the "pStages[]" is spread across libraries, so build it up in the double for loop
@@ -1380,7 +1380,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
         if (modified_lib->instrumentation_data.was_instrumented &&
             (modified_lib->instrumentation_data.instrumented_pipeline_lib != VK_NULL_HANDLE)) {
             assert(modified_lib->instrumentation_data.instrumented_pipeline_lib != VK_NULL_HANDLE);
-            const_cast<VkPipeline *>(modified_library_ci->pLibraries)[modified_lib_i] =
+            const_cast<VkPipeline*>(modified_library_ci->pLibraries)[modified_lib_i] =
                 modified_lib->instrumentation_data.instrumented_pipeline_lib;
             linked_pipeline_state.instrumentation_data.was_instrumented = true;
             continue;
@@ -1398,7 +1398,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             IsPipelineSelectedForInstrumentation(modified_lib->VkHandle(), loc.dot(vvl::Field::pLibraries, modified_lib_i));
         for (uint32_t stage_state_i = 0; stage_state_i < static_cast<uint32_t>(modified_lib->stage_states.size());
              ++stage_state_i) {
-            const ShaderStageState &modified_stage_state = modified_lib->stage_states[stage_state_i];
+            const ShaderStageState& modified_stage_state = modified_lib->stage_states[stage_state_i];
             auto modified_module_state = std::const_pointer_cast<vvl::ShaderModule>(modified_stage_state.module_state);
             ASSERT_AND_CONTINUE(modified_module_state);
             if (!modified_module_state->spirv) {
@@ -1406,13 +1406,13 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             }
             std::unique_lock<std::mutex> module_lock(modified_module_state->module_mutex_);
 
-            chassis::ShaderInstrumentationMetadata &instrumentation_metadata = shader_instrumentation_metadata[shader_i++];
+            chassis::ShaderInstrumentationMetadata& instrumentation_metadata = shader_instrumentation_metadata[shader_i++];
 
             // Check pNext for inlined SPIR-V
             // ---
-            vku::safe_VkShaderModuleCreateInfo *modified_shader_module_ci = nullptr;
+            vku::safe_VkShaderModuleCreateInfo* modified_shader_module_ci = nullptr;
             {
-                vku::safe_VkPipelineShaderStageCreateInfo *modified_stage_ci = nullptr;
+                vku::safe_VkPipelineShaderStageCreateInfo* modified_stage_ci = nullptr;
                 const VkShaderStageFlagBits stage = modified_stage_state.GetStage();
                 for (uint32_t i = 0; i < new_lib_ci.stageCount; ++i) {
                     if (new_lib_ci.pStages[i].stage == stage) {
@@ -1430,7 +1430,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
                 }
 
                 modified_shader_module_ci =
-                    const_cast<vku::safe_VkShaderModuleCreateInfo *>(reinterpret_cast<const vku::safe_VkShaderModuleCreateInfo *>(
+                    const_cast<vku::safe_VkShaderModuleCreateInfo*>(reinterpret_cast<const vku::safe_VkShaderModuleCreateInfo*>(
                         vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(modified_stage_ci->pNext)));
 
                 // TODO - this is in need of testing, when only selecting various library as well as selecting everything
@@ -1441,7 +1441,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
                 }
 
                 if (modified_stage_state.descriptor_heap_mode) {
-                    AddDescriptorHeapMappings(reinterpret_cast<VkBaseOutStructure *>(modified_stage_ci));
+                    AddDescriptorHeapMappings(reinterpret_cast<VkBaseOutStructure*>(modified_stage_ci));
                 }
             }
 
@@ -1529,14 +1529,14 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             modified_lib->instrumentation_data.was_instrumented = true;
             linked_pipeline_state.instrumentation_data.was_instrumented = true;
 
-            const_cast<VkPipeline *>(modified_library_ci->pLibraries)[modified_lib_i] = instrumented_pipeline_lib;
+            const_cast<VkPipeline*>(modified_library_ci->pLibraries)[modified_lib_i] = instrumented_pipeline_lib;
         }
     }
     return true;
 }
 
 void GpuShaderInstrumentor::PostCallRecordPipelineCreationShaderInstrumentationGPL(
-    vvl::Pipeline &pipeline_state, std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata) {
+    vvl::Pipeline& pipeline_state, std::vector<chassis::ShaderInstrumentationMetadata>& shader_instrumentation_metadata) {
     // if we return early from NeedPipelineCreationShaderInstrumentation, will need to skip at this point in PostCall
     if (shader_instrumentation_metadata.empty()) {
         return;
@@ -1557,15 +1557,15 @@ void GpuShaderInstrumentor::PostCallRecordPipelineCreationShaderInstrumentationG
         vku::safe_VkGraphicsPipelineCreateInfo new_lib_pipeline_ci(lib->GraphicsCreateInfo());
 
         for (uint32_t stage_state_i = 0; stage_state_i < static_cast<uint32_t>(lib->stage_states.size()); ++stage_state_i) {
-            auto &instrumentation_metadata = shader_instrumentation_metadata[shader_index++];
+            auto& instrumentation_metadata = shader_instrumentation_metadata[shader_index++];
 
             // if the shader for some reason was not instrumented, there is nothing to save
             if (!instrumentation_metadata.IsInstrumented()) {
                 continue;
             }
 
-            const auto &stage_state = lib->stage_states[stage_state_i];
-            auto &module_state = stage_state.module_state;
+            const auto& stage_state = lib->stage_states[stage_state_i];
+            auto& module_state = stage_state.module_state;
 
             // We currently need to store a copy of the original, non-instrumented shader so if there is debug information,
             // we can reference it by the instruction number printed out in the shader. Since the application can destroy the
@@ -1588,7 +1588,7 @@ void GpuShaderInstrumentor::PostCallRecordPipelineCreationShaderInstrumentationG
     }
 }
 
-static bool GpuValidateShader(const std::vector<uint32_t> &input, spv_target_env target_env, std::string &error) {
+static bool GpuValidateShader(const std::vector<uint32_t>& input, spv_target_env target_env, std::string& error) {
     // Use SPIRV-Tools validator to try and catch any issues with the module
     spv_context ctx = spvContextCreate(target_env);
     spv_const_binary_t binary{input.data(), input.size()};
@@ -1704,7 +1704,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t>& in
     }
 
     // If there were GLSL written function injected, we will grab them and link them in here
-    for (const auto &info : module.link_infos_) {
+    for (const auto& info : module.link_infos_) {
         module.LinkFunctions(info);
     }
 
@@ -1762,12 +1762,12 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t>& in
     return true;
 }
 
-void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
+void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location& loc, const char* const specific_message) const {
     aborted_ = true;
     std::string error_message = specific_message;
 
-    const char *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
-    const char *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
+    const char* layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
+    const char* vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
 
     LogError(vuid, objlist, loc, "Internal Error, %s is being disabled. Details:\n%s", layer_name, error_message.c_str());
 
@@ -1779,26 +1779,26 @@ void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location 
 
 // Dedicated warning VUID that likely can be ignored.
 // We want to always warn the user when adjusting settings/limits/features/etc on them
-void GpuShaderInstrumentor::AdjustmentWarning(LogObjectList objlist, const Location &loc,
-                                              const char *const specific_message) const {
+void GpuShaderInstrumentor::AdjustmentWarning(LogObjectList objlist, const Location& loc,
+                                              const char* const specific_message) const {
     LogWarning("WARNING-Setting-Limit-Adjusted", objlist, loc, "Warning that validation is adjusting settings:\n%s",
                specific_message);
 }
 
-void GpuShaderInstrumentor::InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
-    const char *vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
+void GpuShaderInstrumentor::InternalWarning(LogObjectList objlist, const Location& loc, const char* const specific_message) const {
+    const char* vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
     LogWarning(vuid, objlist, loc, "Internal Warning: %s", specific_message);
 }
 
-void GpuShaderInstrumentor::InternalInfo(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
-    const char *vuid = gpuav_settings.debug_printf_only ? "INFO-DEBUG-PRINTF" : "INFO-GPU-Assisted-Validation";
+void GpuShaderInstrumentor::InternalInfo(LogObjectList objlist, const Location& loc, const char* const specific_message) const {
+    const char* vuid = gpuav_settings.debug_printf_only ? "INFO-DEBUG-PRINTF" : "INFO-GPU-Assisted-Validation";
     LogInfo(vuid, objlist, loc, "Internal Info: %s", specific_message);
 }
 
 // The lock (debug_output_mutex) is held by the caller,
 // because the latter has code paths that make multiple calls of this function,
 // and all such calls have to access the same debug reporting state to ensure consistency of output information.
-static std::string LookupDebugUtilsNameNoLock(const DebugReport *debug_report, const uint64_t object) {
+static std::string LookupDebugUtilsNameNoLock(const DebugReport* debug_report, const uint64_t object) {
     auto object_label = debug_report->GetUtilsObjectNameNoLock(object);
     if (object_label != "") {
         object_label = "(" + object_label + ")";
@@ -1927,7 +1927,9 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer comm
 
         uint32_t invalid_index_command = dispatch_instance_->settings.gpuav_settings.invalid_index_command;
         if (action_command_index == invalid_index_command) {
-            ss << "Index Unknown (After " << invalid_index_command << " commands, we stop tracking) \nThis can be adjusted setting env var VK_LAYER_GPUAV_MAX_INDICES_COUNT to a higher value";
+            ss << "Index Unknown (After " << invalid_index_command
+               << " commands, we stop tracking) \nThis can be adjusted setting env var VK_LAYER_GPUAV_MAX_INDICES_COUNT to a "
+                  "higher value";
         } else {
             ss << "Index " << action_command_index << '\n';
         }

--- a/layers/gpuav/instrumentation/mesh_shading.cpp
+++ b/layers/gpuav/instrumentation/mesh_shading.cpp
@@ -20,7 +20,7 @@
 
 namespace gpuav {
 
-void RegisterMeshShadingValidation(Validator &gpuav, CommandBufferSubState &cb) {
+void RegisterMeshShadingValidation(Validator& gpuav, CommandBufferSubState& cb) {
     if (!gpuav.gpuav_settings.shader_instrumentation.mesh_shading) {
         return;
     }

--- a/layers/gpuav/instrumentation/ray_hit_object.cpp
+++ b/layers/gpuav/instrumentation/ray_hit_object.cpp
@@ -21,7 +21,7 @@
 
 namespace gpuav {
 
-void RegisterRayHitObjectValidation(Validator &gpuav, CommandBufferSubState &cb) {
+void RegisterRayHitObjectValidation(Validator& gpuav, CommandBufferSubState& cb) {
     if (!gpuav.gpuav_settings.shader_instrumentation.ray_hit_object) {
         return;
     }
@@ -126,7 +126,8 @@ void RegisterRayHitObjectValidation(Validator &gpuav, CommandBufferSubState &cb)
                     const uint32_t sbt_index = error_record[kInst_LogError_ParameterOffset_0];
                     const uint32_t max_sbt_index = error_record[kInst_LogError_ParameterOffset_1];
                     strm << "OpHitObjectSetShaderBindingTableRecordIndexEXT SBT index (" << std::dec << sbt_index
-                         << ") exceeds VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT::maxShaderBindingTableRecordIndex (" << max_sbt_index << "). ";
+                         << ") exceeds VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT::maxShaderBindingTableRecordIndex ("
+                         << max_sbt_index << "). ";
                     out_vuid_msg = "VUID-RuntimeSpirv-maxShaderBindingTableRecordIndex-11888";
                 } break;
                 default:

--- a/layers/gpuav/instrumentation/ray_query.cpp
+++ b/layers/gpuav/instrumentation/ray_query.cpp
@@ -20,7 +20,7 @@
 
 namespace gpuav {
 
-void RegisterRayQueryValidation(Validator &gpuav, CommandBufferSubState &cb) {
+void RegisterRayQueryValidation(Validator& gpuav, CommandBufferSubState& cb) {
     if (!gpuav.gpuav_settings.shader_instrumentation.ray_query) {
         return;
     }

--- a/layers/gpuav/instrumentation/sanitizer.cpp
+++ b/layers/gpuav/instrumentation/sanitizer.cpp
@@ -29,106 +29,104 @@ static std::string GetSpirvSpecLink(const uint32_t opcode) {
     return "\nSee more at https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#" + std::string(string_SpvOpcode(opcode));
 }
 
-void RegisterSanitizer(Validator &gpuav, CommandBufferSubState &cb) {
+void RegisterSanitizer(Validator& gpuav, CommandBufferSubState& cb) {
     if (!gpuav.gpuav_settings.shader_instrumentation.sanitizer) {
         return;
     }
 
     cb.on_instrumentation_error_logger_register_functions.emplace_back([](Validator& gpuav, CommandBufferSubState& cb,
                                                                           const LastBound& last_bound) {
-        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator& gpuav, const Location& loc,
-                                                                                 const uint32_t* error_record,
-                                                                                 const InstrumentedShader*,
-                                                                                 std::string& out_error_msg,
-                                                                                 std::string& out_vuid_msg) {
-            using namespace glsl;
-            bool error_found = false;
-            if (GetErrorGroup(error_record) != kErrorGroup_InstSanitizer) {
+        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger =
+            [](Validator& gpuav, const Location& loc, const uint32_t* error_record, const InstrumentedShader*,
+               std::string& out_error_msg, std::string& out_vuid_msg) {
+                using namespace glsl;
+                bool error_found = false;
+                if (GetErrorGroup(error_record) != kErrorGroup_InstSanitizer) {
+                    return error_found;
+                }
+                error_found = true;
+
+                std::ostringstream strm;
+
+                const uint32_t error_sub_code = GetSubError(error_record);
+                switch (error_sub_code) {
+                    case kErrorSubCode_Sanitizer_DivideZero: {
+                        const uint32_t opcode = error_record[kInst_LogError_ParameterOffset_0];
+                        const uint32_t vector_size = error_record[kInst_LogError_ParameterOffset_1];
+                        const bool is_float = opcode == spv::OpFMod || opcode == spv::OpFRem;
+                        strm << (is_float ? "Float" : "Integer") << " divide by zero. Operand 2 of " << string_SpvOpcode(opcode)
+                             << " is ";
+                        if (vector_size == 0) {
+                            strm << "zero.";
+                        } else {
+                            strm << "a " << vector_size << "-wide vector which contains a zero value.";
+                        }
+                        if (is_float) {
+                            strm << " The result value is undefined.";
+                        }
+                        strm << GetSpirvSpecLink(opcode);
+                        out_vuid_msg = "SPIRV-Sanitizer-Divide-By-Zero";
+                    } break;
+                    case kErrorSubCode_Sanitizer_ImageGather: {
+                        const uint32_t component_value = error_record[kInst_LogError_ParameterOffset_0];
+                        const int32_t signed_value = (int32_t)component_value;
+                        strm << "OpImageGather has a component value of ";
+                        if (signed_value > 0) {
+                            strm << component_value;
+                        } else {
+                            strm << signed_value;
+                        }
+                        strm << ", but it must be 0, 1, 2, or 3" << GetSpirvSpecLink(spv::OpImageGather);
+                        out_vuid_msg = "SPIRV-Sanitizer-Image-Gather";
+                    } break;
+                    case kErrorSubCode_Sanitizer_Pow: {
+                        // Pow is only valid with a scalar/vector of 16/32-bit float
+                        const uint32_t vector_size = error_record[kInst_LogError_ParameterOffset_0];
+                        // Should use std::bit_cast but requires c++20
+                        const float x_value = *(float*)(error_record + kInst_LogError_ParameterOffset_1);
+                        const float y_value = *(float*)(error_record + kInst_LogError_ParameterOffset_2);
+                        strm << "Pow (from GLSL.std.450) has an undefined result because operand (x < 0) or (x == 0 && y <= 0)\n  ";
+                        if (vector_size > 0) {
+                            // Would need a new way to print more than 2 bytes out to get this to work
+                            strm << "Using a vector of size " << vector_size << " but currently only can print out scalar values";
+                        } else {
+                            strm << "X == " << x_value << ", Y == " << y_value;
+                        }
+                        out_vuid_msg = "SPIRV-Sanitizer-Pow";
+                    } break;
+                    case kErrorSubCode_Sanitizer_Atan2: {
+                        // Atan is only valid with a scalar/vector of 16/32-bit float
+                        strm << "Atan2 (from GLSL.std.450) has an undefined result because both values used are zero.";
+                        out_vuid_msg = "SPIRV-Sanitizer-Atan2";
+                    } break;
+                    case kErrorSubCode_Sanitizer_Fminmax: {
+                        // simple encoding done in inst_sanitizer_fminman (sanitizer.comp)
+                        const uint32_t invalid_encode = error_record[kInst_LogError_ParameterOffset_0];
+                        const bool x_is_invalid = (invalid_encode & 0x1) != 0;
+                        const bool y_is_invalid = (invalid_encode & 0x2) != 0;
+                        const uint32_t vector_size = error_record[kInst_LogError_ParameterOffset_1];
+                        const uint32_t glsl_opcode = error_record[kInst_LogError_ParameterOffset_2];
+                        strm << (glsl_opcode == GLSLstd450FMin ? "FMin" : "FMax")
+                             << " (from GLSL.std.450) has an undefined result because ";
+                        if (x_is_invalid && y_is_invalid) {
+                            strm << "both the x and y operands are NaN\n";
+                        } else if (x_is_invalid) {
+                            strm << "the x operand is NaN\n";
+                        } else {
+                            strm << "the y operand is NaN\n";
+                        }
+                        if (vector_size > 0) {
+                            strm << "Using a vector of size " << vector_size << " but currently only can print out scalar values";
+                        }
+                        out_vuid_msg = "SPIRV-Sanitizer-Fminmax";
+                    } break;
+                    default:
+                        error_found = false;
+                        break;
+                }
+                out_error_msg += strm.str();
                 return error_found;
-            }
-            error_found = true;
-
-            std::ostringstream strm;
-
-            const uint32_t error_sub_code = GetSubError(error_record);
-            switch (error_sub_code) {
-                case kErrorSubCode_Sanitizer_DivideZero: {
-                    const uint32_t opcode = error_record[kInst_LogError_ParameterOffset_0];
-                    const uint32_t vector_size = error_record[kInst_LogError_ParameterOffset_1];
-                    const bool is_float = opcode == spv::OpFMod || opcode == spv::OpFRem;
-                    strm << (is_float ? "Float" : "Integer") << " divide by zero. Operand 2 of " << string_SpvOpcode(opcode)
-                         << " is ";
-                    if (vector_size == 0) {
-                        strm << "zero.";
-                    } else {
-                        strm << "a " << vector_size << "-wide vector which contains a zero value.";
-                    }
-                    if (is_float) {
-                        strm << " The result value is undefined.";
-                    }
-                    strm << GetSpirvSpecLink(opcode);
-                    out_vuid_msg = "SPIRV-Sanitizer-Divide-By-Zero";
-                } break;
-                case kErrorSubCode_Sanitizer_ImageGather: {
-                    const uint32_t component_value = error_record[kInst_LogError_ParameterOffset_0];
-                    const int32_t signed_value = (int32_t)component_value;
-                    strm << "OpImageGather has a component value of ";
-                    if (signed_value > 0) {
-                        strm << component_value;
-                    } else {
-                        strm << signed_value;
-                    }
-                    strm << ", but it must be 0, 1, 2, or 3" << GetSpirvSpecLink(spv::OpImageGather);
-                    out_vuid_msg = "SPIRV-Sanitizer-Image-Gather";
-                } break;
-                case kErrorSubCode_Sanitizer_Pow: {
-                    // Pow is only valid with a scalar/vector of 16/32-bit float
-                    const uint32_t vector_size = error_record[kInst_LogError_ParameterOffset_0];
-                    // Should use std::bit_cast but requires c++20
-                    const float x_value = *(float*)(error_record + kInst_LogError_ParameterOffset_1);
-                    const float y_value = *(float*)(error_record + kInst_LogError_ParameterOffset_2);
-                    strm << "Pow (from GLSL.std.450) has an undefined result because operand (x < 0) or (x == 0 && y <= 0)\n  ";
-                    if (vector_size > 0) {
-                        // Would need a new way to print more than 2 bytes out to get this to work
-                        strm << "Using a vector of size " << vector_size << " but currently only can print out scalar values";
-                    } else {
-                        strm << "X == " << x_value << ", Y == " << y_value;
-                    }
-                    out_vuid_msg = "SPIRV-Sanitizer-Pow";
-                } break;
-                case kErrorSubCode_Sanitizer_Atan2: {
-                    // Atan is only valid with a scalar/vector of 16/32-bit float
-                    strm << "Atan2 (from GLSL.std.450) has an undefined result because both values used are zero.";
-                    out_vuid_msg = "SPIRV-Sanitizer-Atan2";
-                } break;
-                case kErrorSubCode_Sanitizer_Fminmax: {
-                    // simple encoding done in inst_sanitizer_fminman (sanitizer.comp)
-                    const uint32_t invalid_encode = error_record[kInst_LogError_ParameterOffset_0];
-                    const bool x_is_invalid = (invalid_encode & 0x1) != 0;
-                    const bool y_is_invalid = (invalid_encode & 0x2) != 0;
-                    const uint32_t vector_size = error_record[kInst_LogError_ParameterOffset_1];
-                    const uint32_t glsl_opcode = error_record[kInst_LogError_ParameterOffset_2];
-                    strm << (glsl_opcode == GLSLstd450FMin ? "FMin" : "FMax")
-                         << " (from GLSL.std.450) has an undefined result because ";
-                    if (x_is_invalid && y_is_invalid) {
-                        strm << "both the x and y operands are NaN\n";
-                    } else if (x_is_invalid) {
-                        strm << "the x operand is NaN\n";
-                    } else {
-                        strm << "the y operand is NaN\n";
-                    }
-                    if (vector_size > 0) {
-                        strm << "Using a vector of size " << vector_size << " but currently only can print out scalar values";
-                    }
-                    out_vuid_msg = "SPIRV-Sanitizer-Fminmax";
-                } break;
-                default:
-                    error_found = false;
-                    break;
-            }
-            out_error_msg += strm.str();
-            return error_found;
-        };
+            };
 
         return inst_error_logger;
     });

--- a/layers/gpuav/instrumentation/shared_memory_data_race.cpp
+++ b/layers/gpuav/instrumentation/shared_memory_data_race.cpp
@@ -22,7 +22,7 @@
 
 namespace gpuav {
 
-void RegisterSharedMemoryDataRaceValidation(Validator &gpuav, CommandBufferSubState &cb) {
+void RegisterSharedMemoryDataRaceValidation(Validator& gpuav, CommandBufferSubState& cb) {
     if (!gpuav.gpuav_settings.shader_instrumentation.shared_memory_data_race) {
         return;
     }

--- a/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
@@ -37,13 +37,13 @@ struct VertexAttributeFetchLimit {
 // Computes vertex attributes fetching limits based on the set of bound vertex buffers.
 // Used to detect out of bounds indices in index buffers.
 static std::pair<std::optional<VertexAttributeFetchLimit>, std::optional<VertexAttributeFetchLimit>> GetVertexAttributeFetchLimits(
-    const vvl::CommandBuffer &cb_state) {
-    const LastBound &last_bound = cb_state.GetLastBoundGraphics();
-    const vvl::Pipeline *pipeline_state = last_bound.pipeline_state;
+    const vvl::CommandBuffer& cb_state) {
+    const LastBound& last_bound = cb_state.GetLastBoundGraphics();
+    const vvl::Pipeline* pipeline_state = last_bound.pipeline_state;
 
     const bool dynamic_vertex_input = last_bound.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT);
 
-    const auto &vertex_binding_descriptions =
+    const auto& vertex_binding_descriptions =
         dynamic_vertex_input ? cb_state.dynamic_state_value.vertex_bindings : pipeline_state->vertex_input_state->bindings;
 
     std::optional<VertexAttributeFetchLimit> vertex_attribute_fetch_limit_vertex_input_rate;
@@ -51,12 +51,12 @@ static std::pair<std::optional<VertexAttributeFetchLimit>, std::optional<VertexA
 
     small_vector<uint32_t, 32> vertex_shader_used_locations;
     {
-        const ::spirv::EntryPoint *vertex_entry_point = last_bound.GetVertexEntryPoint();
+        const ::spirv::EntryPoint* vertex_entry_point = last_bound.GetVertexEntryPoint();
         if (!vertex_entry_point) {
             return {std::optional<VertexAttributeFetchLimit>{}, std::optional<VertexAttributeFetchLimit>{}};
         }
-        for (const ::spirv::StageInterfaceVariable &interface_var : vertex_entry_point->stage_interface_variables) {
-            for (const ::spirv::InterfaceSlot &interface_slot : interface_var.interface_slots) {
+        for (const ::spirv::StageInterfaceVariable& interface_var : vertex_entry_point->stage_interface_variables) {
+            for (const ::spirv::InterfaceSlot& interface_slot : interface_var.interface_slots) {
                 const uint32_t location = interface_slot.Location();
                 if (std::find(vertex_shader_used_locations.begin(), vertex_shader_used_locations.end(), location) ==
                     vertex_shader_used_locations.end()) {
@@ -66,14 +66,14 @@ static std::pair<std::optional<VertexAttributeFetchLimit>, std::optional<VertexA
         }
     }
 
-    for (const auto &[binding, vertex_binding_desc] : vertex_binding_descriptions) {
-        const vvl::VertexBufferBinding *vbb = vvl::Find(cb_state.current_vertex_buffer_binding_info, binding);
+    for (const auto& [binding, vertex_binding_desc] : vertex_binding_descriptions) {
+        const vvl::VertexBufferBinding* vbb = vvl::Find(cb_state.current_vertex_buffer_binding_info, binding);
         if (!vbb) {
             // Validation error
             continue;
         }
 
-        for (const auto &[location, attrib] : vertex_binding_desc.locations) {
+        for (const auto& [location, attrib] : vertex_binding_desc.locations) {
             if (std::find(vertex_shader_used_locations.begin(), vertex_shader_used_locations.end(), location) ==
                 vertex_shader_used_locations.end()) {
                 continue;
@@ -146,7 +146,7 @@ static std::pair<std::optional<VertexAttributeFetchLimit>, std::optional<VertexA
     return {vertex_attribute_fetch_limit_vertex_input_rate, vertex_attribute_fetch_limit_instance_input_rate};
 }
 
-void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSubState &cb) {
+void RegisterVertexAttributeFetchOobValidation(Validator& gpuav, CommandBufferSubState& cb) {
     if (!gpuav.gpuav_settings.shader_instrumentation.vertex_attribute_fetch_oob) {
         return;
     }
@@ -160,8 +160,8 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
     // Used to communicate error info between lambdas
     auto error_info = std::make_shared<ErrorInfo>();
 
-    cb.on_instrumentation_error_logger_register_functions.emplace_back([error_info](Validator &gpuav, CommandBufferSubState &cb,
-                                                                                    const LastBound &last_bound) {
+    cb.on_instrumentation_error_logger_register_functions.emplace_back([error_info](Validator& gpuav, CommandBufferSubState& cb,
+                                                                                    const LastBound& last_bound) {
         auto local_error_info = std::make_shared<ErrorInfo>();
         *local_error_info = *error_info;
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [local_error_info = std::move(local_error_info)](
@@ -203,7 +203,7 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
             assert(local_error_info->index_buffer_binding.has_value());
 
             auto add_vertex_buffer_binding_info =
-                [&gpuav, error_sub_code](const VertexAttributeFetchLimit &vertex_attribute_fetch_limit, std::string &out) {
+                [&gpuav, error_sub_code](const VertexAttributeFetchLimit& vertex_attribute_fetch_limit, std::string& out) {
                     out += "Vertex Buffer (";
                     out += gpuav.FormatHandle(vertex_attribute_fetch_limit.binding_info.Buffer());
                     out += ") binding info:\n";
@@ -231,7 +231,7 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
                     }
                 };
 
-            auto add_vertex_attribute_info = [](const VertexAttributeFetchLimit &vertex_attribute_fetch_limit, std::string &out) {
+            auto add_vertex_attribute_info = [](const VertexAttributeFetchLimit& vertex_attribute_fetch_limit, std::string& out) {
                 out += "The following VkVertexInputAttributeDescription caused OOB access:\n";
                 out += "  - Location: ";
                 out += std::to_string(vertex_attribute_fetch_limit.attribute.location);
@@ -314,14 +314,14 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
         return inst_error_logger;
     });
 
-    auto get_vertex_attribute_fetch_limits_buffer_range = [error_info](CommandBufferSubState &cb) {
+    auto get_vertex_attribute_fetch_limits_buffer_range = [error_info](CommandBufferSubState& cb) {
         vko::BufferRange vertex_attribute_fetch_limits_buffer_range =
             cb.gpu_resources_manager.GetHostCoherentBufferRange(4 * sizeof(uint32_t));
         if (vertex_attribute_fetch_limits_buffer_range.buffer == VK_NULL_HANDLE) {
             return vertex_attribute_fetch_limits_buffer_range;
         }
 
-        auto vertex_attribute_fetch_limits_buffer_ptr = (uint32_t *)vertex_attribute_fetch_limits_buffer_range.offset_mapped_ptr;
+        auto vertex_attribute_fetch_limits_buffer_ptr = (uint32_t*)vertex_attribute_fetch_limits_buffer_range.offset_mapped_ptr;
 
         const auto [vertex_attribute_fetch_limit_vertex_input_rate, vertex_attribute_fetch_limit_instance_input_rate] =
             GetVertexAttributeFetchLimits(cb.base);
@@ -349,9 +349,9 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
     };
 
     cb.on_instrumentation_desc_set_update_functions.emplace_back(
-        [&gpuav, get_vertex_attribute_fetch_limits_buffer_range](CommandBufferSubState &cb, VkPipelineBindPoint bind_point,
-                                                                 const Location &loc, VkDescriptorBufferInfo &out_buffer_info,
-                                                                 uint32_t &out_dst_binding) {
+        [&gpuav, get_vertex_attribute_fetch_limits_buffer_range](CommandBufferSubState& cb, VkPipelineBindPoint bind_point,
+                                                                 const Location& loc, VkDescriptorBufferInfo& out_buffer_info,
+                                                                 uint32_t& out_dst_binding) {
             if (!vvl::IsCommandDrawVertex(loc.function)) {
                 return;
             }
@@ -367,7 +367,7 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
                 out_buffer_info.range = vertex_attribute_fetch_limits_buffer_range.size;
             } else {
                 // Point all non-indexed draws to our global buffer that will bypass the check in shader
-                VertexAttributeFetchOff &resource = gpuav.shared_resources_cache.GetOrCreate<VertexAttributeFetchOff>(gpuav, false);
+                VertexAttributeFetchOff& resource = gpuav.shared_resources_cache.GetOrCreate<VertexAttributeFetchOff>(gpuav, false);
                 if (!resource.valid) {
                     return;
                 }
@@ -380,9 +380,9 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
         });
 
     cb.on_instrumentation_desc_heap_update_functions.emplace_back(
-        [&gpuav, error_info, get_vertex_attribute_fetch_limits_buffer_range](CommandBufferSubState &cb, VkPipelineBindPoint,
-                                                                             const Location &loc, VkDeviceAddress &out_address,
-                                                                             uint32_t &out_dst_binding) {
+        [&gpuav, error_info, get_vertex_attribute_fetch_limits_buffer_range](CommandBufferSubState& cb, VkPipelineBindPoint,
+                                                                             const Location& loc, VkDeviceAddress& out_address,
+                                                                             uint32_t& out_dst_binding) {
             if (!vvl::IsCommandDrawVertex(loc.function)) {
                 return;
             }
@@ -397,7 +397,7 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
                 vertex_attribute_fetch_limits_buffer_address = vertex_attribute_fetch_limits_buffer_range.offset_address;
             } else {
                 // Point all non-indexed draws to our global buffer that will bypass the check in shader
-                VertexAttributeFetchOff &resource = gpuav.shared_resources_cache.GetOrCreate<VertexAttributeFetchOff>(gpuav, true);
+                VertexAttributeFetchOff& resource = gpuav.shared_resources_cache.GetOrCreate<VertexAttributeFetchOff>(gpuav, true);
                 if (!resource.valid) return;
                 vertex_attribute_fetch_limits_buffer_address = resource.buffer.Address();
             }

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -31,7 +31,7 @@
 
 namespace gpuav {
 
-CommandBufferSubState::CommandBufferSubState(Validator &gpuav, vvl::CommandBuffer &cb)
+CommandBufferSubState::CommandBufferSubState(Validator& gpuav, vvl::CommandBuffer& cb)
     : vvl::CommandBufferSubState(cb), gpu_resources_manager(gpuav, false), cmd_errors_counts_buffer_(gpuav), gpuav_(gpuav) {
     Location loc(vvl::Func::vkAllocateCommandBuffers);
     AllocateResources(loc);
@@ -39,7 +39,7 @@ CommandBufferSubState::CommandBufferSubState(Validator &gpuav, vvl::CommandBuffe
 
 CommandBufferSubState::~CommandBufferSubState() {}
 
-void CommandBufferSubState::AllocateResources(const Location &loc) {
+void CommandBufferSubState::AllocateResources(const Location& loc) {
     VkResult result = VK_SUCCESS;
 
     // Instrumentation descriptor set layout
@@ -65,7 +65,7 @@ void CommandBufferSubState::AllocateResources(const Location &loc) {
 
         memset(error_output_buffer_range_.offset_mapped_ptr, 0, (size_t)error_output_buffer_range_.size);
         if (gpuav_.gpuav_settings.shader_instrumentation.descriptor_checks) {
-            ((uint32_t *)error_output_buffer_range_.offset_mapped_ptr)[cst::stream_output_flags_offset] =
+            ((uint32_t*)error_output_buffer_range_.offset_mapped_ptr)[cst::stream_output_flags_offset] =
                 cst::inst_buffer_oob_enabled;
         }
     }
@@ -93,18 +93,18 @@ void CommandBufferSubState::AllocateResources(const Location &loc) {
 }
 
 // Common logic after any draw/dispatch/traceRays
-void CommandBufferSubState::RecordActionCommand(LastBound &last_bound, const Location &) {
+void CommandBufferSubState::RecordActionCommand(LastBound& last_bound, const Location&) {
     PostCallSetupShaderInstrumentationResources(gpuav_, *this, last_bound);
     IncrementActionCommandCount(last_bound.bind_point);
 }
 
-void CommandBufferSubState::UpdateLastBoundDescriptorSets(VkPipelineBindPoint bind_point, const Location &loc) {
+void CommandBufferSubState::UpdateLastBoundDescriptorSets(VkPipelineBindPoint bind_point, const Location& loc) {
     descriptor::UpdateBoundDescriptors(gpuav_, *this, bind_point, loc);
 }
 
 void CommandBufferSubState::Destroy() { ResetCBState(true); }
 
-void CommandBufferSubState::Reset(const Location &loc) {
+void CommandBufferSubState::Reset(const Location& loc) {
     ResetCBState(false);
     // TODO: Calling AllocateResources in Reset like so is a kind of a hack,
     // relying on CommandBuffer internal logic to work.
@@ -113,7 +113,7 @@ void CommandBufferSubState::Reset(const Location &loc) {
 }
 
 void CommandBufferSubState::RecordPushConstants(VkPipelineLayout layout, VkShaderStageFlags stage_flags, uint32_t offset,
-                                                uint32_t size, const void *values) {
+                                                uint32_t size, const void* values) {
     if (IsStageInPipelineBindPoint(stage_flags, VK_PIPELINE_BIND_POINT_GRAPHICS)) {
         push_constant_latest_used_layout[vvl::BindPointGraphics] = layout;
     } else if (IsStageInPipelineBindPoint(stage_flags, VK_PIPELINE_BIND_POINT_COMPUTE)) {
@@ -130,7 +130,7 @@ void CommandBufferSubState::RecordPushConstants(VkPipelineLayout layout, VkShade
     push_constant_data.stage_flags = stage_flags;
     push_constant_data.offset = offset;
     push_constant_data.values.resize(size);
-    auto byte_values = static_cast<const std::byte *>(values);
+    auto byte_values = static_cast<const std::byte*>(values);
     std::copy(byte_values, byte_values + size, push_constant_data.values.data());
     // Always add submitted push constant values, even if the same data is already stored.
     // Storing duplicated data, or data submitted by one vkCmdPushConstants call
@@ -146,14 +146,14 @@ void CommandBufferSubState::ClearPushConstants() {
     push_constant_latest_used_layout.fill(VK_NULL_HANDLE);
 }
 
-void CommandBufferSubState::RecordEndRendering(const VkRenderingEndInfoEXT *) { valcmd::FlushValidationCmds(gpuav_, *this); }
+void CommandBufferSubState::RecordEndRendering(const VkRenderingEndInfoEXT*) { valcmd::FlushValidationCmds(gpuav_, *this); }
 
-void CommandBufferSubState::RecordEndRenderPass(const VkSubpassEndInfo *, const Location &) {
+void CommandBufferSubState::RecordEndRenderPass(const VkSubpassEndInfo*, const Location&) {
     valcmd::FlushValidationCmds(gpuav_, *this);
 }
 
 // For things like vkCmdCopyImage there is no "last bound" as not shaders are attached to it
-void CommandBufferSubState::AddCommandErrorLogger(const Location &loc, const LastBound *last_bound,
+void CommandBufferSubState::AddCommandErrorLogger(const Location& loc, const LastBound* last_bound,
                                                   ErrorLoggerFunc error_logger_func) {
     if (command_error_loggers_.size() == gpuav_.gpuav_settings.invalid_index_command) {
         return;
@@ -231,7 +231,7 @@ uint32_t CommandBufferSubState::GetActionCommandIndex(VkPipelineBindPoint bind_p
 }
 
 std::string CommandBufferSubState::GetDebugLabelRegion(uint32_t label_command_i,
-                                                       const std::vector<std::string> &initial_label_stack) const {
+                                                       const std::vector<std::string>& initial_label_stack) const {
     std::string debug_region_name;
     if (label_command_i != vvl::kNoIndex32) {
         debug_region_name = base.GetDebugRegionName(base.GetLabelCommands(), label_command_i, initial_label_stack);
@@ -240,7 +240,7 @@ std::string CommandBufferSubState::GetDebugLabelRegion(uint32_t label_command_i,
         // no debug label region was yet opened in the corresponding command buffer,
         // but still a region might have been started in another previously submitted
         // command buffer. So just compute region name from initial_label_stack.
-        for (const std::string &label_name : initial_label_stack) {
+        for (const std::string& label_name : initial_label_stack) {
             if (!debug_region_name.empty()) {
                 debug_region_name += "::";
             }
@@ -254,10 +254,10 @@ struct FenceWaiter {
     std::vector<VkFence> fences;
 };
 
-bool CommandBufferSubState::PreSubmit(QueueSubState &queue, const Location &loc) {
+bool CommandBufferSubState::PreSubmit(QueueSubState& queue, const Location& loc) {
     VVL_ZoneScoped;
     if (!on_pre_cb_submission_functions.empty()) {
-        vko::CommandPool &cb_pool =
+        vko::CommandPool& cb_pool =
             queue.shared_resources_cache.GetOrCreate<vko::CommandPool>(gpuav_, queue.base.queue_family_index, loc);
         auto [per_pre_submission_cb, fence] = cb_pool.GetCommandBuffer();
         if (per_pre_submission_cb == VK_NULL_HANDLE) {
@@ -267,7 +267,7 @@ bool CommandBufferSubState::PreSubmit(QueueSubState &queue, const Location &loc)
         VkCommandBufferBeginInfo cb_bi = vku::InitStructHelper();
         cb_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         DispatchBeginCommandBuffer(per_pre_submission_cb, &cb_bi);
-        for (auto &pre_submission_func : on_pre_cb_submission_functions) {
+        for (auto& pre_submission_func : on_pre_cb_submission_functions) {
             pre_submission_func(gpuav_, *this, per_pre_submission_cb);
         }
         DispatchEndCommandBuffer(per_pre_submission_cb);
@@ -284,10 +284,10 @@ bool CommandBufferSubState::PreSubmit(QueueSubState &queue, const Location &loc)
     return true;
 }
 
-bool CommandBufferSubState::PostSubmit(QueueSubState &queue, const Location &loc) {
+bool CommandBufferSubState::PostSubmit(QueueSubState& queue, const Location& loc) {
     VVL_ZoneScoped;
     if (!on_post_cb_submission_functions.empty()) {
-        vko::CommandPool &cb_pool =
+        vko::CommandPool& cb_pool =
             queue.shared_resources_cache.GetOrCreate<vko::CommandPool>(gpuav_, queue.base.queue_family_index, loc);
         auto [per_post_submission_cb, fence] = cb_pool.GetCommandBuffer();
         if (per_post_submission_cb == VK_NULL_HANDLE) {
@@ -297,7 +297,7 @@ bool CommandBufferSubState::PostSubmit(QueueSubState &queue, const Location &loc
         VkCommandBufferBeginInfo cb_bi = vku::InitStructHelper();
         cb_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         DispatchBeginCommandBuffer(per_post_submission_cb, &cb_bi);
-        for (auto &post_submission_func : on_post_cb_submission_functions) {
+        for (auto& post_submission_func : on_post_cb_submission_functions) {
             post_submission_func(gpuav_, *this, per_post_submission_cb);
         }
         DispatchEndCommandBuffer(per_post_submission_cb);
@@ -310,7 +310,7 @@ bool CommandBufferSubState::PostSubmit(QueueSubState &queue, const Location &loc
             gpuav_.InternalError(queue.Handle(), loc, "Failed to submit per post submission command buffer");
         }
 
-        FenceWaiter &fence_waiter = queue.shared_resources_cache.GetOrCreate<FenceWaiter>();
+        FenceWaiter& fence_waiter = queue.shared_resources_cache.GetOrCreate<FenceWaiter>();
         fence_waiter.fences.emplace_back(fence);
     }
 
@@ -320,7 +320,7 @@ bool CommandBufferSubState::PostSubmit(QueueSubState &queue, const Location &loc
 bool CommandBufferSubState::NeedsPostProcess() { return error_output_buffer_range_.buffer != VK_NULL_HANDLE; }
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
-void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::string> &initial_label_stack, const Location &loc) {
+void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::string>& initial_label_stack, const Location& loc) {
     VVL_ZoneScoped;
 
     // CommandBuffer::Destroy can happen on an other thread,
@@ -331,7 +331,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
     }
 
     {
-        auto error_output_buffer_ptr = (uint32_t *)error_output_buffer_range_.offset_mapped_ptr;
+        auto error_output_buffer_ptr = (uint32_t*)error_output_buffer_range_.offset_mapped_ptr;
 
         // The second word in the debug output buffer is the number of words that would have
         // been written by the shader instrumentation, if there was enough room in the buffer we provided.
@@ -342,12 +342,12 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
 
         // A zero here means that the shader instrumentation didn't write anything.
         if (total_words != 0) {
-            uint32_t *const error_records_start = &error_output_buffer_ptr[cst::stream_output_data_offset];
+            uint32_t* const error_records_start = &error_output_buffer_ptr[cst::stream_output_data_offset];
             assert(glsl::kErrorBufferByteSize > cst::stream_output_data_offset);
-            uint32_t *const error_records_end =
+            uint32_t* const error_records_end =
                 error_output_buffer_ptr + (glsl::kErrorBufferByteSize - cst::stream_output_data_offset);
 
-            uint32_t *error_record_ptr = error_records_start;
+            uint32_t* error_record_ptr = error_records_start;
             uint32_t record_size = error_record_ptr[glsl::kHeader_ErrorRecordSizeOffset];
             assert(record_size == glsl::kErrorRecordSize);
 
@@ -367,7 +367,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
                     break;  // only report once
                 } else {
                     // normal case
-                    const CommandErrorLogger &error_logger = GetErrorLogger(error_logger_i);
+                    const CommandErrorLogger& error_logger = GetErrorLogger(error_logger_i);
                     const LogObjectList objlist(queue, error_logger.objlist);
 
                     std::string debug_region_name = GetDebugLabelRegion(error_logger.label_cmd_i, initial_label_stack);
@@ -397,7 +397,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
 
     bool success = true;
     LabelLogging label_logging = {initial_label_stack};
-    for (auto &on_cb_completion_func : on_cb_completion_functions) {
+    for (auto& on_cb_completion_func : on_cb_completion_functions) {
         success = on_cb_completion_func(gpuav_, *this, label_logging, loc);
         if (!success) {
             break;
@@ -405,7 +405,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
     }
 }
 
-QueueSubState::QueueSubState(Validator &gpuav, vvl::Queue &q) : vvl::QueueSubState(q), gpuav_(gpuav), timeline_khr_(false) {}
+QueueSubState::QueueSubState(Validator& gpuav, vvl::Queue& q) : vvl::QueueSubState(q), gpuav_(gpuav), timeline_khr_(false) {}
 
 QueueSubState::~QueueSubState() {
     shared_resources_cache.Clear();
@@ -427,7 +427,7 @@ QueueSubState::~QueueSubState() {
 // #ARNO_TODO do we still need that?
 // Submit a memory barrier on graphics queues.
 // Lazy-create and record the needed command buffer.
-void QueueSubState::SubmitBarrier(const Location &loc, uint64_t seq) {
+void QueueSubState::SubmitBarrier(const Location& loc, uint64_t seq) {
     if (barrier_command_pool_ == VK_NULL_HANDLE) {
         VkResult result = VK_SUCCESS;
 
@@ -501,20 +501,20 @@ void QueueSubState::SubmitBarrier(const Location &loc, uint64_t seq) {
     }
 }
 
-void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission> &submissions) {
+void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
     bool success = true;
-    for (const auto &submission : submissions) {
+    for (const auto& submission : submissions) {
         auto loc = submission.loc.Get();
-        for (auto &cb_submission : submission.cb_submissions) {
+        for (auto& cb_submission : submission.cb_submissions) {
             auto guard = cb_submission.cb->ReadLock();
-            auto &gpu_cb = SubState(*cb_submission.cb);
+            auto& gpu_cb = SubState(*cb_submission.cb);
             success = gpu_cb.PreSubmit(*this, loc);
             if (!success) {
                 return;
             }
-            for (auto *secondary_cb : gpu_cb.base.linked_command_buffers) {
+            for (auto* secondary_cb : gpu_cb.base.linked_command_buffers) {
                 auto secondary_guard = secondary_cb->ReadLock();
-                auto &secondary_gpu_cb = SubState(*secondary_cb);
+                auto& secondary_gpu_cb = SubState(*secondary_cb);
                 success = secondary_gpu_cb.PreSubmit(*this, loc);
                 if (!success) {
                     return;
@@ -524,20 +524,20 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission> &submissions) {
     }
 }
 
-void QueueSubState::PostSubmit(std::deque<vvl::QueueSubmission> &submissions) {
+void QueueSubState::PostSubmit(std::deque<vvl::QueueSubmission>& submissions) {
     bool success = true;
-    for (const auto &submission : submissions) {
+    for (const auto& submission : submissions) {
         auto loc = submission.loc.Get();
-        for (auto &cb_submission : submission.cb_submissions) {
+        for (auto& cb_submission : submission.cb_submissions) {
             auto guard = cb_submission.cb->ReadLock();
-            auto &gpu_cb = SubState(*cb_submission.cb);
+            auto& gpu_cb = SubState(*cb_submission.cb);
             success = gpu_cb.PostSubmit(*this, loc);
             if (!success) {
                 return;
             }
-            for (auto *secondary_cb : gpu_cb.base.linked_command_buffers) {
+            for (auto* secondary_cb : gpu_cb.base.linked_command_buffers) {
                 auto secondary_guard = secondary_cb->ReadLock();
-                auto &secondary_gpu_cb = SubState(*secondary_cb);
+                auto& secondary_gpu_cb = SubState(*secondary_cb);
                 success = secondary_gpu_cb.PostSubmit(*this, loc);
                 if (!success) {
                     return;
@@ -552,7 +552,7 @@ void QueueSubState::PostSubmit(std::deque<vvl::QueueSubmission> &submissions) {
     }
 }
 
-void QueueSubState::Retire(vvl::QueueSubmission &submission) {
+void QueueSubState::Retire(vvl::QueueSubmission& submission) {
     VVL_ZoneScoped;
     if (submission.loc.Get().function == vvl::Func::vkQueuePresentKHR) {
         // Present batch does not have any GPU-AV work to post process, skip it.
@@ -573,22 +573,22 @@ void QueueSubState::Retire(vvl::QueueSubmission &submission) {
             DispatchWaitSemaphores(gpuav_.device, &wait_info, 1'000'000'000);
         }
 
-        FenceWaiter *fence_waiter = shared_resources_cache.TryGet<FenceWaiter>();
+        FenceWaiter* fence_waiter = shared_resources_cache.TryGet<FenceWaiter>();
         if (fence_waiter && !fence_waiter->fences.empty()) {
             DispatchWaitForFences(gpuav_.device, uint32_t(fence_waiter->fences.size()), fence_waiter->fences.data(), VK_TRUE,
                                   UINT64_MAX);
             fence_waiter->fences.clear();
         }
 
-        for (std::vector<vvl::CommandBufferSubmission> &cb_submissions : retiring_) {
-            for (vvl::CommandBufferSubmission &cb_submission : cb_submissions) {
+        for (std::vector<vvl::CommandBufferSubmission>& cb_submissions : retiring_) {
+            for (vvl::CommandBufferSubmission& cb_submission : cb_submissions) {
                 auto guard = cb_submission.cb->WriteLock();
-                auto &gpu_cb = SubState(*cb_submission.cb);
+                auto& gpu_cb = SubState(*cb_submission.cb);
                 auto loc = submission.loc.Get();
                 gpu_cb.OnCompletion(VkHandle(), cb_submission.initial_label_stack, loc);
-                for (vvl::CommandBuffer *secondary_cb : gpu_cb.base.linked_command_buffers) {
+                for (vvl::CommandBuffer* secondary_cb : gpu_cb.base.linked_command_buffers) {
                     auto secondary_guard = secondary_cb->WriteLock();
-                    auto &secondary_gpu_cb = SubState(*secondary_cb);
+                    auto& secondary_gpu_cb = SubState(*secondary_cb);
                     secondary_gpu_cb.OnCompletion(VkHandle(), cb_submission.initial_label_stack, loc);
                 }
             }
@@ -597,78 +597,78 @@ void QueueSubState::Retire(vvl::QueueSubmission &submission) {
     }
 }
 
-ImageSubState::ImageSubState(vvl::Image &obj, DescriptorHeap &heap)
+ImageSubState::ImageSubState(vvl::Image& obj, DescriptorHeap& heap)
     : vvl::ImageSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void ImageSubState::Destroy() { id_tracker.reset(); }
 
-void ImageSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+void ImageSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-ImageViewSubState::ImageViewSubState(vvl::ImageView &obj, DescriptorHeap &heap)
+ImageViewSubState::ImageViewSubState(vvl::ImageView& obj, DescriptorHeap& heap)
     : vvl::ImageViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void ImageViewSubState::Destroy() { id_tracker.reset(); }
 
-void ImageViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+void ImageViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-BufferSubState::BufferSubState(vvl::Buffer &obj, DescriptorHeap &heap)
+BufferSubState::BufferSubState(vvl::Buffer& obj, DescriptorHeap& heap)
     : vvl::BufferSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void BufferSubState::Destroy() { id_tracker.reset(); }
 
-void BufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+void BufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-BufferViewSubState::BufferViewSubState(vvl::BufferView &obj, DescriptorHeap &heap)
+BufferViewSubState::BufferViewSubState(vvl::BufferView& obj, DescriptorHeap& heap)
     : vvl::BufferViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void BufferViewSubState::Destroy() { id_tracker.reset(); }
 
-void BufferViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+void BufferViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-SamplerSubState::SamplerSubState(vvl::Sampler &obj, DescriptorHeap &heap)
+SamplerSubState::SamplerSubState(vvl::Sampler& obj, DescriptorHeap& heap)
     : vvl::SamplerSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void SamplerSubState::Destroy() { id_tracker.reset(); }
 
-void SamplerSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+void SamplerSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-AccelerationStructureNVSubState::AccelerationStructureNVSubState(vvl::AccelerationStructureNV &obj, DescriptorHeap &heap)
+AccelerationStructureNVSubState::AccelerationStructureNVSubState(vvl::AccelerationStructureNV& obj, DescriptorHeap& heap)
     : vvl::AccelerationStructureNVSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void AccelerationStructureNVSubState::Destroy() { id_tracker.reset(); }
 
-void AccelerationStructureNVSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) {
+void AccelerationStructureNVSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) {
     id_tracker.reset();
 }
 
-AccelerationStructureKHRSubState::AccelerationStructureKHRSubState(vvl::AccelerationStructureKHR &obj, DescriptorHeap &heap)
+AccelerationStructureKHRSubState::AccelerationStructureKHRSubState(vvl::AccelerationStructureKHR& obj, DescriptorHeap& heap)
     : vvl::AccelerationStructureKHRSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void AccelerationStructureKHRSubState::Destroy() { id_tracker.reset(); }
 
-void AccelerationStructureKHRSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) {
+void AccelerationStructureKHRSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) {
     id_tracker.reset();
 }
 
-TensorSubState::TensorSubState(vvl::Tensor &obj, DescriptorHeap &heap)
+TensorSubState::TensorSubState(vvl::Tensor& obj, DescriptorHeap& heap)
     : vvl::TensorSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void TensorSubState::Destroy() { id_tracker.reset(); }
 
-void TensorSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+void TensorSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-TensorViewSubState::TensorViewSubState(vvl::TensorView &obj, DescriptorHeap &heap)
+TensorViewSubState::TensorViewSubState(vvl::TensorView& obj, DescriptorHeap& heap)
     : vvl::TensorViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
 
 void TensorViewSubState::Destroy() { id_tracker.reset(); }
 
-void TensorViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+void TensorViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-ShaderObjectSubState::ShaderObjectSubState(vvl::ShaderObject &obj) : vvl::ShaderObjectSubState(obj) {}
+ShaderObjectSubState::ShaderObjectSubState(vvl::ShaderObject& obj) : vvl::ShaderObjectSubState(obj) {}
 
-PipelineSubState::PipelineSubState(Validator &gpuav, vvl::Pipeline &pipeline) : vvl::PipelineSubState(pipeline), gpuav_(gpuav) {}
+PipelineSubState::PipelineSubState(Validator& gpuav, vvl::Pipeline& pipeline) : vvl::PipelineSubState(pipeline), gpuav_(gpuav) {}
 
-VkPipelineLayout PipelineSubState::GetPipelineLayoutUnion(const Location &loc, vvl::DescriptorMode mode) const {
+VkPipelineLayout PipelineSubState::GetPipelineLayoutUnion(const Location& loc, vvl::DescriptorMode mode) const {
     std::unique_lock<std::mutex> recreated_layout_lock(recreated_layout_mutex);
     if (recreated_layout != VK_NULL_HANDLE) {
         return recreated_layout;
@@ -687,7 +687,7 @@ VkPipelineLayout PipelineSubState::GetPipelineLayoutUnion(const Location &loc, v
     std::vector<size_t> recreated_desc_set_layouts_indices;
 
     for (size_t set_layout_i = 0; set_layout_i < pipeline_layout_state->set_layouts.list.size(); ++set_layout_i) {
-        const auto &set_layout = pipeline_layout_state->set_layouts.list[set_layout_i];
+        const auto& set_layout = pipeline_layout_state->set_layouts.list[set_layout_i];
         if (!set_layout) {
             set_layout_handles.emplace_back(VK_NULL_HANDLE);
         } else {

--- a/layers/gpuav/resources/gpuav_vulkan_objects.cpp
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.cpp
@@ -34,14 +34,14 @@ DescriptorSetManager::DescriptorSetManager(VkDevice device, uint32_t num_binding
     : device(device), num_bindings_in_set(num_bindings_in_set) {}
 
 DescriptorSetManager::~DescriptorSetManager() {
-    for (auto &pool : desc_pool_map_) {
+    for (auto& pool : desc_pool_map_) {
         DispatchDestroyDescriptorPool(device, pool.first, nullptr);
     }
     desc_pool_map_.clear();
 }
 
-VkResult DescriptorSetManager::GetDescriptorSet(VkDescriptorPool *out_desc_pool, VkDescriptorSetLayout ds_layout,
-                                                VkDescriptorSet *out_desc_sets) {
+VkResult DescriptorSetManager::GetDescriptorSet(VkDescriptorPool* out_desc_pool, VkDescriptorSetLayout ds_layout,
+                                                VkDescriptorSet* out_desc_sets) {
     std::vector<VkDescriptorSet> desc_sets;
     VkResult result = GetDescriptorSets(1, out_desc_pool, ds_layout, &desc_sets);
     assert(result == VK_SUCCESS);
@@ -51,8 +51,8 @@ VkResult DescriptorSetManager::GetDescriptorSet(VkDescriptorPool *out_desc_pool,
     return result;
 }
 
-VkResult DescriptorSetManager::GetDescriptorSets(uint32_t count, VkDescriptorPool *out_pool, VkDescriptorSetLayout ds_layout,
-                                                 std::vector<VkDescriptorSet> *out_desc_sets) {
+VkResult DescriptorSetManager::GetDescriptorSets(uint32_t count, VkDescriptorPool* out_pool, VkDescriptorSetLayout ds_layout,
+                                                 std::vector<VkDescriptorSet>* out_desc_sets) {
     std::lock_guard guard(lock_);
 
     VkResult result = VK_SUCCESS;
@@ -65,7 +65,7 @@ VkResult DescriptorSetManager::GetDescriptorSets(uint32_t count, VkDescriptorPoo
     out_desc_sets->clear();
     out_desc_sets->resize(count);
 
-    for (auto &[desc_pool, pool_tracker] : desc_pool_map_) {
+    for (auto& [desc_pool, pool_tracker] : desc_pool_map_) {
         if (pool_tracker.used + count < pool_tracker.size) {
             desc_pool_to_use = desc_pool;
             break;
@@ -142,7 +142,7 @@ void DescriptorSetManager::PutBackDescriptorSet(VkDescriptorPool desc_pool, VkDe
     return;
 }
 
-void *Buffer::GetMappedPtr() const { return mapped_ptr; }
+void* Buffer::GetMappedPtr() const { return mapped_ptr; }
 
 void Buffer::FlushAllocation(VkDeviceSize offset, VkDeviceSize size) const {
     VkResult result = vmaFlushAllocation(gpuav.vma_allocator_, allocation, offset, size);
@@ -190,7 +190,7 @@ VkResult Buffer::Create(const VkBufferCreateInfo* buffer_create_info, const VmaA
     static_assert(VK_MAX_MEMORY_HEAPS <= 16u);
     VmaBudget budgets[VK_MAX_MEMORY_HEAPS] = {};
     vmaGetHeapBudgets(gpuav.vma_allocator_, budgets);
-    constexpr std::array<const char *, VK_MAX_MEMORY_HEAPS> heap_names = {
+    constexpr std::array<const char*, VK_MAX_MEMORY_HEAPS> heap_names = {
         {"GPU Heap 0 (kB)", "GPU Heap 1 (kB)", "GPU Heap 2 (kB)", "GPU Heap 3 (kB)", "GPU Heap 4 (kB)", "GPU Heap 5 (kB)",
          "GPU Heap 6 (kB)", "GPU Heap 7 (kB)", "GPU Heap 8 (kB)", "GPU Heap 9 (kB)", "GPU Heap 10 (kB)", "GPU Heap 11 (kB)",
          "GPU Heap 12 (kB)", "GPU Heap 13 (kB)", "GPU Heap 14 (kB)", "GPU Heap 15 (kB)"}};
@@ -217,7 +217,7 @@ void Buffer::Destroy() {
     static_assert(VK_MAX_MEMORY_HEAPS <= 16u);
     VmaBudget budgets[VK_MAX_MEMORY_HEAPS] = {};
     vmaGetHeapBudgets(gpuav.vma_allocator_, budgets);
-    constexpr std::array<const char *, VK_MAX_MEMORY_HEAPS> heap_names = {
+    constexpr std::array<const char*, VK_MAX_MEMORY_HEAPS> heap_names = {
         {"GPU Heap 0 (kB)", "GPU Heap 1 (kB)", "GPU Heap 2 (kB)", "GPU Heap 3 (kB)", "GPU Heap 4 (kB)", "GPU Heap 5 (kB)",
          "GPU Heap 6 (kB)", "GPU Heap 7 (kB)", "GPU Heap 8 (kB)", "GPU Heap 9 (kB)", "GPU Heap 10 (kB)", "GPU Heap 11 (kB)",
          "GPU Heap 12 (kB)", "GPU Heap 13 (kB)", "GPU Heap 14 (kB)", "GPU Heap 15 (kB)"}};
@@ -230,16 +230,16 @@ void Buffer::Destroy() {
 void Buffer::Clear() const {
     // Caller is in charge of calling Flush/Invalidate as needed
     assert(mapped_ptr);
-    memset((uint8_t *)mapped_ptr, 0, static_cast<size_t>(size));
+    memset((uint8_t*)mapped_ptr, 0, static_cast<size_t>(size));
 }
 
 void BufferRange::Clear() const {
     // Caller is in charge of calling Flush/Invalidate as needed
     assert(offset_mapped_ptr);
-    memset((uint8_t *)offset_mapped_ptr, 0, static_cast<size_t>(size));
+    memset((uint8_t*)offset_mapped_ptr, 0, static_cast<size_t>(size));
 }
 
-void CmdSynchronizedCopyBufferRange(VkCommandBuffer cb, const vko::BufferRange &dst, const vko::BufferRange &src) {
+void CmdSynchronizedCopyBufferRange(VkCommandBuffer cb, const vko::BufferRange& dst, const vko::BufferRange& src) {
     assert(dst.size == src.size);
     VkBufferMemoryBarrier barrier_write_after_read = vku::InitStructHelper();
     barrier_write_after_read.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
@@ -268,7 +268,7 @@ void CmdSynchronizedCopyBufferRange(VkCommandBuffer cb, const vko::BufferRange &
                                &barrier_read_before_write, 0, nullptr);
 }
 
-GpuResourcesManager::GpuResourcesManager(Validator &gpuav, bool thread_safe_buffer_caches)
+GpuResourcesManager::GpuResourcesManager(Validator& gpuav, bool thread_safe_buffer_caches)
     : gpuav_(gpuav), buffer_caches_(thread_safe_buffer_caches) {
     const bool force_host_access = gpuav.IsAllDeviceLocalMappable();
 
@@ -327,7 +327,7 @@ GpuResourcesManager::GpuResourcesManager(Validator &gpuav, bool thread_safe_buff
 VkDescriptorSet GpuResourcesManager::GetManagedDescriptorSet(VkDescriptorSetLayout desc_set_layout) {
     // Look for a descriptor set layout matching input,
     // if found get or add an associated descriptor set
-    for (LayoutToSets &layout_to_sets : cache_layouts_to_sets_) {
+    for (LayoutToSets& layout_to_sets : cache_layouts_to_sets_) {
         if (layout_to_sets.desc_set_layout != desc_set_layout) {
             continue;
         }
@@ -376,12 +376,12 @@ vko::BufferRange GpuResourcesManager::GetHostCachedBufferRange(VkDeviceSize size
 }
 
 // Only used for Host Cache
-void GpuResourcesManager::FlushAllocation(const vko::BufferRange &buffer_range) {
+void GpuResourcesManager::FlushAllocation(const vko::BufferRange& buffer_range) {
     vmaFlushAllocation(gpuav_.vma_allocator_, buffer_range.vma_alloc, 0, VK_WHOLE_SIZE);
 }
 
 // Only used for Host Cache
-void GpuResourcesManager::InvalidateAllocation(const vko::BufferRange &buffer_range) {
+void GpuResourcesManager::InvalidateAllocation(const vko::BufferRange& buffer_range) {
     vmaInvalidateAllocation(gpuav_.vma_allocator_, buffer_range.vma_alloc, 0, VK_WHOLE_SIZE);
 }
 
@@ -394,7 +394,7 @@ vko::BufferRange GpuResourcesManager::GetDeviceLocalBufferRange(VkDeviceSize siz
     return buffer_caches_.device_local.GetBufferRange(gpuav_, size, alignment, min_buffer_block_size);
 }
 
-void GpuResourcesManager::ReturnDeviceLocalBufferRange(const vko::BufferRange &buffer_range) {
+void GpuResourcesManager::ReturnDeviceLocalBufferRange(const vko::BufferRange& buffer_range) {
     buffer_caches_.device_local.ReturnBufferRange(buffer_range);
 }
 
@@ -417,7 +417,7 @@ vko::BufferRange GpuResourcesManager::GetStagingBufferRange(VkDeviceSize size) {
 }
 
 void GpuResourcesManager::ReturnResources() {
-    for (LayoutToSets &layout_to_set : cache_layouts_to_sets_) {
+    for (LayoutToSets& layout_to_set : cache_layouts_to_sets_) {
         layout_to_set.first_available_desc_set = 0;
     }
 
@@ -425,8 +425,8 @@ void GpuResourcesManager::ReturnResources() {
 }
 
 void GpuResourcesManager::DestroyResources() {
-    for (LayoutToSets &layout_to_set : cache_layouts_to_sets_) {
-        for (CachedDescriptor &cached_descriptor : layout_to_set.cached_descriptors) {
+    for (LayoutToSets& layout_to_set : cache_layouts_to_sets_) {
+        for (CachedDescriptor& cached_descriptor : layout_to_set.cached_descriptors) {
             gpuav_.desc_set_manager_->PutBackDescriptorSet(cached_descriptor.desc_pool, cached_descriptor.desc_set);
         }
         layout_to_set.cached_descriptors.clear();
@@ -448,7 +448,7 @@ void GpuResourcesManager::BufferCache::Create(VkBufferUsageFlags buffer_usage_fl
 
 GpuResourcesManager::BufferCache::~BufferCache() { DestroyBuffers(); }
 
-vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator &gpuav, VkDeviceSize byte_size, VkDeviceSize alignment,
+vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator& gpuav, VkDeviceSize byte_size, VkDeviceSize alignment,
                                                                   VkDeviceSize min_buffer_block_byte_size) {
     std::unique_lock<std::mutex> lock(mtx, std::defer_lock);
     if (thread_safe_) {
@@ -459,7 +459,7 @@ vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator &gpu
     if (total_available_byte_size_ >= byte_size) {
         for (size_t i = 0; i < cached_buffers_blocks_.size(); ++i) {
             const size_t cached_buffer_i = (next_avail_buffer_pos_hint_ + i) % cached_buffers_blocks_.size();
-            CachedBufferBlock &cached_buffer = cached_buffers_blocks_[cached_buffer_i];
+            CachedBufferBlock& cached_buffer = cached_buffers_blocks_[cached_buffer_i];
 
             // Is there enough space in the current cached buffer to fit the aligned sub-allocation?
             const VkDeviceAddress aligned_free_range_begin = Align(cached_buffer.used_range.end, alignment);
@@ -485,9 +485,9 @@ vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator &gpu
                     next_avail_buffer_pos_hint_ = (cached_buffer_i + 1) % cached_buffers_blocks_.size();
                 }
                 const VkDeviceSize buffer_offset = returned_addr_range.begin - cached_buffer.buffer.Address();
-                uint8_t *offset_mapped_ptr = nullptr;
+                uint8_t* offset_mapped_ptr = nullptr;
                 if (cached_buffer.buffer.GetMappedPtr()) {
-                    offset_mapped_ptr = (uint8_t *)cached_buffer.buffer.GetMappedPtr() + buffer_offset;
+                    offset_mapped_ptr = (uint8_t*)cached_buffer.buffer.GetMappedPtr() + buffer_offset;
                 }
                 const VkDeviceAddress offset_address = returned_addr_range.begin;
                 assert(offset_address % alignment == 0);
@@ -519,18 +519,18 @@ vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator &gpu
     return {buffer.VkHandle(),
             buffer_offset,
             cached_buffer_block.used_range.size(),
-            (uint8_t *)cached_buffer_block.buffer.GetMappedPtr() + buffer_offset,
+            (uint8_t*)cached_buffer_block.buffer.GetMappedPtr() + buffer_offset,
             returned_addr,
             cached_buffer_block.buffer.Allocation()};
 }
 
-void GpuResourcesManager::BufferCache::ReturnBufferRange(const vko::BufferRange &buffer_range) {
+void GpuResourcesManager::BufferCache::ReturnBufferRange(const vko::BufferRange& buffer_range) {
     std::unique_lock<std::mutex> lock(mtx, std::defer_lock);
     if (thread_safe_) {
         lock.lock();
     }
 
-    for (CachedBufferBlock &cached_buffer_block : cached_buffers_blocks_) {
+    for (CachedBufferBlock& cached_buffer_block : cached_buffers_blocks_) {
         if (buffer_range.buffer != cached_buffer_block.buffer.VkHandle()) {
             continue;
         }
@@ -553,7 +553,7 @@ void GpuResourcesManager::BufferCache::ReturnBuffers() {
     }
 
     total_available_byte_size_ = 0;
-    for (CachedBufferBlock &cached_buffer_block : cached_buffers_blocks_) {
+    for (CachedBufferBlock& cached_buffer_block : cached_buffers_blocks_) {
         cached_buffer_block.used_range = {cached_buffer_block.buffer.Address(), cached_buffer_block.buffer.Address()};
         total_available_byte_size_ += cached_buffer_block.total_range.size();
     }
@@ -565,17 +565,17 @@ void GpuResourcesManager::BufferCache::DestroyBuffers() {
         lock.lock();
     }
 
-    for (CachedBufferBlock &cached_buffer_block : cached_buffers_blocks_) {
+    for (CachedBufferBlock& cached_buffer_block : cached_buffers_blocks_) {
         cached_buffer_block.buffer.Destroy();
     }
     cached_buffers_blocks_.clear();
 }
 
-bool StagingBuffer::CanDeviceEverStage(Validator &gpuav) {
+bool StagingBuffer::CanDeviceEverStage(Validator& gpuav) {
     return gpuav.phys_dev_props.deviceType != VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
 }
 
-StagingBuffer::StagingBuffer(GpuResourcesManager &gpu_resources_manager, VkDeviceSize size, VkCommandBuffer cb)
+StagingBuffer::StagingBuffer(GpuResourcesManager& gpu_resources_manager, VkDeviceSize size, VkCommandBuffer cb)
     : gpu_resources_manager(gpu_resources_manager) {
     VVL_ZoneScoped;
     // Never use staging buffer on integrated GPUs
@@ -650,7 +650,7 @@ void StagingBuffer::CmdCopyDeviceToHost(VkCommandBuffer cb) const {
     // => will wait for cb's fence before reading.
 }
 
-CommandPool::CommandPool(Validator &gpuav, uint32_t queue_family_i, const Location &loc) : gpuav_(gpuav) {
+CommandPool::CommandPool(Validator& gpuav, uint32_t queue_family_i, const Location& loc) : gpuav_(gpuav) {
     VkCommandPoolCreateInfo cmd_pool_ci = vku::InitStructHelper();
     cmd_pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     cmd_pool_ci.queueFamilyIndex = queue_family_i;
@@ -675,7 +675,7 @@ CommandPool::CommandPool(Validator &gpuav, uint32_t queue_family_i, const Locati
     }
 
     fences_.resize(cmd_buf_ai.commandBufferCount);
-    for (VkFence &fence : fences_) {
+    for (VkFence& fence : fences_) {
         VkFenceCreateInfo fence_ci = vku::InitStructHelper();
         fence_ci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
         result = DispatchCreateFence(gpuav_.device, &fence_ci, nullptr, &fence);

--- a/layers/gpuav/spirv/ray_hit_object_pass.cpp
+++ b/layers/gpuav/spirv/ray_hit_object_pass.cpp
@@ -28,13 +28,16 @@ const static OfflineModule kOfflineModule = {instrumentation_ray_hit_object_comp
                                              UseErrorPayloadVariable};
 
 const static OfflineFunction kOfflineFunction = {"inst_ray_hit_object", instrumentation_ray_hit_object_comp_function_0_offset};
-const static OfflineFunction kSBTIndexCheckFunction = {"inst_ray_hit_object_sbt_index_check", instrumentation_ray_hit_object_comp_function_1_offset};
+const static OfflineFunction kSBTIndexCheckFunction = {"inst_ray_hit_object_sbt_index_check",
+                                                       instrumentation_ray_hit_object_comp_function_1_offset};
 
 RayHitObjectPass::RayHitObjectPass(Module& module) : Pass(module, kOfflineModule) { module.use_bda_ = true; }
 
 uint32_t RayHitObjectPass::GetLinkFunctionId() { return GetLinkFunction(link_function_id_, kOfflineFunction); }
 
-uint32_t RayHitObjectPass::GetSBTIndexCheckFunctionId() { return GetLinkFunction(sbt_index_check_function_id_, kSBTIndexCheckFunction); }
+uint32_t RayHitObjectPass::GetSBTIndexCheckFunctionId() {
+    return GetLinkFunction(sbt_index_check_function_id_, kSBTIndexCheckFunction);
+}
 
 // OpHitObjectTraceRayEXT
 // OpHitObjectTraceRayMotionEXT
@@ -74,8 +77,8 @@ uint32_t RayHitObjectPass::CreateFunctionCall(BasicBlock& block, InstructionIt* 
     }
 
     block.CreateInstruction(spv::OpFunctionCall,
-                            {bool_type, function_result, function_def, inst_position_id, opcode_type_id, ray_flags_id, ray_origin_id, ray_tmin_id,
-                             ray_direction_id, ray_tmax_id, pipeline_flags_id, time_id},
+                            {bool_type, function_result, function_def, inst_position_id, opcode_type_id, ray_flags_id,
+                             ray_origin_id, ray_tmin_id, ray_direction_id, ray_tmax_id, pipeline_flags_id, time_id},
                             inst_it);
     module_.need_log_error_ = true;
     return function_result;
@@ -97,8 +100,7 @@ uint32_t RayHitObjectPass::CreateSBTIndexCheckFunctionCall(BasicBlock& block, In
     const uint32_t max_sbt_index_id = type_manager_.CreateConstantUInt32(max_sbt_index).Id();
 
     block.CreateInstruction(spv::OpFunctionCall,
-                            {bool_type, function_result, function_def, inst_position_id, sbt_index_id, max_sbt_index_id},
-                            inst_it);
+                            {bool_type, function_result, function_def, inst_position_id, sbt_index_id, max_sbt_index_id}, inst_it);
     module_.need_log_error_ = true;
     return function_result;
 }

--- a/layers/gpuav/spirv/spec_constant.cpp
+++ b/layers/gpuav/spirv/spec_constant.cpp
@@ -280,7 +280,6 @@ bool Module::ConstantFoldVectorShuffle(Instruction* inst, const Type& result_typ
 }
 
 bool Module::ConstantFoldCompositeExtract(Instruction* inst, const Type& result_type) {
-
     // There might be multiple indices
     uint32_t current_id = inst->Word(4);
     for (uint32_t i = 5; i < inst->Length(); i++) {
@@ -340,7 +339,7 @@ bool Module::ConstantFoldCompositeInsert(Instruction* inst, const Type& result_t
     const uint32_t vec_length = result_type.VectorSize();
     for (uint32_t i = 0; i < vec_length; i++) {
         if (i == index) {
-            uint32_t insert_id = inst->Word(4); // |object| operand
+            uint32_t insert_id = inst->Word(4);  // |object| operand
             words.emplace_back(insert_id);
         } else if (base_composite->inst_.Opcode() == spv::OpConstantNull) {
             words.emplace_back(type_manager_.GetConstantZeroUint32().Id());
@@ -373,14 +372,13 @@ bool Module::ConstantFold(Instruction* inst, const Type& result_type) {
         return ConstantFoldCompositeInsert(inst, result_type);
     }
 
-
     const bool is_vector = result_type.spv_type_ == SpvType::kVector;
     uint32_t vector_length = is_vector ? result_type.inst_.Word(3) : 1;
     const Type& scalar_type = is_vector ? *type_manager_.FindTypeById(result_type.inst_.Word(2)) : result_type;
 
     small_vector<uint32_t, 4> new_composite_components;
 
-    const uint32_t start_operand_index = 4; // into OpSpecConstantOp
+    const uint32_t start_operand_index = 4;  // into OpSpecConstantOp
     const uint32_t final_operand_index = inst->Length();
     // Scalar will have a single lane
     for (uint32_t lane = 0; lane < vector_length; lane++) {

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -31,7 +31,7 @@ namespace valcmd {
 
 struct CopyBufferToImageValidationShader {
     static size_t GetSpirvSize() { return validation_cmd_copy_buffer_to_image_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_copy_buffer_to_image_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_copy_buffer_to_image_comp; }
 
     struct EmptyPushData {
     } push_constants;
@@ -66,8 +66,8 @@ struct CopyBufferToImageValidationShader {
     }
 };
 
-void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubState &cb_state,
-                       const VkCopyBufferToImageInfo2 *copy_buffer_to_img_info) {
+void CopyBufferToImage(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state,
+                       const VkCopyBufferToImageInfo2* copy_buffer_to_img_info) {
     if (!gpuav.gpuav_settings.validate_buffer_copies) {
         return;
     }
@@ -89,9 +89,9 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
         return;
     }
 
-    ValidationCommandsGpuavState &val_cmd_gpuav_state =
+    ValidationCommandsGpuavState& val_cmd_gpuav_state =
         gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
-    valpipe::ComputePipeline<CopyBufferToImageValidationShader> &validation_pipeline =
+    valpipe::ComputePipeline<CopyBufferToImageValidationShader>& validation_pipeline =
         gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<CopyBufferToImageValidationShader>>(
             gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
     if (!validation_pipeline.valid) {
@@ -136,13 +136,13 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
             uniform_buffer_constants_byte_size + sizeof(BufferImageCopy) * copy_buffer_to_img_info->regionCount;
         vko::BufferRange copy_src_regions_mem_buffer_range = cb_state.gpu_resources_manager.GetHostCoherentBufferRange(buffer_size);
 
-        auto gpu_regions_u32_ptr = (uint32_t *)copy_src_regions_mem_buffer_range.offset_mapped_ptr;
+        auto gpu_regions_u32_ptr = (uint32_t*)copy_src_regions_mem_buffer_range.offset_mapped_ptr;
 
         const uint32_t block_size = image_state->create_info.format == VK_FORMAT_D32_SFLOAT ? 4 : 5;
         uint32_t gpu_regions_count = 0;
-        BufferImageCopy *gpu_regions_ptr =
-            reinterpret_cast<BufferImageCopy *>(&gpu_regions_u32_ptr[uniform_buffer_constants_byte_size / sizeof(uint32_t)]);
-        for (const auto &cpu_region : vvl::make_span(copy_buffer_to_img_info->pRegions, copy_buffer_to_img_info->regionCount)) {
+        BufferImageCopy* gpu_regions_ptr =
+            reinterpret_cast<BufferImageCopy*>(&gpu_regions_u32_ptr[uniform_buffer_constants_byte_size / sizeof(uint32_t)]);
+        for (const auto& cpu_region : vvl::make_span(copy_buffer_to_img_info->pRegions, copy_buffer_to_img_info->regionCount)) {
             if (cpu_region.imageSubresource.aspectMask != VK_IMAGE_ASPECT_DEPTH_BIT) {
                 continue;
             }
@@ -155,7 +155,7 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
                 continue;
             }
 
-            BufferImageCopy &gpu_region = gpu_regions_ptr[gpu_regions_count];
+            BufferImageCopy& gpu_region = gpu_regions_ptr[gpu_regions_count];
             gpu_region.src_buffer_byte_offset = static_cast<uint32_t>(cpu_region.bufferOffset);
             gpu_region.start_layer = cpu_region.imageSubresource.baseArrayLayer;
             gpu_region.layer_count = cpu_region.imageSubresource.layerCount;
@@ -214,8 +214,8 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
     }
 
     CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, src_buffer = copy_buffer_to_img_info->srcBuffer](
-                                                              const uint32_t *error_record, const Location &loc_with_debug_region,
-                                                              const LogObjectList &objlist) {
+                                                              const uint32_t* error_record, const Location& loc_with_debug_region,
+                                                              const LogObjectList& objlist) {
         bool skip = false;
         using namespace glsl;
 

--- a/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
@@ -40,7 +40,7 @@ static constexpr std::string_view kWarningCopyMemoryToImageIndirectCommand =
 
 struct CopyMemoryIndirectValidationShader {
     static size_t GetSpirvSize() { return validation_cmd_copy_memory_indirect_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_copy_memory_indirect_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_copy_memory_indirect_comp; }
 
     struct EmptyPushData {
     } push_constants;
@@ -64,8 +64,8 @@ struct CopyMemoryIndirectValidationShader {
     }
 };
 
-void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubState &cb_state,
-                        const CopyMemoryIndirectCommon &api_copy_info) {
+void CopyMemoryIndirect(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state,
+                        const CopyMemoryIndirectCommon& api_copy_info) {
     if (!gpuav.gpuav_settings.validate_copy_memory_indirect) {
         return;
     }
@@ -74,9 +74,9 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
         return;
     }
 
-    ValidationCommandsGpuavState &val_cmd_gpuav_state =
+    ValidationCommandsGpuavState& val_cmd_gpuav_state =
         gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
-    valpipe::ComputePipeline<CopyMemoryIndirectValidationShader> &validation_pipeline =
+    valpipe::ComputePipeline<CopyMemoryIndirectValidationShader>& validation_pipeline =
         gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<CopyMemoryIndirectValidationShader>>(
             gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
     if (!validation_pipeline.valid) {
@@ -106,7 +106,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
         const VkDeviceSize buffer_size = sizeof(CopyMemoryIndirectApiData);
         vko::BufferRange api_input_buffer_range = cb_state.gpu_resources_manager.GetHostCoherentBufferRange(buffer_size);
 
-        auto gpu_region_ptr = (CopyMemoryIndirectApiData *)api_input_buffer_range.offset_mapped_ptr;
+        auto gpu_region_ptr = (CopyMemoryIndirectApiData*)api_input_buffer_range.offset_mapped_ptr;
         gpu_region_ptr->range_address = api_copy_info.address_range.address;
         // While these are VkDeviceSize, there is no known way these can be over 4GB
         gpu_region_ptr->range_size = (uint32_t)api_copy_info.address_range.size;
@@ -154,9 +154,9 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
         }
     }
 
-    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, api_copy_info](const uint32_t *error_record,
-                                                                                  const Location &loc_with_debug_region,
-                                                                                  const LogObjectList &objlist) {
+    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, api_copy_info](const uint32_t* error_record,
+                                                                                  const Location& loc_with_debug_region,
+                                                                                  const LogObjectList& objlist) {
         bool skip = false;
         using namespace glsl;
 

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -29,7 +29,7 @@ namespace valcmd {
 
 struct DispatchValidationShader {
     static size_t GetSpirvSize() { return validation_cmd_dispatch_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_dispatch_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_dispatch_comp; }
 
     glsl::DispatchPushData push_constants{};
     valpipe::BoundStorageBuffer indirect_buffer_binding = {glsl::kPreDispatchBinding_DispatchIndirectBuffer};
@@ -53,15 +53,15 @@ struct DispatchValidationShader {
     }
 };
 
-void DispatchIndirect(Validator &gpuav, const Location &loc, CommandBufferSubState &cb_state, const LastBound &last_bound,
+void DispatchIndirect(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state, const LastBound& last_bound,
                       VkBuffer indirect_buffer, VkDeviceSize indirect_offset) {
     if (!gpuav.gpuav_settings.validate_indirect_dispatches_buffers) {
         return;
     }
 
-    ValidationCommandsGpuavState &val_cmd_gpuav_state =
+    ValidationCommandsGpuavState& val_cmd_gpuav_state =
         gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
-    valpipe::ComputePipeline<DispatchValidationShader> &validation_pipeline =
+    valpipe::ComputePipeline<DispatchValidationShader>& validation_pipeline =
         gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<DispatchValidationShader>>(
             gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
     if (!validation_pipeline.valid) {
@@ -98,7 +98,7 @@ void DispatchIndirect(Validator &gpuav, const Location &loc, CommandBufferSubSta
     }
 
     CommandBufferSubState::ErrorLoggerFunc error_logger =
-        [&gpuav](const uint32_t *error_record, const Location &loc_with_debug_region, const LogObjectList &objlist) {
+        [&gpuav](const uint32_t* error_record, const Location& loc_with_debug_region, const LogObjectList& objlist) {
             bool skip = false;
             using namespace glsl;
 

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -39,9 +39,9 @@ struct SharedDrawValidationResources {
     vko::Buffer dummy_buffer;  // Used to fill unused buffer bindings in validation pipelines
     bool valid = false;
 
-    SharedDrawValidationResources(Validator &gpuav) : dummy_buffer(gpuav) {
+    SharedDrawValidationResources(Validator& gpuav) : dummy_buffer(gpuav) {
         VkBufferCreateInfo dummy_buffer_info = vku::InitStructHelper();
-        dummy_buffer_info.size = 64;// whatever
+        dummy_buffer_info.size = 64;  // whatever
         dummy_buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         VmaAllocationCreateInfo alloc_info = {};
         alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
@@ -60,20 +60,20 @@ struct SharedDrawValidationResources {
     ~SharedDrawValidationResources() { dummy_buffer.Destroy(); }
 };
 
-using ValidationCommandFunc = stdext::inplace_function<void(Validator &gpuav, CommandBufferSubState &cb_state), 192>;
+using ValidationCommandFunc = stdext::inplace_function<void(Validator& gpuav, CommandBufferSubState& cb_state), 192>;
 struct ValidationCmdCbState {
     std::vector<ValidationCommandFunc> per_render_pass_validation_commands;
 };
 
-void FlushValidationCmds(Validator &gpuav, CommandBufferSubState &cb_state) {
-    ValidationCmdCbState *val_cmd_cb_state = cb_state.shared_resources_cache.TryGet<ValidationCmdCbState>();
+void FlushValidationCmds(Validator& gpuav, CommandBufferSubState& cb_state) {
+    ValidationCmdCbState* val_cmd_cb_state = cb_state.shared_resources_cache.TryGet<ValidationCmdCbState>();
     if (!val_cmd_cb_state) {
         return;
     }
 
     valpipe::RestorablePipelineState restorable_state(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE);
 
-    for (auto &validation_cmd : val_cmd_cb_state->per_render_pass_validation_commands) {
+    for (auto& validation_cmd : val_cmd_cb_state->per_render_pass_validation_commands) {
         validation_cmd(gpuav, cb_state);
     }
     val_cmd_cb_state->per_render_pass_validation_commands.clear();
@@ -81,7 +81,7 @@ void FlushValidationCmds(Validator &gpuav, CommandBufferSubState &cb_state) {
 
 struct FirstInstanceValidationShader {
     static size_t GetSpirvSize() { return validation_cmd_first_instance_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_first_instance_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_first_instance_comp; }
 
     glsl::FirstInstancePushData push_constants{};
     valpipe::BoundStorageBuffer draw_buffer_binding = {glsl::kPreDrawBinding_IndirectBuffer};
@@ -113,10 +113,10 @@ struct FirstInstanceValidationShader {
     }
 };
 
-void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Location &loc, const LastBound &last_bound,
+void FirstInstance(Validator& gpuav, CommandBufferSubState& cb_state, const Location& loc, const LastBound& last_bound,
                    VkBuffer api_buffer, VkDeviceSize api_offset, uint32_t api_stride, vvl::Struct api_struct_name,
                    uint32_t first_instance_member_pos, uint32_t api_draw_count, VkBuffer api_count_buffer,
-                   VkDeviceSize api_count_buffer_offset, const FirstInstanceValidationVuidSelector &vuid_selector) {
+                   VkDeviceSize api_count_buffer_offset, const FirstInstanceValidationVuidSelector& vuid_selector) {
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
         return;
     }
@@ -129,16 +129,16 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
     ValidationCommandFunc validation_cmd = [api_buffer, api_offset, api_stride, first_instance_member_pos, api_draw_count,
                                             api_count_buffer, api_count_buffer_offset, draw_i = cb_state.draw_index,
                                             error_logger_i = cb_state.GetErrorLoggerIndex(),
-                                            loc](Validator &gpuav, CommandBufferSubState &cb_state) {
-        SharedDrawValidationResources &shared_draw_validation_resources =
+                                            loc](Validator& gpuav, CommandBufferSubState& cb_state) {
+        SharedDrawValidationResources& shared_draw_validation_resources =
             gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
         if (!shared_draw_validation_resources.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
             return;
         }
-        ValidationCommandsGpuavState &val_cmd_gpuav_state =
+        ValidationCommandsGpuavState& val_cmd_gpuav_state =
             gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
-        valpipe::ComputePipeline<FirstInstanceValidationShader> &validation_pipeline =
+        valpipe::ComputePipeline<FirstInstanceValidationShader>& validation_pipeline =
             gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<FirstInstanceValidationShader>>(
                 gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
         if (!validation_pipeline.valid) {
@@ -230,14 +230,14 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
         }
     };
 
-    ValidationCmdCbState &val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
+    ValidationCmdCbState& val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
     val_cmd_cb_state.per_render_pass_validation_commands.emplace_back(std::move(validation_cmd));
 
     // Register error logger. Happens per command GPU-AV intercepts
     // ---
-    ErrorLoggerFunc error_logger = [&gpuav, vuid, api_struct_name](const uint32_t *error_record,
-                                                                   const Location &loc_with_debug_region,
-                                                                   const LogObjectList &objlist) {
+    ErrorLoggerFunc error_logger = [&gpuav, vuid, api_struct_name](const uint32_t* error_record,
+                                                                   const Location& loc_with_debug_region,
+                                                                   const LogObjectList& objlist) {
         bool skip = false;
         using namespace glsl;
 
@@ -262,12 +262,12 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
 }
 
 struct FirstInstanceVUIDs {
-    const char *vuid_09461{};
-    const char *vuid_09462{};
-    const char *vuid_00501_00554{};
+    const char* vuid_09461{};
+    const char* vuid_09462{};
+    const char* vuid_00501_00554{};
 };
 
-static FirstInstanceValidationVuidSelector GetFirstInstanceValidationVuidSelector(const FirstInstanceVUIDs &first_instance_vuids) {
+static FirstInstanceValidationVuidSelector GetFirstInstanceValidationVuidSelector(const FirstInstanceVUIDs& first_instance_vuids) {
     FirstInstanceValidationVuidSelector vuid_selector = [first_instance_vuids](Validator& gpuav, const LastBound& last_bound) {
         if (!gpuav.phys_dev_props_core14.supportsNonZeroFirstInstance) {
             if (last_bound.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
@@ -294,15 +294,15 @@ static FirstInstanceValidationVuidSelector GetFirstInstanceValidationVuidSelecto
         }
 
         // Return null to show |firstInstance| could be anything and it will still be valid
-        return (const char *)nullptr;
+        return (const char*)nullptr;
     };
 
     return vuid_selector;
 }
 
 template <>
-void FirstInstance<VkDrawIndirectCommand>(Validator &gpuav, CommandBufferSubState &cb_state, const Location &loc,
-                                          const LastBound &last_bound, VkBuffer buffer, VkDeviceSize offset, uint32_t draw_count,
+void FirstInstance<VkDrawIndirectCommand>(Validator& gpuav, CommandBufferSubState& cb_state, const Location& loc,
+                                          const LastBound& last_bound, VkBuffer buffer, VkDeviceSize offset, uint32_t draw_count,
                                           VkBuffer count_buffer, VkDeviceSize count_buffer_offset) {
     FirstInstanceVUIDs vuids;
     vuids.vuid_09461 = "VUID-VkDrawIndirectCommand-pNext-09461";
@@ -315,8 +315,8 @@ void FirstInstance<VkDrawIndirectCommand>(Validator &gpuav, CommandBufferSubStat
 }
 
 template <>
-void FirstInstance<VkDrawIndexedIndirectCommand>(Validator &gpuav, CommandBufferSubState &cb_state, const Location &loc,
-                                                 const LastBound &last_bound, VkBuffer buffer, VkDeviceSize offset,
+void FirstInstance<VkDrawIndexedIndirectCommand>(Validator& gpuav, CommandBufferSubState& cb_state, const Location& loc,
+                                                 const LastBound& last_bound, VkBuffer buffer, VkDeviceSize offset,
                                                  uint32_t draw_count, VkBuffer count_buffer, VkDeviceSize count_buffer_offset) {
     FirstInstanceVUIDs vuids;
     vuids.vuid_09461 = "VUID-VkDrawIndexedIndirectCommand-pNext-09461";
@@ -330,7 +330,7 @@ void FirstInstance<VkDrawIndexedIndirectCommand>(Validator &gpuav, CommandBuffer
 
 struct CountBufferValidationShader {
     static size_t GetSpirvSize() { return validation_cmd_count_buffer_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_count_buffer_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_count_buffer_comp; }
 
     glsl::CountBufferPushData push_constants{};
     valpipe::BoundStorageBuffer count_buffer_binding = {glsl::kPreDrawBinding_CountBuffer};
@@ -353,9 +353,9 @@ struct CountBufferValidationShader {
     }
 };
 
-void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Location &loc, const LastBound &last_bound,
+void CountBuffer(Validator& gpuav, CommandBufferSubState& cb_state, const Location& loc, const LastBound& last_bound,
                  VkBuffer api_buffer, VkDeviceSize api_offset, uint32_t api_struct_size_byte, vvl::Struct api_struct_name,
-                 uint32_t api_stride, VkBuffer api_count_buffer, VkDeviceSize api_count_buffer_offset, const char *vuid) {
+                 uint32_t api_stride, VkBuffer api_count_buffer, VkDeviceSize api_count_buffer_offset, const char* vuid) {
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
         return;
     }
@@ -369,16 +369,16 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
     ValidationCommandFunc validation_cmd = [draw_buffer_size = draw_buffer_state->create_info.size, api_offset,
                                             api_struct_size_byte, api_stride, api_count_buffer, api_count_buffer_offset,
                                             draw_i = cb_state.draw_index, error_logger_i = cb_state.GetErrorLoggerIndex(),
-                                            loc](Validator &gpuav, CommandBufferSubState &cb_state) {
-        SharedDrawValidationResources &shared_draw_validation_resources =
+                                            loc](Validator& gpuav, CommandBufferSubState& cb_state) {
+        SharedDrawValidationResources& shared_draw_validation_resources =
             gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
         if (!shared_draw_validation_resources.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
             return;
         }
-        ValidationCommandsGpuavState &val_cmd_gpuav_state =
+        ValidationCommandsGpuavState& val_cmd_gpuav_state =
             gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
-        valpipe::ComputePipeline<CountBufferValidationShader> &validation_pipeline =
+        valpipe::ComputePipeline<CountBufferValidationShader>& validation_pipeline =
             gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<CountBufferValidationShader>>(
                 gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
         if (!validation_pipeline.valid) {
@@ -424,15 +424,15 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
         }
     };
 
-    ValidationCmdCbState &val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
+    ValidationCmdCbState& val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
     val_cmd_cb_state.per_render_pass_validation_commands.emplace_back(std::move(validation_cmd));
 
     // Register error logger
     // ---
     ErrorLoggerFunc error_logger = [&gpuav, api_buffer, draw_buffer_size = draw_buffer_state->create_info.size, api_offset,
                                     api_struct_size_byte, api_stride, api_struct_name,
-                                    vuid](const uint32_t *error_record, const Location &loc_with_debug_region,
-                                          const LogObjectList &objlist) {
+                                    vuid](const uint32_t* error_record, const Location& loc_with_debug_region,
+                                          const LogObjectList& objlist) {
         bool skip = false;
         using namespace glsl;
 
@@ -475,7 +475,7 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
 
 struct MeshValidationShader {
     static size_t GetSpirvSize() { return validation_cmd_draw_mesh_indirect_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_draw_mesh_indirect_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_draw_mesh_indirect_comp; }
 
     glsl::DrawMeshPushData push_constants{};
     valpipe::BoundStorageBuffer draw_buffer_binding = {glsl::kPreDrawBinding_IndirectBuffer};
@@ -507,7 +507,7 @@ struct MeshValidationShader {
     }
 };
 
-void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const Location &loc, const LastBound &last_bound,
+void DrawMeshIndirect(Validator& gpuav, CommandBufferSubState& cb_state, const Location& loc, const LastBound& last_bound,
                       VkBuffer api_buffer, VkDeviceSize api_offset, uint32_t api_stride, VkBuffer api_count_buffer,
                       VkDeviceSize api_count_buffer_offset, uint32_t api_draw_count) {
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
@@ -523,118 +523,118 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
     const VkShaderStageFlags stages = last_bound.GetAllActiveBoundStages();
     const bool is_task_shader = (stages & VK_SHADER_STAGE_TASK_BIT_EXT) == VK_SHADER_STAGE_TASK_BIT_EXT;
 
-    ValidationCommandFunc validation_cmd =
-        [api_buffer, draw_buffer_full_size = draw_buffer_state->create_info.size, api_offset, api_stride, api_count_buffer,
-         api_count_buffer_offset, api_draw_count, is_task_shader, draw_i = cb_state.draw_index,
-         error_logger_i = cb_state.GetErrorLoggerIndex(), loc](Validator &gpuav, CommandBufferSubState &cb_state) {
-            SharedDrawValidationResources &shared_draw_validation_resources =
-                gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
-            if (!shared_draw_validation_resources.valid) {
-                gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
+    ValidationCommandFunc validation_cmd = [api_buffer, draw_buffer_full_size = draw_buffer_state->create_info.size, api_offset,
+                                            api_stride, api_count_buffer, api_count_buffer_offset, api_draw_count, is_task_shader,
+                                            draw_i = cb_state.draw_index, error_logger_i = cb_state.GetErrorLoggerIndex(),
+                                            loc](Validator& gpuav, CommandBufferSubState& cb_state) {
+        SharedDrawValidationResources& shared_draw_validation_resources =
+            gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
+        if (!shared_draw_validation_resources.valid) {
+            gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
+            return;
+        }
+        ValidationCommandsGpuavState& val_cmd_gpuav_state =
+            gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
+        valpipe::ComputePipeline<MeshValidationShader>& validation_pipeline =
+            gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<MeshValidationShader>>(
+                gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
+        if (!validation_pipeline.valid) {
+            gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create MeshValidationShader.");
+            return;
+        }
+
+        // Setup shader resources
+        // ---
+        {
+            MeshValidationShader shader_resources;
+            shader_resources.push_constants.api_stride_dwords = api_stride / sizeof(uint32_t);
+            shader_resources.push_constants.api_draw_count = api_draw_count;
+            const auto& properties = gpuav.phys_dev_ext_props.mesh_shader_props_ext;
+            if (is_task_shader) {
+                shader_resources.push_constants.max_workgroup_count_x = properties.maxTaskWorkGroupCount[0];
+                shader_resources.push_constants.max_workgroup_count_y = properties.maxTaskWorkGroupCount[1];
+                shader_resources.push_constants.max_workgroup_count_z = properties.maxTaskWorkGroupCount[2];
+                shader_resources.push_constants.max_workgroup_total_count = properties.maxTaskWorkGroupTotalCount;
+            } else {
+                shader_resources.push_constants.max_workgroup_count_x = properties.maxMeshWorkGroupCount[0];
+                shader_resources.push_constants.max_workgroup_count_y = properties.maxMeshWorkGroupCount[1];
+                shader_resources.push_constants.max_workgroup_count_z = properties.maxMeshWorkGroupCount[2];
+                shader_resources.push_constants.max_workgroup_total_count = properties.maxMeshWorkGroupTotalCount;
+            }
+
+            shader_resources.draw_buffer_binding.info = {api_buffer, 0, VK_WHOLE_SIZE};
+            shader_resources.push_constants.api_offset_dwords = uint32_t(api_offset / sizeof(uint32_t));
+            if (api_count_buffer != VK_NULL_HANDLE) {
+                shader_resources.push_constants.flags |= glsl::kDrawMeshFlags_DrawCountFromBuffer;
+                shader_resources.count_buffer_binding.info = {api_count_buffer, 0, sizeof(uint32_t)};
+                shader_resources.push_constants.api_count_buffer_offset_dwords =
+                    uint32_t(api_count_buffer_offset / sizeof(uint32_t));
+            } else {
+                shader_resources.count_buffer_binding.info = {shared_draw_validation_resources.dummy_buffer.VkHandle(), 0,
+                                                              VK_WHOLE_SIZE};
+            }
+
+            if (!BindShaderResources(validation_pipeline, gpuav, cb_state, draw_i, error_logger_i, shader_resources)) {
                 return;
             }
-            ValidationCommandsGpuavState &val_cmd_gpuav_state =
-                gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
-            valpipe::ComputePipeline<MeshValidationShader> &validation_pipeline =
-                gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<MeshValidationShader>>(
-                    gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
-            if (!validation_pipeline.valid) {
-                gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create MeshValidationShader.");
-                return;
-            }
+        }
 
-            // Setup shader resources
-            // ---
-            {
-                MeshValidationShader shader_resources;
-                shader_resources.push_constants.api_stride_dwords = api_stride / sizeof(uint32_t);
-                shader_resources.push_constants.api_draw_count = api_draw_count;
-                const auto &properties = gpuav.phys_dev_ext_props.mesh_shader_props_ext;
-                if (is_task_shader) {
-                    shader_resources.push_constants.max_workgroup_count_x = properties.maxTaskWorkGroupCount[0];
-                    shader_resources.push_constants.max_workgroup_count_y = properties.maxTaskWorkGroupCount[1];
-                    shader_resources.push_constants.max_workgroup_count_z = properties.maxTaskWorkGroupCount[2];
-                    shader_resources.push_constants.max_workgroup_total_count = properties.maxTaskWorkGroupTotalCount;
+        // Setup validation pipeline
+        // ---
+        {
+            DispatchCmdBindPipeline(cb_state.VkHandle(), VK_PIPELINE_BIND_POINT_COMPUTE, validation_pipeline.pipeline);
+
+            uint32_t max_held_draw_cmds = 0;
+            if (draw_buffer_full_size > api_offset) {
+                // If drawCount is less than or equal to one, stride is ignored
+                if (api_draw_count > 1) {
+                    max_held_draw_cmds = static_cast<uint32_t>((draw_buffer_full_size - api_offset) / api_stride);
                 } else {
-                    shader_resources.push_constants.max_workgroup_count_x = properties.maxMeshWorkGroupCount[0];
-                    shader_resources.push_constants.max_workgroup_count_y = properties.maxMeshWorkGroupCount[1];
-                    shader_resources.push_constants.max_workgroup_count_z = properties.maxMeshWorkGroupCount[2];
-                    shader_resources.push_constants.max_workgroup_total_count = properties.maxMeshWorkGroupTotalCount;
-                }
-
-                shader_resources.draw_buffer_binding.info = {api_buffer, 0, VK_WHOLE_SIZE};
-                shader_resources.push_constants.api_offset_dwords = uint32_t(api_offset / sizeof(uint32_t));
-                if (api_count_buffer != VK_NULL_HANDLE) {
-                    shader_resources.push_constants.flags |= glsl::kDrawMeshFlags_DrawCountFromBuffer;
-                    shader_resources.count_buffer_binding.info = {api_count_buffer, 0, sizeof(uint32_t)};
-                    shader_resources.push_constants.api_count_buffer_offset_dwords =
-                        uint32_t(api_count_buffer_offset / sizeof(uint32_t));
-                } else {
-                    shader_resources.count_buffer_binding.info = {shared_draw_validation_resources.dummy_buffer.VkHandle(), 0,
-                                                                  VK_WHOLE_SIZE};
-                }
-
-                if (!BindShaderResources(validation_pipeline, gpuav, cb_state, draw_i, error_logger_i, shader_resources)) {
-                    return;
+                    max_held_draw_cmds = 1;
                 }
             }
+            const uint32_t work_group_count = std::min(api_draw_count, max_held_draw_cmds);
+            DispatchCmdDispatch(cb_state.VkHandle(), work_group_count, 1, 1);
 
-            // Setup validation pipeline
-            // ---
-            {
-                DispatchCmdBindPipeline(cb_state.VkHandle(), VK_PIPELINE_BIND_POINT_COMPUTE, validation_pipeline.pipeline);
+            // synchronize draw buffer validation (read) against subsequent writes
+            std::array<VkBufferMemoryBarrier, 2> buffer_memory_barriers = {};
+            uint32_t buffer_memory_barriers_count = 1;
+            buffer_memory_barriers[0] = vku::InitStructHelper();
+            buffer_memory_barriers[0].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+            buffer_memory_barriers[0].dstAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+            buffer_memory_barriers[0].buffer = api_buffer;
+            buffer_memory_barriers[0].offset = api_offset;
+            buffer_memory_barriers[0].size = work_group_count * sizeof(uint32_t);
 
-                uint32_t max_held_draw_cmds = 0;
-                if (draw_buffer_full_size > api_offset) {
-                    // If drawCount is less than or equal to one, stride is ignored
-                    if (api_draw_count > 1) {
-                        max_held_draw_cmds = static_cast<uint32_t>((draw_buffer_full_size - api_offset) / api_stride);
-                    } else {
-                        max_held_draw_cmds = 1;
-                    }
-                }
-                const uint32_t work_group_count = std::min(api_draw_count, max_held_draw_cmds);
-                DispatchCmdDispatch(cb_state.VkHandle(), work_group_count, 1, 1);
-
-                // synchronize draw buffer validation (read) against subsequent writes
-                std::array<VkBufferMemoryBarrier, 2> buffer_memory_barriers = {};
-                uint32_t buffer_memory_barriers_count = 1;
-                buffer_memory_barriers[0] = vku::InitStructHelper();
-                buffer_memory_barriers[0].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
-                buffer_memory_barriers[0].dstAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
-                buffer_memory_barriers[0].buffer = api_buffer;
-                buffer_memory_barriers[0].offset = api_offset;
-                buffer_memory_barriers[0].size = work_group_count * sizeof(uint32_t);
-
-                if (api_count_buffer) {
-                    buffer_memory_barriers[1] = vku::InitStructHelper();
-                    buffer_memory_barriers[1].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
-                    buffer_memory_barriers[1].dstAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
-                    buffer_memory_barriers[1].buffer = api_count_buffer;
-                    buffer_memory_barriers[1].offset = api_count_buffer_offset;
-                    buffer_memory_barriers[1].size = sizeof(uint32_t);
-                    ++buffer_memory_barriers_count;
-                }
-
-                DispatchCmdPipelineBarrier(cb_state.VkHandle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-                                           VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, buffer_memory_barriers_count,
-                                           buffer_memory_barriers.data(), 0, nullptr);
+            if (api_count_buffer) {
+                buffer_memory_barriers[1] = vku::InitStructHelper();
+                buffer_memory_barriers[1].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
+                buffer_memory_barriers[1].dstAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+                buffer_memory_barriers[1].buffer = api_count_buffer;
+                buffer_memory_barriers[1].offset = api_count_buffer_offset;
+                buffer_memory_barriers[1].size = sizeof(uint32_t);
+                ++buffer_memory_barriers_count;
             }
-        };
 
-    ValidationCmdCbState &val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
+            DispatchCmdPipelineBarrier(cb_state.VkHandle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                       VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, buffer_memory_barriers_count,
+                                       buffer_memory_barriers.data(), 0, nullptr);
+        }
+    };
+
+    ValidationCmdCbState& val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
     val_cmd_cb_state.per_render_pass_validation_commands.emplace_back(std::move(validation_cmd));
 
     // Register error logger
     // ---
-    ErrorLoggerFunc error_logger = [&gpuav, is_task_shader](const uint32_t *error_record, const Location &loc_with_debug_region,
-                                                            const LogObjectList &objlist) {
+    ErrorLoggerFunc error_logger = [&gpuav, is_task_shader](const uint32_t* error_record, const Location& loc_with_debug_region,
+                                                            const LogObjectList& objlist) {
         bool skip = false;
         using namespace glsl;
 
         const uint32_t draw_i = error_record[kValCmd_ErrorPayloadDword_1];
-        const char *group_count_name = is_task_shader ? "maxTaskWorkGroupCount" : "maxMeshWorkGroupCount";
-        const char *group_count_total_name = is_task_shader ? "maxTaskWorkGroupTotalCount" : "maxMeshWorkGroupTotalCount";
+        const char* group_count_name = is_task_shader ? "maxTaskWorkGroupCount" : "maxMeshWorkGroupCount";
+        const char* group_count_total_name = is_task_shader ? "maxTaskWorkGroupTotalCount" : "maxMeshWorkGroupTotalCount";
 
         const uint32_t error_sub_code = GetSubError(error_record);
         switch (error_sub_code) {
@@ -707,7 +707,7 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
 
 struct DrawIndexedIndirectIndexBufferShader {
     static size_t GetSpirvSize() { return validation_cmd_draw_indexed_indirect_index_buffer_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_draw_indexed_indirect_index_buffer_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_draw_indexed_indirect_index_buffer_comp; }
 
     glsl::DrawIndexedIndirectIndexBufferPushData push_constants{};
     valpipe::BoundStorageBuffer draw_buffer_binding = {glsl::kPreDrawBinding_IndirectBuffer};
@@ -742,7 +742,7 @@ struct DrawIndexedIndirectIndexBufferShader {
 
 struct SetupDrawCountDispatchIndirectShader {
     static size_t GetSpirvSize() { return validation_cmd_setup_draw_indexed_indirect_index_buffer_comp_size * sizeof(uint32_t); }
-    static const uint32_t *GetSpirv() { return validation_cmd_setup_draw_indexed_indirect_index_buffer_comp; }
+    static const uint32_t* GetSpirv() { return validation_cmd_setup_draw_indexed_indirect_index_buffer_comp; }
 
     glsl::DrawIndexedIndirectIndexBufferPushData push_constants{};
     valpipe::BoundStorageBuffer count_buffer_binding = {glsl::kPreDrawBinding_CountBuffer};
@@ -781,10 +781,10 @@ struct SetupDrawCountDispatchIndirectShader {
 
 // Use "api_" prefix to make it clear which buffer/offset/etc we are talking about
 // "api" helps to distinguish it is input from the user at the API level
-void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Location &loc,
-                                    const LastBound &last_bound, VkBuffer api_buffer, VkDeviceSize api_offset, uint32_t api_stride,
+void DrawIndexedIndirectIndexBuffer(Validator& gpuav, CommandBufferSubState& cb_state, const Location& loc,
+                                    const LastBound& last_bound, VkBuffer api_buffer, VkDeviceSize api_offset, uint32_t api_stride,
                                     uint32_t api_draw_count, VkBuffer api_count_buffer, VkDeviceSize api_count_buffer_offset,
-                                    const char *vuid) {
+                                    const char* vuid) {
     if (!gpuav.gpuav_settings.validate_index_buffers) {
         return;
     }
@@ -814,22 +814,22 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
     ValidationCommandFunc validation_cmd = [index_buffer_binding = cb_state.base.index_buffer_binding, api_buffer, api_offset,
                                             api_stride, api_draw_count, api_count_buffer, api_count_buffer_offset,
                                             draw_i = cb_state.draw_index, error_logger_i = cb_state.GetErrorLoggerIndex(),
-                                            loc](Validator &gpuav, CommandBufferSubState &cb_state) {
-        SharedDrawValidationResources &shared_draw_validation_resources =
+                                            loc](Validator& gpuav, CommandBufferSubState& cb_state) {
+        SharedDrawValidationResources& shared_draw_validation_resources =
             gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
         if (!shared_draw_validation_resources.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
             return;
         }
-        valpipe::ComputePipeline<SetupDrawCountDispatchIndirectShader> &setup_validation_dispatch_pipeline =
+        valpipe::ComputePipeline<SetupDrawCountDispatchIndirectShader>& setup_validation_dispatch_pipeline =
             gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<SetupDrawCountDispatchIndirectShader>>(gpuav, loc);
         if (!setup_validation_dispatch_pipeline.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SetupDrawCountDispatchIndirectShader.");
             return;
         }
-        ValidationCommandsGpuavState &val_cmd_gpuav_state =
+        ValidationCommandsGpuavState& val_cmd_gpuav_state =
             gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
-        valpipe::ComputePipeline<DrawIndexedIndirectIndexBufferShader> &validation_pipeline =
+        valpipe::ComputePipeline<DrawIndexedIndirectIndexBufferShader>& validation_pipeline =
             gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<DrawIndexedIndirectIndexBufferShader>>(
                 gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
         if (!validation_pipeline.valid) {
@@ -956,13 +956,13 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
         }
     };
 
-    ValidationCmdCbState &val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
+    ValidationCmdCbState& val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCmdCbState>();
     val_cmd_cb_state.per_render_pass_validation_commands.emplace_back(std::move(validation_cmd));
 
     ErrorLoggerFunc error_logger = [&gpuav, vuid, api_buffer, api_offset, api_stride,
                                     index_buffer_binding = cb_state.base.index_buffer_binding](
-                                       const uint32_t *error_record, const Location &loc_with_debug_region,
-                                       const LogObjectList &objlist) {
+                                       const uint32_t* error_record, const Location& loc_with_debug_region,
+                                       const LogObjectList& objlist) {
         bool skip = false;
         using namespace glsl;
 

--- a/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.cpp
@@ -28,26 +28,26 @@ namespace gpuav {
 
 namespace valcmd {
 namespace internal {
-static void BindErrorLoggingDescSet(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineBindPoint bind_point,
+static void BindErrorLoggingDescSet(Validator& gpuav, CommandBufferSubState& cb_state, VkPipelineBindPoint bind_point,
                                     VkPipelineLayout pipeline_layout, uint32_t cmd_index, uint32_t error_logger_index) {
     assert(cmd_index < gpuav.gpuav_settings.indices_buffer_count);
     assert(error_logger_index < gpuav.gpuav_settings.indices_buffer_count);
     std::array<uint32_t, 2> dynamic_offsets = {
         {cmd_index * gpuav.indices_buffer_alignment_, error_logger_index * gpuav.indices_buffer_alignment_}};
 
-    ValidationCommandsGpuavState &val_cmd_gpuav_state =
+    ValidationCommandsGpuavState& val_cmd_gpuav_state =
         gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, Location(vvl::Func::Empty));
-    ValidationCommandsCbState &val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCbState>(
+    ValidationCommandsCbState& val_cmd_cb_state = cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCbState>(
         gpuav, cb_state, val_cmd_gpuav_state.error_logging_desc_set_layout_, Location(vvl::Func::Empty));
     DispatchCmdBindDescriptorSets(cb_state.VkHandle(), bind_point, pipeline_layout, glsl::kDiagCommonDescriptorSet, 1,
                                   &val_cmd_cb_state.error_logging_desc_set_, static_cast<uint32_t>(dynamic_offsets.size()),
                                   dynamic_offsets.data());
 }
 
-void BindShaderResourcesHelper(Validator &gpuav, CommandBufferSubState &cb_state, uint32_t cmd_index, uint32_t error_logger_index,
+void BindShaderResourcesHelper(Validator& gpuav, CommandBufferSubState& cb_state, uint32_t cmd_index, uint32_t error_logger_index,
                                VkPipelineLayout pipeline_layout, VkDescriptorSet desc_set,
-                               const std::vector<VkWriteDescriptorSet> &descriptor_writes, const uint32_t push_constants_byte_size,
-                               const void *push_constants, bool bind_error_logging_desc_set) {
+                               const std::vector<VkWriteDescriptorSet>& descriptor_writes, const uint32_t push_constants_byte_size,
+                               const void* push_constants, bool bind_error_logging_desc_set) {
     // Error logging resources
     if (bind_error_logging_desc_set) {
         BindErrorLoggingDescSet(gpuav, cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, cmd_index, error_logger_index);
@@ -64,8 +64,8 @@ void BindShaderResourcesHelper(Validator &gpuav, CommandBufferSubState &cb_state
     }
 }
 
-void BindShaderPushConstantsHelper(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineLayout pipeline_layout,
-                                   const uint32_t push_constants_byte_size, const void *push_constants) {
+void BindShaderPushConstantsHelper(Validator& gpuav, CommandBufferSubState& cb_state, VkPipelineLayout pipeline_layout,
+                                   const uint32_t push_constants_byte_size, const void* push_constants) {
     // Any push constants byte size below 4 is illegal. Can come from empty push constant struct
     if (push_constants_byte_size >= 4) {
         DispatchCmdPushConstants(cb_state.VkHandle(), pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, push_constants_byte_size,
@@ -75,7 +75,7 @@ void BindShaderPushConstantsHelper(Validator &gpuav, CommandBufferSubState &cb_s
 
 }  // namespace internal
 
-ValidationCommandsGpuavState::ValidationCommandsGpuavState(Validator &gpuav, const Location &loc) : gpuav_(gpuav) {
+ValidationCommandsGpuavState::ValidationCommandsGpuavState(Validator& gpuav, const Location& loc) : gpuav_(gpuav) {
     const std::array<VkDescriptorSetLayoutBinding, 4> validation_cmd_bindings = {{
         // Error output buffer
         {glsl::kBindingDiagErrorBuffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -104,8 +104,8 @@ ValidationCommandsGpuavState::~ValidationCommandsGpuavState() {
     }
 }
 
-ValidationCommandsCbState::ValidationCommandsCbState(Validator &gpuav, CommandBufferSubState &cb,
-                                                     VkDescriptorSetLayout error_logging_desc_set_layout, const Location &loc)
+ValidationCommandsCbState::ValidationCommandsCbState(Validator& gpuav, CommandBufferSubState& cb,
+                                                     VkDescriptorSetLayout error_logging_desc_set_layout, const Location& loc)
     : gpuav_(gpuav) {
     assert((validation_cmd_desc_pool_ == VK_NULL_HANDLE) == (error_logging_desc_set_ == VK_NULL_HANDLE));
     if (validation_cmd_desc_pool_ == VK_NULL_HANDLE && error_logging_desc_set_ == VK_NULL_HANDLE) {

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -41,7 +41,7 @@
 #include "mimalloc-new-delete.h"
 #endif
 
-const auto &VkValFeatureDisableLookup() {
+const auto& VkValFeatureDisableLookup() {
     static const vvl::unordered_map<std::string, VkValidationFeatureDisableEXT> vk_val_feature_disable_lookup = {
         {"VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT", VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT},
         {"VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT", VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT},
@@ -55,7 +55,7 @@ const auto &VkValFeatureDisableLookup() {
     return vk_val_feature_disable_lookup;
 }
 
-const auto &VkValFeatureEnableLookup() {
+const auto& VkValFeatureEnableLookup() {
     static const vvl::unordered_map<std::string, VkValidationFeatureEnableEXT> vk_val_feature_enable_lookup = {
         {"VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT", VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT},
         {"VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",
@@ -68,7 +68,7 @@ const auto &VkValFeatureEnableLookup() {
     return vk_val_feature_enable_lookup;
 }
 
-const auto &ValidationDisableLookup() {
+const auto& ValidationDisableLookup() {
     static const vvl::unordered_map<std::string, ValidationCheckDisables> validation_disable_lookup = {
         {"VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE", VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE},
         {"VALIDATION_CHECK_DISABLE_OBJECT_IN_USE", VALIDATION_CHECK_DISABLE_OBJECT_IN_USE},
@@ -78,7 +78,7 @@ const auto &ValidationDisableLookup() {
     return validation_disable_lookup;
 }
 
-const auto &ValidationEnableLookup() {
+const auto& ValidationEnableLookup() {
     static const vvl::unordered_map<std::string, ValidationCheckEnables> validation_enable_lookup = {
         {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM},
         {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD},
@@ -90,7 +90,7 @@ const auto &ValidationEnableLookup() {
 }
 
 // This should mirror the 'DisableFlags' enumerated type
-const std::vector<std::string> &GetDisableFlagNameHelper() {
+const std::vector<std::string>& GetDisableFlagNameHelper() {
     static const std::vector<std::string> disable_flag_name_helper = {
         "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",                // command_buffer_state,
         "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",                       // object_in_use,
@@ -107,7 +107,7 @@ const std::vector<std::string> &GetDisableFlagNameHelper() {
     return disable_flag_name_helper;
 }
 
-const std::vector<std::string> &GetEnableFlagNameHelper() {
+const std::vector<std::string>& GetEnableFlagNameHelper() {
     // This should mirror the 'EnableFlags' enumerated type
     static const std::vector<std::string> enable_flag_name_helper = {
         "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT",                       // gpu_validation,
@@ -134,115 +134,115 @@ const std::vector<std::string> &GetEnableFlagNameHelper() {
 
 // Corresponding to VkValidationFeatureEnableEXT
 // ---
-const char *VK_LAYER_ENABLES = "enables";
-const char *VK_LAYER_VALIDATE_BEST_PRACTICES = "validate_best_practices";
-const char *VK_LAYER_VALIDATE_BEST_PRACTICES_ARM = "validate_best_practices_arm";
-const char *VK_LAYER_VALIDATE_BEST_PRACTICES_AMD = "validate_best_practices_amd";
-const char *VK_LAYER_VALIDATE_BEST_PRACTICES_IMG = "validate_best_practices_img";
-const char *VK_LAYER_VALIDATE_BEST_PRACTICES_NVIDIA = "validate_best_practices_nvidia";
-const char *VK_LAYER_VALIDATE_SYNC = "validate_sync";
+const char* VK_LAYER_ENABLES = "enables";
+const char* VK_LAYER_VALIDATE_BEST_PRACTICES = "validate_best_practices";
+const char* VK_LAYER_VALIDATE_BEST_PRACTICES_ARM = "validate_best_practices_arm";
+const char* VK_LAYER_VALIDATE_BEST_PRACTICES_AMD = "validate_best_practices_amd";
+const char* VK_LAYER_VALIDATE_BEST_PRACTICES_IMG = "validate_best_practices_img";
+const char* VK_LAYER_VALIDATE_BEST_PRACTICES_NVIDIA = "validate_best_practices_nvidia";
+const char* VK_LAYER_VALIDATE_SYNC = "validate_sync";
 
 // Corresponding to VkValidationFeatureDisableEXT
 // ---
-const char *VK_LAYER_DISABLES = "disables";
-const char *VK_LAYER_CHECK_SHADERS = "check_shaders";
-const char *VK_LAYER_THREAD_SAFETY = "thread_safety";
-const char *VK_LAYER_STATELESS_PARAM = "stateless_param";
-const char *VK_LAYER_LEGACY_DETECTION = "legacy_detection";
-const char *VK_LAYER_OBJECT_LIFETIME = "object_lifetime";
-const char *VK_LAYER_VALIDATE_CORE = "validate_core";
-const char *VK_LAYER_UNIQUE_HANDLES = "unique_handles";
-const char *VK_LAYER_CHECK_SHADERS_CACHING = "check_shaders_caching";
+const char* VK_LAYER_DISABLES = "disables";
+const char* VK_LAYER_CHECK_SHADERS = "check_shaders";
+const char* VK_LAYER_THREAD_SAFETY = "thread_safety";
+const char* VK_LAYER_STATELESS_PARAM = "stateless_param";
+const char* VK_LAYER_LEGACY_DETECTION = "legacy_detection";
+const char* VK_LAYER_OBJECT_LIFETIME = "object_lifetime";
+const char* VK_LAYER_VALIDATE_CORE = "validate_core";
+const char* VK_LAYER_UNIQUE_HANDLES = "unique_handles";
+const char* VK_LAYER_CHECK_SHADERS_CACHING = "check_shaders_caching";
 
 // Additional checks exposed in vkconfig, but not in VkValidationFeatureDisableEXT
 // ---
-const char *VK_LAYER_CHECK_COMMAND_BUFFER = "check_command_buffer";
-const char *VK_LAYER_CHECK_OBJECT_IN_USE = "check_object_in_use";
-const char *VK_LAYER_CHECK_QUERY = "check_query";
-const char *VK_LAYER_CHECK_IMAGE_LAYOUT = "check_image_layout";
+const char* VK_LAYER_CHECK_COMMAND_BUFFER = "check_command_buffer";
+const char* VK_LAYER_CHECK_OBJECT_IN_USE = "check_object_in_use";
+const char* VK_LAYER_CHECK_QUERY = "check_query";
+const char* VK_LAYER_CHECK_IMAGE_LAYOUT = "check_image_layout";
 
 // Options related to debug reporting
 // ---
-const char *VK_LAYER_MESSAGE_ID_FILTER = "message_id_filter";
-const char *VK_LAYER_CUSTOM_STYPE_LIST = "custom_stype_list";
-const char *VK_LAYER_ENABLE_MESSAGE_LIMIT = "enable_message_limit";
-const char *VK_LAYER_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
+const char* VK_LAYER_MESSAGE_ID_FILTER = "message_id_filter";
+const char* VK_LAYER_CUSTOM_STYPE_LIST = "custom_stype_list";
+const char* VK_LAYER_ENABLE_MESSAGE_LIMIT = "enable_message_limit";
+const char* VK_LAYER_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 
 // Global settings
 // ---
-const char *VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
+const char* VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
 // Debug settings used for internal development
-const char *VK_LAYER_DEBUG_DISABLE_SPIRV_VAL = "debug_disable_spirv_val";
+const char* VK_LAYER_DEBUG_DISABLE_SPIRV_VAL = "debug_disable_spirv_val";
 
 // DebugPrintf (which is now part of GPU-AV internally)
 // ---
 // Quick, single setting to turn on DebugPrintf
-const char *VK_LAYER_PRINTF_ONLY_PRESET = "printf_only_preset";
+const char* VK_LAYER_PRINTF_ONLY_PRESET = "printf_only_preset";
 // Was added a new way to set things without having to use VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT
-const char *VK_LAYER_PRINTF_ENABLE = "printf_enable";
-const char *VK_LAYER_PRINTF_TO_STDOUT = "printf_to_stdout";
-const char *VK_LAYER_PRINTF_VERBOSE = "printf_verbose";
-const char *VK_LAYER_PRINTF_BUFFER_SIZE = "printf_buffer_size";
+const char* VK_LAYER_PRINTF_ENABLE = "printf_enable";
+const char* VK_LAYER_PRINTF_TO_STDOUT = "printf_to_stdout";
+const char* VK_LAYER_PRINTF_VERBOSE = "printf_verbose";
+const char* VK_LAYER_PRINTF_BUFFER_SIZE = "printf_buffer_size";
 
 // GPU-AV
 // ---
-const char *VK_LAYER_GPUAV_ENABLE = "gpuav_enable";
-const char *VK_LAYER_GPUAV_SAFE_MODE = "gpuav_safe_mode";
-const char *VK_LAYER_GPUAV_SHADER_INSTRUMENTATION = "gpuav_shader_instrumentation";
-const char *VK_LAYER_GPUAV_DESCRIPTOR_CHECKS = "gpuav_descriptor_checks";
-const char *VK_LAYER_GPUAV_BUFFER_ADDRESS_OOB = "gpuav_buffer_address_oob";
-const char *VK_LAYER_GPUAV_VALIDATE_RAY_QUERY = "gpuav_validate_ray_query";
-const char *VK_LAYER_GPUAV_MESH_SHADING = "gpuav_mesh_shading";
-const char *VK_LAYER_GPUAV_POST_PROCESS_DESCRIPTOR_INDEXING = "gpuav_post_process_descriptor_indexing";
-const char *VK_LAYER_GPUAV_VERTEX_ATTRIBUTE_FETCH_OOB = "gpuav_vertex_attribute_fetch_oob";
-const char *VK_LAYER_GPUAV_SHADER_SANITIZER = "gpuav_shader_sanitizer";
+const char* VK_LAYER_GPUAV_ENABLE = "gpuav_enable";
+const char* VK_LAYER_GPUAV_SAFE_MODE = "gpuav_safe_mode";
+const char* VK_LAYER_GPUAV_SHADER_INSTRUMENTATION = "gpuav_shader_instrumentation";
+const char* VK_LAYER_GPUAV_DESCRIPTOR_CHECKS = "gpuav_descriptor_checks";
+const char* VK_LAYER_GPUAV_BUFFER_ADDRESS_OOB = "gpuav_buffer_address_oob";
+const char* VK_LAYER_GPUAV_VALIDATE_RAY_QUERY = "gpuav_validate_ray_query";
+const char* VK_LAYER_GPUAV_MESH_SHADING = "gpuav_mesh_shading";
+const char* VK_LAYER_GPUAV_POST_PROCESS_DESCRIPTOR_INDEXING = "gpuav_post_process_descriptor_indexing";
+const char* VK_LAYER_GPUAV_VERTEX_ATTRIBUTE_FETCH_OOB = "gpuav_vertex_attribute_fetch_oob";
+const char* VK_LAYER_GPUAV_SHADER_SANITIZER = "gpuav_shader_sanitizer";
 const char* VK_LAYER_GPUAV_SHARED_MEMORY_DATA_RACE = "gpuav_shared_memory_data_race";
-const char *VK_LAYER_GPUAV_MAX_INDICES_COUNT = "gpuav_max_indices_count";
-const char *VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS = "gpuav_select_instrumented_shaders";
-const char *VK_LAYER_GPUAV_SHADERS_TO_INSTRUMENT = "gpuav_shaders_to_instrument";
+const char* VK_LAYER_GPUAV_MAX_INDICES_COUNT = "gpuav_max_indices_count";
+const char* VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS = "gpuav_select_instrumented_shaders";
+const char* VK_LAYER_GPUAV_SHADERS_TO_INSTRUMENT = "gpuav_shaders_to_instrument";
 
-const char *VK_LAYER_GPUAV_BUFFERS_VALIDATION = "gpuav_buffers_validation";
-const char *VK_LAYER_GPUAV_INDIRECT_DRAWS_BUFFERS = "gpuav_indirect_draws_buffers";
-const char *VK_LAYER_GPUAV_INDIRECT_DISPATCHES_BUFFERS = "gpuav_indirect_dispatches_buffers";
-const char *VK_LAYER_GPUAV_INDIRECT_TRACE_RAYS_BUFFERS = "gpuav_indirect_trace_rays_buffers";
-const char *VK_LAYER_GPUAV_BUFFER_COPIES = "gpuav_buffer_copies";
-const char *VK_LAYER_GPUAV_COPY_MEMORY_INDIRECT = "gpuav_copy_memory_indirect";
-const char *VK_LAYER_GPUAV_INDEX_BUFFERS = "gpuav_index_buffers";
-const char *VK_LAYER_GPUAV_ACCELERATION_STRUCTURES_BUILDS = "gpuav_acceleration_structures_builds";
-const char *VK_LAYER_GPUAV_RAY_TRACING_BUFFERS_CONSISTENCY = "gpuav_ray_tracing_buffers_consistency";
+const char* VK_LAYER_GPUAV_BUFFERS_VALIDATION = "gpuav_buffers_validation";
+const char* VK_LAYER_GPUAV_INDIRECT_DRAWS_BUFFERS = "gpuav_indirect_draws_buffers";
+const char* VK_LAYER_GPUAV_INDIRECT_DISPATCHES_BUFFERS = "gpuav_indirect_dispatches_buffers";
+const char* VK_LAYER_GPUAV_INDIRECT_TRACE_RAYS_BUFFERS = "gpuav_indirect_trace_rays_buffers";
+const char* VK_LAYER_GPUAV_BUFFER_COPIES = "gpuav_buffer_copies";
+const char* VK_LAYER_GPUAV_COPY_MEMORY_INDIRECT = "gpuav_copy_memory_indirect";
+const char* VK_LAYER_GPUAV_INDEX_BUFFERS = "gpuav_index_buffers";
+const char* VK_LAYER_GPUAV_ACCELERATION_STRUCTURES_BUILDS = "gpuav_acceleration_structures_builds";
+const char* VK_LAYER_GPUAV_RAY_TRACING_BUFFERS_CONSISTENCY = "gpuav_ray_tracing_buffers_consistency";
 
 // A temporary workaround until we get proper Descriptor Buffer support
-const char *VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE = "gpuav_descriptor_buffer_override";
+const char* VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE = "gpuav_descriptor_buffer_override";
 
-const char *VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS = "gpuav_force_on_robustness";
+const char* VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS = "gpuav_force_on_robustness";
 
-const char *VK_LAYER_GPUAV_DEBUG_DISABLE_ALL = "gpuav_debug_disable_all";
-const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
-const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
-const char *VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTATIONS_COUNT = "gpuav_debug_max_instrumentations_count";
-const char *VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO = "gpuav_debug_print_instrumentation_info";
+const char* VK_LAYER_GPUAV_DEBUG_DISABLE_ALL = "gpuav_debug_disable_all";
+const char* VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
+const char* VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
+const char* VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTATIONS_COUNT = "gpuav_debug_max_instrumentations_count";
+const char* VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO = "gpuav_debug_print_instrumentation_info";
 
 // SyncVal
 // ---
-const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
-const char *VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
-const char *VK_LAYER_SYNCVAL_LOAD_OP_AFTER_STORE_OP_VALIDATION = "syncval_load_op_after_store_op_validation";
-const char *VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES = "syncval_message_extra_properties";
+const char* VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
+const char* VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
+const char* VK_LAYER_SYNCVAL_LOAD_OP_AFTER_STORE_OP_VALIDATION = "syncval_load_op_after_store_op_validation";
+const char* VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES = "syncval_message_extra_properties";
 
 // Message Formatting
 // ---
-const char *VK_LAYER_MESSAGE_FORMAT_JSON = "message_format_json";
-const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
+const char* VK_LAYER_MESSAGE_FORMAT_JSON = "message_format_json";
+const char* VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 // Until post 1.3.290 SDK release, these were not possible to set via environment variables
-const char *VK_LAYER_LOG_FILENAME = "log_filename";
-const char *VK_LAYER_DEBUG_ACTION = "debug_action";
-const char *VK_LAYER_REPORT_FLAGS = "report_flags";
+const char* VK_LAYER_LOG_FILENAME = "log_filename";
+const char* VK_LAYER_DEBUG_ACTION = "debug_action";
+const char* VK_LAYER_REPORT_FLAGS = "report_flags";
 
 // Don't need any setting helper when using self vvl and don't want unused function warnings
 #if !defined(BUILD_SELF_VVL)
 
 // Set the local disable flag for the appropriate VALIDATION_CHECK_DISABLE enum
-void SetValidationDisable(ValidationDisabled &disable_data, const ValidationCheckDisables disable_id) {
+void SetValidationDisable(ValidationDisabled& disable_data, const ValidationCheckDisables disable_id) {
     switch (disable_id) {
         case VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE:
             disable_data[command_buffer_state] = true;
@@ -262,7 +262,7 @@ void SetValidationDisable(ValidationDisabled &disable_data, const ValidationChec
 }
 
 // Set the local disable flag for a single VK_VALIDATION_FEATURE_DISABLE_* flag
-void SetValidationFeatureDisable(ValidationDisabled &disable_data, const VkValidationFeatureDisableEXT feature_disable) {
+void SetValidationFeatureDisable(ValidationDisabled& disable_data, const VkValidationFeatureDisableEXT feature_disable) {
     switch (feature_disable) {
         case VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT:
             disable_data[shader_validation] = true;
@@ -295,7 +295,7 @@ void SetValidationFeatureDisable(ValidationDisabled &disable_data, const VkValid
 }
 
 // Set the local enable flag for the appropriate VALIDATION_CHECK_ENABLE enum
-void SetValidationEnable(ValidationEnabled &enable_data, const ValidationCheckEnables enable_id) {
+void SetValidationEnable(ValidationEnabled& enable_data, const ValidationCheckEnables enable_id) {
     switch (enable_id) {
         case VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM:
             enable_data[vendor_specific_arm] = true;
@@ -321,7 +321,7 @@ void SetValidationEnable(ValidationEnabled &enable_data, const ValidationCheckEn
 }
 
 // Set the local enable flag for a single VK_VALIDATION_FEATURE_ENABLE_* flag
-void SetValidationFeatureEnable(ValidationEnabled &enable_data, const VkValidationFeatureEnableEXT feature_enable) {
+void SetValidationFeatureEnable(ValidationEnabled& enable_data, const VkValidationFeatureEnableEXT feature_enable) {
     switch (feature_enable) {
         case VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT:
             enable_data[gpu_validation] = true;
@@ -344,7 +344,7 @@ void SetValidationFeatureEnable(ValidationEnabled &enable_data, const VkValidati
 }
 
 // Set the local disable flag for settings specified through the VK_EXT_validation_flags extension
-void SetValidationFlags(ValidationDisabled &disabled, const VkValidationFlagsEXT *val_flags_struct) {
+void SetValidationFlags(ValidationDisabled& disabled, const VkValidationFlagsEXT* val_flags_struct) {
     for (uint32_t i = 0; i < val_flags_struct->disabledValidationCheckCount; ++i) {
         switch (val_flags_struct->pDisabledValidationChecks[i]) {
             case VK_VALIDATION_CHECK_SHADERS_EXT:
@@ -361,8 +361,8 @@ void SetValidationFlags(ValidationDisabled &disabled, const VkValidationFlagsEXT
 }
 
 // Process Validation Features flags specified through the ValidationFeature extension
-void SetValidationFeatures(ValidationDisabled &disable_data, ValidationEnabled &enable_data,
-                           const VkValidationFeaturesEXT *val_features_struct) {
+void SetValidationFeatures(ValidationDisabled& disable_data, ValidationEnabled& enable_data,
+                           const VkValidationFeaturesEXT* val_features_struct) {
     for (uint32_t i = 0; i < val_features_struct->disabledValidationFeatureCount; ++i) {
         SetValidationFeatureDisable(disable_data, val_features_struct->pDisabledValidationFeatures[i]);
     }
@@ -371,7 +371,7 @@ void SetValidationFeatures(ValidationDisabled &disable_data, ValidationEnabled &
     }
 }
 
-std::string GetNextToken(std::string *token_list, const std::string &delimiter, size_t *pos) {
+std::string GetNextToken(std::string* token_list, const std::string& delimiter, size_t* pos) {
     std::string token;
     *pos = token_list->find(delimiter);
     if (*pos != std::string::npos) {
@@ -440,7 +440,7 @@ bool SetLocalDisableSetting(std::string list_of_disabled, const std::string& del
     return used;
 }
 
-uint32_t TokenToUint(std::string &token) {
+uint32_t TokenToUint(std::string& token) {
     uint32_t int_id = 0;
     if ((token.find("0x") == 0) || token.find("0X") == 0) {  // Handle hex format
         int_id = static_cast<uint32_t>(std::strtoul(token.c_str(), nullptr, 16));
@@ -450,7 +450,7 @@ uint32_t TokenToUint(std::string &token) {
     return int_id;
 }
 
-void CreateFilterMessageIdList(std::string raw_id_list, const std::string &delimiter, vvl::unordered_set<uint32_t> &filter_list) {
+void CreateFilterMessageIdList(std::string raw_id_list, const std::string& delimiter, vvl::unordered_set<uint32_t>& filter_list) {
     size_t pos = 0;
     std::string token;
     while (raw_id_list.length() != 0) {
@@ -476,7 +476,7 @@ void CreateFilterMessageIdList(std::string raw_id_list, const std::string &delim
 // very unlikely things to hit validation layers messages (as everything after will likely crumble) so should be ok.
 //
 // Returns if valid
-static bool ValidateLayerSettingsCreateInfo(const VkLayerSettingsCreateInfoEXT *layer_settings) {
+static bool ValidateLayerSettingsCreateInfo(const VkLayerSettingsCreateInfoEXT* layer_settings) {
     bool valid = true;
     if (!layer_settings) return valid;
     const Location loc(vvl::Func::vkCreateInstance, vvl::Field::pCreateInfo);
@@ -523,8 +523,8 @@ static bool ValidateLayerSettingsCreateInfo(const VkLayerSettingsCreateInfoEXT *
     return valid;
 }
 
-static void SetValidationSetting(VkuLayerSettingSet layer_setting_set, ValidationDisabled &disable_data,
-                                 const DisableFlags feature_disable, const char *setting) {
+static void SetValidationSetting(VkuLayerSettingSet layer_setting_set, ValidationDisabled& disable_data,
+                                 const DisableFlags feature_disable, const char* setting) {
     if (vkuHasLayerSetting(layer_setting_set, setting)) {
         bool enabled = true;
         vkuGetLayerSettingValue(layer_setting_set, setting, enabled);
@@ -532,8 +532,8 @@ static void SetValidationSetting(VkuLayerSettingSet layer_setting_set, Validatio
     }
 }
 
-static void SetValidationSetting(VkuLayerSettingSet layer_setting_set, ValidationEnabled &enable_data,
-                                 const EnableFlags feature_enable, const char *setting) {
+static void SetValidationSetting(VkuLayerSettingSet layer_setting_set, ValidationEnabled& enable_data,
+                                 const EnableFlags feature_enable, const char* setting) {
     if (vkuHasLayerSetting(layer_setting_set, setting)) {
         bool enabled = true;
         vkuGetLayerSettingValue(layer_setting_set, setting, enabled);
@@ -541,7 +541,7 @@ static void SetValidationSetting(VkuLayerSettingSet layer_setting_set, Validatio
     }
 }
 
-static std::string Merge(const std::vector<std::string> &strings) {
+static std::string Merge(const std::vector<std::string>& strings) {
     std::string result;
 
     for (std::size_t i = 0, n = strings.size(); i < n; ++i) {
@@ -556,8 +556,8 @@ static std::string Merge(const std::vector<std::string> &strings) {
 
 // If log_filename is NULL or stdout, return stdout, otherwise try to open log_filename
 // as a filename. If successful, return file handle, otherwise stdout
-FILE *GetLayerLogOutput(const char *log_filename, std::vector<std::string> &setting_warnings) {
-    FILE *log_output = NULL;
+FILE* GetLayerLogOutput(const char* log_filename, std::vector<std::string>& setting_warnings) {
+    FILE* log_output = NULL;
     if (!log_filename || !strcmp("stdout", log_filename)) {
         log_output = stdout;
     } else {
@@ -584,9 +584,9 @@ enum VkLayerDbgActionBits {
 };
 using VkLayerDbgActionFlags = VkFlags;
 
-static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuLayerSettingSet &layer_setting_set,
-                                       std::vector<std::string> &setting_warnings) {
-    DebugReport *debug_report = settings_data->debug_report;
+static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuLayerSettingSet& layer_setting_set,
+                                       std::vector<std::string>& setting_warnings) {
+    DebugReport* debug_report = settings_data->debug_report;
     // Message ID Filtering
     std::vector<std::string> message_id_filter;
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_ID_FILTER)) {
@@ -644,7 +644,7 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
         {std::string("VK_DBG_LAYER_ACTION_BREAK"), VK_DBG_LAYER_ACTION_BREAK},
         {std::string("VK_DBG_LAYER_ACTION_DEBUG_OUTPUT"), VK_DBG_LAYER_ACTION_DEBUG_OUTPUT},
         {std::string("VK_DBG_LAYER_ACTION_DEFAULT"), VK_DBG_LAYER_ACTION_DEFAULT}};
-    for (const auto &element : debug_actions_list) {
+    for (const auto& element : debug_actions_list) {
         auto enum_value = debug_actions_option.find(element);
         if (enum_value != debug_actions_option.end()) {
             debug_action |= enum_value->second;
@@ -674,7 +674,7 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
                                                                            {std::string("perf"), kPerformanceWarningBit},
                                                                            {std::string("error"), kErrorBit},
                                                                            {std::string("verbose"), kVerboseBit}};
-    for (const auto &element : report_flags_list) {
+    for (const auto& element : report_flags_list) {
         auto enum_value = report_flags_options.find(element);
         if (enum_value != report_flags_options.end()) {
             report_flags |= enum_value->second;
@@ -745,13 +745,13 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
 
     VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
     if (debug_action & VK_DBG_LAYER_ACTION_LOG_MSG) {
-        FILE *log_output = GetLayerLogOutput(log_filename.c_str(), setting_warnings);
+        FILE* log_output = GetLayerLogOutput(log_filename.c_str(), setting_warnings);
         if (log_output != stdout) {
             // This particular warning is designed to show the user where the debug callback is going (which is important to know!),
             // so it makes no sense to put the warning in the callback location. For this one only we attempt to print to the
             // everywhere else possible
             const std::string tmp = "Validation Layer Info - Logging validation error to " + log_filename + "\n";
-            const char *cstr = tmp.c_str();
+            const char* cstr = tmp.c_str();
             printf("%s", cstr);
 #ifdef VK_USE_PLATFORM_WIN32_KHR
             OutputDebugString(cstr);
@@ -761,7 +761,7 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
 #endif
         }
         dbg_create_info.pfnUserCallback = MessengerLogCallback;
-        dbg_create_info.pUserData = (void *)log_output;
+        dbg_create_info.pUserData = (void*)log_output;
         LayerCreateMessengerCallback(debug_report, default_layer_callback, &dbg_create_info, &messenger);
     } else if (!is_stdout) {
         setting_warnings.emplace_back("The log_filename was set to " + log_filename +
@@ -850,7 +850,7 @@ static std::string GetDeprecatedEnabledDisabledWarning(const std::vector<std::st
     return ss.str();
 }
 
-static const char *GetDefaultPrefix() {
+static const char* GetDefaultPrefix() {
 #ifdef __ANDROID__
     return "vvl";
 #else
@@ -860,7 +860,7 @@ static const char *GetDefaultPrefix() {
 #endif  // !defined(BUILD_SELF_VVL)
 
 // Global list of sType,size identifiers
-std::vector<std::pair<uint32_t, uint32_t>> &GetCustomStypeInfo() {
+std::vector<std::pair<uint32_t, uint32_t>>& GetCustomStypeInfo() {
     static std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
     return custom_stype_info;
 }
@@ -872,19 +872,19 @@ std::vector<std::pair<uint32_t, uint32_t>> &GetCustomStypeInfo() {
 #endif
 
 // Process enables and disables set though the vk_layer_settings.txt config file or through an environment variable
-void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
+void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
     // When compiling a build for self validation, ProcessConfigAndEnvSettings immediately returns,
     // so that the layer always defaults to the standard validation options we want,
     // and does not try to process option coming from the VVL we are debugging
 #if defined(BUILD_SELF_VVL)
     // Setup default messenger callback to stdout and just error validation messages
-    FILE *log_output = stdout;
+    FILE* log_output = stdout;
     VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
     VkDebugUtilsMessengerCreateInfoEXT dbg_create_info = vku::InitStructHelper();
     dbg_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
     dbg_create_info.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
     dbg_create_info.pfnUserCallback = MessengerLogCallback;
-    dbg_create_info.pUserData = (void *)log_output;
+    dbg_create_info.pUserData = (void*)log_output;
     LayerCreateMessengerCallback(settings_data->debug_report, true, &dbg_create_info, &messenger);
 
 #ifdef WIN32
@@ -940,7 +940,7 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         setting_warnings.emplace_back(GetDeprecatedEnabledDisabledWarning(enabled, disabled));
     }
 
-    GlobalSettings &global_settings = *settings_data->global_settings;
+    GlobalSettings& global_settings = *settings_data->global_settings;
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_FINE_GRAINED_LOCKING)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_FINE_GRAINED_LOCKING, global_settings.fine_grained_locking);
     }
@@ -953,7 +953,7 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         vkuGetLayerSettingValues(layer_setting_set, VK_LAYER_CUSTOM_STYPE_LIST, GetCustomStypeInfo());
     }
 
-    GpuAVSettings &gpuav_settings = *settings_data->gpuav_settings;
+    GpuAVSettings& gpuav_settings = *settings_data->gpuav_settings;
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_SAFE_MODE)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_SAFE_MODE, gpuav_settings.safe_mode);
     }
@@ -1137,7 +1137,7 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         }
     }
 
-    SyncValSettings &syncval_settings = *settings_data->syncval_settings;
+    SyncValSettings& syncval_settings = *settings_data->syncval_settings;
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION,
                                 syncval_settings.submit_time_validation);
@@ -1158,18 +1158,18 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                                 syncval_settings.message_extra_properties);
     }
 
-    const char *REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_message_extra_properties_pretty_print";
+    const char* REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_message_extra_properties_pretty_print";
     if (vkuHasLayerSetting(layer_setting_set, REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT)) {
         setting_warnings.emplace_back(std::string(REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT) +
                                       " was removed. The main purpose of the extra properties section is to filter syncval error "
                                       "messages. The priority is to have a fixed and easy-to-parse layout.");
     }
 
-    const auto *validation_features_ext = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(settings_data->create_info);
+    const auto* validation_features_ext = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(settings_data->create_info);
     if (validation_features_ext) {
         SetValidationFeatures(settings_data->disabled, settings_data->enabled, validation_features_ext);
     }
-    const auto *validation_flags_ext = vku::FindStructInPNextChain<VkValidationFlagsEXT>(settings_data->create_info);
+    const auto* validation_flags_ext = vku::FindStructInPNextChain<VkValidationFlagsEXT>(settings_data->create_info);
     if (validation_flags_ext) {
         SetValidationFlags(settings_data->disabled, validation_flags_ext);
     }
@@ -1244,7 +1244,8 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         bool gpuav_enable = false;
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_ENABLE, gpuav_enable);
         if (printf_only_preset) {
-            setting_warnings.emplace_back(std::string(VK_LAYER_PRINTF_ONLY_PRESET) + " was set, so ignoring " + std::string(VK_LAYER_GPUAV_ENABLE) + ".");
+            setting_warnings.emplace_back(std::string(VK_LAYER_PRINTF_ONLY_PRESET) + " was set, so ignoring " +
+                                          std::string(VK_LAYER_GPUAV_ENABLE) + ".");
         } else if (gpuav_enable) {
             // enabled the new way, but chassis uses this to create Validation Object
             settings_data->enabled[gpu_validation] = true;
@@ -1299,12 +1300,12 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
 
     // Grab application name here while we have access to it and know if to save it or not
     if (settings_data->debug_report->message_format_settings.display_application_name) {
-        const VkApplicationInfo *app_info = settings_data->create_info->pApplicationInfo;
+        const VkApplicationInfo* app_info = settings_data->create_info->pApplicationInfo;
         settings_data->debug_report->message_format_settings.application_name =
             (app_info && app_info->pApplicationName) ? app_info->pApplicationName : "";
     }
 
-    for (const auto &warning : setting_warnings) {
+    for (const auto& warning : setting_warnings) {
         Location loc(vvl::Func::vkCreateInstance);
         settings_data->debug_report->LogMessage(kWarningBit, "VALIDATION-SETTINGS", {}, loc, warning);
     }

--- a/layers/object_tracker/object_lifetime_validation.cpp
+++ b/layers/object_tracker/object_lifetime_validation.cpp
@@ -29,8 +29,7 @@ namespace object_lifetimes {
 static std::shared_mutex lifetime_set_mutex;
 static vvl::unordered_set<Tracker*> lifetime_set;
 
-Instance::Instance(vvl::dispatch::Instance *dispatch)
-        : BaseClass(dispatch, LayerObjectTypeObjectTracker), tracker(debug_report) {
+Instance::Instance(vvl::dispatch::Instance* dispatch) : BaseClass(dispatch, LayerObjectTypeObjectTracker), tracker(debug_report) {
     WriteLockGuard lock(lifetime_set_mutex);
     lifetime_set.insert(&tracker);
 }
@@ -40,7 +39,7 @@ Instance::~Instance() {
     lifetime_set.erase(&tracker);
 }
 
-Device::Device(vvl::dispatch::Device *dev, Instance *instance)
+Device::Device(vvl::dispatch::Device* dev, Instance* instance)
     : BaseClass(dev, instance, LayerObjectTypeObjectTracker), tracker(debug_report) {
     WriteLockGuard lock(lifetime_set_mutex);
     lifetime_set.insert(&tracker);
@@ -51,7 +50,7 @@ Device::~Device() {
     lifetime_set.erase(&tracker);
 }
 
-VulkanTypedHandle ObjTrackStateTypedHandle(const ObjectState &track_state) {
+VulkanTypedHandle ObjTrackStateTypedHandle(const ObjectState& track_state) {
     // TODO: Unify Typed Handle representation (i.e. VulkanTypedHandle everywhere there are handle/type pairs)
     VulkanTypedHandle typed_handle;
     typed_handle.handle = track_state.handle;
@@ -59,8 +58,8 @@ VulkanTypedHandle ObjTrackStateTypedHandle(const ObjectState &track_state) {
     return typed_handle;
 }
 
-void ObjectState::MakePoisonous(Tracker &tracker, VulkanTypedHandle poisoner,
-                                const std::vector<VulkanTypedHandle> &parent_poison_chain) {
+void ObjectState::MakePoisonous(Tracker& tracker, VulkanTypedHandle poisoner,
+                                const std::vector<VulkanTypedHandle>& parent_poison_chain) {
     auto lock = WriteLock();
     if ((status_flags & kObjectStatusPoisoned) != 0) {
         return;  // Already poisoned, once is enough
@@ -119,7 +118,7 @@ void Tracker::RegisterPoisonPair(VulkanTypedHandle poisonee, VulkanTypedHandle p
     }
 }
 
-bool Tracker::CheckPoisoning(const ObjectState &object_state, const char *vuid, const Location &loc) const {
+bool Tracker::CheckPoisoning(const ObjectState& object_state, const char* vuid, const Location& loc) const {
     bool skip = false;
     auto lock = object_state.ReadLock();
     if ((object_state.status_flags & kObjectStatusPoisoned) != 0) {
@@ -131,7 +130,7 @@ bool Tracker::CheckPoisoning(const ObjectState &object_state, const char *vuid, 
     return skip;
 }
 
-std::string Tracker::DescribePoisonChain(const std::vector<VulkanTypedHandle> &poison_chain) const {
+std::string Tracker::DescribePoisonChain(const std::vector<VulkanTypedHandle>& poison_chain) const {
     std::ostringstream ss;
     assert(!poison_chain.empty());
     for (size_t i = poison_chain.size() - 1; i > 0; i--) {
@@ -151,8 +150,8 @@ std::string Tracker::DescribePoisonChain(const std::vector<VulkanTypedHandle> &p
     return ss.str();
 }
 
-bool Tracker::CheckObjectValidity(VulkanTypedHandle object, bool poisoned_object_allowed, const char *invalid_handle_vuid,
-                                  const char *wrong_parent_vuid, const Location &loc) const {
+bool Tracker::CheckObjectValidity(VulkanTypedHandle object, bool poisoned_object_allowed, const char* invalid_handle_vuid,
+                                  const char* wrong_parent_vuid, const Location& loc) const {
     bool skip = false;
 
     // Check if this instance of lifetime validation tracks the object
@@ -164,10 +163,10 @@ bool Tracker::CheckObjectValidity(VulkanTypedHandle object, bool poisoned_object
     }
 
     // Object not found, look for it in other device object maps
-    const Tracker *other_lifetimes = nullptr;
+    const Tracker* other_lifetimes = nullptr;
     {
         ReadLockGuard lock(lifetime_set_mutex);
-        for (const auto *lifetimes : lifetime_set) {
+        for (const auto* lifetimes : lifetime_set) {
             if (lifetimes != this && lifetimes->TracksObject(object)) {
                 other_lifetimes = lifetimes;
                 break;
@@ -194,25 +193,25 @@ bool Tracker::CheckObjectValidity(VulkanTypedHandle object, bool poisoned_object
                     FormatHandle(handle_).c_str());
 }
 
-void Tracker::SetDeviceHandle(const Device &device) {
+void Tracker::SetDeviceHandle(const Device& device) {
     handle_ = VulkanTypedHandle(device.device, kVulkanObjectTypeDevice);
     is_device_maintenance4_enabled_ = device.enabled_features.maintenance4;
 }
 
 void Tracker::SetInstanceHandle(VkInstance instance) { handle_ = VulkanTypedHandle(instance, kVulkanObjectTypeInstance); }
 
-void Device::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void Device::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) {
     BaseClass::FinishDeviceSetup(pCreateInfo, loc);
     tracker.SetDeviceHandle(*this);
 }
 
-bool Device::CheckPipelineObjectValidity(uint64_t object_handle, const char *invalid_handle_vuid, const Location &loc) const {
+bool Device::CheckPipelineObjectValidity(uint64_t object_handle, const char* invalid_handle_vuid, const Location& loc) const {
     bool skip = false;
-    const auto &itr = linked_graphics_pipeline_map.find(object_handle);
+    const auto& itr = linked_graphics_pipeline_map.find(object_handle);
     if (itr == linked_graphics_pipeline_map.end()) {
         return skip;  // no-linked
     }
-    for (const auto &pipeline : itr->second) {
+    for (const auto& pipeline : itr->second) {
         if (!tracker.TracksObject(pipeline->TypedHandle())) {
             skip |= LogError(invalid_handle_vuid, instance, loc,
                              "Invalid VkPipeline Object 0x%" PRIxLEAST64
@@ -229,7 +228,7 @@ bool Device::CheckPipelineObjectValidity(uint64_t object_handle, const char *inv
     return skip;
 }
 
-void Tracker::CreateObject(VulkanTypedHandle object, const VkAllocationCallbacks *pAllocator, const Location &loc,
+void Tracker::CreateObject(VulkanTypedHandle object, const VkAllocationCallbacks* pAllocator, const Location& loc,
                            uint64_t parent_handle) {
     if (TracksObject(object)) {
         return;
@@ -258,9 +257,9 @@ void Tracker::CreateObject(VulkanTypedHandle object, const VkAllocationCallbacks
     }
 }
 
-bool Tracker::ValidateDestroyObject(VulkanTypedHandle object, const VkAllocationCallbacks *pAllocator,
-                                    const char *expected_custom_allocator_code, const char *expected_default_allocator_code,
-                                    const Location &loc) const {
+bool Tracker::ValidateDestroyObject(VulkanTypedHandle object, const VkAllocationCallbacks* pAllocator,
+                                    const char* expected_custom_allocator_code, const char* expected_default_allocator_code,
+                                    const Location& loc) const {
     bool skip = false;
 
     const uint64_t object_handle = object.handle;
@@ -290,7 +289,7 @@ bool Tracker::ValidateDestroyObject(VulkanTypedHandle object, const VkAllocation
     return skip;
 }
 
-void Tracker::RecordDestroyObject(VulkanTypedHandle object, const Location &loc) {
+void Tracker::RecordDestroyObject(VulkanTypedHandle object, const Location& loc) {
     if (auto object_state = GetObjectState(object)) {
         {
             // Lock to iterate over objects_to_poison and poisoners arrays
@@ -320,7 +319,7 @@ void Tracker::RecordDestroyObject(VulkanTypedHandle object, const Location &loc)
     }
 }
 
-void Tracker::DestroyObjectSilently(VulkanTypedHandle object, const Location &loc) {
+void Tracker::DestroyObjectSilently(VulkanTypedHandle object, const Location& loc) {
     assert(object.handle);
     auto item = object_map[object.type].pop(object.handle);
     if (item == object_map[object.type].end()) {
@@ -335,18 +334,18 @@ void Tracker::DestroyObjectSilently(VulkanTypedHandle object, const Location &lo
     }
 }
 
-void Tracker::DestroyUndestroyedObjects(VulkanObjectType object_type, const Location &loc) {
+void Tracker::DestroyUndestroyedObjects(VulkanObjectType object_type, const Location& loc) {
     auto snapshot = object_map[object_type].snapshot();
     VulkanTypedHandle object;
     object.type = object_type;
-    for (const auto &item : snapshot) {
+    for (const auto& item : snapshot) {
         object.handle = item.second->handle;
         DestroyObjectSilently(object, loc);
     }
 }
 
-bool Device::ValidateAnonymousObject(uint64_t object, VkObjectType core_object_type, const char *invalid_handle_vuid,
-                                     const char *wrong_parent_vuid, const Location &loc) const {
+bool Device::ValidateAnonymousObject(uint64_t object, VkObjectType core_object_type, const char* invalid_handle_vuid,
+                                     const char* wrong_parent_vuid, const Location& loc) const {
     VulkanTypedHandle typed_handle;
     typed_handle.handle = object;
     typed_handle.type = ConvertCoreObjectToVulkanObject(core_object_type);
@@ -354,11 +353,11 @@ bool Device::ValidateAnonymousObject(uint64_t object, VkObjectType core_object_t
 }
 
 void Device::AllocateCommandBuffer(const VkCommandPool command_pool, const VkCommandBuffer command_buffer,
-                                   VkCommandBufferLevel level, const Location &loc) {
+                                   VkCommandBufferLevel level, const Location& loc) {
     tracker.CreateObject(command_buffer, kVulkanObjectTypeCommandBuffer, nullptr, loc, command_pool);
 }
 
-bool Device::ValidateCommandBuffer(VkCommandPool command_pool, VkCommandBuffer command_buffer, const Location &loc) const {
+bool Device::ValidateCommandBuffer(VkCommandPool command_pool, VkCommandBuffer command_buffer, const Location& loc) const {
     bool skip = false;
     uint64_t object_handle = HandleToUint64(command_buffer);
     auto iter = tracker.object_map[kVulkanObjectTypeCommandBuffer].find(object_handle);
@@ -381,7 +380,7 @@ bool Device::ValidateCommandBuffer(VkCommandPool command_pool, VkCommandBuffer c
     return skip;
 }
 
-void Device::AllocateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set, const Location &loc) {
+void Device::AllocateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set, const Location& loc) {
     tracker.CreateObject(descriptor_set, kVulkanObjectTypeDescriptorSet, nullptr, loc, descriptor_pool);
     auto itr = tracker.object_map[kVulkanObjectTypeDescriptorPool].find(HandleToUint64(descriptor_pool));
     if (itr != tracker.object_map[kVulkanObjectTypeDescriptorPool].end()) {
@@ -389,7 +388,7 @@ void Device::AllocateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescripto
     }
 }
 
-bool Device::ValidateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set, const Location &loc) const {
+bool Device::ValidateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set, const Location& loc) const {
     bool skip = false;
     uint64_t object_handle = HandleToUint64(descriptor_set);
     auto ds_item = tracker.object_map[kVulkanObjectTypeDescriptorSet].find(object_handle);
@@ -411,7 +410,7 @@ bool Device::ValidateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescripto
     return skip;
 }
 
-bool Device::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool is_push_descriptor, const Location &loc) const {
+bool Device::ValidateDescriptorWrite(VkWriteDescriptorSet const* desc, bool is_push_descriptor, const Location& loc) const {
     bool skip = false;
 
     // VkWriteDescriptorSet::dstSet is ignored for push vkCmdPushDescriptorSetKHR, so can be bad handle
@@ -491,7 +490,7 @@ bool Device::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool is_p
 
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR: {
-            if (const auto *acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(desc->pNext)) {
+            if (const auto* acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(desc->pNext)) {
                 for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
                     skip |= ValidateObject(
                         acc_info->pAccelerationStructures[i], kVulkanObjectTypeAccelerationStructureKHR, true,
@@ -500,7 +499,7 @@ bool Device::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool is_p
                         loc.pNext(Struct::VkWriteDescriptorSetAccelerationStructureKHR, Field::pAccelerationStructures, i));
                 }
             }
-            if (const auto *acc_info_nv = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(desc->pNext)) {
+            if (const auto* acc_info_nv = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(desc->pNext)) {
                 for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
                     skip |= ValidateObject(
                         acc_info_nv->pAccelerationStructures[i], kVulkanObjectTypeAccelerationStructureNV, true,
@@ -530,7 +529,7 @@ bool Device::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool is_p
         }
 
         case VK_DESCRIPTOR_TYPE_TENSOR_ARM: {
-            if (const auto *tensor_info = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(desc->pNext)) {
+            if (const auto* tensor_info = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(desc->pNext)) {
                 for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
                     skip |= ValidateObject(tensor_info->pTensorViews[i], kVulkanObjectTypeTensorViewARM, true,
                                            "VUID-VkWriteDescriptorSetTensorARM-pTensorViews-parameter",
@@ -556,8 +555,8 @@ bool Device::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool is_p
 
 bool Device::PreCallValidateCmdPushDescriptorSet(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                  VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                                 const VkWriteDescriptorSet *pDescriptorWrites,
-                                                 const ErrorObject &error_obj) const {
+                                                 const VkWriteDescriptorSet* pDescriptorWrites,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: commandBuffer: "VUID-vkCmdPushDescriptorSet-commandBuffer-parameter"
     skip |= ValidateObject(layout, kVulkanObjectTypePipelineLayout, false, "VUID-vkCmdPushDescriptorSet-layout-parameter",
@@ -573,15 +572,15 @@ bool Device::PreCallValidateCmdPushDescriptorSet(VkCommandBuffer commandBuffer, 
 
 bool Device::PreCallValidateCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                     VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                                    const VkWriteDescriptorSet *pDescriptorWrites,
-                                                    const ErrorObject &error_obj) const {
+                                                    const VkWriteDescriptorSet* pDescriptorWrites,
+                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCmdPushDescriptorSet(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount,
                                                pDescriptorWrites, error_obj);
 }
 
 bool Device::PreCallValidateCmdPushDescriptorSet2(VkCommandBuffer commandBuffer,
-                                                  const VkPushDescriptorSetInfo *pPushDescriptorSetInfo,
-                                                  const ErrorObject &error_obj) const {
+                                                  const VkPushDescriptorSetInfo* pPushDescriptorSetInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: commandBuffer: "VUID-vkCmdPushDescriptorSet2-commandBuffer-parameter"
     skip |= ValidateObject(pPushDescriptorSetInfo->layout, kVulkanObjectTypePipelineLayout, true,
@@ -599,16 +598,16 @@ bool Device::PreCallValidateCmdPushDescriptorSet2(VkCommandBuffer commandBuffer,
 }
 
 bool Device::PreCallValidateCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
-                                                     const VkPushDescriptorSetInfoKHR *pPushDescriptorSetInfo,
-                                                     const ErrorObject &error_obj) const {
+                                                     const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCmdPushDescriptorSet2(commandBuffer, pPushDescriptorSetInfo, error_obj);
 }
 
-void Device::CreateQueue(VkQueue vkObj, const Location &loc) {
+void Device::CreateQueue(VkQueue vkObj, const Location& loc) {
     tracker.CreateObject(vkObj, kVulkanObjectTypeQueue, nullptr, loc, device);
 }
 
-void Device::CreateSwapchainImageObject(VkImage swapchain_image, VkSwapchainKHR swapchain, const Location &loc) {
+void Device::CreateSwapchainImageObject(VkImage swapchain_image, VkSwapchainKHR swapchain, const Location& loc) {
     tracker.CreateObject(swapchain_image, kVulkanObjectTypeImage, nullptr, loc, swapchain);
 }
 
@@ -621,13 +620,13 @@ void Instance::FindLeakedObjects(VulkanObjectType object_type, std::vector<Vulka
         (object_type == kVulkanObjectTypeImage)
             ? tracker.object_map[object_type].snapshot(
                   [swapchain_snapshot =
-                       tracker.object_map[kVulkanObjectTypeSwapchainKHR].snapshot()](const std::shared_ptr<ObjectState> &pNode) {
-                      return std::find_if(swapchain_snapshot.begin(), swapchain_snapshot.end(), [&](const auto &swapchain_item) {
+                       tracker.object_map[kVulkanObjectTypeSwapchainKHR].snapshot()](const std::shared_ptr<ObjectState>& pNode) {
+                      return std::find_if(swapchain_snapshot.begin(), swapchain_snapshot.end(), [&](const auto& swapchain_item) {
                                  return pNode->parent_object == swapchain_item.second->handle;
                              }) == swapchain_snapshot.end();
                   })
             : tracker.object_map[object_type].snapshot();
-    for (const auto &item : snapshot) {
+    for (const auto& item : snapshot) {
         const auto object_info = item.second;
         leaked_list.emplace_back(ObjTrackStateTypedHandle(*object_info));
     }
@@ -669,13 +668,13 @@ void Device::FindLeakedObjects(VulkanObjectType object_type, std::vector<VulkanT
         (object_type == kVulkanObjectTypeImage)
             ? tracker.object_map[object_type].snapshot(
                   [swapchain_snapshot =
-                       tracker.object_map[kVulkanObjectTypeSwapchainKHR].snapshot()](const std::shared_ptr<ObjectState> &pNode) {
-                      return std::find_if(swapchain_snapshot.begin(), swapchain_snapshot.end(), [&](const auto &swapchain_item) {
+                       tracker.object_map[kVulkanObjectTypeSwapchainKHR].snapshot()](const std::shared_ptr<ObjectState>& pNode) {
+                      return std::find_if(swapchain_snapshot.begin(), swapchain_snapshot.end(), [&](const auto& swapchain_item) {
                                  return pNode->parent_object == swapchain_item.second->handle;
                              }) == swapchain_snapshot.end();
                   })
             : tracker.object_map[object_type].snapshot();
-    for (const auto &item : snapshot) {
+    for (const auto& item : snapshot) {
         const auto object_info = item.second;
         leaked_list.emplace_back(ObjTrackStateTypedHandle(*object_info));
     }
@@ -708,14 +707,14 @@ bool Device::ReportLeakedObjects(std::vector<VulkanTypedHandle>& leaked_list, co
     return LogError("VUID-vkDestroyDevice-device-05137", device, loc, "%s", ss.str().c_str());
 }
 
-bool Instance::PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator,
-        const ErrorObject &error_obj) const {
+bool Instance::PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
 
     // Checked by chassis: instance: "VUID-vkDestroyInstance-instance-parameter"
 
     auto snapshot = tracker.object_map[kVulkanObjectTypeDevice].snapshot();
-    for (const auto &iit : snapshot) {
+    for (const auto& iit : snapshot) {
         auto node = iit.second;
 
         VkDevice device = reinterpret_cast<VkDevice>(node->handle);
@@ -723,21 +722,19 @@ bool Instance::PreCallValidateDestroyInstance(VkInstance instance, const VkAlloc
 
         skip |=
             LogError("VUID-vkDestroyInstance-instance-00629", instance, error_obj.location, "%s object %s has not been destroyed.",
-                    string_VkDebugReportObjectTypeEXT(debug_object_type), FormatHandle(ObjTrackStateTypedHandle(*node)).c_str());
+                     string_VkDebugReportObjectTypeEXT(debug_object_type), FormatHandle(ObjTrackStateTypedHandle(*node)).c_str());
 
         // Throw errors if any device objects belonging to this instance have not been destroyed
         auto device_data = vvl::dispatch::GetData(device);
-        auto obj_lifetimes_data = static_cast<Device *>(device_data->GetValidationObject(container_type));
+        auto obj_lifetimes_data = static_cast<Device*>(device_data->GetValidationObject(container_type));
         skip |= obj_lifetimes_data->ReportUndestroyedObjects(error_obj.location);
 
-        skip |= ValidateDestroyObject(device, kVulkanObjectTypeDevice, pAllocator,
-                "VUID-vkDestroyInstance-instance-00630",
-                "VUID-vkDestroyInstance-instance-00631", error_obj.location);
+        skip |= ValidateDestroyObject(device, kVulkanObjectTypeDevice, pAllocator, "VUID-vkDestroyInstance-instance-00630",
+                                      "VUID-vkDestroyInstance-instance-00631", error_obj.location);
     }
 
-    skip |= ValidateDestroyObject(instance, kVulkanObjectTypeInstance, pAllocator,
-            "VUID-vkDestroyInstance-instance-00630",
-            "VUID-vkDestroyInstance-instance-00631", error_obj.location);
+    skip |= ValidateDestroyObject(instance, kVulkanObjectTypeInstance, pAllocator, "VUID-vkDestroyInstance-instance-00630",
+                                  "VUID-vkDestroyInstance-instance-00631", error_obj.location);
 
     // Report any remaining instance objects
     skip |= ReportUndestroyedObjects(error_obj.location);
@@ -745,11 +742,11 @@ bool Instance::PreCallValidateDestroyInstance(VkInstance instance, const VkAlloc
     return skip;
 }
 
-void Instance::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator,
-                                            const RecordObject &record_obj) {
+void Instance::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator,
+                                            const RecordObject& record_obj) {
     // Destroy physical devices
     auto snapshot = tracker.object_map[kVulkanObjectTypePhysicalDevice].snapshot();
-    for (const auto &iit : snapshot) {
+    for (const auto& iit : snapshot) {
         auto node = iit.second;
         VkPhysicalDevice physical_device = reinterpret_cast<VkPhysicalDevice>(node->handle);
         RecordDestroyObject(physical_device, kVulkanObjectTypePhysicalDevice, record_obj.location);
@@ -757,7 +754,7 @@ void Instance::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocat
 
     // Destroy child devices
     auto snapshot2 = tracker.object_map[kVulkanObjectTypeDevice].snapshot();
-    for (const auto &iit : snapshot2) {
+    for (const auto& iit : snapshot2) {
         auto node = iit.second;
         VkDevice device = reinterpret_cast<VkDevice>(node->handle);
         DestroyLeakedObjects();
@@ -766,13 +763,13 @@ void Instance::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocat
     }
 }
 
-void Instance::PostCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator,
-                                             const RecordObject &record_obj) {
+void Instance::PostCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator,
+                                             const RecordObject& record_obj) {
     RecordDestroyObject(instance, kVulkanObjectTypeInstance, record_obj.location);
 }
 
-bool Device::PreCallValidateDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
-                                          const ErrorObject &error_obj) const {
+bool Device::PreCallValidateDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
+                                          const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkDestroyDevice-device-parameter"
 
@@ -784,8 +781,8 @@ bool Device::PreCallValidateDestroyDevice(VkDevice device, const VkAllocationCal
     return skip;
 }
 
-void Device::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
-    auto object_lifetimes = static_cast<Instance *>(dispatch_instance_->GetValidationObject(container_type));
+void Device::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
+    auto object_lifetimes = static_cast<Instance*>(dispatch_instance_->GetValidationObject(container_type));
     // If ObjectTracker was removed (in an early teardown) this might be null, could search in aborted_object_dispatch but if it is
     // there, no need to record anything else
     if (object_lifetimes) {
@@ -797,21 +794,21 @@ void Device::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallb
     tracker.DestroyUndestroyedObjects(kVulkanObjectTypeQueue, record_obj.location);
 }
 
-void Device::PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue *pQueue,
-                                          const RecordObject &record_obj) {
+void Device::PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,
+                                          const RecordObject& record_obj) {
     auto lock = WriteSharedLock();
     CreateQueue(*pQueue, record_obj.location);
 }
 
-void Device::PostCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2 *pQueueInfo, VkQueue *pQueue,
-                                           const RecordObject &record_obj) {
+void Device::PostCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue,
+                                           const RecordObject& record_obj) {
     auto lock = WriteSharedLock();
     CreateQueue(*pQueue, record_obj.location);
 }
 
 bool Device::PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
-                                                 const VkWriteDescriptorSet *pDescriptorWrites, uint32_t descriptorCopyCount,
-                                                 const VkCopyDescriptorSet *pDescriptorCopies, const ErrorObject &error_obj) const {
+                                                 const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
+                                                 const VkCopyDescriptorSet* pDescriptorCopies, const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkUpdateDescriptorSets-device-parameter"
     if (pDescriptorCopies) {
@@ -839,7 +836,7 @@ bool Device::PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descr
 }
 
 bool Device::PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
-                                                const ErrorObject &error_obj) const {
+                                                const ErrorObject& error_obj) const {
     bool skip = false;
     auto lock = ReadSharedLock();
     // Checked by chassis: device: "VUID-vkResetDescriptorPool-device-parameter"
@@ -860,7 +857,7 @@ bool Device::PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPoo
 }
 
 void Device::PreCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
-                                              const RecordObject &record_obj) {
+                                              const RecordObject& record_obj) {
     auto lock = WriteSharedLock();
     // A DescriptorPool's descriptor sets are implicitly deleted when the pool is reset. Remove this pool's descriptor sets from
     // our descriptorSet map.
@@ -874,8 +871,8 @@ void Device::PreCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool 
     }
 }
 
-bool Device::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *begin_info,
-                                               const ErrorObject &error_obj) const {
+bool Device::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* begin_info,
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: commandBuffer: "VUID-vkBeginCommandBuffer-commandBuffer-parameter"
 
@@ -901,8 +898,8 @@ bool Device::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, co
     return skip;
 }
 
-void Device::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
-                                                 VkImage *pSwapchainImages, const RecordObject &record_obj) {
+void Device::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
+                                                 VkImage* pSwapchainImages, const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     auto lock = WriteSharedLock();
     if (pSwapchainImages != NULL) {
@@ -912,16 +909,16 @@ void Device::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR
     }
 }
 
-bool Device::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCreateInfo &create_info,
-                                                   const Location &create_info_loc) const {
+bool Device::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCreateInfo& create_info,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
     if (create_info.pBindings) {
-        const char *parent_vuid = create_info_loc.function == vvl::Func::vkCreateDescriptorSetLayout
+        const char* parent_vuid = create_info_loc.function == vvl::Func::vkCreateDescriptorSetLayout
                                       ? "UNASSIGNED-vkCreateDescriptorSetLayout-pImmutableSamplers-device"
                                       : "UNASSIGNED-vkGetDescriptorSetLayoutSupport-pImmutableSamplers-device";
         for (uint32_t binding_index = 0; binding_index < create_info.bindingCount; ++binding_index) {
             const Location binding_loc = create_info_loc.dot(Field::pBindings, binding_index);
-            const VkDescriptorSetLayoutBinding &binding = create_info.pBindings[binding_index];
+            const VkDescriptorSetLayoutBinding& binding = create_info.pBindings[binding_index];
             const bool is_sampler_type = binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER ||
                                          binding.descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             if (binding.pImmutableSamplers && is_sampler_type) {
@@ -937,23 +934,23 @@ bool Device::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCr
     return skip;
 }
 
-bool Device::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkDescriptorSetLayout *pSetLayout,
-                                                      const ErrorObject &error_obj) const {
+bool Device::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkDescriptorSetLayout* pSetLayout,
+                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkCreateDescriptorSetLayout-device-parameter"
     skip |= ValidateDescriptorSetLayoutCreateInfo(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
     return skip;
 }
 
-void Device::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkDescriptorSetLayout *pSetLayout,
-                                                     const RecordObject &record_obj) {
+void Device::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkDescriptorSetLayout* pSetLayout,
+                                                     const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     tracker.CreateObject(*pSetLayout, kVulkanObjectTypeDescriptorSetLayout, pAllocator, record_obj.location, device);
 
     // Setup poisoning
-    for (const VkDescriptorSetLayoutBinding &binding : vvl::make_span(pCreateInfo->pBindings, pCreateInfo->bindingCount)) {
+    for (const VkDescriptorSetLayoutBinding& binding : vvl::make_span(pCreateInfo->pBindings, pCreateInfo->bindingCount)) {
         if (binding.descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER &&
             binding.descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
             continue;
@@ -967,18 +964,18 @@ void Device::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDe
     }
 }
 
-bool Device::PreCallValidateGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                          VkDescriptorSetLayoutSupport *pSupport,
-                                                          const ErrorObject &error_obj) const {
+bool Device::PreCallValidateGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                          VkDescriptorSetLayoutSupport* pSupport,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkGetDescriptorSetLayoutSupport-device-parameter"
     skip |= ValidateDescriptorSetLayoutCreateInfo(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
     return skip;
 }
 
-void Device::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
-                                                const RecordObject &record_obj) {
+void Device::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
+                                                const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     tracker.CreateObject(*pPipelineLayout, kVulkanObjectTypePipelineLayout, pAllocator, record_obj.location, device);
 
@@ -989,43 +986,43 @@ void Device::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelin
 }
 
 bool Instance::PreCallValidateGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,
-                                                                     uint32_t *pQueueFamilyPropertyCount,
-                                                                     VkQueueFamilyProperties *pQueueFamilyProperties,
-                                                                     const ErrorObject &error_obj) const {
+                                                                     uint32_t* pQueueFamilyPropertyCount,
+                                                                     VkQueueFamilyProperties* pQueueFamilyProperties,
+                                                                     const ErrorObject& error_obj) const {
     constexpr bool skip = false;
     // Checked by chassis: physicalDevice: "VUID-vkGetPhysicalDeviceQueueFamilyProperties-physicalDevice-parameter"
     return skip;
 }
 
 void Instance::PostCallRecordGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,
-                                                                    uint32_t *pQueueFamilyPropertyCount,
-                                                                    VkQueueFamilyProperties *pQueueFamilyProperties,
-                                                                    const RecordObject &record_obj) {}
+                                                                    uint32_t* pQueueFamilyPropertyCount,
+                                                                    VkQueueFamilyProperties* pQueueFamilyProperties,
+                                                                    const RecordObject& record_obj) {}
 
-void Instance::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                            VkInstance *pInstance, const RecordObject &record_obj) {
+void Instance::PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                            VkInstance* pInstance, const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     tracker.CreateObject(*pInstance, kVulkanObjectTypeInstance, pAllocator, record_obj.location, *pInstance);
     tracker.SetInstanceHandle(*pInstance);
 }
 
-bool Instance::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                           const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                           const ErrorObject &error_obj) const {
+bool Instance::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
+                                           const ErrorObject& error_obj) const {
     constexpr bool skip = false;
     // Checked by chassis: physicalDevice: "VUID-vkCreateDevice-physicalDevice-parameter"
     return skip;
 }
 
-void Instance::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                          const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                          const RecordObject &record_obj) {
+void Instance::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                          const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
+                                          const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     tracker.CreateObject(*pDevice, kVulkanObjectTypeDevice, pAllocator, record_obj.location, physicalDevice);
 }
 
-bool Device::PreCallValidateAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo *pAllocateInfo,
-                                                   VkCommandBuffer *pCommandBuffers, const ErrorObject &error_obj) const {
+bool Device::PreCallValidateAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                                   VkCommandBuffer* pCommandBuffers, const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkAllocateCommandBuffers-device-parameter"
 
@@ -1035,8 +1032,8 @@ bool Device::PreCallValidateAllocateCommandBuffers(VkDevice device, const VkComm
     return skip;
 }
 
-void Device::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo *pAllocateInfo,
-                                                  VkCommandBuffer *pCommandBuffers, const RecordObject &record_obj) {
+void Device::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                                  VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     for (uint32_t i = 0; i < pAllocateInfo->commandBufferCount; i++) {
         AllocateCommandBuffer(pAllocateInfo->commandPool, pCommandBuffers[i], pAllocateInfo->level,
@@ -1044,8 +1041,8 @@ void Device::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkComma
     }
 }
 
-bool Device::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                                   VkDescriptorSet *pDescriptorSets, const ErrorObject &error_obj) const {
+bool Device::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                                   VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj) const {
     bool skip = false;
     auto lock = ReadSharedLock();
     // Checked by chassis: device: "VUID-vkAllocateDescriptorSets-device-parameter"
@@ -1062,8 +1059,8 @@ bool Device::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDesc
     return skip;
 }
 
-void Device::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                                  VkDescriptorSet *pDescriptorSets, const RecordObject &record_obj) {
+void Device::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                                  VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     auto lock = WriteSharedLock();
     for (uint32_t i = 0; i < pAllocateInfo->descriptorSetCount; i++) {
@@ -1073,7 +1070,7 @@ void Device::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescr
 }
 
 bool Device::PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
-                                               const VkCommandBuffer *pCommandBuffers, const ErrorObject &error_obj) const {
+                                               const VkCommandBuffer* pCommandBuffers, const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkFreeCommandBuffers-device-parameter"
 
@@ -1091,26 +1088,26 @@ bool Device::PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool co
 }
 
 void Device::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
-                                             const VkCommandBuffer *pCommandBuffers, const RecordObject &record_obj) {
+                                             const VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
     for (uint32_t i = 0; i < commandBufferCount; i++) {
         RecordDestroyObject(pCommandBuffers[i], kVulkanObjectTypeCommandBuffer, record_obj.location);
     }
 }
 
-void Device::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator,
-                                              const RecordObject &record_obj) {
+void Device::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator,
+                                              const RecordObject& record_obj) {
     RecordDestroyObject(swapchain, kVulkanObjectTypeSwapchainKHR, record_obj.location);
 
-    auto &image_map = tracker.object_map[kVulkanObjectTypeImage];
+    auto& image_map = tracker.object_map[kVulkanObjectTypeImage];
     auto snapshot = image_map.snapshot(
-        [swapchain](const std::shared_ptr<ObjectState> &pNode) { return pNode->parent_object == HandleToUint64(swapchain); });
-    for (const auto &itr : snapshot) {
+        [swapchain](const std::shared_ptr<ObjectState>& pNode) { return pNode->parent_object == HandleToUint64(swapchain); });
+    for (const auto& itr : snapshot) {
         image_map.erase(itr.first);
     }
 }
 
 bool Device::PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t descriptorSetCount,
-                                               const VkDescriptorSet *pDescriptorSets, const ErrorObject &error_obj) const {
+                                               const VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj) const {
     auto lock = ReadSharedLock();
     bool skip = false;
     // Checked by chassis: device: "VUID-vkFreeDescriptorSets-device-parameter"
@@ -1129,7 +1126,7 @@ bool Device::PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool
     return skip;
 }
 void Device::PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t descriptorSetCount,
-                                             const VkDescriptorSet *pDescriptorSets, const RecordObject &record_obj) {
+                                             const VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) {
     auto lock = WriteSharedLock();
     std::shared_ptr<ObjectState> pool_node = nullptr;
     auto itr = tracker.object_map[kVulkanObjectTypeDescriptorPool].find(HandleToUint64(descriptorPool));
@@ -1145,7 +1142,7 @@ void Device::PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool d
 }
 
 bool Device::PreCallValidateDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
-                                                  const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
+                                                  const VkAllocationCallbacks* pAllocator, const ErrorObject& error_obj) const {
     auto lock = ReadSharedLock();
     bool skip = false;
     // Checked by chassis: device: "VUID-vkDestroyDescriptorPool-device-parameter"
@@ -1169,7 +1166,7 @@ bool Device::PreCallValidateDestroyDescriptorPool(VkDevice device, VkDescriptorP
     return skip;
 }
 void Device::PreCallRecordDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
-                                                const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     auto lock = WriteSharedLock();
     auto itr = tracker.object_map[kVulkanObjectTypeDescriptorPool].find(HandleToUint64(descriptorPool));
     if (itr != tracker.object_map[kVulkanObjectTypeDescriptorPool].end()) {
@@ -1182,8 +1179,8 @@ void Device::PreCallRecordDestroyDescriptorPool(VkDevice device, VkDescriptorPoo
     RecordDestroyObject(descriptorPool, kVulkanObjectTypeDescriptorPool, record_obj.location);
 }
 
-bool Device::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks *pAllocator,
-                                               const ErrorObject &error_obj) const {
+bool Device::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks* pAllocator,
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkDestroyCommandPool-device-parameter"
 
@@ -1192,8 +1189,8 @@ bool Device::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool co
                            "VUID-vkDestroyCommandPool-commandPool-parent", command_pool_loc);
 
     auto snapshot = tracker.object_map[kVulkanObjectTypeCommandBuffer].snapshot(
-        [commandPool](const std::shared_ptr<ObjectState> &pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
-    for (const auto &itr : snapshot) {
+        [commandPool](const std::shared_ptr<ObjectState>& pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
+    for (const auto& itr : snapshot) {
         auto node = itr.second;
         skip |= ValidateCommandBuffer(commandPool, reinterpret_cast<VkCommandBuffer>(itr.first), command_pool_loc);
         skip |= ValidateDestroyObject(reinterpret_cast<VkCommandBuffer>(itr.first), kVulkanObjectTypeCommandBuffer, nullptr,
@@ -1205,53 +1202,53 @@ bool Device::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPool co
     return skip;
 }
 
-void Device::PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks *pAllocator,
-                                             const RecordObject &record_obj) {
+void Device::PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks* pAllocator,
+                                             const RecordObject& record_obj) {
     auto snapshot = tracker.object_map[kVulkanObjectTypeCommandBuffer].snapshot(
-        [commandPool](const std::shared_ptr<ObjectState> &pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
+        [commandPool](const std::shared_ptr<ObjectState>& pNode) { return pNode->parent_object == HandleToUint64(commandPool); });
     // A CommandPool's cmd buffers are implicitly deleted when pool is deleted. Remove this pool's cmdBuffers from cmd buffer map.
-    for (const auto &itr : snapshot) {
+    for (const auto& itr : snapshot) {
         RecordDestroyObject(reinterpret_cast<VkCommandBuffer>(itr.first), kVulkanObjectTypeCommandBuffer, record_obj.location);
     }
     RecordDestroyObject(commandPool, kVulkanObjectTypeCommandPool, record_obj.location);
 }
 
 bool Instance::PreCallValidateGetPhysicalDeviceQueueFamilyProperties2(VkPhysicalDevice physicalDevice,
-                                                                      uint32_t *pQueueFamilyPropertyCount,
-                                                                      VkQueueFamilyProperties2 *pQueueFamilyProperties,
-                                                                      const ErrorObject &error_obj) const {
+                                                                      uint32_t* pQueueFamilyPropertyCount,
+                                                                      VkQueueFamilyProperties2* pQueueFamilyProperties,
+                                                                      const ErrorObject& error_obj) const {
     constexpr bool skip = false;
     // Checked by chassis: physicalDevice: "VUID-vkGetPhysicalDeviceQueueFamilyProperties2-physicalDevice-parameter"
     return skip;
 }
 
 bool Instance::PreCallValidateGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice,
-                                                                         uint32_t *pQueueFamilyPropertyCount,
-                                                                         VkQueueFamilyProperties2 *pQueueFamilyProperties,
-                                                                         const ErrorObject &error_obj) const {
+                                                                         uint32_t* pQueueFamilyPropertyCount,
+                                                                         VkQueueFamilyProperties2* pQueueFamilyProperties,
+                                                                         const ErrorObject& error_obj) const {
     return PreCallValidateGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties,
                                                                   error_obj);
 }
 
 void Instance::PostCallRecordGetPhysicalDeviceQueueFamilyProperties2(VkPhysicalDevice physicalDevice,
-                                                                     uint32_t *pQueueFamilyPropertyCount,
-                                                                     VkQueueFamilyProperties2 *pQueueFamilyProperties,
-                                                                     const RecordObject &record_obj) {}
+                                                                     uint32_t* pQueueFamilyPropertyCount,
+                                                                     VkQueueFamilyProperties2* pQueueFamilyProperties,
+                                                                     const RecordObject& record_obj) {}
 
 void Instance::PostCallRecordGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice,
-                                                                        uint32_t *pQueueFamilyPropertyCount,
-                                                                        VkQueueFamilyProperties2 *pQueueFamilyProperties,
-                                                                        const RecordObject &record_obj) {}
+                                                                        uint32_t* pQueueFamilyPropertyCount,
+                                                                        VkQueueFamilyProperties2* pQueueFamilyProperties,
+                                                                        const RecordObject& record_obj) {}
 
-void Instance::AllocateDisplayKHR(VkPhysicalDevice physical_device, VkDisplayKHR display, const Location &loc) {
+void Instance::AllocateDisplayKHR(VkPhysicalDevice physical_device, VkDisplayKHR display, const Location& loc) {
     // Note - From https://gitlab.khronos.org/vulkan/vulkan/-/issues/4742
     // It is known that the DisplayKHR and DisplayModeKHR handle list might only ever grow
     tracker.CreateObject(display, kVulkanObjectTypeDisplayKHR, nullptr, loc, physical_device);
 }
 
-void Instance::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                                   VkDisplayPropertiesKHR *pProperties,
-                                                                   const RecordObject &record_obj) {
+void Instance::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                   VkDisplayPropertiesKHR* pProperties,
+                                                                   const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     if (pProperties) {
         for (uint32_t i = 0; i < *pPropertyCount; ++i) {
@@ -1262,8 +1259,8 @@ void Instance::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDev
 }
 
 void Instance::PostCallRecordGetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                                         uint32_t *pPropertyCount, VkDisplayModePropertiesKHR *pProperties,
-                                                         const RecordObject &record_obj) {
+                                                         uint32_t* pPropertyCount, VkDisplayModePropertiesKHR* pProperties,
+                                                         const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     if (pProperties) {
         for (uint32_t i = 0; i < *pPropertyCount; ++i) {
@@ -1273,9 +1270,9 @@ void Instance::PostCallRecordGetDisplayModePropertiesKHR(VkPhysicalDevice physic
     }
 }
 
-void Instance::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                                    VkDisplayProperties2KHR *pProperties,
-                                                                    const RecordObject &record_obj) {
+void Instance::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                    VkDisplayProperties2KHR* pProperties,
+                                                                    const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     if (pProperties) {
         for (uint32_t index = 0; index < *pPropertyCount; ++index) {
@@ -1287,8 +1284,8 @@ void Instance::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(VkPhysicalDe
 }
 
 void Instance::PostCallRecordGetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                                          uint32_t *pPropertyCount, VkDisplayModeProperties2KHR *pProperties,
-                                                          const RecordObject &record_obj) {
+                                                          uint32_t* pPropertyCount, VkDisplayModeProperties2KHR* pProperties,
+                                                          const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     if (pProperties) {
         for (uint32_t index = 0; index < *pPropertyCount; ++index) {
@@ -1300,9 +1297,9 @@ void Instance::PostCallRecordGetDisplayModeProperties2KHR(VkPhysicalDevice physi
     }
 }
 
-void Instance::PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                                        VkDisplayPlanePropertiesKHR *pProperties,
-                                                                        const RecordObject &record_obj) {
+void Instance::PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                        VkDisplayPlanePropertiesKHR* pProperties,
+                                                                        const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     if (pProperties) {
         for (uint32_t index = 0; index < *pPropertyCount; ++index) {
@@ -1312,9 +1309,9 @@ void Instance::PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhysic
     }
 }
 
-void Instance::PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
-                                                                         VkDisplayPlaneProperties2KHR *pProperties,
-                                                                         const RecordObject &record_obj) {
+void Instance::PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
+                                                                         VkDisplayPlaneProperties2KHR* pProperties,
+                                                                         const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     if (pProperties) {
         for (uint32_t index = 0; index < *pPropertyCount; ++index) {
@@ -1325,9 +1322,9 @@ void Instance::PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(VkPhysi
     }
 }
 
-bool Device::PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo *pCreateInfo,
-                                              const VkAllocationCallbacks *pAllocator, VkFramebuffer *pFramebuffer,
-                                              const ErrorObject &error_obj) const {
+bool Device::PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                              const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
+                                              const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkCreateFramebuffer-device-parameter"
 
@@ -1346,8 +1343,8 @@ bool Device::PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebuff
     return skip;
 }
 
-bool Device::PreCallValidateDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT *pTagInfo,
-                                                       const ErrorObject &error_obj) const {
+bool Device::PreCallValidateDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* pTagInfo,
+                                                       const ErrorObject& error_obj) const {
     // Checked by chassis: device: "VUID-vkDebugMarkerSetObjectTagEXT-device-parameter"
     bool skip = false;
     if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT) {
@@ -1369,8 +1366,8 @@ bool Device::PreCallValidateDebugMarkerSetObjectTagEXT(VkDevice device, const Vk
     return skip;
 }
 
-bool Device::PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo,
-                                                        const ErrorObject &error_obj) const {
+bool Device::PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo,
+                                                        const ErrorObject& error_obj) const {
     // Checked by chassis: device: "VUID-vkDebugMarkerSetObjectNameEXT-device-parameter"
     bool skip = false;
     if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT) {
@@ -1392,8 +1389,8 @@ bool Device::PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice device, const V
     return skip;
 }
 
-bool Device::PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo,
-                                                       const ErrorObject &error_obj) const {
+bool Device::PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo,
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkSetDebugUtilsObjectNameEXT-device-parameter"
     const VkObjectType object_type = pNameInfo->objectType;
@@ -1417,8 +1414,8 @@ bool Device::PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, const Vk
     return skip;
 }
 
-bool Device::PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT *pTagInfo,
-                                                      const ErrorObject &error_obj) const {
+bool Device::PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT* pTagInfo,
+                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkSetDebugUtilsObjectTagEXT-device-parameter"
 
@@ -1444,10 +1441,10 @@ bool Device::PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device, const VkD
     return skip;
 }
 
-bool Device::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                           const VkAllocationCallbacks *pAllocator,
-                                                           VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                           const ErrorObject &error_obj) const {
+bool Device::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                           const VkAllocationCallbacks* pAllocator,
+                                                           VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkCreateDescriptorUpdateTemplate-device-parameter"
 
@@ -1469,35 +1466,35 @@ bool Device::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice device, cons
 }
 
 bool Device::PreCallValidateCreateDescriptorUpdateTemplateKHR(VkDevice device,
-                                                              const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                              const VkAllocationCallbacks *pAllocator,
-                                                              VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                              const ErrorObject &error_obj) const {
+                                                              const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                              const VkAllocationCallbacks* pAllocator,
+                                                              VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                              const ErrorObject& error_obj) const {
     return PreCallValidateCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, error_obj);
 }
 
-void Device::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator,
-                                                          VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                          const RecordObject &record_obj) {
+void Device::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device, const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator,
+                                                          VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                          const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
     tracker.CreateObject(*pDescriptorUpdateTemplate, kVulkanObjectTypeDescriptorUpdateTemplate, pAllocator, record_obj.location,
                          device);
 }
 
 void Device::PostCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice device,
-                                                             const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator,
-                                                             VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                             const RecordObject &record_obj) {
+                                                             const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator,
+                                                             VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                             const RecordObject& record_obj) {
     return PostCallRecordCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, record_obj);
 }
 
-bool Device::ValidateAccelerationStructures(const char *src_handle_vuid, const char *dst_handle_vuid, uint32_t count,
-                                            const VkAccelerationStructureBuildGeometryInfoKHR *infos, const Location &loc) const {
+bool Device::ValidateAccelerationStructures(const char* src_handle_vuid, const char* dst_handle_vuid, uint32_t count,
+                                            const VkAccelerationStructureBuildGeometryInfoKHR* infos, const Location& loc) const {
     bool skip = false;
     if (infos) {
-        const char *device_vuid = "VUID-VkAccelerationStructureBuildGeometryInfoKHR-commonparent";
+        const char* device_vuid = "VUID-VkAccelerationStructureBuildGeometryInfoKHR-commonparent";
         for (uint32_t i = 0; i < count; ++i) {
             const Location info_loc = loc.dot(Field::pInfos, i);
             skip |= ValidateObject(infos[i].srcAccelerationStructure, kVulkanObjectTypeAccelerationStructureKHR, true,
@@ -1511,8 +1508,8 @@ bool Device::ValidateAccelerationStructures(const char *src_handle_vuid, const c
 }
 
 bool Device::PreCallValidateCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: commandBuffer: "VUID-vkCmdBuildAccelerationStructuresKHR-commandBuffer-parameter"
 
@@ -1523,11 +1520,11 @@ bool Device::PreCallValidateCmdBuildAccelerationStructuresKHR(
 }
 
 bool Device::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                                      const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-                                                                      const VkDeviceAddress *pIndirectDeviceAddresses,
-                                                                      const uint32_t *pIndirectStrides,
-                                                                      const uint32_t *const *ppMaxPrimitiveCounts,
-                                                                      const ErrorObject &error_obj) const {
+                                                                      const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                                                      const VkDeviceAddress* pIndirectDeviceAddresses,
+                                                                      const uint32_t* pIndirectStrides,
+                                                                      const uint32_t* const* ppMaxPrimitiveCounts,
+                                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: commandBuffer: "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-commandBuffer-parameter"
 
@@ -1539,9 +1536,9 @@ bool Device::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkCommandB
 
 bool Device::PreCallValidateBuildAccelerationStructuresKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                            uint32_t infoCount,
-                                                           const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-                                                           const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos,
-                                                           const ErrorObject &error_obj) const {
+                                                           const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                                           const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos,
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkBuildAccelerationStructuresKHR-device-parameter"
 
@@ -1557,9 +1554,9 @@ bool Device::PreCallValidateBuildAccelerationStructuresKHR(VkDevice device, VkDe
 
 bool Device::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                          VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                         const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
-                                                         const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                         const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkCreateRayTracingPipelinesKHR-device-parameter"
 
@@ -1607,14 +1604,14 @@ bool Device::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDefe
 
 void Device::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                         VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                        const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
-                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                        const RecordObject &record_obj, PipelineStates &pipeline_states,
+                                                        const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                        const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                        const RecordObject& record_obj, PipelineStates& pipeline_states,
                                                         std::shared_ptr<chassis::CreateRayTracingPipelinesKHR> chassis_state) {
     if (VK_ERROR_VALIDATION_FAILED_EXT == record_obj.result) return;
     if (pPipelines) {
         if (deferredOperation != VK_NULL_HANDLE && record_obj.result == VK_OPERATION_DEFERRED_KHR) {
-            auto register_fn = [this, pAllocator, record_obj, chassis_state](std::pair<uint32_t, VkPipeline *> pipelines) {
+            auto register_fn = [this, pAllocator, record_obj, chassis_state](std::pair<uint32_t, VkPipeline*> pipelines) {
                 // Just need to capture chassis state to maintain pipeline creations parameters alive, see
                 // https://vkdoc.net/chapters/deferred-host-operations#deferred-host-operations-requesting
                 (void)chassis_state;
@@ -1626,7 +1623,7 @@ void Device::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDefer
             if (dispatch_device_->wrap_handles) {
                 deferredOperation = dispatch_device_->Unwrap(deferredOperation);
             }
-            std::vector<std::function<void(std::pair<uint32_t, VkPipeline *>)>> cleanup_fn;
+            std::vector<std::function<void(std::pair<uint32_t, VkPipeline*>)>> cleanup_fn;
             auto find_res = dispatch_device_->deferred_operation_post_check.pop(deferredOperation);
             if (find_res->first) {
                 cleanup_fn = std::move(find_res->second);
@@ -1647,9 +1644,9 @@ void Device::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDefer
 }
 
 void Device::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                       const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                       const RecordObject &record_obj) {
+                                                       const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
+                                                       const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                       const RecordObject& record_obj) {
     if (VK_ERROR_VALIDATION_FAILED_EXT == record_obj.result) return;
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
@@ -1663,9 +1660,9 @@ void Device::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipeli
 
 void Device::PostCallRecordCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                        VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                       const VkDataGraphPipelineCreateInfoARM *pCreateInfos,
-                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                       const RecordObject &record_obj) {
+                                                       const VkDataGraphPipelineCreateInfoARM* pCreateInfos,
+                                                       const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                       const RecordObject& record_obj) {
     if (VK_ERROR_VALIDATION_FAILED_EXT == record_obj.result) return;
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
@@ -1678,26 +1675,26 @@ void Device::PostCallRecordCreateDataGraphPipelinesARM(VkDevice device, VkDeferr
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-bool Device::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT *pMetalObjectsInfo,
-                                                  const ErrorObject &error_obj) const {
+bool Device::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT* pMetalObjectsInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkExportMetalObjectsEXT-device-parameter"
 
-    const VkBaseOutStructure *metal_objects_info_ptr = reinterpret_cast<const VkBaseOutStructure *>(pMetalObjectsInfo->pNext);
+    const VkBaseOutStructure* metal_objects_info_ptr = reinterpret_cast<const VkBaseOutStructure*>(pMetalObjectsInfo->pNext);
     while (metal_objects_info_ptr) {
         switch (metal_objects_info_ptr->sType) {
             case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT: {
-                auto metal_command_queue_ptr = reinterpret_cast<const VkExportMetalCommandQueueInfoEXT *>(metal_objects_info_ptr);
+                auto metal_command_queue_ptr = reinterpret_cast<const VkExportMetalCommandQueueInfoEXT*>(metal_objects_info_ptr);
                 skip |= ValidateObject(metal_command_queue_ptr->queue, kVulkanObjectTypeQueue, false,
                                        "VUID-VkExportMetalCommandQueueInfoEXT-queue-parameter", kVUIDUndefined, error_obj.location);
             } break;
             case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT: {
-                auto metal_buffer_ptr = reinterpret_cast<const VkExportMetalBufferInfoEXT *>(metal_objects_info_ptr);
+                auto metal_buffer_ptr = reinterpret_cast<const VkExportMetalBufferInfoEXT*>(metal_objects_info_ptr);
                 skip |= ValidateObject(metal_buffer_ptr->memory, kVulkanObjectTypeDeviceMemory, false,
                                        "VUID-VkExportMetalBufferInfoEXT-memory-parameter", kVUIDUndefined, error_obj.location);
             } break;
             case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT: {
-                auto metal_texture_ptr = reinterpret_cast<const VkExportMetalTextureInfoEXT *>(metal_objects_info_ptr);
+                auto metal_texture_ptr = reinterpret_cast<const VkExportMetalTextureInfoEXT*>(metal_objects_info_ptr);
                 skip |= ValidateObject(metal_texture_ptr->image, kVulkanObjectTypeImage, true,
                                        "VUID-VkExportMetalTextureInfoEXT-image-parameter",
                                        "VUID-VkExportMetalTextureInfoEXT-commonparent", error_obj.location);
@@ -1709,12 +1706,12 @@ bool Device::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportMetal
                                        "VUID-VkExportMetalTextureInfoEXT-commonparent", error_obj.location);
             } break;
             case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT: {
-                auto metal_iosurface_ptr = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(metal_objects_info_ptr);
+                auto metal_iosurface_ptr = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT*>(metal_objects_info_ptr);
                 skip |= ValidateObject(metal_iosurface_ptr->image, kVulkanObjectTypeImage, false,
                                        "VUID-VkExportMetalIOSurfaceInfoEXT-image-parameter", kVUIDUndefined, error_obj.location);
             } break;
             case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT: {
-                auto metal_shared_event_ptr = reinterpret_cast<const VkExportMetalSharedEventInfoEXT *>(metal_objects_info_ptr);
+                auto metal_shared_event_ptr = reinterpret_cast<const VkExportMetalSharedEventInfoEXT*>(metal_objects_info_ptr);
                 skip |= ValidateObject(metal_shared_event_ptr->semaphore, kVulkanObjectTypeSemaphore, true,
                                        "VUID-VkExportMetalSharedEventInfoEXT-semaphore-parameter",
                                        "VUID-VkExportMetalSharedEventInfoEXT-commonparent", error_obj.location);
@@ -1732,8 +1729,8 @@ bool Device::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportMetal
 }
 #endif  //  VK_USE_PLATFORM_METAL_EXT
 
-bool Device::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT *pDescriptorInfo, size_t dataSize,
-                                             void *pDescriptor, const ErrorObject &error_obj) const {
+bool Device::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT* pDescriptorInfo, size_t dataSize,
+                                             void* pDescriptor, const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkGetDescriptorEXT-device-parameter"
     skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, kVUIDUndefined, kVUIDUndefined,
@@ -1744,7 +1741,7 @@ bool Device::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptor
 
 // Need to manually check if objectType and objectHandle are valid
 bool Device::PreCallValidateSetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
-                                           VkPrivateDataSlot privateDataSlot, uint64_t data, const ErrorObject &error_obj) const {
+                                           VkPrivateDataSlot privateDataSlot, uint64_t data, const ErrorObject& error_obj) const {
     bool skip = false;
 
     if (IsInstanceVkObjectType(objectType) || objectType == VK_OBJECT_TYPE_UNKNOWN) {
@@ -1770,7 +1767,7 @@ bool Device::PreCallValidateSetPrivateData(VkDevice device, VkObjectType objectT
 }
 
 bool Device::PreCallValidateGetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
-                                           VkPrivateDataSlot privateDataSlot, uint64_t *pData, const ErrorObject &error_obj) const {
+                                           VkPrivateDataSlot privateDataSlot, uint64_t* pData, const ErrorObject& error_obj) const {
     bool skip = false;
     if (IsInstanceVkObjectType(objectType) || objectType == VK_OBJECT_TYPE_UNKNOWN) {
         skip |= LogError("VUID-vkGetPrivateData-objectType-04018", device, error_obj.location.dot(Field::objectType), "is %s.",
@@ -1795,9 +1792,9 @@ bool Device::PreCallValidateGetPrivateData(VkDevice device, VkObjectType objectT
 }
 
 void Device::PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                  const VkComputePipelineCreateInfo *pCreateInfos,
-                                                  const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                  const RecordObject &record_obj) {
+                                                  const VkComputePipelineCreateInfo* pCreateInfos,
+                                                  const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                  const RecordObject& record_obj) {
     if (VK_ERROR_VALIDATION_FAILED_EXT == record_obj.result) return;
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
@@ -1810,9 +1807,9 @@ void Device::PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCac
 }
 
 void Device::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                   const VkGraphicsPipelineCreateInfo *pCreateInfos,
-                                                   const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                   const RecordObject &record_obj) {
+                                                   const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                   const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                   const RecordObject& record_obj) {
     if (VK_ERROR_VALIDATION_FAILED_EXT == record_obj.result) return;
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
@@ -1830,7 +1827,7 @@ void Device::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCa
                     small_vector<std::shared_ptr<ObjectState>, 4> libraries;
                     for (uint32_t index2 = 0; index2 < pNext->libraryCount; ++index2) {
                         const uint64_t library_handle = HandleToUint64(pNext->pLibraries[index2]);
-                        const auto &linked_pipeline = tracker.object_map[kVulkanObjectTypePipeline].find(library_handle);
+                        const auto& linked_pipeline = tracker.object_map[kVulkanObjectTypePipeline].find(library_handle);
                         libraries.emplace_back(linked_pipeline->second);
                     }
                     linked_graphics_pipeline_map.insert(linked_handle, libraries);
@@ -1840,17 +1837,17 @@ void Device::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCa
     }
 }
 
-void Device::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
-                                          const RecordObject &record_obj) {
+void Device::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator,
+                                          const RecordObject& record_obj) {
     RecordDestroyObject(pipeline, kVulkanObjectTypePipeline, record_obj.location);
 
     linked_graphics_pipeline_map.erase(HandleToUint64(pipeline));
 }
 
-bool Device::PreCallValidateCreateIndirectExecutionSetEXT(VkDevice device, const VkIndirectExecutionSetCreateInfoEXT *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator,
-                                                          VkIndirectExecutionSetEXT *pIndirectExecutionSet,
-                                                          const ErrorObject &error_obj) const {
+bool Device::PreCallValidateCreateIndirectExecutionSetEXT(VkDevice device, const VkIndirectExecutionSetCreateInfoEXT* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator,
+                                                          VkIndirectExecutionSetEXT* pIndirectExecutionSet,
+                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkCreateIndirectExecutionSetEXT-device-parameter"
 
@@ -1864,7 +1861,7 @@ bool Device::PreCallValidateCreateIndirectExecutionSetEXT(VkDevice device, const
     }
 
     if (pCreateInfo->type == VK_INDIRECT_EXECUTION_SET_INFO_TYPE_SHADER_OBJECTS_EXT && pCreateInfo->info.pShaderInfo) {
-        const VkIndirectExecutionSetShaderInfoEXT &shader_info = *pCreateInfo->info.pShaderInfo;
+        const VkIndirectExecutionSetShaderInfoEXT& shader_info = *pCreateInfo->info.pShaderInfo;
         const Location shader_info_loc = info_loc.dot(Field::pShaderInfo);
         if (shader_info.pSetLayoutInfos && shader_info.pInitialShaders) {
             for (uint32_t i = 0; i < shader_info.shaderCount; ++i) {
@@ -1873,7 +1870,7 @@ bool Device::PreCallValidateCreateIndirectExecutionSetEXT(VkDevice device, const
                                        shader_info_loc.dot(Field::pInitialShaders, i));
 
                 const Location set_layout_info_loc = shader_info_loc.dot(Field::pSetLayoutInfos, i);
-                const VkIndirectExecutionSetShaderLayoutInfoEXT &layout_info = shader_info.pSetLayoutInfos[i];
+                const VkIndirectExecutionSetShaderLayoutInfoEXT& layout_info = shader_info.pSetLayoutInfos[i];
                 if ((layout_info.setLayoutCount > 0) && (layout_info.pSetLayouts)) {
                     for (uint32_t layout_index = 0; layout_index < layout_info.setLayoutCount; ++layout_index) {
                         skip |= ValidateObject(layout_info.pSetLayouts[layout_index], kVulkanObjectTypeDescriptorSetLayout, true,
@@ -1889,9 +1886,9 @@ bool Device::PreCallValidateCreateIndirectExecutionSetEXT(VkDevice device, const
     return skip;
 }
 
-bool Device::PreCallValidateReleaseCapturedPipelineDataKHR(VkDevice device, const VkReleaseCapturedPipelineDataInfoKHR *pInfo,
-                                                           const VkAllocationCallbacks *pAllocator,
-                                                           const ErrorObject &error_obj) const {
+bool Device::PreCallValidateReleaseCapturedPipelineDataKHR(VkDevice device, const VkReleaseCapturedPipelineDataInfoKHR* pInfo,
+                                                           const VkAllocationCallbacks* pAllocator,
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     // Checked by chassis: device: "VUID-vkReleaseCapturedPipelineDataKHR-device-parameter"
 
@@ -1909,9 +1906,9 @@ bool Device::PreCallValidateReleaseCapturedPipelineDataKHR(VkDevice device, cons
     return skip;
 }
 
-void Device::PostCallRecordCreatePipelineBinariesKHR(VkDevice device, const VkPipelineBinaryCreateInfoKHR *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator,
-                                                     VkPipelineBinaryHandlesInfoKHR *pBinaries, const RecordObject &record_obj) {
+void Device::PostCallRecordCreatePipelineBinariesKHR(VkDevice device, const VkPipelineBinaryCreateInfoKHR* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator,
+                                                     VkPipelineBinaryHandlesInfoKHR* pBinaries, const RecordObject& record_obj) {
     if (record_obj.result < VK_SUCCESS) return;
 
     if (pBinaries->pPipelineBinaries) {

--- a/layers/profiling/profiling.cpp
+++ b/layers/profiling/profiling.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,46 +26,46 @@
 
 #if defined(VVL_TRACY_CPU_MEMORY)
 
-void *operator new(std ::size_t size) {
+void* operator new(std ::size_t size) {
     auto ptr = malloc(size);
     VVL_TracyAlloc(ptr, size);
     return ptr;
 }
 
-void operator delete(void *ptr) noexcept {
+void operator delete(void* ptr) noexcept {
     VVL_TracyFree(ptr);
     free(ptr);
 }
 
-void *operator new[](std::size_t size) {
+void* operator new[](std::size_t size) {
     auto ptr = malloc(size);
     VVL_TracyAlloc(ptr, size);
     return ptr;
 }
 
-void operator delete[](void *ptr) noexcept {
+void operator delete[](void* ptr) noexcept {
     VVL_TracyFree(ptr);
     free(ptr);
 };
 
-void *operator new(std::size_t size, const std::nothrow_t &) noexcept {
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
     auto ptr = malloc(size);
     VVL_TracyAlloc(ptr, size);
     return ptr;
 }
 
-void operator delete(void *ptr, const std::nothrow_t &) noexcept {
+void operator delete(void* ptr, const std::nothrow_t&) noexcept {
     VVL_TracyFree(ptr);
     free(ptr);
 }
 
-void *operator new[](std::size_t size, const std::nothrow_t &) noexcept {
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
     auto ptr = malloc(size);
     VVL_TracyAlloc(ptr, size);
     return ptr;
 }
 
-void operator delete[](void *ptr, const std::nothrow_t &) noexcept {
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
     VVL_TracyFree(ptr);
     free(ptr);
 }
@@ -77,52 +77,52 @@ void operator delete[](void *ptr, const std::nothrow_t &) noexcept {
 #define vvl_aligned_free(ptr) _aligned_free(ptr)
 #else
 // TODO - Need to understand why on Linux sometimes calling aligned_alloc causes corruption
-void *vvl_aligned_malloc(std::size_t size, std::size_t al) {
-    void *mem = malloc(size + al + sizeof(void *));
-    void **ptr = (void **)((uintptr_t)((uintptr_t)mem + al + sizeof(void *)) & ~(al - 1));
+void* vvl_aligned_malloc(std::size_t size, std::size_t al) {
+    void* mem = malloc(size + al + sizeof(void*));
+    void** ptr = (void**)((uintptr_t)((uintptr_t)mem + al + sizeof(void*)) & ~(al - 1));
     ptr[-1] = mem;
     return ptr;
 }
 
-void vvl_aligned_free(void *ptr) { free(((void **)ptr)[-1]); }
+void vvl_aligned_free(void* ptr) { free(((void**)ptr)[-1]); }
 #endif
 
-void *operator new(std::size_t size, std::align_val_t al) noexcept(false) {
+void* operator new(std::size_t size, std::align_val_t al) noexcept(false) {
     auto ptr = vvl_aligned_malloc(size, size_t(al));
     VVL_TracyAlloc(ptr, size);
     return ptr;
 }
-void *operator new[](std::size_t size, std::align_val_t al) noexcept(false) {
-    auto ptr = vvl_aligned_malloc(size, size_t(al));
-    VVL_TracyAlloc(ptr, size);
-    return ptr;
-}
-
-void *operator new(std::size_t size, std::align_val_t al, const std::nothrow_t &) noexcept {
-    auto ptr = vvl_aligned_malloc(size, size_t(al));
-    VVL_TracyAlloc(ptr, size);
-    return ptr;
-}
-void *operator new[](std::size_t size, std::align_val_t al, const std::nothrow_t &) noexcept {
+void* operator new[](std::size_t size, std::align_val_t al) noexcept(false) {
     auto ptr = vvl_aligned_malloc(size, size_t(al));
     VVL_TracyAlloc(ptr, size);
     return ptr;
 }
 
-void operator delete(void *ptr, std::align_val_t al) noexcept {
+void* operator new(std::size_t size, std::align_val_t al, const std::nothrow_t&) noexcept {
+    auto ptr = vvl_aligned_malloc(size, size_t(al));
+    VVL_TracyAlloc(ptr, size);
+    return ptr;
+}
+void* operator new[](std::size_t size, std::align_val_t al, const std::nothrow_t&) noexcept {
+    auto ptr = vvl_aligned_malloc(size, size_t(al));
+    VVL_TracyAlloc(ptr, size);
+    return ptr;
+}
+
+void operator delete(void* ptr, std::align_val_t al) noexcept {
     VVL_TracyFree(ptr);
     vvl_aligned_free(ptr);
 }
-void operator delete[](void *ptr, std::align_val_t al) noexcept {
+void operator delete[](void* ptr, std::align_val_t al) noexcept {
     VVL_TracyFree(ptr);
     vvl_aligned_free(ptr);
 }
 
-void operator delete(void *ptr, std::align_val_t al, const std::nothrow_t &) noexcept {
+void operator delete(void* ptr, std::align_val_t al, const std::nothrow_t&) noexcept {
     VVL_TracyFree(ptr);
     vvl_aligned_free(ptr);
 }
-void operator delete[](void *ptr, std::align_val_t al, const std::nothrow_t &) noexcept {
+void operator delete[](void* ptr, std::align_val_t al, const std::nothrow_t&) noexcept {
     VVL_TracyFree(ptr);
     vvl_aligned_free(ptr);
 }
@@ -164,7 +164,7 @@ __attribute__((constructor)) static void so_attach(void) { tracy::StartupProfile
 // To do things properly, should be a per device object
 static std::array<TracyVkCtx, 8> tracy_vk_contexts;
 
-TracyVkCtx &GetTracyVkCtx() {
+TracyVkCtx& GetTracyVkCtx() {
     static std::atomic<uint32_t> context_counter = {0};
     uint32_t context_i = context_counter.fetch_add(1, std::memory_order_relaxed);
     context_i = context_i % (uint32_t)tracy_vk_contexts.size();
@@ -211,14 +211,14 @@ struct ZoneProfilingCommandPool {
         return cmd_buffers[cb_i];
     }
 };
-static vvl::concurrent_unordered_map<VkQueue, ZoneProfilingCommandPool *> &GetQueueToGpuZoneProfilingCommandPoolMap() {
-    static vvl::concurrent_unordered_map<VkQueue, ZoneProfilingCommandPool *> map;
+static vvl::concurrent_unordered_map<VkQueue, ZoneProfilingCommandPool*>& GetQueueToGpuZoneProfilingCommandPoolMap() {
+    static vvl::concurrent_unordered_map<VkQueue, ZoneProfilingCommandPool*> map;
     return map;
 }
 
 void TracyVkCollector::Create(VkDevice device, VkQueue queue, uint32_t queue_family_i) {
     if (std::find_if(queue_to_collector_map.begin(), queue_to_collector_map.end(),
-                     [queue](const std::unique_ptr<TracyVkCollector> &collector) { return collector->queue == queue; }) !=
+                     [queue](const std::unique_ptr<TracyVkCollector>& collector) { return collector->queue == queue; }) !=
         queue_to_collector_map.end()) {
         return;
     }
@@ -255,7 +255,7 @@ void TracyVkCollector::Create(VkDevice device, VkQueue queue, uint32_t queue_fam
         assert(result == VK_SUCCESS);
 
         zone_profiling_cmd_pool->fences.resize(cmd_buf_ai.commandBufferCount);
-        for (VkFence &fence : zone_profiling_cmd_pool->fences) {
+        for (VkFence& fence : zone_profiling_cmd_pool->fences) {
             VkFenceCreateInfo fence_ci = vku::InitStructHelper();
             fence_ci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
             result = TracyVkCollector::CreateFence(device, &fence_ci, nullptr, &fence);
@@ -323,7 +323,7 @@ void TracyVkCollector::Create(VkDevice device, VkQueue queue, uint32_t queue_fam
                 VkCommandBufferBeginInfo cmd_buf_bi = vku::InitStructHelper();
                 cmd_buf_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
                 TracyVkCollector::BeginCommandBuffer(collector_ptr->cmd_buf, &cmd_buf_bi);
-                for (TracyVkCtx &tracy_vk_ctx : tracy_vk_contexts) {
+                for (TracyVkCtx& tracy_vk_ctx : tracy_vk_contexts) {
                     tracy_vk_ctx->Collect(collector_ptr->cmd_buf);
                 }
                 TracyVkCollector::EndCommandBuffer(collector_ptr->cmd_buf);
@@ -344,7 +344,7 @@ void TracyVkCollector::Create(VkDevice device, VkQueue queue, uint32_t queue_fam
 #endif
 }
 
-void TracyVkCollector::Destroy(TracyVkCollector &collector) {
+void TracyVkCollector::Destroy(TracyVkCollector& collector) {
 #if defined(TRACY_GPU_PROFILING_DEBUG)
     VVL_TracyMessageStream("[tracyvk] Destroying TracyVkCollector: device: " << collector.device << " queue: " << collector.queue);
 #endif
@@ -396,11 +396,11 @@ std::optional<std::pair<VkCommandBuffer, VkFence>> TracyVkCollector::TryGetColle
 }
 
 // Not thread safe for now, should be fine to profile GFXR traces
-TracyVkCollector &TracyVkCollector::GetTracyVkCollector(VkQueue queue) {
+TracyVkCollector& TracyVkCollector::GetTracyVkCollector(VkQueue queue) {
 #if defined(TRACY_GPU_PROFILING_DEBUG)
     VVL_TracyMessageStream("[tracyvk] Getting TracyVkCollector for queue " << queue);
 #endif
-    for (const std::unique_ptr<TracyVkCollector> &collector : queue_to_collector_map) {
+    for (const std::unique_ptr<TracyVkCollector>& collector : queue_to_collector_map) {
         if (collector->queue == queue) return *collector;
     }
     assert(false);
@@ -409,7 +409,7 @@ TracyVkCollector &TracyVkCollector::GetTracyVkCollector(VkQueue queue) {
 
 void TracyVkCollector::TrySubmitCollectCb(VkQueue queue) {
     VVL_ZoneScoped;
-    TracyVkCollector &collector = GetTracyVkCollector(queue);
+    TracyVkCollector& collector = GetTracyVkCollector(queue);
 
     std::optional<std::pair<VkCommandBuffer, VkFence>> collect_cb = collector.TryGetCollectCb(queue);
     if (collect_cb.has_value()) {
@@ -423,7 +423,7 @@ void TracyVkCollector::TrySubmitCollectCb(VkQueue queue) {
 }
 
 void InitTracyVk(VkInstance instance, VkPhysicalDevice gpu, VkDevice device, PFN_vkGetInstanceProcAddr GetInstanceProcAddr,
-                 PFN_vkGetDeviceProcAddr GetDeviceProcAddr, VkLayerDispatchTable &device_dispatch_table) {
+                 PFN_vkGetDeviceProcAddr GetDeviceProcAddr, VkLayerDispatchTable& device_dispatch_table) {
     VVL_ZoneScoped;
 
     TracyVkCollector::CreateCommandPool = device_dispatch_table.CreateCommandPool;
@@ -440,7 +440,7 @@ void InitTracyVk(VkInstance instance, VkPhysicalDevice gpu, VkDevice device, PFN
     TracyVkCollector::EndCommandBuffer = device_dispatch_table.EndCommandBuffer;
     TracyVkCollector::QueueSubmit = device_dispatch_table.QueueSubmit;
 
-    for (TracyVkCtx &tracy_vk_ctx : tracy_vk_contexts) {
+    for (TracyVkCtx& tracy_vk_ctx : tracy_vk_contexts) {
         tracy_vk_ctx = TracyVkContextHostCalibrated(instance, gpu, device, GetInstanceProcAddr, GetDeviceProcAddr);
         assert(tracy_vk_ctx);
     }
@@ -458,20 +458,20 @@ void CleanupTracyVk(VkDevice device) {
     }
     // Should be per device. Or maybe not, since queue handles are already per device?
     auto queues_to_zpcp = GetQueueToGpuZoneProfilingCommandPoolMap().snapshot();
-    for (auto &[queue, zpcp] : queues_to_zpcp) {
+    for (auto& [queue, zpcp] : queues_to_zpcp) {
         zpcp->Destroy();
         delete zpcp;
     }
     GetQueueToGpuZoneProfilingCommandPoolMap().clear();
 
-    for (TracyVkCtx &tracy_vk_ctx : tracy_vk_contexts) {
+    for (TracyVkCtx& tracy_vk_ctx : tracy_vk_contexts) {
         if (tracy_vk_ctx) {
             TracyVkDestroy(tracy_vk_ctx);
         }
     }
 }
 
-tracy::VkCtxManualScope TracyVkZoneStart(tracy::VkCtx *ctx, const tracy::SourceLocationData *srcloc, VkQueue queue) {
+tracy::VkCtxManualScope TracyVkZoneStart(tracy::VkCtx* ctx, const tracy::SourceLocationData* srcloc, VkQueue queue) {
     VVL_ZoneScoped;
 
     // Get a GPU zone profiling command buffer
@@ -504,7 +504,7 @@ tracy::VkCtxManualScope TracyVkZoneStart(tracy::VkCtx *ctx, const tracy::SourceL
     return ctx_manual_scope;
 }
 
-void TracyVkZoneEnd(tracy::VkCtxManualScope &scope_to_close, VkQueue queue) {
+void TracyVkZoneEnd(tracy::VkCtxManualScope& scope_to_close, VkQueue queue) {
     VVL_ZoneScoped;
 
     // Get a GPU zone profiling command buffer

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -23,24 +23,24 @@
 #include "generated/dispatch_functions.h"
 #include "state_tracker/state_tracker.h"
 
-static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkBufferCreateInfo *create_info) {
-    const auto *external_memory_info = vku::FindStructInPNextChain<VkExternalMemoryBufferCreateInfo>(create_info->pNext);
+static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkBufferCreateInfo* create_info) {
+    const auto* external_memory_info = vku::FindStructInPNextChain<VkExternalMemoryBufferCreateInfo>(create_info->pNext);
     return external_memory_info ? external_memory_info->handleTypes : 0;
 }
 
-static VkMemoryRequirements GetMemoryRequirements(vvl::DeviceState &dev_data, VkBuffer buffer) {
+static VkMemoryRequirements GetMemoryRequirements(vvl::DeviceState& dev_data, VkBuffer buffer) {
     VkMemoryRequirements result{};
     DispatchGetBufferMemoryRequirements(dev_data.device, buffer, &result);
     return result;
 }
 
-static VkBufferUsageFlags2 GetBufferUsageFlags(const VkBufferCreateInfo &create_info) {
-    const auto *usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(create_info.pNext);
+static VkBufferUsageFlags2 GetBufferUsageFlags(const VkBufferCreateInfo& create_info) {
+    const auto* usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(create_info.pNext);
     return usage_flags2 ? usage_flags2->usage : create_info.usage;
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-static bool GetMetalExport(const VkBufferViewCreateInfo *info) {
+static bool GetMetalExport(const VkBufferViewCreateInfo* info) {
     bool retval = false;
     auto export_metal_object_info = vku::FindStructInPNextChain<VkExportMetalObjectCreateInfoEXT>(info->pNext);
     while (export_metal_object_info) {
@@ -63,7 +63,7 @@ namespace vvl {
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
-Buffer::Buffer(DeviceState &dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
+Buffer::Buffer(DeviceState& dev_data, VkBuffer handle, const VkBufferCreateInfo* pCreateInfo)
     : Bindable(handle, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
@@ -84,15 +84,15 @@ Buffer::Buffer(DeviceState &dev_data, VkBuffer handle, const VkBufferCreateInfo 
 
 void Buffer::Destroy() {
     if (!Destroyed()) {
-        for (auto &item : sub_states_) {
+        for (auto& item : sub_states_) {
             item.second->Destroy();
         }
         Bindable::Destroy();
     }
 }
 
-void Buffer::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &item : sub_states_) {
+void Buffer::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
+    for (auto& item : sub_states_) {
         item.second->NotifyInvalidate(invalid_nodes, unlink);
     }
     Bindable::NotifyInvalidate(invalid_nodes, unlink);
@@ -102,7 +102,7 @@ void Buffer::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool u
 #pragma GCC diagnostic pop
 #endif
 
-bool Buffer::CompareCreateInfo(const Buffer &other) const {
+bool Buffer::CompareCreateInfo(const Buffer& other) const {
     bool valid_queue_family = true;
     if (create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
         if (create_info.queueFamilyIndexCount != other.create_info.queueFamilyIndexCount) {
@@ -133,7 +133,7 @@ std::string Buffer::Describe(const Logger& dev_data) const {
     return ss.str();
 }
 
-BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView handle, const VkBufferViewCreateInfo *pCreateInfo,
+BufferView::BufferView(const std::shared_ptr<vvl::Buffer>& bf, VkBufferView handle, const VkBufferViewCreateInfo* pCreateInfo,
                        VkFormatFeatureFlags2 format_features)
     : StateObject(handle, kVulkanObjectTypeBufferView),
       safe_create_info(pCreateInfo),
@@ -146,7 +146,7 @@ BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView hand
 }
 
 void BufferView::Destroy() {
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Destroy();
     }
     if (buffer_state) {
@@ -156,8 +156,8 @@ void BufferView::Destroy() {
     StateObject::Destroy();
 }
 
-void BufferView::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &item : sub_states_) {
+void BufferView::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
+    for (auto& item : sub_states_) {
         item.second->NotifyInvalidate(invalid_nodes, unlink);
     }
     StateObject::NotifyInvalidate(invalid_nodes, unlink);
@@ -182,7 +182,7 @@ void BufferAddressRange::NotifyInvalidate(const StateObject::NodeList& invalid_n
             continue;
         }
 
-        for (const auto &node : invalid_nodes) {
+        for (const auto& node : invalid_nodes) {
             if (node.get() == buffer_state) {
                 buffer_state->RemoveParent(this);
                 internal_range.invalidated_handles.emplace_back(buffer_state->VkHandle());

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -62,7 +62,7 @@ bool AttachmentInfo::IsStencil() const {
 // For Traditional RenderPasses, the index is simply the index into the VkRenderPassCreateInfo::pAttachments,
 // but for dynamic rendering, there is no "standard" way to map the index, instead we have our own custom indexing and it is not
 // obvious at all to the user where it came from
-std::string AttachmentInfo::Describe(const vvl::CommandBuffer &cb_state, uint32_t rp_index) const {
+std::string AttachmentInfo::Describe(const vvl::CommandBuffer& cb_state, uint32_t rp_index) const {
     std::ostringstream ss;
     if (cb_state.attachment_source == AttachmentSource::DynamicRendering) {
         ss << "VkRenderingInfo::";
@@ -114,7 +114,7 @@ std::string AttachmentInfo::Describe(const vvl::CommandBuffer &cb_state, uint32_
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-static bool GetMetalExport(const VkEventCreateInfo *info) {
+static bool GetMetalExport(const VkEventCreateInfo* info) {
     bool retval = false;
     auto export_metal_object_info = vku::FindStructInPNextChain<VkExportMetalObjectCreateInfoEXT>(info->pNext);
     while (export_metal_object_info) {
@@ -130,7 +130,7 @@ static bool GetMetalExport(const VkEventCreateInfo *info) {
 
 namespace vvl {
 
-Event::Event(VkEvent handle, const VkEventCreateInfo *create_info)
+Event::Event(VkEvent handle, const VkEventCreateInfo* create_info)
     : StateObject(handle, kVulkanObjectTypeEvent),
       flags(create_info->flags)
 #ifdef VK_USE_PLATFORM_METAL_EXT
@@ -140,7 +140,7 @@ Event::Event(VkEvent handle, const VkEventCreateInfo *create_info)
 {
 }
 
-CommandPool::CommandPool(DeviceState &dev, VkCommandPool handle, const VkCommandPoolCreateInfo *create_info, VkQueueFlags flags)
+CommandPool::CommandPool(DeviceState& dev, VkCommandPool handle, const VkCommandPoolCreateInfo* create_info, VkQueueFlags flags)
     : StateObject(handle, kVulkanObjectTypeCommandPool),
       dev_data(dev),
       createFlags(create_info->flags),
@@ -148,7 +148,7 @@ CommandPool::CommandPool(DeviceState &dev, VkCommandPool handle, const VkCommand
       queue_flags(flags),
       unprotected((create_info->flags & VK_COMMAND_POOL_CREATE_PROTECTED_BIT) == 0) {}
 
-void CommandPool::Allocate(const VkCommandBufferAllocateInfo *allocate_info, const VkCommandBuffer *command_buffers) {
+void CommandPool::Allocate(const VkCommandBufferAllocateInfo* allocate_info, const VkCommandBuffer* command_buffers) {
     for (uint32_t i = 0; i < allocate_info->commandBufferCount; i++) {
         auto new_cb = dev_data.CreateCmdBufferState(command_buffers[i], allocate_info, this);
         commandBuffers.emplace(command_buffers[i], new_cb.get());
@@ -156,7 +156,7 @@ void CommandPool::Allocate(const VkCommandBufferAllocateInfo *allocate_info, con
     }
 }
 
-void CommandPool::Free(uint32_t count, const VkCommandBuffer *command_buffers) {
+void CommandPool::Free(uint32_t count, const VkCommandBuffer* command_buffers) {
     for (uint32_t i = 0; i < count; i++) {
         auto iter = commandBuffers.find(command_buffers[i]);
         if (iter != commandBuffers.end()) {
@@ -166,15 +166,15 @@ void CommandPool::Free(uint32_t count, const VkCommandBuffer *command_buffers) {
     }
 }
 
-void CommandPool::Reset(const Location &loc) {
-    for (auto &entry : commandBuffers) {
+void CommandPool::Reset(const Location& loc) {
+    for (auto& entry : commandBuffers) {
         auto guard = entry.second->WriteLock();
         entry.second->Reset(loc);
     }
 }
 
 void CommandPool::Destroy() {
-    for (auto &entry : commandBuffers) {
+    for (auto& entry : commandBuffers) {
         dev_data.Destroy<CommandBuffer>(entry.first);
     }
     commandBuffers.clear();
@@ -188,7 +188,7 @@ void CommandBuffer::SetActiveSubpass(uint32_t subpass) {
 }
 
 // Put here, instead of vvl::RenderPass for ease of access
-const char *CommandBuffer::DescribeActiveColorAttachment() const {
+const char* CommandBuffer::DescribeActiveColorAttachment() const {
     if (!active_render_pass) {
         return "";
     } else if (active_render_pass->UsesDynamicRendering()) {
@@ -198,8 +198,8 @@ const char *CommandBuffer::DescribeActiveColorAttachment() const {
     }
 }
 
-CommandBuffer::CommandBuffer(DeviceState &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *allocate_info,
-                             const vvl::CommandPool *pool)
+CommandBuffer::CommandBuffer(DeviceState& dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* allocate_info,
+                             const vvl::CommandPool* pool)
     : RefcountedStateObject(handle, kVulkanObjectTypeCommandBuffer),
       allocate_info(*allocate_info),
       command_pool(pool),
@@ -213,27 +213,27 @@ CommandBuffer::CommandBuffer(DeviceState &dev, VkCommandBuffer handle, const VkC
 }
 
 // Get the image viewstate for a given framebuffer attachment
-vvl::ImageView *CommandBuffer::GetActiveAttachmentImageViewState(uint32_t index) {
+vvl::ImageView* CommandBuffer::GetActiveAttachmentImageViewState(uint32_t index) {
     assert(!active_attachments.empty() && index != VK_ATTACHMENT_UNUSED && (index < active_attachments.size()));
     return active_attachments[index].image_view;
 }
 
 // Get the image viewstate for a given framebuffer attachment
-const vvl::ImageView *CommandBuffer::GetActiveAttachmentImageViewState(uint32_t index) const {
+const vvl::ImageView* CommandBuffer::GetActiveAttachmentImageViewState(uint32_t index) const {
     if (active_attachments.empty() || index == VK_ATTACHMENT_UNUSED || (index >= active_attachments.size())) {
         return nullptr;
     }
     return active_attachments[index].image_view;
 }
 
-void CommandBuffer::AddChild(std::shared_ptr<StateObject> &child_node) {
+void CommandBuffer::AddChild(std::shared_ptr<StateObject>& child_node) {
     assert(child_node);
     if (child_node->AddParent(this)) {
         object_bindings.insert(child_node);
     }
 }
 
-void CommandBuffer::RemoveChild(std::shared_ptr<StateObject> &child_node) {
+void CommandBuffer::RemoveChild(std::shared_ptr<StateObject>& child_node) {
     assert(child_node);
     child_node->RemoveParent(this);
     object_bindings.erase(child_node);
@@ -288,7 +288,7 @@ void CommandBuffer::InvalidateDescriptorMode(vvl::DescriptorMode invalidate_mode
 // Maintain the createInfo and set state to CB_NEW, but clear all other state
 void CommandBuffer::ResetCBState() {
     // Remove object bindings
-    for (const auto &obj : object_bindings) {
+    for (const auto& obj : object_bindings) {
         obj->RemoveParent(this);
     }
     object_bindings.clear();
@@ -345,7 +345,7 @@ void CommandBuffer::ResetCBState() {
     linked_command_buffers.clear();
     bound_tile_memory = nullptr;
 
-    for (auto &item : lastBound) {
+    for (auto& item : lastBound) {
         item.Reset();
     }
     active_framebuffer = VK_NULL_HANDLE;
@@ -381,11 +381,11 @@ void CommandBuffer::ResetCBState() {
     dev_data.debug_report->ResetCmdDebugUtilsLabel(VkHandle());
 }
 
-void CommandBuffer::Reset(const Location &loc) {
+void CommandBuffer::Reset(const Location& loc) {
     ResetCBState();
     // Remove reverse command buffer links.
     Invalidate(true);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Reset(loc);
     }
 }
@@ -397,25 +397,25 @@ void CommandBuffer::Destroy() {
         auto guard = WriteLock();
         ResetCBState();
     }
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Destroy();
     }
     sub_states_.clear();
     StateObject::Destroy();
 }
 
-void CommandBuffer::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
+void CommandBuffer::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
     {
         auto guard = WriteLock();
         assert(!invalid_nodes.empty());
         // Save all of the vulkan handles between the command buffer and the now invalid node
         LogObjectList log_list;
-        for (auto &obj : invalid_nodes) {
+        for (auto& obj : invalid_nodes) {
             log_list.add(obj->Handle());
         }
 
         bool found_invalid = false;
-        for (auto &obj : invalid_nodes) {
+        for (auto& obj : invalid_nodes) {
             // Only record a broken binding if one of the nodes in the invalid chain is still
             // being tracked by the command buffer. This is to try to avoid race conditions
             // caused by separate CommandBuffer and StateObject::parent_nodes locking.
@@ -426,7 +426,7 @@ void CommandBuffer::NotifyInvalidate(const StateObject::NodeList &invalid_nodes,
             switch (obj->Type()) {
                 case kVulkanObjectTypeCommandBuffer:
                     if (unlink) {
-                        linked_command_buffers.erase(static_cast<CommandBuffer *>(obj.get()));
+                        linked_command_buffers.erase(static_cast<CommandBuffer*>(obj.get()));
                     }
                     break;
                 case kVulkanObjectTypeImage:
@@ -456,7 +456,7 @@ void CommandBuffer::NotifyInvalidate(const StateObject::NodeList &invalid_nodes,
             broken_bindings.emplace(invalid_nodes[0]->Handle(), log_list);
         }
     }
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->NotifyInvalidate(invalid_nodes, unlink);
     }
     StateObject::NotifyInvalidate(invalid_nodes, unlink);
@@ -472,7 +472,7 @@ std::shared_ptr<const CommandBufferImageLayoutMap> CommandBuffer::GetImageLayout
 }
 
 // The non-const variant only needs the image state, as the factory requires it to construct a new entry
-std::shared_ptr<CommandBufferImageLayoutMap> CommandBuffer::GetOrCreateImageLayoutMap(const vvl::Image &image_state) {
+std::shared_ptr<CommandBufferImageLayoutMap> CommandBuffer::GetOrCreateImageLayoutMap(const vvl::Image& image_state) {
     // Make sure we don't create a nullptr keyed entry for a zombie Image
     if (image_state.Destroyed() || !image_state.layout_map) {
         return nullptr;
@@ -487,7 +487,7 @@ std::shared_ptr<CommandBufferImageLayoutMap> CommandBuffer::GetOrCreateImageLayo
         // Since they use the same global layout state, use it as a key
         // for the local state. We don't need a lock on the global range
         // map to do a lookup based on its pointer.
-        const auto *p_global_layout_map = image_state.layout_map.get();
+        const auto* p_global_layout_map = image_state.layout_map.get();
         auto alias_iter = aliased_image_layout_map.find(p_global_layout_map);
         if (alias_iter != aliased_image_layout_map.end()) {
             image_layout_map = alias_iter->second;
@@ -513,18 +513,18 @@ std::shared_ptr<CommandBufferImageLayoutMap> CommandBuffer::GetOrCreateImageLayo
     return image_layout_map;
 }
 
-void CommandBuffer::RecordCommand(const Location &loc) {
+void CommandBuffer::RecordCommand(const Location& loc) {
     command_count++;
 
     if (first_action_or_sync_command == Func::Empty) {
-        const CommandValidationInfo &info = GetCommandValidationInfo(loc.function);
+        const CommandValidationInfo& info = GetCommandValidationInfo(loc.function);
         if (info.action || info.synchronization) {
             first_action_or_sync_command = loc.function;
         }
     }
 }
 
-void CommandBuffer::RecordBeginQuery(const QueryObject &query_obj, const Location &loc) {
+void CommandBuffer::RecordBeginQuery(const QueryObject& query_obj, const Location& loc) {
     active_queries.insert(query_obj);
     started_queries.insert(query_obj);
 
@@ -533,28 +533,28 @@ void CommandBuffer::RecordBeginQuery(const QueryObject &query_obj, const Locatio
         render_pass_queries.insert(query_obj);
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBeginQuery(query_obj, loc);
     }
 }
 
-void CommandBuffer::RecordEndQuery(const QueryObject &query_obj, const Location &loc) {
+void CommandBuffer::RecordEndQuery(const QueryObject& query_obj, const Location& loc) {
     active_queries.erase(query_obj);
     updated_queries.insert(query_obj);
     if (query_obj.inside_render_pass) {
         render_pass_queries.erase(query_obj);
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordEndQuery(query_obj, loc);
     }
 }
 
-bool CommandBuffer::UpdatesQuery(const QueryObject &query_obj) const {
+bool CommandBuffer::UpdatesQuery(const QueryObject& query_obj) const {
     // Clear out the perf_pass from the caller because it isn't known when the command buffer is recorded.
     auto key = query_obj;
     key.perf_pass = 0;
-    for (auto *sub_cb : linked_command_buffers) {
+    for (auto* sub_cb : linked_command_buffers) {
         if (sub_cb->updated_queries.find(key) != sub_cb->updated_queries.end()) {
             return true;
         }
@@ -569,12 +569,12 @@ void CommandBuffer::RecordEndQueries(VkQueryPool queryPool, uint32_t firstQuery,
         updated_queries.insert(query_obj);
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordEndQueries(queryPool, firstQuery, queryCount);
     }
 }
 
-void CommandBuffer::RecordWriteTimestamp(VkQueryPool queryPool, uint32_t slot, const Location &loc) {
+void CommandBuffer::RecordWriteTimestamp(VkQueryPool queryPool, uint32_t slot, const Location& loc) {
     RecordCommand(loc);
     if (dev_data.disabled[query_validation]) {
         return;
@@ -586,7 +586,7 @@ void CommandBuffer::RecordWriteTimestamp(VkQueryPool queryPool, uint32_t slot, c
     }
 
     QueryObject query_obj = {queryPool, slot};
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordWriteTimestamp(query_obj, loc);
     }
 
@@ -598,7 +598,7 @@ void CommandBuffer::RecordWriteTimestamp(VkQueryPool queryPool, uint32_t slot, c
     }
 }
 
-void CommandBuffer::RecordResetQueryPool(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, const Location &loc) {
+void CommandBuffer::RecordResetQueryPool(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, const Location& loc) {
     RecordCommand(loc);
     if (dev_data.disabled[query_validation]) {
         return;
@@ -616,14 +616,14 @@ void CommandBuffer::RecordResetQueryPool(VkQueryPool queryPool, uint32_t firstQu
     }
 
     const bool is_perf_query = pool_state->create_info.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR;
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordResetQueryPool(queryPool, firstQuery, queryCount, is_perf_query, loc);
     }
 }
 
 void CommandBuffer::RecordCopyQueryPoolResults(VkQueryPool queryPool, VkBuffer dstBuffer, uint32_t firstQuery, uint32_t queryCount,
                                                VkDeviceSize dstOffset, VkDeviceSize stride, VkQueryResultFlags flags,
-                                               const Location &loc) {
+                                               const Location& loc) {
     RecordCommand(loc);
     if (dev_data.disabled[query_validation]) {
         return;
@@ -637,7 +637,7 @@ void CommandBuffer::RecordCopyQueryPoolResults(VkQueryPool queryPool, VkBuffer d
         AddChild(pool_state);
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyQueryPoolResults(*pool_state, *buffer_state, firstQuery, queryCount, dstOffset, stride, flags, loc);
     }
 }
@@ -663,7 +663,7 @@ void CommandBuffer::RecordCopyQueryPoolResultsToMemory(VkQueryPool queryPool, ui
 }
 
 void CommandBuffer::RecordWriteAccelerationStructuresProperties(VkQueryPool queryPool, uint32_t firstQuery,
-                                                                uint32_t accelerationStructureCount, const Location &loc) {
+                                                                uint32_t accelerationStructureCount, const Location& loc) {
     RecordCommand(loc);
     if (dev_data.disabled[query_validation]) {
         return;
@@ -674,7 +674,7 @@ void CommandBuffer::RecordWriteAccelerationStructuresProperties(VkQueryPool quer
         AddChild(pool_state);
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordWriteAccelerationStructuresProperties(queryPool, firstQuery, accelerationStructureCount, loc);
     }
 
@@ -688,7 +688,7 @@ void CommandBuffer::RecordWriteAccelerationStructuresProperties(VkQueryPool quer
 
 void CommandBuffer::UpdateSubpassAttachments() {
     ASSERT_AND_RETURN(active_render_pass);
-    const auto &subpass = active_render_pass->create_info.pSubpasses[GetActiveSubpass()];
+    const auto& subpass = active_render_pass->create_info.pSubpasses[GetActiveSubpass()];
     assert(active_subpasses.size() == active_attachments.size());
 
     for (size_t i = 0; i < active_attachments.size(); ++i) {
@@ -737,7 +737,7 @@ void CommandBuffer::UpdateSubpassAttachments() {
             active_attachments[attachment_index].type = AttachmentInfo::Type::DepthStencil;
             active_attachments[attachment_index].layout = subpass.pDepthStencilAttachment->layout;
             // Look for potential dedicated stencil layout
-            if (const auto *stencil_layout =
+            if (const auto* stencil_layout =
                     vku::FindStructInPNextChain<VkAttachmentReferenceStencilLayout>(subpass.pDepthStencilAttachment->pNext)) {
                 active_attachments[attachment_index].separate_stencil_layout = stencil_layout->stencilLayout;
             }
@@ -774,10 +774,11 @@ void CommandBuffer::UpdateSubpassAttachments() {
 }
 
 // For non Dynamic Renderpass we update the attachments
-void CommandBuffer::UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPassBegin) {
+void CommandBuffer::UpdateAttachmentsView(const VkRenderPassBeginInfo* pRenderPassBegin) {
     const bool imageless = (active_framebuffer->create_info.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) != 0;
-    const VkRenderPassAttachmentBeginInfo *attachment_info_struct = nullptr;
-    if (pRenderPassBegin) attachment_info_struct = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(pRenderPassBegin->pNext);
+    const VkRenderPassAttachmentBeginInfo* attachment_info_struct = nullptr;
+    if (pRenderPassBegin)
+        attachment_info_struct = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(pRenderPassBegin->pNext);
 
     for (uint32_t i = 0; i < active_attachments.size(); ++i) {
         if (imageless) {
@@ -793,8 +794,8 @@ void CommandBuffer::UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPa
     UpdateSubpassAttachments();
 }
 
-void CommandBuffer::RecordBeginRenderPass(const VkRenderPassBeginInfo &render_pass_begin,
-                                          const VkSubpassBeginInfo &subpass_begin_info, const Location &loc) {
+void CommandBuffer::RecordBeginRenderPass(const VkRenderPassBeginInfo& render_pass_begin,
+                                          const VkSubpassBeginInfo& subpass_begin_info, const Location& loc) {
     RecordCommand(loc);
     active_framebuffer = dev_data.Get<vvl::Framebuffer>(render_pass_begin.framebuffer);
     active_render_pass = dev_data.Get<vvl::RenderPass>(render_pass_begin.renderPass);
@@ -839,13 +840,13 @@ void CommandBuffer::RecordBeginRenderPass(const VkRenderPassBeginInfo &render_pa
         AddChild(active_framebuffer);
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBeginRenderPass(render_pass_begin, subpass_begin_info, loc);
     }
 }
 
-void CommandBuffer::RecordNextSubpass(const VkSubpassBeginInfo &subpass_begin_info, const VkSubpassEndInfo *subpass_end_info,
-                                      const Location &loc) {
+void CommandBuffer::RecordNextSubpass(const VkSubpassBeginInfo& subpass_begin_info, const VkSubpassEndInfo* subpass_end_info,
+                                      const Location& loc) {
     RecordCommand(loc);
     SetActiveSubpass(GetActiveSubpass() + 1);
     active_subpass_contents = subpass_begin_info.contents;
@@ -865,14 +866,14 @@ void CommandBuffer::RecordNextSubpass(const VkSubpassBeginInfo &subpass_begin_in
         UnbindResources();
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordNextSubpass(subpass_begin_info, subpass_end_info, loc);
     }
 }
 
-void CommandBuffer::RecordEndRenderPass(const VkSubpassEndInfo *subpass_end_info, const Location &loc) {
+void CommandBuffer::RecordEndRenderPass(const VkSubpassEndInfo* subpass_end_info, const Location& loc) {
     // Call first so SubState can use render pass object before we destroy it
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordEndRenderPass(subpass_end_info, loc);
     }
 
@@ -887,7 +888,7 @@ void CommandBuffer::RecordEndRenderPass(const VkSubpassEndInfo *subpass_end_info
     sample_locations_begin_info = {};
 }
 
-static void InitDefaultRenderingAttachments(CommandBuffer::RenderingAttachment &attachments, uint32_t count) {
+static void InitDefaultRenderingAttachments(CommandBuffer::RenderingAttachment& attachments, uint32_t count) {
     attachments.color_locations.resize(count);
     attachments.color_indexes.resize(count);
     attachments.depth_index = nullptr;
@@ -901,7 +902,7 @@ static void InitDefaultRenderingAttachments(CommandBuffer::RenderingAttachment &
     }
 }
 
-void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, const Location &loc) {
+void CommandBuffer::RecordBeginRendering(const VkRenderingInfo& rendering_info, const Location& loc) {
     RecordCommand(loc);
     active_render_pass = std::make_shared<vvl::RenderPass>(rendering_info);
     render_area = rendering_info.renderArea;
@@ -954,9 +955,9 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
     active_attachments.resize(attachment_count);
 
     for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
-        const auto &rendering_attachment = rendering_info.pColorAttachments[i];
+        const auto& rendering_attachment = rendering_info.pColorAttachments[i];
         if (rendering_attachment.imageView != VK_NULL_HANDLE) {
-            auto &color_attachment = active_attachments[GetDynamicRenderingColorAttachmentIndex(i)];
+            auto& color_attachment = active_attachments[GetDynamicRenderingColorAttachmentIndex(i)];
             color_attachment.image_view = dev_data.Get<vvl::ImageView>(rendering_attachment.imageView).get();
             color_attachment.type = AttachmentInfo::Type::Color;
             color_attachment.layout = rendering_attachment.imageLayout;
@@ -968,7 +969,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
             }
             if (rendering_attachment.resolveMode != VK_RESOLVE_MODE_NONE &&
                 rendering_attachment.resolveImageView != VK_NULL_HANDLE) {
-                auto &resolve_attachment = active_attachments[GetDynamicRenderingColorResolveAttachmentIndex(i)];
+                auto& resolve_attachment = active_attachments[GetDynamicRenderingColorResolveAttachmentIndex(i)];
                 resolve_attachment.image_view = dev_data.Get<vvl::ImageView>(rendering_attachment.resolveImageView).get();
                 resolve_attachment.type = AttachmentInfo::Type::ColorResolve;
                 resolve_attachment.layout = rendering_attachment.resolveImageLayout;
@@ -978,7 +979,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
     }
 
     if (rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
-        auto &depth_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Depth)];
+        auto& depth_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Depth)];
         depth_attachment.image_view = dev_data.Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView).get();
         depth_attachment.type = AttachmentInfo::Type::Depth;
         depth_attachment.layout = rendering_info.pDepthAttachment->imageLayout;
@@ -988,7 +989,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
         }
         if (rendering_info.pDepthAttachment->resolveMode != VK_RESOLVE_MODE_NONE &&
             rendering_info.pDepthAttachment->resolveImageView != VK_NULL_HANDLE) {
-            auto &resolve_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::DepthResolve)];
+            auto& resolve_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::DepthResolve)];
             resolve_attachment.image_view = dev_data.Get<vvl::ImageView>(rendering_info.pDepthAttachment->resolveImageView).get();
             resolve_attachment.type = AttachmentInfo::Type::DepthResolve;
             resolve_attachment.layout = rendering_info.pDepthAttachment->resolveImageLayout;
@@ -996,7 +997,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
     }
 
     if (rendering_info.pStencilAttachment && rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
-        auto &stencil_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Stencil)];
+        auto& stencil_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Stencil)];
         stencil_attachment.image_view = dev_data.Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView).get();
         stencil_attachment.type = AttachmentInfo::Type::Stencil;
         stencil_attachment.layout = rendering_info.pStencilAttachment->imageLayout;
@@ -1006,7 +1007,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
         }
         if (rendering_info.pStencilAttachment->resolveMode != VK_RESOLVE_MODE_NONE &&
             rendering_info.pStencilAttachment->resolveImageView != VK_NULL_HANDLE) {
-            auto &resolve_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::StencilResolve)];
+            auto& resolve_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::StencilResolve)];
             resolve_attachment.image_view = dev_data.Get<vvl::ImageView>(rendering_info.pStencilAttachment->resolveImageView).get();
             resolve_attachment.type = AttachmentInfo::Type::StencilResolve;
             resolve_attachment.layout = rendering_info.pStencilAttachment->resolveImageLayout;
@@ -1015,7 +1016,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
 
     if (auto fragment_density_map_info =
             vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext)) {
-        auto &fdm_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::FragmentDensityMap)];
+        auto& fdm_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::FragmentDensityMap)];
         fdm_attachment.image_view = dev_data.Get<vvl::ImageView>(fragment_density_map_info->imageView).get();
         fdm_attachment.type = AttachmentInfo::Type::FragmentDensityMap;
         fdm_attachment.layout = fragment_density_map_info->imageLayout;
@@ -1027,7 +1028,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
 
     if (auto fsr_attachment_info =
             vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(rendering_info.pNext)) {
-        auto &fsr_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::FragmentShadingRate)];
+        auto& fsr_attachment = active_attachments[GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::FragmentShadingRate)];
         fsr_attachment.image_view = dev_data.Get<vvl::ImageView>(fsr_attachment_info->imageView).get();
         fsr_attachment.type = AttachmentInfo::Type::FragmentShadingRate;
         fsr_attachment.layout = fsr_attachment_info->imageLayout;
@@ -1037,14 +1038,14 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
         }
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBeginRendering(rendering_info, loc);
     }
 }
 
-void CommandBuffer::RecordEndRendering(const VkRenderingEndInfoEXT *pRenderingEndInfo, const Location &loc) {
+void CommandBuffer::RecordEndRendering(const VkRenderingEndInfoEXT* pRenderingEndInfo, const Location& loc) {
     // Call first so SubState can use render pass object before we destroy it
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordEndRendering(pRenderingEndInfo);
     }
 
@@ -1053,14 +1054,14 @@ void CommandBuffer::RecordEndRendering(const VkRenderingEndInfoEXT *pRenderingEn
     active_color_attachments_index.clear();
 }
 
-void CommandBuffer::RecordBeginCustomResolve(const Location &loc) {
+void CommandBuffer::RecordBeginCustomResolve(const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBeginCustomResolve();
     }
 }
 
-void CommandBuffer::RecordBeginVideoCoding(const VkVideoBeginCodingInfoKHR &begin_info, const Location &loc) {
+void CommandBuffer::RecordBeginVideoCoding(const VkVideoBeginCodingInfoKHR& begin_info, const Location& loc) {
     RecordCommand(loc);
     bound_video_session = dev_data.Get<vvl::VideoSession>(begin_info.videoSession);
     ASSERT_AND_RETURN(bound_video_session);
@@ -1079,7 +1080,7 @@ void CommandBuffer::RecordBeginVideoCoding(const VkVideoBeginCodingInfoKHR &begi
     }
 
     // Need to record substate first
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBeginVideoCoding(*bound_video_session, begin_info, loc);
     }
 
@@ -1115,8 +1116,8 @@ void CommandBuffer::RecordBeginVideoCoding(const VkVideoBeginCodingInfoKHR &begi
 
             // Enqueue submission time DPB slot deactivation
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [deactivated_slots](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
-                    for (const auto &slot_index : deactivated_slots) {
+                [deactivated_slots](const vvl::VideoSession* vs_state, vvl::VideoSessionDeviceState& dev_state, bool do_validate) {
+                    for (const auto& slot_index : deactivated_slots) {
                         dev_state.Deactivate(slot_index);
                     }
                     return false;
@@ -1125,7 +1126,7 @@ void CommandBuffer::RecordBeginVideoCoding(const VkVideoBeginCodingInfoKHR &begi
     }
 }
 
-void CommandBuffer::RecordEndVideoCoding(const Location &loc) {
+void CommandBuffer::RecordEndVideoCoding(const Location& loc) {
     RecordCommand(loc);
     bound_video_session = nullptr;
     bound_video_session_parameters = nullptr;
@@ -1133,26 +1134,26 @@ void CommandBuffer::RecordEndVideoCoding(const Location &loc) {
     video_encode_quality_level.reset();
 }
 
-void CommandBuffer::RecordControlVideoCoding(const VkVideoCodingControlInfoKHR &control_info, const Location &loc) {
+void CommandBuffer::RecordControlVideoCoding(const VkVideoCodingControlInfoKHR& control_info, const Location& loc) {
     RecordCommand(loc);
     if (!bound_video_session) {
         return;
     }
 
     // Need to record substate first
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordControlVideoCoding(*bound_video_session, control_info, loc);
     }
 
     if (control_info.flags & VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR) {
         // Remove DPB slot index association for bound video picture resources
-        for (auto &binding : bound_video_picture_resources) {
+        for (auto& binding : bound_video_picture_resources) {
             binding.second = -1;
         }
 
         // Enqueue submission time video session state reset/initialization
         video_session_updates[bound_video_session->VkHandle()].emplace_back(
-            [](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
+            [](const vvl::VideoSession* vs_state, vvl::VideoSessionDeviceState& dev_state, bool do_validate) {
                 dev_state.Reset();
                 return false;
             });
@@ -1165,7 +1166,7 @@ void CommandBuffer::RecordControlVideoCoding(const VkVideoCodingControlInfoKHR &
 
             // Enqueue rate control specific device state changes
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [state](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
+                [state](const vvl::VideoSession* vs_state, vvl::VideoSessionDeviceState& dev_state, bool do_validate) {
                     dev_state.SetRateControlState(state);
                     return false;
                 });
@@ -1180,7 +1181,7 @@ void CommandBuffer::RecordControlVideoCoding(const VkVideoCodingControlInfoKHR &
 
             // Enqueue encode quality level device state change
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [quality_level](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
+                [quality_level](const vvl::VideoSession* vs_state, vvl::VideoSessionDeviceState& dev_state, bool do_validate) {
                     dev_state.SetEncodeQualityLevel(quality_level);
                     return false;
                 });
@@ -1188,8 +1189,8 @@ void CommandBuffer::RecordControlVideoCoding(const VkVideoCodingControlInfoKHR &
     }
 }
 
-void vvl::CommandBuffer::RecordVideoInlineQueries(const VkVideoInlineQueryInfoKHR &query_info) {
-    for (auto &item : sub_states_) {
+void vvl::CommandBuffer::RecordVideoInlineQueries(const VkVideoInlineQueryInfoKHR& query_info) {
+    for (auto& item : sub_states_) {
         item.second->RecordVideoInlineQueries(query_info);
     }
 
@@ -1198,14 +1199,14 @@ void vvl::CommandBuffer::RecordVideoInlineQueries(const VkVideoInlineQueryInfoKH
     }
 }
 
-void CommandBuffer::RecordDecodeVideo(const VkVideoDecodeInfoKHR &decode_info, const Location &loc) {
+void CommandBuffer::RecordDecodeVideo(const VkVideoDecodeInfoKHR& decode_info, const Location& loc) {
     RecordCommand(loc);
     if (!bound_video_session) {
         return;
     }
 
     // Need to record substate first
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordDecodeVideo(*bound_video_session, decode_info, loc);
     }
 
@@ -1218,7 +1219,7 @@ void CommandBuffer::RecordDecodeVideo(const VkVideoDecodeInfoKHR &decode_info, c
         // Enqueue submission time reference slot setup or invalidation
         bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(decode_info);
         video_session_updates[bound_video_session->VkHandle()].emplace_back(
-            [setup_slot, reference_setup_requested](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state,
+            [setup_slot, reference_setup_requested](const vvl::VideoSession* vs_state, vvl::VideoSessionDeviceState& dev_state,
                                                     bool do_validate) {
                 if (reference_setup_requested) {
                     dev_state.Activate(setup_slot.index, setup_slot.picture_id, setup_slot.resource);
@@ -1230,7 +1231,7 @@ void CommandBuffer::RecordDecodeVideo(const VkVideoDecodeInfoKHR &decode_info, c
     }
 
     // Update active query indices
-    for (auto &query : active_queries) {
+    for (auto& query : active_queries) {
         uint32_t op_count = bound_video_session->GetVideoDecodeOperationCount(&decode_info);
         query.active_query_index += op_count;
     }
@@ -1244,14 +1245,14 @@ void CommandBuffer::RecordDecodeVideo(const VkVideoDecodeInfoKHR &decode_info, c
     }
 }
 
-void vvl::CommandBuffer::RecordEncodeVideo(const VkVideoEncodeInfoKHR &encode_info, const Location &loc) {
+void vvl::CommandBuffer::RecordEncodeVideo(const VkVideoEncodeInfoKHR& encode_info, const Location& loc) {
     RecordCommand(loc);
     if (!bound_video_session) {
         return;
     }
 
     // Need to record substate first
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordEncodeVideo(*bound_video_session, encode_info, loc);
     }
 
@@ -1264,7 +1265,7 @@ void vvl::CommandBuffer::RecordEncodeVideo(const VkVideoEncodeInfoKHR &encode_in
         // Enqueue submission time reference slot setup or invalidation
         bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(encode_info);
         video_session_updates[bound_video_session->VkHandle()].emplace_back(
-            [setup_slot, reference_setup_requested](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state,
+            [setup_slot, reference_setup_requested](const vvl::VideoSession* vs_state, vvl::VideoSessionDeviceState& dev_state,
                                                     bool do_validate) {
                 if (reference_setup_requested) {
                     dev_state.Activate(setup_slot.index, setup_slot.picture_id, setup_slot.resource);
@@ -1276,7 +1277,7 @@ void vvl::CommandBuffer::RecordEncodeVideo(const VkVideoEncodeInfoKHR &encode_in
     }
 
     // Update active query indices
-    for (auto &query : active_queries) {
+    for (auto& query : active_queries) {
         uint32_t op_count = bound_video_session->GetVideoEncodeOperationCount(&encode_info);
         query.active_query_index += op_count;
     }
@@ -1290,17 +1291,19 @@ void vvl::CommandBuffer::RecordEncodeVideo(const VkVideoEncodeInfoKHR &encode_in
     }
 }
 
-static void SetRenderingAttachmentLocations(CommandBuffer::RenderingAttachment &attachments, const VkRenderingAttachmentLocationInfo *pLocationInfo) {
+static void SetRenderingAttachmentLocations(CommandBuffer::RenderingAttachment& attachments,
+                                            const VkRenderingAttachmentLocationInfo* pLocationInfo) {
     attachments.color_locations.resize(pLocationInfo->colorAttachmentCount);
-    const uint32_t *locations = pLocationInfo->pColorAttachmentLocations;
+    const uint32_t* locations = pLocationInfo->pColorAttachmentLocations;
     for (uint32_t i = 0; i < pLocationInfo->colorAttachmentCount; ++i) {
         attachments.color_locations[i] = locations ? locations[i] : i;
     }
 }
 
-static void SetRenderingInputAttachmentIndices(CommandBuffer::RenderingAttachment &attachments, const VkRenderingInputAttachmentIndexInfo *pLocationInfo) {
+static void SetRenderingInputAttachmentIndices(CommandBuffer::RenderingAttachment& attachments,
+                                               const VkRenderingInputAttachmentIndexInfo* pLocationInfo) {
     attachments.color_indexes.resize(pLocationInfo->colorAttachmentCount);
-    const uint32_t *indexes = pLocationInfo->pColorAttachmentInputIndices;
+    const uint32_t* indexes = pLocationInfo->pColorAttachmentInputIndices;
     for (uint32_t i = 0; i < pLocationInfo->colorAttachmentCount; ++i) {
         attachments.color_indexes[i] = indexes ? indexes[i] : i;
     }
@@ -1318,7 +1321,7 @@ static void SetRenderingInputAttachmentIndices(CommandBuffer::RenderingAttachmen
     }
 }
 
-void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
+void CommandBuffer::Begin(const VkCommandBufferBeginInfo* pBeginInfo) {
     if (IsRecorded(state)) {
         Location loc(Func::vkBeginCommandBuffer);
         Reset(loc);
@@ -1393,7 +1396,7 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     performance_lock_acquired = dev_data.performance_lock_acquired;
     updated_queries.clear();
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Begin(*pBeginInfo);
     }
 }
@@ -1402,12 +1405,12 @@ void CommandBuffer::End(VkResult result) {
     if (result == VK_SUCCESS) {
         state = CbState::Recorded;
     }
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->End();
     }
 }
 
-void CommandBuffer::RecordExecuteCommands(vvl::span<const VkCommandBuffer> secondary_command_buffers, const Location &loc) {
+void CommandBuffer::RecordExecuteCommands(vvl::span<const VkCommandBuffer> secondary_command_buffers, const Location& loc) {
     RecordCommand(loc);
     uint32_t cmd_index = 0;
     for (const VkCommandBuffer sub_command_buffer : secondary_command_buffers) {
@@ -1425,7 +1428,7 @@ void CommandBuffer::RecordExecuteCommands(vvl::span<const VkCommandBuffer> secon
         // NOTE: The update/population of the image_layout_map is done in CoreChecks, but for other classes derived from
         // Device these maps will be empty, so leaving the propagation in the the state tracker should be a no-op
         // for those other classes.
-        for (const auto &[image, secondary_cb_layout_map] : secondary_cb_state->image_layout_registry) {
+        for (const auto& [image, secondary_cb_layout_map] : secondary_cb_state->image_layout_registry) {
             const auto image_state = dev_data.Get<vvl::Image>(image);
             if (!image_state || image_state->Destroyed() || !secondary_cb_layout_map ||
                 image_state->GetId() != secondary_cb_layout_map->image_id) {
@@ -1433,12 +1436,12 @@ void CommandBuffer::RecordExecuteCommands(vvl::span<const VkCommandBuffer> secon
             }
             if (auto cb_layout_map = GetOrCreateImageLayoutMap(*image_state)) {
                 struct Updater {
-                    void update(ImageLayoutState &dst, const ImageLayoutState &src) const {
+                    void update(ImageLayoutState& dst, const ImageLayoutState& src) const {
                         if (src.current_layout != kInvalidLayout && src.current_layout != dst.current_layout) {
                             dst.current_layout = src.current_layout;
                         }
                     }
-                    std::optional<ImageLayoutState> insert(const ImageLayoutState &src) const {
+                    std::optional<ImageLayoutState> insert(const ImageLayoutState& src) const {
                         return std::optional<ImageLayoutState>(vvl::in_place, src);
                     }
                 };
@@ -1450,7 +1453,7 @@ void CommandBuffer::RecordExecuteCommands(vvl::span<const VkCommandBuffer> secon
         linked_command_buffers.insert(secondary_cb_state.get());
         AddChild(secondary_cb_state);
 
-        for (auto &event : secondary_cb_state->events) {
+        for (auto& event : secondary_cb_state->events) {
             events.push_back(event);
         }
 
@@ -1479,7 +1482,7 @@ void CommandBuffer::RecordExecuteCommands(vvl::span<const VkCommandBuffer> secon
         label_commands_.insert(label_commands_.end(), secondary_cb_state->label_commands_.begin(),
                                secondary_cb_state->label_commands_.end());
 
-        for (auto &item : sub_states_) {
+        for (auto& item : sub_states_) {
             item.second->RecordExecuteCommand(*secondary_cb_state, cmd_index, loc);
         }
 
@@ -1489,8 +1492,8 @@ void CommandBuffer::RecordExecuteCommands(vvl::span<const VkCommandBuffer> secon
 
 void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint,
                                            std::shared_ptr<const vvl::PipelineLayout> pipeline_layout, uint32_t set,
-                                           uint32_t descriptorWriteCount, const VkWriteDescriptorSet *pDescriptorWrites,
-                                           const Location &loc) {
+                                           uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites,
+                                           const Location& loc) {
     // Short circuit invalid updates
     if ((set >= pipeline_layout->set_layouts.list.size()) || !pipeline_layout->set_layouts.list[set] ||
         !pipeline_layout->set_layouts.list[set]->IsPushDescriptor()) {
@@ -1498,9 +1501,9 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
     }
 
     // We need a descriptor set to update the bindings with, compatible with the passed layout
-    const auto &dsl = pipeline_layout->set_layouts.list[set];
-    auto &last_bound = lastBound[ConvertToVvlBindPoint(pipelineBindPoint)];
-    auto &push_descriptor_set = last_bound.push_descriptor_set;
+    const auto& dsl = pipeline_layout->set_layouts.list[set];
+    auto& last_bound = lastBound[ConvertToVvlBindPoint(pipelineBindPoint)];
+    auto& push_descriptor_set = last_bound.push_descriptor_set;
     // If we are disturbing the current push_desriptor_set clear it
     if (!push_descriptor_set || !last_bound.IsBoundSetCompatible(set, *pipeline_layout)) {
         last_bound.UnbindAndResetPushDescriptorSet(dev_data.CreatePushDescriptorSet(dsl));
@@ -1513,36 +1516,36 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
 }
 
 // Generic function to handle state update for all CmdDraw* type functions
-void CommandBuffer::RecordDraw(const Location &loc) {
+void CommandBuffer::RecordDraw(const Location& loc) {
     RecordCommand(loc);
-    LastBound &last_bound = lastBound[vvl::BindPointGraphics];
-    for (auto &item : sub_states_) {
+    LastBound& last_bound = lastBound[vvl::BindPointGraphics];
+    for (auto& item : sub_states_) {
         item.second->RecordActionCommand(last_bound, loc);
     }
 }
 
 // Generic function to handle state update for all CmdDispatch* type functions
-void CommandBuffer::RecordDispatch(const Location &loc) {
+void CommandBuffer::RecordDispatch(const Location& loc) {
     RecordCommand(loc);
-    LastBound &last_bound = lastBound[vvl::BindPointCompute];
-    for (auto &item : sub_states_) {
+    LastBound& last_bound = lastBound[vvl::BindPointCompute];
+    for (auto& item : sub_states_) {
         item.second->RecordActionCommand(last_bound, loc);
     }
 }
 
 // Generic function to handle state update for all CmdTraceRay* type functions
-void CommandBuffer::RecordTraceRay(const Location &loc) {
+void CommandBuffer::RecordTraceRay(const Location& loc) {
     RecordCommand(loc);
-    LastBound &last_bound = lastBound[vvl::BindPointRayTracing];
-    for (auto &item : sub_states_) {
+    LastBound& last_bound = lastBound[vvl::BindPointRayTracing];
+    for (auto& item : sub_states_) {
         item.second->RecordActionCommand(last_bound, loc);
     }
 }
 
-void CommandBuffer::RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipeline &pipeline) {
+void CommandBuffer::RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipeline& pipeline) {
     BindLastBoundPipeline(ConvertToVvlBindPoint(bind_point), &pipeline);
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBindPipeline(bind_point, pipeline);
     }
 
@@ -1572,14 +1575,14 @@ void CommandBuffer::RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipe
 
         if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT) &&
             !pipeline.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE) && pipeline.vertex_input_state) {
-            for (const auto &[binding_index, binding_state] : pipeline.vertex_input_state->bindings) {
+            for (const auto& [binding_index, binding_state] : pipeline.vertex_input_state->bindings) {
                 current_vertex_buffer_binding_info[binding_index].stride = binding_state.desc.stride;
             }
         }
 
         if (!dev_data.enabled_features.variableMultisampleRate) {
-            if (const auto *multisample_state = pipeline.MultisampleState(); multisample_state) {
-                if (const auto &render_pass = active_render_pass) {
+            if (const auto* multisample_state = pipeline.MultisampleState(); multisample_state) {
+                if (const auto& render_pass = active_render_pass) {
                     const uint32_t subpass = GetActiveSubpass();
                     // if render pass uses no attachment, all bound pipelines in the same subpass must have the same
                     // pMultisampleState->rasterizationSamples. To check that, record pMultisampleState->rasterizationSamples of the
@@ -1606,7 +1609,7 @@ void CommandBuffer::RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipe
 }
 
 // Helper for descriptor set (and buffer) updates.
-static bool PushDescriptorCleanup(LastBound &last_bound, uint32_t set_idx) {
+static bool PushDescriptorCleanup(LastBound& last_bound, uint32_t set_idx) {
     // All uses are from loops over ds_slots, but just in case..
     assert(set_idx < last_bound.ds_slots.size());
 
@@ -1624,21 +1627,21 @@ static bool PushDescriptorCleanup(LastBound &last_bound, uint32_t set_idx) {
 // is called for CmdBindDescriptorSets or CmdPushDescriptorSet.
 void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_bind_point,
                                                   std::shared_ptr<const vvl::PipelineLayout> pipeline_layout, uint32_t first_set,
-                                                  uint32_t set_count, const VkDescriptorSet *pDescriptorSets,
-                                                  std::shared_ptr<vvl::DescriptorSet> &push_descriptor_set,
-                                                  uint32_t dynamic_offset_count, const uint32_t *p_dynamic_offsets,
-                                                  const Location &loc) {
+                                                  uint32_t set_count, const VkDescriptorSet* pDescriptorSets,
+                                                  std::shared_ptr<vvl::DescriptorSet>& push_descriptor_set,
+                                                  uint32_t dynamic_offset_count, const uint32_t* p_dynamic_offsets,
+                                                  const Location& loc) {
     ASSERT_AND_RETURN((pDescriptorSets == nullptr) ^ (push_descriptor_set == nullptr));
 
     uint32_t required_size = first_set + set_count;
     const uint32_t last_binding_index = required_size - 1;
     ASSERT_AND_RETURN(last_binding_index < pipeline_layout->set_compat_ids.size());
 
-    auto &last_bound = lastBound[ConvertToVvlBindPoint(pipeline_bind_point)];
+    auto& last_bound = lastBound[ConvertToVvlBindPoint(pipeline_bind_point)];
     last_bound.desc_set_pipeline_layout = pipeline_layout;
     last_bound.desc_set_bound_command = loc.function;
     last_bound.SetDescriptorMode(DescriptorModeClassic, loc.function);
-    auto &pipe_compat_ids = pipeline_layout->set_compat_ids;
+    auto& pipe_compat_ids = pipeline_layout->set_compat_ids;
     // Resize binding arrays
     if (last_binding_index >= last_bound.ds_slots.size()) {
         last_bound.ds_slots.resize(required_size);
@@ -1667,7 +1670,7 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
 
     // For any previously bound sets, need to set them to "invalid" if they were disturbed by this update
     for (uint32_t set_idx = 0; set_idx < first_set; ++set_idx) {
-        auto &ds_slot = last_bound.ds_slots[set_idx];
+        auto& ds_slot = last_bound.ds_slots[set_idx];
         if (ds_slot.compat_id_for_set != pipe_compat_ids[set_idx]) {
             PushDescriptorCleanup(last_bound, set_idx);
             ds_slot.Reset();
@@ -1676,10 +1679,10 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
     }
 
     // Now update the bound sets with the input sets
-    const uint32_t *input_dynamic_offsets = p_dynamic_offsets;  // "read" pointer for dynamic offset data
+    const uint32_t* input_dynamic_offsets = p_dynamic_offsets;  // "read" pointer for dynamic offset data
     for (uint32_t input_idx = 0; input_idx < set_count; input_idx++) {
         auto set_idx = input_idx + first_set;  // set_idx is index within layout, input_idx is index within input descriptor sets
-        auto &ds_slot = last_bound.ds_slots[set_idx];
+        auto& ds_slot = last_bound.ds_slots[set_idx];
         auto descriptor_set =
             push_descriptor_set ? push_descriptor_set : dev_data.Get<vvl::DescriptorSet>(pDescriptorSets[input_idx]);
 
@@ -1696,7 +1699,7 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
             auto set_dynamic_descriptor_count = descriptor_set->GetDynamicDescriptorCount();
             // TODO: Add logic for tracking push_descriptor offsets (here or in caller)
             if (set_dynamic_descriptor_count && input_dynamic_offsets) {
-                const uint32_t *end_offset = input_dynamic_offsets + set_dynamic_descriptor_count;
+                const uint32_t* end_offset = input_dynamic_offsets + set_dynamic_descriptor_count;
                 ds_slot.dynamic_offsets = std::vector<uint32_t>(input_dynamic_offsets, end_offset);
                 input_dynamic_offsets = end_offset;
                 assert(input_dynamic_offsets <= (p_dynamic_offsets + dynamic_offset_count));
@@ -1706,23 +1709,23 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
         }
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->UpdateLastBoundDescriptorSets(pipeline_bind_point, loc);
     }
 }
 
 void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipeline_bind_point,
                                                      std::shared_ptr<const vvl::PipelineLayout> pipeline_layout, uint32_t first_set,
-                                                     uint32_t set_count, const uint32_t *buffer_indicies,
-                                                     const VkDeviceSize *buffer_offsets) {
+                                                     uint32_t set_count, const uint32_t* buffer_indicies,
+                                                     const VkDeviceSize* buffer_offsets) {
     uint32_t required_size = first_set + set_count;
     const uint32_t last_binding_index = required_size - 1;
     assert(last_binding_index < pipeline_layout->set_compat_ids.size());
 
     const vvl::BindPoint vvl_bind_point = ConvertToVvlBindPoint(pipeline_bind_point);
-    auto &last_bound = lastBound[vvl_bind_point];
+    auto& last_bound = lastBound[vvl_bind_point];
     last_bound.desc_set_pipeline_layout = pipeline_layout;
-    auto &pipe_compat_ids = pipeline_layout->set_compat_ids;
+    auto& pipe_compat_ids = pipeline_layout->set_compat_ids;
     // Resize binding arrays
     if (last_binding_index >= last_bound.ds_slots.size()) {
         last_bound.ds_slots.resize(required_size);
@@ -1758,7 +1761,7 @@ void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipelin
     // Now update the bound sets with the input sets
     for (uint32_t input_idx = 0; input_idx < set_count; input_idx++) {
         auto set_idx = input_idx + first_set;  // set_idx is index within layout, input_idx is index within input descriptor sets
-        auto &ds_slot = last_bound.ds_slots[set_idx];
+        auto& ds_slot = last_bound.ds_slots[set_idx];
         ds_slot.Reset();
 
         // Record binding
@@ -1768,7 +1771,7 @@ void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipelin
 }
 
 // Set image layout for given subresource range
-void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageSubresourceRange &normalized_subresource_range,
+void CommandBuffer::SetImageLayout(const vvl::Image& image_state, const VkImageSubresourceRange& normalized_subresource_range,
                                    VkImageLayout layout, VkImageLayout expected_layout) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(image_state)) {
         if (image_state.subresource_encoder.InRange(normalized_subresource_range)) {
@@ -1781,8 +1784,8 @@ void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageS
     }
 }
 
-void CommandBuffer::TrackImageViewFirstLayout(const vvl::ImageView &view_state, VkImageLayout layout,
-                                              const char *submit_time_layout_mismatch_vuid) {
+void CommandBuffer::TrackImageViewFirstLayout(const vvl::ImageView& view_state, VkImageLayout layout,
+                                              const char* submit_time_layout_mismatch_vuid) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(*view_state.image_state.get())) {
         RangeGenerator range_gen(view_state.range_generator);
         TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, view_state.normalized_subresource_range.aspectMask,
@@ -1790,8 +1793,8 @@ void CommandBuffer::TrackImageViewFirstLayout(const vvl::ImageView &view_state, 
     }
 }
 
-void CommandBuffer::TrackDepthAttachmentFirstLayout(const vvl::ImageView &view_state, VkImageLayout layout,
-                                                    const char *submit_time_layout_mismatch_vuid) {
+void CommandBuffer::TrackDepthAttachmentFirstLayout(const vvl::ImageView& view_state, VkImageLayout layout,
+                                                    const char* submit_time_layout_mismatch_vuid) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(*view_state.image_state.get())) {
         // According to the spec for dynamic rendering depth attachment, we must ignore
         // the aspect used to create the image view and use the DEPTH aspect instead
@@ -1804,8 +1807,8 @@ void CommandBuffer::TrackDepthAttachmentFirstLayout(const vvl::ImageView &view_s
     }
 }
 
-void CommandBuffer::TrackStencilAttachmentFirstLayout(const vvl::ImageView &view_state, VkImageLayout layout,
-                                                      const char *submit_time_layout_mismatch_vuid) {
+void CommandBuffer::TrackStencilAttachmentFirstLayout(const vvl::ImageView& view_state, VkImageLayout layout,
+                                                      const char* submit_time_layout_mismatch_vuid) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(*view_state.image_state.get())) {
         // According to the spec for dynamic rendering stencil attachment, we must ignore
         // the aspect used to create the image view and use the STENCIL aspect instead
@@ -1818,7 +1821,7 @@ void CommandBuffer::TrackStencilAttachmentFirstLayout(const vvl::ImageView &view
     }
 }
 
-void CommandBuffer::TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range,
+void CommandBuffer::TrackImageFirstLayout(const vvl::Image& image_state, const VkImageSubresourceRange& subresource_range,
                                           int32_t depth_offset, uint32_t depth_extent, VkImageLayout layout) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(image_state)) {
         VkImageSubresourceRange normalized_subresource_range = image_state.NormalizeSubresourceRange(subresource_range);
@@ -1834,8 +1837,8 @@ void CommandBuffer::TrackImageFirstLayout(const vvl::Image &image_state, const V
     }
 }
 
-void CommandBuffer::SetImageViewLayout(const vvl::ImageView &view_state, VkImageLayout layout, VkImageLayout layoutStencil) {
-    const vvl::Image *image_state = view_state.image_state.get();
+void CommandBuffer::SetImageViewLayout(const vvl::ImageView& view_state, VkImageLayout layout, VkImageLayout layoutStencil) {
+    const vvl::Image* image_state = view_state.image_state.get();
 
     VkImageSubresourceRange sub_range = view_state.GetRangeGeneratorRange(dev_data.extensions);
 
@@ -1863,7 +1866,7 @@ void CommandBuffer::RecordStateCmd(CBDynamicState state) {
     command_count++;
     RecordDynamicState(state);
 
-    vvl::Pipeline *pipeline = GetLastBoundGraphics().pipeline_state;
+    vvl::Pipeline* pipeline = GetLastBoundGraphics().pipeline_state;
     if (pipeline && !pipeline->IsDynamic(state)) {
         dirty_static_state = true;
     }
@@ -1875,7 +1878,7 @@ void CommandBuffer::RecordDynamicState(CBDynamicState state) {
     dynamic_state_status.history.set(state);
 }
 
-void CommandBuffer::RecordSetViewport(uint32_t first_viewport, uint32_t viewport_count, const VkViewport *viewports) {
+void CommandBuffer::RecordSetViewport(uint32_t first_viewport, uint32_t viewport_count, const VkViewport* viewports) {
     RecordStateCmd(CB_DYNAMIC_STATE_VIEWPORT);
     if (dynamic_state_value.viewports.size() < first_viewport + viewport_count) {
         dynamic_state_value.viewports.resize(first_viewport + viewport_count);
@@ -1883,12 +1886,12 @@ void CommandBuffer::RecordSetViewport(uint32_t first_viewport, uint32_t viewport
     for (size_t i = 0; i < viewport_count; ++i) {
         dynamic_state_value.viewports[first_viewport + i] = viewports[i];
     }
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordSetViewport(first_viewport, viewport_count);
     }
 }
 
-void CommandBuffer::RecordSetViewportWithCount(uint32_t viewport_count, const VkViewport *viewports) {
+void CommandBuffer::RecordSetViewportWithCount(uint32_t viewport_count, const VkViewport* viewports) {
     RecordStateCmd(CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
     dynamic_state_value.viewport_count = viewport_count;
     dynamic_state_value.viewports.resize(viewport_count);
@@ -1896,14 +1899,14 @@ void CommandBuffer::RecordSetViewportWithCount(uint32_t viewport_count, const Vk
         dynamic_state_value.viewports[i] = viewports[i];
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordSetViewportWithCount(viewport_count);
     }
 }
 
 void CommandBuffer::RecordSetScissor(uint32_t first_scissor, uint32_t scissor_count) {
     RecordStateCmd(CB_DYNAMIC_STATE_SCISSOR);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordSetScissor(first_scissor, scissor_count);
     }
 }
@@ -1911,93 +1914,93 @@ void CommandBuffer::RecordSetScissor(uint32_t first_scissor, uint32_t scissor_co
 void CommandBuffer::RecordSetScissorWithCount(uint32_t scissor_count) {
     RecordStateCmd(CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
     dynamic_state_value.scissor_count = scissor_count;
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordSetScissorWithCount(scissor_count);
     }
 }
 
 void CommandBuffer::RecordSetDepthCompareOp(VkCompareOp depth_compare_op) {
     RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_COMPARE_OP);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordSetDepthCompareOp(depth_compare_op);
     }
 }
 void CommandBuffer::RecordSetDepthTestEnable(VkBool32 depth_test_enable) {
     RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE);
     dynamic_state_value.depth_test_enable = depth_test_enable;
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordSetDepthTestEnable(depth_test_enable);
     }
 }
 
-void CommandBuffer::RecordCopyBuffer(vvl::Buffer &src_buffer_state, vvl::Buffer &dst_buffer_state, uint32_t region_count,
-                                     const VkBufferCopy *regions, const Location &loc) {
+void CommandBuffer::RecordCopyBuffer(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
+                                     const VkBufferCopy* regions, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyBuffer(src_buffer_state, dst_buffer_state, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyBuffer2(vvl::Buffer &src_buffer_state, vvl::Buffer &dst_buffer_state, uint32_t region_count,
-                                      const VkBufferCopy2 *regions, const Location &loc) {
+void CommandBuffer::RecordCopyBuffer2(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
+                                      const VkBufferCopy2* regions, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyBuffer2(src_buffer_state, dst_buffer_state, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
-                                    VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy *regions,
-                                    const Location &loc) {
+void CommandBuffer::RecordCopyImage(vvl::Image& src_image_state, vvl::Image& dst_image_state, VkImageLayout src_image_layout,
+                                    VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy* regions,
+                                    const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyImage(src_image_state, dst_image_state, src_image_layout, dst_image_layout, region_count, regions,
                                      loc);
     }
 }
 
-void CommandBuffer::RecordCopyImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
-                                     VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy2 *regions,
-                                     const Location &loc) {
+void CommandBuffer::RecordCopyImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state, VkImageLayout src_image_layout,
+                                     VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy2* regions,
+                                     const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyImage2(src_image_state, dst_image_state, src_image_layout, dst_image_layout, region_count, regions,
                                       loc);
     }
 }
 
-void CommandBuffer::RecordCopyBufferToImage(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state,
-                                            VkImageLayout dst_image_layout, uint32_t region_count, const VkBufferImageCopy *regions,
-                                            const Location &loc) {
+void CommandBuffer::RecordCopyBufferToImage(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state,
+                                            VkImageLayout dst_image_layout, uint32_t region_count, const VkBufferImageCopy* regions,
+                                            const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyBufferToImage(src_buffer_state, dst_image_state, dst_image_layout, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyBufferToImage2(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state,
+void CommandBuffer::RecordCopyBufferToImage2(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state,
                                              VkImageLayout dst_image_layout, uint32_t region_count,
-                                             const VkBufferImageCopy2 *regions, const Location &loc) {
+                                             const VkBufferImageCopy2* regions, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyBufferToImage2(src_buffer_state, dst_image_state, dst_image_layout, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyImageToBuffer(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state,
-                                            VkImageLayout src_image_layout, uint32_t region_count, const VkBufferImageCopy *regions,
-                                            const Location &loc) {
+void CommandBuffer::RecordCopyImageToBuffer(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state,
+                                            VkImageLayout src_image_layout, uint32_t region_count, const VkBufferImageCopy* regions,
+                                            const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyImageToBuffer(src_image_state, dst_buffer_state, src_image_layout, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state,
+void CommandBuffer::RecordCopyImageToBuffer2(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state,
                                              VkImageLayout src_image_layout, uint32_t region_count,
-                                             const VkBufferImageCopy2 *regions, const Location &loc) {
+                                             const VkBufferImageCopy2* regions, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordCopyImageToBuffer2(src_image_state, dst_buffer_state, src_image_layout, region_count, regions, loc);
     }
 }
@@ -2024,78 +2027,78 @@ void CommandBuffer::RecordCopyMemory(uint32_t region_count, const VkDeviceMemory
     RecordCommand(loc);
 }
 
-void CommandBuffer::RecordBlitImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
-                                    VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit *regions,
-                                    const Location &loc) {
+void CommandBuffer::RecordBlitImage(vvl::Image& src_image_state, vvl::Image& dst_image_state, VkImageLayout src_image_layout,
+                                    VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit* regions,
+                                    const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBlitImage(src_image_state, dst_image_state, src_image_layout, dst_image_layout, region_count, regions,
                                      loc);
     }
 }
 
-void CommandBuffer::RecordBlitImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
-                                     VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit2 *regions,
-                                     const Location &loc) {
+void CommandBuffer::RecordBlitImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state, VkImageLayout src_image_layout,
+                                     VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit2* regions,
+                                     const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBlitImage2(src_image_state, dst_image_state, src_image_layout, dst_image_layout, region_count, regions,
                                       loc);
     }
 }
 
-void CommandBuffer::RecordResolveImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, uint32_t region_count,
-                                       const VkImageResolve *regions, const Location &loc) {
+void CommandBuffer::RecordResolveImage(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
+                                       const VkImageResolve* regions, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordResolveImage(src_image_state, dst_image_state, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordResolveImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, uint32_t region_count,
-                                        const VkImageResolve2 *regions, const Location &loc) {
+void CommandBuffer::RecordResolveImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
+                                        const VkImageResolve2* regions, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordResolveImage2(src_image_state, dst_image_state, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordClearColorImage(vvl::Image &image_state, VkImageLayout image_layout,
-                                          const VkClearColorValue *color_values, uint32_t range_count,
-                                          const VkImageSubresourceRange *ranges, const Location &loc) {
+void CommandBuffer::RecordClearColorImage(vvl::Image& image_state, VkImageLayout image_layout,
+                                          const VkClearColorValue* color_values, uint32_t range_count,
+                                          const VkImageSubresourceRange* ranges, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordClearColorImage(image_state, image_layout, color_values, range_count, ranges, loc);
     }
 }
 
-void CommandBuffer::RecordClearDepthStencilImage(vvl::Image &image_state, VkImageLayout image_layout,
-                                                 const VkClearDepthStencilValue *depth_stencil_values, uint32_t range_count,
-                                                 const VkImageSubresourceRange *ranges, const Location &loc) {
+void CommandBuffer::RecordClearDepthStencilImage(vvl::Image& image_state, VkImageLayout image_layout,
+                                                 const VkClearDepthStencilValue* depth_stencil_values, uint32_t range_count,
+                                                 const VkImageSubresourceRange* ranges, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordClearDepthStencilImage(image_state, image_layout, depth_stencil_values, range_count, ranges, loc);
     }
 }
 
-void CommandBuffer::RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment *pAttachments, uint32_t rect_count,
-                                           const VkClearRect *pRects, const Location &loc) {
+void CommandBuffer::RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment* pAttachments, uint32_t rect_count,
+                                           const VkClearRect* pRects, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordClearAttachments(attachment_count, pAttachments, rect_count, pRects, loc);
     }
 }
 
-void CommandBuffer::RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {
+void CommandBuffer::RecordFillBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordFillBuffer(buffer_state, offset, size, loc);
     }
 }
 
-void CommandBuffer::RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {
+void CommandBuffer::RecordUpdateBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordUpdateBuffer(buffer_state, offset, size, loc);
     }
 }
@@ -2112,10 +2115,10 @@ void CommandBuffer::RecordUpdateMemory(VkDeviceAddressRangeKHR range, const Loca
     (void)range;
 }
 
-void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const VkDependencyInfo *dependency_info,
-                                   const Location &loc) {
+void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const VkDependencyInfo* dependency_info,
+                                   const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordSetEvent(event, stage_mask, dependency_info);
     }
 
@@ -2130,9 +2133,9 @@ void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_ma
     }
 }
 
-void CommandBuffer::RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const Location &loc) {
+void CommandBuffer::RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const Location& loc) {
     RecordCommand(loc);
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordResetEvent(event, stage_mask);
     }
 
@@ -2147,9 +2150,9 @@ void CommandBuffer::RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_
     }
 }
 
-void CommandBuffer::RecordWaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags2 src_stage_mask,
-                                     const VkDependencyInfo *dependency_info, const Location &loc) {
-    for (auto &item : sub_states_) {
+void CommandBuffer::RecordWaitEvents(uint32_t eventCount, const VkEvent* pEvents, VkPipelineStageFlags2 src_stage_mask,
+                                     const VkDependencyInfo* dependency_info, const Location& loc) {
+    for (auto& item : sub_states_) {
         item.second->RecordWaitEvents(eventCount, pEvents, src_stage_mask, dependency_info, loc);
     }
     for (uint32_t i = 0; i < eventCount; ++i) {
@@ -2164,10 +2167,10 @@ void CommandBuffer::RecordWaitEvents(uint32_t eventCount, const VkEvent *pEvents
     }
 }
 
-void CommandBuffer::RecordBarrierObjects(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers,
-                                         uint32_t image_barrier_count, const VkImageMemoryBarrier *image_barriers,
+void CommandBuffer::RecordBarrierObjects(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier* buffer_barriers,
+                                         uint32_t image_barrier_count, const VkImageMemoryBarrier* image_barriers,
                                          VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
-                                         const Location &loc) {
+                                         const Location& loc) {
     if (!dev_data.disabled[command_buffer_state]) {
         for (uint32_t i = 0; i < buffer_barrier_count; i++) {
             if (auto buffer_state = dev_data.Get<vvl::Buffer>(buffer_barriers[i].buffer)) {
@@ -2181,13 +2184,13 @@ void CommandBuffer::RecordBarrierObjects(uint32_t buffer_barrier_count, const Vk
         }
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordBarriers(buffer_barrier_count, buffer_barriers, image_barrier_count, image_barriers, src_stage_mask,
                                     dst_stage_mask, loc);
     }
 }
 
-void CommandBuffer::RecordBarrierObjects(const VkDependencyInfo &dep_info, const Location &loc) {
+void CommandBuffer::RecordBarrierObjects(const VkDependencyInfo& dep_info, const Location& loc) {
     if (!dev_data.disabled[command_buffer_state]) {
         for (uint32_t i = 0; i < dep_info.bufferMemoryBarrierCount; i++) {
             if (auto buffer_state = dev_data.Get<vvl::Buffer>(dep_info.pBufferMemoryBarriers[i].buffer)) {
@@ -2204,14 +2207,14 @@ void CommandBuffer::RecordBarrierObjects(const VkDependencyInfo &dep_info, const
     // TODO - When moving here, these were not in CoreCheck, need to understand if we want SetEvents or not to validate the same
     // things as WaitEvent/PipelineBarriers
     if (loc.function != vvl::Func::vkCmdSetEvent2 && loc.function != vvl::Func::vkCmdSetEvent2KHR) {
-        for (auto &item : sub_states_) {
+        for (auto& item : sub_states_) {
             item.second->RecordBarriers2(dep_info, loc);
         }
     }
 }
 
-void CommandBuffer::RecordPushConstants(const vvl::PipelineLayout &pipeline_layout_state, VkShaderStageFlags stage_flags,
-                                        uint32_t offset, uint32_t size, const void *values) {
+void CommandBuffer::RecordPushConstants(const vvl::PipelineLayout& pipeline_layout_state, VkShaderStageFlags stage_flags,
+                                        uint32_t offset, uint32_t size, const void* values) {
     // Discussed in details in https://github.com/KhronosGroup/Vulkan-Docs/issues/1081
     // Internal discussion and CTS were written to prove that this is not called after an incompatible vkCmdBindPipeline
     // "Binding a pipeline with a layout that is not compatible with the push constant layout does not disturb the push constant
@@ -2223,12 +2226,12 @@ void CommandBuffer::RecordPushConstants(const vvl::PipelineLayout &pipeline_layo
     // triggered
     if (push_constant_ranges_layout != pipeline_layout_state.push_constant_ranges_layout) {
         push_constant_ranges_layout = pipeline_layout_state.push_constant_ranges_layout;
-        for (auto &item : sub_states_) {
+        for (auto& item : sub_states_) {
             item.second->ClearPushConstants();
         }
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->RecordPushConstants(pipeline_layout_state.VkHandle(), stage_flags, offset, size, values);
     }
 }
@@ -2245,44 +2248,44 @@ void CommandBuffer::RecordCmdPushDataEXT(const VkPushDataInfoEXT& push_data_info
     }
 }
 
-void CommandBuffer::RecordBeginConditionalRendering(const Location &loc) {
+void CommandBuffer::RecordBeginConditionalRendering(const Location& loc) {
     RecordCommand(loc);
     conditional_rendering_active = true;
     conditional_rendering_inside_render_pass = active_render_pass != nullptr;
     conditional_rendering_subpass = GetActiveSubpass();
 }
 
-void CommandBuffer::RecordEndConditionalRendering(const Location &loc) {
+void CommandBuffer::RecordEndConditionalRendering(const Location& loc) {
     RecordCommand(loc);
     conditional_rendering_active = false;
     conditional_rendering_inside_render_pass = false;
     conditional_rendering_subpass = 0;
 }
 
-void CommandBuffer::RecordSetRenderingAttachmentLocations(const VkRenderingAttachmentLocationInfo *pLocationInfo,
-                                                          const Location &loc) {
+void CommandBuffer::RecordSetRenderingAttachmentLocations(const VkRenderingAttachmentLocationInfo* pLocationInfo,
+                                                          const Location& loc) {
     RecordCommand(loc);
     rendering_attachments.set_color_locations = true;
     SetRenderingAttachmentLocations(rendering_attachments, pLocationInfo);
 }
 
-void CommandBuffer::RecordSetRenderingInputAttachmentIndices(const VkRenderingInputAttachmentIndexInfo *pLocationInfo,
-                                                             const Location &loc) {
+void CommandBuffer::RecordSetRenderingInputAttachmentIndices(const VkRenderingInputAttachmentIndexInfo* pLocationInfo,
+                                                             const Location& loc) {
     RecordCommand(loc);
     rendering_attachments.set_color_indexes = true;
     SetRenderingInputAttachmentIndices(rendering_attachments, pLocationInfo);
 }
 
-void CommandBuffer::SubmitTimeValidate(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc) {
-    for (const auto &it : video_session_updates) {
+void CommandBuffer::SubmitTimeValidate(Queue& queue_state, uint32_t perf_submit_pass, const Location& loc) {
+    for (const auto& it : video_session_updates) {
         auto video_session_state = dev_data.Get<vvl::VideoSession>(it.first);
         auto device_state = video_session_state->DeviceStateWrite();
-        for (const auto &function : it.second) {
+        for (const auto& function : it.second) {
             function(video_session_state.get(), *device_state, /*do_validate*/ false);
         }
     }
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Submit(queue_state, perf_submit_pass, loc);
     }
 }
@@ -2332,8 +2335,8 @@ bool CommandBuffer::HasExternalFormatResolveAttachment() const {
     return false;
 }
 
-void CommandBuffer::BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject *shader_object_state) {
-    auto &last_bound_state = lastBound[ConvertStageToVvlBindPoint(shader_stage)];
+void CommandBuffer::BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject* shader_object_state) {
+    auto& last_bound_state = lastBound[ConvertStageToVvlBindPoint(shader_stage)];
     const auto stage_index = static_cast<uint32_t>(VkShaderStageToShaderObjectStage(shader_stage));
     last_bound_state.shader_object_bound[stage_index] = true;
     last_bound_state.shader_object_states[stage_index] = shader_object_state;
@@ -2360,8 +2363,8 @@ void CommandBuffer::UnbindResources() {
 
 LogObjectList CommandBuffer::GetObjectList(VkShaderStageFlagBits stage) const {
     LogObjectList objlist(handle_);
-    const auto &last_bound = lastBound[ConvertStageToVvlBindPoint(stage)];
-    const auto *pipeline_state = last_bound.pipeline_state;
+    const auto& last_bound = lastBound[ConvertStageToVvlBindPoint(stage)];
+    const auto* pipeline_state = last_bound.pipeline_state;
 
     if (pipeline_state) {
         objlist.add(pipeline_state->Handle());
@@ -2374,8 +2377,8 @@ LogObjectList CommandBuffer::GetObjectList(VkShaderStageFlagBits stage) const {
 LogObjectList CommandBuffer::GetObjectList(VkPipelineBindPoint pipeline_bind_point) const {
     LogObjectList objlist(handle_);
 
-    const auto &last_bound = lastBound[ConvertToVvlBindPoint(pipeline_bind_point)];
-    const auto *pipeline_state = last_bound.pipeline_state;
+    const auto& last_bound = lastBound[ConvertToVvlBindPoint(pipeline_bind_point)];
+    const auto* pipeline_state = last_bound.pipeline_state;
 
     if (pipeline_state) {
         objlist.add(pipeline_state->Handle());
@@ -2416,7 +2419,7 @@ LogObjectList CommandBuffer::GetObjectList(VkPipelineBindPoint pipeline_bind_poi
     return objlist;
 }
 
-void CommandBuffer::BeginLabel(const char *label_name) {
+void CommandBuffer::BeginLabel(const char* label_name) {
     ++label_stack_depth_;
     label_commands_.emplace_back(LabelCommand{true, label_name});
 }
@@ -2426,9 +2429,9 @@ void CommandBuffer::EndLabel() {
     label_commands_.emplace_back(LabelCommand{false, std::string()});
 }
 
-void CommandBuffer::ReplayLabelCommands(const vvl::span<const LabelCommand> &label_commands,
-                                        std::vector<std::string> &label_stack) {
-    for (const LabelCommand &command : label_commands) {
+void CommandBuffer::ReplayLabelCommands(const vvl::span<const LabelCommand>& label_commands,
+                                        std::vector<std::string>& label_stack) {
+    for (const LabelCommand& command : label_commands) {
         if (command.begin) {
             label_stack.emplace_back(command.label_name.empty() ? "(empty label)" : command.label_name);
         } else if (!label_stack.empty()) {
@@ -2441,8 +2444,8 @@ void CommandBuffer::ReplayLabelCommands(const vvl::span<const LabelCommand> &lab
     }
 }
 
-std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand> &label_commands, uint32_t label_command_index,
-                                              const std::vector<std::string> &initial_label_stack) {
+std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand>& label_commands, uint32_t label_command_index,
+                                              const std::vector<std::string>& initial_label_stack) {
     if (label_command_index >= label_commands.size()) {
         // Can happen due to core validation error when in-use command buffer was re-recorded.
         // It's a bug if this happens in a valid vulkan program.
@@ -2454,7 +2457,7 @@ std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand> &l
 
     // Build up complete debug region name from all enclosing regions
     std::string debug_region;
-    for (const std::string &label_name : label_stack) {
+    for (const std::string& label_name : label_stack) {
         if (!debug_region.empty()) {
             debug_region += "::";
         }

--- a/layers/state_tracker/data_graph_pipeline_session_state.cpp
+++ b/layers/state_tracker/data_graph_pipeline_session_state.cpp
@@ -18,17 +18,17 @@
 
 namespace vvl {
 
-DataGraphPipelineSession::DataGraphPipelineSession(DeviceState &dev_data, VkDataGraphPipelineSessionARM handle,
-                                                   const VkDataGraphPipelineSessionCreateInfoARM *pCreateInfo)
+DataGraphPipelineSession::DataGraphPipelineSession(DeviceState& dev_data, VkDataGraphPipelineSessionARM handle,
+                                                   const VkDataGraphPipelineSessionCreateInfoARM* pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeDataGraphPipelineSessionARM),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       session_(handle),
-      unprotected_((pCreateInfo->flags & VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_PROTECTED_BIT_ARM) == 0) {
-}
+      unprotected_((pCreateInfo->flags & VK_DATA_GRAPH_PIPELINE_SESSION_CREATE_PROTECTED_BIT_ARM) == 0) {}
 
-void DataGraphPipelineSession::InitMemoryRequirements(VkDevice device, const VkDataGraphPipelineSessionBindPointRequirementARM *p_bind_point_reqs, uint32_t n_reqs) {
-
+void DataGraphPipelineSession::InitMemoryRequirements(VkDevice device,
+                                                      const VkDataGraphPipelineSessionBindPointRequirementARM* p_bind_point_reqs,
+                                                      uint32_t n_reqs) {
     bind_point_reqs_.resize(n_reqs);
     memcpy(bind_point_reqs_.data(), p_bind_point_reqs, n_reqs * sizeof(VkDataGraphPipelineSessionBindPointRequirementARM));
 
@@ -53,8 +53,9 @@ void DataGraphPipelineSession::AddBoundMemory(VkDataGraphPipelineSessionBindPoin
     bound_memory_map_[bind_point].push_back(binding);
 }
 
-const VkDataGraphPipelineSessionBindPointRequirementARM *DataGraphPipelineSession::FindBindPointRequirement(VkDataGraphPipelineSessionBindPointARM bind_point) const {
-    for (auto &bpr : bind_point_reqs_) {
+const VkDataGraphPipelineSessionBindPointRequirementARM* DataGraphPipelineSession::FindBindPointRequirement(
+    VkDataGraphPipelineSessionBindPointARM bind_point) const {
+    for (auto& bpr : bind_point_reqs_) {
         if (bpr.bindPoint == bind_point) {
             return &bpr;
         }

--- a/layers/state_tracker/descriptor_set_layouts.cpp
+++ b/layers/state_tracker/descriptor_set_layouts.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@
 
 namespace vvl {
 
-DescriptorSetLayoutList::DescriptorSetLayoutList(size_t size) : list(size){}
+DescriptorSetLayoutList::DescriptorSetLayoutList(size_t size) : list(size) {}
 
-const vvl::DescriptorSetLayout *DescriptorSetLayoutList::FindFromVariable(const spirv::ResourceInterfaceVariable &variable) const {
+const vvl::DescriptorSetLayout* DescriptorSetLayoutList::FindFromVariable(const spirv::ResourceInterfaceVariable& variable) const {
     const uint32_t set = variable.decorations.set;
     if (set < list.size()) {
         const std::shared_ptr<vvl::DescriptorSetLayout const> set_layout = list[set];

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -32,11 +32,11 @@
 #include "containers/limits.h"
 #include "utils/assert_utils.h"
 
-static vvl::DescriptorPool::TypeCountMap GetMaxTypeCounts(const VkDescriptorPoolCreateInfo *create_info) {
+static vvl::DescriptorPool::TypeCountMap GetMaxTypeCounts(const VkDescriptorPoolCreateInfo* create_info) {
     vvl::DescriptorPool::TypeCountMap counts;
     // Collect maximums per descriptor type.
     for (uint32_t i = 0; i < create_info->poolSizeCount; ++i) {
-        const auto &pool_size = create_info->pPoolSizes[i];
+        const auto& pool_size = create_info->pPoolSizes[i];
         uint32_t type = static_cast<uint32_t>(pool_size.type);
         // Same descriptor types can appear several times
         counts[type] += pool_size.descriptorCount;
@@ -44,8 +44,8 @@ static vvl::DescriptorPool::TypeCountMap GetMaxTypeCounts(const VkDescriptorPool
     return counts;
 }
 
-vvl::DescriptorPool::DescriptorPool(vvl::DeviceState &dev, const VkDescriptorPool handle,
-                                    const VkDescriptorPoolCreateInfo *pCreateInfo)
+vvl::DescriptorPool::DescriptorPool(vvl::DeviceState& dev, const VkDescriptorPool handle,
+                                    const VkDescriptorPoolCreateInfo* pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeDescriptorPool),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -55,8 +55,8 @@ vvl::DescriptorPool::DescriptorPool(vvl::DeviceState &dev, const VkDescriptorPoo
       available_counts_(max_descriptor_type_count),
       dev_data_(dev) {}
 
-void vvl::DescriptorPool::Allocate(const VkDescriptorSetAllocateInfo *alloc_info, const VkDescriptorSet *descriptor_sets,
-                                   const vvl::AllocateDescriptorSetsData &ds_data) {
+void vvl::DescriptorPool::Allocate(const VkDescriptorSetAllocateInfo* alloc_info, const VkDescriptorSet* descriptor_sets,
+                                   const vvl::AllocateDescriptorSetsData& ds_data) {
     auto guard = WriteLock();
     const auto alloc_count = alloc_info->descriptorSetCount;
     // Account for sets and individual descriptors allocated from pool
@@ -65,7 +65,7 @@ void vvl::DescriptorPool::Allocate(const VkDescriptorSetAllocateInfo *alloc_info
         available_counts_[it->first] -= ds_data.required_descriptors_by_type.at(it->first);
     }
 
-    const auto *variable_count_info =
+    const auto* variable_count_info =
         vku::FindStructInPNextChain<VkDescriptorSetVariableDescriptorCountAllocateInfo>(alloc_info->pNext);
     const bool variable_count_valid = variable_count_info && variable_count_info->descriptorSetCount == alloc_count;
 
@@ -86,7 +86,7 @@ void vvl::DescriptorPool::Allocate(const VkDescriptorSetAllocateInfo *alloc_info
     }
 }
 
-void vvl::DescriptorPool::Free(uint32_t count, const VkDescriptorSet *descriptor_sets) {
+void vvl::DescriptorPool::Free(uint32_t count, const VkDescriptorSet* descriptor_sets) {
     auto guard = WriteLock();
     // Update available descriptor sets in pool
     available_sets_ += count;
@@ -98,8 +98,8 @@ void vvl::DescriptorPool::Free(uint32_t count, const VkDescriptorSet *descriptor
         if (descriptor_sets[i] != VK_NULL_HANDLE) {
             auto iter = sets_.find(descriptor_sets[i]);
             ASSERT_AND_CONTINUE(iter != sets_.end());
-            auto *set_state = iter->second;
-            const auto &layout = set_state->Layout();
+            auto* set_state = iter->second;
+            const auto& layout = set_state->Layout();
             uint32_t type_index = 0, descriptor_count = 0;
             for (uint32_t j = 0; j < layout.GetBindingCount(); ++j) {
                 type_index = static_cast<uint32_t>(layout.GetTypeFromIndex(j));
@@ -124,10 +124,10 @@ void vvl::DescriptorPool::Reset() {
     available_sets_ = maxSets;
 }
 
-const VulkanTypedHandle *vvl::DescriptorPool::InUse() const {
+const VulkanTypedHandle* vvl::DescriptorPool::InUse() const {
     auto guard = ReadLock();
-    for (const auto &entry : sets_) {
-        const auto *ds = entry.second;
+    for (const auto& entry : sets_) {
+        const auto* ds = entry.second;
         if (ds) {
             return ds->InUse();
         }
@@ -144,14 +144,14 @@ void vvl::DescriptorPool::Destroy() {
 // state that comes from a different array/structure so they can stay together
 // while being sorted by binding number.
 struct ExtendedBinding {
-    ExtendedBinding(const VkDescriptorSetLayoutBinding *l, VkDescriptorBindingFlags f) : layout_binding(l), binding_flags(f) {}
+    ExtendedBinding(const VkDescriptorSetLayoutBinding* l, VkDescriptorBindingFlags f) : layout_binding(l), binding_flags(f) {}
 
-    const VkDescriptorSetLayoutBinding *layout_binding;
+    const VkDescriptorSetLayoutBinding* layout_binding;
     VkDescriptorBindingFlags binding_flags;
 };
 
 struct BindingNumCmp {
-    bool operator()(const ExtendedBinding &a, const ExtendedBinding &b) const {
+    bool operator()(const ExtendedBinding& a, const ExtendedBinding& b) const {
         return a.layout_binding->binding < b.layout_binding->binding;
     }
 };
@@ -197,13 +197,13 @@ using DescriptorSetLayout = vvl::DescriptorSetLayout;
 using DescriptorSetLayoutDef = vvl::DescriptorSetLayoutDef;
 using DescriptorSetLayoutId = vvl::DescriptorSetLayoutId;
 
-std::string DescriptorSetLayoutDef::DescribeDifference(uint32_t index, const DescriptorSetLayoutDef &other) const {
+std::string DescriptorSetLayoutDef::DescribeDifference(uint32_t index, const DescriptorSetLayoutDef& other) const {
     std::ostringstream ss;
     ss << "Set " << index << " ";
     auto lhs_binding_flags = GetBindingFlags();
     auto rhs_binding_flags = other.GetBindingFlags();
-    const auto &lhs_bindings = GetBindings();
-    const auto &rhs_bindings = other.GetBindings();
+    const auto& lhs_bindings = GetBindings();
+    const auto& rhs_bindings = other.GetBindings();
 
     if (GetCreateFlags() != other.GetCreateFlags()) {
         ss << "VkDescriptorSetLayoutCreateFlags " << string_VkDescriptorSetLayoutCreateFlags(GetCreateFlags()) << " doesn't match "
@@ -229,8 +229,8 @@ std::string DescriptorSetLayoutDef::DescribeDifference(uint32_t index, const Des
             if (found) {
                 break;
             }
-            const auto &l = lhs_bindings[i];
-            const auto &r = rhs_bindings[i];
+            const auto& l = lhs_bindings[i];
+            const auto& r = rhs_bindings[i];
             if (l.binding != r.binding) {
                 ss << "VkDescriptorSetLayoutBinding::binding " << l.binding << " doesn't match " << r.binding;
                 found = true;
@@ -273,15 +273,15 @@ std::string DescriptorSetLayoutDef::DescribeDifference(uint32_t index, const Des
 
 // Construct DescriptorSetLayout instance from given create info
 // Proactively reserve and resize as possible, as the reallocation was visible in profiling
-vvl::DescriptorSetLayoutDef::DescriptorSetLayoutDef(vvl::DeviceState &device_state,
-                                                    const VkDescriptorSetLayoutCreateInfo *p_create_info)
+vvl::DescriptorSetLayoutDef::DescriptorSetLayoutDef(vvl::DeviceState& device_state,
+                                                    const VkDescriptorSetLayoutCreateInfo* p_create_info)
     : flags_(p_create_info->flags),
       has_ycbcr_samplers_(false),
       binding_count_(0),
       descriptor_count_(0),
       non_inline_descriptor_count_(0),
       dynamic_descriptor_count_(0) {
-    const auto *flags_create_info = vku::FindStructInPNextChain<VkDescriptorSetLayoutBindingFlagsCreateInfo>(p_create_info->pNext);
+    const auto* flags_create_info = vku::FindStructInPNextChain<VkDescriptorSetLayoutBindingFlagsCreateInfo>(p_create_info->pNext);
 
     binding_type_stats_ = {0, 0};
     std::set<ExtendedBinding, BindingNumCmp> sorted_bindings;
@@ -301,13 +301,13 @@ vvl::DescriptorSetLayoutDef::DescriptorSetLayoutDef(vvl::DeviceState &device_sta
     bindings_.reserve(binding_count_);
     binding_flags_.reserve(binding_count_);
     binding_to_index_map_.reserve(binding_count_);
-    for (const auto &input_binding : sorted_bindings) {
+    for (const auto& input_binding : sorted_bindings) {
         // Add to binding and map, s.t. it is robust to invalid duplication of binding_num
         const auto binding_num = input_binding.layout_binding->binding;
         binding_to_index_map_[binding_num] = binding_index;
         bindings_.emplace_back(input_binding.layout_binding);
         // safe_VkDescriptorSetLayoutBinding will do some extra "cleanup" logic, so want to use it
-        auto &binding_info = bindings_.back();
+        auto& binding_info = bindings_.back();
         binding_flags_.emplace_back(input_binding.binding_flags);
 
         descriptor_count_ += binding_info.descriptorCount;
@@ -368,11 +368,11 @@ vvl::DescriptorSetLayoutDef::DescriptorSetLayoutDef(vvl::DeviceState &device_sta
 
     // Need to do after because of the way we sort above, the |index| in pMutableDescriptorTypeLists[index] is based on the create
     // info, but this information is lost and we have changed to a sorted list based on bindings.
-    if (const auto *mutable_descriptor_type_create_info =
+    if (const auto* mutable_descriptor_type_create_info =
             vku::FindStructInPNextChain<VkMutableDescriptorTypeCreateInfoEXT>(p_create_info->pNext)) {
         mutable_bindings_.resize(mutable_descriptor_type_create_info->mutableDescriptorTypeListCount);
         for (uint32_t i = 0; i < mutable_descriptor_type_create_info->mutableDescriptorTypeListCount; ++i) {
-            const auto &list = mutable_descriptor_type_create_info->pMutableDescriptorTypeLists[i];
+            const auto& list = mutable_descriptor_type_create_info->pMutableDescriptorTypeLists[i];
             const uint32_t mutable_index = binding_to_index_map_[p_create_info->pBindings[i].binding];
             mutable_bindings_[mutable_index].original_index = i;
             mutable_bindings_[mutable_index].types.resize(list.descriptorTypeCount);
@@ -390,7 +390,7 @@ size_t vvl::DescriptorSetLayoutDef::hash() const {
     hash_util::HashCombiner hc;
     hc << flags_;
     for (auto [i, safe_binding] : vvl::enumerate(bindings_)) {
-        const VkDescriptorSetLayoutBinding &binding = *safe_binding.ptr();
+        const VkDescriptorSetLayoutBinding& binding = *safe_binding.ptr();
         const size_t samplers_combined_hash = binding.pImmutableSamplers ? immutable_sampler_combined_hashes_[i] : 0;
         hc.Combine(DescriptorSetLayoutBindingHashingData{binding, samplers_combined_hash});
     }
@@ -402,11 +402,11 @@ size_t vvl::DescriptorSetLayoutDef::hash() const {
 // The asserts in "Get" are reduced to the set where no valid answer(like null or 0) could be given
 // Common code for all binding lookups.
 uint32_t vvl::DescriptorSetLayoutDef::GetIndexFromBinding(uint32_t binding) const {
-    const auto &bi_itr = binding_to_index_map_.find(binding);
+    const auto& bi_itr = binding_to_index_map_.find(binding);
     if (bi_itr != binding_to_index_map_.cend()) return bi_itr->second;
     return GetBindingCount();
 }
-VkDescriptorSetLayoutBinding const *vvl::DescriptorSetLayoutDef::GetDescriptorSetLayoutBindingPtrFromIndex(
+VkDescriptorSetLayoutBinding const* vvl::DescriptorSetLayoutDef::GetDescriptorSetLayoutBindingPtrFromIndex(
     const uint32_t index) const {
     if (index >= bindings_.size()) return nullptr;
     return bindings_[index].ptr();
@@ -428,7 +428,7 @@ VkDescriptorBindingFlags vvl::DescriptorSetLayoutDef::GetDescriptorBindingFlagsF
     return binding_flags_[index];
 }
 
-const vvl::IndexRange &vvl::DescriptorSetLayoutDef::GetGlobalIndexRangeFromIndex(uint32_t index) const {
+const vvl::IndexRange& vvl::DescriptorSetLayoutDef::GetGlobalIndexRangeFromIndex(uint32_t index) const {
     const static IndexRange k_invalid_range = {0xFFFFFFFF, 0xFFFFFFFF};
     if (index >= binding_flags_.size()) return k_invalid_range;
     return global_index_range_[index];
@@ -436,7 +436,7 @@ const vvl::IndexRange &vvl::DescriptorSetLayoutDef::GetGlobalIndexRangeFromIndex
 
 // For the given binding, return the global index range (half open)
 // As start and end are often needed in pairs, get both with a single lookup.
-const vvl::IndexRange &vvl::DescriptorSetLayoutDef::GetGlobalIndexRangeFromBinding(const uint32_t binding) const {
+const vvl::IndexRange& vvl::DescriptorSetLayoutDef::GetGlobalIndexRangeFromBinding(const uint32_t binding) const {
     uint32_t index = GetIndexFromBinding(binding);
     return GetGlobalIndexRangeFromIndex(index);
 }
@@ -448,7 +448,7 @@ uint32_t vvl::DescriptorSetLayoutDef::GetNextValidBinding(const uint32_t binding
     return GetMaxBinding() + 1;
 }
 
-const std::vector<vku::safe_VkSamplerCreateInfo> &DescriptorSetLayoutDef::GetImmutableSamplerCreateInfosFromIndex(
+const std::vector<vku::safe_VkSamplerCreateInfo>& DescriptorSetLayoutDef::GetImmutableSamplerCreateInfosFromIndex(
     uint32_t index) const {
     static const std::vector<vku::safe_VkSamplerCreateInfo> empty_sampler_infos;
     if (immutable_sampler_create_infos_.empty()) {
@@ -465,7 +465,7 @@ bool vvl::DescriptorSetLayoutDef::IsTypeMutable(const VkDescriptorType type, uin
     const uint32_t index = GetIndexFromBinding(binding);
     if (index < mutable_bindings_.size()) {
         if (mutable_bindings_[index].types.size() > 0) {
-            for (const VkDescriptorType &mutable_type : mutable_bindings_[index].types) {
+            for (const VkDescriptorType& mutable_type : mutable_bindings_[index].types) {
                 if (type == mutable_type) {
                     return true;
                 }
@@ -485,7 +485,7 @@ std::string vvl::DescriptorSetLayoutDef::PrintMutableTypes(uint32_t binding) con
         ss << "no Mutable Type list at this binding " << binding;
     } else {
         ss << "pMutableDescriptorTypeLists[" << mutable_bindings_[index].original_index << "].pDescriptorTypes is ";
-        const std::vector<VkDescriptorType> &mutable_types = mutable_bindings_[index].types;
+        const std::vector<VkDescriptorType>& mutable_types = mutable_bindings_[index].types;
         if (mutable_types.empty()) {
             ss << "empty";
         } else {
@@ -503,7 +503,7 @@ std::string vvl::DescriptorSetLayoutDef::PrintMutableTypes(uint32_t binding) con
     return ss.str();
 }
 
-const std::vector<VkDescriptorType> &vvl::DescriptorSetLayoutDef::GetMutableTypes(uint32_t binding) const {
+const std::vector<VkDescriptorType>& vvl::DescriptorSetLayoutDef::GetMutableTypes(uint32_t binding) const {
     const uint32_t index = GetIndexFromBinding(binding);
     if (index >= mutable_bindings_.size()) {
         static const std::vector<VkDescriptorType> empty = {};
@@ -532,16 +532,16 @@ std::string vvl::DescriptorSetLayoutDef::DescribeDescriptorBufferSizeAndOffsets(
     return ss.str();
 }
 
-bool vvl::ImmutableSamplersAreEqual(const DescriptorSetLayoutDef &dsl_def1, const DescriptorSetLayoutDef &dsl_def2,
+bool vvl::ImmutableSamplersAreEqual(const DescriptorSetLayoutDef& dsl_def1, const DescriptorSetLayoutDef& dsl_def2,
                                     uint32_t binding_index) {
     const size_t hash1 = dsl_def1.GetImmutableSamplersCombinedHashFromIndex(binding_index);
     const size_t hash2 = dsl_def2.GetImmutableSamplersCombinedHashFromIndex(binding_index);
     if (hash1 != hash2) {
         return false;
     }
-    const std::vector<vku::safe_VkSamplerCreateInfo> &create_infos1 =
+    const std::vector<vku::safe_VkSamplerCreateInfo>& create_infos1 =
         dsl_def1.GetImmutableSamplerCreateInfosFromIndex(binding_index);
-    const std::vector<vku::safe_VkSamplerCreateInfo> &create_infos2 =
+    const std::vector<vku::safe_VkSamplerCreateInfo>& create_infos2 =
         dsl_def1.GetImmutableSamplerCreateInfosFromIndex(binding_index);
     if (create_infos1.size() != create_infos2.size()) {
         return false;
@@ -554,20 +554,20 @@ bool vvl::ImmutableSamplersAreEqual(const DescriptorSetLayoutDef &dsl_def1, cons
     return true;
 }
 
-bool vvl::operator==(const DescriptorSetLayoutDef &lhs, const DescriptorSetLayoutDef &rhs) {
+bool vvl::operator==(const DescriptorSetLayoutDef& lhs, const DescriptorSetLayoutDef& rhs) {
     // trivial types
     if ((lhs.GetCreateFlags() != rhs.GetCreateFlags()) || (lhs.GetBindingFlags() != rhs.GetBindingFlags())) {
         return false;
     }
     // vectors of vku::safe_VkDescriptorSetLayoutBinding structures
-    const auto &lhs_bindings = lhs.GetBindings();
-    const auto &rhs_bindings = rhs.GetBindings();
+    const auto& lhs_bindings = lhs.GetBindings();
+    const auto& rhs_bindings = rhs.GetBindings();
     if (lhs_bindings.size() != rhs_bindings.size()) {
         return false;
     }
     for (uint32_t i = 0; i < lhs_bindings.size(); i++) {
-        const auto &l = lhs_bindings[i];
-        const auto &r = rhs_bindings[i];
+        const auto& l = lhs_bindings[i];
+        const auto& r = rhs_bindings[i];
         // For things where we are comparing with the bound pipeline, the binding will always be right, but when comparing two
         // arbitrary layouts (ex. templates, DeviceState Generated Commands, etc) the bindings might be different
         if (l.binding != r.binding) {
@@ -588,13 +588,13 @@ bool vvl::operator==(const DescriptorSetLayoutDef &lhs, const DescriptorSetLayou
 }
 
 // If our layout is compatible with rh_ds_layout, return true.
-bool vvl::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const *rh_ds_layout) const {
+bool vvl::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const* rh_ds_layout) const {
     return (this == rh_ds_layout) || (GetLayoutDef() == rh_ds_layout->GetLayoutDef());
 }
 
 // The DescriptorSetLayout stores the per handle data for a descriptor set layout, and references the common defintion for the
 // handle invariant portion
-vvl::DescriptorSetLayout::DescriptorSetLayout(vvl::DeviceState &device_state, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
+vvl::DescriptorSetLayout::DescriptorSetLayout(vvl::DeviceState& device_state, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                               const VkDescriptorSetLayout handle)
     : StateObject(handle, kVulkanObjectTypeDescriptorSetLayout),
       layout_id_(device_state.GetCanonicalId(pCreateInfo)),
@@ -618,9 +618,9 @@ vvl::DescriptorSetLayout::DescriptorSetLayout(vvl::DeviceState &device_state, co
     }
 }
 
-vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorPool *pool_state,
-                                  const std::shared_ptr<DescriptorSetLayout const> &layout, uint32_t variable_count,
-                                  vvl::DeviceState *state_data)
+vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorPool* pool_state,
+                                  const std::shared_ptr<DescriptorSetLayout const>& layout, uint32_t variable_count,
+                                  vvl::DeviceState* state_data)
     : StateObject(handle, kVulkanObjectTypeDescriptorSet),
       some_update_(false),
       pool_state_(pool_state),
@@ -720,14 +720,14 @@ vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorP
 
 void vvl::DescriptorSet::LinkChildNodes() {
     // Connect child node(s), which cannot safely be done in the constructor.
-    for (auto &binding : bindings_) {
+    for (auto& binding : bindings_) {
         binding->AddParent(this);
     }
 }
 
-void vvl::DescriptorSet::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void vvl::DescriptorSet::NotifyInvalidate(const NodeList& invalid_nodes, bool unlink) {
     BaseClass::NotifyInvalidate(invalid_nodes, unlink);
-    for (auto &binding : bindings_) {
+    for (auto& binding : bindings_) {
         binding->NotifyInvalidate(invalid_nodes, unlink);
     }
 }
@@ -749,7 +749,7 @@ uint32_t vvl::DescriptorSet::GetDynamicOffsetIndexFromBinding(uint32_t dynamic_b
 
 std::pair<uint32_t, uint32_t> vvl::DescriptorSet::GetBindingAndIndex(const uint32_t global_descriptor_index) const {
     uint32_t current_offset = 0;
-    for (const auto &binding_state : bindings_) {
+    for (const auto& binding_state : bindings_) {
         const uint32_t binding_index = binding_state->binding;
         // maps to BuildBindingLayouts()
         const uint32_t count = (binding_state->type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) ? 1 : binding_state->count;
@@ -767,7 +767,7 @@ std::pair<uint32_t, uint32_t> vvl::DescriptorSet::GetBindingAndIndex(const uint3
 }
 
 void vvl::DescriptorSet::Destroy() {
-    for (auto &binding : bindings_) {
+    for (auto& binding : bindings_) {
         binding->RemoveParent(this);
     }
     StateObject::Destroy();
@@ -775,13 +775,13 @@ void vvl::DescriptorSet::Destroy() {
 
 // Will let things like GPU-AV know descriptor sets are updated
 void vvl::DescriptorSet::NotifyUpdate() {
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->NotifyUpdate();
     }
 }
 
 // Loop through the write updates to do for a push descriptor set, ignoring dstSet
-void vvl::DescriptorSet::PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs) {
+void vvl::DescriptorSet::PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet* write_descs) {
     assert(IsPushDescriptor());
     for (uint32_t i = 0; i < write_count; i++) {
         PerformWriteUpdate(write_descs[i]);
@@ -797,12 +797,12 @@ void vvl::DescriptorSet::PerformPushDescriptorsUpdate(uint32_t write_count, cons
 }
 
 // Perform write update in given update struct
-void vvl::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &update) {
+void vvl::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet& update) {
     // Perform update on a per-binding basis as consecutive updates roll over to next binding
     auto descriptors_remaining = update.descriptorCount;
     auto iter = FindDescriptor(update.dstBinding, update.dstArrayElement);
     ASSERT_AND_RETURN(iter.IsValid());
-    auto &orig_binding = iter.CurrentBinding();
+    auto& orig_binding = iter.CurrentBinding();
 
     // Verify next consecutive binding matches type, stage flags & immutable sampler use and if AtEnd
     for (uint32_t i = 0; i < descriptors_remaining; ++i, ++iter) {
@@ -826,18 +826,18 @@ void vvl::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &update) 
 }
 
 // Perform Copy update
-void vvl::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet &update, const DescriptorSet &src_set) {
+void vvl::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet& update, const DescriptorSet& src_set) {
     auto src_iter = src_set.FindDescriptor(update.srcBinding, update.srcArrayElement);
     auto dst_iter = FindDescriptor(update.dstBinding, update.dstArrayElement);
     ASSERT_AND_RETURN(src_iter.IsValid() && dst_iter.IsValid());
     // Update parameters all look good so perform update
     for (uint32_t i = 0; i < update.descriptorCount; ++i, ++src_iter, ++dst_iter) {
-        auto &src = *src_iter;
-        auto &dst = *dst_iter;
+        auto& src = *src_iter;
+        auto& dst = *dst_iter;
         if (src_iter.updated()) {
             auto type = src_iter.CurrentBinding().type;
             if (type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
-                const auto &mutable_src = static_cast<const MutableDescriptor &>(src);
+                const auto& mutable_src = static_cast<const MutableDescriptor&>(src);
                 type = mutable_src.ActiveType();
             }
             dst.CopyUpdate(*this, *state_data_, src, IsBindless(src_iter.CurrentBinding().binding_flags), type);
@@ -864,15 +864,15 @@ void vvl::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet &update, co
 // TODO: Modify the UpdateImageLayoutDrawState virtural functions to *only* set initial layout and not change layouts
 // Prereq: This should be called for a set that has been confirmed to be active for the given cb_state, meaning it's going
 //   to be used in a draw by the given cb_state
-void vvl::DescriptorSet::UpdateImageLayoutDrawStates(vvl::DeviceState *device_data, vvl::CommandBuffer &cb_state,
-                                                     const BindingVariableMap &binding_req_map) {
+void vvl::DescriptorSet::UpdateImageLayoutDrawStates(vvl::DeviceState* device_data, vvl::CommandBuffer& cb_state,
+                                                     const BindingVariableMap& binding_req_map) {
     // Descriptor UpdateImageLayoutDrawState only call image layout validation callbacks. If it is disabled, skip the entire loop.
     if (device_data->disabled[image_layout_validation]) return;
 
     // For the active slots, use set# to look up descriptorSet from boundDescriptorSets, and bind all of that descriptor set's
     // resources
-    for (const auto &binding_req_pair : binding_req_map) {
-        auto *binding = GetBinding(binding_req_pair.first);
+    for (const auto& binding_req_pair : binding_req_map) {
+        auto* binding = GetBinding(binding_req_pair.first);
         ASSERT_AND_CONTINUE(binding);
 
         // core validation doesn't handle descriptor indexing, that is only done by GPU-AV
@@ -882,21 +882,21 @@ void vvl::DescriptorSet::UpdateImageLayoutDrawStates(vvl::DeviceState *device_da
 
         switch (binding->descriptor_class) {
             case DescriptorClass::Image: {
-                auto *image_binding = static_cast<ImageBinding *>(binding);
+                auto* image_binding = static_cast<ImageBinding*>(binding);
                 for (uint32_t i = 0; i < image_binding->count; ++i) {
                     image_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
                 }
                 break;
             }
             case DescriptorClass::ImageSampler: {
-                auto *image_binding = static_cast<ImageSamplerBinding *>(binding);
+                auto* image_binding = static_cast<ImageSamplerBinding*>(binding);
                 for (uint32_t i = 0; i < image_binding->count; ++i) {
                     image_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
                 }
                 break;
             }
             case DescriptorClass::Mutable: {
-                auto *mutable_binding = static_cast<MutableBinding *>(binding);
+                auto* mutable_binding = static_cast<MutableBinding*>(binding);
                 for (uint32_t i = 0; i < mutable_binding->count; ++i) {
                     mutable_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
                 }
@@ -909,8 +909,8 @@ void vvl::DescriptorSet::UpdateImageLayoutDrawStates(vvl::DeviceState *device_da
 }
 
 // This is used to decide if we should validate the Descirptors on the CPU or GPU-AV
-bool vvl::DescriptorSet::ValidateBindingOnGPU(const DescriptorBinding &binding,
-                                              const spirv::ResourceInterfaceVariable &variable) const {
+bool vvl::DescriptorSet::ValidateBindingOnGPU(const DescriptorBinding& binding,
+                                              const spirv::ResourceInterfaceVariable& variable) const {
     // Some applications (notably Doom Eternal) might have large non-bindless descriptors attached (basically doing Descriptor
     // Indexing without the extension). Trying to loop through these on the CPU will bring FPS down by over 50% so we make use of
     // the post processing to detect which descriptors were actually accessed
@@ -936,7 +936,7 @@ bool vvl::DescriptorSet::ValidateBindingOnGPU(const DescriptorBinding &binding,
 // correctly managing links to the parent DescriptorSet.
 // src and dst are shared pointers.
 template <typename T>
-static void ReplaceStatePtr(DescriptorSet &set_state, T &dst, const T &src, bool is_bindless) {
+static void ReplaceStatePtr(DescriptorSet& set_state, T& dst, const T& src, bool is_bindless) {
     if (dst && !is_bindless) {
         dst->RemoveParent(&set_state);
     }
@@ -948,24 +948,24 @@ static void ReplaceStatePtr(DescriptorSet &set_state, T &dst, const T &src, bool
     }
 }
 
-void vvl::SamplerDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                         const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
+void vvl::SamplerDescriptor::WriteUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                         const VkWriteDescriptorSet& update, const uint32_t index, bool is_bindless) {
     if (!immutable_ && update.pImageInfo) {
         ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(update.pImageInfo[index].sampler),
                         is_bindless);
     }
 }
 
-void vvl::SamplerDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data, const Descriptor &src,
+void vvl::SamplerDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data, const Descriptor& src,
                                         bool is_bindless, VkDescriptorType) {
     if (src.GetClass() == DescriptorClass::Mutable) {
-        auto &sampler_src = static_cast<const MutableDescriptor &>(src);
+        auto& sampler_src = static_cast<const MutableDescriptor&>(src);
         if (!immutable_) {
             ReplaceStatePtr(set_state, sampler_state_, sampler_src.GetSharedSamplerState(), is_bindless);
         }
         return;
     }
-    auto &sampler_src = static_cast<const SamplerDescriptor &>(src);
+    auto& sampler_src = static_cast<const SamplerDescriptor&>(src);
     if (!immutable_) {
         ReplaceStatePtr(set_state, sampler_state_, sampler_src.sampler_state_, is_bindless);
     }
@@ -973,29 +973,29 @@ void vvl::SamplerDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Dev
 
 VkSampler vvl::SamplerDescriptor::GetSampler() const { return sampler_state_ ? sampler_state_->VkHandle() : VK_NULL_HANDLE; }
 
-void vvl::SamplerDescriptor::SetImmutableSampler(std::shared_ptr<vvl::Sampler> &&state) {
+void vvl::SamplerDescriptor::SetImmutableSampler(std::shared_ptr<vvl::Sampler>&& state) {
     sampler_state_ = std::move(state);
     immutable_ = true;
 }
 
-bool vvl::SamplerDescriptor::AddParent(StateObject *state_object) {
+bool vvl::SamplerDescriptor::AddParent(StateObject* state_object) {
     bool result = false;
     if (sampler_state_) {
         result = sampler_state_->AddParent(state_object);
     }
     return result;
 }
-void vvl::SamplerDescriptor::RemoveParent(StateObject *state_object) {
+void vvl::SamplerDescriptor::RemoveParent(StateObject* state_object) {
     if (sampler_state_) {
         sampler_state_->RemoveParent(state_object);
     }
 }
 bool vvl::SamplerDescriptor::Invalid() const { return !sampler_state_ || sampler_state_->Invalid(); }
 
-void vvl::ImageSamplerDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                              const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
+void vvl::ImageSamplerDescriptor::WriteUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                              const VkWriteDescriptorSet& update, const uint32_t index, bool is_bindless) {
     if (!update.pImageInfo) return;
-    const auto &image_info = update.pImageInfo[index];
+    const auto& image_info = update.pImageInfo[index];
     if (!immutable_) {
         ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(image_info.sampler), is_bindless);
     }
@@ -1004,17 +1004,17 @@ void vvl::ImageSamplerDescriptor::WriteUpdate(DescriptorSet &set_state, const vv
     UpdateKnownValidView(is_bindless);
 }
 
-void vvl::ImageSamplerDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data, const Descriptor &src,
+void vvl::ImageSamplerDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data, const Descriptor& src,
                                              bool is_bindless, VkDescriptorType src_type) {
     if (src.GetClass() == DescriptorClass::Mutable) {
-        auto &image_src = static_cast<const MutableDescriptor &>(src);
+        auto& image_src = static_cast<const MutableDescriptor&>(src);
         if (!immutable_) {
             ReplaceStatePtr(set_state, sampler_state_, image_src.GetSharedSamplerState(), is_bindless);
         }
         ImageDescriptor::CopyUpdate(set_state, dev_data, src, is_bindless, src_type);
         return;
     }
-    auto &image_src = static_cast<const ImageSamplerDescriptor &>(src);
+    auto& image_src = static_cast<const ImageSamplerDescriptor&>(src);
     if (!immutable_) {
         ReplaceStatePtr(set_state, sampler_state_, image_src.sampler_state_, is_bindless);
     }
@@ -1023,19 +1023,19 @@ void vvl::ImageSamplerDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl
 
 VkSampler vvl::ImageSamplerDescriptor::GetSampler() const { return sampler_state_ ? sampler_state_->VkHandle() : VK_NULL_HANDLE; }
 
-void vvl::ImageSamplerDescriptor::SetImmutableSampler(std::shared_ptr<vvl::Sampler> &&state) {
+void vvl::ImageSamplerDescriptor::SetImmutableSampler(std::shared_ptr<vvl::Sampler>&& state) {
     sampler_state_ = std::move(state);
     immutable_ = true;
 }
 
-bool vvl::ImageSamplerDescriptor::AddParent(StateObject *state_object) {
+bool vvl::ImageSamplerDescriptor::AddParent(StateObject* state_object) {
     bool result = ImageDescriptor::AddParent(state_object);
     if (sampler_state_) {
         result |= sampler_state_->AddParent(state_object);
     }
     return result;
 }
-void vvl::ImageSamplerDescriptor::RemoveParent(StateObject *state_object) {
+void vvl::ImageSamplerDescriptor::RemoveParent(StateObject* state_object) {
     ImageDescriptor::RemoveParent(state_object);
     if (sampler_state_) {
         sampler_state_->RemoveParent(state_object);
@@ -1046,33 +1046,33 @@ bool vvl::ImageSamplerDescriptor::Invalid() const {
     return ImageDescriptor::Invalid() || !sampler_state_ || sampler_state_->Invalid();
 }
 
-void vvl::ImageDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                       const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
+void vvl::ImageDescriptor::WriteUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                       const VkWriteDescriptorSet& update, const uint32_t index, bool is_bindless) {
     if (!update.pImageInfo) return;
-    const auto &image_info = update.pImageInfo[index];
+    const auto& image_info = update.pImageInfo[index];
     image_layout_ = image_info.imageLayout;
     ReplaceStatePtr(set_state, image_view_state_, dev_data.GetConstCastShared<vvl::ImageView>(image_info.imageView), is_bindless);
     UpdateKnownValidView(is_bindless);
 }
 
-void vvl::ImageDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data, const Descriptor &src,
+void vvl::ImageDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data, const Descriptor& src,
                                       bool is_bindless, VkDescriptorType src_type) {
     if (src.GetClass() == DescriptorClass::Mutable) {
-        auto &image_src = static_cast<const MutableDescriptor &>(src);
+        auto& image_src = static_cast<const MutableDescriptor&>(src);
 
         image_layout_ = image_src.GetImageLayout();
         ReplaceStatePtr(set_state, image_view_state_, image_src.GetSharedImageViewState(), is_bindless);
         UpdateKnownValidView(is_bindless);
         return;
     }
-    auto &image_src = static_cast<const ImageDescriptor &>(src);
+    auto& image_src = static_cast<const ImageDescriptor&>(src);
 
     image_layout_ = image_src.image_layout_;
     ReplaceStatePtr(set_state, image_view_state_, image_src.image_view_state_, is_bindless);
     UpdateKnownValidView(is_bindless);
 }
 
-void vvl::ImageDescriptor::UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_state) {
+void vvl::ImageDescriptor::UpdateImageLayoutDrawState(vvl::CommandBuffer& cb_state) {
     // Add binding for image
     if (auto iv_state = GetImageViewState()) {
         cb_state.TrackImageViewFirstLayout(*iv_state, image_layout_, nullptr);
@@ -1083,19 +1083,19 @@ VkImageView vvl::ImageDescriptor::GetImageView() const {
     return image_view_state_ ? image_view_state_->VkHandle() : VK_NULL_HANDLE;
 }
 
-bool vvl::ImageDescriptor::AddParent(StateObject *state_object) {
+bool vvl::ImageDescriptor::AddParent(StateObject* state_object) {
     bool result = false;
     if (image_view_state_) {
         result = image_view_state_->AddParent(state_object);
     }
     return result;
 }
-void vvl::ImageDescriptor::RemoveParent(StateObject *state_object) {
+void vvl::ImageDescriptor::RemoveParent(StateObject* state_object) {
     if (image_view_state_) {
         image_view_state_->RemoveParent(state_object);
     }
 }
-void vvl::ImageDescriptor::InvalidateNode(const std::shared_ptr<StateObject> &invalid_node, bool unlink) {
+void vvl::ImageDescriptor::InvalidateNode(const std::shared_ptr<StateObject>& invalid_node, bool unlink) {
     if (invalid_node == image_view_state_) {
         known_valid_view_ = false;
         if (unlink) {
@@ -1108,25 +1108,25 @@ bool vvl::ImageDescriptor::Invalid() const { return !known_valid_view_ && Comput
 bool vvl::ImageDescriptor::ComputeInvalid() const { return !image_view_state_ || image_view_state_->Invalid(); }
 void vvl::ImageDescriptor::UpdateKnownValidView(bool is_bindless) { known_valid_view_ = !is_bindless && !ComputeInvalid(); }
 
-void vvl::BufferDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                        const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
-    const auto &buffer_info = update.pBufferInfo[index];
+void vvl::BufferDescriptor::WriteUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                        const VkWriteDescriptorSet& update, const uint32_t index, bool is_bindless) {
+    const auto& buffer_info = update.pBufferInfo[index];
     offset_ = buffer_info.offset;
     range_ = buffer_info.range;
     auto buffer_state = dev_data.GetConstCastShared<vvl::Buffer>(buffer_info.buffer);
     ReplaceStatePtr(set_state, buffer_state_, buffer_state, is_bindless);
 }
 
-void vvl::BufferDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data, const Descriptor &src,
+void vvl::BufferDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data, const Descriptor& src,
                                        bool is_bindless, VkDescriptorType src_type) {
     if (src.GetClass() == DescriptorClass::Mutable) {
-        const auto &buff_desc = static_cast<const MutableDescriptor &>(src);
+        const auto& buff_desc = static_cast<const MutableDescriptor&>(src);
         offset_ = buff_desc.GetOffset();
         range_ = buff_desc.GetRange();
         ReplaceStatePtr(set_state, buffer_state_, buff_desc.GetSharedBufferState(), is_bindless);
         return;
     }
-    const auto &buff_desc = static_cast<const BufferDescriptor &>(src);
+    const auto& buff_desc = static_cast<const BufferDescriptor&>(src);
     offset_ = buff_desc.offset_;
     range_ = buff_desc.range_;
     ReplaceStatePtr(set_state, buffer_state_, buff_desc.buffer_state_, is_bindless);
@@ -1134,14 +1134,14 @@ void vvl::BufferDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Devi
 
 VkBuffer vvl::BufferDescriptor::GetBuffer() const { return buffer_state_ ? buffer_state_->VkHandle() : VK_NULL_HANDLE; }
 
-bool vvl::BufferDescriptor::AddParent(StateObject *state_object) {
+bool vvl::BufferDescriptor::AddParent(StateObject* state_object) {
     bool result = false;
     if (buffer_state_) {
         result = buffer_state_->AddParent(state_object);
     }
     return result;
 }
-void vvl::BufferDescriptor::RemoveParent(StateObject *state_object) {
+void vvl::BufferDescriptor::RemoveParent(StateObject* state_object) {
     if (buffer_state_) {
         buffer_state_->RemoveParent(state_object);
     }
@@ -1159,34 +1159,34 @@ VkDeviceSize vvl::BufferDescriptor::GetEffectiveRange() const {
     }
 }
 
-void vvl::TexelDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                       const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
+void vvl::TexelDescriptor::WriteUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                       const VkWriteDescriptorSet& update, const uint32_t index, bool is_bindless) {
     auto buffer_view = dev_data.GetConstCastShared<vvl::BufferView>(update.pTexelBufferView[index]);
     ReplaceStatePtr(set_state, buffer_view_state_, buffer_view, is_bindless);
 }
 
-void vvl::TexelDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data, const Descriptor &src,
+void vvl::TexelDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data, const Descriptor& src,
                                       bool is_bindless, VkDescriptorType src_type) {
     if (src.GetClass() == DescriptorClass::Mutable) {
-        ReplaceStatePtr(set_state, buffer_view_state_, static_cast<const MutableDescriptor &>(src).GetSharedBufferViewState(),
+        ReplaceStatePtr(set_state, buffer_view_state_, static_cast<const MutableDescriptor&>(src).GetSharedBufferViewState(),
                         is_bindless);
         return;
     }
-    ReplaceStatePtr(set_state, buffer_view_state_, static_cast<const TexelDescriptor &>(src).buffer_view_state_, is_bindless);
+    ReplaceStatePtr(set_state, buffer_view_state_, static_cast<const TexelDescriptor&>(src).buffer_view_state_, is_bindless);
 }
 
 VkBufferView vvl::TexelDescriptor::GetBufferView() const {
     return buffer_view_state_ ? buffer_view_state_->VkHandle() : VK_NULL_HANDLE;
 }
 
-bool vvl::TexelDescriptor::AddParent(StateObject *state_object) {
+bool vvl::TexelDescriptor::AddParent(StateObject* state_object) {
     bool result = false;
     if (buffer_view_state_) {
         result = buffer_view_state_->AddParent(state_object);
     }
     return result;
 }
-void vvl::TexelDescriptor::RemoveParent(StateObject *state_object) {
+void vvl::TexelDescriptor::RemoveParent(StateObject* state_object) {
     if (buffer_view_state_) {
         buffer_view_state_->RemoveParent(state_object);
     }
@@ -1194,11 +1194,11 @@ void vvl::TexelDescriptor::RemoveParent(StateObject *state_object) {
 
 bool vvl::TexelDescriptor::Invalid() const { return !buffer_view_state_ || buffer_view_state_->Invalid(); }
 
-void vvl::AccelerationStructureDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                                       const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
-    const auto *acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(update.pNext);
-    const auto *acc_info_nv = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
-    const auto *acc_info_partition_nv =
+void vvl::AccelerationStructureDescriptor::WriteUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                                       const VkWriteDescriptorSet& update, const uint32_t index, bool is_bindless) {
+    const auto* acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(update.pNext);
+    const auto* acc_info_nv = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
+    const auto* acc_info_partition_nv =
         vku::FindStructInPNextChain<VkWriteDescriptorSetPartitionedAccelerationStructureNV>(update.pNext);
     assert(acc_info || acc_info_nv || acc_info_partition_nv);
 
@@ -1217,10 +1217,10 @@ void vvl::AccelerationStructureDescriptor::WriteUpdate(DescriptorSet &set_state,
     }
 }
 
-void vvl::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                                      const Descriptor &src, bool is_bindless, VkDescriptorType src_type) {
+void vvl::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                                      const Descriptor& src, bool is_bindless, VkDescriptorType src_type) {
     if (src.GetClass() == DescriptorClass::Mutable) {
-        auto &acc_desc = static_cast<const MutableDescriptor &>(src);
+        auto& acc_desc = static_cast<const MutableDescriptor&>(src);
         is_khr_ = acc_desc.IsAccelerationStructureKHR();
         if (is_khr_) {
             acc_ = acc_desc.GetAccelerationStructureKHR();
@@ -1232,7 +1232,7 @@ void vvl::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet &set_state, 
         }
         return;
     }
-    auto acc_desc = static_cast<const AccelerationStructureDescriptor &>(src);
+    auto acc_desc = static_cast<const AccelerationStructureDescriptor&>(src);
     is_khr_ = acc_desc.is_khr_;
     if (is_khr_) {
         acc_ = acc_desc.acc_;
@@ -1243,7 +1243,7 @@ void vvl::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet &set_state, 
     }
 }
 
-bool vvl::AccelerationStructureDescriptor::AddParent(StateObject *state_object) {
+bool vvl::AccelerationStructureDescriptor::AddParent(StateObject* state_object) {
     bool result = false;
     if (acc_state_) {
         result |= acc_state_->AddParent(state_object);
@@ -1253,7 +1253,7 @@ bool vvl::AccelerationStructureDescriptor::AddParent(StateObject *state_object) 
     }
     return result;
 }
-void vvl::AccelerationStructureDescriptor::RemoveParent(StateObject *state_object) {
+void vvl::AccelerationStructureDescriptor::RemoveParent(StateObject* state_object) {
     if (acc_state_) {
         acc_state_->RemoveParent(state_object);
     }
@@ -1280,8 +1280,8 @@ vvl::MutableDescriptor::MutableDescriptor()
       is_khr_(false),
       acc_(VK_NULL_HANDLE) {}
 
-void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data,
-                                         const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
+void vvl::MutableDescriptor::WriteUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data,
+                                         const VkWriteDescriptorSet& update, const uint32_t index, bool is_bindless) {
     VkDeviceSize buffer_size = 0;
     switch (DescriptorTypeToClass(update.descriptorType)) {
         case DescriptorClass::PlainSampler:
@@ -1292,7 +1292,7 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
             break;
         case DescriptorClass::ImageSampler: {
             if (update.pImageInfo) {
-                const VkDescriptorImageInfo &image_info = update.pImageInfo[index];
+                const VkDescriptorImageInfo& image_info = update.pImageInfo[index];
                 if (!immutable_) {
                     ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(image_info.sampler),
                                     is_bindless);
@@ -1306,7 +1306,7 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
         case DescriptorClass::Image: {
             if (update.pImageInfo) {
                 // The VkSampler is ignored and may be garbage
-                const VkDescriptorImageInfo &image_info = update.pImageInfo[index];
+                const VkDescriptorImageInfo& image_info = update.pImageInfo[index];
                 image_layout_ = image_info.imageLayout;
                 ReplaceStatePtr(set_state, image_view_state_, dev_data.GetConstCastShared<vvl::ImageView>(image_info.imageView),
                                 is_bindless);
@@ -1315,7 +1315,7 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
         }
         case DescriptorClass::GeneralBuffer: {
             if (update.pBufferInfo) {
-                const VkDescriptorBufferInfo &buffer_info = update.pBufferInfo[index];
+                const VkDescriptorBufferInfo& buffer_info = update.pBufferInfo[index];
                 offset_ = buffer_info.offset;
                 range_ = buffer_info.range;
                 // can be null if using nullDescriptors
@@ -1328,7 +1328,7 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
             break;
         }
         case DescriptorClass::Tensor: {
-            const auto *tensor_info = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(update.pNext);
+            const auto* tensor_info = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(update.pNext);
             assert(tensor_info);
             assert(index < tensor_info->tensorViewCount);
             const auto tensor_view_state = dev_data.GetConstCastShared<vvl::TensorView>(tensor_info->pTensorViews[index]);
@@ -1347,8 +1347,8 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
             break;
         }
         case DescriptorClass::AccelerationStructure: {
-            const auto *acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(update.pNext);
-            const auto *acc_info_nv = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
+            const auto* acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(update.pNext);
+            const auto* acc_info_nv = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
             assert(acc_info || acc_info_nv);
             is_khr_ = (acc_info != NULL);
             if (is_khr_) {
@@ -1370,19 +1370,19 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
     SetDescriptorType(update.descriptorType, buffer_size);
 }
 
-void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::DeviceState &dev_data, const Descriptor &src,
+void vvl::MutableDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::DeviceState& dev_data, const Descriptor& src,
                                         bool is_bindless, VkDescriptorType src_type) {
     VkDeviceSize buffer_size = 0;
     switch (src.GetClass()) {
         case DescriptorClass::PlainSampler: {
-            auto &sampler_src = static_cast<const SamplerDescriptor &>(src);
+            auto& sampler_src = static_cast<const SamplerDescriptor&>(src);
             if (!immutable_) {
                 ReplaceStatePtr(set_state, sampler_state_, sampler_src.GetSharedSamplerState(), is_bindless);
             }
             break;
         }
         case DescriptorClass::ImageSampler: {
-            auto &image_src = static_cast<const ImageSamplerDescriptor &>(src);
+            auto& image_src = static_cast<const ImageSamplerDescriptor&>(src);
             if (!immutable_) {
                 ReplaceStatePtr(set_state, sampler_state_, image_src.GetSharedSamplerState(), is_bindless);
             }
@@ -1392,20 +1392,20 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Dev
             break;
         }
         case DescriptorClass::Image: {
-            auto &image_src = static_cast<const ImageDescriptor &>(src);
+            auto& image_src = static_cast<const ImageDescriptor&>(src);
 
             image_layout_ = image_src.GetImageLayout();
             ReplaceStatePtr(set_state, image_view_state_, image_src.GetSharedImageViewState(), is_bindless);
             break;
         }
         case DescriptorClass::TexelBuffer: {
-            ReplaceStatePtr(set_state, buffer_view_state_, static_cast<const TexelDescriptor &>(src).GetSharedBufferViewState(),
+            ReplaceStatePtr(set_state, buffer_view_state_, static_cast<const TexelDescriptor&>(src).GetSharedBufferViewState(),
                             is_bindless);
             buffer_size = buffer_view_state_ ? buffer_view_state_->Size() : vvl::kNoIndex32;
             break;
         }
         case DescriptorClass::GeneralBuffer: {
-            const auto buff_desc = static_cast<const BufferDescriptor &>(src);
+            const auto buff_desc = static_cast<const BufferDescriptor&>(src);
             offset_ = buff_desc.GetOffset();
             range_ = buff_desc.GetRange();
             ReplaceStatePtr(set_state, buffer_state_, buff_desc.GetSharedBufferState(), is_bindless);
@@ -1413,7 +1413,7 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Dev
             break;
         }
         case DescriptorClass::AccelerationStructure: {
-            auto &acc_desc = static_cast<const AccelerationStructureDescriptor &>(src);
+            auto& acc_desc = static_cast<const AccelerationStructureDescriptor&>(src);
             if (is_khr_) {
                 acc_ = acc_desc.GetAccelerationStructure();
                 ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_),
@@ -1426,7 +1426,7 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Dev
             break;
         }
         case DescriptorClass::Mutable: {
-            const auto &mutable_src = static_cast<const MutableDescriptor &>(src);
+            const auto& mutable_src = static_cast<const MutableDescriptor&>(src);
             auto active_class = DescriptorTypeToClass(mutable_src.ActiveType());
             switch (active_class) {
                 case DescriptorClass::PlainSampler: {
@@ -1478,7 +1478,7 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Dev
             break;
         }
         case vvl::DescriptorClass::Tensor: {
-            const auto tensor_desc = static_cast<const MutableDescriptor *>(&src);
+            const auto tensor_desc = static_cast<const MutableDescriptor*>(&src);
             tensor_view_count_ = tensor_desc->GetTensorViewCount();
             tensor_views_ = tensor_desc->GetTensorViews();
             ReplaceStatePtr(set_state, tensor_view_state_, std::shared_ptr<vvl::TensorView>(), is_bindless);
@@ -1508,7 +1508,7 @@ VkDeviceSize vvl::MutableDescriptor::GetEffectiveRange() const {
 
 std::shared_ptr<vvl::Tensor> vvl::MutableDescriptor::GetSharedTensor() const { return tensor_view_state_->tensor_state; }
 
-void vvl::MutableDescriptor::UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_state) {
+void vvl::MutableDescriptor::UpdateImageLayoutDrawState(vvl::CommandBuffer& cb_state) {
     const vvl::DescriptorClass active_class = ActiveClass();
     if (active_class == DescriptorClass::Image || active_class == DescriptorClass::ImageSampler) {
         if (image_view_state_) {
@@ -1517,7 +1517,7 @@ void vvl::MutableDescriptor::UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_s
     }
 }
 
-bool vvl::MutableDescriptor::AddParent(StateObject *state_object) {
+bool vvl::MutableDescriptor::AddParent(StateObject* state_object) {
     bool result = false;
     const vvl::DescriptorClass active_class = ActiveClass();
     switch (active_class) {
@@ -1569,7 +1569,7 @@ bool vvl::MutableDescriptor::AddParent(StateObject *state_object) {
     }
     return result;
 }
-void vvl::MutableDescriptor::RemoveParent(StateObject *state_object) {
+void vvl::MutableDescriptor::RemoveParent(StateObject* state_object) {
     if (sampler_state_) {
         sampler_state_->RemoveParent(state_object);
     }
@@ -1628,7 +1628,7 @@ bool vvl::MutableDescriptor::Invalid() const {
     return false;
 }
 
-std::string vvl::DslErrorSource::PrintMessage(const Logger &error_logger) const {
+std::string vvl::DslErrorSource::PrintMessage(const Logger& error_logger) const {
     std::ostringstream msg;
     msg << "The VkDescriptorSetLayout was used to ";
     if (pipeline_layout_handle_ == VK_NULL_HANDLE) {
@@ -1639,28 +1639,28 @@ std::string vvl::DslErrorSource::PrintMessage(const Logger &error_logger) const 
     msg << "";
     return msg.str();
 }
-void vvl::TensorDescriptor::WriteUpdate(DescriptorSet &set_state, const DeviceState &dev_data, const VkWriteDescriptorSet &update,
+void vvl::TensorDescriptor::WriteUpdate(DescriptorSet& set_state, const DeviceState& dev_data, const VkWriteDescriptorSet& update,
                                         const uint32_t index, bool is_bindless) {
-    const auto tensor_info = reinterpret_cast<const VkWriteDescriptorSetTensorARM *>(update.pNext);
+    const auto tensor_info = reinterpret_cast<const VkWriteDescriptorSetTensorARM*>(update.pNext);
     tensor_view_count_ = tensor_info->tensorViewCount;
     tensor_views_ = tensor_info->pTensorViews;
     auto tensor_view = dev_data.GetConstCastShared<vvl::TensorView>(tensor_views_[index]);
     ReplaceStatePtr(set_state, tensor_view_state_, tensor_view, is_bindless);
 }
 
-void vvl::TensorDescriptor::CopyUpdate(DescriptorSet &set_state, const DeviceState &dev_data, const Descriptor &src,
+void vvl::TensorDescriptor::CopyUpdate(DescriptorSet& set_state, const DeviceState& dev_data, const Descriptor& src,
                                        bool is_bindless, VkDescriptorType type) {
     if (src.GetClass() == vvl::DescriptorClass::Mutable) {
-        const auto tensor_desc = static_cast<const MutableDescriptor *>(&src);
+        const auto tensor_desc = static_cast<const MutableDescriptor*>(&src);
         tensor_view_count_ = tensor_desc->GetTensorViewCount();
         tensor_views_ = tensor_desc->GetTensorViews();
         ReplaceStatePtr(set_state, tensor_view_state_, std::shared_ptr<vvl::TensorView>(), is_bindless);
         return;
     }
-    const auto tensor_desc = static_cast<const TensorDescriptor *>(&src);
+    const auto tensor_desc = static_cast<const TensorDescriptor*>(&src);
     tensor_view_count_ = tensor_desc->tensor_view_count_;
     tensor_views_ = tensor_desc->tensor_views_;
     ReplaceStatePtr(set_state, tensor_view_state_, std::shared_ptr<vvl::TensorView>(), is_bindless);
 }
 
-const vvl::Tensor *vvl::TensorDescriptor::GetTensorState() const { return tensor_view_state_->tensor_state.get(); }
+const vvl::Tensor* vvl::TensorDescriptor::GetTensorState() const { return tensor_view_state_->tensor_state.get(); }

--- a/layers/state_tracker/device_generated_commands_state.cpp
+++ b/layers/state_tracker/device_generated_commands_state.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -19,31 +19,31 @@
 
 #include "state_tracker/device_generated_commands_state.h"
 
-vvl::IndirectExecutionSet::IndirectExecutionSet(vvl::DeviceState &dev, VkIndirectExecutionSetEXT handle,
-                                                const VkIndirectExecutionSetCreateInfoEXT *pCreateInfo)
+vvl::IndirectExecutionSet::IndirectExecutionSet(vvl::DeviceState& dev, VkIndirectExecutionSetEXT handle,
+                                                const VkIndirectExecutionSetCreateInfoEXT* pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeIndirectExecutionSetEXT),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       is_pipeline(pCreateInfo->type == VK_INDIRECT_EXECUTION_SET_INFO_TYPE_PIPELINES_EXT),
       is_shader_objects(pCreateInfo->type == VK_INDIRECT_EXECUTION_SET_INFO_TYPE_SHADER_OBJECTS_EXT) {
     if (is_pipeline && pCreateInfo->info.pPipelineInfo) {
-        const VkIndirectExecutionSetPipelineInfoEXT &pipeline_info = *pCreateInfo->info.pPipelineInfo;
+        const VkIndirectExecutionSetPipelineInfoEXT& pipeline_info = *pCreateInfo->info.pPipelineInfo;
         max_pipeline_count = pipeline_info.maxPipelineCount;
     } else if (is_shader_objects && pCreateInfo->info.pShaderInfo) {
-        const VkIndirectExecutionSetShaderInfoEXT &shader_info = *pCreateInfo->info.pShaderInfo;
+        const VkIndirectExecutionSetShaderInfoEXT& shader_info = *pCreateInfo->info.pShaderInfo;
         max_shader_count = shader_info.maxShaderCount;
     }
 }
 
-vvl::IndirectCommandsLayout::IndirectCommandsLayout(vvl::DeviceState &dev, VkIndirectCommandsLayoutEXT handle,
-                                                    const VkIndirectCommandsLayoutCreateInfoEXT *pCreateInfo)
+vvl::IndirectCommandsLayout::IndirectCommandsLayout(vvl::DeviceState& dev, VkIndirectCommandsLayoutEXT handle,
+                                                    const VkIndirectCommandsLayoutCreateInfoEXT* pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeIndirectCommandsLayoutEXT),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       // default to graphics as it is most common and has most cases
       bind_point(VK_PIPELINE_BIND_POINT_GRAPHICS) {
     for (uint32_t i = 0; i < pCreateInfo->tokenCount; i++) {
-        const VkIndirectCommandsLayoutTokenEXT &token = pCreateInfo->pTokens[i];
+        const VkIndirectCommandsLayoutTokenEXT& token = pCreateInfo->pTokens[i];
         switch (token.type) {
             case VK_INDIRECT_COMMANDS_TOKEN_TYPE_EXECUTION_SET_EXT:
                 has_execution_set_token = true;

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -30,14 +30,14 @@ using DeviceMemoryState = vvl::BindableMemoryTracker::DeviceMemoryState;
 namespace vvl {
 // It is allowed to export memory into the handles of different types,
 // that's why we use set of flags (VkExternalMemoryHandleTypeFlags)
-static VkExternalMemoryHandleTypeFlags GetExportHandleTypes(const VkMemoryAllocateInfo &alloc_info) {
+static VkExternalMemoryHandleTypeFlags GetExportHandleTypes(const VkMemoryAllocateInfo& alloc_info) {
     auto export_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(alloc_info.pNext);
     return export_info ? export_info->handleTypes : 0;
 }
 
 // Import works with a single handle type, that's why VkExternalMemoryHandleTypeFlagBits type is used.
 // Since FlagBits-type cannot have a value of 0, we use std::optional to indicate the presense of an import operation.
-std::optional<VkExternalMemoryHandleTypeFlagBits> GetImportHandleType(const VkMemoryAllocateInfo &alloc_info) {
+std::optional<VkExternalMemoryHandleTypeFlagBits> GetImportHandleType(const VkMemoryAllocateInfo& alloc_info) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     auto win32_import = vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoKHR>(alloc_info.pNext);
     if (win32_import) {
@@ -63,7 +63,7 @@ std::optional<VkExternalMemoryHandleTypeFlagBits> GetImportHandleType(const VkMe
     return std::nullopt;
 }
 
-static bool IsMultiInstance(const VkMemoryAllocateInfo &alloc_info, const VkMemoryHeap &memory_heap,
+static bool IsMultiInstance(const VkMemoryAllocateInfo& alloc_info, const VkMemoryHeap& memory_heap,
                             uint32_t physical_device_count) {
     auto alloc_flags = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(alloc_info.pNext);
     if (alloc_flags && (alloc_flags->flags & VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT)) {
@@ -76,7 +76,7 @@ static bool IsMultiInstance(const VkMemoryAllocateInfo &alloc_info, const VkMemo
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-static bool GetMetalExport(const VkMemoryAllocateInfo &alloc_info) {
+static bool GetMetalExport(const VkMemoryAllocateInfo& alloc_info) {
     bool retval = false;
     auto export_metal_object_info = vku::FindStructInPNextChain<VkExportMetalObjectCreateInfoEXT>(alloc_info.pNext);
     while (export_metal_object_info) {
@@ -90,9 +90,9 @@ static bool GetMetalExport(const VkMemoryAllocateInfo &alloc_info) {
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
-DeviceMemory::DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo *in_allocate_info, uint64_t fake_address,
-                           const VkMemoryType &memory_type, const VkMemoryHeap &memory_heap,
-                           std::optional<DedicatedBinding> &&dedicated_binding, uint32_t physical_device_count)
+DeviceMemory::DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo* in_allocate_info, uint64_t fake_address,
+                           const VkMemoryType& memory_type, const VkMemoryHeap& memory_heap,
+                           std::optional<DedicatedBinding>&& dedicated_binding, uint32_t physical_device_count)
     : StateObject(handle, kVulkanObjectTypeDeviceMemory),
       safe_allocate_info(in_allocate_info),
       allocate_info(*safe_allocate_info.ptr()),
@@ -110,7 +110,7 @@ DeviceMemory::DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo *in
 }
 }  // namespace vvl
 
-void vvl::BindableLinearMemoryTracker::BindMemory(StateObject *parent, std::shared_ptr<vvl::DeviceMemory> &memory_state,
+void vvl::BindableLinearMemoryTracker::BindMemory(StateObject* parent, std::shared_ptr<vvl::DeviceMemory>& memory_state,
                                                   VkDeviceSize memory_offset, VkDeviceSize resource_offset, VkDeviceSize size) {
     ASSERT_AND_RETURN(memory_state);
 
@@ -122,7 +122,7 @@ DeviceMemoryState vvl::BindableLinearMemoryTracker::GetBoundMemoryStates() const
     return binding_.memory_state ? DeviceMemoryState{binding_.memory_state} : DeviceMemoryState{};
 }
 
-BoundMemoryRange vvl::BindableLinearMemoryTracker::GetBoundMemoryRange(const MemoryRange &range) const {
+BoundMemoryRange vvl::BindableLinearMemoryTracker::GetBoundMemoryRange(const MemoryRange& range) const {
     return binding_.memory_state ? BoundMemoryRange{BoundMemoryRange::value_type{
                                        binding_.memory_state->VkHandle(),
                                        BoundMemoryRange::value_type::second_type{
@@ -130,18 +130,18 @@ BoundMemoryRange vvl::BindableLinearMemoryTracker::GetBoundMemoryRange(const Mem
                                  : BoundMemoryRange{};
 }
 
-BoundRanges vvl::BindableLinearMemoryTracker::GetBoundRanges(const BufferRange &ranges_bounds,
-                                                             const std::vector<BufferRange> &ranges) const {
+BoundRanges vvl::BindableLinearMemoryTracker::GetBoundRanges(const BufferRange& ranges_bounds,
+                                                             const std::vector<BufferRange>& ranges) const {
     BoundRanges memory_to_bound_ranges_map;
     if (!binding_.memory_state) {
         return memory_to_bound_ranges_map;
     }
 
     const VkDeviceMemory bound_memory = binding_.memory_state->VkHandle();
-    std::vector<std::pair<MemoryRange, BufferRange>> &bound_ranges = memory_to_bound_ranges_map[bound_memory];
+    std::vector<std::pair<MemoryRange, BufferRange>>& bound_ranges = memory_to_bound_ranges_map[bound_memory];
     bound_ranges.reserve(ranges.size());
 
-    for (const BufferRange &buffer_range : ranges) {
+    for (const BufferRange& buffer_range : ranges) {
         const MemoryRange memory_range_bounds(binding_.memory_offset,
                                               binding_.memory_offset + buffer_range.begin + buffer_range.distance());
         bound_ranges.emplace_back(memory_range_bounds, buffer_range);
@@ -153,7 +153,7 @@ BoundRanges vvl::BindableLinearMemoryTracker::GetBoundRanges(const BufferRange &
 unsigned vvl::BindableSparseMemoryTracker::CountDeviceMemory(VkDeviceMemory memory) const {
     unsigned count = 0u;
     auto guard = ReadLockGuard{binding_lock_};
-    for (const auto &range_state : binding_map_) {
+    for (const auto& range_state : binding_map_) {
         count += (range_state.second.memory_state && range_state.second.memory_state->VkHandle() == memory);
     }
     return count;
@@ -164,7 +164,7 @@ bool vvl::BindableSparseMemoryTracker::HasFullRangeBound() const {
         VkDeviceSize current_offset = 0u;
         {
             auto guard = ReadLockGuard{binding_lock_};
-            for (const auto &range : binding_map_) {
+            for (const auto& range : binding_map_) {
                 if (current_offset != range.first.begin || !range.second.memory_state || range.second.memory_state->Invalid()) {
                     return false;
                 }
@@ -178,7 +178,7 @@ bool vvl::BindableSparseMemoryTracker::HasFullRangeBound() const {
     return true;
 }
 
-void vvl::BindableSparseMemoryTracker::BindMemory(StateObject *parent, std::shared_ptr<vvl::DeviceMemory> &memory_state,
+void vvl::BindableSparseMemoryTracker::BindMemory(StateObject* parent, std::shared_ptr<vvl::DeviceMemory>& memory_state,
                                                   VkDeviceSize memory_offset, VkDeviceSize resource_offset, VkDeviceSize size) {
     MemoryBinding memory_data{memory_state, memory_offset, resource_offset};
     BindingMap::value_type item{{resource_offset, resource_offset + size}, memory_data};
@@ -186,24 +186,24 @@ void vvl::BindableSparseMemoryTracker::BindMemory(StateObject *parent, std::shar
     auto guard = WriteLockGuard{binding_lock_};
 
     // Since we don't know which ranges will be removed, we need to unbind everything and rebind later
-    for (auto &value_pair : binding_map_) {
+    for (auto& value_pair : binding_map_) {
         if (value_pair.second.memory_state) value_pair.second.memory_state->RemoveParent(parent);
     }
     binding_map_.overwrite_range(item);
 
-    for (auto &value_pair : binding_map_) {
+    for (auto& value_pair : binding_map_) {
         if (value_pair.second.memory_state) value_pair.second.memory_state->AddParent(parent);
     }
 }
 
-BoundMemoryRange vvl::BindableSparseMemoryTracker::GetBoundMemoryRange(const MemoryRange &range) const {
+BoundMemoryRange vvl::BindableSparseMemoryTracker::GetBoundMemoryRange(const MemoryRange& range) const {
     BoundMemoryRange mem_ranges;
     auto guard = ReadLockGuard{binding_lock_};
     auto begin = binding_map_.lower_bound(range);
     auto end = binding_map_.upper_bound(range);
 
     for (auto it = begin; it != end; ++it) {
-        const auto &[resource_range, memory_data] = *it;
+        const auto& [resource_range, memory_data] = *it;
         if (memory_data.memory_state && memory_data.memory_state->VkHandle() != VK_NULL_HANDLE) {
             const VkDeviceSize memory_range_start =
                 std::max(range.begin, memory_data.resource_offset) - memory_data.resource_offset + memory_data.memory_offset;
@@ -216,15 +216,15 @@ BoundMemoryRange vvl::BindableSparseMemoryTracker::GetBoundMemoryRange(const Mem
     return mem_ranges;
 }
 
-BoundRanges vvl::BindableSparseMemoryTracker::GetBoundRanges(const BufferRange &ranges_bounds,
-                                                             const std::vector<BufferRange> &buffer_ranges) const {
+BoundRanges vvl::BindableSparseMemoryTracker::GetBoundRanges(const BufferRange& ranges_bounds,
+                                                             const std::vector<BufferRange>& buffer_ranges) const {
     BoundRanges memory_to_bound_ranges_map;
     auto guard = ReadLockGuard{binding_lock_};
     auto begin = binding_map_.lower_bound(ranges_bounds);
     auto end = binding_map_.upper_bound(ranges_bounds);
 
     for (auto it = begin; it != end; ++it) {
-        const auto &[bounds_buffer_range, bounds_buffer_range_memory] = *it;
+        const auto& [bounds_buffer_range, bounds_buffer_range_memory] = *it;
 
         if (bounds_buffer_range_memory.memory_state && bounds_buffer_range_memory.memory_state->VkHandle() != VK_NULL_HANDLE) {
             MemoryRange bounds_memory_range;
@@ -240,7 +240,7 @@ BoundRanges vvl::BindableSparseMemoryTracker::GetBoundRanges(const BufferRange &
                 BufferRange(bounds_buffer_range_memory.resource_offset,
                             bounds_buffer_range_memory.resource_offset + bounds_buffer_range.distance());
 
-            for (const BufferRange &buffer_range : buffer_ranges) {
+            for (const BufferRange& buffer_range : buffer_ranges) {
                 if (!bounds_mem_and_buffer_range.second.intersects(buffer_range)) {
                     continue;
                 }
@@ -256,12 +256,12 @@ BoundRanges vvl::BindableSparseMemoryTracker::GetBoundRanges(const BufferRange &
                 mem_and_buffer_range.first = bounds_mem_and_buffer_range.first & memory_range;
                 mem_and_buffer_range.second = bounds_mem_and_buffer_range.second & buffer_range;
 
-                std::vector<std::pair<MemoryRange, BufferRange>> &vk_memory_ranges_vec =
+                std::vector<std::pair<MemoryRange, BufferRange>>& vk_memory_ranges_vec =
                     memory_to_bound_ranges_map[bounds_buffer_range_memory.memory_state->VkHandle()];
                 auto insert_pos =
                     std::lower_bound(vk_memory_ranges_vec.begin(), vk_memory_ranges_vec.end(), mem_and_buffer_range,
-                                     [](const std::pair<MemoryRange, BufferRange> &lhs,
-                                        const std::pair<MemoryRange, BufferRange> &rhs) { return lhs.first < rhs.first; });
+                                     [](const std::pair<MemoryRange, BufferRange>& lhs,
+                                        const std::pair<MemoryRange, BufferRange>& rhs) { return lhs.first < rhs.first; });
                 vk_memory_ranges_vec.insert(insert_pos, mem_and_buffer_range);
             }
         }
@@ -274,7 +274,7 @@ DeviceMemoryState vvl::BindableSparseMemoryTracker::GetBoundMemoryStates() const
 
     {
         auto guard = ReadLockGuard{binding_lock_};
-        for (auto &binding : binding_map_) {
+        for (auto& binding : binding_map_) {
             if (binding.second.memory_state) dev_memory_states.emplace(binding.second.memory_state);
         }
     }
@@ -282,8 +282,8 @@ DeviceMemoryState vvl::BindableSparseMemoryTracker::GetBoundMemoryStates() const
     return dev_memory_states;
 }
 
-
-vvl::BindableMultiplanarMemoryTracker::BindableMultiplanarMemoryTracker(const VkMemoryRequirements *requirements, uint32_t num_planes)
+vvl::BindableMultiplanarMemoryTracker::BindableMultiplanarMemoryTracker(const VkMemoryRequirements* requirements,
+                                                                        uint32_t num_planes)
     : planes_(num_planes) {
     for (unsigned i = 0; i < num_planes; ++i) {
         planes_[i].size = requirements[i].size;
@@ -292,7 +292,7 @@ vvl::BindableMultiplanarMemoryTracker::BindableMultiplanarMemoryTracker(const Vk
 unsigned vvl::BindableMultiplanarMemoryTracker::CountDeviceMemory(VkDeviceMemory memory) const {
     unsigned count = 0u;
     for (size_t i = 0u; i < planes_.size(); i++) {
-        const auto &plane = planes_[i];
+        const auto& plane = planes_[i];
         count += (plane.binding.memory_state && plane.binding.memory_state->VkHandle() == memory);
     }
 
@@ -310,7 +310,7 @@ bool vvl::BindableMultiplanarMemoryTracker::HasFullRangeBound() const {
 }
 
 // resource_offset is the plane index
-void vvl::BindableMultiplanarMemoryTracker::BindMemory(StateObject *parent, std::shared_ptr<vvl::DeviceMemory> &memory_state,
+void vvl::BindableMultiplanarMemoryTracker::BindMemory(StateObject* parent, std::shared_ptr<vvl::DeviceMemory>& memory_state,
                                                        VkDeviceSize memory_offset, VkDeviceSize resource_offset,
                                                        VkDeviceSize size) {
     ASSERT_AND_RETURN(memory_state);
@@ -324,11 +324,11 @@ void vvl::BindableMultiplanarMemoryTracker::BindMemory(StateObject *parent, std:
 // To access plane 0 range must be [0, planes_[0].size)
 // To access plane 1 range must be [planes_[0].size, planes_[1].size)
 // To access plane 2 range must be [planes_[1].size, planes_[2].size)
-BoundMemoryRange vvl::BindableMultiplanarMemoryTracker::GetBoundMemoryRange(const MemoryRange &range) const {
+BoundMemoryRange vvl::BindableMultiplanarMemoryTracker::GetBoundMemoryRange(const MemoryRange& range) const {
     BoundMemoryRange mem_ranges;
     VkDeviceSize start_offset = 0u;
     for (unsigned i = 0u; i < planes_.size(); ++i) {
-        const auto &plane = planes_[i];
+        const auto& plane = planes_[i];
         MemoryRange plane_range{start_offset, start_offset + plane.size};
         if (plane.binding.memory_state && range.intersects(plane_range)) {
             VkDeviceSize range_end = range.end > plane_range.end ? plane_range.end : range.end;
@@ -354,20 +354,20 @@ DeviceMemoryState vvl::BindableMultiplanarMemoryTracker::GetBoundMemoryStates() 
     return dev_memory_states;
 }
 
-std::pair<VkDeviceMemory, MemoryRange> vvl::Bindable::GetResourceMemoryOverlap(
-        const MemoryRange &memory_region, const Bindable *other_resource,
-        const MemoryRange &other_memory_region) const {
+std::pair<VkDeviceMemory, MemoryRange> vvl::Bindable::GetResourceMemoryOverlap(const MemoryRange& memory_region,
+                                                                               const Bindable* other_resource,
+                                                                               const MemoryRange& other_memory_region) const {
     if (!other_resource) return {VK_NULL_HANDLE, {}};
 
     auto ranges = GetBoundMemoryRange(memory_region);
     auto other_ranges = other_resource->GetBoundMemoryRange(other_memory_region);
 
-    for (const auto &[memory, memory_ranges] : ranges) {
+    for (const auto& [memory, memory_ranges] : ranges) {
         // Check if we have memory from same VkDeviceMemory bound
         if (auto it = other_ranges.find(memory); it != other_ranges.end()) {
             // Check if any of the bound memory ranges overlap
-            for (const auto &memory_range : memory_ranges) {
-                for (const auto &other_memory_range : it->second) {
+            for (const auto& memory_range : memory_ranges) {
+                for (const auto& other_memory_range : it->second) {
                     if (other_memory_range.intersects(memory_range)) {
                         auto memory_space_intersection = other_memory_range & memory_range;
                         return {memory, memory_space_intersection};
@@ -381,14 +381,14 @@ std::pair<VkDeviceMemory, MemoryRange> vvl::Bindable::GetResourceMemoryOverlap(
 
 VkDeviceSize vvl::Bindable::GetFakeBaseAddress() const {
     // TODO: Sparse resources are not implemented yet
-    const auto *binding = Binding();
+    const auto* binding = Binding();
     return binding ? binding->memory_offset + binding->memory_state->fake_base_address : 0;
 }
 
 void vvl::Bindable::CacheInvalidMemory() const {
     need_to_recache_invalid_memory_ = false;
     cached_invalid_memory_.clear();
-    for (auto const &bindable : GetBoundMemoryStates()) {
+    for (auto const& bindable : GetBoundMemoryStates()) {
         if (bindable->Invalid()) {
             cached_invalid_memory_.insert(bindable);
         }

--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -21,12 +21,12 @@
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/wsi_state.h"
 
-static VkExternalFenceHandleTypeFlags GetExportHandleTypes(const VkFenceCreateInfo *info) {
+static VkExternalFenceHandleTypeFlags GetExportHandleTypes(const VkFenceCreateInfo* info) {
     auto export_info = vku::FindStructInPNextChain<VkExportFenceCreateInfo>(info->pNext);
     return export_info ? export_info->handleTypes : 0;
 }
 
-vvl::Fence::Fence(Logger &logger, VkFence handle, const VkFenceCreateInfo *pCreateInfo)
+vvl::Fence::Fence(Logger& logger, VkFence handle, const VkFenceCreateInfo* pCreateInfo)
     : RefcountedStateObject(handle, kVulkanObjectTypeFence),
       flags(pCreateInfo->flags),
       export_handle_types(GetExportHandleTypes(pCreateInfo)),
@@ -35,7 +35,7 @@ vvl::Fence::Fence(Logger &logger, VkFence handle, const VkFenceCreateInfo *pCrea
       waiter_(completed_.get_future()),
       logger_(logger) {}
 
-const VulkanTypedHandle *vvl::Fence::InUse() const {
+const VulkanTypedHandle* vvl::Fence::InUse() const {
     auto guard = ReadLock();
     // Fence does not have a parent (in the sense of a VVL state object), and the value returned
     // by the base class InUse is not useful for reporting (it is the fence's own handle)
@@ -53,7 +53,7 @@ const VulkanTypedHandle *vvl::Fence::InUse() const {
     return &empty;
 }
 
-bool vvl::Fence::EnqueueSignal(vvl::Queue *queue_state, uint64_t next_seq) {
+bool vvl::Fence::EnqueueSignal(vvl::Queue* queue_state, uint64_t next_seq) {
     auto guard = WriteLock();
     if (scope_ != kInternal) {
         return true;
@@ -73,7 +73,7 @@ bool vvl::Fence::EnqueueSignal(vvl::Queue *queue_state, uint64_t next_seq) {
 }
 
 // Called from a non-queue operation, such as vkWaitForFences()|
-void vvl::Fence::NotifyAndWait(const Location &loc) {
+void vvl::Fence::NotifyAndWait(const Location& loc) {
     std::shared_future<void> waiter;
     std::optional<SubmissionReference> present_submission_ref;
     {
@@ -104,7 +104,7 @@ void vvl::Fence::NotifyAndWait(const Location &loc) {
         // NOTE: Functions like QueueWaitIdle put fence in the retired state, still it can have
         // the list of present semaphores, which are not cleared by QueueWaitIdle when swapchain
         // maintenance extension is enabled. That's the reason this code is not under kInflight condition.
-        for (auto &semaphore : present_wait_semaphores_) {
+        for (auto& semaphore : present_wait_semaphores_) {
             semaphore->ClearSwapchainWaitInfo();
         }
         present_wait_semaphores_.clear();
@@ -190,13 +190,13 @@ std::optional<VkExternalFenceHandleTypeFlagBits> vvl::Fence::ImportedHandleType(
     return imported_handle_type_;
 }
 
-void vvl::Fence::SetAcquiredImage(const std::shared_ptr<vvl::Swapchain> &swapchain, uint32_t image_index) {
+void vvl::Fence::SetAcquiredImage(const std::shared_ptr<vvl::Swapchain>& swapchain, uint32_t image_index) {
     auto guard = WriteLock();
     acquired_image_swapchain_ = swapchain;
     acquired_image_index_ = image_index;
 }
 
-void vvl::Fence::SetPresentSubmissionRef(const SubmissionReference &present_submission_ref) {
+void vvl::Fence::SetPresentSubmissionRef(const SubmissionReference& present_submission_ref) {
     auto guard = WriteLock();
     // At this point, in an error-free scenario, "present_submission_ref_" member has no value
     // (as an optional). If the fence is reused without being waited on (which causes a validation
@@ -216,7 +216,7 @@ void vvl::Fence::SetPresentSubmissionRef(const SubmissionReference &present_subm
 
 void vvl::Fence::SetPresentWaitSemaphores(vvl::span<std::shared_ptr<vvl::Semaphore>> present_wait_semaphores) {
     present_wait_semaphores_.clear();
-    for (const auto &semaphore : present_wait_semaphores) {
+    for (const auto& semaphore : present_wait_semaphores) {
         present_wait_semaphores_.emplace_back(semaphore);
     }
 }

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -34,18 +34,18 @@
 
 using RangeGenerator = subresource_adapter::RangeGenerator;
 
-static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkImageCreateInfo *pCreateInfo) {
-    const auto *external_memory_info = vku::FindStructInPNextChain<VkExternalMemoryImageCreateInfo>(pCreateInfo->pNext);
+static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkImageCreateInfo* pCreateInfo) {
+    const auto* external_memory_info = vku::FindStructInPNextChain<VkExternalMemoryImageCreateInfo>(pCreateInfo->pNext);
     return external_memory_info ? external_memory_info->handleTypes : 0;
 }
 
-static VkSwapchainKHR GetSwapchain(const VkImageCreateInfo *pCreateInfo) {
-    const auto *swapchain_info = vku::FindStructInPNextChain<VkImageSwapchainCreateInfoKHR>(pCreateInfo->pNext);
+static VkSwapchainKHR GetSwapchain(const VkImageCreateInfo* pCreateInfo) {
+    const auto* swapchain_info = vku::FindStructInPNextChain<VkImageSwapchainCreateInfoKHR>(pCreateInfo->pNext);
     return swapchain_info ? swapchain_info->swapchain : VK_NULL_HANDLE;
 }
 
-static vvl::Image::MemoryReqs GetMemoryRequirements(const vvl::DeviceState &dev_data, VkImage img,
-                                                    const VkImageCreateInfo *create_info, bool disjoint, bool is_external_ahb) {
+static vvl::Image::MemoryReqs GetMemoryRequirements(const vvl::DeviceState& dev_data, VkImage img,
+                                                    const VkImageCreateInfo* create_info, bool disjoint, bool is_external_ahb) {
     vvl::Image::MemoryReqs result{};
     // Record the memory requirements in case they won't be queried
     // External AHB memory can't be queried until after memory is bound
@@ -84,7 +84,7 @@ static vvl::Image::MemoryReqs GetMemoryRequirements(const vvl::DeviceState &dev_
     return result;
 }
 
-static std::vector<VkSparseImageMemoryRequirements> GetSparseRequirements(const vvl::DeviceState &dev_data, VkImage img,
+static std::vector<VkSparseImageMemoryRequirements> GetSparseRequirements(const vvl::DeviceState& dev_data, VkImage img,
                                                                           bool sparse_residency) {
     std::vector<VkSparseImageMemoryRequirements> result;
     if (sparse_residency) {
@@ -96,7 +96,7 @@ static std::vector<VkSparseImageMemoryRequirements> GetSparseRequirements(const 
     return result;
 }
 
-static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &create_info) {
+static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo& create_info) {
     const VkFormat format = create_info.format;
     VkImageAspectFlags aspect_mask = 0;
     if (vkuFormatIsMultiplane(format)) {
@@ -115,7 +115,7 @@ static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &creat
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-static bool GetMetalExport(const VkImageCreateInfo *info, VkExportMetalObjectTypeFlagBitsEXT object_type_required) {
+static bool GetMetalExport(const VkImageCreateInfo* info, VkExportMetalObjectTypeFlagBitsEXT object_type_required) {
     bool retval = false;
     auto export_metal_object_info = vku::FindStructInPNextChain<VkExportMetalObjectCreateInfoEXT>(info->pNext);
     while (export_metal_object_info) {
@@ -131,7 +131,7 @@ static bool GetMetalExport(const VkImageCreateInfo *info, VkExportMetalObjectTyp
 
 namespace vvl {
 
-Image::Image(const vvl::DeviceState &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2 ff)
+Image::Image(const vvl::DeviceState& dev_data, VkImage img, const VkImageCreateInfo* pCreateInfo, VkFormatFeatureFlags2 ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
@@ -169,7 +169,7 @@ Image::Image(const vvl::DeviceState &dev_data, VkImage img, const VkImageCreateI
     }
 }
 
-Image::Image(const vvl::DeviceState &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+Image::Image(const vvl::DeviceState& dev_data, VkImage img, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
              uint32_t swapchain_index, VkFormatFeatureFlags2 ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
@@ -201,7 +201,7 @@ Image::Image(const vvl::DeviceState &dev_data, VkImage img, const VkImageCreateI
 }
 
 void Image::Destroy() {
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Destroy();
     }
     // NOTE: due to corner cases in aliased images, the layout_range_map MUST not be cleaned up here.
@@ -217,11 +217,11 @@ void Image::Destroy() {
 }
 
 // Get buffer size from VkBufferImageCopy / VkBufferImageCopy2 structure, for a given format
-template VkDeviceSize Image::GetBufferSizeFromCopyImage<VkBufferImageCopy>(const VkBufferImageCopy &) const;
-template VkDeviceSize Image::GetBufferSizeFromCopyImage<VkBufferImageCopy2>(const VkBufferImageCopy2 &) const;
+template VkDeviceSize Image::GetBufferSizeFromCopyImage<VkBufferImageCopy>(const VkBufferImageCopy&) const;
+template VkDeviceSize Image::GetBufferSizeFromCopyImage<VkBufferImageCopy2>(const VkBufferImageCopy2&) const;
 
 template <typename RegionType>
-VkDeviceSize Image::GetBufferSizeFromCopyImage(const RegionType &region) const {
+VkDeviceSize Image::GetBufferSizeFromCopyImage(const RegionType& region) const {
     VkDeviceSize buffer_size = 0;
     VkExtent3D copy_extent = region.imageExtent;
     VkDeviceSize buffer_width = (0 == region.bufferRowLength ? copy_extent.width : region.bufferRowLength);
@@ -290,8 +290,8 @@ VkDeviceSize Image::GetBufferSizeFromCopyImage(const RegionType &region) const {
     return buffer_size;
 }
 
-void Image::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &item : sub_states_) {
+void Image::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
+    for (auto& item : sub_states_) {
         item.second->NotifyInvalidate(invalid_nodes, unlink);
     }
     Bindable::NotifyInvalidate(invalid_nodes, unlink);
@@ -300,7 +300,7 @@ void Image::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool un
     }
 }
 
-bool Image::IsCreateInfoEqual(const VkImageCreateInfo &other_create_info) const {
+bool Image::IsCreateInfoEqual(const VkImageCreateInfo& other_create_info) const {
     bool is_equal = (create_info.sType == other_create_info.sType) && (create_info.flags == other_create_info.flags);
     is_equal = is_equal && IsImageTypeEqual(other_create_info) && IsFormatEqual(other_create_info);
     is_equal = is_equal && IsMipLevelsEqual(other_create_info) && IsArrayLayersEqual(other_create_info);
@@ -312,7 +312,7 @@ bool Image::IsCreateInfoEqual(const VkImageCreateInfo &other_create_info) const 
 }
 
 // Check image compatibility rules for VK_NV_dedicated_allocation_image_aliasing
-bool Image::IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_create_info) const {
+bool Image::IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo& other_create_info) const {
     bool is_compatible = (create_info.sType == other_create_info.sType) && (create_info.flags == other_create_info.flags);
     is_compatible = is_compatible && IsImageTypeEqual(other_create_info) && IsFormatEqual(other_create_info);
     is_compatible = is_compatible && IsMipLevelsEqual(other_create_info);
@@ -329,7 +329,7 @@ bool Image::IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImage
     return is_compatible;
 }
 
-bool Image::IsCompatibleAliasing(const Image *other_image_state) const {
+bool Image::IsCompatibleAliasing(const Image* other_image_state) const {
     if (!IsSwapchainImage() && !other_image_state->IsSwapchainImage() &&
         !(create_info.flags & other_image_state->create_info.flags & VK_IMAGE_CREATE_ALIAS_BIT)) {
         return false;
@@ -348,19 +348,19 @@ bool Image::IsCompatibleAliasing(const Image *other_image_state) const {
     return false;
 }
 
-VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceLayers &sub) const {
+VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceLayers& sub) const {
     return GetEffectiveExtent(create_info, sub.aspectMask, sub.mipLevel);
 }
 
-VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresource &sub) const {
+VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresource& sub) const {
     return GetEffectiveExtent(create_info, sub.aspectMask, sub.mipLevel);
 }
 
-VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceRange &range) const {
+VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceRange& range) const {
     return GetEffectiveExtent(create_info, range.aspectMask, range.baseMipLevel);
 }
 
-std::string Image::DescribeSubresourceLayers(const VkImageSubresourceLayers &subresource) const {
+std::string Image::DescribeSubresourceLayers(const VkImageSubresourceLayers& subresource) const {
     std::ostringstream ss;
     VkExtent3D subresource_extent = GetEffectiveSubresourceExtent(subresource);
 
@@ -396,7 +396,7 @@ std::string Image::DescribeSubresourceLayers(const VkImageSubresourceLayers &sub
     return ss.str();
 }
 
-VkImageSubresourceRange Image::NormalizeSubresourceRange(const VkImageSubresourceRange &range) const {
+VkImageSubresourceRange Image::NormalizeSubresourceRange(const VkImageSubresourceRange& range) const {
     VkImageSubresourceRange norm = range;
     norm.levelCount = GetEffectiveLevelCount(range, create_info.mipLevels);
     norm.layerCount = GetEffectiveLayerCount(range, create_info.arrayLayers);
@@ -404,13 +404,13 @@ VkImageSubresourceRange Image::NormalizeSubresourceRange(const VkImageSubresourc
     return norm;
 }
 
-uint32_t Image::NormalizeLayerCount(const VkImageSubresourceLayers &resource) const {
+uint32_t Image::NormalizeLayerCount(const VkImageSubresourceLayers& resource) const {
     return (resource.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (create_info.arrayLayers - resource.baseArrayLayer)
                                                               : resource.layerCount;
 }
 
-VkImageSubresourceRange Image::GetSubresourceEncoderRange(const DeviceState &device_state,
-                                                          const VkImageSubresourceRange &full_range) {
+VkImageSubresourceRange Image::GetSubresourceEncoderRange(const DeviceState& device_state,
+                                                          const VkImageSubresourceRange& full_range) {
     VkImageSubresourceRange encoder_range = full_range;
     if (CanTransitionDepthSlices(device_state.extensions, create_info)) {
         encoder_range.layerCount = create_info.extent.depth;
@@ -426,7 +426,7 @@ void Image::SetInitialLayoutMap() {
     std::shared_ptr<ImageLayoutMap> new_layout_map;
     std::shared_ptr<std::shared_mutex> new_layout_map_lock;
 
-    auto get_layout_map = [&new_layout_map, &new_layout_map_lock](const Image &other_image) {
+    auto get_layout_map = [&new_layout_map, &new_layout_map_lock](const Image& other_image) {
         new_layout_map = other_image.layout_map;
         new_layout_map_lock = other_image.layout_map_lock;
         return true;
@@ -454,7 +454,7 @@ void Image::SetInitialLayoutMap() {
     layout_map_lock = std::move(new_layout_map_lock);
 }
 
-void Image::SetImageLayout(const VkImageSubresourceRange &range, VkImageLayout layout) {
+void Image::SetImageLayout(const VkImageSubresourceRange& range, VkImageLayout layout) {
     using sparse_container::update_range_value;
     using sparse_container::value_precedence;
     RangeGenerator range_gen(subresource_encoder, NormalizeSubresourceRange(range));
@@ -464,18 +464,18 @@ void Image::SetImageLayout(const VkImageSubresourceRange &range, VkImageLayout l
     }
 }
 
-void Image::SetSwapchain(std::shared_ptr<vvl::Swapchain> &swapchain, uint32_t swapchain_index) {
+void Image::SetSwapchain(std::shared_ptr<vvl::Swapchain>& swapchain, uint32_t swapchain_index) {
     assert(IsSwapchainImage());
     bind_swapchain = swapchain;
     swapchain_image_index = swapchain_index;
     bind_swapchain->AddParent(this);
 
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->SetSwapchain(*swapchain);
     }
 }
 
-bool Image::CompareCreateInfo(const Image &other) const {
+bool Image::CompareCreateInfo(const Image& other) const {
     bool valid_queue_family = true;
     if (create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
         if (create_info.queueFamilyIndexCount != other.create_info.queueFamilyIndexCount) {
@@ -574,15 +574,15 @@ ImageView::ImageView(const DeviceState& device_state, const std::shared_ptr<vvl:
       inherited_usage(GetInheritedUsage(create_info, *image_state)) {
 }
 
-void ImageView::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &item : sub_states_) {
+void ImageView::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
+    for (auto& item : sub_states_) {
         item.second->NotifyInvalidate(invalid_nodes, unlink);
     }
     StateObject::NotifyInvalidate(invalid_nodes, unlink);
 }
 
 void ImageView::Destroy() {
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Destroy();
     }
     if (image_state) {
@@ -599,9 +599,9 @@ uint32_t ImageView::GetAttachmentLayerCount() const {
     return create_info.subresourceRange.layerCount;
 }
 
-VkImageSubresourceRange ImageView::NormalizeImageViewSubresourceRange(const Image &image_state,
-                                                                      const VkImageViewCreateInfo &image_view_ci) {
-    const VkImageCreateInfo &image_ci = image_state.create_info;
+VkImageSubresourceRange ImageView::NormalizeImageViewSubresourceRange(const Image& image_state,
+                                                                      const VkImageViewCreateInfo& image_view_ci) {
+    const VkImageCreateInfo& image_ci = image_state.create_info;
 
     VkImageSubresourceRange range = image_view_ci.subresourceRange;
     range.levelCount = GetEffectiveLevelCount(range, image_ci.mipLevels);
@@ -618,7 +618,7 @@ VkImageSubresourceRange ImageView::NormalizeImageViewSubresourceRange(const Imag
     return range;
 }
 
-VkImageSubresourceRange ImageView::GetRangeGeneratorRange(const DeviceExtensions &extensions) const {
+VkImageSubresourceRange ImageView::GetRangeGeneratorRange(const DeviceExtensions& extensions) const {
     VkImageSubresourceRange subres_range = create_info.subresourceRange;
 
     // if we're mapping a 3D image to a 2d image view, convert the view's subresource range to be compatible with the
@@ -638,7 +638,7 @@ VkImageSubresourceRange ImageView::GetRangeGeneratorRange(const DeviceExtensions
     return image_state->NormalizeSubresourceRange(subres_range);
 }
 
-bool ImageView::OverlapSubresource(const ImageView &compare_view) const {
+bool ImageView::OverlapSubresource(const ImageView& compare_view) const {
     if (VkHandle() == compare_view.VkHandle()) {
         return true;
     }

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -31,9 +31,9 @@
 #include "chassis/chassis_modification_state.h"
 #include "utils/vk_api_utils.h"
 
-void LastBound::UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorSet> &&ds) {
+void LastBound::UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorSet>&& ds) {
     if (push_descriptor_set) {
-        for (auto &ds_slot : ds_slots) {
+        for (auto& ds_slot : ds_slots) {
             if (ds_slot.ds_state == push_descriptor_set) {
                 cb_state.RemoveChild(ds_slot.ds_state);
                 ds_slot.ds_state.reset();
@@ -209,7 +209,7 @@ bool LastBound::IsLogicOpEnabled() const {
             return cb_state.dynamic_state_value.logic_op_enable;
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             return color_blend->logicOpEnable;
         }
     }
@@ -222,7 +222,7 @@ VkColorComponentFlags LastBound::GetColorWriteMask(uint32_t i) const {
             return cb_state.dynamic_state_value.color_write_masks[i];
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             if (i < color_blend->attachmentCount) {
                 return color_blend->pAttachments[i].colorWriteMask;
             }
@@ -237,7 +237,7 @@ bool LastBound::IsColorWriteEnabled(uint32_t i) const {
             return cb_state.dynamic_state_value.color_write_enabled[i];
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             auto color_write = vku::FindStructInPNextChain<VkPipelineColorWriteCreateInfoEXT>(color_blend->pNext);
             if (color_write && i < color_write->attachmentCount) {
                 return color_write->pColorWriteEnables[i];
@@ -253,7 +253,7 @@ bool LastBound::IsColorBlendEnabled(uint32_t i) const {
             return cb_state.dynamic_state_value.color_blend_enabled[i];
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             if (i < color_blend->attachmentCount) {
                 return color_blend->pAttachments[i].blendEnable;
             }
@@ -270,7 +270,7 @@ std::string LastBound::DescribeColorBlendEnabled(uint32_t i) const {
             ss << (cb_state.dynamic_state_value.color_blend_enabled[i] ? "VK_TRUE" : "VK_FALSE");
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             if (i < color_blend->attachmentCount) {
                 ss << "VkPipelineColorBlendStateCreateInfo::pAttachments[" << i << "].blendEnable is ";
                 ss << (color_blend->pAttachments[i].blendEnable ? "VK_TRUE" : "VK_FALSE");
@@ -289,14 +289,14 @@ bool LastBound::IsBlendConstantsEnabled(uint32_t i) const {
             if (i >= cb_state.dynamic_state_value.color_blend_equations.size()) {
                 return false;  // this color attachment was set with vkCmdSetColorBlendAdvancedEXT instead
             }
-            const VkColorBlendEquationEXT &eq = cb_state.dynamic_state_value.color_blend_equations[i];
+            const VkColorBlendEquationEXT& eq = cb_state.dynamic_state_value.color_blend_equations[i];
             return IsValueIn(eq.srcColorBlendFactor, const_factors) || IsValueIn(eq.dstColorBlendFactor, const_factors) ||
                    IsValueIn(eq.srcAlphaBlendFactor, const_factors) || IsValueIn(eq.dstAlphaBlendFactor, const_factors);
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             if (i < color_blend->attachmentCount) {
-                const VkPipelineColorBlendAttachmentState &eq = color_blend->pAttachments[i];
+                const VkPipelineColorBlendAttachmentState& eq = color_blend->pAttachments[i];
                 return IsValueIn(eq.srcColorBlendFactor, const_factors) || IsValueIn(eq.dstColorBlendFactor, const_factors) ||
                        IsValueIn(eq.srcAlphaBlendFactor, const_factors) || IsValueIn(eq.dstAlphaBlendFactor, const_factors);
             }
@@ -311,16 +311,16 @@ bool LastBound::IsDualBlending(uint32_t i) const {
             if (i >= cb_state.dynamic_state_value.color_blend_equations.size()) {
                 return false;  // this color attachment was set with vkCmdSetColorBlendAdvancedEXT instead
             }
-            const VkColorBlendEquationEXT &eq = cb_state.dynamic_state_value.color_blend_equations[i];
+            const VkColorBlendEquationEXT& eq = cb_state.dynamic_state_value.color_blend_equations[i];
             return IsSecondaryColorInputBlendFactor(eq.srcColorBlendFactor) ||
                    IsSecondaryColorInputBlendFactor(eq.dstColorBlendFactor) ||
                    IsSecondaryColorInputBlendFactor(eq.srcAlphaBlendFactor) ||
                    IsSecondaryColorInputBlendFactor(eq.dstAlphaBlendFactor);
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             if (i < color_blend->attachmentCount) {
-                const VkPipelineColorBlendAttachmentState &eq = color_blend->pAttachments[i];
+                const VkPipelineColorBlendAttachmentState& eq = color_blend->pAttachments[i];
                 return IsSecondaryColorInputBlendFactor(eq.srcColorBlendFactor) ||
                        IsSecondaryColorInputBlendFactor(eq.dstColorBlendFactor) ||
                        IsSecondaryColorInputBlendFactor(eq.srcAlphaBlendFactor) ||
@@ -335,7 +335,7 @@ std::string LastBound::DescribeBlendFactorEquation(uint32_t i) const {
     std::ostringstream ss;
     if (IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
         if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
-            const VkColorBlendEquationEXT &eq = cb_state.dynamic_state_value.color_blend_equations[i];
+            const VkColorBlendEquationEXT& eq = cb_state.dynamic_state_value.color_blend_equations[i];
             ss << "The following are set by vkCmdSetColorBlendEquationEXT::pColorBlendEquations[" << i << "]\n";
             ss << "  srcColorBlendFactor = " << string_VkBlendFactor(eq.srcColorBlendFactor) << "\n";
             ss << "  dstColorBlendFactor = " << string_VkBlendFactor(eq.dstColorBlendFactor) << "\n";
@@ -343,9 +343,9 @@ std::string LastBound::DescribeBlendFactorEquation(uint32_t i) const {
             ss << "  dstAlphaBlendFactor = " << string_VkBlendFactor(eq.dstAlphaBlendFactor) << "\n";
         }
     } else {
-        if (const auto &color_blend = pipeline_state->ColorBlendState()) {
+        if (const auto& color_blend = pipeline_state->ColorBlendState()) {
             if (i < color_blend->attachmentCount) {
-                const VkPipelineColorBlendAttachmentState &eq = color_blend->pAttachments[i];
+                const VkPipelineColorBlendAttachmentState& eq = color_blend->pAttachments[i];
                 ss << "The following are set by VkPipelineColorBlendStateCreateInfo::pAttachments[" << i << "]\n";
                 ss << "  srcColorBlendFactor = " << string_VkBlendFactor(eq.srcColorBlendFactor) << "\n";
                 ss << "  dstColorBlendFactor = " << string_VkBlendFactor(eq.dstColorBlendFactor) << "\n";
@@ -392,7 +392,7 @@ bool LastBound::IsSampleLocationsEnable() const {
         }
     } else {
         if (auto ms_state = pipeline_state->MultisampleState()) {
-            if (const auto *sample_location_state =
+            if (const auto* sample_location_state =
                     vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(ms_state->pNext)) {
                 return sample_location_state->sampleLocationsEnable;
             }
@@ -424,7 +424,7 @@ bool LastBound::IsCoverageToColorEnabled() const {
         }
     } else {
         if (auto ms_state = pipeline_state->MultisampleState()) {
-            if (const auto *coverage_to_color_state =
+            if (const auto* coverage_to_color_state =
                     vku::FindStructInPNextChain<VkPipelineCoverageToColorStateCreateInfoNV>(ms_state->pNext)) {
                 return coverage_to_color_state->coverageToColorEnable;
             }
@@ -440,7 +440,7 @@ bool LastBound::IsCoverageModulationTableEnable() const {
         }
     } else {
         if (auto ms_state = pipeline_state->MultisampleState()) {
-            if (const auto *coverage_modulation_state =
+            if (const auto* coverage_modulation_state =
                     vku::FindStructInPNextChain<VkPipelineCoverageModulationStateCreateInfoNV>(ms_state->pNext)) {
                 return coverage_modulation_state->coverageModulationTableEnable;
             }
@@ -473,8 +473,8 @@ bool LastBound::IsDiscardRectangleEnable() const {
         // "If the VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT dynamic state is not enabled for the pipeline the presence of this
         // structure in the VkGraphicsPipelineCreateInfo chain, and a discardRectangleCount greater than zero, implicitly enables
         // discard rectangles in the pipeline"
-        const void *pipeline_pnext = pipeline_state->GetCreateInfoPNext();
-        if (const auto *discard_rectangle_state =
+        const void* pipeline_pnext = pipeline_state->GetCreateInfoPNext();
+        if (const auto* discard_rectangle_state =
                 vku::FindStructInPNextChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pipeline_pnext)) {
             return discard_rectangle_state->discardRectangleCount > 0;
         }
@@ -489,7 +489,7 @@ bool LastBound::IsShadingRateImageEnable() const {
         }
     } else {
         if (auto viewport_state = pipeline_state->ViewportState()) {
-            if (const auto *shading_rate_image_state =
+            if (const auto* shading_rate_image_state =
                     vku::FindStructInPNextChain<VkPipelineViewportShadingRateImageStateCreateInfoNV>(viewport_state->pNext)) {
                 return shading_rate_image_state->shadingRateImageEnable;
             }
@@ -505,7 +505,7 @@ bool LastBound::IsViewportWScalingEnable() const {
         }
     } else {
         if (auto viewport_state = pipeline_state->ViewportState()) {
-            if (const auto *viewport_w_scaling_state =
+            if (const auto* viewport_w_scaling_state =
                     vku::FindStructInPNextChain<VkPipelineViewportWScalingStateCreateInfoNV>(viewport_state->pNext)) {
                 return viewport_w_scaling_state->viewportWScalingEnable;
             }
@@ -560,7 +560,7 @@ VkCoverageModulationModeNV LastBound::GetCoverageModulationMode() const {
         }
     } else {
         if (auto ms_state = pipeline_state->MultisampleState()) {
-            if (const auto *coverage_modulation_state =
+            if (const auto* coverage_modulation_state =
                     vku::FindStructInPNextChain<VkPipelineCoverageModulationStateCreateInfoNV>(ms_state->pNext)) {
                 return coverage_modulation_state->coverageModulationMode;
             }
@@ -576,7 +576,7 @@ uint32_t LastBound::GetViewportSwizzleCount() const {
         }
     } else {
         if (auto viewport_state = pipeline_state->ViewportState()) {
-            if (const auto *viewport_swizzle_state =
+            if (const auto* viewport_swizzle_state =
                     vku::FindStructInPNextChain<VkPipelineViewportSwizzleStateCreateInfoNV>(viewport_state->pNext)) {
                 return viewport_swizzle_state->viewportCount;
             }
@@ -634,7 +634,7 @@ VkPrimitiveTopology LastBound::ClipSpaceTopology() const {
         if (mesh_shader_bound || geom_shader_bound) {
             // Can only have either a mesh or geometry stage, so can search both at once
             assert(!mesh_shader_bound || !geom_shader_bound);
-            for (const ShaderStageState &shader_stage_state : pipeline_state->stage_states) {
+            for (const ShaderStageState& shader_stage_state : pipeline_state->stage_states) {
                 const VkShaderStageFlagBits stage = shader_stage_state.GetStage();
                 if (stage == VK_SHADER_STAGE_MESH_BIT_EXT || stage == VK_SHADER_STAGE_GEOMETRY_BIT) {
                     if (shader_stage_state.HasSpirv()) {
@@ -644,7 +644,7 @@ VkPrimitiveTopology LastBound::ClipSpaceTopology() const {
             }
         } else if (tesc_shader_bound || tese_shader_bound) {
             VkPrimitiveTopology tess_output_topology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
-            for (const ShaderStageState &shader_stage_state : pipeline_state->stage_states) {
+            for (const ShaderStageState& shader_stage_state : pipeline_state->stage_states) {
                 const VkShaderStageFlagBits stage = shader_stage_state.GetStage();
                 if (stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT || stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT) {
                     if (shader_stage_state.HasSpirv()) {
@@ -664,25 +664,25 @@ VkPrimitiveTopology LastBound::ClipSpaceTopology() const {
         }
     } else {  // shader object
         if (mesh_shader_bound) {
-            vvl::ShaderObject *mesh_shader = GetShaderObjectState(ShaderObjectStage::MESH);
+            vvl::ShaderObject* mesh_shader = GetShaderObjectState(ShaderObjectStage::MESH);
             if (mesh_shader && mesh_shader->stage.entrypoint) {
                 return mesh_shader->stage.entrypoint->execution_mode.GetGeometryMeshOutputTopology();
             }
         } else if (geom_shader_bound) {
-            vvl::ShaderObject *geom_shader = GetShaderObjectState(ShaderObjectStage::GEOMETRY);
+            vvl::ShaderObject* geom_shader = GetShaderObjectState(ShaderObjectStage::GEOMETRY);
             if (geom_shader && geom_shader->stage.entrypoint) {
                 return geom_shader->stage.entrypoint->execution_mode.GetGeometryMeshOutputTopology();
             }
         } else if (tesc_shader_bound || tese_shader_bound) {
             VkPrimitiveTopology tess_output_topology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
-            vvl::ShaderObject *tesc_shader = GetShaderObjectState(ShaderObjectStage::TESSELLATION_CONTROL);
+            vvl::ShaderObject* tesc_shader = GetShaderObjectState(ShaderObjectStage::TESSELLATION_CONTROL);
             if (tesc_shader && tesc_shader->stage.entrypoint) {
                 if (tesc_shader->stage.entrypoint->execution_mode.Has(spirv::ExecutionModeSet::point_mode_bit)) {
                     return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
                 }
             }
 
-            vvl::ShaderObject *tese_shader = GetShaderObjectState(ShaderObjectStage::TESSELLATION_EVALUATION);
+            vvl::ShaderObject* tese_shader = GetShaderObjectState(ShaderObjectStage::TESSELLATION_EVALUATION);
             if (tese_shader && tese_shader->stage.entrypoint) {
                 if (tese_shader->stage.entrypoint->execution_mode.Has(spirv::ExecutionModeSet::point_mode_bit)) {
                     return VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
@@ -724,7 +724,7 @@ bool LastBound::IsSampleShadingEnabled() const {
         return false;  // if no fragment shader, no sample shading
     }
 
-    for (const auto &variable : fragment_entry_point->stage_interface_variables) {
+    for (const auto& variable : fragment_entry_point->stage_interface_variables) {
         if (variable.storage_class != spv::StorageClassInput) {
             continue;
         }
@@ -762,7 +762,7 @@ std::string LastBound::DescribeSampleShading() const {
 
     bool is_implicit = false;
     if (auto fragment_entry_point = GetFragmentEntryPoint()) {
-        for (const auto &variable : fragment_entry_point->stage_interface_variables) {
+        for (const auto& variable : fragment_entry_point->stage_interface_variables) {
             if (variable.storage_class != spv::StorageClassInput) {
                 continue;
             }
@@ -802,26 +802,26 @@ VkShaderEXT LastBound::GetShaderObject(ShaderObjectStage stage) const {
     return shader_object_states[static_cast<uint32_t>(stage)]->VkHandle();
 }
 
-vvl::ShaderObject *LastBound::GetShaderObjectState(ShaderObjectStage stage) const {
+vvl::ShaderObject* LastBound::GetShaderObjectState(ShaderObjectStage stage) const {
     return shader_object_states[static_cast<uint32_t>(stage)];
 }
 
-const vvl::ShaderObject *LastBound::GetShaderObjectStateIfValid(ShaderObjectStage stage) const {
+const vvl::ShaderObject* LastBound::GetShaderObjectStateIfValid(ShaderObjectStage stage) const {
     if (!shader_object_bound[static_cast<uint32_t>(stage)]) {
         return nullptr;
     }
     return shader_object_states[static_cast<uint32_t>(stage)];
 }
 
-const vvl::ShaderObject *LastBound::GetFirstShader() const {
+const vvl::ShaderObject* LastBound::GetFirstShader() const {
     if (bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
         return GetShaderObjectStateIfValid(ShaderObjectStage::COMPUTE);
     } else if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS) {
-        if (const vvl::ShaderObject *vs = GetShaderObjectStateIfValid(ShaderObjectStage::VERTEX)) {
+        if (const vvl::ShaderObject* vs = GetShaderObjectStateIfValid(ShaderObjectStage::VERTEX)) {
             return vs;
         }
 
-        if (const vvl::ShaderObject *ms = GetShaderObjectStateIfValid(ShaderObjectStage::MESH)) {
+        if (const vvl::ShaderObject* ms = GetShaderObjectStateIfValid(ShaderObjectStage::MESH)) {
             return ms;
         }
     }
@@ -844,8 +844,8 @@ bool LastBound::IsValidShaderObjectOrNullBound(ShaderObjectStage stage) const {
     return shader_object_bound[static_cast<uint32_t>(stage)];
 }
 
-std::vector<vvl::ShaderObject *> LastBound::GetAllBoundGraphicsShaderObjects() {
-    std::vector<vvl::ShaderObject *> shaders;
+std::vector<vvl::ShaderObject*> LastBound::GetAllBoundGraphicsShaderObjects() {
+    std::vector<vvl::ShaderObject*> shaders;
 
     if (IsValidShaderObjectBound(ShaderObjectStage::VERTEX)) {
         shaders.emplace_back(shader_object_states[static_cast<uint32_t>(ShaderObjectStage::VERTEX)]);
@@ -926,21 +926,21 @@ VkShaderStageFlags LastBound::GetAllActiveBoundStages() const {
     return stages;
 }
 
-bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const {
+bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::PipelineLayout& pipeline_layout) const {
     if ((set >= ds_slots.size()) || (set >= pipeline_layout.set_compat_ids.size())) {
         return false;
     }
     return (*(ds_slots[set].compat_id_for_set) == *(pipeline_layout.set_compat_ids[set]));
 }
 
-bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::ShaderObject &shader_object_state) const {
+bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::ShaderObject& shader_object_state) const {
     if ((set >= ds_slots.size()) || (set >= shader_object_state.set_compat_ids.size())) {
         return false;
     }
     return (*(ds_slots[set].compat_id_for_set) == *(shader_object_state.set_compat_ids[set]));
 };
 
-std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const {
+std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::PipelineLayout& pipeline_layout) const {
     std::ostringstream ss;
     if (set >= ds_slots.size()) {
         ss << "The set (" << set << ") is out of bounds for the number of sets bound (" << ds_slots.size()
@@ -955,7 +955,7 @@ std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::Pipelin
     return ss.str();
 }
 
-std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderObject &shader_object_state) const {
+std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderObject& shader_object_state) const {
     std::ostringstream ss;
     if (set >= ds_slots.size()) {
         ss << "The set (" << set << ") is out of bounds for the number of sets bound (" << ds_slots.size()
@@ -970,22 +970,22 @@ std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderO
     return ss.str();
 }
 
-const spirv::EntryPoint *LastBound::GetVertexEntryPoint() const {
+const spirv::EntryPoint* LastBound::GetVertexEntryPoint() const {
     if (pipeline_state) {
         const ShaderStageState* stage_state = pipeline_state->GetShaderStageState(VK_SHADER_STAGE_VERTEX_BIT);
         if (stage_state) {
             return stage_state->entrypoint.get();
         }
-    } else if (const auto *shader_object = GetShaderObjectState(ShaderObjectStage::VERTEX)) {
+    } else if (const auto* shader_object = GetShaderObjectState(ShaderObjectStage::VERTEX)) {
         return shader_object->stage.entrypoint.get();
     }
     return nullptr;
 }
 
-const spirv::EntryPoint *LastBound::GetFragmentEntryPoint() const {
+const spirv::EntryPoint* LastBound::GetFragmentEntryPoint() const {
     if (pipeline_state && pipeline_state->fragment_shader_state) {
         return pipeline_state->fragment_shader_state->fragment_entry_point.get();
-    } else if (const auto *shader_object = GetShaderObjectState(ShaderObjectStage::FRAGMENT)) {
+    } else if (const auto* shader_object = GetShaderObjectState(ShaderObjectStage::FRAGMENT)) {
         return shader_object->stage.entrypoint.get();
     }
     return nullptr;

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -46,14 +46,14 @@ size_t PipelineLayoutCompatDef::hash() const {
     hash_util::HashCombiner hc;
     // The set number is integral to the CompatDef's distinctiveness
     hc << set << push_constant_ranges.get() << is_independent_sets;
-    const auto &descriptor_set_layouts = *set_layouts_id.get();
+    const auto& descriptor_set_layouts = *set_layouts_id.get();
     for (uint32_t i = 0; i <= set; i++) {
         hc << descriptor_set_layouts[i].get();
     }
     return hc.Value();
 }
 
-bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef &other) const {
+bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef& other) const {
     if ((set != other.set) || (push_constant_ranges != other.push_constant_ranges) ||
         (is_independent_sets != other.is_independent_sets)) {
         return false;
@@ -65,9 +65,9 @@ bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef &other) c
     }
 
     // They aren't exactly the same PipelineLayoutSetLayouts, so we need to check if the required subsets match
-    const auto &descriptor_set_layouts = *set_layouts_id.get();
+    const auto& descriptor_set_layouts = *set_layouts_id.get();
     assert(set < descriptor_set_layouts.size());
-    const auto &other_ds_layouts = *other.set_layouts_id.get();
+    const auto& other_ds_layouts = *other.set_layouts_id.get();
     assert(set < other_ds_layouts.size());
     for (uint32_t i = 0; i <= set; i++) {
         if (descriptor_set_layouts[i] != other_ds_layouts[i]) {
@@ -77,7 +77,7 @@ bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef &other) c
     return true;
 }
 
-std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutCompatDef &other) const {
+std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutCompatDef& other) const {
     std::ostringstream ss;
     if (set != other.set) {
         ss << "The set " << set << " is different from the non-compatible VkPipelineLayout (" << other.set << ")\n";
@@ -108,8 +108,8 @@ std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutComp
                   "pipeline was.";
         }
     } else {
-        const auto &descriptor_set_layouts = *set_layouts_id.get();
-        const auto &other_ds_layouts = *other.set_layouts_id.get();
+        const auto& descriptor_set_layouts = *set_layouts_id.get();
+        const auto& other_ds_layouts = *other.set_layouts_id.get();
         for (uint32_t i = 0; i <= set; i++) {
             if (descriptor_set_layouts[i] != other_ds_layouts[i]) {
                 if (!descriptor_set_layouts[i] || !other_ds_layouts[i]) {
@@ -123,14 +123,14 @@ std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutComp
     return ss.str();
 }
 
-static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId &pcr_id,
-                                             const PipelineLayoutSetLayoutsId &set_layouts_id, bool is_independent_sets) {
+static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId& pcr_id,
+                                             const PipelineLayoutSetLayoutsId& set_layouts_id, bool is_independent_sets) {
     return pipeline_layout_compat_dict.LookUp(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id, is_independent_sets));
 }
 
 // For repeatable sorting, not very useful for "memory in range" search
 struct PushConstantRangeCompare {
-    bool operator()(const VkPushConstantRange *lhs, const VkPushConstantRange *rhs) const {
+    bool operator()(const VkPushConstantRange* lhs, const VkPushConstantRange* rhs) const {
         if (lhs->offset == rhs->offset) {
             if (lhs->size == rhs->size) {
                 // The comparison is arbitrary, but avoids false aliasing by comparing all fields.
@@ -143,29 +143,29 @@ struct PushConstantRangeCompare {
     }
 };
 
-PushConstantRangesId GetCanonicalId(uint32_t pushConstantRangeCount, const VkPushConstantRange *pPushConstantRanges) {
+PushConstantRangesId GetCanonicalId(uint32_t pushConstantRangeCount, const VkPushConstantRange* pPushConstantRanges) {
     if (!pPushConstantRanges) {
         // Hand back the empty entry (creating as needed)...
         return push_constant_ranges_dict.LookUp(PushConstantRanges());
     }
 
     // Sort the input ranges to ensure equivalent ranges map to the same id
-    std::set<const VkPushConstantRange *, PushConstantRangeCompare> sorted;
+    std::set<const VkPushConstantRange*, PushConstantRangeCompare> sorted;
     for (uint32_t i = 0; i < pushConstantRangeCount; i++) {
         sorted.insert(pPushConstantRanges + i);
     }
 
     PushConstantRanges ranges;
     ranges.reserve(sorted.size());
-    for (const auto *range : sorted) {
+    for (const auto* range : sorted) {
         ranges.emplace_back(*range);
     }
     return push_constant_ranges_dict.LookUp(std::move(ranges));
 }
 
-static PushConstantRangesId GetPushConstantRangesFromLayouts(const vvl::span<const vvl::PipelineLayout *const> &layouts) {
+static PushConstantRangesId GetPushConstantRangesFromLayouts(const vvl::span<const vvl::PipelineLayout* const>& layouts) {
     PushConstantRangesId ret{};
-    for (const auto *layout : layouts) {
+    for (const auto* layout : layouts) {
         if (layout && layout->push_constant_ranges_layout) {
             ret = layout->push_constant_ranges_layout;
 
@@ -177,8 +177,8 @@ static PushConstantRangesId GetPushConstantRangesFromLayouts(const vvl::span<con
     return ret;
 }
 
-std::vector<PipelineLayoutCompatId> GetCompatForSet(const vvl::DescriptorSetLayoutList &set_layouts,
-                                                    const PushConstantRangesId &push_constant_ranges,
+std::vector<PipelineLayoutCompatId> GetCompatForSet(const vvl::DescriptorSetLayoutList& set_layouts,
+                                                    const PushConstantRangesId& push_constant_ranges,
                                                     VkPipelineLayoutCreateFlags pipeline_layout_create_flags) {
     PipelineLayoutSetLayoutsDef set_layout_ids(set_layouts.list.size());
     for (size_t i = 0; i < set_layouts.list.size(); i++) {
@@ -201,7 +201,7 @@ std::vector<PipelineLayoutCompatId> GetCompatForSet(const vvl::DescriptorSetLayo
 }
 
 // This is called when merging the flags from the pipeline layouts in libraries
-VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const vvl::PipelineLayout *const> &layouts) {
+VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const vvl::PipelineLayout* const>& layouts) {
     // from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9870 and
     // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4264
     // We do not actually combine the flags, instead we only take the flags from the final linked pipeline layout
@@ -210,7 +210,7 @@ VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const vvl::PipelineLa
 
 namespace vvl {
 
-static DescriptorSetLayoutList GetSetLayouts(DeviceState &dev_data, const VkPipelineLayoutCreateInfo *pCreateInfo) {
+static DescriptorSetLayoutList GetSetLayouts(DeviceState& dev_data, const VkPipelineLayoutCreateInfo* pCreateInfo) {
     DescriptorSetLayoutList set_layouts(pCreateInfo->setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
@@ -219,10 +219,10 @@ static DescriptorSetLayoutList GetSetLayouts(DeviceState &dev_data, const VkPipe
     return set_layouts;
 }
 
-static DescriptorSetLayoutList GetSetLayouts(const vvl::span<const PipelineLayout *const> &layouts) {
+static DescriptorSetLayoutList GetSetLayouts(const vvl::span<const PipelineLayout* const>& layouts) {
     DescriptorSetLayoutList set_layouts;
     size_t num_layouts = 0;
-    for (const auto &layout : layouts) {
+    for (const auto& layout : layouts) {
         if (layout && (layout->set_layouts.list.size() > num_layouts)) {
             num_layouts = layout->set_layouts.list.size();
         }
@@ -230,8 +230,8 @@ static DescriptorSetLayoutList GetSetLayouts(const vvl::span<const PipelineLayou
 
     set_layouts.list.reserve(num_layouts);
     for (size_t i = 0; i < num_layouts; ++i) {
-        const PipelineLayout *used_layout = nullptr;
-        for (const auto *layout : layouts) {
+        const PipelineLayout* used_layout = nullptr;
+        for (const auto* layout : layouts) {
             if (layout) {
                 if (layout->set_layouts.list.size() > i) {
                     // This _could_ be the layout we're looking for
@@ -262,8 +262,8 @@ static bool HasDescriptorBuffer(const DescriptorSetLayoutList& set_layouts) {
     return false;
 }
 
-static bool HasImmutableSamplers(const DescriptorSetLayoutList &set_layouts) {
-    for (const auto &set_layout : set_layouts.list) {
+static bool HasImmutableSamplers(const DescriptorSetLayoutList& set_layouts) {
+    for (const auto& set_layout : set_layouts.list) {
         if (set_layout && set_layout->HasImmutableSamplers()) {
             return true;
         }

--- a/layers/state_tracker/pipeline_library_state.cpp
+++ b/layers/state_tracker/pipeline_library_state.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2017, 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2017, 2019-2025 Valve Corporation
- * Copyright (c) 2015-2017, 2019-2025 LunarG, Inc.
+/* Copyright (c) 2015-2017, 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2017, 2019-2026 Valve Corporation
+ * Copyright (c) 2015-2017, 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ bool PipelineLibraryState::IsIndependentSets() const {
     return false;
 }
 
-VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGraphicsPipelineCreateInfo &create_info)
+VertexInputState::VertexInputState(const vvl::Pipeline& p, const vku::safe_VkGraphicsPipelineCreateInfo& create_info)
     : PipelineLibraryState(p) {
     for (uint32_t i = 0; i < create_info.stageCount; i++) {
         if (create_info.pStages && create_info.pStages[i].stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
@@ -45,11 +45,11 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
                  vvl::enumerate(input_state->pVertexBindingDescriptions, input_state->vertexBindingDescriptionCount)) {
                 bindings.emplace(description.binding, VertexBindingState(i, &description));
             }
-            const auto *divisor_info = vku::FindStructInPNextChain<VkPipelineVertexInputDivisorStateCreateInfo>(input_state->pNext);
+            const auto* divisor_info = vku::FindStructInPNextChain<VkPipelineVertexInputDivisorStateCreateInfo>(input_state->pNext);
             if (divisor_info) {
                 for (const auto [i, di] :
                      vvl::enumerate(divisor_info->pVertexBindingDivisors, divisor_info->vertexBindingDivisorCount)) {
-                    if (auto *binding_state = vvl::Find(bindings, di.binding)) {
+                    if (auto* binding_state = vvl::Find(bindings, di.binding)) {
                         binding_state->desc.divisor = di.divisor;
                     }
                 }
@@ -57,7 +57,7 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
         }
         for (const auto [i, description] :
              vvl::enumerate(input_state->pVertexAttributeDescriptions, input_state->vertexAttributeDescriptionCount)) {
-            auto *binding_state = vvl::Find(bindings, description.binding);
+            auto* binding_state = vvl::Find(bindings, description.binding);
             if (!binding_state) {
                 continue;
             }
@@ -66,8 +66,8 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
     }
 }
 
-PreRasterState::PreRasterState(const vvl::Pipeline &p, const vvl::DeviceState &state_data,
-                               const vku::safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp,
+PreRasterState::PreRasterState(const vvl::Pipeline& p, const vvl::DeviceState& state_data,
+                               const vku::safe_VkGraphicsPipelineCreateInfo& create_info, std::shared_ptr<const vvl::RenderPass> rp,
                                spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages])
     : PipelineLibraryState(p),
       pipeline_layout(state_data.Get<vvl::PipelineLayout>(create_info.layout)),
@@ -79,7 +79,7 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const vvl::DeviceState &s
     VkShaderStageFlags all_stages = 0;
 
     for (uint32_t i = 0; i < create_info.stageCount; ++i) {
-        const auto &stage_ci = create_info.pStages[i];
+        const auto& stage_ci = create_info.pStages[i];
         const VkShaderStageFlagBits stage = stage_ci.stage;
         if ((stage & ValidShaderStages()) == 0) {
             continue;
@@ -94,7 +94,7 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const vvl::DeviceState &s
         if (!module_state) {
             // Using VkShaderModuleCreateInfo to inline with VK_KHR_maintenance5
             if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(stage_ci.pNext)) {
-                spirv::StatelessData *stateless_data_stage =
+                spirv::StatelessData* stateless_data_stage =
                     (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                 auto spirv_module = vvl::CreateSpirvModuleState(shader_ci->codeSize, shader_ci->pCode, state_data.global_settings,
                                                                 stateless_data_stage);
@@ -163,44 +163,44 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const vvl::DeviceState &s
 }
 
 std::unique_ptr<const vku::safe_VkPipelineColorBlendStateCreateInfo> ToSafeColorBlendState(
-    const vku::safe_VkPipelineColorBlendStateCreateInfo &cbs) {
+    const vku::safe_VkPipelineColorBlendStateCreateInfo& cbs) {
     // This is needlessly copied here. Might better to make this a plain pointer, with an optional "backing unique_ptr"
     return std::make_unique<const vku::safe_VkPipelineColorBlendStateCreateInfo>(cbs);
 }
 std::unique_ptr<const vku::safe_VkPipelineColorBlendStateCreateInfo> ToSafeColorBlendState(
-    const VkPipelineColorBlendStateCreateInfo &cbs) {
+    const VkPipelineColorBlendStateCreateInfo& cbs) {
     return std::make_unique<const vku::safe_VkPipelineColorBlendStateCreateInfo>(&cbs);
 }
 std::unique_ptr<const vku::safe_VkPipelineMultisampleStateCreateInfo> ToSafeMultisampleState(
-    const vku::safe_VkPipelineMultisampleStateCreateInfo &cbs) {
+    const vku::safe_VkPipelineMultisampleStateCreateInfo& cbs) {
     // This is needlessly copied here. Might better to make this a plain pointer, with an optional "backing unique_ptr"
     return std::make_unique<const vku::safe_VkPipelineMultisampleStateCreateInfo>(cbs);
 }
 std::unique_ptr<const vku::safe_VkPipelineMultisampleStateCreateInfo> ToSafeMultisampleState(
-    const VkPipelineMultisampleStateCreateInfo &cbs) {
+    const VkPipelineMultisampleStateCreateInfo& cbs) {
     return std::make_unique<const vku::safe_VkPipelineMultisampleStateCreateInfo>(&cbs);
 }
 std::unique_ptr<const vku::safe_VkPipelineDepthStencilStateCreateInfo> ToSafeDepthStencilState(
-    const vku::safe_VkPipelineDepthStencilStateCreateInfo &cbs) {
+    const vku::safe_VkPipelineDepthStencilStateCreateInfo& cbs) {
     // This is needlessly copied here. Might better to make this a plain pointer, with an optional "backing unique_ptr"
     return std::make_unique<const vku::safe_VkPipelineDepthStencilStateCreateInfo>(cbs);
 }
 std::unique_ptr<const vku::safe_VkPipelineDepthStencilStateCreateInfo> ToSafeDepthStencilState(
-    const VkPipelineDepthStencilStateCreateInfo &cbs) {
+    const VkPipelineDepthStencilStateCreateInfo& cbs) {
     return std::make_unique<const vku::safe_VkPipelineDepthStencilStateCreateInfo>(&cbs);
 }
 std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(
-    const vku::safe_VkPipelineShaderStageCreateInfo &cbs) {
+    const vku::safe_VkPipelineShaderStageCreateInfo& cbs) {
     // This is needlessly copied here. Might better to make this a plain pointer, with an optional "backing unique_ptr"
     return std::make_unique<const vku::safe_VkPipelineShaderStageCreateInfo>(cbs);
 }
-std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo &cbs) {
+std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo& cbs) {
     return std::make_unique<const vku::safe_VkPipelineShaderStageCreateInfo>(&cbs);
 }
 
 template <typename CreateInfo>
-void SetFragmentShaderInfoPrivate(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
-                                  const vvl::DeviceState &state_data, const CreateInfo &create_info,
+void SetFragmentShaderInfoPrivate(const vvl::Pipeline& pipeline_state, FragmentShaderState& fs_state,
+                                  const vvl::DeviceState& state_data, const CreateInfo& create_info,
                                   spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     for (uint32_t i = 0; i < create_info.stageCount; ++i) {
         if (create_info.pStages[i].stage != VK_SHADER_STAGE_FRAGMENT_BIT) {
@@ -214,7 +214,7 @@ void SetFragmentShaderInfoPrivate(const vvl::Pipeline &pipeline_state, FragmentS
         if (!module_state) {
             // Using VkShaderModuleCreateInfo to inline with VK_KHR_maintenance5
             if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(create_info.pStages[i].pNext)) {
-                spirv::StatelessData *stateless_data_stage =
+                spirv::StatelessData* stateless_data_stage =
                     (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                 auto spirv_module = vvl::CreateSpirvModuleState(shader_ci->codeSize, shader_ci->pCode, state_data.global_settings,
                                                                 stateless_data_stage);
@@ -247,23 +247,23 @@ void SetFragmentShaderInfoPrivate(const vvl::Pipeline &pipeline_state, FragmentS
 }
 
 // static
-void FragmentShaderState::SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
-                                                const vvl::DeviceState &state_data, const VkGraphicsPipelineCreateInfo &create_info,
+void FragmentShaderState::SetFragmentShaderInfo(const vvl::Pipeline& pipeline_state, FragmentShaderState& fs_state,
+                                                const vvl::DeviceState& state_data, const VkGraphicsPipelineCreateInfo& create_info,
                                                 spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     SetFragmentShaderInfoPrivate(pipeline_state, fs_state, state_data, create_info, stateless_data);
 }
 
 // static
-void FragmentShaderState::SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
-                                                const vvl::DeviceState &state_data,
-                                                const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
+void FragmentShaderState::SetFragmentShaderInfo(const vvl::Pipeline& pipeline_state, FragmentShaderState& fs_state,
+                                                const vvl::DeviceState& state_data,
+                                                const vku::safe_VkGraphicsPipelineCreateInfo& create_info,
                                                 spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     SetFragmentShaderInfoPrivate(pipeline_state, fs_state, state_data, create_info, stateless_data);
 }
 
-FragmentShaderState::FragmentShaderState(const vvl::Pipeline &p, const vvl::DeviceState &dev_data,
+FragmentShaderState::FragmentShaderState(const vvl::Pipeline& p, const vvl::DeviceState& dev_data,
                                          std::shared_ptr<const vvl::RenderPass> rp, uint32_t subpass_index, VkPipelineLayout layout)
     : PipelineLibraryState(p), rp_state(rp), subpass(subpass_index), pipeline_layout(dev_data.Get<vvl::PipelineLayout>(layout)) {}
 
-FragmentOutputState::FragmentOutputState(const vvl::Pipeline &p, std::shared_ptr<const vvl::RenderPass> rp, uint32_t subpass_index)
+FragmentOutputState::FragmentOutputState(const vvl::Pipeline& p, std::shared_ptr<const vvl::RenderPass> rp, uint32_t subpass_index)
     : PipelineLibraryState(p), rp_state(rp), subpass(subpass_index) {}

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -29,9 +29,9 @@
 
 namespace vvl {
 
-static vku::safe_VkGraphicsPipelineCreateInfo MakeGraphicsCreateInfo(const VkGraphicsPipelineCreateInfo &ci,
+static vku::safe_VkGraphicsPipelineCreateInfo MakeGraphicsCreateInfo(const VkGraphicsPipelineCreateInfo& ci,
                                                                      std::shared_ptr<const vvl::RenderPass> rpstate,
-                                                                     const DeviceState &state_data) {
+                                                                     const DeviceState& state_data) {
     bool use_color = false;
     bool use_depth_stencil = false;
 
@@ -51,15 +51,15 @@ static vku::safe_VkGraphicsPipelineCreateInfo MakeGraphicsCreateInfo(const VkGra
     }
 
     vku::PNextCopyState copy_state = {
-        [&state_data, &ci](VkBaseOutStructure *safe_struct, const VkBaseOutStructure *in_struct) -> bool {
+        [&state_data, &ci](VkBaseOutStructure* safe_struct, const VkBaseOutStructure* in_struct) -> bool {
             return Pipeline::PnextRenderingInfoCustomCopy(state_data, ci, safe_struct, in_struct);
         }};
     return vku::safe_VkGraphicsPipelineCreateInfo(&ci, use_color, use_depth_stencil, &copy_state);
 }
 
 static std::shared_ptr<vvl::ShaderModule> GetShaderModuleFromInlinedSpirv(
-    const DeviceState &state_data, const vku::safe_VkPipelineShaderStageCreateInfo &shader_stage_ci,
-    spirv::StatelessData *stateless_data) {
+    const DeviceState& state_data, const vku::safe_VkPipelineShaderStageCreateInfo& shader_stage_ci,
+    spirv::StatelessData* stateless_data) {
     // Using VkShaderModuleCreateInfo to inline SPIR-V with VK_KHR_maintenance5
     if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(shader_stage_ci.pNext)) {
         // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10029
@@ -90,8 +90,8 @@ uint32_t Pipeline::CountDescriptorHeapEmbeddedSamplers(const Pipeline& pipe_stat
     return count;
 }
 
-std::vector<ShaderStageState> Pipeline::GetStageStates(const DeviceState &state_data, const Pipeline &pipe_state,
-                                                       VkPipelineLayout pipeline_layout, spirv::StatelessData *stateless_data) {
+std::vector<ShaderStageState> Pipeline::GetStageStates(const DeviceState& state_data, const Pipeline& pipe_state,
+                                                       VkPipelineLayout pipeline_layout, spirv::StatelessData* stateless_data) {
     std::vector<ShaderStageState> stage_states;
 
     std::vector<VkShaderStageFlagBits> lookup_in_library_stages = {VK_SHADER_STAGE_VERTEX_BIT,
@@ -103,7 +103,7 @@ std::vector<ShaderStageState> Pipeline::GetStageStates(const DeviceState &state_
                                                                    VK_SHADER_STAGE_MESH_BIT_EXT};
 
     // Because GPL, we can't just "know our pipeline layout" here and have to do a state lookup to get it
-    const DescriptorSetLayoutList *descriptor_set_layouts = nullptr;
+    const DescriptorSetLayoutList* descriptor_set_layouts = nullptr;
     if (const auto pipeline_layout_state = state_data.Get<vvl::PipelineLayout>(pipeline_layout)) {
         descriptor_set_layouts = &pipeline_layout_state->set_layouts;
     }
@@ -114,7 +114,7 @@ std::vector<ShaderStageState> Pipeline::GetStageStates(const DeviceState &state_
             continue;  // pStages are ignored if not using one of these libraries
         }
 
-        const auto &stage_ci = pipe_state.shader_stages_ci[stage_index];
+        const auto& stage_ci = pipe_state.shader_stages_ci[stage_index];
         auto module_state = state_data.Get<vvl::ShaderModule>(stage_ci.module);
         if (!module_state && pipe_state.pipeline_cache) {
             // Attempt to look up the pipeline cache for shader module data
@@ -146,10 +146,10 @@ std::vector<ShaderStageState> Pipeline::GetStageStates(const DeviceState &state_
         }
     }
 
-    for (const auto &stage_flag : lookup_in_library_stages) {
+    for (const auto& stage_flag : lookup_in_library_stages) {
         // Check if stage has been supplied by a library
         std::shared_ptr<const vvl::ShaderModule> module_state = nullptr;
-        const vku::safe_VkPipelineShaderStageCreateInfo *stage_ci = nullptr;
+        const vku::safe_VkPipelineShaderStageCreateInfo* stage_ci = nullptr;
         switch (stage_flag) {
             case VK_SHADER_STAGE_VERTEX_BIT:
                 if (pipe_state.pre_raster_state && pipe_state.pre_raster_state->vertex_shader) {
@@ -208,36 +208,38 @@ std::vector<ShaderStageState> Pipeline::GetStageStates(const DeviceState &state_
     return stage_states;
 }
 
-std::vector<ShaderStageState> Pipeline::GetDataGraphStageStates(const DeviceState &state_data, Pipeline &pipe_state, VkPipelineLayout pipeline_layout, spirv::StatelessData *stateless_data) {
-
+std::vector<ShaderStageState> Pipeline::GetDataGraphStageStates(const DeviceState& state_data, Pipeline& pipe_state,
+                                                                VkPipelineLayout pipeline_layout,
+                                                                spirv::StatelessData* stateless_data) {
     assert(VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CREATE_INFO_ARM == pipe_state.GetCreateInfoSType());
 
     std::vector<ShaderStageState> stage_states;
 
     auto create_info = pipe_state.DataGraphCreateInfo();
 
-    const DescriptorSetLayoutList *descriptor_set_layouts = nullptr;
+    const DescriptorSetLayoutList* descriptor_set_layouts = nullptr;
     if (const auto pipeline_layout_state = state_data.Get<vvl::PipelineLayout>(pipeline_layout)) {
         descriptor_set_layouts = &pipeline_layout_state->set_layouts;
     }
 
     // The ShaderModule for a datagraph can be defined in 2 ways (but not both, see VU 9873):
     // - as the 'module' member of the VkDataGraphPipelineShaderModuleCreateInfoARM structure
-    auto *dg_shader_ci = vku::FindStructInPNextChain<VkDataGraphPipelineShaderModuleCreateInfoARM>(create_info.pNext);
+    auto* dg_shader_ci = vku::FindStructInPNextChain<VkDataGraphPipelineShaderModuleCreateInfoARM>(create_info.pNext);
     // - or with a VkShaderModuleCreateInfo
-    auto *shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(create_info.pNext);
+    auto* shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(create_info.pNext);
 
     std::shared_ptr<const vvl::ShaderModule> module_state = nullptr;
     if (dg_shader_ci && dg_shader_ci->module != VK_NULL_HANDLE) {
         module_state = state_data.Get<vvl::ShaderModule>(dg_shader_ci->module);
     } else if (shader_ci && shader_ci->pCode && shader_ci->codeSize > 0) {
-        auto spirv_module = vvl::CreateSpirvModuleState(shader_ci->codeSize, shader_ci->pCode, state_data.global_settings, stateless_data);
+        auto spirv_module =
+            vvl::CreateSpirvModuleState(shader_ci->codeSize, shader_ci->pCode, state_data.global_settings, stateless_data);
         module_state = std::make_shared<const vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module);
     }
 
     if (module_state) {
-        // The existence of dg_shader_ci is guaranteed if we have a module. Having dg_shader_ci == NULL is a very contrived situation,
-        // see test NegativeDataGraph.DataGraphWrongCreateInfoStructs
+        // The existence of dg_shader_ci is guaranteed if we have a module. Having dg_shader_ci == NULL is a very contrived
+        // situation, see test NegativeDataGraph.DataGraphWrongCreateInfoStructs
         assert(dg_shader_ci);
         pipe_state.data_graph_shader_stage_ci = vku::InitStructHelper();
         pipe_state.data_graph_shader_stage_ci.module = module_state->VkHandle();
@@ -252,18 +254,18 @@ std::vector<ShaderStageState> Pipeline::GetDataGraphStageStates(const DeviceStat
 }
 
 std::vector<ShaderStageState> Pipeline::GetRayTracingStageStates(
-    const DeviceState &state_data, const Pipeline &pipe_state, VkPipelineLayout pipeline_layout,
-    std::vector<spirv::StatelessData> *inout_per_shader_stateless_data) {
+    const DeviceState& state_data, const Pipeline& pipe_state, VkPipelineLayout pipeline_layout,
+    std::vector<spirv::StatelessData>* inout_per_shader_stateless_data) {
     std::vector<ShaderStageState> stage_states;
 
     // Duplicated code because we decided to form GetStageStates for RTX sadly
-    const DescriptorSetLayoutList *descriptor_set_layouts = nullptr;
+    const DescriptorSetLayoutList* descriptor_set_layouts = nullptr;
     if (const auto pipeline_layout_state = state_data.Get<vvl::PipelineLayout>(pipeline_layout)) {
         descriptor_set_layouts = &pipeline_layout_state->set_layouts;
     }
 
     for (size_t stage_index = 0; stage_index < pipe_state.shader_stages_ci.size(); ++stage_index) {
-        const auto &stage_ci = pipe_state.shader_stages_ci[stage_index];
+        const auto& stage_ci = pipe_state.shader_stages_ci[stage_index];
         auto module_state = state_data.Get<vvl::ShaderModule>(stage_ci.module);
         if (!module_state && pipe_state.pipeline_cache) {
             // Attempt to look up the pipeline cache for shader module data
@@ -274,7 +276,7 @@ std::vector<ShaderStageState> Pipeline::GetRayTracingStageStates(
             if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(stage_ci.pNext)) {
                 (void)shader_ci;
                 inout_per_shader_stateless_data->resize(inout_per_shader_stateless_data->size() + 1);
-                spirv::StatelessData *stateless_data =
+                spirv::StatelessData* stateless_data =
                     &inout_per_shader_stateless_data->at(inout_per_shader_stateless_data->size() - 1);
                 module_state = GetShaderModuleFromInlinedSpirv(state_data, stage_ci, stateless_data);
             }
@@ -286,7 +288,7 @@ std::vector<ShaderStageState> Pipeline::GetRayTracingStageStates(
         }
     }
 
-    const vku::safe_VkRayTracingPipelineCreateInfoCommon &rt_ci = pipe_state.RayTracingCreateInfo();
+    const vku::safe_VkRayTracingPipelineCreateInfoCommon& rt_ci = pipe_state.RayTracingCreateInfo();
     if (rt_ci.pLibraryInfo) {
         for (VkPipeline lib : vvl::make_span(rt_ci.pLibraryInfo->pLibraries, rt_ci.pLibraryInfo->libraryCount)) {
             auto lib_state = state_data.Get<vvl::Pipeline>(lib);
@@ -302,24 +304,24 @@ std::vector<ShaderStageState> Pipeline::GetRayTracingStageStates(
     return stage_states;
 }
 
-static uint32_t GetCreateInfoShaders(const Pipeline &pipe_state) {
+static uint32_t GetCreateInfoShaders(const Pipeline& pipe_state) {
     uint32_t result = 0;
     if (pipe_state.pipeline_type == VK_PIPELINE_BIND_POINT_GRAPHICS && !pipe_state.OwnsLibState(pipe_state.fragment_shader_state) &&
         !pipe_state.OwnsLibState(pipe_state.pre_raster_state)) {
         return result;  // pStages are ignored if not using one of these libraries
     }
 
-    for (const auto &stage_ci : pipe_state.shader_stages_ci) {
+    for (const auto& stage_ci : pipe_state.shader_stages_ci) {
         result |= stage_ci.stage;
     }
     return result;
 }
 
-static uint32_t GetLinkingShaders(const VkPipelineLibraryCreateInfoKHR *link_info, const DeviceState &state_data) {
+static uint32_t GetLinkingShaders(const VkPipelineLibraryCreateInfoKHR* link_info, const DeviceState& state_data) {
     uint32_t result = 0;
     if (link_info) {
         for (uint32_t i = 0; i < link_info->libraryCount; ++i) {
-            const auto &state = state_data.Get<vvl::Pipeline>(link_info->pLibraries[i]);
+            const auto& state = state_data.Get<vvl::Pipeline>(link_info->pLibraries[i]);
             if (state) {
                 result |= state->active_shaders;
             }
@@ -328,7 +330,7 @@ static uint32_t GetLinkingShaders(const VkPipelineLibraryCreateInfoKHR *link_inf
     return result;
 }
 
-static CBDynamicFlags GetGraphicsDynamicState(Pipeline &pipe_state) {
+static CBDynamicFlags GetGraphicsDynamicState(Pipeline& pipe_state) {
     CBDynamicFlags flags = 0;
 
     // "Dynamic state values set via pDynamicState must be ignored if the state they correspond to is not otherwise statically set
@@ -340,7 +342,7 @@ static CBDynamicFlags GetGraphicsDynamicState(Pipeline &pipe_state) {
     const bool has_fragment_shader_state = pipe_state.OwnsLibState(pipe_state.fragment_shader_state);
     const bool has_fragment_output_state = pipe_state.OwnsLibState(pipe_state.fragment_output_state);
 
-    const auto *dynamic_state_ci = pipe_state.GraphicsCreateInfo().pDynamicState;
+    const auto* dynamic_state_ci = pipe_state.GraphicsCreateInfo().pDynamicState;
     if (dynamic_state_ci) {
         for (const VkDynamicState vk_dynamic_state :
              vvl::make_span(dynamic_state_ci->pDynamicStates, dynamic_state_ci->dynamicStateCount)) {
@@ -500,7 +502,7 @@ static CBDynamicFlags GetGraphicsDynamicState(Pipeline &pipe_state) {
 // We "view" things as being dynamic if the pipeline does not have those shader stages, the spec says:
 // "If the state is not included ... in the new pipeline object, then that command buffer state is not disturbed. For example, mesh
 // shading pipelines do not include vertex input state and therefore do not disturb any such command buffer state."
-static CBDynamicFlags GetIgnoredDynamicState(Pipeline &pipe_state) {
+static CBDynamicFlags GetIgnoredDynamicState(Pipeline& pipe_state) {
     CBDynamicFlags flags = 0;
     if ((pipe_state.active_shaders & VK_SHADER_STAGE_VERTEX_BIT) == 0) {
         flags |= kVertexDynamicState;
@@ -521,7 +523,7 @@ static CBDynamicFlags GetIgnoredDynamicState(Pipeline &pipe_state) {
 }
 
 // This will only get the topology if possible
-static VkPrimitiveTopology GetRasterizationInputTopology(const Pipeline &pipe_state, const DeviceState &state) {
+static VkPrimitiveTopology GetRasterizationInputTopology(const Pipeline& pipe_state, const DeviceState& state) {
     VkPrimitiveTopology topology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
     if (!pipe_state.RasterizationState()) {
         return topology;
@@ -529,7 +531,7 @@ static VkPrimitiveTopology GetRasterizationInputTopology(const Pipeline &pipe_st
 
     // Get Clip Space Topology first
     if (pipe_state.active_shaders & (VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_MESH_BIT_EXT)) {
-        for (const ShaderStageState &shader_stage_state : pipe_state.stage_states) {
+        for (const ShaderStageState& shader_stage_state : pipe_state.stage_states) {
             const VkShaderStageFlagBits stage = shader_stage_state.GetStage();
             if (stage == VK_SHADER_STAGE_MESH_BIT_EXT || stage == VK_SHADER_STAGE_GEOMETRY_BIT) {
                 if (shader_stage_state.HasSpirv()) {
@@ -539,7 +541,7 @@ static VkPrimitiveTopology GetRasterizationInputTopology(const Pipeline &pipe_st
             }
         }
     } else if (pipe_state.active_shaders & VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
-        for (const ShaderStageState &shader_stage_state : pipe_state.stage_states) {
+        for (const ShaderStageState& shader_stage_state : pipe_state.stage_states) {
             const VkShaderStageFlagBits stage = shader_stage_state.GetStage();
             if (stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT || stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT) {
                 if (shader_stage_state.HasSpirv()) {
@@ -582,10 +584,10 @@ static VkPrimitiveTopology GetRasterizationInputTopology(const Pipeline &pipe_st
     return topology;
 }
 
-static CBDynamicFlags GetRayTracingDynamicState(Pipeline &pipe_state) {
+static CBDynamicFlags GetRayTracingDynamicState(Pipeline& pipe_state) {
     CBDynamicFlags flags = 0;
 
-    const auto *dynamic_state_ci = pipe_state.RayTracingCreateInfo().pDynamicState;
+    const auto* dynamic_state_ci = pipe_state.RayTracingCreateInfo().pDynamicState;
     if (dynamic_state_ci) {
         for (const VkDynamicState vk_dynamic_state :
              vvl::make_span(dynamic_state_ci->pDynamicStates, dynamic_state_ci->dynamicStateCount)) {
@@ -602,7 +604,7 @@ static CBDynamicFlags GetRayTracingDynamicState(Pipeline &pipe_state) {
     return flags;
 }
 
-static bool UsesPipelineRobustness(const void *pNext, const Pipeline &pipe_state) {
+static bool UsesPipelineRobustness(const void* pNext, const Pipeline& pipe_state) {
     bool result = false;
     const auto robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pNext);
     if (!robustness_info) {
@@ -613,7 +615,7 @@ static bool UsesPipelineRobustness(const void *pNext, const Pipeline &pipe_state
     result |= (robustness_info->uniformBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) ||
               (robustness_info->uniformBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS);
     if (!result) {
-        for (const auto &stage_ci : pipe_state.shader_stages_ci) {
+        for (const auto& stage_ci : pipe_state.shader_stages_ci) {
             const auto stage_robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(stage_ci.pNext);
             if (stage_robustness_info) {
                 result |=
@@ -628,7 +630,7 @@ static bool UsesPipelineRobustness(const void *pNext, const Pipeline &pipe_state
     return result;
 }
 
-static bool UsesPipelineVertexRobustness(const void *pNext, const Pipeline &pipe_state) {
+static bool UsesPipelineVertexRobustness(const void* pNext, const Pipeline& pipe_state) {
     bool result = false;
     const auto robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pNext);
     if (!robustness_info) {
@@ -637,7 +639,7 @@ static bool UsesPipelineVertexRobustness(const void *pNext, const Pipeline &pipe
     result |= (robustness_info->vertexInputs == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) ||
               (robustness_info->vertexInputs == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS);
     if (!result) {
-        for (const auto &stage_ci : pipe_state.shader_stages_ci) {
+        for (const auto& stage_ci : pipe_state.shader_stages_ci) {
             const auto stage_robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(stage_ci.pNext);
             if (stage_robustness_info) {
                 result |= (stage_robustness_info->vertexInputs == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) ||
@@ -648,7 +650,7 @@ static bool UsesPipelineVertexRobustness(const void *pNext, const Pipeline &pipe
     return result;
 }
 
-static bool IgnoreColorAttachments(const DeviceState &state_data, Pipeline &pipe_state) {
+static bool IgnoreColorAttachments(const DeviceState& state_data, Pipeline& pipe_state) {
     // If the libraries used to create this pipeline are ignoring color attachments, this pipeline should as well
     if (pipe_state.library_create_info) {
         for (uint32_t i = 0; i < pipe_state.library_create_info->libraryCount; i++) {
@@ -665,12 +667,12 @@ static bool IgnoreColorAttachments(const DeviceState &state_data, Pipeline &pipe
                                             pipe_state.IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT));
 }
 
-static bool UsesShaderModuleId(const Pipeline &pipe_state) {
+static bool UsesShaderModuleId(const Pipeline& pipe_state) {
     if (pipe_state.shader_stages_ci.data() == nullptr) {
         return false;
     }
 
-    for (const auto &stage_ci : pipe_state.shader_stages_ci) {
+    for (const auto& stage_ci : pipe_state.shader_stages_ci) {
         // if using GPL, can have null pStages
         if (stage_ci.ptr()) {
             const auto module_id_info =
@@ -683,14 +685,14 @@ static bool UsesShaderModuleId(const Pipeline &pipe_state) {
     return false;
 }
 
-static vvl::unordered_set<uint32_t> GetFSOutputLocations(const std::vector<ShaderStageState> &stage_states) {
+static vvl::unordered_set<uint32_t> GetFSOutputLocations(const std::vector<ShaderStageState>& stage_states) {
     vvl::unordered_set<uint32_t> result;
     for (const ShaderStageState& stage_state : stage_states) {
         if (!stage_state.HasSpirv()) {
             continue;
         }
         if (stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT) {
-            for (const auto *variable : stage_state.entrypoint->user_defined_interface_variables) {
+            for (const auto* variable : stage_state.entrypoint->user_defined_interface_variables) {
                 if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
                     continue;  // not an output interface
                 }
@@ -704,7 +706,7 @@ static vvl::unordered_set<uint32_t> GetFSOutputLocations(const std::vector<Shade
     return result;
 }
 
-static VkPipelineCreateFlags2 GetPipelineCreateFlags(const void *pNext, VkPipelineCreateFlags2 flags) {
+static VkPipelineCreateFlags2 GetPipelineCreateFlags(const void* pNext, VkPipelineCreateFlags2 flags) {
     const auto flags2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(pNext);
     if (flags2) {
         return flags2->flags;
@@ -712,7 +714,7 @@ static VkPipelineCreateFlags2 GetPipelineCreateFlags(const void *pNext, VkPipeli
     return flags;
 }
 
-const Location Pipeline::GetCreateFlagsLoc(const Location &create_info_loc) const {
+const Location Pipeline::GetCreateFlagsLoc(const Location& create_info_loc) const {
     if (vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(GetCreateInfoPNext())) {
         return create_info_loc.pNext(Struct::VkPipelineCreateFlags2CreateInfo, Field::flags);
     } else {
@@ -720,8 +722,8 @@ const Location Pipeline::GetCreateFlagsLoc(const Location &create_info_loc) cons
     }
 }
 
-std::shared_ptr<VertexInputState> Pipeline::CreateVertexInputState(const Pipeline &p, const DeviceState &state,
-                                                                   const vku::safe_VkGraphicsPipelineCreateInfo &create_info) {
+std::shared_ptr<VertexInputState> Pipeline::CreateVertexInputState(const Pipeline& p, const DeviceState& state,
+                                                                   const vku::safe_VkGraphicsPipelineCreateInfo& create_info) {
     const auto lib_type = GetGraphicsLibType(create_info);
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT) {
         // Creating a vertex input graphics library
@@ -743,8 +745,8 @@ std::shared_ptr<VertexInputState> Pipeline::CreateVertexInputState(const Pipelin
 }
 
 std::shared_ptr<PreRasterState> Pipeline::CreatePreRasterState(
-    const Pipeline &p, const DeviceState &state, const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
-    const std::shared_ptr<const vvl::RenderPass> &rp, spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
+    const Pipeline& p, const DeviceState& state, const vku::safe_VkGraphicsPipelineCreateInfo& create_info,
+    const std::shared_ptr<const vvl::RenderPass>& rp, spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     const auto lib_type = GetGraphicsLibType(create_info);
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT) {
         // Creating a pre-raster graphics library
@@ -766,8 +768,8 @@ std::shared_ptr<PreRasterState> Pipeline::CreatePreRasterState(
 }
 
 std::shared_ptr<FragmentShaderState> Pipeline::CreateFragmentShaderState(
-    const Pipeline &p, const DeviceState &state, const VkGraphicsPipelineCreateInfo &create_info,
-    const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp,
+    const Pipeline& p, const DeviceState& state, const VkGraphicsPipelineCreateInfo& create_info,
+    const vku::safe_VkGraphicsPipelineCreateInfo& safe_create_info, const std::shared_ptr<const vvl::RenderPass>& rp,
     spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     const auto lib_type = GetGraphicsLibType(create_info);
 
@@ -797,8 +799,8 @@ std::shared_ptr<FragmentShaderState> Pipeline::CreateFragmentShaderState(
 // Pointers that should be ignored have been set to null in safe_create_info, but if this is a graphics library we need the "raw"
 // create_info.
 std::shared_ptr<FragmentOutputState> Pipeline::CreateFragmentOutputState(
-    const Pipeline &p, const DeviceState &state, const VkGraphicsPipelineCreateInfo &create_info,
-    const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp) {
+    const Pipeline& p, const DeviceState& state, const VkGraphicsPipelineCreateInfo& create_info,
+    const vku::safe_VkGraphicsPipelineCreateInfo& safe_create_info, const std::shared_ptr<const vvl::RenderPass>& rp) {
     // If this pipeline is being created a non-executable (i.e., does not contain complete state) pipeline with FO state, then
     // unconditionally set this pipeline's FO state.
     const auto lib_type = GetGraphicsLibType(create_info);
@@ -924,11 +926,11 @@ Pipeline::Pipeline(const DeviceState& state_data, const VkGraphicsPipelineCreate
       ignore_color_attachments(IgnoreColorAttachments(state_data, *this)),
       descriptor_heap_embedded_samplers_count(CountDescriptorHeapEmbeddedSamplers(*this)) {
     if (library_create_info) {
-        const auto &exe_layout_state = state_data.Get<vvl::PipelineLayout>(GraphicsCreateInfo().layout);
-        const auto *exe_layout = exe_layout_state.get();
-        const auto *pre_raster_layout =
+        const auto& exe_layout_state = state_data.Get<vvl::PipelineLayout>(GraphicsCreateInfo().layout);
+        const auto* exe_layout = exe_layout_state.get();
+        const auto* pre_raster_layout =
             (pre_raster_state && pre_raster_state->pipeline_layout) ? pre_raster_state->pipeline_layout.get() : nullptr;
-        const auto *fragment_shader_layout = (fragment_shader_state && fragment_shader_state->pipeline_layout)
+        const auto* fragment_shader_layout = (fragment_shader_state && fragment_shader_state->pipeline_layout)
                                                  ? fragment_shader_state->pipeline_layout.get()
                                                  : nullptr;
         std::array<decltype(exe_layout), 3> layouts;
@@ -941,7 +943,7 @@ Pipeline::Pipeline(const DeviceState& state_data, const VkGraphicsPipelineCreate
         // TODO Could store the graphics_lib_type in the library state rather than searching for it again here.
         //      Or, could store a pointer back to the owning Pipeline.
         for (uint32_t i = 0; i < library_create_info->libraryCount; ++i) {
-            const auto &state = state_data.Get<vvl::Pipeline>(library_create_info->pLibraries[i]);
+            const auto& state = state_data.Get<vvl::Pipeline>(library_create_info->pLibraries[i]);
             if (state) {
                 graphics_lib_type |= state->graphics_lib_type;
             }
@@ -1058,7 +1060,7 @@ Pipeline::Pipeline(const DeviceState& state_data, const VkDataGraphPipelineCreat
 }
 
 void Pipeline::Destroy() {
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Destroy();
     }
     sub_states_.clear();
@@ -1067,7 +1069,7 @@ void Pipeline::Destroy() {
 
 }  // namespace vvl
 
-bool IsPipelineLayoutSetCompatible(uint32_t set, const vvl::PipelineLayout *a, const vvl::PipelineLayout *b) {
+bool IsPipelineLayoutSetCompatible(uint32_t set, const vvl::PipelineLayout* a, const vvl::PipelineLayout* b) {
     if (!a || !b) {
         return false;
     }
@@ -1077,7 +1079,7 @@ bool IsPipelineLayoutSetCompatible(uint32_t set, const vvl::PipelineLayout *a, c
     return *(a->set_compat_ids[set]) == *(b->set_compat_ids[set]);
 }
 
-std::string DescribePipelineLayoutSetNonCompatible(uint32_t set, const vvl::PipelineLayout *a, const vvl::PipelineLayout *b) {
+std::string DescribePipelineLayoutSetNonCompatible(uint32_t set, const vvl::PipelineLayout* a, const vvl::PipelineLayout* b) {
     std::ostringstream ss;
     if (!a || !b) {
         ss << "The set (" << set << ") has a null VkPipelineLayout object\n";

--- a/layers/state_tracker/query_state.cpp
+++ b/layers/state_tracker/query_state.cpp
@@ -25,9 +25,9 @@
 
 namespace vvl {
 
-QueryPool::QueryPool(VkQueryPool handle, const VkQueryPoolCreateInfo *pCreateInfo, uint32_t index_count,
+QueryPool::QueryPool(VkQueryPool handle, const VkQueryPoolCreateInfo* pCreateInfo, uint32_t index_count,
                      uint32_t perf_queue_family_index, uint32_t n_perf_pass, bool has_cb, bool has_rb,
-                     std::shared_ptr<const vvl::VideoProfileDesc> &&supp_video_profile,
+                     std::shared_ptr<const vvl::VideoProfileDesc>&& supp_video_profile,
                      VkVideoEncodeFeedbackFlagsKHR enabled_video_encode_feedback_flags)
     : StateObject(handle, kVulkanObjectTypeQueryPool),
       safe_create_info(pCreateInfo),
@@ -56,7 +56,7 @@ void QueryPool::SetQueryState(uint32_t query, uint32_t perf_pass, QueryState sta
     assert(query < query_states_.size());
     assert((n_performance_passes == 0 && perf_pass == 0) || (perf_pass < n_performance_passes));
     if (state == QUERYSTATE_RESET) {
-        for (auto &state : query_states_[query]) {
+        for (auto& state : query_states_[query]) {
             state = QUERYSTATE_RESET;
         }
     } else {
@@ -166,7 +166,7 @@ uint32_t QueryPool::GetQuerySize(VkQueryResultFlags flags) const {
 
 }  // namespace vvl
 
-QueryCount::QueryCount(vvl::CommandBuffer &cb_state) {
+QueryCount::QueryCount(vvl::CommandBuffer& cb_state) {
     count = 1;
     subpass = cb_state.GetActiveSubpass();
     inside_render_pass = cb_state.active_render_pass != nullptr;

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -27,13 +27,13 @@
 #include "profiling/profiling.h"
 
 void vvl::QueueSubmission::BeginUse() {
-    for (SemaphoreInfo &wait : wait_semaphores) {
+    for (SemaphoreInfo& wait : wait_semaphores) {
         wait.semaphore->BeginUse();
     }
-    for (CommandBufferSubmission &cb_submission : cb_submissions) {
+    for (CommandBufferSubmission& cb_submission : cb_submissions) {
         cb_submission.cb->BeginUse();
     }
-    for (SemaphoreInfo &signal : signal_semaphores) {
+    for (SemaphoreInfo& signal : signal_semaphores) {
         signal.semaphore->BeginUse();
     }
     if (fence) {
@@ -42,13 +42,13 @@ void vvl::QueueSubmission::BeginUse() {
 }
 
 void vvl::QueueSubmission::EndUse() {
-    for (SemaphoreInfo &wait : wait_semaphores) {
+    for (SemaphoreInfo& wait : wait_semaphores) {
         wait.semaphore->EndUse();
     }
-    for (CommandBufferSubmission &cb_submission : cb_submissions) {
+    for (CommandBufferSubmission& cb_submission : cb_submissions) {
         cb_submission.cb->EndUse();
     }
-    for (SemaphoreInfo &signal : signal_semaphores) {
+    for (SemaphoreInfo& signal : signal_semaphores) {
         signal.semaphore->EndUse();
     }
     if (fence) {
@@ -56,18 +56,18 @@ void vvl::QueueSubmission::EndUse() {
     }
 }
 
-vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
+vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) {
     if (!submissions.empty()) {
         submissions.back().is_last_submission = true;
     }
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->PreSubmit(submissions);
     }
     PreSubmitResult result;
-    for (QueueSubmission &submission : submissions) {
-        for (CommandBufferSubmission &cb_submission : submission.cb_submissions) {
+    for (QueueSubmission& submission : submissions) {
+        for (CommandBufferSubmission& cb_submission : submission.cb_submissions) {
             auto cb_guard = cb_submission.cb->WriteLock();
-            for (CommandBuffer *secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
+            for (CommandBuffer* secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
                 auto secondary_guard = secondary_cmd_buffer->WriteLock();
                 secondary_cmd_buffer->submit_count++;
             }
@@ -80,12 +80,12 @@ vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&s
         submission.seq = ++seq_;
         result.submission_seq = submission.seq;
         submission.BeginUse();
-        for (SemaphoreInfo &wait : submission.wait_semaphores) {
+        for (SemaphoreInfo& wait : submission.wait_semaphores) {
             wait.semaphore->EnqueueWait(SubmissionReference(this, submission.seq), wait.payload);
             timeline_wait_count_ += (wait.semaphore->type == VK_SEMAPHORE_TYPE_TIMELINE) ? 1 : 0;
         }
 
-        for (SemaphoreInfo &signal : submission.signal_semaphores) {
+        for (SemaphoreInfo& signal : submission.signal_semaphores) {
             signal.semaphore->EnqueueSignal(SubmissionReference(this, submission.seq), signal.payload);
         }
 
@@ -116,7 +116,7 @@ void vvl::Queue::Notify(uint64_t until_seq) {
     cond_.notify_one();
 }
 
-void vvl::Queue::Wait(const Location &loc, uint64_t until_seq) {
+void vvl::Queue::Wait(const Location& loc, uint64_t until_seq) {
     std::shared_future<void> waiter;
     {
         auto guard = Lock();
@@ -139,7 +139,7 @@ void vvl::Queue::Wait(const Location &loc, uint64_t until_seq) {
     }
 }
 
-void vvl::Queue::NotifyAndWait(const Location &loc, uint64_t until_seq) {
+void vvl::Queue::NotifyAndWait(const Location& loc, uint64_t until_seq) {
     Notify(until_seq);
     Wait(loc, until_seq);
 }
@@ -167,9 +167,9 @@ std::optional<vvl::SemaphoreInfo> vvl::Queue::FindTimelineWaitWithoutResolvingSi
     {
         auto guard = Lock();
         for (auto it = submissions_.rbegin(); it != submissions_.rend() && processed_waits < timeline_wait_count_; ++it) {
-            const vvl::QueueSubmission &submission = *it;
+            const vvl::QueueSubmission& submission = *it;
             if (submission.seq <= until_seq) {
-                for (const auto &wait_info : submission.wait_semaphores) {
+                for (const auto& wait_info : submission.wait_semaphores) {
                     if (wait_info.semaphore->type == VK_SEMAPHORE_TYPE_TIMELINE) {
                         timeline_waits.emplace_back(wait_info);
                         processed_waits++;
@@ -179,7 +179,7 @@ std::optional<vvl::SemaphoreInfo> vvl::Queue::FindTimelineWaitWithoutResolvingSi
         }
     }
     // Step 2. Query each timeline wait (read-locks Semaphore)
-    for (const SemaphoreInfo &wait_info : timeline_waits) {
+    for (const SemaphoreInfo& wait_info : timeline_waits) {
         if (wait_info.semaphore->Scope() != vvl::Semaphore::kInternal) {
             // For external semaphore we can't track the signal. The conservative assumption
             // for false positive free validation is that the signal is available, so skip
@@ -204,19 +204,19 @@ std::optional<vvl::SemaphoreInfo> vvl::Queue::FindTimelineWaitWithoutResolvingSi
 // This implementation assumes that if error-free program has more active present requests than
 // swapchain images, then at least the oldest present request was completed and corresponding
 // image was re-acquired (and it got pushed to the present queue again).
-void vvl::Queue::UpdatePresentOnlyQueueProgress(const DeviceState &device_state) {
+void vvl::Queue::UpdatePresentOnlyQueueProgress(const DeviceState& device_state) {
     uint64_t seq_to_advance_to = 0;
     {
         auto guard = Lock();
         assert(is_used_for_presentation && !is_used_for_regular_submits);
         small_unordered_map<VkSwapchainKHR, uint32_t, 4> active_presentations;
-        for (const QueueSubmission &submission : submissions_) {
+        for (const QueueSubmission& submission : submissions_) {
             assert(submission.swapchain != VK_NULL_HANDLE);
             active_presentations[submission.swapchain]++;
         }
         // Search for the swapchain with too many enqueued presentation requests
         VkSwapchainKHR swapchain = VK_NULL_HANDLE;
-        for (const auto &[handle, count] : active_presentations) {
+        for (const auto& [handle, count] : active_presentations) {
             if (auto swapchain_state = device_state.Get<Swapchain>(handle)) {
                 if (count > swapchain_state->images.size()) {
                     swapchain = handle;
@@ -226,7 +226,7 @@ void vvl::Queue::UpdatePresentOnlyQueueProgress(const DeviceState &device_state)
         }
         // Get seq to retire the oldest presentation submissions.
         if (swapchain != VK_NULL_HANDLE) {
-            for (const QueueSubmission &submission : submissions_) {
+            for (const QueueSubmission& submission : submissions_) {
                 if (submission.swapchain == swapchain) {
                     seq_to_advance_to = submission.seq;
                     break;
@@ -251,7 +251,7 @@ void vvl::Queue::Destroy() {
         dead_thread->join();
         dead_thread.reset();
     }
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Destroy();
     }
     StateObject::Destroy();
@@ -264,8 +264,8 @@ void vvl::Queue::PostSubmit() {
     }
 }
 
-void vvl::Queue::PostSubmit(QueueSubmission &submission) {
-    for (auto &item : sub_states_) {
+void vvl::Queue::PostSubmit(QueueSubmission& submission) {
+    for (auto& item : sub_states_) {
         item.second->PostSubmit(submissions_);
     }
 
@@ -277,8 +277,8 @@ void vvl::Queue::PostSubmit(QueueSubmission &submission) {
     }
 }
 
-vvl::QueueSubmission *vvl::Queue::NextSubmission() {
-    QueueSubmission *result = nullptr;
+vvl::QueueSubmission* vvl::Queue::NextSubmission() {
+    QueueSubmission* result = nullptr;
     // Find if the next submission is ready so that the thread function doesn't need to worry
     // about locking.
     auto guard = Lock();
@@ -294,9 +294,9 @@ vvl::QueueSubmission *vvl::Queue::NextSubmission() {
     return result;
 }
 
-void vvl::Queue::Retire(QueueSubmission &submission) {
+void vvl::Queue::Retire(QueueSubmission& submission) {
     submission.EndUse();
-    for (auto &wait : submission.wait_semaphores) {
+    for (auto& wait : submission.wait_semaphores) {
         wait.semaphore->RetireWait(this, wait.payload, submission.loc.Get(), true);
         timeline_wait_count_ -= (wait.semaphore->type == VK_SEMAPHORE_TYPE_TIMELINE) ? 1 : 0;
     }
@@ -305,12 +305,12 @@ void vvl::Queue::Retire(QueueSubmission &submission) {
     // NOTE: we still need to run semaphore/fence retire routines which do not work with Vulkan
     // handles but ensure correct invariants (for example, Fence::Retire sets its std::promise)
     if (!dev_data_.is_device_lost) {
-        for (auto &item : sub_states_) {
+        for (auto& item : sub_states_) {
             item.second->Retire(submission);
         }
     }
 
-    for (auto &signal : submission.signal_semaphores) {
+    for (auto& signal : submission.signal_semaphores) {
         signal.semaphore->RetireSignal(signal.payload);
     }
     if (submission.fence) {
@@ -321,7 +321,7 @@ void vvl::Queue::Retire(QueueSubmission &submission) {
 void vvl::Queue::ThreadFunc() {
     VVL_TracySetThreadName(__FUNCTION__);
 
-    QueueSubmission *submission = nullptr;
+    QueueSubmission* submission = nullptr;
 
     // Roll this queue forward, one submission at a time.
     while (true) {

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -51,10 +51,10 @@ static VkSubpassDependency2 ImplicitDependencyToExternal(uint32_t subpass) {
 
 // NOTE: The functions below are only called from the vvl::RenderPass constructor, and use const_cast<> to set up
 // members that never change after construction is finished.
-static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl::RenderPass &render_pass) {
-    auto &self_dependencies = const_cast<std::vector<std::vector<uint32_t>> &>(render_pass.self_dependencies);
+static void RecordRenderPassDAG(const VkRenderPassCreateInfo2* pCreateInfo, vvl::RenderPass& render_pass) {
+    auto& self_dependencies = const_cast<std::vector<std::vector<uint32_t>>&>(render_pass.self_dependencies);
     self_dependencies.resize(pCreateInfo->subpassCount);
-    auto &subpass_dependency_infos = const_cast<std::vector<SubpassDependencyInfo> &>(render_pass.subpass_dependency_infos);
+    auto& subpass_dependency_infos = const_cast<std::vector<SubpassDependencyInfo>&>(render_pass.subpass_dependency_infos);
     subpass_dependency_infos.resize(pCreateInfo->subpassCount);
 
     for (uint32_t i = 0; i < pCreateInfo->subpassCount; ++i) {
@@ -62,7 +62,7 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
         subpass_dependency_infos[i].subpass = i;
     }
     for (uint32_t i = 0; i < pCreateInfo->dependencyCount; ++i) {
-        const VkSubpassDependency2 &dependency = pCreateInfo->pDependencies[i];
+        const VkSubpassDependency2& dependency = pCreateInfo->pDependencies[i];
         const uint32_t src_subpass = dependency.srcSubpass;
         const uint32_t dst_subpass = dependency.dstSubpass;
 
@@ -88,7 +88,7 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
     // If no barriers to external are provided for a given subpass, add them.
     // This is used for initialLayout/finalLayout transitions when corresponding
     // subpass is the first/last subpass that uses the attachment.
-    for (SubpassDependencyInfo &info : subpass_dependency_infos) {
+    for (SubpassDependencyInfo& info : subpass_dependency_infos) {
         if (info.barrier_from_external.empty()) {
             info.implicit_barrier_from_external = ImplicitDependencyFromExternal(info.subpass);
             info.barrier_from_external.emplace_back(&info.implicit_barrier_from_external);
@@ -106,11 +106,11 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
     // small and the K for |= from the prev is must less than for set, we'll accept the brute force.
     std::vector<std::vector<bool>> pass_depends(pCreateInfo->subpassCount);
     for (uint32_t i = 1; i < pCreateInfo->subpassCount; ++i) {
-        auto &depends = pass_depends[i];
+        auto& depends = pass_depends[i];
         depends.resize(i);
-        SubpassDependencyInfo &info = subpass_dependency_infos[i];
-        for (const auto &[src_subpass, _] : info.dependencies) {
-            const auto &src_depends = pass_depends[src_subpass];
+        SubpassDependencyInfo& info = subpass_dependency_infos[i];
+        for (const auto& [src_subpass, _] : info.dependencies) {
+            const auto& src_depends = pass_depends[src_subpass];
             for (uint32_t j = 0; j < src_subpass; j++) {
                 depends[j] = depends[j] || src_depends[j];
             }
@@ -125,28 +125,28 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
 }
 
 struct AttachmentTracker {  // This is really only of local interest, but a bit big for a lambda
-    vvl::RenderPass &rp;
-    std::vector<vvl::RenderPass::SubpassPerView> &first;
-    std::vector<vvl::RenderPass::SubpassPerView> &last;
-    std::vector<std::vector<vvl::RenderPass::AttachmentTransition>> &subpass_transitions;
+    vvl::RenderPass& rp;
+    std::vector<vvl::RenderPass::SubpassPerView>& first;
+    std::vector<vvl::RenderPass::SubpassPerView>& last;
+    std::vector<std::vector<vvl::RenderPass::AttachmentTransition>>& subpass_transitions;
     std::vector<VkImageLayout> attachment_layout;
     std::vector<std::vector<VkImageLayout>> subpass_attachment_layout;
 
-    explicit AttachmentTracker(vvl::RenderPass &render_pass, int32_t max_view_index)
+    explicit AttachmentTracker(vvl::RenderPass& render_pass, int32_t max_view_index)
         : rp(render_pass),
-          first(const_cast<std::vector<vvl::RenderPass::SubpassPerView> &>(rp.attachment_first_subpass)),
-          last(const_cast<std::vector<vvl::RenderPass::SubpassPerView> &>(rp.attachment_last_subpass)),
+          first(const_cast<std::vector<vvl::RenderPass::SubpassPerView>&>(rp.attachment_first_subpass)),
+          last(const_cast<std::vector<vvl::RenderPass::SubpassPerView>&>(rp.attachment_last_subpass)),
           subpass_transitions(
-              const_cast<std::vector<std::vector<vvl::RenderPass::AttachmentTransition>> &>(rp.subpass_transitions)) {
+              const_cast<std::vector<std::vector<vvl::RenderPass::AttachmentTransition>>&>(rp.subpass_transitions)) {
         const uint32_t attachment_count = rp.create_info.attachmentCount;
 
         first.resize(attachment_count);
-        for (auto &subpass_per_view : first) {
+        for (auto& subpass_per_view : first) {
             subpass_per_view.resize(max_view_index + 1, VK_SUBPASS_EXTERNAL);
         }
 
         last.resize(attachment_count);
-        for (auto &subpass_per_view : last) {
+        for (auto& subpass_per_view : last) {
             subpass_per_view.resize(max_view_index + 1, VK_SUBPASS_EXTERNAL);
         }
 
@@ -154,7 +154,7 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
         subpass_transitions.resize(rp.create_info.subpassCount + 1);
 
         subpass_attachment_layout.resize(rp.create_info.subpassCount);
-        for (auto &subpass_layouts : subpass_attachment_layout) {
+        for (auto& subpass_layouts : subpass_attachment_layout) {
             subpass_layouts.resize(attachment_count, kInvalidLayout);
         }
 
@@ -164,13 +164,13 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
         }
     }
 
-    void Update(uint32_t subpass, const uint32_t *preserved, uint32_t count) {
+    void Update(uint32_t subpass, const uint32_t* preserved, uint32_t count) {
         // for preserved attachment, preserve the layout from the most recent (max subpass) dependency
         // or initial, if none
 
         // max_prev is invariant across attachments
         uint32_t max_prev = VK_SUBPASS_EXTERNAL;
-        for (const auto &[src_subpass, _] : rp.subpass_dependency_infos[subpass].dependencies) {
+        for (const auto& [src_subpass, _] : rp.subpass_dependency_infos[subpass].dependencies) {
             max_prev = (max_prev == VK_SUBPASS_EXTERNAL) ? src_subpass : std::max(src_subpass, max_prev);
         }
 
@@ -183,7 +183,7 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
         }
     }
 
-    void Update(uint32_t subpass, uint32_t view_mask, const VkAttachmentReference2 *attach_ref, uint32_t count) {
+    void Update(uint32_t subpass, uint32_t view_mask, const VkAttachmentReference2* attach_ref, uint32_t count) {
         if (!attach_ref) {
             return;
         }
@@ -217,7 +217,7 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
                     no_external_transition = false;
                 }
                 // Transition between subpasses
-                for (const auto &[src_subpass, _] : rp.subpass_dependency_infos[subpass].dependencies) {
+                for (const auto& [src_subpass, _] : rp.subpass_dependency_infos[subpass].dependencies) {
                     const auto prev_layout = subpass_attachment_layout[src_subpass][attachment];
                     if ((prev_layout != kInvalidLayout) && (prev_layout != layout)) {
                         subpass_transitions[subpass].emplace_back(
@@ -253,7 +253,7 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
     void FinalTransitions() {
         // The last subpass that used the attachment is the maximum SubpassPerView value
         // that is not VK_SUBPASS_EXTERNAL.
-        auto get_last_subpass = [](const vvl::RenderPass::SubpassPerView &subpass_per_view) {
+        auto get_last_subpass = [](const vvl::RenderPass::SubpassPerView& subpass_per_view) {
             uint32_t max_subpass = VK_SUBPASS_EXTERNAL;
             for (uint32_t subpass : subpass_per_view) {
                 if (max_subpass == VK_SUBPASS_EXTERNAL) {
@@ -271,7 +271,7 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
             const auto final_layout = rp.create_info.pAttachments[attachment].finalLayout;
             const uint32_t last_transition_subpass = get_last_subpass(last[attachment]);
             if (last_transition_subpass != VK_SUBPASS_EXTERNAL && final_layout != attachment_layout[attachment]) {
-                auto &final_transitions = subpass_transitions[rp.create_info.subpassCount];
+                auto& final_transitions = subpass_transitions[rp.create_info.subpassCount];
                 final_transitions.emplace_back(vvl::RenderPass::AttachmentTransition{last_transition_subpass, attachment,
                                                                                      attachment_layout[attachment], final_layout});
             }
@@ -279,25 +279,25 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
     }
 };
 
-static bool IsRenderPassMultiViewEnabled(const VkRenderPassCreateInfo2 &renderpass_ci) {
+static bool IsRenderPassMultiViewEnabled(const VkRenderPassCreateInfo2& renderpass_ci) {
     // From the spec:
     // If the VkSubpassDescription2::viewMask member of any element of pSubpasses is not zero,
     // multiview functionality is considered to be enabled for this render pass.
     bool is_multiview_enabled = false;
     for (uint32_t subpass_index = 0; subpass_index < renderpass_ci.subpassCount; subpass_index++) {
-        const VkSubpassDescription2 &subpass = renderpass_ci.pSubpasses[subpass_index];
+        const VkSubpassDescription2& subpass = renderpass_ci.pSubpasses[subpass_index];
         is_multiview_enabled |= (subpass.viewMask != 0);
     }
     return is_multiview_enabled;
 }
 
-static void InitRenderPassState(vvl::RenderPass &render_pass) {
+static void InitRenderPassState(vvl::RenderPass& render_pass) {
     auto create_info = render_pass.create_info.ptr();
 
     RecordRenderPassDAG(create_info, render_pass);
 
     uint32_t all_view_mask = 0;
-    for (const auto &subpass : vvl::make_span(create_info->pSubpasses, create_info->subpassCount)) {
+    for (const auto& subpass : vvl::make_span(create_info->pSubpasses, create_info->subpassCount)) {
         all_view_mask |= subpass.viewMask;
     }
     const uint32_t max_view_index = all_view_mask ? MostSignificantBit(all_view_mask) : 0;
@@ -305,7 +305,7 @@ static void InitRenderPassState(vvl::RenderPass &render_pass) {
     AttachmentTracker attachment_tracker(render_pass, max_view_index);
 
     for (uint32_t subpass_index = 0; subpass_index < create_info->subpassCount; ++subpass_index) {
-        const VkSubpassDescription2 &subpass = create_info->pSubpasses[subpass_index];
+        const VkSubpassDescription2& subpass = create_info->pSubpasses[subpass_index];
         attachment_tracker.Update(subpass_index, subpass.viewMask, subpass.pColorAttachments, subpass.colorAttachmentCount);
         attachment_tracker.Update(subpass_index, subpass.viewMask, subpass.pResolveAttachments, subpass.colorAttachmentCount);
         attachment_tracker.Update(subpass_index, subpass.viewMask, subpass.pDepthStencilAttachment, 1);
@@ -328,7 +328,7 @@ RenderPass::RenderPass(VkRenderPass handle, VkRenderPassCreateInfo2 const* pCrea
     InitRenderPassState(*this);
 }
 
-static vku::safe_VkRenderPassCreateInfo2 ConvertCreateInfo(const VkRenderPassCreateInfo &create_info) {
+static vku::safe_VkRenderPassCreateInfo2 ConvertCreateInfo(const VkRenderPassCreateInfo& create_info) {
     vku::safe_VkRenderPassCreateInfo2 create_info_2 = ConvertVkRenderPassCreateInfoToV2KHR(create_info);
     return create_info_2;
 }
@@ -358,7 +358,7 @@ bool RenderPass::UsesColorAttachment(uint32_t subpass_num) const {
     bool result = false;
 
     if (subpass_num < create_info.subpassCount) {
-        const auto &subpass = create_info.pSubpasses[subpass_num];
+        const auto& subpass = create_info.pSubpasses[subpass_num];
 
         for (uint32_t i = 0; i < subpass.colorAttachmentCount; ++i) {
             if (subpass.pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) {
@@ -374,7 +374,7 @@ bool RenderPass::UsesColorAttachment(uint32_t subpass_num) const {
         if (subpass.pResolveAttachments != nullptr) {
             for (uint32_t i = 0; i < subpass.colorAttachmentCount && !result; ++i) {
                 uint32_t resolveAttachmentIndex = subpass.pResolveAttachments[i].attachment;
-                const void *resolveAtatchmentPNextChain = create_info.pAttachments[resolveAttachmentIndex].pNext;
+                const void* resolveAtatchmentPNextChain = create_info.pAttachments[resolveAttachmentIndex].pNext;
                 if (vku::FindStructInPNextChain<VkExternalFormatANDROID>(resolveAtatchmentPNextChain)) result = true;
             }
         }
@@ -386,7 +386,7 @@ bool RenderPass::UsesColorAttachment(uint32_t subpass_num) const {
 bool RenderPass::UsesDepthStencilAttachment(uint32_t subpass_num) const {
     bool result = false;
     if (subpass_num < create_info.subpassCount) {
-        const auto &subpass = create_info.pSubpasses[subpass_num];
+        const auto& subpass = create_info.pSubpasses[subpass_num];
         if (subpass.pDepthStencilAttachment && subpass.pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
             result = true;
         }
@@ -418,7 +418,7 @@ VkRenderingFlags RenderPass::GetRenderingFlags() const {
     return 0;
 }
 
-const VkMultisampledRenderToSingleSampledInfoEXT *RenderPass::GetMSRTSSInfo(uint32_t subpass) const {
+const VkMultisampledRenderToSingleSampledInfoEXT* RenderPass::GetMSRTSSInfo(uint32_t subpass) const {
     if (UsesDynamicRendering()) {
         return vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(
             dynamic_rendering_begin_rendering_info.pNext);
@@ -444,8 +444,8 @@ RenderPass::RenderPass(VkCommandBufferInheritanceRenderingInfo const* pInheritan
       dynamic_rendering_color_attachment_count(inheritance_rendering_info.colorAttachmentCount),
       has_multiview_enabled(false) {}
 
-Framebuffer::Framebuffer(VkFramebuffer handle, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
-                         std::vector<std::shared_ptr<vvl::ImageView>> &&attachments)
+Framebuffer::Framebuffer(VkFramebuffer handle, const VkFramebufferCreateInfo* pCreateInfo, std::shared_ptr<RenderPass>&& rpstate,
+                         std::vector<std::shared_ptr<vvl::ImageView>>&& attachments)
     : StateObject(handle, kVulkanObjectTypeFramebuffer),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -454,13 +454,13 @@ Framebuffer::Framebuffer(VkFramebuffer handle, const VkFramebufferCreateInfo *pC
 
 void Framebuffer::LinkChildNodes() {
     // Connect child node(s), which cannot safely be done in the constructor.
-    for (auto &a : attachments_view_state) {
+    for (auto& a : attachments_view_state) {
         a->AddParent(this);
     }
 }
 
 void Framebuffer::Destroy() {
-    for (auto &view : attachments_view_state) {
+    for (auto& view : attachments_view_state) {
         view->RemoveParent(this);
     }
     attachments_view_state.clear();

--- a/layers/state_tracker/sampler_state.cpp
+++ b/layers/state_tracker/sampler_state.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 #include "utils/hash_util.h"
 #include "utils/image_utils.h"
 
-bool DescriptorSlot::operator==(const DescriptorSlot &rhs) const { return set == rhs.set && binding == rhs.binding; }
+bool DescriptorSlot::operator==(const DescriptorSlot& rhs) const { return set == rhs.set && binding == rhs.binding; }
 
 size_t DescriptorSlot::Hash() const {
     hash_util::HashCombiner hc;
@@ -27,7 +27,7 @@ size_t DescriptorSlot::Hash() const {
     return hc.Value();
 }
 
-bool SamplerUsedByImage::operator==(const SamplerUsedByImage &rhs) const {
+bool SamplerUsedByImage::operator==(const SamplerUsedByImage& rhs) const {
     return sampler_slot == rhs.sampler_slot && sampler_index == rhs.sampler_index;
 }
 
@@ -39,7 +39,7 @@ size_t SamplerUsedByImage::Hash() const {
 
 namespace vvl {
 
-Sampler::Sampler(const VkSampler handle, const VkSamplerCreateInfo *pCreateInfo)
+Sampler::Sampler(const VkSampler handle, const VkSamplerCreateInfo* pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeSampler),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -47,7 +47,7 @@ Sampler::Sampler(const VkSampler handle, const VkSamplerCreateInfo *pCreateInfo)
       customCreateInfo(GetCustomCreateInfo(pCreateInfo)) {}
 
 SamplerYcbcrConversion::SamplerYcbcrConversion(VkSamplerYcbcrConversion handle,
-                                               const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
+                                               const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
                                                VkFormatFeatureFlags2 features)
     : StateObject(handle, kVulkanObjectTypeSamplerYcbcrConversion),
       safe_create_info(pCreateInfo),
@@ -55,7 +55,7 @@ SamplerYcbcrConversion::SamplerYcbcrConversion(VkSamplerYcbcrConversion handle,
       format_features(features),
       external_format(GetExternalFormat(pCreateInfo->pNext)) {}
 
-bool SamplerYcbcrConversion::operator!=(const SamplerYcbcrConversion &rhs) const {
+bool SamplerYcbcrConversion::operator!=(const SamplerYcbcrConversion& rhs) const {
     return (create_info.format != rhs.create_info.format) || (create_info.ycbcrModel != rhs.create_info.ycbcrModel) ||
            (create_info.ycbcrRange != rhs.create_info.ycbcrRange) || (create_info.components.r != rhs.create_info.components.r) ||
            (create_info.components.g != rhs.create_info.components.g) ||

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -31,7 +31,7 @@ static bool CanWaitBinarySemaphoreAfterOperation(vvl::Semaphore::OpType op_type)
     return op_type == vvl::Semaphore::kSignal || op_type == vvl::Semaphore::kBinaryAcquire;
 }
 
-static VkExternalSemaphoreHandleTypeFlags GetExportHandleTypes(const VkSemaphoreCreateInfo *pCreateInfo) {
+static VkExternalSemaphoreHandleTypeFlags GetExportHandleTypes(const VkSemaphoreCreateInfo* pCreateInfo) {
     auto export_info = vku::FindStructInPNextChain<VkExportSemaphoreCreateInfo>(pCreateInfo->pNext);
     return export_info ? export_info->handleTypes : 0;
 }
@@ -41,8 +41,8 @@ void vvl::Semaphore::TimePoint::Notify() const {
     signal_submit->queue->Notify(signal_submit->seq);
 }
 
-vvl::Semaphore::Semaphore(DeviceState &device, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
-                          const VkSemaphoreCreateInfo *pCreateInfo)
+vvl::Semaphore::Semaphore(DeviceState& device, VkSemaphore handle, const VkSemaphoreTypeCreateInfo* type_create_info,
+                          const VkSemaphoreCreateInfo* pCreateInfo)
     : RefcountedStateObject(handle, kVulkanObjectTypeSemaphore),
       type(type_create_info ? type_create_info->semaphoreType : VK_SEMAPHORE_TYPE_BINARY),
       flags(pCreateInfo->flags),
@@ -57,7 +57,7 @@ vvl::Semaphore::Semaphore(DeviceState &device, VkSemaphore handle, const VkSemap
       next_payload_(current_payload_ + 1) {
 }
 
-const VulkanTypedHandle *vvl::Semaphore::InUse() const {
+const VulkanTypedHandle* vvl::Semaphore::InUse() const {
     auto guard = ReadLock();
     // Semaphore does not have a parent (in the sense of a VVL state object), and the value returned
     // by the base class InUse is not useful for reporting (it is the semaphore's own handle)
@@ -66,11 +66,11 @@ const VulkanTypedHandle *vvl::Semaphore::InUse() const {
         return nullptr;
     }
     // Scan timeline to find the first queue that uses the semaphore
-    for (const auto &[_, timepoint] : timeline_) {
+    for (const auto& [_, timepoint] : timeline_) {
         if (timepoint.signal_submit.has_value() && timepoint.signal_submit->queue) {
             return &timepoint.signal_submit->queue->Handle();
         } else {
-            for (const SubmissionReference &wait_submit : timepoint.wait_submits) {
+            for (const SubmissionReference& wait_submit : timepoint.wait_submits) {
                 if (wait_submit.queue) {
                     return &wait_submit.queue->Handle();
                 }
@@ -102,7 +102,7 @@ enum vvl::Semaphore::Scope vvl::Semaphore::Scope() const {
     return scope_;
 }
 
-void vvl::Semaphore::EnqueueSignal(const SubmissionReference &signal_submit, uint64_t &payload) {
+void vvl::Semaphore::EnqueueSignal(const SubmissionReference& signal_submit, uint64_t& payload) {
     auto guard = WriteLock();
     if (type == VK_SEMAPHORE_TYPE_BINARY) {
         payload = next_payload_++;
@@ -129,7 +129,7 @@ void vvl::Semaphore::EnqueueSignal(const SubmissionReference &signal_submit, uin
     timeline_[payload].signal_submit.emplace(signal_submit);
 }
 
-void vvl::Semaphore::EnqueueWait(const SubmissionReference &wait_submit, uint64_t &payload) {
+void vvl::Semaphore::EnqueueWait(const SubmissionReference& wait_submit, uint64_t& payload) {
     auto guard = WriteLock();
     if (type == VK_SEMAPHORE_TYPE_BINARY) {
         // Update the swapchain image acquire state if the semaphore was used by the acquire operation
@@ -180,7 +180,7 @@ void vvl::Semaphore::EnqueueAcquire(vvl::Func acquire_command) {
     timeline_[payload].acquire_command.emplace(acquire_command);
 }
 
-std::optional<uint64_t> vvl::Semaphore::CheckMaxDiffThreshold(uint64_t value, const char *&payload_type) const {
+std::optional<uint64_t> vvl::Semaphore::CheckMaxDiffThreshold(uint64_t value, const char*& payload_type) const {
     assert(type == VK_SEMAPHORE_TYPE_TIMELINE);
     auto guard = ReadLock();
 
@@ -197,12 +197,12 @@ std::optional<uint64_t> vvl::Semaphore::CheckMaxDiffThreshold(uint64_t value, co
     // has already been checked. One of these entries may equal the current payload (e.g., for
     // host signals), but in that case it will not exceed the threshold.
     if (!timeline_.empty()) {
-        const auto &[first_payload, first_timepoint] = *timeline_.begin();
+        const auto& [first_payload, first_timepoint] = *timeline_.begin();
         if (AbsDiff(value, first_payload) > max_diff) {
             payload_type = first_timepoint.HasWaiters() ? "pending wait" : "pending signal";
             return first_payload;
         }
-        const auto &[last_payload, last_timepoint] = *timeline_.rbegin();
+        const auto& [last_payload, last_timepoint] = *timeline_.rbegin();
         if (AbsDiff(value, last_payload) > max_diff) {
             payload_type = last_timepoint.HasWaiters() ? "pending wait" : "pending signal";
             return last_payload;
@@ -219,7 +219,7 @@ bool vvl::Semaphore::HasPendingTimelineSignal(uint64_t signal_value) const {
     if (it == timeline_.end()) {
         return false;
     }
-    const TimePoint &timepoint = it->second;
+    const TimePoint& timepoint = it->second;
     if (!timepoint.signal_submit.has_value()) {
         return false;
     }
@@ -239,7 +239,7 @@ std::optional<vvl::SubmissionReference> vvl::Semaphore::GetPendingBinarySignalSu
     if (timeline_.empty()) {
         return {};
     }
-    const TimePoint &timepoint = timeline_.rbegin()->second;
+    const TimePoint& timepoint = timeline_.rbegin()->second;
     assert(timepoint.HasSignaler());  // semaphore was signaled or acquired
 
     if (!timepoint.signal_submit.has_value()) {
@@ -256,7 +256,7 @@ std::optional<vvl::SubmissionReference> vvl::Semaphore::GetPendingBinaryWaitSubm
     if (timeline_.empty()) {
         return {};
     }
-    const auto &timepoint = timeline_.rbegin()->second;
+    const auto& timepoint = timeline_.rbegin()->second;
     assert(timepoint.wait_submits.empty() || timepoint.wait_submits.size() == 1);
 
     // No waits
@@ -276,9 +276,9 @@ std::optional<vvl::SemaphoreInfo> vvl::Semaphore::GetPendingBinarySignalTimeline
     if (timeline_.empty()) {
         return {};
     }
-    const TimePoint &timepoint = timeline_.rbegin()->second;
+    const TimePoint& timepoint = timeline_.rbegin()->second;
     assert(timepoint.HasSignaler());
-    const auto &signal_submit = timepoint.signal_submit;
+    const auto& signal_submit = timepoint.signal_submit;
 
     // A signal not associated with a queue cannot be blocked by timeline wait
     // (host signal or image acquire signal)
@@ -314,7 +314,7 @@ bool vvl::Semaphore::CanBinaryBeWaited() const {
         return CanWaitBinarySemaphoreAfterOperation(completed_.op_type);
     }
 
-    const TimePoint &timepoint = timeline_.rbegin()->second;
+    const TimePoint& timepoint = timeline_.rbegin()->second;
 
     assert(scope_ == vvl::Semaphore::kInternal);  // Ensured by all calling sites
 
@@ -326,7 +326,7 @@ bool vvl::Semaphore::CanBinaryBeWaited() const {
     return !timepoint.HasWaiters();
 }
 
-void vvl::Semaphore::GetLastBinarySignalSource(VkQueue &queue, vvl::Func &acquire_command) const {
+void vvl::Semaphore::GetLastBinarySignalSource(VkQueue& queue, vvl::Func& acquire_command) const {
     assert(type == VK_SEMAPHORE_TYPE_BINARY);
     queue = VK_NULL_HANDLE;
     acquire_command = vvl::Func::Empty;
@@ -339,7 +339,7 @@ void vvl::Semaphore::GetLastBinarySignalSource(VkQueue &queue, vvl::Func &acquir
             acquire_command = *completed_.acquire_command;
         }
     } else {
-        const TimePoint &timepoint = timeline_.rbegin()->second;
+        const TimePoint& timepoint = timeline_.rbegin()->second;
         if (timepoint.signal_submit.has_value() && timepoint.signal_submit->queue) {
             queue = timepoint.signal_submit->queue->VkHandle();
         } else if (timepoint.acquire_command.has_value()) {
@@ -376,7 +376,7 @@ bool vvl::Semaphore::HasResolvingTimelineSignal(uint64_t wait_payload) const {
     return false;
 }
 
-bool vvl::Semaphore::CanRetireBinaryWait(TimePoint &timepoint) const {
+bool vvl::Semaphore::CanRetireBinaryWait(TimePoint& timepoint) const {
     assert(type == VK_SEMAPHORE_TYPE_BINARY);
     // The only allowed configuration when binary semaphore wait does not have a signal
     // is external semaphore. Just retire the wait because there is no guarantee we can
@@ -393,7 +393,7 @@ bool vvl::Semaphore::CanRetireBinaryWait(TimePoint &timepoint) const {
     return false;
 }
 
-bool vvl::Semaphore::CanRetireTimelineWait(const vvl::Queue *current_queue, uint64_t payload) const {
+bool vvl::Semaphore::CanRetireTimelineWait(const vvl::Queue* current_queue, uint64_t payload) const {
     assert(type == VK_SEMAPHORE_TYPE_TIMELINE);
 
     // In the correct program the resolving signal is the next signal on the timeline,
@@ -401,7 +401,7 @@ bool vvl::Semaphore::CanRetireTimelineWait(const vvl::Queue *current_queue, uint
     auto it = timeline_.find(payload);
     assert(it != timeline_.end());
     for (; it != timeline_.end(); ++it) {
-        const TimePoint &t = it->second;
+        const TimePoint& t = it->second;
         if (!t.signal_submit.has_value()) {
             continue;
         }
@@ -422,7 +422,7 @@ bool vvl::Semaphore::CanRetireTimelineWait(const vvl::Queue *current_queue, uint
     }
 
     // Found host signal that finishes this wait
-    const TimePoint &t = it->second;
+    const TimePoint& t = it->second;
     if (t.signal_submit->queue == nullptr) {
         return true;
     }
@@ -432,7 +432,7 @@ bool vvl::Semaphore::CanRetireTimelineWait(const vvl::Queue *current_queue, uint
     return false;
 }
 
-void vvl::Semaphore::RetireWait(vvl::Queue *current_queue, uint64_t payload, const Location &loc, bool queue_thread) {
+void vvl::Semaphore::RetireWait(vvl::Queue* current_queue, uint64_t payload, const Location& loc, bool queue_thread) {
     std::shared_future<void> waiter;
     bool retire_external_payload = false;
     uint64_t external_payload = 0;
@@ -452,7 +452,7 @@ void vvl::Semaphore::RetireWait(vvl::Queue *current_queue, uint64_t payload, con
                 // (external payload, which is already reached by the gpu, is larger then found signal,
                 // this means that earlier signals were also processed, so we can retire them)
                 for (auto it = std::make_reverse_iterator(payload_it); it != timeline_.rend(); ++it) {
-                    const TimePoint &t = it->second;
+                    const TimePoint& t = it->second;
                     if (t.signal_submit.has_value() && t.signal_submit->queue) {
                         retire_external_payload = true;
                         external_payload = payload;
@@ -468,7 +468,7 @@ void vvl::Semaphore::RetireWait(vvl::Queue *current_queue, uint64_t payload, con
                 imported_handle_type_.reset();
             }
         }
-        TimePoint &timepoint = vvl::FindExisting(timeline_, payload);
+        TimePoint& timepoint = vvl::FindExisting(timeline_, payload);
 
         bool retire = false;
         if (timepoint.acquire_command) {
@@ -502,11 +502,11 @@ void vvl::Semaphore::RetireSignal(uint64_t payload) {
     if (payload <= completed_.payload) {
         return;
     }
-    TimePoint &timepoint = vvl::FindExisting(timeline_, payload);
+    TimePoint& timepoint = vvl::FindExisting(timeline_, payload);
     assert(timepoint.signal_submit.has_value());
 
     OpType completed_op = kSignal;
-    const Queue *completed_op_queue = timepoint.signal_submit->queue;
+    const Queue* completed_op_queue = timepoint.signal_submit->queue;
 
     // If there is a wait operation then mark it as the last completed instead.
     // The reason to do this here instead on the waiter side (after it is unblocked)
@@ -523,7 +523,7 @@ void vvl::Semaphore::RetireSignal(uint64_t payload) {
     RetireTimePoint(payload, completed_op, completed_op_queue);
 }
 
-void vvl::Semaphore::RetireTimePoint(uint64_t payload, OpType completed_op, const Queue *completed_op_queue) {
+void vvl::Semaphore::RetireTimePoint(uint64_t payload, OpType completed_op, const Queue* completed_op_queue) {
     auto it = timeline_.begin();
     while (it != timeline_.end() && it->first <= payload) {
         assert(it->first > completed_.payload);
@@ -546,7 +546,7 @@ void vvl::Semaphore::RetireTimePoint(uint64_t payload, OpType completed_op, cons
             smallest_pending_signal_value_.reset();
         } else if (smallest_pending_signal_value_.has_value() && timeline_.begin()->first > *smallest_pending_signal_value_) {
             smallest_pending_signal_value_.reset();
-            for (const auto &[payload, timepoint] : timeline_) {
+            for (const auto& [payload, timepoint] : timeline_) {
                 if (!timepoint.signal_submit.has_value()) {
                     continue;
                 }
@@ -562,8 +562,8 @@ void vvl::Semaphore::RetireTimePoint(uint64_t payload, OpType completed_op, cons
     }
 }
 
-void vvl::Semaphore::WaitTimePoint(std::shared_future<void> &&waiter, uint64_t payload, bool unblock_validation_object,
-                                   const Location &loc) {
+void vvl::Semaphore::WaitTimePoint(std::shared_future<void>&& waiter, uint64_t payload, bool unblock_validation_object,
+                                   const Location& loc) {
     if (unblock_validation_object) {
         device_.BeginBlockingOperation();
     }
@@ -583,13 +583,13 @@ void vvl::Semaphore::WaitTimePoint(std::shared_future<void> &&waiter, uint64_t p
     }
 }
 
-void vvl::Semaphore::SetAcquiredImage(const std::shared_ptr<vvl::Swapchain> &swapchain, uint32_t image_index) {
+void vvl::Semaphore::SetAcquiredImage(const std::shared_ptr<vvl::Swapchain>& swapchain, uint32_t image_index) {
     auto guard = WriteLock();
     acquired_image_swapchain_ = swapchain;
     acquired_image_index_ = image_index;
 }
 
-void vvl::Semaphore::SetSwapchainWaitInfo(const SwapchainWaitInfo &info) {
+void vvl::Semaphore::SetSwapchainWaitInfo(const SwapchainWaitInfo& info) {
     auto guard = WriteLock();
     swapchain_wait_info_.emplace(info);
 }
@@ -648,7 +648,7 @@ std::optional<VkExternalSemaphoreHandleTypeFlagBits> vvl::Semaphore::ImportedHan
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-bool vvl::Semaphore::GetMetalExport(const VkSemaphoreCreateInfo *info) {
+bool vvl::Semaphore::GetMetalExport(const VkSemaphoreCreateInfo* info) {
     bool retval = false;
     auto export_metal_object_info = vku::FindStructInPNextChain<VkExportMetalObjectCreateInfoEXT>(info->pNext);
     while (export_metal_object_info) {

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -615,8 +615,8 @@ vvl::unordered_set<uint32_t> EntryPoint::GetAccessibleIds(const Module& module_s
     }
 
     std::unordered_map<uint32_t, uint32_t> entry_exit_pairs = {
-        { spv::OpFunction, spv::OpFunctionEnd },
-        { spv::OpGraphARM, spv::OpGraphEndARM },
+        {spv::OpFunction, spv::OpFunctionEnd},
+        {spv::OpGraphARM, spv::OpGraphEndARM},
     };
     worklist.insert(entrypoint.id);
     while (!worklist.empty()) {
@@ -713,7 +713,7 @@ std::vector<ResourceInterfaceVariable> EntryPoint::GetResourceInterfaceVariables
 
 std::vector<const Instruction*> EntryPoint::GetDataGraphConstants(const Module& module_state, EntryPoint& entrypoint,
                                                                   const ParsedInfo& parsed) {
-    std::vector<const Instruction *> constants;
+    std::vector<const Instruction*> constants;
     // Check to skip to not spend time if not using VK_ARM_data_graph
     if (parsed.has_graph_constant_arm) {
         for (const auto& accessible_id : entrypoint.accessible_ids) {

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -22,7 +22,7 @@
 #include "utils/shader_utils.h"
 
 namespace vvl {
-static DescriptorSetLayoutList GetSetLayouts(DeviceState &dev_data, const VkShaderCreateInfoEXT &pCreateInfo) {
+static DescriptorSetLayoutList GetSetLayouts(DeviceState& dev_data, const VkShaderCreateInfoEXT& pCreateInfo) {
     DescriptorSetLayoutList set_layouts(pCreateInfo.setLayoutCount);
     for (uint32_t i = 0; i < pCreateInfo.setLayoutCount; ++i) {
         set_layouts.list[i] = dev_data.Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);

--- a/layers/state_tracker/shader_stage_state.cpp
+++ b/layers/state_tracker/shader_stage_state.cpp
@@ -25,12 +25,12 @@
 #include "containers/container_utils.h"
 
 // Common for both Pipeline and Shader Object
-void GetActiveSlots(ActiveSlotMap &active_slots, const std::shared_ptr<const spirv::EntryPoint> &entrypoint) {
+void GetActiveSlots(ActiveSlotMap& active_slots, const std::shared_ptr<const spirv::EntryPoint>& entrypoint) {
     if (!entrypoint) {
         return;
     }
     // Capture descriptor uses for the pipeline
-    for (const auto &variable : entrypoint->resource_interface_variables) {
+    for (const auto& variable : entrypoint->resource_interface_variables) {
         // While validating shaders capture which slots are used by the pipeline
         DescriptorRequirement entry;
         entry.variable = &variable;
@@ -40,30 +40,30 @@ void GetActiveSlots(ActiveSlotMap &active_slots, const std::shared_ptr<const spi
 }
 
 // Used by pipeline
-ActiveSlotMap GetActiveSlots(const std::vector<ShaderStageState> &stage_states) {
+ActiveSlotMap GetActiveSlots(const std::vector<ShaderStageState>& stage_states) {
     ActiveSlotMap active_slots;
-    for (const auto &stage : stage_states) {
+    for (const auto& stage : stage_states) {
         GetActiveSlots(active_slots, stage.entrypoint);
     }
     return active_slots;
 }
 
 // Used by Shader Object
-ActiveSlotMap GetActiveSlots(const std::shared_ptr<const spirv::EntryPoint> &entrypoint) {
+ActiveSlotMap GetActiveSlots(const std::shared_ptr<const spirv::EntryPoint>& entrypoint) {
     ActiveSlotMap active_slots;
     GetActiveSlots(active_slots, entrypoint);
     return active_slots;
 }
 
-uint32_t GetMaxActiveSlot(const ActiveSlotMap &active_slots) {
+uint32_t GetMaxActiveSlot(const ActiveSlotMap& active_slots) {
     uint32_t max_active_slot = 0;
-    for (const auto &entry : active_slots) {
+    for (const auto& entry : active_slots) {
         max_active_slot = std::max(max_active_slot, entry.first);
     }
     return max_active_slot;
 }
 
-const char *ShaderStageState::GetPName() const {
+const char* ShaderStageState::GetPName() const {
     return (pipeline_create_info) ? pipeline_create_info->pName : shader_object_create_info->pName;
 }
 
@@ -71,11 +71,11 @@ VkShaderStageFlagBits ShaderStageState::GetStage() const {
     return (pipeline_create_info) ? pipeline_create_info->stage : shader_object_create_info->stage;
 }
 
-vku::safe_VkSpecializationInfo *ShaderStageState::GetSpecializationInfo() const {
+vku::safe_VkSpecializationInfo* ShaderStageState::GetSpecializationInfo() const {
     return (pipeline_create_info) ? pipeline_create_info->pSpecializationInfo : shader_object_create_info->pSpecializationInfo;
 }
 
-const void *ShaderStageState::GetPNext() const {
+const void* ShaderStageState::GetPNext() const {
     return (pipeline_create_info) ? pipeline_create_info->pNext : shader_object_create_info->pNext;
 }
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -60,7 +60,7 @@
 
 namespace vvl {
 
-DeviceState::DeviceState(vvl::dispatch::Device *dev, InstanceState *instance)
+DeviceState::DeviceState(vvl::dispatch::Device* dev, InstanceState* instance)
     : BaseClass(dev, instance, LayerObjectTypeStateTracker),
       instance_state(instance),
       special_supported(dev->stateless_device_data.special_supported) {
@@ -70,7 +70,7 @@ DeviceState::DeviceState(vvl::dispatch::Device *dev, InstanceState *instance)
 
 DeviceState::~DeviceState() { DestroyObjectMaps(); }
 
-void DeviceState::AddProxy(DeviceProxy &proxy) { proxies.emplace(proxy.container_type, proxy); }
+void DeviceState::AddProxy(DeviceProxy& proxy) { proxies.emplace(proxy.container_type, proxy); }
 
 void DeviceState::RemoveProxy(LayerObjectTypeId id) {
     proxies.erase(id);
@@ -98,7 +98,7 @@ void DeviceState::RemoveSubState(LayerObjectTypeId id) {
     ForEachShared<vvl::ShaderObject>([id](std::shared_ptr<vvl::ShaderObject> state) { state->RemoveSubState(id); });
 }
 
-VkDeviceAddress DeviceState::GetBufferDeviceAddressHelper(VkBuffer buffer, const DeviceExtensions *exts = nullptr) const {
+VkDeviceAddress DeviceState::GetBufferDeviceAddressHelper(VkBuffer buffer, const DeviceExtensions* exts = nullptr) const {
     // GPU-AV needs to pass in the modified extensions, since it may turn on BDA on its own
     if (!exts) {
         exts = &extensions;
@@ -151,12 +151,12 @@ void DeviceState::TrackDeviceAddressRange(vvl::CommandBuffer& cb_state, const vv
 
 // NOTE:  Beware the lifespan of the rp_begin when holding  the return.  If the rp_begin isn't a "safe" copy, "IMAGELESS"
 //        attachments won't persist past the API entry point exit.
-static std::pair<uint32_t, const VkImageView *> GetFramebufferAttachments(const VkRenderPassBeginInfo &rp_begin,
-                                                                          const Framebuffer &fb_state) {
-    const VkImageView *attachments = fb_state.create_info.pAttachments;
+static std::pair<uint32_t, const VkImageView*> GetFramebufferAttachments(const VkRenderPassBeginInfo& rp_begin,
+                                                                         const Framebuffer& fb_state) {
+    const VkImageView* attachments = fb_state.create_info.pAttachments;
     uint32_t count = fb_state.create_info.attachmentCount;
     if (fb_state.create_info.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
-        const auto *framebuffer_attachments = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(rp_begin.pNext);
+        const auto* framebuffer_attachments = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(rp_begin.pNext);
         if (framebuffer_attachments) {
             attachments = framebuffer_attachments->pAttachments;
             count = framebuffer_attachments->attachmentCount;
@@ -166,13 +166,13 @@ static std::pair<uint32_t, const VkImageView *> GetFramebufferAttachments(const 
 }
 
 template <typename ImageViewPointer, typename Get>
-std::vector<ImageViewPointer> GetAttachmentViewsImpl(const VkRenderPassBeginInfo &rp_begin, const Framebuffer &fb_state,
-                                                     const Get &get_fn) {
+std::vector<ImageViewPointer> GetAttachmentViewsImpl(const VkRenderPassBeginInfo& rp_begin, const Framebuffer& fb_state,
+                                                     const Get& get_fn) {
     std::vector<ImageViewPointer> views;
 
     const auto count_attachment = GetFramebufferAttachments(rp_begin, fb_state);
     const auto attachment_count = count_attachment.first;
-    const auto *attachments = count_attachment.second;
+    const auto* attachments = count_attachment.second;
     views.resize(attachment_count, nullptr);
     for (uint32_t i = 0; i < attachment_count; i++) {
         if (attachments[i] != VK_NULL_HANDLE) {
@@ -182,13 +182,13 @@ std::vector<ImageViewPointer> GetAttachmentViewsImpl(const VkRenderPassBeginInfo
     return views;
 }
 
-std::vector<std::shared_ptr<const ImageView>> DeviceState::GetAttachmentViews(const VkRenderPassBeginInfo &rp_begin,
-                                                                              const Framebuffer &fb_state) const {
+std::vector<std::shared_ptr<const ImageView>> DeviceState::GetAttachmentViews(const VkRenderPassBeginInfo& rp_begin,
+                                                                              const Framebuffer& fb_state) const {
     auto get_fn = [this](VkImageView handle) { return this->Get<ImageView>(handle); };
     return GetAttachmentViewsImpl<std::shared_ptr<const ImageView>>(rp_begin, fb_state, get_fn);
 }
 
-DescriptorSetLayoutId DeviceState::GetCanonicalId(const VkDescriptorSetLayoutCreateInfo *p_create_info) {
+DescriptorSetLayoutId DeviceState::GetCanonicalId(const VkDescriptorSetLayoutCreateInfo* p_create_info) {
     return descriptor_set_layout_canonical_ids_.LookUp(DescriptorSetLayoutDef(*this, p_create_info));
 }
 
@@ -196,7 +196,7 @@ DescriptorSetLayoutId DeviceState::GetCanonicalId(const VkDescriptorSetLayoutCre
 // Android-specific validation that uses types defined only with VK_USE_PLATFORM_ANDROID_KHR
 // This could also move into a seperate core_validation_android.cpp file... ?
 
-VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void *pNext) const {
+VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void* pNext) const {
     VkFormatFeatureFlags2 format_features = 0;
     const uint64_t external_format = GetExternalFormat(pNext);
     if ((0 != external_format)) {
@@ -209,9 +209,9 @@ VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void *
     return format_features;
 }
 
-void DeviceState::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer *buffer,
-                                                                          VkAndroidHardwareBufferPropertiesANDROID *pProperties,
-                                                                          const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
+                                                                          VkAndroidHardwareBufferPropertiesANDROID* pProperties,
+                                                                          const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -250,7 +250,7 @@ void DeviceState::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevi
 
 #else
 
-VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void *pNext) const {
+VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void* pNext) const {
     (void)pNext;
     return 0;
 }
@@ -312,7 +312,7 @@ VkFormatFeatureFlags2 InstanceState::GetImageFormatFeatures(VkPhysicalDevice phy
 
         VkFormatProperties2 format_properties_2 = vku::InitStructHelper();
         VkDrmFormatModifierPropertiesListEXT drm_properties_list = vku::InitStructHelper();
-        format_properties_2.pNext = (void *)&drm_properties_list;
+        format_properties_2.pNext = (void*)&drm_properties_list;
         DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, format, &format_properties_2);
         std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties;
         drm_properties.resize(drm_properties_list.drmFormatModifierCount);
@@ -334,19 +334,19 @@ VkFormatFeatureFlags2 InstanceState::GetImageFormatFeatures(VkPhysicalDevice phy
     return format_features;
 }
 
-std::shared_ptr<Image> DeviceState::CreateImageState(VkImage handle, const VkImageCreateInfo *create_info,
+std::shared_ptr<Image> DeviceState::CreateImageState(VkImage handle, const VkImageCreateInfo* create_info,
                                                      VkFormatFeatureFlags2 features) {
     return std::make_shared<Image>(*this, handle, create_info, features);
 }
 
-std::shared_ptr<Image> DeviceState::CreateImageState(VkImage handle, const VkImageCreateInfo *create_info, VkSwapchainKHR swapchain,
+std::shared_ptr<Image> DeviceState::CreateImageState(VkImage handle, const VkImageCreateInfo* create_info, VkSwapchainKHR swapchain,
                                                      uint32_t swapchain_index, VkFormatFeatureFlags2 features) {
     return std::make_shared<Image>(*this, handle, create_info, swapchain, swapchain_index, features);
 }
 
-void DeviceState::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
-                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage,
-                                            const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkImage* pImage,
+                                            const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -362,14 +362,14 @@ void DeviceState::PostCallRecordCreateImage(VkDevice device, const VkImageCreate
     Add(CreateImageState(*pImage, pCreateInfo, format_features));
 }
 
-void DeviceState::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,
-                                            const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
+                                            const RecordObject& record_obj) {
     Destroy<Image>(image);
 }
 
 void DeviceState::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                                   const VkClearColorValue *pColor, uint32_t rangeCount,
-                                                   const VkImageSubresourceRange *pRanges, const RecordObject &record_obj) {
+                                                   const VkClearColorValue* pColor, uint32_t rangeCount,
+                                                   const VkImageSubresourceRange* pRanges, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) {
         return;
     }
@@ -382,8 +382,8 @@ void DeviceState::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer
 }
 
 void DeviceState::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                                          const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount,
-                                                          const VkImageSubresourceRange *pRanges, const RecordObject &record_obj) {
+                                                          const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
+                                                          const VkImageSubresourceRange* pRanges, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) {
         return;
     }
@@ -396,8 +396,8 @@ void DeviceState::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer comman
 }
 
 void DeviceState::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                    const VkClearAttachment *pAttachments, uint32_t rectCount,
-                                                    const VkClearRect *pRects, const RecordObject &record_obj) {
+                                                    const VkClearAttachment* pAttachments, uint32_t rectCount,
+                                                    const VkClearRect* pRects, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) {
         return;
     }
@@ -407,7 +407,7 @@ void DeviceState::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffe
 
 void DeviceState::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                             const VkImageCopy *pRegions, const RecordObject &record_obj) {
+                                             const VkImageCopy* pRegions, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -420,13 +420,13 @@ void DeviceState::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkIm
                               record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR *pCopyImageInfo,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR* pCopyImageInfo,
+                                                 const RecordObject& record_obj) {
     PostCallRecordCmdCopyImage2(commandBuffer, pCopyImageInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
-                                              const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo,
+                                              const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -441,7 +441,7 @@ void DeviceState::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, con
 
 void DeviceState::PostCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                const VkImageResolve *pRegions, const RecordObject &record_obj) {
+                                                const VkImageResolve* pRegions, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -454,13 +454,13 @@ void DeviceState::PostCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, V
     cb_state->RecordResolveImage(*src_image_state, *dst_image_state, regionCount, pRegions, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR *pResolveImageInfo,
-                                                    const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR* pResolveImageInfo,
+                                                    const RecordObject& record_obj) {
     PostCallRecordCmdResolveImage2(commandBuffer, pResolveImageInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
+                                                 const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -476,7 +476,7 @@ void DeviceState::PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, 
 
 void DeviceState::PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                             const VkImageBlit *pRegions, VkFilter filter, const RecordObject &record_obj) {
+                                             const VkImageBlit* pRegions, VkFilter filter, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -490,13 +490,13 @@ void DeviceState::PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkIm
                               record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR *pBlitImageInfo,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR* pBlitImageInfo,
+                                                 const RecordObject& record_obj) {
     PostCallRecordCmdBlitImage2(commandBuffer, pBlitImageInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo,
-                                              const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
+                                              const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -516,11 +516,11 @@ struct BufferAddressInfillUpdateOps {
     using Value = typename Map::value_type;
     using Mapped = typename Map::mapped_type;
     using Range = typename Map::key_type;
-    void infill(Map &map, const Iterator &pos, const Range &infill_range) const {
+    void infill(Map& map, const Iterator& pos, const Range& infill_range) const {
         map.insert(pos, Value(infill_range, insert_value));
     }
-    void update(const Iterator &pos) const {
-        auto &current_buffer_list = pos->second;
+    void update(const Iterator& pos) const {
+        auto& current_buffer_list = pos->second;
         assert(!current_buffer_list.empty());
         const auto buffer_found_it = std::find(current_buffer_list.begin(), current_buffer_list.end(), insert_value[0]);
         if (buffer_found_it == current_buffer_list.end()) {
@@ -530,32 +530,32 @@ struct BufferAddressInfillUpdateOps {
             current_buffer_list.emplace_back(insert_value[0]);
         }
     }
-    const Mapped &insert_value;
+    const Mapped& insert_value;
 };
 
-std::shared_ptr<Buffer> DeviceState::CreateBufferState(VkBuffer handle, const VkBufferCreateInfo *create_info) {
+std::shared_ptr<Buffer> DeviceState::CreateBufferState(VkBuffer handle, const VkBufferCreateInfo* create_info) {
     return std::make_shared<Buffer>(*this, handle, create_info);
 }
 
-std::shared_ptr<vvl::Tensor> DeviceState::CreateTensorState(VkTensorARM handle, const VkTensorCreateInfoARM *create_info) {
+std::shared_ptr<vvl::Tensor> DeviceState::CreateTensorState(VkTensorARM handle, const VkTensorCreateInfoARM* create_info) {
     return std::make_shared<vvl::Tensor>(*this, handle, create_info);
 }
 
-void DeviceState::PostCallRecordCreateTensorARM(VkDevice device, const VkTensorCreateInfoARM *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkTensorARM *pTensor,
-                                                const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateTensorARM(VkDevice device, const VkTensorCreateInfoARM* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkTensorARM* pTensor,
+                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) return;
     std::shared_ptr<vvl::Tensor> tensor_state = CreateTensorState(*pTensor, pCreateInfo);
     Add(std::move(tensor_state));
 }
 
-void DeviceState::PreCallRecordDestroyTensorARM(VkDevice device, VkTensorARM tensor, const VkAllocationCallbacks *pAllocator,
-                                                const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyTensorARM(VkDevice device, VkTensorARM tensor, const VkAllocationCallbacks* pAllocator,
+                                                const RecordObject& record_obj) {
     Destroy<Tensor>(tensor);
 }
 
 void DeviceState::PostCallRecordBindTensorMemoryARM(VkDevice device, uint32_t bindInfoCount,
-                                                    const VkBindTensorMemoryInfoARM *pBindInfos, const RecordObject &record_obj) {
+                                                    const VkBindTensorMemoryInfoARM* pBindInfos, const RecordObject& record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         auto tensor_state = Get<vvl::Tensor>(pBindInfos[i].tensor);
@@ -566,15 +566,15 @@ void DeviceState::PostCallRecordBindTensorMemoryARM(VkDevice device, uint32_t bi
     }
 }
 
-void DeviceState::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
-                                             const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
-                                             const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+                                             const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
+                                             const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     std::shared_ptr<Buffer> buffer_state = CreateBufferState(*pBuffer, pCreateInfo);
 
-    const auto *opaque_capture_address = vku::FindStructInPNextChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext);
+    const auto* opaque_capture_address = vku::FindStructInPNextChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext);
     if (opaque_capture_address && (opaque_capture_address->opaqueCaptureAddress != 0)) {
         WriteLockGuard guard(buffer_address_lock_);
         // address is used for GPU-AV and ray tracing buffer validation
@@ -590,15 +590,15 @@ void DeviceState::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCrea
     Add(std::move(buffer_state));
 }
 
-std::shared_ptr<BufferView> DeviceState::CreateBufferViewState(const std::shared_ptr<Buffer> &buffer, VkBufferView handle,
-                                                               const VkBufferViewCreateInfo *create_info,
+std::shared_ptr<BufferView> DeviceState::CreateBufferViewState(const std::shared_ptr<Buffer>& buffer, VkBufferView handle,
+                                                               const VkBufferViewCreateInfo* create_info,
                                                                VkFormatFeatureFlags2 format_features) {
     return std::make_shared<BufferView>(buffer, handle, create_info, format_features);
 }
 
-void DeviceState::PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkBufferView *pView,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
+                                                 const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -620,15 +620,15 @@ void DeviceState::PostCallRecordCreateBufferView(VkDevice device, const VkBuffer
 }
 
 std::shared_ptr<vvl::DataGraphPipelineSession> DeviceState::CreateDataGraphPipelineSessionState(
-    VkDataGraphPipelineSessionARM handle, const VkDataGraphPipelineSessionCreateInfoARM *pCreateInfo) {
+    VkDataGraphPipelineSessionARM handle, const VkDataGraphPipelineSessionCreateInfoARM* pCreateInfo) {
     return std::make_shared<vvl::DataGraphPipelineSession>(*this, handle, pCreateInfo);
 }
 
 void DeviceState::PostCallRecordCreateDataGraphPipelineSessionARM(VkDevice device,
-                                                                  const VkDataGraphPipelineSessionCreateInfoARM *pCreateInfo,
-                                                                  const VkAllocationCallbacks *pAllocator,
-                                                                  VkDataGraphPipelineSessionARM *pSession,
-                                                                  const RecordObject &record_obj) {
+                                                                  const VkDataGraphPipelineSessionCreateInfoARM* pCreateInfo,
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  VkDataGraphPipelineSessionARM* pSession,
+                                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) return;
     std::shared_ptr<vvl::DataGraphPipelineSession> pipeline_session_state =
         CreateDataGraphPipelineSessionState(*pSession, pCreateInfo);
@@ -636,13 +636,13 @@ void DeviceState::PostCallRecordCreateDataGraphPipelineSessionARM(VkDevice devic
 }
 
 void DeviceState::PostCallRecordBindDataGraphPipelineSessionMemoryARM(VkDevice device, uint32_t bindInfoCount,
-                                                                      const VkBindDataGraphPipelineSessionMemoryInfoARM *pBindInfos,
-                                                                      const RecordObject &record_obj) {
+                                                                      const VkBindDataGraphPipelineSessionMemoryInfoARM* pBindInfos,
+                                                                      const RecordObject& record_obj) {
     if (VK_SUCCESS != record_obj.result) {
         return;
     }
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        auto &bind_info = pBindInfos[i];
+        auto& bind_info = pBindInfos[i];
         auto session_state = Get<vvl::DataGraphPipelineSession>(bind_info.session);
         if (session_state) {
             auto mem_info = std::shared_ptr<vvl::DeviceMemory>(Get<vvl::DeviceMemory>(bind_info.memory));
@@ -652,16 +652,16 @@ void DeviceState::PostCallRecordBindDataGraphPipelineSessionMemoryARM(VkDevice d
     }
 }
 
-std::shared_ptr<ImageView> DeviceState::CreateImageViewState(const std::shared_ptr<Image> &image_state, VkImageView handle,
-                                                             const VkImageViewCreateInfo *create_info,
+std::shared_ptr<ImageView> DeviceState::CreateImageViewState(const std::shared_ptr<Image>& image_state, VkImageView handle,
+                                                             const VkImageViewCreateInfo* create_info,
                                                              VkFormatFeatureFlags2 format_features,
-                                                             const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props) {
+                                                             const VkFilterCubicImageViewImageFormatPropertiesEXT& cubic_props) {
     return std::make_shared<ImageView>(*this, image_state, handle, create_info, format_features, cubic_props);
 }
 
-void DeviceState::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkImageView *pView,
-                                                const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkImageView* pView,
+                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -702,7 +702,7 @@ void DeviceState::PostCallRecordCreateImageView(VkDevice device, const VkImageVi
 }
 
 void DeviceState::PostCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                              uint32_t regionCount, const VkBufferCopy *pRegions, const RecordObject &record_obj) {
+                                              uint32_t regionCount, const VkBufferCopy* pRegions, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -714,8 +714,8 @@ void DeviceState::PostCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkB
     cb_state->RecordCopyBuffer(*src_buffer_state, *dst_buffer_state, regionCount, pRegions, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdCopyTensorARM(VkCommandBuffer commandBuffer, const VkCopyTensorInfoARM *pCopyTensorInfo,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdCopyTensorARM(VkCommandBuffer commandBuffer, const VkCopyTensorInfoARM* pCopyTensorInfo,
+                                                 const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -726,15 +726,15 @@ void DeviceState::PostCallRecordCmdCopyTensorARM(VkCommandBuffer commandBuffer, 
     cb_state->AddChild(dst_tensor_state);
 }
 
-std::shared_ptr<vvl::TensorView> DeviceState::CreateTensorViewState(const std::shared_ptr<vvl::Tensor> &tensor,
+std::shared_ptr<vvl::TensorView> DeviceState::CreateTensorViewState(const std::shared_ptr<vvl::Tensor>& tensor,
                                                                     VkTensorViewARM handle,
-                                                                    const VkTensorViewCreateInfoARM *pCreateInfo) {
+                                                                    const VkTensorViewCreateInfoARM* pCreateInfo) {
     return std::make_shared<vvl::TensorView>(tensor, handle, pCreateInfo);
 }
 
-void DeviceState::PostCallRecordCreateTensorViewARM(VkDevice device, const VkTensorViewCreateInfoARM *pCreateInfo,
-                                                    const VkAllocationCallbacks *pAllocator, VkTensorViewARM *pView,
-                                                    const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateTensorViewARM(VkDevice device, const VkTensorViewCreateInfoARM* pCreateInfo,
+                                                    const VkAllocationCallbacks* pAllocator, VkTensorViewARM* pView,
+                                                    const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) return;
 
     auto tensor_state = Get<vvl::Tensor>(pCreateInfo->tensor);
@@ -743,17 +743,17 @@ void DeviceState::PostCallRecordCreateTensorViewARM(VkDevice device, const VkTen
 }
 
 void DeviceState::PreCallRecordDestroyTensorViewARM(VkDevice device, VkTensorViewARM tensorView,
-                                                    const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                    const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<TensorView>(tensorView);
 }
 
-void DeviceState::PostCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR* pCopyBufferInfo,
+                                                  const RecordObject& record_obj) {
     PostCallRecordCmdCopyBuffer2(commandBuffer, pCopyBufferInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo,
-                                               const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
+                                               const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -766,13 +766,13 @@ void DeviceState::PostCallRecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, co
                                 record_obj.location);
 }
 
-void DeviceState::PreCallRecordDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks *pAllocator,
-                                                const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks* pAllocator,
+                                                const RecordObject& record_obj) {
     Destroy<ImageView>(imageView);
 }
 
-void DeviceState::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
-                                             const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
+                                             const RecordObject& record_obj) {
     if (auto buffer_state = Get<Buffer>(buffer)) {
         WriteLockGuard guard(buffer_address_lock_);
 
@@ -781,7 +781,7 @@ void DeviceState::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, c
         if (buffer_state->deviceAddress != 0) {
             const vvl::range<VkDeviceAddress> address_range = buffer_state->DeviceAddressRange();
 
-            buffer_address_map_.erase_range_or_touch(address_range, [buffer_state_raw = buffer_state.get()](auto &buffers) {
+            buffer_address_map_.erase_range_or_touch(address_range, [buffer_state_raw = buffer_state.get()](auto& buffers) {
                 assert(!buffers.empty());
                 const auto buffer_found_it = std::find(buffers.begin(), buffers.end(), buffer_state_raw);
                 assert(buffer_found_it != buffers.end());
@@ -807,15 +807,15 @@ void DeviceState::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, c
     Destroy<Buffer>(buffer);
 }
 
-void DeviceState::PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks *pAllocator,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks* pAllocator,
+                                                 const RecordObject& record_obj) {
     Destroy<BufferView>(bufferView);
 }
 
 static constexpr VkBufferUsageFlags2 kDescriptorBufferUsages =
     VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
-void DeviceState::RecordCreateDescriptorBuffer(const vvl::Buffer &buffer_state, const VkBufferCreateInfo &create_info) {
+void DeviceState::RecordCreateDescriptorBuffer(const vvl::Buffer& buffer_state, const VkBufferCreateInfo& create_info) {
     if ((buffer_state.usage & kDescriptorBufferUsages) != 0) {
         const VkDeviceSize size = create_info.size;
         descriptor_buffer_address_space.all += size;
@@ -830,7 +830,7 @@ void DeviceState::RecordCreateDescriptorBuffer(const vvl::Buffer &buffer_state, 
     }
 }
 
-void DeviceState::RecordDestoryDescriptorBuffer(const vvl::Buffer &buffer_state) {
+void DeviceState::RecordDestoryDescriptorBuffer(const vvl::Buffer& buffer_state) {
     if ((buffer_state.usage & kDescriptorBufferUsages) != 0) {
         const VkDeviceSize size = buffer_state.create_info.size;
         descriptor_buffer_address_space.all -= size;
@@ -846,7 +846,7 @@ void DeviceState::RecordDestoryDescriptorBuffer(const vvl::Buffer &buffer_state)
 }
 
 void DeviceState::PostCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                              VkDeviceSize size, uint32_t data, const RecordObject &record_obj) {
+                                              VkDeviceSize size, uint32_t data, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -869,8 +869,8 @@ void DeviceState::PostCallRecordCmdFillMemoryKHR(VkCommandBuffer commandBuffer, 
 }
 
 void DeviceState::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                                     VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions,
-                                                     const RecordObject &record_obj) {
+                                                     VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions,
+                                                     const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -885,14 +885,14 @@ void DeviceState::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuff
 }
 
 void DeviceState::PostCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
-                                                         const VkCopyImageToBufferInfo2KHR *pCopyImageToBufferInfo,
-                                                         const RecordObject &record_obj) {
+                                                         const VkCopyImageToBufferInfo2KHR* pCopyImageToBufferInfo,
+                                                         const RecordObject& record_obj) {
     PostCallRecordCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
-                                                      const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
-                                                      const RecordObject &record_obj) {
+                                                      const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo,
+                                                      const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -925,8 +925,8 @@ void DeviceState::PostCallRecordCmdCopyMemoryToImageKHR(VkCommandBuffer commandB
 }
 
 void DeviceState::PostCallRecordCmdCopyImageToMemoryKHR(VkCommandBuffer commandBuffer,
-                                                        const VkCopyDeviceMemoryImageInfoKHR *pCopyMemoryInfo,
-                                                        const RecordObject &record_obj) {
+                                                        const VkCopyDeviceMemoryImageInfoKHR* pCopyMemoryInfo,
+                                                        const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -956,7 +956,7 @@ void DeviceState::PostCallRecordCmdCopyMemoryKHR(VkCommandBuffer commandBuffer, 
 
 void DeviceState::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                      VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                     const VkBufferImageCopy *pRegions, const RecordObject &record_obj) {
+                                                     const VkBufferImageCopy* pRegions, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -971,14 +971,14 @@ void DeviceState::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuff
 }
 
 void DeviceState::PostCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                                         const VkCopyBufferToImageInfo2KHR *pCopyBufferToImageInfo,
-                                                         const RecordObject &record_obj) {
+                                                         const VkCopyBufferToImageInfo2KHR* pCopyBufferToImageInfo,
+                                                         const RecordObject& record_obj) {
     PostCallRecordCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
-                                                      const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
-                                                      const RecordObject &record_obj) {
+                                                      const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
+                                                      const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -1051,12 +1051,12 @@ VkFormatFeatureFlags2 DeviceState::GetPotentialFormatFeatures(VkFormat format) c
 
 std::shared_ptr<Queue> DeviceState::CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,
                                                 VkDeviceQueueCreateFlags flags,
-                                                const VkQueueFamilyProperties &queueFamilyProperties) {
+                                                const VkQueueFamilyProperties& queueFamilyProperties) {
     return std::make_shared<Queue>(*this, handle, family_index, queue_index, flags, queueFamilyProperties);
 }
 
-void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
-    const auto *device_group_ci = vku::FindStructInPNextChain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext);
+void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) {
+    const auto* device_group_ci = vku::FindStructInPNextChain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext);
     if (device_group_ci) {
         physical_device_count = device_group_ci->physicalDeviceCount;
         if (physical_device_count == 0) {
@@ -1079,12 +1079,12 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const
         DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, queue_family_properties_list.data());
 
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
-            const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
+            const VkDeviceQueueCreateInfo& queue_create_info = pCreateInfo->pQueueCreateInfos[i];
             queue_family_index_set.insert(queue_create_info.queueFamilyIndex);
             device_queue_info_list.emplace_back(
                 DeviceQueueInfo{i, queue_create_info.queueFamilyIndex, queue_create_info.flags, queue_create_info.queueCount});
         }
-        for (const auto &queue_info : device_queue_info_list) {
+        for (const auto& queue_info : device_queue_info_list) {
             for (uint32_t i = 0; i < queue_info.queue_count; i++) {
                 VkQueue queue = VK_NULL_HANDLE;
                 // vkGetDeviceQueue2() was added in vulkan 1.1, and there was never a KHR version of it.
@@ -1107,7 +1107,7 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const
     // Query queue family extension properties
     if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         uint32_t queue_family_count = (uint32_t)physical_device_state->queue_family_properties.size();
-        auto &ext_props = queue_family_ext_props;
+        auto& ext_props = queue_family_ext_props;
         ext_props.resize(queue_family_count);
 
         std::vector<VkQueueFamilyProperties2> props(queue_family_count, vku::InitStruct<VkQueueFamilyProperties2>());
@@ -1141,7 +1141,7 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const
     }
 
     // internal pipeline cache control
-    const auto *cache_control = vku::FindStructInPNextChain<VkDevicePipelineBinaryInternalCacheControlKHR>(pCreateInfo->pNext);
+    const auto* cache_control = vku::FindStructInPNextChain<VkDevicePipelineBinaryInternalCacheControlKHR>(pCreateInfo->pNext);
     disable_internal_pipeline_cache = cache_control && cache_control->disableInternalCache;
 
     if (IsExtEnabled(extensions.vk_nv_cooperative_matrix)) {
@@ -1253,7 +1253,7 @@ void DeviceState::DestroyObjectMaps() {
     // Because swapchains are associated with Surfaces, which are at instance level,
     // they need to be explicitly destroyed here to avoid continued references to
     // the device we're destroying.
-    for (auto &entry : swapchain_map_.snapshot()) {
+    for (auto& entry : swapchain_map_.snapshot()) {
         entry.second->Destroy();
     }
     swapchain_map_.clear();
@@ -1268,7 +1268,7 @@ void DeviceState::DestroyObjectMaps() {
     mem_obj_map_.clear();
 
     // Queues persist until device is destroyed
-    for (auto &entry : queue_map_.snapshot()) {
+    for (auto& entry : queue_map_.snapshot()) {
         entry.second->Destroy();
     }
     queue_map_.clear();
@@ -1282,8 +1282,8 @@ void DeviceState::DestroyObjectMaps() {
     video_session_parameters_map_.clear();
 }
 
-void DeviceState::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
-                                             const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
+                                             const RecordObject& record_obj) {
     if (!device) {
         return;
     }
@@ -1298,9 +1298,9 @@ void DeviceState::PreCallRecordDestroyDevice(VkDevice device, const VkAllocation
     // device destroy order.
 }
 
-static void UpdateCmdBufLabelStack(const CommandBuffer &cb_state, Queue &queue_state) {
+static void UpdateCmdBufLabelStack(const CommandBuffer& cb_state, Queue& queue_state) {
     if (queue_state.found_unbalanced_cmdbuf_label) return;
-    for (const auto &command : cb_state.GetLabelCommands()) {
+    for (const auto& command : cb_state.GetLabelCommands()) {
         if (command.begin) {
             queue_state.cmdbuf_label_stack.push_back(command.label_name);
         } else {
@@ -1324,15 +1324,15 @@ void DeviceState::CheckDebugCapture() const {
     captured |= IsDebugKeyPressed(instance_state->xlib_display, instance_state->xcb_connection);
 
     if (captured) {
-        for (auto &item : proxies) {
+        for (auto& item : proxies) {
             item.second.DebugCapture();
         }
     }
 #endif
 }
 
-void DeviceState::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
-                                           const RecordObject &record_obj) {
+void DeviceState::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
+                                           const RecordObject& record_obj) {
     CheckDebugCapture();
     auto queue_state = Get<Queue>(queue);
     std::vector<QueueSubmission> submissions;
@@ -1346,8 +1346,8 @@ void DeviceState::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, 
     for (uint32_t submit_i = 0; submit_i < submitCount; submit_i++) {
         Location submit_loc = record_obj.location.dot(Struct::VkSubmitInfo, Field::pSubmits, submit_i);
         QueueSubmission submission(submit_loc);
-        const VkSubmitInfo *submit = &pSubmits[submit_i];
-        auto *timeline_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(submit->pNext);
+        const VkSubmitInfo* submit = &pSubmits[submit_i];
+        auto* timeline_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(submit->pNext);
         for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
             auto wait_semaphore = Get<Semaphore>(submit->pWaitSemaphores[i]);
             uint64_t value{0};
@@ -1370,7 +1370,7 @@ void DeviceState::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, 
         const auto perf_submit = vku::FindStructInPNextChain<VkPerformanceQuerySubmitInfoKHR>(submit->pNext);
         submission.perf_submit_pass = perf_submit ? perf_submit->counterPassIndex : 0;
 
-        for (const VkCommandBuffer &cb : make_span(submit->pCommandBuffers, submit->commandBufferCount)) {
+        for (const VkCommandBuffer& cb : make_span(submit->pCommandBuffers, submit->commandBufferCount)) {
             if (auto cb_state = GetWrite<CommandBuffer>(cb)) {
                 submission.AddCommandBuffer(cb_state, queue_state->cmdbuf_label_stack);
                 UpdateCmdBufLabelStack(*cb_state, *queue_state);
@@ -1385,8 +1385,8 @@ void DeviceState::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, 
     queue_state->PreSubmit(std::move(submissions));
 }
 
-void DeviceState::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
-                                            const RecordObject &record_obj) {
+void DeviceState::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
+                                            const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1395,13 +1395,13 @@ void DeviceState::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount,
     queue_state->is_used_for_regular_submits = true;
 }
 
-void DeviceState::PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits, VkFence fence,
-                                               const RecordObject &record_obj) {
+void DeviceState::PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence,
+                                               const RecordObject& record_obj) {
     PreCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
 }
 
-void DeviceState::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                            const RecordObject &record_obj) {
+void DeviceState::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                            const RecordObject& record_obj) {
     CheckDebugCapture();
     auto queue_state = Get<Queue>(queue);
     std::vector<QueueSubmission> submissions;
@@ -1415,20 +1415,20 @@ void DeviceState::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount,
     for (uint32_t submit_i = 0; submit_i < submitCount; submit_i++) {
         Location submit_loc = record_obj.location.dot(Struct::VkSubmitInfo2, Field::pSubmits, submit_i);
         QueueSubmission submission(submit_loc);
-        const VkSubmitInfo2KHR &submit = pSubmits[submit_i];
-        for (const VkSemaphoreSubmitInfo &wait_sem_info : make_span(submit.pWaitSemaphoreInfos, submit.waitSemaphoreInfoCount)) {
+        const VkSubmitInfo2KHR& submit = pSubmits[submit_i];
+        for (const VkSemaphoreSubmitInfo& wait_sem_info : make_span(submit.pWaitSemaphoreInfos, submit.waitSemaphoreInfoCount)) {
             auto wait_semaphore = Get<Semaphore>(wait_sem_info.semaphore);
             ASSERT_AND_CONTINUE(wait_semaphore);
             const uint64_t value = (wait_semaphore->type == VK_SEMAPHORE_TYPE_BINARY) ? 0 : wait_sem_info.value;
             submission.AddWaitSemaphore(std::move(wait_semaphore), value);
         }
-        for (const VkSemaphoreSubmitInfo &sig_sem_info : make_span(submit.pSignalSemaphoreInfos, submit.signalSemaphoreInfoCount)) {
+        for (const VkSemaphoreSubmitInfo& sig_sem_info : make_span(submit.pSignalSemaphoreInfos, submit.signalSemaphoreInfoCount)) {
             submission.AddSignalSemaphore(Get<Semaphore>(sig_sem_info.semaphore), sig_sem_info.value);
         }
         const auto perf_submit = vku::FindStructInPNextChain<VkPerformanceQuerySubmitInfoKHR>(submit.pNext);
         submission.perf_submit_pass = perf_submit ? perf_submit->counterPassIndex : 0;
 
-        for (const VkCommandBufferSubmitInfo &cb_info : make_span(submit.pCommandBufferInfos, submit.commandBufferInfoCount)) {
+        for (const VkCommandBufferSubmitInfo& cb_info : make_span(submit.pCommandBufferInfos, submit.commandBufferInfoCount)) {
             if (auto cb_state = GetWrite<CommandBuffer>(cb_info.commandBuffer)) {
                 submission.AddCommandBuffer(cb_state, queue_state->cmdbuf_label_stack);
                 UpdateCmdBufLabelStack(*cb_state, *queue_state);
@@ -1442,13 +1442,13 @@ void DeviceState::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount,
     queue_state->PreSubmit(std::move(submissions));
 }
 
-void DeviceState::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits,
-                                                VkFence fence, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits,
+                                                VkFence fence, const RecordObject& record_obj) {
     PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
 }
 
-void DeviceState::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                             const RecordObject &record_obj) {
+void DeviceState::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                             const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1457,14 +1457,14 @@ void DeviceState::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount
     queue_state->is_used_for_regular_submits = true;
 }
 
-void DeviceState::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
-                                               const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory,
-                                               const RecordObject &record_obj) {
+void DeviceState::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                               const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
+                                               const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    const auto &memory_type = phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex];
-    const auto &memory_heap = phys_dev_mem_props.memoryHeaps[memory_type.heapIndex];
+    const auto& memory_type = phys_dev_mem_props.memoryTypes[pAllocateInfo->memoryTypeIndex];
+    const auto& memory_heap = phys_dev_mem_props.memoryHeaps[memory_type.heapIndex];
     auto fake_address = fake_memory.Alloc(pAllocateInfo->allocationSize);
 
     std::optional<DedicatedBinding> dedicated_binding;
@@ -1500,8 +1500,8 @@ void DeviceState::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAl
     return;
 }
 
-void DeviceState::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks *pAllocator,
-                                          const RecordObject &record_obj) {
+void DeviceState::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks* pAllocator,
+                                          const RecordObject& record_obj) {
     if (auto mem_info = Get<DeviceMemory>(mem)) {
         fake_memory.Free(mem_info->fake_base_address);
     }
@@ -1533,21 +1533,21 @@ void DeviceState::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory mem, c
 }
 
 void DeviceState::PostCallRecordSetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority,
-                                                           const RecordObject &record_obj) {
+                                                           const RecordObject& record_obj) {
     auto mem_info = Get<vvl::DeviceMemory>(memory);
     if (mem_info) {
         mem_info->dynamic_priority.emplace(priority);
     }
 }
 
-void DeviceState::PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                               VkFence fence, const RecordObject &record_obj) {
+void DeviceState::PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                                               VkFence fence, const RecordObject& record_obj) {
     auto queue_state = Get<Queue>(queue);
 
     std::vector<QueueSubmission> submissions;
     submissions.reserve(bindInfoCount);
     for (uint32_t bind_idx = 0; bind_idx < bindInfoCount; ++bind_idx) {
-        const VkBindSparseInfo &bind_info = pBindInfo[bind_idx];
+        const VkBindSparseInfo& bind_info = pBindInfo[bind_idx];
         // Track objects tied to memory
         for (uint32_t j = 0; j < bind_info.bufferBindCount; j++) {
             for (uint32_t k = 0; k < bind_info.pBufferBinds[j].bindCount; k++) {
@@ -1581,7 +1581,7 @@ void DeviceState::PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoC
                 }
             }
         }
-        auto *timeline_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(bind_info.pNext);
+        auto* timeline_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(bind_info.pNext);
         Location submit_loc = record_obj.location.dot(Struct::VkBindSparseInfo, Field::pBindInfo, bind_idx);
         QueueSubmission submission(submit_loc);
         for (uint32_t i = 0; i < bind_info.waitSemaphoreCount; ++i) {
@@ -1611,8 +1611,8 @@ void DeviceState::PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoC
     queue_state->PreSubmit(std::move(submissions));
 }
 
-void DeviceState::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                                VkFence fence, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                                                VkFence fence, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1621,9 +1621,9 @@ void DeviceState::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfo
     queue_state->is_used_for_regular_submits = true;
 }
 
-void DeviceState::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
-                                                const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
+                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1638,8 +1638,8 @@ void DeviceState::RecordImportSemaphoreState(VkSemaphore semaphore, VkExternalSe
     }
 }
 
-void DeviceState::PreCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                               const RecordObject &record_obj) {
+void DeviceState::PreCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                               const RecordObject& record_obj) {
     auto semaphore_state = Get<Semaphore>(pSignalInfo->semaphore);
     if (semaphore_state) {
         auto value = pSignalInfo->value;  // const workaround
@@ -1647,12 +1647,12 @@ void DeviceState::PreCallRecordSignalSemaphore(VkDevice device, const VkSemaphor
     }
 }
 
-void DeviceState::PreCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PreCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                                  const RecordObject& record_obj) {
     PreCallRecordSignalSemaphore(device, pSignalInfo, record_obj);
 }
 
-void DeviceState::RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void **ppData) {
+void DeviceState::RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData) {
     if (auto mem_info = Get<DeviceMemory>(mem)) {
         mem_info->mapped_range.offset = offset;
         mem_info->mapped_range.size = size;
@@ -1660,8 +1660,8 @@ void DeviceState::RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, Vk
     }
 }
 
-void DeviceState::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences, VkBool32 waitAll,
-                                              uint64_t timeout, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
+                                              uint64_t timeout, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1679,8 +1679,8 @@ void DeviceState::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCou
     //  vkGetFenceStatus() at which point we'll clean/remove their CBs if complete.
 }
 
-void DeviceState::PreCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                              const RecordObject &record_obj) {
+void DeviceState::PreCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                              const RecordObject& record_obj) {
     for (uint32_t i = 0; i < pWaitInfo->semaphoreCount; i++) {
         if (auto semaphore_state = Get<Semaphore>(pWaitInfo->pSemaphores[i])) {
             auto value = pWaitInfo->pValues[i];  // const workaround
@@ -1689,13 +1689,13 @@ void DeviceState::PreCallRecordWaitSemaphores(VkDevice device, const VkSemaphore
     }
 }
 
-void DeviceState::PreCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PreCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                                 const RecordObject& record_obj) {
     PreCallRecordWaitSemaphores(device, pWaitInfo, timeout, record_obj);
 }
 
-void DeviceState::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                               const RecordObject &record_obj) {
+void DeviceState::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                               const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1713,13 +1713,13 @@ void DeviceState::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphor
     }
 }
 
-void DeviceState::PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                                  const RecordObject& record_obj) {
     PostCallRecordWaitSemaphores(device, pWaitInfo, timeout, record_obj);
 }
 
-void DeviceState::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
-                                                         const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
+                                                         const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1728,12 +1728,12 @@ void DeviceState::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSema
     }
 }
 
-void DeviceState::PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
-                                                            const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
+                                                            const RecordObject& record_obj) {
     PostCallRecordGetSemaphoreCounterValue(device, semaphore, pValue, record_obj);
 }
 
-void DeviceState::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1754,17 +1754,17 @@ void DeviceState::RecordGetDeviceQueueState(uint32_t queue_family_index, uint32_
     }
 }
 
-void DeviceState::PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue *pQueue,
-                                               const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,
+                                               const RecordObject& record_obj) {
     RecordGetDeviceQueueState(queueFamilyIndex, queueIndex, {}, *pQueue);
 }
 
-void DeviceState::PostCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2 *pQueueInfo, VkQueue *pQueue,
-                                                const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue,
+                                                const RecordObject& record_obj) {
     RecordGetDeviceQueueState(pQueueInfo->queueFamilyIndex, pQueueInfo->queueIndex, pQueueInfo->flags, *pQueue);
 }
 
-void DeviceState::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) {
     // We assume this is only ever non-success if it is VK_ERROR_DEVICE_LOST, in that case we don't want to update state
     if (record_obj.result != VK_SUCCESS) {
         return;
@@ -1776,8 +1776,8 @@ void DeviceState::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject 
         // Only for pre-swapchain-maintenance1 code. New code should realy on presentation fence.
         if (!IsExtEnabled(extensions.vk_khr_swapchain_maintenance1) && !IsExtEnabled(extensions.vk_ext_swapchain_maintenance1)) {
             if (queue_state->is_used_for_presentation) {
-                for (const auto &entry : semaphore_map_.snapshot()) {
-                    const std::shared_ptr<vvl::Semaphore> &semaphore_state = entry.second;
+                for (const auto& entry : semaphore_map_.snapshot()) {
+                    const std::shared_ptr<vvl::Semaphore>& semaphore_state = entry.second;
                     semaphore_state->ClearSwapchainWaitInfo();
                 }
             }
@@ -1785,7 +1785,7 @@ void DeviceState::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject 
     }
 }
 
-void DeviceState::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject& record_obj) {
     // We assume this is only ever non-success if it is VK_ERROR_DEVICE_LOST, in that case we don't want to update state
     if (record_obj.result != VK_SUCCESS) {
         return;
@@ -1796,51 +1796,51 @@ void DeviceState::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObje
     // types of bugs in the queue thread.
     std::vector<std::shared_ptr<Queue>> queues;
     queues.reserve(queue_map_.size());
-    for (const auto &entry : queue_map_.snapshot()) {
+    for (const auto& entry : queue_map_.snapshot()) {
         queues.push_back(entry.second);
     }
-    std::sort(queues.begin(), queues.end(), [](const auto &q1, const auto &q2) { return q1->GetId() < q2->GetId(); });
+    std::sort(queues.begin(), queues.end(), [](const auto& q1, const auto& q2) { return q1->GetId() < q2->GetId(); });
 
     // Notify all queues before waiting.
     // NotifyAndWait is not safe here. It deadlocks when a wait depends on the not yet issued notify.
-    for (auto &queue : queues) {
+    for (auto& queue : queues) {
         queue->Notify();
     }
     // All possible forward progress is initiated. Now it's safe to wait.
-    for (auto &queue : queues) {
+    for (auto& queue : queues) {
         queue->Wait(record_obj.location);
     }
     // Reset semaphore's in-use-by-swapchain state.
     // Only for pre-swapchain-maintenance1 code. New code should rely on the presentation fence.
     if (!IsExtEnabled(extensions.vk_khr_swapchain_maintenance1) && !IsExtEnabled(extensions.vk_ext_swapchain_maintenance1)) {
-        for (const auto &entry : semaphore_map_.snapshot()) {
-            const std::shared_ptr<vvl::Semaphore> &semaphore_state = entry.second;
+        for (const auto& entry : semaphore_map_.snapshot()) {
+            const std::shared_ptr<vvl::Semaphore>& semaphore_state = entry.second;
             semaphore_state->ClearSwapchainWaitInfo();
         }
     }
 }
 
-void DeviceState::PreCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks *pAllocator,
-                                            const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks* pAllocator,
+                                            const RecordObject& record_obj) {
     Destroy<Fence>(fence);
 }
 
-void DeviceState::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks *pAllocator,
-                                                const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
+                                                const RecordObject& record_obj) {
     Destroy<Semaphore>(semaphore);
 }
 
-void DeviceState::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks *pAllocator,
-                                            const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator,
+                                            const RecordObject& record_obj) {
     Destroy<Event>(event);
 }
 
-void DeviceState::PreCallRecordDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks *pAllocator,
-                                                const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks* pAllocator,
+                                                const RecordObject& record_obj) {
     Destroy<QueryPool>(queryPool);
 }
 
-void DeviceState::UpdateBindBufferMemoryState(const VkBindBufferMemoryInfo &bind_info) {
+void DeviceState::UpdateBindBufferMemoryState(const VkBindBufferMemoryInfo& bind_info) {
     auto buffer_state = Get<Buffer>(bind_info.buffer);
     if (!buffer_state) return;
 
@@ -1851,7 +1851,7 @@ void DeviceState::UpdateBindBufferMemoryState(const VkBindBufferMemoryInfo &bind
 }
 
 void DeviceState::PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                                 const RecordObject &record_obj) {
+                                                 const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -1862,14 +1862,14 @@ void DeviceState::PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffe
     UpdateBindBufferMemoryState(bind_info);
 }
 
-void DeviceState::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos,
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         // if bindInfoCount is 1, we know for sure if that single buffer was bound or not
         if (bindInfoCount > 1) {
             for (uint32_t i = 0; i < bindInfoCount; i++) {
                 // If user passed in VkBindMemoryStatus, we can update which buffers are valid or not
-                if (auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
+                if (auto* bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
                     if (bind_memory_status->pResult && *bind_memory_status->pResult == VK_SUCCESS) {
                         UpdateBindBufferMemoryState(pBindInfos[i]);
                     }
@@ -1886,20 +1886,20 @@ void DeviceState::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bind
 }
 
 void DeviceState::PostCallRecordBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount,
-                                                     const VkBindBufferMemoryInfo *pBindInfos, const RecordObject &record_obj) {
+                                                     const VkBindBufferMemoryInfo* pBindInfos, const RecordObject& record_obj) {
     PostCallRecordBindBufferMemory2(device, bindInfoCount, pBindInfos, record_obj);
 }
 
 void DeviceState::PreCallRecordDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
-                                                   const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                   const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<ShaderModule>(shaderModule);
 }
 
-void DeviceState::PreCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAllocationCallbacks *pAllocator,
-                                                const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAllocationCallbacks* pAllocator,
+                                                const RecordObject& record_obj) {
     // Don't do state lookup if not needed
     if (enabled_features.descriptorHeap) {
-        if (const auto &shader_state = Get<ShaderObject>(shader)) {
+        if (const auto& shader_state = Get<ShaderObject>(shader)) {
             if (shader_state->descriptor_heap_embedded_samplers_count > 0) {
                 descriptor_heap_global_embedded_sampler_count_ -= shader_state->descriptor_heap_embedded_samplers_count;
             }
@@ -1909,11 +1909,11 @@ void DeviceState::PreCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT sha
     Destroy<ShaderObject>(shader);
 }
 
-void DeviceState::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
-                                               const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator,
+                                               const RecordObject& record_obj) {
     // Don't do state lookup if not needed
     if (enabled_features.descriptorHeap) {
-        if (const auto &pipeline_state = Get<Pipeline>(pipeline)) {
+        if (const auto& pipeline_state = Get<Pipeline>(pipeline)) {
             if (pipeline_state->descriptor_heap_embedded_samplers_count > 0) {
                 descriptor_heap_global_embedded_sampler_count_ -= pipeline_state->descriptor_heap_embedded_samplers_count;
             }
@@ -1924,11 +1924,11 @@ void DeviceState::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipel
 }
 
 void DeviceState::PostCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
-                                                  const VkShaderStageFlagBits *pStages, const VkShaderEXT *pShaders,
-                                                  const RecordObject &record_obj) {
+                                                  const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders,
+                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     for (uint32_t i = 0; i < stageCount; ++i) {
-        ShaderObject *shader_object_state = nullptr;
+        ShaderObject* shader_object_state = nullptr;
         if (pShaders && pShaders[i] != VK_NULL_HANDLE) {
             shader_object_state = Get<ShaderObject>(pShaders[i]).get();
         }
@@ -1941,12 +1941,12 @@ void DeviceState::PostCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer,
 }
 
 void DeviceState::PreCallRecordDestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout,
-                                                     const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<PipelineLayout>(pipelineLayout);
 }
 
-void DeviceState::PreCallRecordDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks *pAllocator,
-                                              const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks* pAllocator,
+                                              const RecordObject& record_obj) {
     if (!sampler) return;
     // Any bound cmd buffers are now invalid
     if (auto sampler_state = Get<Sampler>(sampler)) {
@@ -1959,39 +1959,39 @@ void DeviceState::PreCallRecordDestroySampler(VkDevice device, VkSampler sampler
 }
 
 void DeviceState::PreCallRecordDestroyDescriptorSetLayout(VkDevice device, VkDescriptorSetLayout descriptorSetLayout,
-                                                          const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                          const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<DescriptorSetLayout>(descriptorSetLayout);
 }
 
 void DeviceState::PreCallRecordDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
-                                                     const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<DescriptorPool>(descriptorPool);
 }
 
 void DeviceState::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
-                                                  const VkCommandBuffer *pCommandBuffers, const RecordObject &record_obj) {
+                                                  const VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
     if (auto pool = Get<CommandPool>(commandPool)) {
         pool->Free(commandBufferCount, pCommandBuffers);
     }
 }
 
-std::shared_ptr<CommandPool> DeviceState::CreateCommandPoolState(VkCommandPool handle, const VkCommandPoolCreateInfo *create_info) {
+std::shared_ptr<CommandPool> DeviceState::CreateCommandPoolState(VkCommandPool handle, const VkCommandPoolCreateInfo* create_info) {
     auto queue_flags = physical_device_state->queue_family_properties[create_info->queueFamilyIndex].queueFlags;
     return std::make_shared<CommandPool>(*this, handle, create_info, queue_flags);
 }
 
-void DeviceState::PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     Add(CreateCommandPoolState(*pCommandPool, pCreateInfo));
 }
 
-void DeviceState::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool,
-                                                const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool,
+                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2001,13 +2001,13 @@ void DeviceState::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPo
     uint32_t n_perf_pass = 0;
     bool has_cb = false, has_rb = false;
     if (pCreateInfo->queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
-        const auto *perf = vku::FindStructInPNextChain<VkQueryPoolPerformanceCreateInfoKHR>(pCreateInfo->pNext);
+        const auto* perf = vku::FindStructInPNextChain<VkQueryPoolPerformanceCreateInfoKHR>(pCreateInfo->pNext);
         perf_queue_family_index = perf->queueFamilyIndex;
         index_count = perf->counterIndexCount;
 
-        const QueueFamilyPerfCounters &counters = *physical_device_state->perf_counters[perf_queue_family_index];
+        const QueueFamilyPerfCounters& counters = *physical_device_state->perf_counters[perf_queue_family_index];
         for (uint32_t i = 0; i < perf->counterIndexCount; i++) {
-            const auto &counter = counters.counters[perf->pCounterIndices[i]];
+            const auto& counter = counters.counters[perf->pCounterIndices[i]];
             switch (counter.scope) {
                 case VK_PERFORMANCE_COUNTER_SCOPE_COMMAND_BUFFER_KHR:
                     has_cb = true;
@@ -2025,7 +2025,7 @@ void DeviceState::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPo
 
     VkVideoEncodeFeedbackFlagsKHR video_encode_feedback_flags = 0;
     if (pCreateInfo->queryType == VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR) {
-        const auto *feedback_info = vku::FindStructInPNextChain<VkQueryPoolVideoEncodeFeedbackCreateInfoKHR>(pCreateInfo->pNext);
+        const auto* feedback_info = vku::FindStructInPNextChain<VkQueryPoolVideoEncodeFeedbackCreateInfoKHR>(pCreateInfo->pNext);
         if (feedback_info) {
             video_encode_feedback_flags = feedback_info->encodeFeedbackFlags;
         }
@@ -2038,12 +2038,12 @@ void DeviceState::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPo
 }
 
 void DeviceState::PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
-                                                  const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                  const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<CommandPool>(commandPool);
 }
 
 void DeviceState::PostCallRecordResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags,
-                                                 const RecordObject &record_obj) {
+                                                 const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2053,8 +2053,8 @@ void DeviceState::PostCallRecordResetCommandPool(VkDevice device, VkCommandPool 
     }
 }
 
-void DeviceState::PostCallRecordResetFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences,
-                                            const RecordObject &record_obj) {
+void DeviceState::PostCallRecordResetFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences,
+                                            const RecordObject& record_obj) {
     // Discussion what a failed reset with multiple fences would mean
     // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4253
     if (record_obj.result != VK_SUCCESS) {
@@ -2069,18 +2069,18 @@ void DeviceState::PostCallRecordResetFences(VkDevice device, uint32_t fenceCount
 }
 
 void DeviceState::PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
-                                                  const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                  const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<Framebuffer>(framebuffer);
 }
 
-void DeviceState::PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator,
+                                                 const RecordObject& record_obj) {
     Destroy<RenderPass>(renderPass);
 }
 
-void DeviceState::PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo,
-                                            const VkAllocationCallbacks *pAllocator, VkFence *pFence,
-                                            const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkFence* pFence,
+                                            const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2088,13 +2088,13 @@ void DeviceState::PostCallRecordCreateFence(VkDevice device, const VkFenceCreate
 }
 
 std::shared_ptr<PipelineCache> DeviceState::CreatePipelineCacheState(VkPipelineCache handle,
-                                                                     const VkPipelineCacheCreateInfo *create_info) const {
+                                                                     const VkPipelineCacheCreateInfo* create_info) const {
     return std::make_shared<PipelineCache>(handle, create_info);
 }
 
-void DeviceState::PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
-                                                    const VkAllocationCallbacks *pAllocator, VkPipelineCache *pPipelineCache,
-                                                    const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
+                                                    const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
+                                                    const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2102,13 +2102,13 @@ void DeviceState::PostCallRecordCreatePipelineCache(VkDevice device, const VkPip
 }
 
 void DeviceState::PreCallRecordDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache,
-                                                    const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                    const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<PipelineCache>(pipelineCache);
 }
 
 std::shared_ptr<Pipeline> DeviceState::CreateGraphicsPipelineState(
-    const VkGraphicsPipelineCreateInfo *create_info, std::shared_ptr<const PipelineCache> pipeline_cache,
-    std::shared_ptr<const RenderPass> &&render_pass, std::shared_ptr<const PipelineLayout> &&layout,
+    const VkGraphicsPipelineCreateInfo* create_info, std::shared_ptr<const PipelineCache> pipeline_cache,
+    std::shared_ptr<const RenderPass>&& render_pass, std::shared_ptr<const PipelineLayout>&& layout,
     spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) const {
     return std::make_shared<Pipeline>(*this, create_info, std::move(pipeline_cache), std::move(render_pass), std::move(layout),
                                       stateless_data);
@@ -2116,16 +2116,16 @@ std::shared_ptr<Pipeline> DeviceState::CreateGraphicsPipelineState(
 
 // PreCallValidate used here to have a single global spot to build the vvl::Pipeline object so we can use it right away
 bool DeviceState::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                         const VkGraphicsPipelineCreateInfo *pCreateInfos,
-                                                         const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                         const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                         chassis::CreateGraphicsPipelines &chassis_state) const {
+                                                         const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                         const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                         const ErrorObject& error_obj, PipelineStates& pipeline_states,
+                                                         chassis::CreateGraphicsPipelines& chassis_state) const {
     bool skip = false;
     // Set up the state that CoreChecks, gpu_validation and later StateTracker Record will use.
     pipeline_states.reserve(count);
     auto pipeline_cache = Get<PipelineCache>(pipelineCache);
     for (uint32_t i = 0; i < count; i++) {
-        const auto &create_info = pCreateInfos[i];
+        const auto& create_info = pCreateInfos[i];
         auto layout_state = Get<PipelineLayout>(create_info.layout);
         std::shared_ptr<const RenderPass> render_pass;
 
@@ -2218,10 +2218,10 @@ bool DeviceState::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipe
 }
 
 void DeviceState::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                        const VkGraphicsPipelineCreateInfo *pCreateInfos,
-                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                        const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                        chassis::CreateGraphicsPipelines &chassis_state) {
+                                                        const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                        const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                        const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                        chassis::CreateGraphicsPipelines& chassis_state) {
     for (uint32_t i = 0; i < count; i++) {
         const VkPipeline pipeline_handle = pPipelines[i];
         if (pipeline_handle == VK_NULL_HANDLE) {
@@ -2240,19 +2240,19 @@ void DeviceState::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipel
     pipeline_states.clear();
 }
 
-std::shared_ptr<Pipeline> DeviceState::CreateComputePipelineState(const VkComputePipelineCreateInfo *create_info,
+std::shared_ptr<Pipeline> DeviceState::CreateComputePipelineState(const VkComputePipelineCreateInfo* create_info,
                                                                   std::shared_ptr<const PipelineCache> pipeline_cache,
-                                                                  std::shared_ptr<const PipelineLayout> &&layout,
-                                                                  spirv::StatelessData *stateless_data) const {
+                                                                  std::shared_ptr<const PipelineLayout>&& layout,
+                                                                  spirv::StatelessData* stateless_data) const {
     return std::make_shared<Pipeline>(*this, create_info, std::move(pipeline_cache), std::move(layout), stateless_data);
 }
 
 // PreCallValidate used here to have a single global spot to build the vvl::Pipeline object so we can use it right away
 bool DeviceState::PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                        const VkComputePipelineCreateInfo *pCreateInfos,
-                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                        const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                        chassis::CreateComputePipelines &chassis_state) const {
+                                                        const VkComputePipelineCreateInfo* pCreateInfos,
+                                                        const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                        const ErrorObject& error_obj, PipelineStates& pipeline_states,
+                                                        chassis::CreateComputePipelines& chassis_state) const {
     pipeline_states.reserve(count);
     auto pipeline_cache = Get<PipelineCache>(pipelineCache);
     for (uint32_t i = 0; i < count; i++) {
@@ -2264,10 +2264,10 @@ bool DeviceState::PreCallValidateCreateComputePipelines(VkDevice device, VkPipel
 }
 
 void DeviceState::PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                       const VkComputePipelineCreateInfo *pCreateInfos,
-                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                       const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                       chassis::CreateComputePipelines &chassis_state) {
+                                                       const VkComputePipelineCreateInfo* pCreateInfos,
+                                                       const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                       const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                       chassis::CreateComputePipelines& chassis_state) {
     for (uint32_t i = 0; i < count; i++) {
         const VkPipeline pipeline_handle = pPipelines[i];
         if (pipeline_handle == VK_NULL_HANDLE) {
@@ -2285,17 +2285,17 @@ void DeviceState::PostCallRecordCreateComputePipelines(VkDevice device, VkPipeli
 }
 
 // TODO - Add tests and pass down StatelessData
-std::shared_ptr<Pipeline> DeviceState::CreateRayTracingPipelineStateNV(const VkRayTracingPipelineCreateInfoNV *create_info,
+std::shared_ptr<Pipeline> DeviceState::CreateRayTracingPipelineStateNV(const VkRayTracingPipelineCreateInfoNV* create_info,
                                                                        std::shared_ptr<const PipelineCache> pipeline_cache,
-                                                                       std::shared_ptr<const PipelineLayout> &&layout) const {
+                                                                       std::shared_ptr<const PipelineLayout>&& layout) const {
     return std::make_shared<Pipeline>(*this, create_info, std::move(pipeline_cache), std::move(layout));
 }
 
 // PreCallValidate used here to have a single global spot to build the vvl::Pipeline object so we can use it right away
 bool DeviceState::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                             const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-                                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                             const ErrorObject &error_obj, PipelineStates &pipeline_states) const {
+                                                             const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
+                                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                             const ErrorObject& error_obj, PipelineStates& pipeline_states) const {
     pipeline_states.reserve(count);
     auto pipeline_cache = Get<PipelineCache>(pipelineCache);
     for (uint32_t i = 0; i < count; i++) {
@@ -2307,9 +2307,9 @@ bool DeviceState::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, Vk
 }
 
 void DeviceState::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                            const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-                                                            const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                            const RecordObject &record_obj, PipelineStates &pipeline_states) {
+                                                            const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
+                                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                            const RecordObject& record_obj, PipelineStates& pipeline_states) {
     for (uint32_t i = 0; i < count; i++) {
         const VkPipeline pipeline_handle = pPipelines[i];
         if (pipeline_handle == VK_NULL_HANDLE) {
@@ -2327,20 +2327,20 @@ void DeviceState::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkP
 }
 
 // TODO - Add tests and pass down StatelessData
-std::shared_ptr<Pipeline> DeviceState::CreateRayTracingPipelineStateKHR(const VkRayTracingPipelineCreateInfoKHR *create_info,
+std::shared_ptr<Pipeline> DeviceState::CreateRayTracingPipelineStateKHR(const VkRayTracingPipelineCreateInfoKHR* create_info,
                                                                         std::shared_ptr<const PipelineCache> pipeline_cache,
-                                                                        std::shared_ptr<const PipelineLayout> &&layout,
-                                                                        std::vector<spirv::StatelessData> &stateless_data) const {
+                                                                        std::shared_ptr<const PipelineLayout>&& layout,
+                                                                        std::vector<spirv::StatelessData>& stateless_data) const {
     return std::make_shared<Pipeline>(*this, create_info, std::move(pipeline_cache), std::move(layout), &stateless_data);
 }
 
 // PreCallValidate used here to have a single global spot to build the vvl::Pipeline object so we can use it right away
 bool DeviceState::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                               VkPipelineCache pipelineCache, uint32_t count,
-                                                              const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
-                                                              const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                              const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                              chassis::CreateRayTracingPipelinesKHR &chassis_state) const {
+                                                              const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                              const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                              const ErrorObject& error_obj, PipelineStates& pipeline_states,
+                                                              chassis::CreateRayTracingPipelinesKHR& chassis_state) const {
     pipeline_states.reserve(count);
     auto pipeline_cache = Get<PipelineCache>(pipelineCache);
     for (uint32_t i = 0; i < count; i++) {
@@ -2353,9 +2353,9 @@ bool DeviceState::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, V
 
 void DeviceState::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                              VkPipelineCache pipelineCache, uint32_t count,
-                                                             const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
-                                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                             const RecordObject &record_obj, PipelineStates &pipeline_states,
+                                                             const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                             const RecordObject& record_obj, PipelineStates& pipeline_states,
                                                              std::shared_ptr<chassis::CreateRayTracingPipelinesKHR> chassis_state) {
     const bool is_operation_deferred = (deferredOperation != VK_NULL_HANDLE && record_obj.result == VK_OPERATION_DEFERRED_KHR);
     if (!is_operation_deferred) {
@@ -2382,13 +2382,13 @@ void DeviceState::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, Vk
         if (dispatch_device_->wrap_handles) {
             deferredOperation = dispatch_device_->Unwrap(deferredOperation);
         }
-        std::vector<std::function<void(std::pair<uint32_t, VkPipeline *>)>> cleanup_fn;
+        std::vector<std::function<void(std::pair<uint32_t, VkPipeline*>)>> cleanup_fn;
         auto find_res = dispatch_device_->deferred_operation_post_check.pop(deferredOperation);
         if (find_res->first) {
             cleanup_fn = std::move(find_res->second);
         }
         // Mutable lambda because we want to move the shared pointer contained in the copied vector
-        cleanup_fn.emplace_back([this, chassis_state, pipeline_states](std::pair<uint32_t, VkPipeline *> pipelines) mutable {
+        cleanup_fn.emplace_back([this, chassis_state, pipeline_states](std::pair<uint32_t, VkPipeline*> pipelines) mutable {
             // Just need to capture chassis state to maintain pipeline creations parameters alive, see
             // https://vkdoc.net/chapters/deferred-host-operations#deferred-host-operations-requesting
             (void)chassis_state;
@@ -2405,19 +2405,19 @@ void DeviceState::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, Vk
     }
 }
 
-std::shared_ptr<vvl::Pipeline> DeviceState::CreateDataGraphPipelineState(const VkDataGraphPipelineCreateInfoARM *pCreateInfo,
+std::shared_ptr<vvl::Pipeline> DeviceState::CreateDataGraphPipelineState(const VkDataGraphPipelineCreateInfoARM* pCreateInfo,
                                                                          std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
-                                                                         std::shared_ptr<const vvl::PipelineLayout> &&layout,
-                                                                         spirv::StatelessData *stateless_data) const {
+                                                                         std::shared_ptr<const vvl::PipelineLayout>&& layout,
+                                                                         spirv::StatelessData* stateless_data) const {
     return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(layout), stateless_data);
 }
 
 bool DeviceState::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                              VkPipelineCache pipelineCache, uint32_t count,
-                                                             const VkDataGraphPipelineCreateInfoARM *pCreateInfos,
-                                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                             const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                             chassis::CreateDataGraphPipelinesARM &chassis_state) const {
+                                                             const VkDataGraphPipelineCreateInfoARM* pCreateInfos,
+                                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                             const ErrorObject& error_obj, PipelineStates& pipeline_states,
+                                                             chassis::CreateDataGraphPipelinesARM& chassis_state) const {
     pipeline_states.reserve(count);
     auto pipeline_cache = Get<vvl::PipelineCache>(pipelineCache);
     for (uint32_t i = 0; i < count; i++) {
@@ -2430,10 +2430,10 @@ bool DeviceState::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, Vk
 
 void DeviceState::PostCallRecordCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                             VkPipelineCache pipelineCache, uint32_t count,
-                                                            const VkDataGraphPipelineCreateInfoARM *pCreateInfos,
-                                                            const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                            const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                            chassis::CreateDataGraphPipelinesARM &chassis_state) {
+                                                            const VkDataGraphPipelineCreateInfoARM* pCreateInfos,
+                                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                            const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                            chassis::CreateDataGraphPipelinesARM& chassis_state) {
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {
@@ -2445,16 +2445,16 @@ void DeviceState::PostCallRecordCreateDataGraphPipelinesARM(VkDevice device, VkD
 }
 
 void DeviceState::PostCallRecordCmdDispatchDataGraphARM(VkCommandBuffer commandBuffer, VkDataGraphPipelineSessionARM session,
-                                                        const VkDataGraphPipelineDispatchInfoARM *pInfo,
-                                                        const RecordObject &record_obj) {
+                                                        const VkDataGraphPipelineDispatchInfoARM* pInfo,
+                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     std::shared_ptr<vvl::DataGraphPipelineSession> pipeline_session = Get<vvl::DataGraphPipelineSession>(session);
     cb_state->AddChild(pipeline_session);
 }
 
-void DeviceState::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
-                                              const VkAllocationCallbacks *pAllocator, VkSampler *pSampler,
-                                              const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                              const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
+                                              const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2466,18 +2466,18 @@ void DeviceState::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCr
     }
 }
 
-void DeviceState::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator,
-                                                          VkDescriptorSetLayout *pSetLayout, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator,
+                                                          VkDescriptorSetLayout* pSetLayout, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     Add(std::make_shared<DescriptorSetLayout>(*this, pCreateInfo, *pSetLayout));
 }
 
-void DeviceState::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
-                                                     const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
+                                                     const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2485,25 +2485,25 @@ void DeviceState::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPi
 }
 
 std::shared_ptr<DescriptorPool> DeviceState::CreateDescriptorPoolState(VkDescriptorPool handle,
-                                                                       const VkDescriptorPoolCreateInfo *create_info) {
+                                                                       const VkDescriptorPoolCreateInfo* create_info) {
     return std::make_shared<DescriptorPool>(*this, handle, create_info);
 }
 
-std::shared_ptr<DescriptorSet> DeviceState::CreateDescriptorSet(VkDescriptorSet handle, DescriptorPool *pool,
-                                                                const std::shared_ptr<DescriptorSetLayout const> &layout,
+std::shared_ptr<DescriptorSet> DeviceState::CreateDescriptorSet(VkDescriptorSet handle, DescriptorPool* pool,
+                                                                const std::shared_ptr<DescriptorSetLayout const>& layout,
                                                                 uint32_t variable_count) {
     return std::make_shared<DescriptorSet>(handle, pool, layout, variable_count, this);
 }
 std::shared_ptr<vvl::DescriptorSet> DeviceState::CreatePushDescriptorSet(
-    const std::shared_ptr<vvl::DescriptorSetLayout const> &layout) {
+    const std::shared_ptr<vvl::DescriptorSetLayout const>& layout) {
     auto ds = CreateDescriptorSet(VK_NULL_HANDLE, nullptr, layout, 0);
     NotifyCreated(*ds);
     return ds;
 }
 
-void DeviceState::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkDescriptorPool *pDescriptorPool,
-                                                     const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
+                                                     const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2511,7 +2511,7 @@ void DeviceState::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDe
 }
 
 void DeviceState::PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
-                                                    VkDescriptorPoolResetFlags flags, const RecordObject &record_obj) {
+                                                    VkDescriptorPoolResetFlags flags, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2521,10 +2521,10 @@ void DeviceState::PostCallRecordResetDescriptorPool(VkDevice device, VkDescripto
 }
 
 // We do some state tracking prior so other things can use it at PreCallValidate time as well
-bool DeviceState::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                                        VkDescriptorSet *pDescriptorSets, const ErrorObject &error_obj,
-                                                        AllocateDescriptorSetsData &ads_state) const {
-    const auto *count_allocate_info =
+bool DeviceState::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                                        VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj,
+                                                        AllocateDescriptorSetsData& ads_state) const {
+    const auto* count_allocate_info =
         vku::FindStructInPNextChain<VkDescriptorSetVariableDescriptorCountAllocateInfo>(pAllocateInfo->pNext);
 
     ads_state.layout_nodes.resize(pAllocateInfo->descriptorSetCount);
@@ -2533,7 +2533,7 @@ bool DeviceState::PreCallValidateAllocateDescriptorSets(VkDevice device, const V
             ads_state.layout_nodes[i] = layout;
             // Count total descriptors required per type
             for (uint32_t j = 0; j < layout->GetBindingCount(); ++j) {
-                const auto &binding_layout = layout->GetDescriptorSetLayoutBindingPtrFromIndex(j);
+                const auto& binding_layout = layout->GetDescriptorSetLayoutBindingPtrFromIndex(j);
                 uint32_t type_index = static_cast<uint32_t>(binding_layout->descriptorType);
                 uint32_t descriptor_count = binding_layout->descriptorCount;
                 if (count_allocate_info && i < count_allocate_info->descriptorSetCount) {
@@ -2566,8 +2566,8 @@ bool DeviceState::PreCallValidateAllocateDescriptorSets(VkDevice device, const V
 
 // This is calculated once in DeviceState::PreCallValidateAllocateDescriptorSets, but if found an error, provide a way to show how
 // we calculated this
-std::string DeviceState::PrintDescriptorAllocation(const VkDescriptorSetAllocateInfo &allocate_info,
-                                                   const vvl::DescriptorPool &pool_state, VkDescriptorType type) const {
+std::string DeviceState::PrintDescriptorAllocation(const VkDescriptorSetAllocateInfo& allocate_info,
+                                                   const vvl::DescriptorPool& pool_state, VkDescriptorType type) const {
     std::ostringstream ss;
     ss << "Where " << string_VkDescriptorType(type) << " is found in the pool:\n";
     for (const auto [pool_size_i, pool_size] :
@@ -2577,13 +2577,13 @@ std::string DeviceState::PrintDescriptorAllocation(const VkDescriptorSetAllocate
         }
     }
 
-    const auto *count_allocate_info =
+    const auto* count_allocate_info =
         vku::FindStructInPNextChain<VkDescriptorSetVariableDescriptorCountAllocateInfo>(allocate_info.pNext);
     ss << "Where the allocation are being requested:\n";
     for (const auto [set_layout_i, set_layout] : vvl::enumerate(allocate_info.pSetLayouts, allocate_info.descriptorSetCount)) {
         if (auto ds_layout_state = Get<vvl::DescriptorSetLayout>(set_layout)) {
             for (uint32_t i = 0; i < ds_layout_state->GetBindingCount(); ++i) {
-                const auto &binding_layout = ds_layout_state->GetDescriptorSetLayoutBindingPtrFromIndex(i);
+                const auto& binding_layout = ds_layout_state->GetDescriptorSetLayoutBindingPtrFromIndex(i);
                 if (binding_layout->descriptorType != type) {
                     continue;
                 }
@@ -2621,9 +2621,9 @@ std::string DeviceState::PrintDescriptorAllocation(const VkDescriptorSetAllocate
 }
 
 // Allocation state was good and call down chain was made so update state based on allocating descriptor sets
-void DeviceState::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
-                                                       VkDescriptorSet *pDescriptorSets, const RecordObject &record_obj,
-                                                       AllocateDescriptorSetsData &ads_state) {
+void DeviceState::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                                       VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj,
+                                                       AllocateDescriptorSetsData& ads_state) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2634,14 +2634,14 @@ void DeviceState::PostCallRecordAllocateDescriptorSets(VkDevice device, const Vk
 }
 
 void DeviceState::PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t count,
-                                                  const VkDescriptorSet *pDescriptorSets, const RecordObject &record_obj) {
+                                                  const VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) {
     if (auto ds_pool_state = Get<DescriptorPool>(descriptorPool)) {
         ds_pool_state->Free(count, pDescriptorSets);
     }
 }
 
-void DeviceState::PerformUpdateDescriptorSets(uint32_t write_count, const VkWriteDescriptorSet *p_wds, uint32_t copy_count,
-                                              const VkCopyDescriptorSet *p_cds) {
+void DeviceState::PerformUpdateDescriptorSets(uint32_t write_count, const VkWriteDescriptorSet* p_wds, uint32_t copy_count,
+                                              const VkCopyDescriptorSet* p_cds) {
     // Write updates first
     for (uint32_t i = 0; i < write_count; ++i) {
         const VkDescriptorSet dst_set = p_wds[i].dstSet;
@@ -2662,13 +2662,13 @@ void DeviceState::PerformUpdateDescriptorSets(uint32_t write_count, const VkWrit
 }
 
 void DeviceState::PreCallRecordUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
-                                                    const VkWriteDescriptorSet *pDescriptorWrites, uint32_t descriptorCopyCount,
-                                                    const VkCopyDescriptorSet *pDescriptorCopies, const RecordObject &record_obj) {
+                                                    const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
+                                                    const VkCopyDescriptorSet* pDescriptorCopies, const RecordObject& record_obj) {
     PerformUpdateDescriptorSets(descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
 }
 
-void DeviceState::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo *pAllocateInfo,
-                                                       VkCommandBuffer *pCommandBuffers, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                                       VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2677,19 +2677,19 @@ void DeviceState::PostCallRecordAllocateCommandBuffers(VkDevice device, const Vk
     }
 }
 
-void DeviceState::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *pBeginInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
+                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->Begin(pBeginInfo);
 }
 
-void DeviceState::PostCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->End(record_obj.result);
 }
 
 void DeviceState::PostCallRecordResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags,
-                                                   const RecordObject &record_obj) {
+                                                   const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2698,7 +2698,7 @@ void DeviceState::PostCallRecordResetCommandBuffer(VkCommandBuffer commandBuffer
 }
 
 void DeviceState::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
-                                                VkPipeline pipeline, const RecordObject &record_obj) {
+                                                VkPipeline pipeline, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     auto pipeline_state = Get<Pipeline>(pipeline);
@@ -2711,14 +2711,14 @@ void DeviceState::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, V
 }
 
 void DeviceState::PostCallRecordCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
-                                               const VkViewport *pViewports, const RecordObject &record_obj) {
+                                               const VkViewport* pViewports, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetViewport(firstViewport, viewportCount, pViewports);
 }
 
 void DeviceState::PostCallRecordCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
-                                                         uint32_t exclusiveScissorCount, const VkRect2D *pExclusiveScissors,
-                                                         const RecordObject &record_obj) {
+                                                         uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors,
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV);
     // TODO: We don't have VUIDs for validating that all exclusive scissors have been set.
@@ -2734,8 +2734,8 @@ void DeviceState::PostCallRecordCmdSetExclusiveScissorNV(VkCommandBuffer command
 
 void DeviceState::PostCallRecordCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                                uint32_t exclusiveScissorCount,
-                                                               const VkBool32 *pExclusiveScissorEnables,
-                                                               const RecordObject &record_obj) {
+                                                               const VkBool32* pExclusiveScissorEnables,
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_ENABLE_NV);
 
@@ -2748,7 +2748,7 @@ void DeviceState::PostCallRecordCmdSetExclusiveScissorEnableNV(VkCommandBuffer c
 }
 
 void DeviceState::PostCallRecordCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
-                                                          VkImageLayout imageLayout, const RecordObject &record_obj) {
+                                                          VkImageLayout imageLayout, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -2762,8 +2762,8 @@ void DeviceState::PostCallRecordCmdBindShadingRateImageNV(VkCommandBuffer comman
 
 void DeviceState::PostCallRecordCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                                    uint32_t viewportCount,
-                                                                   const VkShadingRatePaletteNV *pShadingRatePalettes,
-                                                                   const RecordObject &record_obj) {
+                                                                   const VkShadingRatePaletteNV* pShadingRatePalettes,
+                                                                   const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV);
     // TODO: We don't have VUIDs for validating that all shading rate palettes have been set.
@@ -2772,15 +2772,15 @@ void DeviceState::PostCallRecordCmdSetViewportShadingRatePaletteNV(VkCommandBuff
 }
 
 std::shared_ptr<AccelerationStructureNV> DeviceState::CreateAccelerationStructureState(
-    VkAccelerationStructureNV handle, const VkAccelerationStructureCreateInfoNV *create_info) {
+    VkAccelerationStructureNV handle, const VkAccelerationStructureCreateInfoNV* create_info) {
     return std::make_shared<AccelerationStructureNV>(device, handle, create_info);
 }
 
 void DeviceState::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
-                                                              const VkAccelerationStructureCreateInfoNV *pCreateInfo,
-                                                              const VkAllocationCallbacks *pAllocator,
-                                                              VkAccelerationStructureNV *pAccelerationStructure,
-                                                              const RecordObject &record_obj) {
+                                                              const VkAccelerationStructureCreateInfoNV* pCreateInfo,
+                                                              const VkAllocationCallbacks* pAllocator,
+                                                              VkAccelerationStructureNV* pAccelerationStructure,
+                                                              const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2788,8 +2788,8 @@ void DeviceState::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
 }
 
 std::shared_ptr<AccelerationStructureKHR> DeviceState::CreateAccelerationStructureState(
-    VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *create_info,
-    std::shared_ptr<Buffer> &&buf_state) {
+    VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR* create_info,
+    std::shared_ptr<Buffer>&& buf_state) {
     // If the buffer's device address has not been queried,
     // get it here. Since it is used for the purpose of
     // validation, do not try to update buffer_state, since
@@ -2806,10 +2806,10 @@ std::shared_ptr<AccelerationStructureKHR> DeviceState::CreateAccelerationStructu
 }
 
 void DeviceState::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
-                                                               const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
-                                                               const VkAllocationCallbacks *pAllocator,
-                                                               VkAccelerationStructureKHR *pAccelerationStructure,
-                                                               const RecordObject &record_obj) {
+                                                               const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
+                                                               const VkAllocationCallbacks* pAllocator,
+                                                               VkAccelerationStructureKHR* pAccelerationStructure,
+                                                               const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2839,8 +2839,8 @@ void DeviceState::PostCallRecordCreateAccelerationStructure2KHR(VkDevice device,
 
 void DeviceState::PostCallRecordBuildAccelerationStructuresKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
-    const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const RecordObject &record_obj) {
+    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
     // Discussion what a failed build with multiple AccelerationStructures would mean
     // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4254
     if (record_obj.result != VK_SUCCESS) {
@@ -2855,8 +2855,8 @@ void DeviceState::PostCallRecordBuildAccelerationStructuresKHR(
 }
 
 // helper method for device side acceleration structure builds
-void DeviceState::RecordDeviceAccelerationStructureBuildInfo(CommandBuffer &cb_state,
-                                                             const VkAccelerationStructureBuildGeometryInfoKHR &info) {
+void DeviceState::RecordDeviceAccelerationStructureBuildInfo(CommandBuffer& cb_state,
+                                                             const VkAccelerationStructureBuildGeometryInfoKHR& info) {
     auto dst_as_state = Get<AccelerationStructureKHR>(info.dstAccelerationStructure);
     if (dst_as_state) {
         dst_as_state->Build(&info, false, nullptr);
@@ -2878,8 +2878,8 @@ void DeviceState::RecordDeviceAccelerationStructureBuildInfo(CommandBuffer &cb_s
 }
 
 void DeviceState::PostCallRecordCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
 
@@ -2893,11 +2893,11 @@ void DeviceState::PostCallRecordCmdBuildAccelerationStructuresKHR(
 }
 
 void DeviceState::PostCallRecordCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                                          const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-                                                                          const VkDeviceAddress *pIndirectDeviceAddresses,
-                                                                          const uint32_t *pIndirectStrides,
-                                                                          const uint32_t *const *ppMaxPrimitiveCounts,
-                                                                          const RecordObject &record_obj) {
+                                                                          const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+                                                                          const VkDeviceAddress* pIndirectDeviceAddresses,
+                                                                          const uint32_t* pIndirectStrides,
+                                                                          const uint32_t* const* ppMaxPrimitiveCounts,
+                                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
 
@@ -2912,8 +2912,8 @@ void DeviceState::PostCallRecordCmdBuildAccelerationStructuresIndirectKHR(VkComm
 }
 
 void DeviceState::PostCallRecordGetAccelerationStructureMemoryRequirementsNV(
-    VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV *pInfo, VkMemoryRequirements2 *pMemoryRequirements,
-    const RecordObject &record_obj) {
+    VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo, VkMemoryRequirements2* pMemoryRequirements,
+    const RecordObject& record_obj) {
     if (auto as_state = Get<AccelerationStructureNV>(pInfo->accelerationStructure)) {
         if (pInfo->type == VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV) {
             as_state->memory_requirements_checked = true;
@@ -2926,13 +2926,13 @@ void DeviceState::PostCallRecordGetAccelerationStructureMemoryRequirementsNV(
 }
 
 void DeviceState::PostCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
-                                                                  const VkBindAccelerationStructureMemoryInfoNV *pBindInfos,
-                                                                  const RecordObject &record_obj) {
+                                                                  const VkBindAccelerationStructureMemoryInfoNV* pBindInfos,
+                                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        const VkBindAccelerationStructureMemoryInfoNV &info = pBindInfos[i];
+        const VkBindAccelerationStructureMemoryInfoNV& info = pBindInfos[i];
 
         if (auto as_state = Get<AccelerationStructureNV>(info.accelerationStructure)) {
             // Track objects tied to memory
@@ -2950,11 +2950,11 @@ void DeviceState::PostCallRecordBindAccelerationStructureMemoryNV(VkDevice devic
 }
 
 void DeviceState::PostCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer,
-                                                                const VkAccelerationStructureInfoNV *pInfo, VkBuffer instanceData,
+                                                                const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData,
                                                                 VkDeviceSize instanceOffset, VkBool32 update,
                                                                 VkAccelerationStructureNV dst, VkAccelerationStructureNV src,
                                                                 VkBuffer scratch, VkDeviceSize scratchOffset,
-                                                                const RecordObject &record_obj) {
+                                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     if (!cb_state) {
         return;
@@ -2980,7 +2980,7 @@ void DeviceState::PostCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer 
         }
 
         for (uint32_t i = 0; i < pInfo->geometryCount; i++) {
-            const auto &geom = pInfo->pGeometries[i];
+            const auto& geom = pInfo->pGeometries[i];
 
             if (auto vertex_buffer = Get<Buffer>(geom.geometry.triangles.vertexData)) {
                 cb_state->AddChild(vertex_buffer);
@@ -3001,7 +3001,7 @@ void DeviceState::PostCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer 
 void DeviceState::PostCallRecordCmdCopyAccelerationStructureNV(VkCommandBuffer commandBuffer, VkAccelerationStructureNV dst,
                                                                VkAccelerationStructureNV src,
                                                                VkCopyAccelerationStructureModeNV mode,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -3017,8 +3017,8 @@ void DeviceState::PostCallRecordCmdCopyAccelerationStructureNV(VkCommandBuffer c
 }
 
 void DeviceState::PreCallRecordDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure,
-                                                               const VkAllocationCallbacks *pAllocator,
-                                                               const RecordObject &record_obj) {
+                                                               const VkAllocationCallbacks* pAllocator,
+                                                               const RecordObject& record_obj) {
     if (auto as_state = Get<vvl::AccelerationStructureKHR>(accelerationStructure)) {
         if (as_state->acceleration_structure_address != 0) {
             WriteLockGuard lock(as_with_addresses.array_mutex);
@@ -3037,14 +3037,14 @@ void DeviceState::PreCallRecordDestroyAccelerationStructureKHR(VkDevice device, 
 }
 
 void DeviceState::PreCallRecordDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
-                                                              const VkAllocationCallbacks *pAllocator,
-                                                              const RecordObject &record_obj) {
+                                                              const VkAllocationCallbacks* pAllocator,
+                                                              const RecordObject& record_obj) {
     Destroy<AccelerationStructureNV>(accelerationStructure);
 }
 
 void DeviceState::PostCallRecordCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                                         uint32_t viewportCount, const VkViewportWScalingNV *pViewportWScalings,
-                                                         const RecordObject &record_obj) {
+                                                         uint32_t viewportCount, const VkViewportWScalingNV* pViewportWScalings,
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV);
     cb_state->dynamic_state_value.viewport_w_scaling_first = firstViewport;
@@ -3055,65 +3055,65 @@ void DeviceState::PostCallRecordCmdSetViewportWScalingNV(VkCommandBuffer command
     }
 }
 
-void DeviceState::PostCallRecordCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_LINE_WIDTH);
 }
 
 void DeviceState::PostCallRecordCmdSetLineStipple(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                                  uint16_t lineStipplePattern, const RecordObject &record_obj) {
+                                                  uint16_t lineStipplePattern, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_LINE_STIPPLE);
 }
 
 void DeviceState::PostCallRecordCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                                     uint16_t lineStipplePattern, const RecordObject &record_obj) {
+                                                     uint16_t lineStipplePattern, const RecordObject& record_obj) {
     PostCallRecordCmdSetLineStipple(commandBuffer, lineStippleFactor, lineStipplePattern, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetLineStippleKHR(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                                     uint16_t lineStipplePattern, const RecordObject &record_obj) {
+                                                     uint16_t lineStipplePattern, const RecordObject& record_obj) {
     PostCallRecordCmdSetLineStipple(commandBuffer, lineStippleFactor, lineStipplePattern, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor, float depthBiasClamp,
-                                                float depthBiasSlopeFactor, const RecordObject &record_obj) {
+                                                float depthBiasSlopeFactor, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_BIAS);
 }
 
-void DeviceState::PostCallRecordCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT *pDepthBiasInfo,
-                                                    const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT* pDepthBiasInfo,
+                                                    const RecordObject& record_obj) {
     PostCallRecordCmdSetDepthBias(commandBuffer, pDepthBiasInfo->depthBiasConstantFactor, pDepthBiasInfo->depthBiasClamp,
                                   pDepthBiasInfo->depthBiasSlopeFactor, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
-                                              const VkRect2D *pScissors, const RecordObject &record_obj) {
+                                              const VkRect2D* pScissors, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetScissor(firstScissor, scissorCount);
 }
 
 void DeviceState::PostCallRecordCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4],
-                                                     const RecordObject &record_obj) {
+                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_BLEND_CONSTANTS);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds, float maxDepthBounds,
-                                                  const RecordObject &record_obj) {
+                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_BOUNDS);
 }
 
 void DeviceState::PostCallRecordCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                                         uint32_t compareMask, const RecordObject &record_obj) {
+                                                         uint32_t compareMask, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_STENCIL_COMPARE_MASK);
 }
 
 void DeviceState::PostCallRecordCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                                       uint32_t writeMask, const RecordObject &record_obj) {
+                                                       uint32_t writeMask, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_STENCIL_WRITE_MASK);
     if (faceMask == VK_STENCIL_FACE_FRONT_BIT || faceMask == VK_STENCIL_FACE_FRONT_AND_BACK) {
@@ -3125,7 +3125,7 @@ void DeviceState::PostCallRecordCmdSetStencilWriteMask(VkCommandBuffer commandBu
 }
 
 void DeviceState::PostCallRecordCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
-                                                       uint32_t reference, const RecordObject &record_obj) {
+                                                       uint32_t reference, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_STENCIL_REFERENCE);
 }
@@ -3133,8 +3133,8 @@ void DeviceState::PostCallRecordCmdSetStencilReference(VkCommandBuffer commandBu
 // Update the bound state for the bind point, including the effects of incompatible pipeline layouts
 void DeviceState::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                       VkPipelineLayout layout, uint32_t firstSet, uint32_t setCount,
-                                                      const VkDescriptorSet *pDescriptorSets, uint32_t dynamicOffsetCount,
-                                                      const uint32_t *pDynamicOffsets, const RecordObject &record_obj) {
+                                                      const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
+                                                      const uint32_t* pDynamicOffsets, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto pipeline_layout = Get<PipelineLayout>(layout);
     if (!cb_state || !pipeline_layout) {
@@ -3154,8 +3154,8 @@ void DeviceState::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuf
 }
 
 void DeviceState::PostCallRecordCmdBindDescriptorSets2(VkCommandBuffer commandBuffer,
-                                                       const VkBindDescriptorSetsInfo *pBindDescriptorSetsInfo,
-                                                       const RecordObject &record_obj) {
+                                                       const VkBindDescriptorSetsInfo* pBindDescriptorSetsInfo,
+                                                       const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto pipeline_layout = Get<PipelineLayout>(pBindDescriptorSetsInfo->layout);
     ASSERT_AND_RETURN(cb_state && pipeline_layout);
@@ -3190,15 +3190,15 @@ void DeviceState::PostCallRecordCmdBindDescriptorSets2(VkCommandBuffer commandBu
 }
 
 void DeviceState::PostCallRecordCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
-                                                          const VkBindDescriptorSetsInfoKHR *pBindDescriptorSetsInfo,
-                                                          const RecordObject &record_obj) {
+                                                          const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo,
+                                                          const RecordObject& record_obj) {
     PostCallRecordCmdBindDescriptorSets2(commandBuffer, pBindDescriptorSetsInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdPushDescriptorSet(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                      VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                                     const VkWriteDescriptorSet *pDescriptorWrites,
-                                                     const RecordObject &record_obj) {
+                                                     const VkWriteDescriptorSet* pDescriptorWrites,
+                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto pipeline_layout = Get<PipelineLayout>(layout);
     ASSERT_AND_RETURN(pipeline_layout);
@@ -3214,15 +3214,15 @@ void DeviceState::PostCallRecordCmdPushDescriptorSet(VkCommandBuffer commandBuff
 
 void DeviceState::PostCallRecordCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                         VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                                        const VkWriteDescriptorSet *pDescriptorWrites,
-                                                        const RecordObject &record_obj) {
+                                                        const VkWriteDescriptorSet* pDescriptorWrites,
+                                                        const RecordObject& record_obj) {
     PostCallRecordCmdPushDescriptorSet(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites,
                                        record_obj);
 }
 
 void DeviceState::PostCallRecordCmdPushDescriptorSet2(VkCommandBuffer commandBuffer,
-                                                      const VkPushDescriptorSetInfo *pPushDescriptorSetInfo,
-                                                      const RecordObject &record_obj) {
+                                                      const VkPushDescriptorSetInfo* pPushDescriptorSetInfo,
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto pipeline_layout = Get<PipelineLayout>(pPushDescriptorSetInfo->layout);
     ASSERT_AND_RETURN(pipeline_layout);
@@ -3250,20 +3250,20 @@ void DeviceState::PostCallRecordCmdPushDescriptorSet2(VkCommandBuffer commandBuf
 }
 
 void DeviceState::PostCallRecordCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
-                                                         const VkPushDescriptorSetInfoKHR *pPushDescriptorSetInfo,
-                                                         const RecordObject &record_obj) {
+                                                         const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo,
+                                                         const RecordObject& record_obj) {
     PostCallRecordCmdPushDescriptorSet2(commandBuffer, pPushDescriptorSetInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                                            const VkDescriptorBufferBindingInfoEXT *pBindingInfos,
-                                                            const RecordObject &record_obj) {
+                                                            const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
+                                                            const RecordObject& record_obj) {
     auto cb_state = Get<CommandBuffer>(commandBuffer);
     cb_state->descriptor_buffer.ever_bound = true;
 
     cb_state->descriptor_buffer.binding_info.resize(bufferCount);
     for (uint32_t i = 0; i < bufferCount; i++) {
-        const VkDescriptorBufferBindingInfoEXT &binding_info = pBindingInfos[i];
+        const VkDescriptorBufferBindingInfoEXT& binding_info = pBindingInfos[i];
         VkBufferUsageFlags2 buffer_usage = binding_info.usage;
         if (const auto usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(binding_info.pNext)) {
             buffer_usage = usage_flags2->usage;
@@ -3280,14 +3280,14 @@ void DeviceState::PostCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
 void DeviceState::PostCallRecordCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
                                                                            VkPipelineBindPoint pipelineBindPoint,
                                                                            VkPipelineLayout layout, uint32_t set,
-                                                                           const RecordObject &record_obj) {
+                                                                           const RecordObject& record_obj) {
     auto cb_state = Get<CommandBuffer>(commandBuffer);
     cb_state->SetDescriptorMode(DescriptorModeBuffer, record_obj.location.function);
 }
 
 void DeviceState::PostCallRecordCmdBindDescriptorBufferEmbeddedSamplers2EXT(
-    VkCommandBuffer commandBuffer, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT *pBindDescriptorBufferEmbeddedSamplersInfo,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo,
+    const RecordObject& record_obj) {
     auto cb_state = Get<CommandBuffer>(commandBuffer);
     cb_state->SetDescriptorMode(DescriptorModeBuffer, record_obj.location.function);
 }
@@ -3295,8 +3295,8 @@ void DeviceState::PostCallRecordCmdBindDescriptorBufferEmbeddedSamplers2EXT(
 void DeviceState::PostCallRecordCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer,
                                                                  VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
                                                                  uint32_t firstSet, uint32_t setCount,
-                                                                 const uint32_t *pBufferIndices, const VkDeviceSize *pOffsets,
-                                                                 const RecordObject &record_obj) {
+                                                                 const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets,
+                                                                 const RecordObject& record_obj) {
     auto cb_state = Get<CommandBuffer>(commandBuffer);
     auto pipeline_layout = Get<PipelineLayout>(layout);
     ASSERT_AND_RETURN(pipeline_layout);
@@ -3307,8 +3307,8 @@ void DeviceState::PostCallRecordCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer
 }
 
 void DeviceState::PostCallRecordCmdSetDescriptorBufferOffsets2EXT(
-    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT *pSetDescriptorBufferOffsetsInfo,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo,
+    const RecordObject& record_obj) {
     auto cb_state = Get<CommandBuffer>(commandBuffer);
     auto pipeline_layout = Get<PipelineLayout>(pSetDescriptorBufferOffsetsInfo->layout);
     ASSERT_AND_RETURN(pipeline_layout);
@@ -3336,8 +3336,8 @@ void DeviceState::PostCallRecordCmdSetDescriptorBufferOffsets2EXT(
 }
 
 void DeviceState::PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
-                                                 VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void *pValues,
-                                                 const RecordObject &record_obj) {
+                                                 VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues,
+                                                 const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto pipeline_layout_state = Get<PipelineLayout>(layout);
     ASSERT_AND_RETURN(cb_state && pipeline_layout_state);
@@ -3348,20 +3348,20 @@ void DeviceState::PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, 
     cb_state->InvalidateDescriptorMode(vvl::DescriptorModeHeap, record_obj.location.function);
 }
 
-void DeviceState::PostCallRecordCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo *pPushConstantsInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo* pPushConstantsInfo,
+                                                  const RecordObject& record_obj) {
     PostCallRecordCmdPushConstants(commandBuffer, pPushConstantsInfo->layout, pPushConstantsInfo->stageFlags,
                                    pPushConstantsInfo->offset, pPushConstantsInfo->size, pPushConstantsInfo->pValues, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
-                                                     const VkPushConstantsInfoKHR *pPushConstantsInfo,
-                                                     const RecordObject &record_obj) {
+                                                     const VkPushConstantsInfoKHR* pPushConstantsInfo,
+                                                     const RecordObject& record_obj) {
     PostCallRecordCmdPushConstants2(commandBuffer, pPushConstantsInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                   VkIndexType indexType, const RecordObject &record_obj) {
+                                                   VkIndexType indexType, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     if (buffer == VK_NULL_HANDLE) {
         if (enabled_features.maintenance6) {
@@ -3383,7 +3383,7 @@ void DeviceState::PostCallRecordCmdBindIndexBuffer(VkCommandBuffer commandBuffer
 }
 
 void DeviceState::PostCallRecordCmdBindIndexBuffer2(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                    VkDeviceSize size, VkIndexType indexType, const RecordObject &record_obj) {
+                                                    VkDeviceSize size, VkIndexType indexType, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     if (buffer == VK_NULL_HANDLE) {
         if (enabled_features.maintenance6) {
@@ -3403,20 +3403,20 @@ void DeviceState::PostCallRecordCmdBindIndexBuffer2(VkCommandBuffer commandBuffe
 }
 
 void DeviceState::PostCallRecordCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                       VkDeviceSize size, VkIndexType indexType, const RecordObject &record_obj) {
+                                                       VkDeviceSize size, VkIndexType indexType, const RecordObject& record_obj) {
     PostCallRecordCmdBindIndexBuffer2(commandBuffer, buffer, offset, size, indexType, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdBindIndexBuffer3KHR(VkCommandBuffer commandBuffer, const VkBindIndexBuffer3InfoKHR *pInfo,
-                                                       const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBindIndexBuffer3KHR(VkCommandBuffer commandBuffer, const VkBindIndexBuffer3InfoKHR* pInfo,
+                                                       const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->index_buffer_binding = IndexBufferBinding(pInfo->addressRange.address, pInfo->addressRange.size, pInfo->indexType);
     TrackDeviceAddressRange(*cb_state, pInfo->addressRange.address, pInfo->addressRange.size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 }
 
 void DeviceState::PostCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                                     const VkBuffer *pBuffers, const VkDeviceSize *pOffsets,
-                                                     const RecordObject &record_obj) {
+                                                     const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
+                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     cb_state->bind_vertex_buffer_3_used = false;
@@ -3435,7 +3435,7 @@ void DeviceState::PostCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuff
 }
 
 void DeviceState::PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                VkDeviceSize dataSize, const void *pData, const RecordObject &record_obj) {
+                                                VkDeviceSize dataSize, const void* pData, const RecordObject& record_obj) {
     if (disabled[command_buffer_state]) return;
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
@@ -3459,18 +3459,18 @@ void DeviceState::PostCallRecordCmdUpdateMemoryKHR(VkCommandBuffer commandBuffer
 }
 
 void DeviceState::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                            const RecordObject &record_obj) {
+                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetEvent(event, stageMask, nullptr, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                                const VkDependencyInfoKHR *pDependencyInfo, const RecordObject &record_obj) {
+                                                const VkDependencyInfoKHR* pDependencyInfo, const RecordObject& record_obj) {
     PostCallRecordCmdSetEvent2(commandBuffer, event, pDependencyInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo *pDependencyInfo,
-                                             const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
+                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto exec_scopes = sync_utils::GetExecScopes(*pDependencyInfo);
 
@@ -3479,28 +3479,28 @@ void DeviceState::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEv
 }
 
 void DeviceState::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                              const RecordObject &record_obj) {
+                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordResetEvent(event, stageMask, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
-                                                  const RecordObject &record_obj) {
+                                                  const RecordObject& record_obj) {
     PostCallRecordCmdResetEvent2(commandBuffer, event, stageMask, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
-                                               const RecordObject &record_obj) {
+                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordResetEvent(event, stageMask, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+void DeviceState::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                               VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
-                                              uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-                                              uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
-                                              uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
-                                              const RecordObject &record_obj) {
+                                              uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+                                              uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                              uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
+                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     cb_state->RecordWaitEvents(eventCount, pEvents, sourceStageMask, nullptr, record_obj.location);
@@ -3508,19 +3508,19 @@ void DeviceState::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uin
                                    sourceStageMask, dstStageMask, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                  const VkDependencyInfoKHR *pDependencyInfos, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                  const VkDependencyInfoKHR* pDependencyInfos, const RecordObject& record_obj) {
     PostCallRecordCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                               const VkDependencyInfo *pDependencyInfos, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                               const VkDependencyInfo* pDependencyInfos, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     for (uint32_t i = 0; i < eventCount; i++) {
-        const auto &dep_info = pDependencyInfos[i];
+        const auto& dep_info = pDependencyInfos[i];
         auto exec_scopes = sync_utils::GetExecScopes(dep_info);
-        const Location &dep_info_loc = record_obj.location.dot(vvl::Field::pDependencyInfos, i);
+        const Location& dep_info_loc = record_obj.location.dot(vvl::Field::pDependencyInfos, i);
         cb_state->RecordWaitEvents(1, &pEvents[i], exec_scopes.src, &pDependencyInfos[i], dep_info_loc);
         cb_state->RecordBarrierObjects(dep_info, dep_info_loc);
     }
@@ -3528,29 +3528,29 @@ void DeviceState::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
 
 void DeviceState::PostCallRecordCmdPipelineBarrier(
     VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-    const VkImageMemoryBarrier *pImageMemoryBarriers, const RecordObject &record_obj) {
+    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+    const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     cb_state->RecordBarrierObjects(bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers,
                                    srcStageMask, dstStageMask, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR *pDependencyInfo,
-                                                       const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR* pDependencyInfo,
+                                                       const RecordObject& record_obj) {
     PostCallRecordCmdPipelineBarrier2(commandBuffer, pDependencyInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,
-                                                    const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
+                                                    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     cb_state->RecordBarrierObjects(*pDependencyInfo, record_obj.location.dot(vvl::Field::pDependencyInfo));
 }
 
 void DeviceState::PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                              VkQueryControlFlags flags, const RecordObject &record_obj) {
+                                              VkQueryControlFlags flags, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     if (disabled[query_validation]) {
@@ -3573,7 +3573,7 @@ void DeviceState::PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
 }
 
 void DeviceState::PostCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                            const RecordObject &record_obj) {
+                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     if (disabled[query_validation]) {
@@ -3597,7 +3597,7 @@ void DeviceState::PostCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQue
 }
 
 void DeviceState::PostCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
-                                                  uint32_t queryCount, const RecordObject &record_obj) {
+                                                  uint32_t queryCount, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordResetQueryPool(queryPool, firstQuery, queryCount, record_obj.location);
 }
@@ -3605,7 +3605,7 @@ void DeviceState::PostCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer,
 void DeviceState::PostCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                                         uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                         VkDeviceSize stride, VkQueryResultFlags flags,
-                                                        const RecordObject &record_obj) {
+                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCopyQueryPoolResults(queryPool, dstBuffer, firstQuery, queryCount, dstOffset, stride, flags,
                                          record_obj.location);
@@ -3624,32 +3624,32 @@ void DeviceState::PostCallRecordCmdCopyQueryPoolResultsToMemoryKHR(VkCommandBuff
 }
 
 void DeviceState::PostCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
-                                                  VkQueryPool queryPool, uint32_t slot, const RecordObject &record_obj) {
+                                                  VkQueryPool queryPool, uint32_t slot, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordWriteTimestamp(queryPool, slot, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR pipelineStage,
-                                                      VkQueryPool queryPool, uint32_t slot, const RecordObject &record_obj) {
+                                                      VkQueryPool queryPool, uint32_t slot, const RecordObject& record_obj) {
     PostCallRecordCmdWriteTimestamp2(commandBuffer, pipelineStage, queryPool, slot, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 pipelineStage,
-                                                   VkQueryPool queryPool, uint32_t slot, const RecordObject &record_obj) {
+                                                   VkQueryPool queryPool, uint32_t slot, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordWriteTimestamp(queryPool, slot, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdWriteAccelerationStructuresPropertiesKHR(
-    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR *pAccelerationStructures,
-    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures,
+    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordWriteAccelerationStructuresProperties(queryPool, firstQuery, accelerationStructureCount, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkVideoSessionKHR *pVideoSession,
-                                                      const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession,
+                                                      const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3659,9 +3659,9 @@ void DeviceState::PostCallRecordCreateVideoSessionKHR(VkDevice device, const VkV
 }
 
 void DeviceState::PostCallRecordGetVideoSessionMemoryRequirementsKHR(VkDevice device, VkVideoSessionKHR videoSession,
-                                                                     uint32_t *pMemoryRequirementsCount,
-                                                                     VkVideoSessionMemoryRequirementsKHR *pMemoryRequirements,
-                                                                     const RecordObject &record_obj) {
+                                                                     uint32_t* pMemoryRequirementsCount,
+                                                                     VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements,
+                                                                     const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3680,8 +3680,8 @@ void DeviceState::PostCallRecordGetVideoSessionMemoryRequirementsKHR(VkDevice de
 
 void DeviceState::PostCallRecordBindVideoSessionMemoryKHR(VkDevice device, VkVideoSessionKHR videoSession,
                                                           uint32_t bindSessionMemoryInfoCount,
-                                                          const VkBindVideoSessionMemoryInfoKHR *pBindSessionMemoryInfos,
-                                                          const RecordObject &record_obj) {
+                                                          const VkBindVideoSessionMemoryInfoKHR* pBindSessionMemoryInfos,
+                                                          const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3695,15 +3695,15 @@ void DeviceState::PostCallRecordBindVideoSessionMemoryKHR(VkDevice device, VkVid
 }
 
 void DeviceState::PreCallRecordDestroyVideoSessionKHR(VkDevice device, VkVideoSessionKHR videoSession,
-                                                      const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                      const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<VideoSession>(videoSession);
 }
 
 void DeviceState::PostCallRecordCreateVideoSessionParametersKHR(VkDevice device,
-                                                                const VkVideoSessionParametersCreateInfoKHR *pCreateInfo,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                VkVideoSessionParametersKHR *pVideoSessionParameters,
-                                                                const RecordObject &record_obj) {
+                                                                const VkVideoSessionParametersCreateInfoKHR* pCreateInfo,
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                VkVideoSessionParametersKHR* pVideoSessionParameters,
+                                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3714,8 +3714,8 @@ void DeviceState::PostCallRecordCreateVideoSessionParametersKHR(VkDevice device,
 }
 
 void DeviceState::PostCallRecordUpdateVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters,
-                                                                const VkVideoSessionParametersUpdateInfoKHR *pUpdateInfo,
-                                                                const RecordObject &record_obj) {
+                                                                const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo,
+                                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3724,14 +3724,14 @@ void DeviceState::PostCallRecordUpdateVideoSessionParametersKHR(VkDevice device,
 }
 
 void DeviceState::PreCallRecordDestroyVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                const RecordObject &record_obj) {
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                const RecordObject& record_obj) {
     Destroy<VideoSessionParameters>(videoSessionParameters);
 }
 
-void DeviceState::PostCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkFramebuffer *pFramebuffer,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3748,24 +3748,24 @@ void DeviceState::PostCallRecordCreateFramebuffer(VkDevice device, const VkFrame
     Add(std::make_shared<Framebuffer>(*pFramebuffer, pCreateInfo, Get<RenderPass>(pCreateInfo->renderPass), std::move(views)));
 }
 
-void DeviceState::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                 const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     Add(std::make_shared<RenderPass>(*pRenderPass, pCreateInfo));
 }
 
-void DeviceState::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                     const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                     const RecordObject& record_obj) {
     PostCallRecordCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, record_obj);
 }
 
-void DeviceState::PostCallRecordCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3773,37 +3773,37 @@ void DeviceState::PostCallRecordCreateRenderPass2(VkDevice device, const VkRende
     Add(std::make_shared<RenderPass>(*pRenderPass, pCreateInfo));
 }
 
-void DeviceState::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                   VkSubpassContents contents, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                   VkSubpassContents contents, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     cb_state->RecordBeginRenderPass(*pRenderPassBegin, subpass_begin_info, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                       const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                       const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                       const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                       const RecordObject& record_obj) {
     PostCallRecordCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdBeginCustomResolveEXT(VkCommandBuffer commandBuffer,
-                                                         const VkBeginCustomResolveInfoEXT *pBeginCustomResolveInfo,
-                                                         const RecordObject &record_obj) {
+                                                         const VkBeginCustomResolveInfoEXT* pBeginCustomResolveInfo,
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordBeginCustomResolve(record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR *pBeginInfo,
-                                                       const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo,
+                                                       const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordBeginVideoCoding(*pBeginInfo, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                             uint32_t counterBufferCount, const VkBuffer *pCounterBuffers,
-                                                             const VkDeviceSize *pCounterBufferOffsets,
-                                                             const RecordObject &record_obj) {
+                                                             uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
+                                                             const VkDeviceSize* pCounterBufferOffsets,
+                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     cb_state->transform_feedback_active = true;
@@ -3823,9 +3823,9 @@ void DeviceState::PostCallRecordCmdBeginTransformFeedback2EXT(VkCommandBuffer co
 }
 
 void DeviceState::PostCallRecordCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                           uint32_t counterBufferCount, const VkBuffer *pCounterBuffers,
-                                                           const VkDeviceSize *pCounterBufferOffsets,
-                                                           const RecordObject &record_obj) {
+                                                           uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
+                                                           const VkDeviceSize* pCounterBufferOffsets,
+                                                           const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     cb_state->transform_feedback_active = false;
@@ -3846,37 +3846,37 @@ void DeviceState::PostCallRecordCmdEndTransformFeedback2EXT(VkCommandBuffer comm
 
 void DeviceState::PostCallRecordCmdDrawIndirectByteCount2EXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
                                                              uint32_t firstInstance,
-                                                             const VkBindTransformFeedbackBuffer2InfoEXT *pCounterInfo,
+                                                             const VkBindTransformFeedbackBuffer2InfoEXT* pCounterInfo,
                                                              uint32_t counterOffset, uint32_t vertexStride,
-                                                             const RecordObject &record_obj) {
+                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     TrackDeviceAddressRange(*cb_state, pCounterInfo->addressRange.address, pCounterInfo->addressRange.size,
                             VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT);
 }
 
-void DeviceState::PostCallRecordCmdWriteMarkerToMemoryAMD(VkCommandBuffer commandBuffer, const VkMemoryMarkerInfoAMD *pInfo,
-                                                          const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdWriteMarkerToMemoryAMD(VkCommandBuffer commandBuffer, const VkMemoryMarkerInfoAMD* pInfo,
+                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     TrackDeviceAddressRange(*cb_state, pInfo->dstRange.address, pInfo->dstRange.size, VK_BUFFER_USAGE_2_TRANSFER_DST_BIT);
 }
 
 void DeviceState::PostCallRecordCmdBeginConditionalRenderingEXT(
-    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT *pConditionalRenderingBegin,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin,
+    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordBeginConditionalRendering(record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordEndConditionalRendering(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdBeginConditionalRendering2EXT(
-    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfo2EXT *pConditionalRenderingBegin,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfo2EXT* pConditionalRenderingBegin,
+    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordBeginConditionalRendering(record_obj.location);
     TrackDeviceAddressRange(*cb_state, pConditionalRenderingBegin->addressRange.address,
@@ -3884,139 +3884,139 @@ void DeviceState::PostCallRecordCmdBeginConditionalRendering2EXT(
 }
 
 void DeviceState::PostCallRecordCmdBindTileMemoryQCOM(VkCommandBuffer commandBuffer,
-                                                      const VkTileMemoryBindInfoQCOM *pTileMemoryBindInfo,
-                                                      const RecordObject &record_obj) {
+                                                      const VkTileMemoryBindInfoQCOM* pTileMemoryBindInfo,
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     // The bound tile memory can be reset by the application
     cb_state->bound_tile_memory = pTileMemoryBindInfo ? Get<vvl::DeviceMemory>(pTileMemoryBindInfo->memory) : nullptr;
 }
 
-void DeviceState::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR *pRenderingInfo,
-                                                     const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,
+                                                     const RecordObject& record_obj) {
     PostCallRecordCmdBeginRendering(commandBuffer, pRenderingInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
+                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordBeginRendering(*pRenderingInfo, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     PostCallRecordCmdEndRendering(commandBuffer, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordEndRendering(nullptr, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdEndRendering2EXT(VkCommandBuffer commandBuffer, const VkRenderingEndInfoEXT *pRenderingEndInfo,
-                                                    const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndRendering2EXT(VkCommandBuffer commandBuffer, const VkRenderingEndInfoEXT* pRenderingEndInfo,
+                                                    const RecordObject& record_obj) {
     PostCallRecordCmdEndRendering2KHR(commandBuffer, pRenderingEndInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdEndRendering2KHR(VkCommandBuffer commandBuffer, const VkRenderingEndInfoKHR *pRenderingEndInfo,
-                                                    const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndRendering2KHR(VkCommandBuffer commandBuffer, const VkRenderingEndInfoKHR* pRenderingEndInfo,
+                                                    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordEndRendering(pRenderingEndInfo, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                    const VkSubpassBeginInfo *pSubpassBeginInfo, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                    const VkSubpassBeginInfo* pSubpassBeginInfo, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordBeginRenderPass(*pRenderPassBegin, *pSubpassBeginInfo, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
-                                               const RecordObject &record_obj) {
+                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     cb_state->RecordNextSubpass(subpass_begin_info, nullptr, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                   const VkSubpassEndInfo *pSubpassEndInfo, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                   const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) {
     PostCallRecordCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                const VkSubpassEndInfo *pSubpassEndInfo, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordNextSubpass(*pSubpassBeginInfo, pSubpassEndInfo, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordEndRenderPass(nullptr, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                                     const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                                     const RecordObject& record_obj) {
     PostCallRecordCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordEndRenderPass(pSubpassEndInfo, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR *pEndCodingInfo,
-                                                     const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo,
+                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordEndVideoCoding(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBuffersCount,
-                                                   const VkCommandBuffer *pCommandBuffers, const RecordObject &record_obj) {
+                                                   const VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordExecuteCommands({pCommandBuffers, commandBuffersCount}, record_obj.location);
 }
 
 void DeviceState::PostCallRecordMapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size,
-                                          VkFlags flags, void **ppData, const RecordObject &record_obj) {
+                                          VkFlags flags, void** ppData, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     RecordMappedMemory(mem, offset, size, ppData);
 }
 
-void DeviceState::PostCallRecordMapMemory2(VkDevice device, const VkMemoryMapInfo *pMemoryMapInfo, void **ppData,
-                                           const RecordObject &record_obj) {
+void DeviceState::PostCallRecordMapMemory2(VkDevice device, const VkMemoryMapInfo* pMemoryMapInfo, void** ppData,
+                                           const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     RecordMappedMemory(pMemoryMapInfo->memory, pMemoryMapInfo->offset, pMemoryMapInfo->size, ppData);
 }
 
-void DeviceState::PostCallRecordMapMemory2KHR(VkDevice device, const VkMemoryMapInfoKHR *pMemoryMapInfo, void **ppData,
-                                              const RecordObject &record_obj) {
+void DeviceState::PostCallRecordMapMemory2KHR(VkDevice device, const VkMemoryMapInfoKHR* pMemoryMapInfo, void** ppData,
+                                              const RecordObject& record_obj) {
     PostCallRecordMapMemory2(device, pMemoryMapInfo, ppData, record_obj);
 }
 
-void DeviceState::PreCallRecordUnmapMemory(VkDevice device, VkDeviceMemory mem, const RecordObject &record_obj) {
+void DeviceState::PreCallRecordUnmapMemory(VkDevice device, VkDeviceMemory mem, const RecordObject& record_obj) {
     if (auto mem_info = Get<DeviceMemory>(mem)) {
         mem_info->mapped_range = MemRange();
         mem_info->p_driver_data = nullptr;
     }
 }
 
-void DeviceState::PreCallRecordUnmapMemory2(VkDevice device, const VkMemoryUnmapInfo *pMemoryUnmapInfo,
-                                            const RecordObject &record_obj) {
+void DeviceState::PreCallRecordUnmapMemory2(VkDevice device, const VkMemoryUnmapInfo* pMemoryUnmapInfo,
+                                            const RecordObject& record_obj) {
     if (auto mem_info = Get<DeviceMemory>(pMemoryUnmapInfo->memory)) {
         mem_info->mapped_range = MemRange();
         mem_info->p_driver_data = nullptr;
     }
 }
 
-void DeviceState::PreCallRecordUnmapMemory2KHR(VkDevice device, const VkMemoryUnmapInfoKHR *pMemoryUnmapInfo,
-                                               const RecordObject &record_obj) {
+void DeviceState::PreCallRecordUnmapMemory2KHR(VkDevice device, const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo,
+                                               const RecordObject& record_obj) {
     PreCallRecordUnmapMemory2(device, pMemoryUnmapInfo, record_obj);
 }
 
-void DeviceState::UpdateBindImageMemoryState(const VkBindImageMemoryInfo &bind_info) {
+void DeviceState::UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bind_info) {
     auto image_state = Get<Image>(bind_info.image);
     if (!image_state) return;
 
@@ -4042,7 +4042,7 @@ void DeviceState::UpdateBindImageMemoryState(const VkBindImageMemoryInfo &bind_i
 }
 
 void DeviceState::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                                const RecordObject &record_obj) {
+                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4053,14 +4053,14 @@ void DeviceState::PostCallRecordBindImageMemory(VkDevice device, VkImage image, 
     UpdateBindImageMemoryState(bind_info);
 }
 
-void DeviceState::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                                 const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         // if bindInfoCount is 1, we know for sure if that single image was bound or not
         if (bindInfoCount > 1) {
             for (uint32_t i = 0; i < bindInfoCount; i++) {
                 // If user passed in VkBindMemoryStatus, we can update which images are valid or not
-                if (auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
+                if (auto* bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
                     if (bind_memory_status->pResult && *bind_memory_status->pResult == VK_SUCCESS) {
                         UpdateBindImageMemoryState(pBindInfos[i]);
                     }
@@ -4077,11 +4077,11 @@ void DeviceState::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindI
 }
 
 void DeviceState::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount,
-                                                    const VkBindImageMemoryInfo *pBindInfos, const RecordObject &record_obj) {
+                                                    const VkBindImageMemoryInfo* pBindInfos, const RecordObject& record_obj) {
     PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 }
 
-void DeviceState::PreCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject &record_obj) {
+void DeviceState::PreCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) {
     if (auto event_state = Get<Event>(event)) {
         event_state->signaled = true;
         event_state->signal_src_stage_mask = VK_PIPELINE_STAGE_HOST_BIT;
@@ -4089,8 +4089,8 @@ void DeviceState::PreCallRecordSetEvent(VkDevice device, VkEvent event, const Re
     }
 }
 
-void DeviceState::PostCallRecordImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR *pImportSemaphoreFdInfo,
-                                                     const RecordObject &record_obj) {
+void DeviceState::PostCallRecordImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo,
+                                                     const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4098,14 +4098,14 @@ void DeviceState::PostCallRecordImportSemaphoreFdKHR(VkDevice device, const VkIm
                                pImportSemaphoreFdInfo->flags);
 }
 
-void DeviceState::RecordGetExternalSemaphoreState(Semaphore &semaphore_state, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
+void DeviceState::RecordGetExternalSemaphoreState(Semaphore& semaphore_state, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
     semaphore_state.Export(handle_type);
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-void InstanceState::PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR *pCreateInfo,
-                                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                        const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                        const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4113,7 +4113,7 @@ void InstanceState::PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, con
 }
 
 void DeviceState::PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
-                                                                  const RecordObject &record_obj) {
+                                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4123,7 +4123,7 @@ void DeviceState::PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice devic
 }
 
 void DeviceState::PostCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
-                                                                  const RecordObject &record_obj) {
+                                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4133,7 +4133,7 @@ void DeviceState::PostCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice devic
 }
 
 void DeviceState::PostCallRecordImportSemaphoreWin32HandleKHR(
-    VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *pImportSemaphoreWin32HandleInfo, const RecordObject &record_obj) {
+    VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4142,8 +4142,8 @@ void DeviceState::PostCallRecordImportSemaphoreWin32HandleKHR(
 }
 
 void DeviceState::PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device,
-                                                           const VkSemaphoreGetWin32HandleInfoKHR *pGetWin32HandleInfo,
-                                                           HANDLE *pHandle, const RecordObject &record_obj) {
+                                                           const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                           HANDLE* pHandle, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4153,8 +4153,8 @@ void DeviceState::PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device,
 }
 
 void DeviceState::PostCallRecordImportFenceWin32HandleKHR(VkDevice device,
-                                                          const VkImportFenceWin32HandleInfoKHR *pImportFenceWin32HandleInfo,
-                                                          const RecordObject &record_obj) {
+                                                          const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo,
+                                                          const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4162,16 +4162,16 @@ void DeviceState::PostCallRecordImportFenceWin32HandleKHR(VkDevice device,
                            pImportFenceWin32HandleInfo->flags);
 }
 
-void DeviceState::PostCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR *pGetWin32HandleInfo,
-                                                       HANDLE *pHandle, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                       HANDLE* pHandle, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     RecordGetExternalFenceState(pGetWin32HandleInfo->fence, pGetWin32HandleInfo->handleType, record_obj.location);
 }
 
-void DeviceState::PostCallRecordGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR *pGetWin32HandleInfo,
-                                                        HANDLE *pHandle, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                        HANDLE* pHandle, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4196,8 +4196,8 @@ void DeviceState::PostCallRecordGetMemoryWin32HandleKHR(VkDevice device, const V
 
 #ifdef VK_USE_PLATFORM_FUCHSIA
 void DeviceState::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
-    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA *pImportSemaphoreZirconHandleInfo,
-    const RecordObject &record_obj) {
+    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo,
+    const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4206,8 +4206,8 @@ void DeviceState::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
 }
 
 void DeviceState::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
-                                                                const VkSemaphoreGetZirconHandleInfoFUCHSIA *pGetZirconHandleInfo,
-                                                                zx_handle_t *pZirconHandle, const RecordObject &record_obj) {
+                                                                const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
+                                                                zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4217,8 +4217,8 @@ void DeviceState::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
 }
 #endif  // VK_USE_PLATFORM_FUCHSIA
 
-void DeviceState::PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4241,8 +4241,8 @@ void DeviceState::RecordImportFenceState(VkFence fence, VkExternalFenceHandleTyp
     }
 }
 
-void DeviceState::PostCallRecordGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                               const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                               const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4264,15 +4264,15 @@ void DeviceState::PostCallRecordGetMemoryFdKHR(VkDevice device, const VkMemoryGe
     }
 }
 
-void DeviceState::PostCallRecordImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR *pImportFenceFdInfo,
-                                                 const RecordObject &record_obj) {
+void DeviceState::PostCallRecordImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo,
+                                                 const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     RecordImportFenceState(pImportFenceFdInfo->fence, pImportFenceFdInfo->handleType, pImportFenceFdInfo->flags);
 }
 
-void DeviceState::RecordGetExternalFenceState(VkFence fence, VkExternalFenceHandleTypeFlagBits handle_type, const Location &loc) {
+void DeviceState::RecordGetExternalFenceState(VkFence fence, VkExternalFenceHandleTypeFlagBits handle_type, const Location& loc) {
     if (auto fence_state = Get<Fence>(fence)) {
         // We no longer can track inflight fence after the export - perform early retire.
         fence_state->NotifyAndWait(loc);
@@ -4280,26 +4280,26 @@ void DeviceState::RecordGetExternalFenceState(VkFence fence, VkExternalFenceHand
     }
 }
 
-void DeviceState::PostCallRecordGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                              const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                              const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     RecordGetExternalFenceState(pGetFdInfo->fence, pGetFdInfo->handleType, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo *pCreateInfo,
-                                            const VkAllocationCallbacks *pAllocator, VkEvent *pEvent,
-                                            const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkEvent* pEvent,
+                                            const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     Add(std::make_shared<Event>(*pEvent, pCreateInfo));
 }
 
-void DeviceState::RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR *pCreateInfo,
-                                             VkSwapchainKHR *pSwapchain, std::shared_ptr<Surface> &&surface_state,
-                                             Swapchain *old_swapchain_state) {
+void DeviceState::RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                             VkSwapchainKHR* pSwapchain, std::shared_ptr<Surface>&& surface_state,
+                                             Swapchain* old_swapchain_state) {
     if (result == VK_SUCCESS) {
         if (surface_state->swapchain) {
             surface_state->RemoveParent(surface_state->swapchain);
@@ -4328,7 +4328,7 @@ void DeviceState::RecordCreateSwapchainState(VkResult result, const VkSwapchainC
                 return;
             }
             swapchain->images.resize(swapchain_image_count);
-            const auto &image_ci = swapchain->image_create_info;
+            const auto& image_ci = swapchain->image_create_info;
             for (uint32_t i = 0; i < swapchain_image_count; ++i) {
                 auto format_features =
                     instance_state->GetImageFormatFeatures(physical_device, special_supported.vk_khr_format_feature_flags2,
@@ -4359,9 +4359,9 @@ void DeviceState::RecordCreateSwapchainState(VkResult result, const VkSwapchainC
     }
 }
 
-void DeviceState::PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain,
-                                                   const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
+                                                   const RecordObject& record_obj) {
     // Handle result in RecordCreateSwapchainState
     auto surface_state = instance_state->Get<Surface>(pCreateInfo->surface);
     auto old_swapchain_state = Get<Swapchain>(pCreateInfo->oldSwapchain);
@@ -4369,14 +4369,14 @@ void DeviceState::PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwap
 }
 
 void DeviceState::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
-                                                   const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                   const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<Swapchain>(swapchain);
 }
 
 void InstanceState::PostCallRecordCreateDisplayModeKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                                       const VkDisplayModeCreateInfoKHR *pCreateInfo,
-                                                       const VkAllocationCallbacks *pAllocator, VkDisplayModeKHR *pMode,
-                                                       const RecordObject &record_obj) {
+                                                       const VkDisplayModeCreateInfoKHR* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode,
+                                                       const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         std::ostringstream ss;
         ss << "failed with " << string_VkResult(record_obj.result)
@@ -4405,8 +4405,8 @@ void InstanceState::PostCallRecordCreateDisplayModeKHR(VkPhysicalDevice physical
     Add(std::make_shared<DisplayMode>(*pMode, physicalDevice, display));
 }
 
-void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
-                                                const RecordObject &record_obj) {
+void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
+                                                const RecordObject& record_obj) {
     // spec: If vkQueuePresentKHR fails to enqueue the corresponding set of queue operations, it may return
     // VK_ERROR_OUT_OF_HOST_MEMORY or VK_ERROR_OUT_OF_DEVICE_MEMORY. If it does, the implementation must ensure that the state and
     // contents of any resources or synchronization primitives referenced is unaffected by the call or its failure.
@@ -4424,11 +4424,11 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
     }
 
     const Location present_loc = record_obj.location.dot(Field::pPresentInfo);
-    const auto *present_fence_info = vku::FindStructInPNextChain<VkSwapchainPresentFenceInfoKHR>(pPresentInfo->pNext);
+    const auto* present_fence_info = vku::FindStructInPNextChain<VkSwapchainPresentFenceInfoKHR>(pPresentInfo->pNext);
 
     std::vector<QueueSubmission> present_submissions;  // TODO: use small_vector. Update interfaces to use span
     for (uint32_t i = 0; i < pPresentInfo->swapchainCount; ++i) {
-        QueueSubmission &present_submission = present_submissions.emplace_back(present_loc.dot(Field::pSwapchains, i));
+        QueueSubmission& present_submission = present_submissions.emplace_back(present_loc.dot(Field::pSwapchains, i));
         if (present_fence_info) {
             present_submission.AddFence(Get<Fence>(present_fence_info->pFences[i]));
         }
@@ -4482,7 +4482,7 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
     // If we wait on the present fence, then it can update present semaphores
     // that they are no longer in use by the swapchain.
     bool has_external_fence = false;
-    for (QueueSubmission &present_submission : present_submissions) {
+    for (QueueSubmission& present_submission : present_submissions) {
         if (present_submission.fence) {
             present_submission.fence->SetPresentWaitSemaphores(present_wait_semaphores);
             if (present_submission.fence->Scope() != Fence::kInternal) {
@@ -4500,9 +4500,9 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
         queue_state->UpdatePresentOnlyQueueProgress(*this);
     }
 
-    const auto *present_id_info = vku::FindStructInPNextChain<VkPresentIdKHR>(pPresentInfo->pNext);
-    const auto *present_id_info_2 = vku::FindStructInPNextChain<VkPresentId2KHR>(pPresentInfo->pNext);
-    const auto *present_timings_info = vku::FindStructInPNextChain<VkPresentTimingsInfoEXT>(pPresentInfo->pNext);
+    const auto* present_id_info = vku::FindStructInPNextChain<VkPresentIdKHR>(pPresentInfo->pNext);
+    const auto* present_id_info_2 = vku::FindStructInPNextChain<VkPresentId2KHR>(pPresentInfo->pNext);
+    const auto* present_timings_info = vku::FindStructInPNextChain<VkPresentTimingsInfoEXT>(pPresentInfo->pNext);
     for (uint32_t i = 0; i < pPresentInfo->swapchainCount; ++i) {
         auto swapchain_data = Get<Swapchain>(pPresentInfo->pSwapchains[i]);
         if (!swapchain_data) {
@@ -4517,7 +4517,7 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
         // be tracked here, however the presentation will be dropped
         if (local_result == VK_ERROR_PRESENT_TIMING_QUEUE_FULL_EXT) {
             queue_state->Notify(result.submission_seq);
-            for (const auto &semaphore : present_wait_semaphores) {
+            for (const auto& semaphore : present_wait_semaphores) {
                 semaphore->ClearSwapchainWaitInfo();
             }
             continue;
@@ -4557,8 +4557,8 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
     }
 }
 
-void DeviceState::PostCallRecordReleaseSwapchainImagesKHR(VkDevice device, const VkReleaseSwapchainImagesInfoKHR *pReleaseInfo,
-                                                          const RecordObject &record_obj) {
+void DeviceState::PostCallRecordReleaseSwapchainImagesKHR(VkDevice device, const VkReleaseSwapchainImagesInfoKHR* pReleaseInfo,
+                                                          const RecordObject& record_obj) {
     if (auto swapchain_data = Get<Swapchain>(pReleaseInfo->swapchain)) {
         for (uint32_t i = 0; i < pReleaseInfo->imageIndexCount; ++i) {
             swapchain_data->ReleaseImage(pReleaseInfo->pImageIndices[i]);
@@ -4566,20 +4566,20 @@ void DeviceState::PostCallRecordReleaseSwapchainImagesKHR(VkDevice device, const
     }
 }
 
-void DeviceState::PostCallRecordReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT *pReleaseInfo,
-                                                          const RecordObject &record_obj) {
+void DeviceState::PostCallRecordReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo,
+                                                          const RecordObject& record_obj) {
     PostCallRecordReleaseSwapchainImagesKHR(device, pReleaseInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordSetSwapchainPresentTimingQueueSizeEXT(VkDevice device, VkSwapchainKHR swapchain, uint32_t size,
-                                                                      const RecordObject &record_obj) {
+                                                                      const RecordObject& record_obj) {
     auto swapchain_state = Get<Swapchain>(swapchain);
     swapchain_state->present_timing_queue_size = size;
 }
 
 void DeviceState::PostCallRecordGetSwapchainTimeDomainPropertiesEXT(
-    VkDevice device, VkSwapchainKHR swapchain, VkSwapchainTimeDomainPropertiesEXT *pSwapchainTimeDomainProperties,
-    uint64_t *pTimeDomainsCounter, const RecordObject &record_obj) {
+    VkDevice device, VkSwapchainKHR swapchain, VkSwapchainTimeDomainPropertiesEXT* pSwapchainTimeDomainProperties,
+    uint64_t* pTimeDomainsCounter, const RecordObject& record_obj) {
     auto swapchain_state = Get<Swapchain>(swapchain);
     if (pSwapchainTimeDomainProperties->pTimeDomainIds) {
         for (uint32_t i = 0; i < pSwapchainTimeDomainProperties->timeDomainCount; ++i) {
@@ -4590,8 +4590,8 @@ void DeviceState::PostCallRecordGetSwapchainTimeDomainPropertiesEXT(
 }
 
 void DeviceState::PostCallRecordGetPastPresentationTimingEXT(
-    VkDevice device, const VkPastPresentationTimingInfoEXT *pPastPresentationTimingInfo,
-    VkPastPresentationTimingPropertiesEXT *pPastPresentationTimingProperties, const RecordObject &record_obj) {
+    VkDevice device, const VkPastPresentationTimingInfoEXT* pPastPresentationTimingInfo,
+    VkPastPresentationTimingPropertiesEXT* pPastPresentationTimingProperties, const RecordObject& record_obj) {
     if (pPastPresentationTimingProperties->pPresentationTimings != nullptr) {
         auto swapchain = Get<Swapchain>(pPastPresentationTimingInfo->swapchain);
         for (uint32_t i = 0; i < pPastPresentationTimingProperties->presentationTimingCount; ++i) {
@@ -4606,13 +4606,13 @@ void DeviceState::PostCallRecordGetPastPresentationTimingEXT(
 }
 
 void DeviceState::PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
-                                                          const VkSwapchainCreateInfoKHR *pCreateInfos,
-                                                          const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchains,
-                                                          const RecordObject &record_obj) {
+                                                          const VkSwapchainCreateInfoKHR* pCreateInfos,
+                                                          const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains,
+                                                          const RecordObject& record_obj) {
     // Handle result in RecordCreateSwapchainState
     if (pCreateInfos) {
         for (uint32_t i = 0; i < swapchainCount; i++) {
-            const VkSwapchainCreateInfoKHR &create_info = pCreateInfos[i];
+            const VkSwapchainCreateInfoKHR& create_info = pCreateInfos[i];
             auto surface_state = instance_state->Get<Surface>(create_info.surface);
             auto old_swapchain_state = Get<Swapchain>(create_info.oldSwapchain);
             RecordCreateSwapchainState(record_obj.result, &create_info, &pSwapchains[i], std::move(surface_state),
@@ -4622,7 +4622,7 @@ void DeviceState::PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint3
 }
 
 void DeviceState::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
-                                              VkFence fence, uint32_t *pImageIndex, Func command) {
+                                              VkFence fence, uint32_t* pImageIndex, Func command) {
     auto fence_state = Get<Fence>(fence);
     if (fence_state) {
         // Treat as inflight since it is valid to wait on this fence, even in cases where it is technically a temporary
@@ -4645,20 +4645,20 @@ void DeviceState::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR sw
 }
 
 void DeviceState::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
-                                                    VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
-                                                    const RecordObject &record_obj) {
+                                                    VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
+                                                    const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_SUBOPTIMAL_KHR != record_obj.result)) return;
     RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex, record_obj.location.function);
 }
 
-void DeviceState::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
-                                                     uint32_t *pImageIndex, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
+                                                     uint32_t* pImageIndex, const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_SUBOPTIMAL_KHR != record_obj.result)) return;
     RecordAcquireNextImageState(device, pAcquireInfo->swapchain, pAcquireInfo->timeout, pAcquireInfo->semaphore,
                                 pAcquireInfo->fence, pImageIndex, record_obj.location.function);
 }
 
-void DeviceState::RecordWaitForPresent(VkDevice device, VkSwapchainKHR swapchain, uint64_t present_id, const Location &location) {
+void DeviceState::RecordWaitForPresent(VkDevice device, VkSwapchainKHR swapchain, uint64_t present_id, const Location& location) {
     if (auto swapchain_state = Get<Swapchain>(swapchain)) {
         // Find the smallest registered present id >= the given present id,
         // and ensure that the queue has progressed to the corresponding seq location
@@ -4674,7 +4674,7 @@ void DeviceState::RecordWaitForPresent(VkDevice device, VkSwapchainKHR swapchain
 }
 
 void DeviceState::PostCallRecordWaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout,
-                                                  const RecordObject &record_obj) {
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS && record_obj.result != VK_SUBOPTIMAL_KHR) {
         return;
     }
@@ -4682,7 +4682,7 @@ void DeviceState::PostCallRecordWaitForPresentKHR(VkDevice device, VkSwapchainKH
 }
 
 void DeviceState::PostCallRecordWaitForPresent2KHR(VkDevice device, VkSwapchainKHR swapchain,
-                                                   const VkPresentWait2InfoKHR *pPresentWait2Info, const RecordObject &record_obj) {
+                                                   const VkPresentWait2InfoKHR* pPresentWait2Info, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS && record_obj.result != VK_SUBOPTIMAL_KHR) {
         return;
     }
@@ -4693,8 +4693,8 @@ std::shared_ptr<PhysicalDevice> InstanceState::CreatePhysicalDeviceState(VkPhysi
     return std::make_shared<PhysicalDevice>(handle);
 }
 
-void InstanceState::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                                 VkInstance *pInstance, const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                                 VkInstance* pInstance, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4723,11 +4723,11 @@ void InstanceState::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCr
 #endif  // VK_USE_PLATFORM_METAL_EXT
 }
 
-void InstanceState::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                              const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                              const RecordObject &record_obj, vku::safe_VkDeviceCreateInfo *modified_create_info) {
+void InstanceState::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                              const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
+                                              const RecordObject& record_obj, vku::safe_VkDeviceCreateInfo* modified_create_info) {
 #if defined(VVL_TRACY_GPU)
-    auto ext_already_enabled = [](const vku::safe_VkDeviceCreateInfo *dci, const char *ext_name) {
+    auto ext_already_enabled = [](const vku::safe_VkDeviceCreateInfo* dci, const char* ext_name) {
         bool ext_enabled = false;
         for (auto ext : make_span(dci->ppEnabledExtensionNames, dci->enabledExtensionCount)) {
             if (strcmp(ext, ext_name) == 0) {
@@ -4738,8 +4738,8 @@ void InstanceState::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, c
         return ext_enabled;
     };
 
-    auto enable_ext = [](vku::safe_VkDeviceCreateInfo *dci, const char *ext_name) {
-        const char **tmp_ppEnabledExtensionNames = new const char *[dci->enabledExtensionCount + 1];
+    auto enable_ext = [](vku::safe_VkDeviceCreateInfo* dci, const char* ext_name) {
+        const char** tmp_ppEnabledExtensionNames = new const char*[dci->enabledExtensionCount + 1];
         for (uint32_t i = 0; i < dci->enabledExtensionCount; ++i) {
             tmp_ppEnabledExtensionNames[i] = vku::SafeStringCopy(dci->ppEnabledExtensionNames[i]);
         }
@@ -4751,7 +4751,7 @@ void InstanceState::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, c
     if (!ext_already_enabled(modified_create_info, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME)) {
         enable_ext(modified_create_info, VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     }
-    auto host_query_reset_feature = const_cast<VkPhysicalDeviceHostQueryResetFeatures *>(
+    auto host_query_reset_feature = const_cast<VkPhysicalDeviceHostQueryResetFeatures*>(
         vku::FindStructInPNextChain<VkPhysicalDeviceHostQueryResetFeatures>(pCreateInfo->pNext));
     if (host_query_reset_feature) {
         host_query_reset_feature->hostQueryReset = VK_TRUE;
@@ -4768,45 +4768,45 @@ void InstanceState::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, c
 }
 
 // Common function to update state for GetPhysicalDeviceQueueFamilyProperties & 2KHR version
-static void StateUpdateCommonGetPhysicalDeviceQueueFamilyProperties(PhysicalDevice *pd_state, uint32_t count) {
+static void StateUpdateCommonGetPhysicalDeviceQueueFamilyProperties(PhysicalDevice* pd_state, uint32_t count) {
     pd_state->queue_family_known_count = std::max(pd_state->queue_family_known_count, count);
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice,
-                                                                         uint32_t *pQueueFamilyPropertyCount,
-                                                                         VkQueueFamilyProperties *pQueueFamilyProperties,
-                                                                         const RecordObject &record_obj) {
+                                                                         uint32_t* pQueueFamilyPropertyCount,
+                                                                         VkQueueFamilyProperties* pQueueFamilyProperties,
+                                                                         const RecordObject& record_obj) {
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     StateUpdateCommonGetPhysicalDeviceQueueFamilyProperties(pd_state.get(), *pQueueFamilyPropertyCount);
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceQueueFamilyProperties2(VkPhysicalDevice physicalDevice,
-                                                                          uint32_t *pQueueFamilyPropertyCount,
-                                                                          VkQueueFamilyProperties2 *pQueueFamilyProperties,
-                                                                          const RecordObject &record_obj) {
+                                                                          uint32_t* pQueueFamilyPropertyCount,
+                                                                          VkQueueFamilyProperties2* pQueueFamilyProperties,
+                                                                          const RecordObject& record_obj) {
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     StateUpdateCommonGetPhysicalDeviceQueueFamilyProperties(pd_state.get(), *pQueueFamilyPropertyCount);
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysicalDevice physicalDevice,
-                                                                             uint32_t *pQueueFamilyPropertyCount,
-                                                                             VkQueueFamilyProperties2 *pQueueFamilyProperties,
-                                                                             const RecordObject &record_obj) {
+                                                                             uint32_t* pQueueFamilyPropertyCount,
+                                                                             VkQueueFamilyProperties2* pQueueFamilyProperties,
+                                                                             const RecordObject& record_obj) {
     PostCallRecordGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties,
                                                           record_obj);
 }
 
 void InstanceState::PreCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
-                                                   const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+                                                   const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     Destroy<Surface>(surface);
 }
 
-void InstanceState::RecordVulkanSurface(VkSurfaceKHR *pSurface) { Add(std::make_shared<Surface>(*pSurface)); }
+void InstanceState::RecordVulkanSurface(VkSurfaceKHR* pSurface) { Add(std::make_shared<Surface>(*pSurface)); }
 
 void InstanceState::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance,
-                                                               const VkDisplaySurfaceCreateInfoKHR *pCreateInfo,
-                                                               const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                               const RecordObject &record_obj) {
+                                                               const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
+                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                               const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4814,9 +4814,9 @@ void InstanceState::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instan
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-void InstanceState::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                          const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                          const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4826,9 +4826,9 @@ void InstanceState::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, c
 
 #ifdef VK_USE_PLATFORM_FUCHSIA
 void InstanceState::PostCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance instance,
-                                                                const VkImagePipeSurfaceCreateInfoFUCHSIA *pCreateInfo,
-                                                                const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                                const RecordObject &record_obj) {
+                                                                const VkImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo,
+                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4837,9 +4837,9 @@ void InstanceState::PostCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance insta
 #endif  // VK_USE_PLATFORM_FUCHSIA
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
-void InstanceState::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                      const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                      const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4848,9 +4848,9 @@ void InstanceState::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const
 #endif  // VK_USE_PLATFORM_IOS_MVK
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
-void InstanceState::PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK *pCreateInfo,
-                                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                        const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                        const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4859,9 +4859,9 @@ void InstanceState::PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, con
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-void InstanceState::PostCallRecordCreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT *pCreateInfo,
-                                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                        const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                        const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4870,9 +4870,9 @@ void InstanceState::PostCallRecordCreateMetalSurfaceEXT(VkInstance instance, con
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-void InstanceState::PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                          const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                          const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4881,37 +4881,37 @@ void InstanceState::PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, c
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-void InstanceState::PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                      const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                      const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
 #if defined(DEBUG_CAPTURE_KEYBOARD)
-    xcb_connection = (void *)pCreateInfo->connection;
+    xcb_connection = (void*)pCreateInfo->connection;
 #endif
     RecordVulkanSurface(pSurface);
 }
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-void InstanceState::PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR *pCreateInfo,
-                                                       const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                       const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                       const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
 #if defined(DEBUG_CAPTURE_KEYBOARD)
-    xlib_display = (void *)pCreateInfo->dpy;
+    xlib_display = (void*)pCreateInfo->dpy;
 #endif
     RecordVulkanSurface(pSurface);
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
-void InstanceState::PostCallRecordCreateScreenSurfaceQNX(VkInstance instance, const VkScreenSurfaceCreateInfoQNX *pCreateInfo,
-                                                         const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                         const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateScreenSurfaceQNX(VkInstance instance, const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                         const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4919,9 +4919,9 @@ void InstanceState::PostCallRecordCreateScreenSurfaceQNX(VkInstance instance, co
 }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
-void InstanceState::PostCallRecordCreateHeadlessSurfaceEXT(VkInstance instance, const VkHeadlessSurfaceCreateInfoEXT *pCreateInfo,
-                                                           const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                           const RecordObject &record_obj) {
+void InstanceState::PostCallRecordCreateHeadlessSurfaceEXT(VkInstance instance, const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
+                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                           const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4929,8 +4929,8 @@ void InstanceState::PostCallRecordCreateHeadlessSurfaceEXT(VkInstance instance, 
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                          VkSurfaceCapabilitiesKHR *pSurfaceCapabilities,
-                                                                          const RecordObject &record_obj) {
+                                                                          VkSurfaceCapabilitiesKHR* pSurfaceCapabilities,
+                                                                          const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4944,9 +4944,9 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhys
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice,
-                                                                           const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                           VkSurfaceCapabilities2KHR *pSurfaceCapabilities,
-                                                                           const RecordObject &record_obj) {
+                                                                           const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                           VkSurfaceCapabilities2KHR* pSurfaceCapabilities,
+                                                                           const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -4962,7 +4962,7 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhy
         if (!pSurfaceInfo->pNext) {
             surface_state->UpdateCapabilitiesCache(physicalDevice, pSurfaceCapabilities->surfaceCapabilities);
         } else if (IsExtEnabled(extensions.vk_khr_surface_maintenance1) || IsExtEnabled(extensions.vk_ext_surface_maintenance1)) {
-            const auto *surface_present_mode = vku::FindStructInPNextChain<VkSurfacePresentModeKHR>(pSurfaceInfo->pNext);
+            const auto* surface_present_mode = vku::FindStructInPNextChain<VkSurfacePresentModeKHR>(pSurfaceInfo->pNext);
             if (surface_present_mode) {
                 // The surface caps caching should take into account pSurfaceInfo->pNext chain structure,
                 // because each pNext element can affect query result. Here we support caching for a common
@@ -4981,8 +4981,8 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhy
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                           VkSurfaceCapabilities2EXT *pSurfaceCapabilities,
-                                                                           const RecordObject &record_obj) {
+                                                                           VkSurfaceCapabilities2EXT* pSurfaceCapabilities,
+                                                                           const RecordObject& record_obj) {
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     ASSERT_AND_RETURN(pd_state);
     pd_state->SetCallState(record_obj.location.function, CallState::Uncalled);
@@ -5000,8 +5000,8 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhy
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
-                                                                     VkSurfaceKHR surface, VkBool32 *pSupported,
-                                                                     const RecordObject &record_obj) {
+                                                                     VkSurfaceKHR surface, VkBool32* pSupported,
+                                                                     const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -5011,9 +5011,9 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalD
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                          uint32_t *pPresentModeCount,
-                                                                          VkPresentModeKHR *pPresentModes,
-                                                                          const RecordObject &record_obj) {
+                                                                          uint32_t* pPresentModeCount,
+                                                                          VkPresentModeKHR* pPresentModes,
+                                                                          const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_INCOMPLETE != record_obj.result)) return;
 
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
@@ -5034,9 +5034,9 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(VkPhys
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                     uint32_t *pSurfaceFormatCount,
-                                                                     VkSurfaceFormatKHR *pSurfaceFormats,
-                                                                     const RecordObject &record_obj) {
+                                                                     uint32_t* pSurfaceFormatCount,
+                                                                     VkSurfaceFormatKHR* pSurfaceFormats,
+                                                                     const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_INCOMPLETE != record_obj.result)) return;
 
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
@@ -5066,10 +5066,10 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalD
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice,
-                                                                      const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                      uint32_t *pSurfaceFormatCount,
-                                                                      VkSurfaceFormat2KHR *pSurfaceFormats,
-                                                                      const RecordObject &record_obj) {
+                                                                      const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                      uint32_t* pSurfaceFormatCount,
+                                                                      VkSurfaceFormat2KHR* pSurfaceFormats,
+                                                                      const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_INCOMPLETE != record_obj.result)) return;
 
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
@@ -5097,64 +5097,64 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(VkPhysical
     }
 }
 
-void DeviceState::PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
-                                                          const RecordObject &record_obj) {
+void DeviceState::PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
+                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     debug_report->BeginCmdDebugUtilsLabel(commandBuffer, pLabelInfo);
 }
 
-void DeviceState::PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
-                                                           const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
+                                                           const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->BeginLabel((pLabelInfo && pLabelInfo->pLabelName) ? pLabelInfo->pLabelName : "");
 }
 
-void DeviceState::PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     cb_state->EndLabel();
     debug_report->EndCmdDebugUtilsLabel(commandBuffer);
 }
 
-void DeviceState::PreCallRecordCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
-                                                           const RecordObject &record_obj) {
+void DeviceState::PreCallRecordCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
+                                                           const RecordObject& record_obj) {
     debug_report->InsertCmdDebugUtilsLabel(commandBuffer, pLabelInfo);
 
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
 }
 
-void DeviceState::PostCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR *pInfo,
-                                                        const RecordObject &record_obj) {
+void DeviceState::PostCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo,
+                                                        const RecordObject& record_obj) {
     if (record_obj.result == VK_SUCCESS) performance_lock_acquired = true;
 }
 
-void DeviceState::PostCallRecordReleaseProfilingLockKHR(VkDevice device, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordReleaseProfilingLockKHR(VkDevice device, const RecordObject& record_obj) {
     performance_lock_acquired = false;
-    for (auto &cmd_buffer : command_buffer_map_.snapshot()) {
+    for (auto& cmd_buffer : command_buffer_map_.snapshot()) {
         cmd_buffer.second->performance_lock_released = true;
     }
 }
 
 void DeviceState::PreCallRecordDestroyDescriptorUpdateTemplate(VkDevice device, VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                               const VkAllocationCallbacks *pAllocator,
-                                                               const RecordObject &record_obj) {
+                                                               const VkAllocationCallbacks* pAllocator,
+                                                               const RecordObject& record_obj) {
     Destroy<DescriptorUpdateTemplate>(descriptorUpdateTemplate);
 }
 
 void DeviceState::PreCallRecordDestroyDescriptorUpdateTemplateKHR(VkDevice device,
                                                                   VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                  const VkAllocationCallbacks *pAllocator,
-                                                                  const RecordObject &record_obj) {
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  const RecordObject& record_obj) {
     PreCallRecordDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator, record_obj);
 }
 
 void DeviceState::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device,
-                                                               const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                               const VkAllocationCallbacks *pAllocator,
-                                                               VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                               const RecordObject &record_obj) {
+                                                               const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                               const VkAllocationCallbacks* pAllocator,
+                                                               VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                               const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -5162,16 +5162,16 @@ void DeviceState::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device,
 }
 
 void DeviceState::PostCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice device,
-                                                                  const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo,
-                                                                  const VkAllocationCallbacks *pAllocator,
-                                                                  VkDescriptorUpdateTemplate *pDescriptorUpdateTemplate,
-                                                                  const RecordObject &record_obj) {
+                                                                  const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
+                                                                  const RecordObject& record_obj) {
     PostCallRecordCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, record_obj);
 }
 
 void DeviceState::PreCallRecordUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
                                                                VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                               const void *pData, const RecordObject &record_obj) {
+                                                               const void* pData, const RecordObject& record_obj) {
     if (auto const template_state = Get<DescriptorUpdateTemplate>(descriptorUpdateTemplate)) {
         // TODO: Record template push descriptor updates
         if (template_state->create_info.templateType == VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET) {
@@ -5182,14 +5182,14 @@ void DeviceState::PreCallRecordUpdateDescriptorSetWithTemplate(VkDevice device, 
 
 void DeviceState::PreCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
                                                                   VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                  const void *pData, const RecordObject &record_obj) {
+                                                                  const void* pData, const RecordObject& record_obj) {
     PreCallRecordUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdPushDescriptorSetWithTemplate(VkCommandBuffer commandBuffer,
                                                                  VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                 VkPipelineLayout layout, uint32_t set, const void *pData,
-                                                                 const RecordObject &record_obj) {
+                                                                 VkPipelineLayout layout, uint32_t set, const void* pData,
+                                                                 const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto template_state = Get<DescriptorUpdateTemplate>(descriptorUpdateTemplate);
     auto pipeline_layout = Get<PipelineLayout>(layout);
@@ -5215,14 +5215,14 @@ void DeviceState::PostCallRecordCmdPushDescriptorSetWithTemplate(VkCommandBuffer
 
 void DeviceState::PostCallRecordCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
                                                                     VkDescriptorUpdateTemplate descriptorUpdateTemplate,
-                                                                    VkPipelineLayout layout, uint32_t set, const void *pData,
-                                                                    const RecordObject &record_obj) {
+                                                                    VkPipelineLayout layout, uint32_t set, const void* pData,
+                                                                    const RecordObject& record_obj) {
     PostCallRecordCmdPushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, layout, set, pData, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdPushDescriptorSetWithTemplate2(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfo *pPushDescriptorSetWithTemplateInfo,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfo* pPushDescriptorSetWithTemplateInfo,
+    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto template_state = Get<DescriptorUpdateTemplate>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate);
     auto pipeline_layout = Get<PipelineLayout>(pPushDescriptorSetWithTemplateInfo->layout);
@@ -5248,31 +5248,31 @@ void DeviceState::PostCallRecordCmdPushDescriptorSetWithTemplate2(
 }
 
 void DeviceState::PostCallRecordCmdPushDescriptorSetWithTemplate2KHR(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR *pPushDescriptorSetWithTemplateInfo,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo,
+    const RecordObject& record_obj) {
     PostCallRecordCmdPushDescriptorSetWithTemplate2(commandBuffer, pPushDescriptorSetWithTemplateInfo, record_obj);
 }
 
-void InstanceState::PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures *pFeatures,
-                                                            const RecordObject &record_obj) {
+void InstanceState::PostCallRecordGetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures* pFeatures,
+                                                            const RecordObject& record_obj) {
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     pd_state->SetCallState(record_obj.location.function, true);
 }
 
-void InstanceState::PostCallRecordGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2 *pFeatures,
-                                                             const RecordObject &record_obj) {
+void InstanceState::PostCallRecordGetPhysicalDeviceFeatures2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures,
+                                                             const RecordObject& record_obj) {
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     pd_state->SetCallState(record_obj.location.function, true);
 }
 
 void InstanceState::PostCallRecordGetPhysicalDeviceFeatures2KHR(VkPhysicalDevice physicalDevice,
-                                                                VkPhysicalDeviceFeatures2 *pFeatures,
-                                                                const RecordObject &record_obj) {
+                                                                VkPhysicalDeviceFeatures2* pFeatures,
+                                                                const RecordObject& record_obj) {
     PostCallRecordGetPhysicalDeviceFeatures2(physicalDevice, pFeatures, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                                        VkQueryControlFlags flags, uint32_t index, const RecordObject &record_obj) {
+                                                        VkQueryControlFlags flags, uint32_t index, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     if (disabled[query_validation]) {
@@ -5295,7 +5295,7 @@ void DeviceState::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandB
 }
 
 void DeviceState::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                                      uint32_t index, const RecordObject &record_obj) {
+                                                      uint32_t index, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     if (disabled[query_validation]) {
@@ -5318,10 +5318,10 @@ void DeviceState::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer commandBuf
     }
 }
 
-void DeviceState::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator,
-                                                             VkSamplerYcbcrConversion *pYcbcrConversion,
-                                                             const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator,
+                                                             VkSamplerYcbcrConversion* pYcbcrConversion,
+                                                             const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -5338,32 +5338,32 @@ void DeviceState::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device, co
 }
 
 void DeviceState::PostCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device,
-                                                                const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                VkSamplerYcbcrConversion *pYcbcrConversion,
-                                                                const RecordObject &record_obj) {
+                                                                const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                VkSamplerYcbcrConversion* pYcbcrConversion,
+                                                                const RecordObject& record_obj) {
     PostCallRecordCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, record_obj);
 }
 
 void DeviceState::PreCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
-                                                             const VkAllocationCallbacks *pAllocator,
-                                                             const RecordObject &record_obj) {
+                                                             const VkAllocationCallbacks* pAllocator,
+                                                             const RecordObject& record_obj) {
     Destroy<SamplerYcbcrConversion>(ycbcrConversion);
 }
 
 void DeviceState::PreCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                const RecordObject &record_obj) {
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                const RecordObject& record_obj) {
     PreCallRecordDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator, record_obj);
 }
 
 void DeviceState::PostCallRecordResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
-                                                  const RecordObject &record_obj) {
+                                                  const RecordObject& record_obj) {
     PostCallRecordResetQueryPool(device, queryPool, firstQuery, queryCount, record_obj);
 }
 
 void DeviceState::PostCallRecordResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
-                                               const RecordObject &record_obj) {
+                                               const RecordObject& record_obj) {
     // Do nothing if the feature is not enabled.
     if (!enabled_features.hostQueryReset) {
         return;
@@ -5389,7 +5389,7 @@ void DeviceState::PostCallRecordResetQueryPool(VkDevice device, VkQueryPool quer
 }
 
 void DeviceState::PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet,
-                                                             const DescriptorUpdateTemplate &template_state, const void *pData) {
+                                                             const DescriptorUpdateTemplate& template_state, const void* pData) {
     // Translate the templated update into a normal update for validation...
     DecodedTemplateUpdate decoded_template(*this, descriptorSet, template_state, pData);
     PerformUpdateDescriptorSets(static_cast<uint32_t>(decoded_template.desc_writes.size()), decoded_template.desc_writes.data(), 0,
@@ -5397,35 +5397,35 @@ void DeviceState::PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet des
 }
 
 void DeviceState::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                        uint32_t firstVertex, uint32_t firstInstance, const RecordObject &record_obj) {
+                                        uint32_t firstVertex, uint32_t firstInstance, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
-                                                uint32_t firstInstance, uint32_t stride, const RecordObject &record_obj) {
+                                                const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
+                                                uint32_t firstInstance, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
-                                               const RecordObject &record_obj) {
+                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                       const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
-                                                       uint32_t firstInstance, uint32_t stride, const int32_t *pVertexOffset,
-                                                       const RecordObject &record_obj) {
+                                                       const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
+                                                       uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset,
+                                                       const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
-                                                uint32_t stride, const RecordObject &record_obj) {
+                                                uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto buffer_state = Get<Buffer>(buffer);
     cb_state->RecordDraw(record_obj.location);
@@ -5435,7 +5435,7 @@ void DeviceState::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, V
 }
 
 void DeviceState::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                       uint32_t count, uint32_t stride, const RecordObject &record_obj) {
+                                                       uint32_t count, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     auto buffer_state = Get<Buffer>(buffer);
     cb_state->RecordDraw(record_obj.location);
@@ -5445,13 +5445,13 @@ void DeviceState::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBu
 }
 
 void DeviceState::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
-                                            const RecordObject &record_obj) {
+                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDispatch(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                    const RecordObject &record_obj) {
+                                                    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDispatch(record_obj.location);
     if (!disabled[command_buffer_state]) {
@@ -5461,26 +5461,26 @@ void DeviceState::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffe
 }
 
 void DeviceState::PostCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t base_x, uint32_t base_y, uint32_t base_z,
-                                                   uint32_t x, uint32_t y, uint32_t z, const RecordObject &record_obj) {
+                                                   uint32_t x, uint32_t y, uint32_t z, const RecordObject& record_obj) {
     PostCallRecordCmdDispatchBase(commandBuffer, x, y, z, base_x, base_y, base_z, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t,
-                                                uint32_t, const RecordObject &record_obj) {
+                                                uint32_t, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDispatch(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                        uint32_t stride, const RecordObject &record_obj) {
+                                                        uint32_t stride, const RecordObject& record_obj) {
     PostCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                        record_obj);
 }
 
 void DeviceState::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                     uint32_t stride, const RecordObject &record_obj) {
+                                                     uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
     if (!disabled[command_buffer_state]) {
@@ -5494,7 +5494,7 @@ void DeviceState::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuff
 void DeviceState::PostCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     PostCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                               record_obj);
 }
@@ -5502,7 +5502,7 @@ void DeviceState::PostCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer c
 void DeviceState::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                             VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                             uint32_t maxDrawCount, uint32_t stride,
-                                                            const RecordObject &record_obj) {
+                                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
     if (!disabled[command_buffer_state]) {
@@ -5514,13 +5514,13 @@ void DeviceState::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer comm
 }
 
 void DeviceState::PostCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
-                                                   const RecordObject &record_obj) {
+                                                   const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                           uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                           uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
     auto buffer_state = Get<Buffer>(buffer);
@@ -5532,7 +5532,7 @@ void DeviceState::PostCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
 void DeviceState::PostCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                 uint32_t maxDrawCount, uint32_t stride,
-                                                                const RecordObject &record_obj) {
+                                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
     if (!disabled[command_buffer_state]) {
@@ -5546,13 +5546,13 @@ void DeviceState::PostCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
 }
 
 void DeviceState::PostCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                                    uint32_t groupCountZ, const RecordObject &record_obj) {
+                                                    uint32_t groupCountZ, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                            uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                            uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
     auto buffer_state = Get<Buffer>(buffer);
@@ -5564,7 +5564,7 @@ void DeviceState::PostCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer comm
 void DeviceState::PostCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                  VkDeviceSize offset, VkBuffer countBuffer,
                                                                  VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                                 uint32_t stride, const RecordObject &record_obj) {
+                                                                 uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDraw(record_obj.location);
     if (!disabled[command_buffer_state]) {
@@ -5641,17 +5641,17 @@ void DeviceState::PostCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
                                                VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset,
                                                VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                                VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
-                                               uint32_t width, uint32_t height, uint32_t depth, const RecordObject &record_obj) {
+                                               uint32_t width, uint32_t height, uint32_t depth, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordTraceRay(record_obj.location.function);
 }
 
 void DeviceState::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                                const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable, uint32_t width,
-                                                uint32_t height, uint32_t depth, const RecordObject &record_obj) {
+                                                const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width,
+                                                uint32_t height, uint32_t depth, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordTraceRay(record_obj.location.function);
     TrackDeviceAddressRange(*cb_state, pRaygenShaderBindingTable->deviceAddress, pRaygenShaderBindingTable->size,
@@ -5665,11 +5665,11 @@ void DeviceState::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
 }
 
 void DeviceState::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                        const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                        const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                        const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                        const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                        VkDeviceAddress indirectDeviceAddress, const RecordObject &record_obj) {
+                                                        const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                        const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                        const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                        const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                        VkDeviceAddress indirectDeviceAddress, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordTraceRay(record_obj.location.function);
     TrackDeviceAddressRange(*cb_state, pRaygenShaderBindingTable->deviceAddress, pRaygenShaderBindingTable->size,
@@ -5683,14 +5683,14 @@ void DeviceState::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandB
 }
 
 void DeviceState::PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
-                                                         const RecordObject &record_obj) {
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordTraceRay(record_obj.location.function);
 }
 
 void DeviceState::PostCallRecordCmdExecuteGeneratedCommandsEXT(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
-                                                               const VkGeneratedCommandsInfoEXT *pGeneratedCommandsInfo,
-                                                               const RecordObject &record_obj) {
+                                                               const VkGeneratedCommandsInfoEXT* pGeneratedCommandsInfo,
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     const VkPipelineBindPoint bind_point = ConvertStageToBindPoint(pGeneratedCommandsInfo->shaderStages);
     if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS) {
@@ -5702,9 +5702,9 @@ void DeviceState::PostCallRecordCmdExecuteGeneratedCommandsEXT(VkCommandBuffer c
     }
 }
 
-void DeviceState::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                                  const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) {
+void DeviceState::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
+                                                  const RecordObject& record_obj, chassis::CreateShaderModule& chassis_state) {
     if (pCreateInfo->codeSize == 0 || !pCreateInfo->pCode) {
         return;
     } else if (chassis_state.module_state) {
@@ -5737,23 +5737,23 @@ void DeviceState::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
 }
 
 void DeviceState::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
-                                                const VkShaderCreateInfoEXT *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                                VkShaderEXT *pShaders, const RecordObject &record_obj,
-                                                chassis::ShaderObject &chassis_state) {
+                                                const VkShaderCreateInfoEXT* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                                VkShaderEXT* pShaders, const RecordObject& record_obj,
+                                                chassis::ShaderObject& chassis_state) {
     for (uint32_t i = 0; i < createInfoCount; ++i) {
-        const VkShaderCreateInfoEXT &create_info = pCreateInfos[i];
+        const VkShaderCreateInfoEXT& create_info = pCreateInfos[i];
         if (create_info.codeSize == 0 || !create_info.pCode || create_info.codeType != VK_SHADER_CODE_TYPE_SPIRV_EXT) {
             continue;
         }
         chassis_state.module_states[i] =
-            CreateSpirvModuleState(create_info.codeSize, static_cast<const uint32_t *>(create_info.pCode), global_settings,
+            CreateSpirvModuleState(create_info.codeSize, static_cast<const uint32_t*>(create_info.pCode), global_settings,
                                    &chassis_state.stateless_data[i]);
     }
 }
 
-void DeviceState::PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                                   const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) {
+void DeviceState::PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
+                                                   const RecordObject& record_obj, chassis::CreateShaderModule& chassis_state) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -5761,9 +5761,9 @@ void DeviceState::PostCallRecordCreateShaderModule(VkDevice device, const VkShad
 }
 
 void DeviceState::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
-                                                 const VkShaderCreateInfoEXT *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                                 VkShaderEXT *pShaders, const RecordObject &record_obj,
-                                                 chassis::ShaderObject &chassis_state) {
+                                                 const VkShaderCreateInfoEXT* pCreateInfos, const VkAllocationCallbacks* pAllocator,
+                                                 VkShaderEXT* pShaders, const RecordObject& record_obj,
+                                                 chassis::ShaderObject& chassis_state) {
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         // If there are multiple shaders being created, and one is bad, will return a non VK_SUCCESS but we need to check if the
         // VkShaderEXT was null or not to actually know if it was created
@@ -5789,8 +5789,8 @@ void DeviceState::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t creat
 }
 
 void DeviceState::PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
-                                                             const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                             const RecordObject &record_obj) {
+                                                             const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                             const RecordObject& record_obj) {
     // Might be deferred
     if (record_obj.result < VK_SUCCESS) {
         return;
@@ -5803,8 +5803,8 @@ void DeviceState::PostCallRecordCopyAccelerationStructureKHR(VkDevice device, Vk
 }
 
 void DeviceState::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                                const RecordObject &record_obj) {
+                                                                const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
     cb_state->RecordCommand(record_obj.location);
@@ -5820,8 +5820,8 @@ void DeviceState::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer 
 }
 
 void DeviceState::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
-                                                                        const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
-                                                                        const RecordObject &record_obj) {
+                                                                        const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
+                                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
     cb_state->RecordCommand(record_obj.location);
@@ -5835,8 +5835,8 @@ void DeviceState::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkComman
 }
 
 void DeviceState::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                        const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
-                                                                        const RecordObject &record_obj) {
+                                                                        const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
+                                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
     cb_state->RecordCommand(record_obj.location);
@@ -5852,8 +5852,8 @@ void DeviceState::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkComman
 }
 
 void DeviceState::PostCallRecordCmdCopyMemoryIndirectKHR(VkCommandBuffer commandBuffer,
-                                                         const VkCopyMemoryIndirectInfoKHR *pCopyMemoryIndirectInfo,
-                                                         const RecordObject &record_obj) {
+                                                         const VkCopyMemoryIndirectInfoKHR* pCopyMemoryIndirectInfo,
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
     cb_state->RecordCommand(record_obj.location);
@@ -5862,8 +5862,8 @@ void DeviceState::PostCallRecordCmdCopyMemoryIndirectKHR(VkCommandBuffer command
 }
 
 void DeviceState::PostCallRecordCmdCopyMemoryToImageIndirectKHR(
-    VkCommandBuffer commandBuffer, const VkCopyMemoryToImageIndirectInfoKHR *pCopyMemoryToImageIndirectInfo,
-    const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkCopyMemoryToImageIndirectInfoKHR* pCopyMemoryToImageIndirectInfo,
+    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
     cb_state->RecordCommand(record_obj.location);
@@ -5872,74 +5872,74 @@ void DeviceState::PostCallRecordCmdCopyMemoryToImageIndirectKHR(
 }
 
 void DeviceState::PostCallRecordCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode,
-                                                  const RecordObject &record_obj) {
+                                                  const RecordObject& record_obj) {
     PostCallRecordCmdSetCullMode(commandBuffer, cullMode, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode,
-                                               const RecordObject &record_obj) {
+                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_CULL_MODE);
     cb_state->dynamic_state_value.cull_mode = cullMode;
 }
 
 void DeviceState::PostCallRecordCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace,
-                                                   const RecordObject &record_obj) {
+                                                   const RecordObject& record_obj) {
     PostCallRecordCmdSetFrontFace(commandBuffer, frontFace, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace,
-                                                const RecordObject &record_obj) {
+                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_FRONT_FACE);
 }
 
 void DeviceState::PostCallRecordCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology,
-                                                           const RecordObject &record_obj) {
+                                                           const RecordObject& record_obj) {
     PostCallRecordCmdSetPrimitiveTopology(commandBuffer, primitiveTopology, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology,
-                                                        const RecordObject &record_obj) {
+                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY);
     cb_state->dynamic_state_value.primitive_topology = primitiveTopology;
 }
 
 void DeviceState::PostCallRecordCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                                           const VkViewport *pViewports, const RecordObject &record_obj) {
+                                                           const VkViewport* pViewports, const RecordObject& record_obj) {
     PostCallRecordCmdSetViewportWithCount(commandBuffer, viewportCount, pViewports, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                                        const VkViewport *pViewports, const RecordObject &record_obj) {
+                                                        const VkViewport* pViewports, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetViewportWithCount(viewportCount, pViewports);
 }
 
 void DeviceState::PostCallRecordCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                                          const VkRect2D *pScissors, const RecordObject &record_obj) {
+                                                          const VkRect2D* pScissors, const RecordObject& record_obj) {
     PostCallRecordCmdSetScissorWithCount(commandBuffer, scissorCount, pScissors, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                                       const VkRect2D *pScissors, const RecordObject &record_obj) {
+                                                       const VkRect2D* pScissors, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetScissorWithCount(scissorCount);
 }
 
 void DeviceState::PostCallRecordCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                         uint32_t bindingCount, const VkBuffer *pBuffers,
-                                                         const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
-                                                         const VkDeviceSize *pStrides, const RecordObject &record_obj) {
+                                                         uint32_t bindingCount, const VkBuffer* pBuffers,
+                                                         const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
+                                                         const VkDeviceSize* pStrides, const RecordObject& record_obj) {
     PostCallRecordCmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides,
                                         record_obj);
 }
 
 void DeviceState::PostCallRecordCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                                      const VkBuffer *pBuffers, const VkDeviceSize *pOffsets,
-                                                      const VkDeviceSize *pSizes, const VkDeviceSize *pStrides,
-                                                      const RecordObject &record_obj) {
+                                                      const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
+                                                      const VkDeviceSize* pSizes, const VkDeviceSize* pStrides,
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     if (pStrides) {
         cb_state->RecordStateCmd(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
@@ -5969,9 +5969,9 @@ void DeviceState::PostCallRecordCmdBindVertexBuffers3KHR(VkCommandBuffer command
     cb_state->bind_vertex_buffer_3_used = true;
 
     for (uint32_t i = 0; i < bindingCount; ++i) {
-        const VkBindVertexBuffer3InfoKHR &binding_info = pBindingInfos[i];
+        const VkBindVertexBuffer3InfoKHR& binding_info = pBindingInfos[i];
 
-        const VkDeviceSize *stride_ptr = binding_info.setStride ? &binding_info.addressRange.stride : nullptr;
+        const VkDeviceSize* stride_ptr = binding_info.setStride ? &binding_info.addressRange.stride : nullptr;
         cb_state->current_vertex_buffer_binding_info[i + firstBinding].Set(binding_info.addressRange.address,
                                                                            binding_info.addressRange.size, stride_ptr);
 
@@ -5990,58 +5990,58 @@ void DeviceState::PostCallRecordCmdBindVertexBuffers3KHR(VkCommandBuffer command
 }
 
 void DeviceState::PostCallRecordCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable,
-                                                         const RecordObject &record_obj) {
+                                                         const RecordObject& record_obj) {
     PostCallRecordCmdSetDepthTestEnable(commandBuffer, depthTestEnable, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable,
-                                                      const RecordObject &record_obj) {
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetDepthTestEnable(depthTestEnable);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable,
-                                                          const RecordObject &record_obj) {
+                                                          const RecordObject& record_obj) {
     PostCallRecordCmdSetDepthWriteEnable(commandBuffer, depthWriteEnable, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable,
-                                                       const RecordObject &record_obj) {
+                                                       const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
     cb_state->dynamic_state_value.depth_write_enable = depthWriteEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp,
-                                                        const RecordObject &record_obj) {
+                                                        const RecordObject& record_obj) {
     PostCallRecordCmdSetDepthCompareOp(commandBuffer, depthCompareOp, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp,
-                                                     const RecordObject &record_obj) {
+                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetDepthCompareOp(depthCompareOp);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     PostCallRecordCmdSetDepthBoundsTestEnable(commandBuffer, depthBoundsTestEnable, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable,
-                                                            const RecordObject &record_obj) {
+                                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE);
     cb_state->dynamic_state_value.depth_bounds_test_enable = depthBoundsTestEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable,
-                                                           const RecordObject &record_obj) {
+                                                           const RecordObject& record_obj) {
     PostCallRecordCmdSetStencilTestEnable(commandBuffer, stencilTestEnable, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable,
-                                                        const RecordObject &record_obj) {
+                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE);
     cb_state->dynamic_state_value.stencil_test_enable = stencilTestEnable;
@@ -6049,13 +6049,13 @@ void DeviceState::PostCallRecordCmdSetStencilTestEnable(VkCommandBuffer commandB
 
 void DeviceState::PostCallRecordCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                                    VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp,
-                                                   const RecordObject &record_obj) {
+                                                   const RecordObject& record_obj) {
     PostCallRecordCmdSetStencilOp(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                                 VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp,
-                                                const RecordObject &record_obj) {
+                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_STENCIL_OP);
     if (faceMask == VK_STENCIL_FACE_FRONT_BIT || faceMask == VK_STENCIL_FACE_FRONT_AND_BACK) {
@@ -6071,8 +6071,8 @@ void DeviceState::PostCallRecordCmdSetStencilOp(VkCommandBuffer commandBuffer, V
 }
 
 void DeviceState::PostCallRecordCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
-                                                          uint32_t discardRectangleCount, const VkRect2D *pDiscardRectangles,
-                                                          const RecordObject &record_obj) {
+                                                          uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles,
+                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT);
     for (uint32_t i = 0; i < discardRectangleCount; i++) {
@@ -6081,7 +6081,7 @@ void DeviceState::PostCallRecordCmdSetDiscardRectangleEXT(VkCommandBuffer comman
 }
 
 void DeviceState::PostCallRecordCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable,
-                                                                const RecordObject &record_obj) {
+                                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT);
     cb_state->dynamic_state_value.discard_rectangle_enable = discardRectangleEnable;
@@ -6089,14 +6089,14 @@ void DeviceState::PostCallRecordCmdSetDiscardRectangleEnableEXT(VkCommandBuffer 
 
 void DeviceState::PostCallRecordCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
                                                               VkDiscardRectangleModeEXT discardRectangleMode,
-                                                              const RecordObject &record_obj) {
+                                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DISCARD_RECTANGLE_MODE_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
-                                                         const VkSampleLocationsInfoEXT *pSampleLocationsInfo,
-                                                         const RecordObject &record_obj) {
+                                                         const VkSampleLocationsInfoEXT* pSampleLocationsInfo,
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
     cb_state->dynamic_state_value.sample_locations_info = *pSampleLocationsInfo;
@@ -6104,94 +6104,94 @@ void DeviceState::PostCallRecordCmdSetSampleLocationsEXT(VkCommandBuffer command
 
 void DeviceState::PostCallRecordCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer, VkCoarseSampleOrderTypeNV sampleOrderType,
                                                           uint32_t customSampleOrderCount,
-                                                          const VkCoarseSampleOrderCustomNV *pCustomSampleOrders,
-                                                          const RecordObject &record_obj) {
+                                                          const VkCoarseSampleOrderCustomNV* pCustomSampleOrders,
+                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_VIEWPORT_COARSE_SAMPLE_ORDER_NV);
 }
 
 void DeviceState::PostCallRecordCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints,
-                                                            const RecordObject &record_obj) {
+                                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT);
 }
 
-void DeviceState::PostCallRecordCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp, const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_LOGIC_OP_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable,
-                                                                 const RecordObject &record_obj) {
+                                                                 const RecordObject& record_obj) {
     PostCallRecordCmdSetRasterizerDiscardEnable(commandBuffer, rasterizerDiscardEnable, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable,
-                                                              const RecordObject &record_obj) {
+                                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
     cb_state->dynamic_state_value.rasterizer_discard_enable = (rasterizerDiscardEnable == VK_TRUE);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable,
-                                                         const RecordObject &record_obj) {
+                                                         const RecordObject& record_obj) {
     PostCallRecordCmdSetDepthBiasEnable(commandBuffer, depthBiasEnable, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable,
-                                                      const RecordObject &record_obj) {
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE);
     cb_state->dynamic_state_value.depth_bias_enable = depthBiasEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable,
-                                                                const RecordObject &record_obj) {
+                                                                const RecordObject& record_obj) {
     PostCallRecordCmdSetPrimitiveRestartEnable(commandBuffer, primitiveRestartEnable, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable,
-                                                             const RecordObject &record_obj) {
+                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE);
     cb_state->dynamic_state_value.primitive_restart_enable = primitiveRestartEnable;
 }
 
-void DeviceState::PostCallRecordCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D *pFragmentSize,
+void DeviceState::PostCallRecordCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize,
                                                              const VkFragmentShadingRateCombinerOpKHR combinerOps[2],
-                                                             const RecordObject &record_obj) {
+                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR);
     cb_state->dynamic_state_value.fragment_size = *pFragmentSize;
 }
 
 void DeviceState::PostCallRecordCmdSetRenderingAttachmentLocations(VkCommandBuffer commandBuffer,
-                                                                   const VkRenderingAttachmentLocationInfo *pLocationInfo,
-                                                                   const RecordObject &record_obj) {
+                                                                   const VkRenderingAttachmentLocationInfo* pLocationInfo,
+                                                                   const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetRenderingAttachmentLocations(pLocationInfo, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdSetRenderingAttachmentLocationsKHR(VkCommandBuffer commandBuffer,
-                                                                      const VkRenderingAttachmentLocationInfoKHR *pLocationInfo,
-                                                                      const RecordObject &record_obj) {
+                                                                      const VkRenderingAttachmentLocationInfoKHR* pLocationInfo,
+                                                                      const RecordObject& record_obj) {
     PostCallRecordCmdSetRenderingAttachmentLocations(commandBuffer, pLocationInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetRenderingInputAttachmentIndices(VkCommandBuffer commandBuffer,
-                                                                      const VkRenderingInputAttachmentIndexInfo *pLocationInfo,
-                                                                      const RecordObject &record_obj) {
+                                                                      const VkRenderingInputAttachmentIndexInfo* pLocationInfo,
+                                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordSetRenderingInputAttachmentIndices(pLocationInfo, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdSetRenderingInputAttachmentIndicesKHR(
-    VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR *pLocationInfo, const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, const VkRenderingInputAttachmentIndexInfoKHR* pLocationInfo, const RecordObject& record_obj) {
     PostCallRecordCmdSetRenderingInputAttachmentIndices(commandBuffer, pLocationInfo, record_obj);
 }
 
 void DeviceState::PostCallRecordCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize,
-                                                                     const RecordObject &record_obj) {
+                                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
     // CB_DYNAMIC_STATE_RAY_TRACING_PIPELINE_STACK_SIZE_KHR);
@@ -6200,10 +6200,10 @@ void DeviceState::PostCallRecordCmdSetRayTracingPipelineStackSizeKHR(VkCommandBu
 }
 
 void DeviceState::PostCallRecordCmdSetVertexInputEXT(VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
-                                                     const VkVertexInputBindingDescription2EXT *pVertexBindingDescriptions,
+                                                     const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions,
                                                      uint32_t vertexAttributeDescriptionCount,
-                                                     const VkVertexInputAttributeDescription2EXT *pVertexAttributeDescriptions,
-                                                     const RecordObject &record_obj) {
+                                                     const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions,
+                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     cb_state->stride_set_with_bind_vertex_buffer_3 = false;
@@ -6212,7 +6212,7 @@ void DeviceState::PostCallRecordCmdSetVertexInputEXT(VkCommandBuffer commandBuff
     if (pipeline_state && pipeline_state->IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE)) {
         cb_state->RecordDynamicState(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     }
-    auto &vertex_bindings = cb_state->dynamic_state_value.vertex_bindings;
+    auto& vertex_bindings = cb_state->dynamic_state_value.vertex_bindings;
 
     // When using Dynamic state, anything not set is invalid, so need to reset map
     // "The vertex attribute description for any location not specified in the pVertexAttributeDescriptions array becomes undefined"
@@ -6225,14 +6225,14 @@ void DeviceState::PostCallRecordCmdSetVertexInputEXT(VkCommandBuffer commandBuff
     }
 
     for (const auto [i, description] : vvl::enumerate(pVertexAttributeDescriptions, vertexAttributeDescriptionCount)) {
-        if (auto *binding_state = vvl::Find(vertex_bindings, description.binding)) {
+        if (auto* binding_state = vvl::Find(vertex_bindings, description.binding)) {
             binding_state->locations.insert_or_assign(description.location, VertexAttrState(i, &description));
         }
     }
 }
 
 void DeviceState::PostCallRecordCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                          const VkBool32 *pColorWriteEnables, const RecordObject &record_obj) {
+                                                          const VkBool32* pColorWriteEnables, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT);
     cb_state->dynamic_state_value.color_write_enable_attachment_count = attachmentCount;
@@ -6246,7 +6246,7 @@ void DeviceState::PostCallRecordCmdSetColorWriteEnableEXT(VkCommandBuffer comman
 }
 
 void DeviceState::PostCallRecordCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer, VkImageAspectFlags aspectMask,
-                                                                      const RecordObject &record_obj) {
+                                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
     cb_state->dynamic_state_value.attachment_feedback_loop_enable = aspectMask;
@@ -6254,27 +6254,27 @@ void DeviceState::PostCallRecordCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandB
 
 void DeviceState::PostCallRecordCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
                                                                   VkTessellationDomainOrigin domainOrigin,
-                                                                  const RecordObject &record_obj) {
+                                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable,
-                                                          const RecordObject &record_obj) {
+                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT);
     cb_state->dynamic_state_value.depth_clamp_enable = depthClampEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetDepthClampRangeEXT(VkCommandBuffer commandBuffer, VkDepthClampModeEXT depthClampMode,
-                                                         const VkDepthClampRangeEXT *pDepthClampRange,
-                                                         const RecordObject &record_obj) {
+                                                         const VkDepthClampRangeEXT* pDepthClampRange,
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_CLAMP_RANGE_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode,
-                                                     const RecordObject &record_obj) {
+                                                     const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_POLYGON_MODE_EXT);
     cb_state->dynamic_state_value.polygon_mode = polygonMode;
@@ -6282,14 +6282,14 @@ void DeviceState::PostCallRecordCmdSetPolygonModeEXT(VkCommandBuffer commandBuff
 
 void DeviceState::PostCallRecordCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
                                                               VkSampleCountFlagBits rasterizationSamples,
-                                                              const RecordObject &record_obj) {
+                                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     cb_state->dynamic_state_value.rasterization_samples = rasterizationSamples;
 }
 
 void DeviceState::PostCallRecordCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
-                                                    const VkSampleMask *pSampleMask, const RecordObject &record_obj) {
+                                                    const VkSampleMask* pSampleMask, const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_SAMPLE_MASK_EXT);
     cb_state->dynamic_state_value.samples_mask_samples = samples;
@@ -6299,29 +6299,29 @@ void DeviceState::PostCallRecordCmdSetSampleMaskEXT(VkCommandBuffer commandBuffe
 }
 
 void DeviceState::PostCallRecordCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToCoverageEnable,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
     cb_state->dynamic_state_value.alpha_to_coverage_enable = alphaToCoverageEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable,
-                                                          const RecordObject &record_obj) {
+                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT);
     cb_state->dynamic_state_value.alpha_to_one_enable = alphaToOneEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable,
-                                                       const RecordObject &record_obj) {
+                                                       const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT);
     cb_state->dynamic_state_value.logic_op_enable = logicOpEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                                          uint32_t attachmentCount, const VkBool32 *pColorBlendEnables,
-                                                          const RecordObject &record_obj) {
+                                                          uint32_t attachmentCount, const VkBool32* pColorBlendEnables,
+                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     for (uint32_t i = 0; i < attachmentCount; i++) {
@@ -6336,8 +6336,8 @@ void DeviceState::PostCallRecordCmdSetColorBlendEnableEXT(VkCommandBuffer comman
 
 void DeviceState::PostCallRecordCmdSetColorBlendEquationEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                             uint32_t attachmentCount,
-                                                            const VkColorBlendEquationEXT *pColorBlendEquations,
-                                                            const RecordObject &record_obj) {
+                                                            const VkColorBlendEquationEXT* pColorBlendEquations,
+                                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
     if (cb_state->dynamic_state_value.color_blend_equations.size() < firstAttachment + attachmentCount) {
@@ -6350,8 +6350,8 @@ void DeviceState::PostCallRecordCmdSetColorBlendEquationEXT(VkCommandBuffer comm
 }
 
 void DeviceState::PostCallRecordCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
-                                                        uint32_t attachmentCount, const VkColorComponentFlags *pColorWriteMasks,
-                                                        const RecordObject &record_obj) {
+                                                        uint32_t attachmentCount, const VkColorComponentFlags* pColorWriteMasks,
+                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT);
     if (cb_state->dynamic_state_value.color_write_masks.size() < firstAttachment + attachmentCount) {
@@ -6364,7 +6364,7 @@ void DeviceState::PostCallRecordCmdSetColorWriteMaskEXT(VkCommandBuffer commandB
 }
 
 void DeviceState::PostCallRecordCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer, uint32_t rasterizationStream,
-                                                             const RecordObject &record_obj) {
+                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT);
     cb_state->dynamic_state_value.rasterization_stream = rasterizationStream;
@@ -6372,7 +6372,7 @@ void DeviceState::PostCallRecordCmdSetRasterizationStreamEXT(VkCommandBuffer com
 
 void DeviceState::PostCallRecordCmdSetConservativeRasterizationModeEXT(
     VkCommandBuffer commandBuffer, VkConservativeRasterizationModeEXT conservativeRasterizationMode,
-    const RecordObject &record_obj) {
+    const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT);
     cb_state->dynamic_state_value.conservative_rasterization_mode = conservativeRasterizationMode;
@@ -6380,19 +6380,19 @@ void DeviceState::PostCallRecordCmdSetConservativeRasterizationModeEXT(
 
 void DeviceState::PostCallRecordCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
                                                                           float extraPrimitiveOverestimationSize,
-                                                                          const RecordObject &record_obj) {
+                                                                          const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable,
-                                                         const RecordObject &record_obj) {
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer, VkBool32 sampleLocationsEnable,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT);
     cb_state->dynamic_state_value.sample_locations_enable = sampleLocationsEnable;
@@ -6400,8 +6400,8 @@ void DeviceState::PostCallRecordCmdSetSampleLocationsEnableEXT(VkCommandBuffer c
 
 void DeviceState::PostCallRecordCmdSetColorBlendAdvancedEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                             uint32_t attachmentCount,
-                                                            const VkColorBlendAdvancedEXT *pColorBlendAdvanced,
-                                                            const RecordObject &record_obj) {
+                                                            const VkColorBlendAdvancedEXT* pColorBlendAdvanced,
+                                                            const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT);
     for (uint32_t i = 0; i < attachmentCount; i++) {
@@ -6411,56 +6411,56 @@ void DeviceState::PostCallRecordCmdSetColorBlendAdvancedEXT(VkCommandBuffer comm
 
 void DeviceState::PostCallRecordCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
                                                              VkProvokingVertexModeEXT provokingVertexMode,
-                                                             const RecordObject &record_obj) {
+                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
                                                                VkLineRasterizationModeEXT lineRasterizationMode,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT);
     cb_state->dynamic_state_value.line_rasterization_mode = lineRasterizationMode;
 }
 
 void DeviceState::PostCallRecordCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable,
-                                                           const RecordObject &record_obj) {
+                                                           const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT);
     cb_state->dynamic_state_value.stippled_line_enable = stippledLineEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer, VkBool32 negativeOneToOne,
-                                                                   const RecordObject &record_obj) {
+                                                                   const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_DEPTH_CLIP_NEGATIVE_ONE_TO_ONE_EXT);
 }
 
 void DeviceState::PostCallRecordCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer, VkBool32 viewportWScalingEnable,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_VIEWPORT_W_SCALING_ENABLE_NV);
     cb_state->dynamic_state_value.viewport_w_scaling_enable = viewportWScalingEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                                        uint32_t viewportCount, const VkViewportSwizzleNV *pViewportSwizzles,
-                                                        const RecordObject &record_obj) {
+                                                        uint32_t viewportCount, const VkViewportSwizzleNV* pViewportSwizzles,
+                                                        const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_VIEWPORT_SWIZZLE_NV);
     cb_state->dynamic_state_value.viewport_swizzle_count = viewportCount;
 }
 
 void DeviceState::PostCallRecordCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer, VkBool32 coverageToColorEnable,
-                                                              const RecordObject &record_obj) {
+                                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COVERAGE_TO_COLOR_ENABLE_NV);
     cb_state->dynamic_state_value.coverage_to_color_enable = coverageToColorEnable;
 }
 
 void DeviceState::PostCallRecordCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer, uint32_t coverageToColorLocation,
-                                                                const RecordObject &record_obj) {
+                                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COVERAGE_TO_COLOR_LOCATION_NV);
     cb_state->dynamic_state_value.coverage_to_color_location = coverageToColorLocation;
@@ -6468,7 +6468,7 @@ void DeviceState::PostCallRecordCmdSetCoverageToColorLocationNV(VkCommandBuffer 
 
 void DeviceState::PostCallRecordCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
                                                                VkCoverageModulationModeNV coverageModulationMode,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COVERAGE_MODULATION_MODE_NV);
     cb_state->dynamic_state_value.coverage_modulation_mode = coverageModulationMode;
@@ -6476,7 +6476,7 @@ void DeviceState::PostCallRecordCmdSetCoverageModulationModeNV(VkCommandBuffer c
 
 void DeviceState::PostCallRecordCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
                                                                       VkBool32 coverageModulationTableEnable,
-                                                                      const RecordObject &record_obj) {
+                                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_ENABLE_NV);
     cb_state->dynamic_state_value.coverage_modulation_table_enable = coverageModulationTableEnable;
@@ -6484,14 +6484,14 @@ void DeviceState::PostCallRecordCmdSetCoverageModulationTableEnableNV(VkCommandB
 
 void DeviceState::PostCallRecordCmdSetCoverageModulationTableNV(VkCommandBuffer commandBuffer,
                                                                 uint32_t coverageModulationTableCount,
-                                                                const float *pCoverageModulationTable,
-                                                                const RecordObject &record_obj) {
+                                                                const float* pCoverageModulationTable,
+                                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_NV);
 }
 
 void DeviceState::PostCallRecordCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer, VkBool32 shadingRateImageEnable,
-                                                               const RecordObject &record_obj) {
+                                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV);
     cb_state->dynamic_state_value.shading_rate_image_enable = shadingRateImageEnable;
@@ -6499,55 +6499,55 @@ void DeviceState::PostCallRecordCmdSetShadingRateImageEnableNV(VkCommandBuffer c
 
 void DeviceState::PostCallRecordCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
                                                                          VkBool32 representativeFragmentTestEnable,
-                                                                         const RecordObject &record_obj) {
+                                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_REPRESENTATIVE_FRAGMENT_TEST_ENABLE_NV);
 }
 
 void DeviceState::PostCallRecordCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
                                                               VkCoverageReductionModeNV coverageReductionMode,
-                                                              const RecordObject &record_obj) {
+                                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordStateCmd(CB_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV);
 }
 
 void DeviceState::PostCallRecordCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
-                                                         const VkVideoCodingControlInfoKHR *pCodingControlInfo,
-                                                         const RecordObject &record_obj) {
+                                                         const VkVideoCodingControlInfoKHR* pCodingControlInfo,
+                                                         const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordControlVideoCoding(*pCodingControlInfo, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR *pDecodeInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo,
+                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordDecodeVideo(*pDecodeInfo, record_obj.location);
 }
 
-void DeviceState::PostCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR *pEncodeInfo,
-                                                  const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo,
+                                                  const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordEncodeVideo(*pEncodeInfo, record_obj.location);
 }
 
 void DeviceState::PostCallRecordGetShaderModuleIdentifierEXT(VkDevice, const VkShaderModule shaderModule,
-                                                             VkShaderModuleIdentifierEXT *pIdentifier,
-                                                             const RecordObject &record_obj) {
+                                                             VkShaderModuleIdentifierEXT* pIdentifier,
+                                                             const RecordObject& record_obj) {
     if (const auto shader_state = Get<ShaderModule>(shaderModule); shader_state) {
         WriteLockGuard guard(shader_identifier_map_lock_);
         shader_identifier_map_.emplace(*pIdentifier, std::move(shader_state));
     }
 }
 
-void DeviceState::PostCallRecordGetShaderModuleCreateInfoIdentifierEXT(VkDevice, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                                       VkShaderModuleIdentifierEXT *pIdentifier,
-                                                                       const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetShaderModuleCreateInfoIdentifierEXT(VkDevice, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                                       VkShaderModuleIdentifierEXT* pIdentifier,
+                                                                       const RecordObject& record_obj) {
     WriteLockGuard guard(shader_identifier_map_lock_);
     shader_identifier_map_.emplace(*pIdentifier, std::make_shared<ShaderModule>());
 }
 
-void DeviceState::PostCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                       const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                       const RecordObject& record_obj) {
     if (record_obj.device_address == 0) {
         return;
     }
@@ -6563,39 +6563,39 @@ void DeviceState::PostCallRecordGetBufferDeviceAddress(VkDevice device, const Vk
     }
 }
 
-void DeviceState::PostCallRecordGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                          const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                          const RecordObject& record_obj) {
     PostCallRecordGetBufferDeviceAddress(device, pInfo, record_obj);
 }
 
-void DeviceState::PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
-                                                          const RecordObject &record_obj) {
+void DeviceState::PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
+                                                          const RecordObject& record_obj) {
     PostCallRecordGetBufferDeviceAddress(device, pInfo, record_obj);
 }
 
-std::shared_ptr<Swapchain> DeviceState::CreateSwapchainState(const VkSwapchainCreateInfoKHR *create_info, VkSwapchainKHR handle) {
+std::shared_ptr<Swapchain> DeviceState::CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info, VkSwapchainKHR handle) {
     return std::make_shared<Swapchain>(*this, create_info, handle);
 }
 
 std::shared_ptr<CommandBuffer> DeviceState::CreateCmdBufferState(VkCommandBuffer handle,
-                                                                 const VkCommandBufferAllocateInfo *allocate_info,
-                                                                 const CommandPool *pool) {
+                                                                 const VkCommandBufferAllocateInfo* allocate_info,
+                                                                 const CommandPool* pool) {
     return std::make_shared<CommandBuffer>(*this, handle, allocate_info, pool);
 }
 
-std::shared_ptr<DeviceMemory> DeviceState::CreateDeviceMemoryState(VkDeviceMemory handle, const VkMemoryAllocateInfo *allocate_info,
-                                                                   uint64_t fake_address, const VkMemoryType &memory_type,
-                                                                   const VkMemoryHeap &memory_heap,
-                                                                   std::optional<DedicatedBinding> &&dedicated_binding,
+std::shared_ptr<DeviceMemory> DeviceState::CreateDeviceMemoryState(VkDeviceMemory handle, const VkMemoryAllocateInfo* allocate_info,
+                                                                   uint64_t fake_address, const VkMemoryType& memory_type,
+                                                                   const VkMemoryHeap& memory_heap,
+                                                                   std::optional<DedicatedBinding>&& dedicated_binding,
                                                                    uint32_t physical_device_count) {
     return std::make_shared<DeviceMemory>(handle, allocate_info, fake_address, memory_type, memory_heap,
                                           std::move(dedicated_binding), physical_device_count);
 }
 
 void DeviceState::PostCallRecordCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                                   uint32_t bindingCount, const VkBuffer *pBuffers,
-                                                                   const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
-                                                                   const RecordObject &record_obj) {
+                                                                   uint32_t bindingCount, const VkBuffer* pBuffers,
+                                                                   const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
+                                                                   const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->transform_feedback_buffers_bound = bindingCount;
 }
@@ -6613,8 +6613,8 @@ void DeviceState::PostCallRecordCmdBindTransformFeedbackBuffers2EXT(VkCommandBuf
 }
 
 void DeviceState::PostCallRecordGetAccelerationStructureDeviceAddressKHR(VkDevice device,
-                                                                         const VkAccelerationStructureDeviceAddressInfoKHR *pInfo,
-                                                                         const RecordObject &record_obj) {
+                                                                         const VkAccelerationStructureDeviceAddressInfoKHR* pInfo,
+                                                                         const RecordObject& record_obj) {
     if (!pInfo) {
         return;
     }
@@ -6631,9 +6631,9 @@ void DeviceState::PostCallRecordGetAccelerationStructureDeviceAddressKHR(VkDevic
     }
 }
 
-small_vector<const vvl::AccelerationStructureKHR *, 2> DeviceState::GetAccelerationStructuresByAddress(
+small_vector<const vvl::AccelerationStructureKHR*, 2> DeviceState::GetAccelerationStructuresByAddress(
     VkDeviceAddress address) const {
-    small_vector<const vvl::AccelerationStructureKHR *, 2> as_vector;
+    small_vector<const vvl::AccelerationStructureKHR*, 2> as_vector;
     if (address == 0) {
         return as_vector;
     }
@@ -6642,19 +6642,19 @@ small_vector<const vvl::AccelerationStructureKHR *, 2> DeviceState::GetAccelerat
     ReadLockGuard lock(as_with_addresses.array_mutex);
     auto as_found_it =
         std::find_if(as_with_addresses.array.begin(), as_with_addresses.array.end(),
-                     [address](vvl::AccelerationStructureKHR *as) { return as->acceleration_structure_address == address; });
+                     [address](vvl::AccelerationStructureKHR* as) { return as->acceleration_structure_address == address; });
 
     while (as_found_it != as_with_addresses.array.end()) {
         as_vector.emplace_back(*as_found_it);
-        as_found_it = std::find_if(as_found_it + 1, as_with_addresses.array.end(), [address](vvl::AccelerationStructureKHR *as) {
+        as_found_it = std::find_if(as_found_it + 1, as_with_addresses.array.end(), [address](vvl::AccelerationStructureKHR* as) {
             return as->acceleration_structure_address == address;
         });
     }
     return as_vector;
 }
 
-void DeviceState::PreCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV *pSleepInfo,
-                                              const RecordObject &record_obj) {
+void DeviceState::PreCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV* pSleepInfo,
+                                              const RecordObject& record_obj) {
     if (auto semaphore_state = Get<Semaphore>(pSleepInfo->signalSemaphore)) {
         auto value = pSleepInfo->value;
         semaphore_state->EnqueueSignal(SubmissionReference{}, value);
@@ -6663,8 +6663,8 @@ void DeviceState::PreCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR sw
 
 // TODO: PostRecord is not needed. Test this. WaitSemaphores will retire the signal.
 // LatencySleepNV does not perform wait but provides information about semaphore to the driver.
-void DeviceState::PostCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV *pSleepInfo,
-                                               const RecordObject &record_obj) {
+void DeviceState::PostCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV* pSleepInfo,
+                                               const RecordObject& record_obj) {
     if (auto semaphore_state = Get<Semaphore>(pSleepInfo->signalSemaphore)) {
         semaphore_state->RetireWait(nullptr, pSleepInfo->value, record_obj.location);
     }
@@ -6687,7 +6687,7 @@ void DeviceState::PostCallRecordCreateIndirectExecutionSetEXT(VkDevice device,
         indirect_execution_state->initial_pipeline = Get<Pipeline>(pipeline_info.initialPipeline);
         indirect_execution_state->shader_stage_flags = indirect_execution_state->initial_pipeline->active_shaders;
     } else if (indirect_execution_state->is_shader_objects && pCreateInfo->info.pShaderInfo) {
-        const VkIndirectExecutionSetShaderInfoEXT &shader_info = *pCreateInfo->info.pShaderInfo;
+        const VkIndirectExecutionSetShaderInfoEXT& shader_info = *pCreateInfo->info.pShaderInfo;
         for (uint32_t i = 0; i < shader_info.shaderCount; i++) {
             const VkShaderEXT shader_handle = shader_info.pInitialShaders[i];
             const auto shader_object = Get<ShaderObject>(shader_handle);
@@ -6712,10 +6712,10 @@ void DeviceState::PreCallRecordDestroyIndirectExecutionSetEXT(VkDevice device, V
 }
 
 void DeviceState::PostCallRecordCreateIndirectCommandsLayoutEXT(VkDevice device,
-                                                                const VkIndirectCommandsLayoutCreateInfoEXT *pCreateInfo,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                VkIndirectCommandsLayoutEXT *pIndirectCommandsLayout,
-                                                                const RecordObject &record_obj) {
+                                                                const VkIndirectCommandsLayoutCreateInfoEXT* pCreateInfo,
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                VkIndirectCommandsLayoutEXT* pIndirectCommandsLayout,
+                                                                const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -6723,8 +6723,8 @@ void DeviceState::PostCallRecordCreateIndirectCommandsLayoutEXT(VkDevice device,
 }
 
 void DeviceState::PreCallRecordDestroyIndirectCommandsLayoutEXT(VkDevice device, VkIndirectCommandsLayoutEXT indirectCommandsLayout,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                const RecordObject &record_obj) {
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                const RecordObject& record_obj) {
     Destroy<IndirectCommandsLayout>(indirectCommandsLayout);
 }
 
@@ -6735,12 +6735,12 @@ struct CommandBufferReservedAddressInfillUpdateOps {
     using Mapped = typename Map::mapped_type;
     using Range = typename Map::key_type;
 
-    void infill(Map &map, const Iterator &pos, const Range &infill_range) const {
+    void infill(Map& map, const Iterator& pos, const Range& infill_range) const {
         map.insert(pos, Value(infill_range, insert_value));
     }
 
-    void update(const Iterator &pos) const {
-        auto &current_buffer_list = pos->second;
+    void update(const Iterator& pos) const {
+        auto& current_buffer_list = pos->second;
         assert(!current_buffer_list.empty());
         const auto buffer_found_it = std::find(current_buffer_list.begin(), current_buffer_list.end(), insert_value[0]);
         if (buffer_found_it == current_buffer_list.end()) {
@@ -6750,14 +6750,14 @@ struct CommandBufferReservedAddressInfillUpdateOps {
             current_buffer_list.emplace_back(insert_value[0]);
         }
     }
-    const Mapped &insert_value;
+    const Mapped& insert_value;
 };
 
 struct CommandBufferReservedAddressRemoveOps {
     using Map = DeviceState::DescriptorHeapReservedAddress::RangeMap;
     using Mapped = Map::mapped_type;
 
-    bool operator()(Mapped &cmd_buffer_list) const {
+    bool operator()(Mapped& cmd_buffer_list) const {
         auto it = std::find(cmd_buffer_list.begin(), cmd_buffer_list.end(), removed_value);
         if (it != cmd_buffer_list.end()) {
             if (cmd_buffer_list.size() == 1) {
@@ -6775,18 +6775,18 @@ struct CommandBufferReservedAddressRemoveOps {
         return false;
     }
 
-    const vvl::CommandBuffer *removed_value;
+    const vvl::CommandBuffer* removed_value;
 };
 
-void DeviceState::UpdateCommandBufferHeapReservedAddressMap(vvl::CommandBuffer *cb_state,
-                                                            const vvl::range<VkDeviceAddress> &new_range, bool is_sampler) {
+void DeviceState::UpdateCommandBufferHeapReservedAddressMap(vvl::CommandBuffer* cb_state,
+                                                            const vvl::range<VkDeviceAddress>& new_range, bool is_sampler) {
     assert(cb_state != nullptr);
 
     WriteLockGuard guard(descriptor_heap_reserved_address.lock);
 
-    const vvl::range<VkDeviceAddress> &existing_range =
+    const vvl::range<VkDeviceAddress>& existing_range =
         is_sampler ? cb_state->descriptor_heap.sampler_reserved : cb_state->descriptor_heap.resource_reserved;
-    DescriptorHeapReservedAddress::RangeMap &cmd_buffer_map =
+    DescriptorHeapReservedAddress::RangeMap& cmd_buffer_map =
         is_sampler ? descriptor_heap_reserved_address.sampler_map : descriptor_heap_reserved_address.resource_map;
 
     if (existing_range.non_empty()) {
@@ -6800,26 +6800,26 @@ void DeviceState::UpdateCommandBufferHeapReservedAddressMap(vvl::CommandBuffer *
     }
 }
 
-void DeviceState::RemoveCommandBufferHeapReservedAddressMap(vvl::CommandBuffer *cb_state) {
+void DeviceState::RemoveCommandBufferHeapReservedAddressMap(vvl::CommandBuffer* cb_state) {
     assert(cb_state != nullptr);
 
     WriteLockGuard guard(descriptor_heap_reserved_address.lock);
 
-    const vvl::range<VkDeviceAddress> &resource_existing_range = cb_state->descriptor_heap.resource_reserved;
+    const vvl::range<VkDeviceAddress>& resource_existing_range = cb_state->descriptor_heap.resource_reserved;
     if (resource_existing_range.non_empty()) {
         CommandBufferReservedAddressRemoveOps remove_ops{cb_state};
         descriptor_heap_reserved_address.resource_map.erase_range_or_touch(resource_existing_range, remove_ops);
     }
 
-    const vvl::range<VkDeviceAddress> &sampler_existing_range = cb_state->descriptor_heap.sampler_reserved;
+    const vvl::range<VkDeviceAddress>& sampler_existing_range = cb_state->descriptor_heap.sampler_reserved;
     if (sampler_existing_range.non_empty()) {
         CommandBufferReservedAddressRemoveOps remove_ops{cb_state};
         descriptor_heap_reserved_address.sampler_map.erase_range_or_touch(sampler_existing_range, remove_ops);
     }
 }
 
-void DeviceState::PostCallRecordCmdBindSamplerHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT *pBindInfo,
-                                                      const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBindSamplerHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT* pBindInfo,
+                                                      const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->descriptor_heap.sampler_bound = true;
 
@@ -6839,8 +6839,8 @@ void DeviceState::PostCallRecordCmdBindSamplerHeapEXT(VkCommandBuffer commandBuf
     TrackDeviceAddressRange(*cb_state, range, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT);
 }
 
-void DeviceState::PostCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT *pBindInfo,
-                                                       const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT* pBindInfo,
+                                                       const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->descriptor_heap.resource_bound = true;
 
@@ -6860,8 +6860,8 @@ void DeviceState::PostCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBu
     TrackDeviceAddressRange(*cb_state, range, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT);
 }
 
-void DeviceState::PostCallRecordCmdPushDataEXT(VkCommandBuffer commandBuffer, const VkPushDataInfoEXT *pPushDataInfo,
-                                               const RecordObject &record_obj) {
+void DeviceState::PostCallRecordCmdPushDataEXT(VkCommandBuffer commandBuffer, const VkPushDataInfoEXT* pPushDataInfo,
+                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state);
     cb_state->RecordCmdPushDataEXT(*pPushDataInfo, record_obj.location);

--- a/layers/state_tracker/tensor_state.cpp
+++ b/layers/state_tracker/tensor_state.cpp
@@ -18,15 +18,16 @@
 #include "state_object.h"
 #include "state_tracker/state_tracker.h"
 
-static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkTensorCreateInfoARM *create_info) {
-    const auto *external_memory_info = vku::FindStructInPNextChain<VkExternalMemoryTensorCreateInfoARM>(create_info->pNext);
+static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkTensorCreateInfoARM* create_info) {
+    const auto* external_memory_info = vku::FindStructInPNextChain<VkExternalMemoryTensorCreateInfoARM>(create_info->pNext);
     return external_memory_info ? external_memory_info->handleTypes : 0;
 }
 
 namespace vvl {
 
-Tensor::Tensor(DeviceState &dev_data, VkTensorARM handle, const VkTensorCreateInfoARM *pCreateInfo)
-    : Bindable(handle, kVulkanObjectTypeTensorARM, false, (pCreateInfo->flags & VK_TENSOR_CREATE_PROTECTED_BIT_ARM) == 0, GetExternalHandleTypes(pCreateInfo)),
+Tensor::Tensor(DeviceState& dev_data, VkTensorARM handle, const VkTensorCreateInfoARM* pCreateInfo)
+    : Bindable(handle, kVulkanObjectTypeTensorARM, false, (pCreateInfo->flags & VK_TENSOR_CREATE_PROTECTED_BIT_ARM) == 0,
+               GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       safe_description(pCreateInfo->pDescription),
@@ -37,7 +38,7 @@ Tensor::Tensor(DeviceState &dev_data, VkTensorARM handle, const VkTensorCreateIn
     SetMemoryTracker(&std::get<BindableLinearMemoryTracker>(tracker_));
 }
 
-bool Tensor::CompareCreateInfo(const Tensor &other) const {
+bool Tensor::CompareCreateInfo(const Tensor& other) const {
     bool valid_queue_family = true;
     if (create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
         if (create_info.queueFamilyIndexCount != other.create_info.queueFamilyIndexCount) {
@@ -81,14 +82,14 @@ bool Tensor::CompareCreateInfo(const Tensor &other) const {
            valid_queue_family && valid_external && valid_dimensions && valid_strides;
 }
 
-TensorView::TensorView(const std::shared_ptr<Tensor> &tensor, VkTensorViewARM handle, const VkTensorViewCreateInfoARM *pCreateInfo)
+TensorView::TensorView(const std::shared_ptr<Tensor>& tensor, VkTensorViewARM handle, const VkTensorViewCreateInfoARM* pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeTensorViewARM),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       tensor_state(tensor) {}
 
 void TensorView::Destroy() {
-    for (auto &item : sub_states_) {
+    for (auto& item : sub_states_) {
         item.second->Destroy();
     }
     if (tensor_state) {
@@ -98,8 +99,8 @@ void TensorView::Destroy() {
     StateObject::Destroy();
 }
 
-void TensorView::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &item : sub_states_) {
+void TensorView::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
+    for (auto& item : sub_states_) {
         item.second->NotifyInvalidate(invalid_nodes, unlink);
     }
     StateObject::NotifyInvalidate(invalid_nodes, unlink);

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -23,7 +23,7 @@
 
 namespace vvl {
 
-VideoProfileDesc::VideoProfileDesc(VkPhysicalDevice physical_device, VkVideoProfileInfoKHR const *profile)
+VideoProfileDesc::VideoProfileDesc(VkPhysicalDevice physical_device, VkVideoProfileInfoKHR const* profile)
     : std::enable_shared_from_this<VideoProfileDesc>(),
       physical_device_(physical_device),
       profile_(),
@@ -41,7 +41,7 @@ VideoProfileDesc::~VideoProfileDesc() {
     }
 }
 
-bool VideoProfileDesc::InitProfile(VkVideoProfileInfoKHR const *profile) {
+bool VideoProfileDesc::InitProfile(VkVideoProfileInfoKHR const* profile) {
     if (profile) {
         profile_.base = *profile;
         profile_.base.pNext = nullptr;
@@ -261,7 +261,7 @@ void VideoProfileDesc::InitQuantizationMapFormats(VkPhysicalDevice physical_devi
     struct QuantMapTypeInfo {
         VkImageUsageFlagBits usage;
         VkVideoEncodeCapabilityFlagBitsKHR cap;
-        SupportedQuantizationMapTexelSizes *supported_texel_sizes;
+        SupportedQuantizationMapTexelSizes* supported_texel_sizes;
     };
 
     const std::vector<QuantMapTypeInfo> map_types{
@@ -271,7 +271,7 @@ void VideoProfileDesc::InitQuantizationMapFormats(VkPhysicalDevice physical_devi
          &emphasis_map_texel_sizes_},
     };
 
-    for (const auto &map_type : map_types) {
+    for (const auto& map_type : map_types) {
         if ((capabilities_.encode.flags & map_type.cap) == 0) continue;
 
         VkPhysicalDeviceVideoFormatInfoKHR info = vku::InitStructHelper();
@@ -298,17 +298,17 @@ void VideoProfileDesc::InitQuantizationMapFormats(VkPhysicalDevice physical_devi
             continue;
         }
 
-        for (const auto &props : map_props) {
+        for (const auto& props : map_props) {
             map_type.supported_texel_sizes->insert(props.quantizationMapTexelSize);
         }
     }
 }
 
 std::shared_ptr<const VideoProfileDesc> VideoProfileDesc::Cache::GetOrCreate(VkPhysicalDevice physical_device,
-                                                                             VkVideoProfileInfoKHR const *profile) {
+                                                                             VkVideoProfileInfoKHR const* profile) {
     VideoProfileDesc desc(physical_device, profile);
     if (desc.GetProfile().valid) {
-        auto &set = entries_[physical_device];
+        auto& set = entries_[physical_device];
         auto it = set.find(&desc);
         if (it != set.end()) {
             return (*it)->shared_from_this();
@@ -324,7 +324,7 @@ std::shared_ptr<const VideoProfileDesc> VideoProfileDesc::Cache::GetOrCreate(VkP
 }
 
 std::shared_ptr<const VideoProfileDesc> VideoProfileDesc::Cache::Get(VkPhysicalDevice physical_device,
-                                                                     VkVideoProfileInfoKHR const *profile) {
+                                                                     VkVideoProfileInfoKHR const* profile) {
     if (profile) {
         std::unique_lock<std::mutex> lock(mutex_);
         return GetOrCreate(physical_device, profile);
@@ -334,7 +334,7 @@ std::shared_ptr<const VideoProfileDesc> VideoProfileDesc::Cache::Get(VkPhysicalD
 }
 
 SupportedVideoProfiles VideoProfileDesc::Cache::Get(VkPhysicalDevice physical_device,
-                                                    VkVideoProfileListInfoKHR const *profile_list) {
+                                                    VkVideoProfileListInfoKHR const* profile_list) {
     SupportedVideoProfiles supported_profiles{};
     if (profile_list) {
         std::unique_lock<std::mutex> lock(mutex_);
@@ -348,7 +348,7 @@ SupportedVideoProfiles VideoProfileDesc::Cache::Get(VkPhysicalDevice physical_de
     return supported_profiles;
 }
 
-void VideoProfileDesc::Cache::Release(VideoProfileDesc const *desc) {
+void VideoProfileDesc::Cache::Release(VideoProfileDesc const* desc) {
     std::unique_lock<std::mutex> lock(mutex_);
     entries_[desc->physical_device_].erase(desc);
 }
@@ -356,7 +356,7 @@ void VideoProfileDesc::Cache::Release(VideoProfileDesc const *desc) {
 VideoPictureResource::VideoPictureResource()
     : image_view_state(nullptr), image_state(nullptr), base_array_layer(0), range(), coded_offset(), coded_extent() {}
 
-VideoPictureResource::VideoPictureResource(const DeviceState &dev_data, VkVideoPictureResourceInfoKHR const &res)
+VideoPictureResource::VideoPictureResource(const DeviceState& dev_data, VkVideoPictureResourceInfoKHR const& res)
     : image_view_state(dev_data.Get<ImageView>(res.imageViewBinding)),
       image_state(image_view_state ? image_view_state->image_state : nullptr),
       base_array_layer(res.baseArrayLayer),
@@ -364,7 +364,7 @@ VideoPictureResource::VideoPictureResource(const DeviceState &dev_data, VkVideoP
       coded_offset(res.codedOffset),
       coded_extent(res.codedExtent) {}
 
-VkImageSubresourceRange VideoPictureResource::GetImageSubresourceRange(ImageView const *image_view_state, uint32_t layer) {
+VkImageSubresourceRange VideoPictureResource::GetImageSubresourceRange(ImageView const* image_view_state, uint32_t layer) {
     VkImageSubresourceRange range{};
     if (image_view_state) {
         range = image_view_state->normalized_subresource_range;
@@ -374,7 +374,7 @@ VkImageSubresourceRange VideoPictureResource::GetImageSubresourceRange(ImageView
     return range;
 }
 
-VkOffset3D VideoPictureResource::GetEffectiveImageOffset(const vvl::VideoSession &vs_state) const {
+VkOffset3D VideoPictureResource::GetEffectiveImageOffset(const vvl::VideoSession& vs_state) const {
     VkOffset3D offset{coded_offset.x, coded_offset.y, 0};
 
     // Round to picture access granularity
@@ -385,7 +385,7 @@ VkOffset3D VideoPictureResource::GetEffectiveImageOffset(const vvl::VideoSession
     return offset;
 }
 
-VkExtent3D VideoPictureResource::GetEffectiveImageExtent(const vvl::VideoSession &vs_state) const {
+VkExtent3D VideoPictureResource::GetEffectiveImageExtent(const vvl::VideoSession& vs_state) const {
     VkExtent3D extent{coded_extent.width, coded_extent.height, 1};
 
     // H.264 decode interlacing with separate planes only accesses half of the coded height
@@ -406,7 +406,7 @@ VkExtent3D VideoPictureResource::GetEffectiveImageExtent(const vvl::VideoSession
     return extent;
 }
 
-VideoPictureID::VideoPictureID(VideoProfileDesc const &profile, VkVideoReferenceSlotInfoKHR const &slot) {
+VideoPictureID::VideoPictureID(VideoProfileDesc const& profile, VkVideoReferenceSlotInfoKHR const& slot) {
     switch (profile.GetCodecOp()) {
         case VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR: {
             auto slot_info = vku::FindStructInPNextChain<VkVideoDecodeH264DpbSlotInfoKHR>(slot.pNext);
@@ -441,7 +441,7 @@ void VideoSessionDeviceState::Reset() {
     encode_.rate_control_state = VideoEncodeRateControlState();
 }
 
-void VideoSessionDeviceState::Activate(int32_t slot_index, const VideoPictureID &picture_id, const VideoPictureResource &res) {
+void VideoSessionDeviceState::Activate(int32_t slot_index, const VideoPictureID& picture_id, const VideoPictureResource& res) {
     assert(!picture_id.IsBothFields());
 
     if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= is_active_.size()) {
@@ -467,7 +467,7 @@ void VideoSessionDeviceState::Activate(int32_t slot_index, const VideoPictureID 
     pictures_per_id_[slot_index][picture_id] = res;
 }
 
-void VideoSessionDeviceState::Invalidate(int32_t slot_index, const VideoPictureID &picture_id) {
+void VideoSessionDeviceState::Invalidate(int32_t slot_index, const VideoPictureID& picture_id) {
     assert(!picture_id.IsBothFields());
 
     if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= is_active_.size()) {
@@ -489,7 +489,7 @@ void VideoSessionDeviceState::Invalidate(int32_t slot_index, const VideoPictureI
             pictures_per_id_[slot_index].erase(picture_id);
             // Check if there are any more references to the previous resource
             auto other_ref_it = std::find_if(std::begin(pictures_per_id_[slot_index]), std::end(pictures_per_id_[slot_index]),
-                                             [&res](const auto &it) { return it.second == res; });
+                                             [&res](const auto& it) { return it.second == res; });
             if (other_ref_it == pictures_per_id_[slot_index].end()) {
                 // If there are no remaining references to the resource, remove it
                 all_pictures_[slot_index].erase(res);
@@ -519,27 +519,27 @@ class RateControlStateMismatchRecorder {
     RateControlStateMismatchRecorder() : has_mismatch_{false}, stream_{}, string_{} {}
 
     template <typename T>
-    void Record(const char *where, T actual, T expected) {
+    void Record(const char* where, T actual, T expected) {
         has_mismatch_ = true;
         stream_ << where << " (" << actual << ") does not match current device state (" << expected << ")." << std::endl;
     }
 
     template <typename T>
-    void RecordDefault(const char *missing_struct, const char *member, T expected) {
+    void RecordDefault(const char* missing_struct, const char* member, T expected) {
         has_mismatch_ = true;
         stream_ << missing_struct << " is not in the pNext chain but the current device state for its " << member
                 << " member is set (" << expected << ")." << std::endl;
     }
 
     template <typename T>
-    void RecordLayer(uint32_t layer_idx, const char *where, T actual, T expected) {
+    void RecordLayer(uint32_t layer_idx, const char* where, T actual, T expected) {
         has_mismatch_ = true;
         stream_ << where << " (" << actual << ") in VkVideoEncodeRateControlLayerInfoKHR::pLayers[" << layer_idx
                 << "] does not match current device state (" << expected << ")." << std::endl;
     }
 
     template <typename T>
-    void RecordLayerDefault(uint32_t layer_idx, const char *missing_struct, const char *member, T expected) {
+    void RecordLayerDefault(uint32_t layer_idx, const char* missing_struct, const char* member, T expected) {
         has_mismatch_ = true;
         stream_ << missing_struct << " is not in the pNext chain of VkVideoEncodeRateControlLayerInfoKHR::pLayers[" << layer_idx
                 << "] but the current device state for its " << member << " member is set (" << expected << ")." << std::endl;
@@ -547,7 +547,7 @@ class RateControlStateMismatchRecorder {
 
     bool HasMismatch() const { return has_mismatch_; }
 
-    const char *c_str() const {
+    const char* c_str() const {
         string_ = stream_.str();
         return string_.c_str();
     }
@@ -558,9 +558,9 @@ class RateControlStateMismatchRecorder {
     mutable std::string string_{};
 };
 
-bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const VideoSession *vs_state,
-                                                       const vku::safe_VkVideoBeginCodingInfoKHR &begin_info,
-                                                       const Location &loc) const {
+bool VideoSessionDeviceState::ValidateRateControlState(const Logger& log, const VideoSession* vs_state,
+                                                       const vku::safe_VkVideoBeginCodingInfoKHR& begin_info,
+                                                       const Location& loc) const {
     bool skip = false;
 
     assert(vs_state->IsEncode());
@@ -568,7 +568,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
     auto rc_base = vku::FindStructInPNextChain<VkVideoEncodeRateControlInfoKHR>(begin_info.pNext);
 
     if (rc_base != nullptr) {
-        const auto &ref_base = encode_.rate_control_state.base;
+        const auto& ref_base = encode_.rate_control_state.base;
         RateControlStateMismatchRecorder mismatch_recorder{};
 
         auto string_bool = [](VkBool32 value) { return value ? "VK_TRUE" : "VK_FALSE"; };
@@ -604,7 +604,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
         switch (vs_state->GetCodecOp()) {
             case VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR: {
                 auto rc_h264 = vku::FindStructInPNextChain<VkVideoEncodeH264RateControlInfoKHR>(begin_info.pNext);
-                const auto &ref_h264 = encode_.rate_control_state.h264;
+                const auto& ref_h264 = encode_.rate_control_state.h264;
                 CHECK_RC_INFO(h264, VkVideoEncodeH264RateControlInfoKHR, flags, string_VkVideoEncodeH264RateControlFlagsKHR);
                 CHECK_RC_INFO(h264, VkVideoEncodeH264RateControlInfoKHR, gopFrameCount, uint32_t);
                 CHECK_RC_INFO(h264, VkVideoEncodeH264RateControlInfoKHR, idrPeriod, uint32_t);
@@ -615,7 +615,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
 
             case VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR: {
                 auto rc_h265 = vku::FindStructInPNextChain<VkVideoEncodeH265RateControlInfoKHR>(begin_info.pNext);
-                const auto &ref_h265 = encode_.rate_control_state.h265;
+                const auto& ref_h265 = encode_.rate_control_state.h265;
                 CHECK_RC_INFO(h265, VkVideoEncodeH265RateControlInfoKHR, flags, string_VkVideoEncodeH265RateControlFlagsKHR);
                 CHECK_RC_INFO(h265, VkVideoEncodeH265RateControlInfoKHR, gopFrameCount, uint32_t);
                 CHECK_RC_INFO(h265, VkVideoEncodeH265RateControlInfoKHR, idrPeriod, uint32_t);
@@ -626,7 +626,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
 
             case VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR: {
                 auto rc_av1 = vku::FindStructInPNextChain<VkVideoEncodeAV1RateControlInfoKHR>(begin_info.pNext);
-                const auto &ref_av1 = encode_.rate_control_state.av1;
+                const auto& ref_av1 = encode_.rate_control_state.av1;
                 CHECK_RC_INFO(av1, VkVideoEncodeAV1RateControlInfoKHR, flags, string_VkVideoEncodeAV1RateControlFlagsKHR);
                 CHECK_RC_INFO(av1, VkVideoEncodeAV1RateControlInfoKHR, gopFrameCount, uint32_t);
                 CHECK_RC_INFO(av1, VkVideoEncodeAV1RateControlInfoKHR, keyFramePeriod, uint32_t);
@@ -642,7 +642,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
 
         for (uint32_t layer_idx = 0; layer_idx < std::min(rc_base->layerCount, ref_base.layerCount); ++layer_idx) {
             const auto rc_layer_base = &rc_base->pLayers[layer_idx];
-            const auto &ref_layer_base = encode_.rate_control_state.layers[layer_idx].base;
+            const auto& ref_layer_base = encode_.rate_control_state.layers[layer_idx].base;
 
             CHECK_RC_LAYER_INFO(base, VkVideoEncodeRateControlLayerInfoKHR, averageBitrate, uint64_t);
             CHECK_RC_LAYER_INFO(base, VkVideoEncodeRateControlLayerInfoKHR, maxBitrate, uint64_t);
@@ -653,7 +653,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
                 case VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR: {
                     auto rc_layer_h264 =
                         vku::FindStructInPNextChain<VkVideoEncodeH264RateControlLayerInfoKHR>(rc_layer_base->pNext);
-                    const auto &ref_layer_h264 = encode_.rate_control_state.layers[layer_idx].h264;
+                    const auto& ref_layer_h264 = encode_.rate_control_state.layers[layer_idx].h264;
                     CHECK_RC_LAYER_INFO(h264, VkVideoEncodeH264RateControlLayerInfoKHR, useMinQp, string_bool);
                     CHECK_RC_LAYER_INFO(h264, VkVideoEncodeH264RateControlLayerInfoKHR, minQp.qpI, int32_t);
                     CHECK_RC_LAYER_INFO(h264, VkVideoEncodeH264RateControlLayerInfoKHR, minQp.qpP, int32_t);
@@ -672,7 +672,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
                 case VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR: {
                     auto rc_layer_h265 =
                         vku::FindStructInPNextChain<VkVideoEncodeH265RateControlLayerInfoKHR>(rc_layer_base->pNext);
-                    const auto &ref_layer_h265 = encode_.rate_control_state.layers[layer_idx].h265;
+                    const auto& ref_layer_h265 = encode_.rate_control_state.layers[layer_idx].h265;
                     CHECK_RC_LAYER_INFO(h265, VkVideoEncodeH265RateControlLayerInfoKHR, useMinQp, string_bool);
                     CHECK_RC_LAYER_INFO(h265, VkVideoEncodeH265RateControlLayerInfoKHR, minQp.qpI, int32_t);
                     CHECK_RC_LAYER_INFO(h265, VkVideoEncodeH265RateControlLayerInfoKHR, minQp.qpP, int32_t);
@@ -690,7 +690,7 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
 
                 case VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR: {
                     auto rc_layer_av1 = vku::FindStructInPNextChain<VkVideoEncodeAV1RateControlLayerInfoKHR>(rc_layer_base->pNext);
-                    const auto &ref_layer_av1 = encode_.rate_control_state.layers[layer_idx].av1;
+                    const auto& ref_layer_av1 = encode_.rate_control_state.layers[layer_idx].av1;
                     CHECK_RC_LAYER_INFO(av1, VkVideoEncodeAV1RateControlLayerInfoKHR, useMinQIndex, string_bool);
                     CHECK_RC_LAYER_INFO(av1, VkVideoEncodeAV1RateControlLayerInfoKHR, minQIndex.intraQIndex, uint32_t);
                     CHECK_RC_LAYER_INFO(av1, VkVideoEncodeAV1RateControlLayerInfoKHR, minQIndex.predictiveQIndex, uint32_t);
@@ -735,13 +735,13 @@ bool VideoSessionDeviceState::ValidateRateControlState(const Logger &log, const 
     return skip;
 }
 
-static VkVideoEncodeIntraRefreshModeFlagBitsKHR InitIntraRefreshMode(const VkVideoSessionCreateInfoKHR *ci) {
+static VkVideoEncodeIntraRefreshModeFlagBitsKHR InitIntraRefreshMode(const VkVideoSessionCreateInfoKHR* ci) {
     auto intra_refresh_info = vku::FindStructInPNextChain<VkVideoEncodeSessionIntraRefreshCreateInfoKHR>(ci->pNext);
     return (intra_refresh_info) ? intra_refresh_info->intraRefreshMode : VK_VIDEO_ENCODE_INTRA_REFRESH_MODE_NONE_KHR;
 }
 
-VideoSession::VideoSession(const DeviceState &dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
-                           std::shared_ptr<const VideoProfileDesc> &&profile_desc)
+VideoSession::VideoSession(const DeviceState& dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const* pCreateInfo,
+                           std::shared_ptr<const VideoProfileDesc>&& profile_desc)
     : StateObject(handle, kVulkanObjectTypeVideoSessionKHR),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -754,7 +754,7 @@ VideoSession::VideoSession(const DeviceState &dev_data, VkVideoSessionKHR handle
       device_state_mutex_(),
       device_state_(pCreateInfo->maxDpbSlots) {}
 
-VideoSession::MemoryBindingMap VideoSession::GetMemoryBindings(const DeviceState &dev_data, VkVideoSessionKHR vs) {
+VideoSession::MemoryBindingMap VideoSession::GetMemoryBindings(const DeviceState& dev_data, VkVideoSessionKHR vs) {
     uint32_t memory_requirement_count;
     DispatchGetVideoSessionMemoryRequirementsKHR(dev_data.device, vs, &memory_requirement_count, nullptr);
 
@@ -770,7 +770,7 @@ VideoSession::MemoryBindingMap VideoSession::GetMemoryBindings(const DeviceState
     return memory_bindings;
 }
 
-bool VideoSession::ReferenceSetupRequested(VkVideoDecodeInfoKHR const &decode_info) const {
+bool VideoSession::ReferenceSetupRequested(VkVideoDecodeInfoKHR const& decode_info) const {
     switch (GetCodecOp()) {
         case VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR: {
             auto pic_info = vku::FindStructInPNextChain<VkVideoDecodeH264PictureInfoKHR>(decode_info.pNext);
@@ -797,7 +797,7 @@ bool VideoSession::ReferenceSetupRequested(VkVideoDecodeInfoKHR const &decode_in
     }
 }
 
-bool VideoSession::ReferenceSetupRequested(VkVideoEncodeInfoKHR const &encode_info) const {
+bool VideoSession::ReferenceSetupRequested(VkVideoEncodeInfoKHR const& encode_info) const {
     switch (GetCodecOp()) {
         case VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR: {
             auto pic_info = vku::FindStructInPNextChain<VkVideoEncodeH264PictureInfoKHR>(encode_info.pNext);
@@ -821,9 +821,9 @@ bool VideoSession::ReferenceSetupRequested(VkVideoEncodeInfoKHR const &encode_in
 }
 
 VideoSessionParameters::VideoSessionParameters(VkVideoSessionParametersKHR handle,
-                                               VkVideoSessionParametersCreateInfoKHR const *pCreateInfo,
-                                               std::shared_ptr<VideoSession> &&vsstate,
-                                               std::shared_ptr<VideoSessionParameters> &&vsp_template)
+                                               VkVideoSessionParametersCreateInfoKHR const* pCreateInfo,
+                                               std::shared_ptr<VideoSession>&& vsstate,
+                                               std::shared_ptr<VideoSessionParameters>&& vsp_template)
     : StateObject(handle, kVulkanObjectTypeVideoSessionParametersKHR),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -929,7 +929,7 @@ VideoSessionParameters::VideoSessionParameters(VkVideoSessionParametersKHR handl
     }
 }
 
-VideoSessionParameters::Config VideoSessionParameters::InitConfig(VkVideoSessionParametersCreateInfoKHR const *pCreateInfo) {
+VideoSessionParameters::Config VideoSessionParameters::InitConfig(VkVideoSessionParametersCreateInfoKHR const* pCreateInfo) {
     Config config{};
 
     if (vs_state->IsEncode()) {
@@ -948,7 +948,7 @@ VideoSessionParameters::Config VideoSessionParameters::InitConfig(VkVideoSession
     return config;
 }
 
-void VideoSessionParameters::Update(VkVideoSessionParametersUpdateInfoKHR const *info) {
+void VideoSessionParameters::Update(VkVideoSessionParametersUpdateInfoKHR const* info) {
     auto lock = Lock();
 
     data_.update_sequence_counter = info->updateSequenceCount;
@@ -1009,61 +1009,61 @@ void VideoSessionParameters::Update(VkVideoSessionParametersUpdateInfoKHR const 
     }
 }
 
-void VideoSessionParameters::AddDecodeH264(VkVideoDecodeH264SessionParametersAddInfoKHR const *info) {
+void VideoSessionParameters::AddDecodeH264(VkVideoDecodeH264SessionParametersAddInfoKHR const* info) {
     for (uint32_t i = 0; i < info->stdSPSCount; ++i) {
-        const auto &entry = info->pStdSPSs[i];
+        const auto& entry = info->pStdSPSs[i];
         data_.h264.sps[GetH264SPSKey(entry)] = entry;
     }
     for (uint32_t i = 0; i < info->stdPPSCount; ++i) {
-        const auto &entry = info->pStdPPSs[i];
+        const auto& entry = info->pStdPPSs[i];
         data_.h264.pps[GetH264PPSKey(entry)] = entry;
     }
 }
 
-void VideoSessionParameters::AddDecodeH265(VkVideoDecodeH265SessionParametersAddInfoKHR const *info) {
+void VideoSessionParameters::AddDecodeH265(VkVideoDecodeH265SessionParametersAddInfoKHR const* info) {
     for (uint32_t i = 0; i < info->stdVPSCount; ++i) {
-        const auto &entry = info->pStdVPSs[i];
+        const auto& entry = info->pStdVPSs[i];
         data_.h265.vps[GetH265VPSKey(entry)] = entry;
     }
     for (uint32_t i = 0; i < info->stdSPSCount; ++i) {
-        const auto &entry = info->pStdSPSs[i];
+        const auto& entry = info->pStdSPSs[i];
         data_.h265.sps[GetH265SPSKey(entry)] = entry;
     }
     for (uint32_t i = 0; i < info->stdPPSCount; ++i) {
-        const auto &entry = info->pStdPPSs[i];
+        const auto& entry = info->pStdPPSs[i];
         data_.h265.pps[GetH265PPSKey(entry)] = entry;
     }
 }
 
-void VideoSessionParameters::AddEncodeH264(VkVideoEncodeH264SessionParametersAddInfoKHR const *info) {
+void VideoSessionParameters::AddEncodeH264(VkVideoEncodeH264SessionParametersAddInfoKHR const* info) {
     for (uint32_t i = 0; i < info->stdSPSCount; ++i) {
-        const auto &entry = info->pStdSPSs[i];
+        const auto& entry = info->pStdSPSs[i];
         data_.h264.sps[GetH264SPSKey(entry)] = entry;
     }
     for (uint32_t i = 0; i < info->stdPPSCount; ++i) {
-        const auto &entry = info->pStdPPSs[i];
+        const auto& entry = info->pStdPPSs[i];
         data_.h264.pps[GetH264PPSKey(entry)] = entry;
     }
 }
 
-void VideoSessionParameters::AddEncodeH265(VkVideoEncodeH265SessionParametersAddInfoKHR const *info) {
+void VideoSessionParameters::AddEncodeH265(VkVideoEncodeH265SessionParametersAddInfoKHR const* info) {
     for (uint32_t i = 0; i < info->stdVPSCount; ++i) {
-        const auto &entry = info->pStdVPSs[i];
+        const auto& entry = info->pStdVPSs[i];
         data_.h265.vps[GetH265VPSKey(entry)] = entry;
     }
     for (uint32_t i = 0; i < info->stdSPSCount; ++i) {
-        const auto &entry = info->pStdSPSs[i];
+        const auto& entry = info->pStdSPSs[i];
         data_.h265.sps[GetH265SPSKey(entry)] = entry;
     }
     for (uint32_t i = 0; i < info->stdPPSCount; ++i) {
-        const auto &entry = info->pStdPPSs[i];
+        const auto& entry = info->pStdPPSs[i];
         data_.h265.pps[GetH265PPSKey(entry)] = entry;
     }
 }
 
-std::string string_VideoProfileDesc(const vvl::VideoProfileDesc &profile) {
+std::string string_VideoProfileDesc(const vvl::VideoProfileDesc& profile) {
     std::ostringstream ss;
-    const vvl::VideoProfileDesc::Profile &internal_profile = profile.GetProfile();
+    const vvl::VideoProfileDesc::Profile& internal_profile = profile.GetProfile();
 
     switch (internal_profile.base.videoCodecOperation) {
         case VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_KHR:
@@ -1247,11 +1247,11 @@ std::string string_VideoProfileDesc(const vvl::VideoProfileDesc &profile) {
     return ss.str();
 }
 
-std::string string_SupportedVideoProfiles(const SupportedVideoProfiles &profiles) {
+std::string string_SupportedVideoProfiles(const SupportedVideoProfiles& profiles) {
     std::ostringstream ss;
 
     if (!profiles.empty()) {
-        for (const auto &profile : profiles) {
+        for (const auto& profile : profiles) {
             ss << "\t" << string_VideoProfileDesc(*profile) << "\n";
         }
     } else {

--- a/layers/state_tracker/wsi_state.cpp
+++ b/layers/state_tracker/wsi_state.cpp
@@ -25,7 +25,7 @@
 #include "state_tracker/semaphore_state.h"
 #include "generated/dispatch_functions.h"
 
-static vku::safe_VkImageCreateInfo GetImageCreateInfo(const VkSwapchainCreateInfoKHR *pCreateInfo) {
+static vku::safe_VkImageCreateInfo GetImageCreateInfo(const VkSwapchainCreateInfoKHR* pCreateInfo) {
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     // Pull out the format list only. This stack variable will get copied onto the heap
     // by the 'safe' constructor used to build the return value below.
@@ -78,7 +78,7 @@ void SwapchainImage::ResetAcquireState() {
 
 void SwapchainImage::ResetPresentWaitSemaphores() {
     const bool swapchain_has_completed_presentation = !present_wait_semaphores.empty();
-    for (auto &semaphore : present_wait_semaphores) {
+    for (auto& semaphore : present_wait_semaphores) {
         semaphore->ClearSwapchainWaitInfo();
     }
     present_wait_semaphores.clear();
@@ -88,14 +88,14 @@ void SwapchainImage::ResetPresentWaitSemaphores() {
     // from the old swapchain as not in-use.
     // NOTE: that's the algorithm we use to track old semaphores without swapchain maintenance1 extension.
     if (swapchain_has_completed_presentation && image_state->bind_swapchain) {
-        for (auto &old_present_wait_semaphore : image_state->bind_swapchain->old_swapchain_present_wait_semaphores) {
+        for (auto& old_present_wait_semaphore : image_state->bind_swapchain->old_swapchain_present_wait_semaphores) {
             old_present_wait_semaphore->ClearSwapchainWaitInfo();
         }
         image_state->bind_swapchain->old_swapchain_present_wait_semaphores.clear();
     }
 }
 
-Swapchain::Swapchain(vvl::DeviceState &dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
+Swapchain::Swapchain(vvl::DeviceState& dev_data_, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
     : StateObject(handle, kVulkanObjectTypeSwapchainKHR),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -121,7 +121,7 @@ Swapchain::Swapchain(vvl::DeviceState &dev_data_, const VkSwapchainCreateInfoKHR
     }
 }
 
-void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference &present_submission_ref,
+void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference& present_submission_ref,
                              vvl::span<std::shared_ptr<vvl::Semaphore>> present_wait_semaphores) {
     if (image_index >= images.size()) {
         return;
@@ -135,7 +135,7 @@ void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id, const Su
 
     images[image_index].present_submission_ref = present_submission_ref;
     images[image_index].present_wait_semaphores.clear();
-    for (const auto &semaphore : present_wait_semaphores) {
+    for (const auto& semaphore : present_wait_semaphores) {
         images[image_index].present_wait_semaphores.emplace_back(semaphore);
     }
 
@@ -144,7 +144,7 @@ void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id, const Su
     // Old swapchain can't track semaphore in-use status anymore. That functionality is part of acquire logic
     // and old swapchain can't acquire new images.
     if (new_swapchain) {
-        auto &old_wait_semaphores = new_swapchain->old_swapchain_present_wait_semaphores;
+        auto& old_wait_semaphores = new_swapchain->old_swapchain_present_wait_semaphores;
         old_wait_semaphores.insert(old_wait_semaphores.end(), present_wait_semaphores.begin(), present_wait_semaphores.end());
     }
 
@@ -173,8 +173,8 @@ void Swapchain::ReleaseImage(uint32_t image_index) {
     }
 }
 
-void Swapchain::AcquireImage(uint32_t image_index, const std::shared_ptr<vvl::Semaphore> &semaphore_state,
-                             const std::shared_ptr<vvl::Fence> &fence_state) {
+void Swapchain::AcquireImage(uint32_t image_index, const std::shared_ptr<vvl::Semaphore>& semaphore_state,
+                             const std::shared_ptr<vvl::Fence>& fence_state) {
     acquired_images++;
     images[image_index].acquired = true;
     images[image_index].acquire_semaphore = semaphore_state;
@@ -214,7 +214,7 @@ void Swapchain::AcquireImage(uint32_t image_index, const std::shared_ptr<vvl::Se
 }
 
 void Swapchain::Destroy() {
-    for (auto &swapchain_image : images) {
+    for (auto& swapchain_image : images) {
         swapchain_image.ResetPresentWaitSemaphores();
         RemoveParent(swapchain_image.image_state);
         dev_data.Destroy<vvl::Image>(swapchain_image.image_state->VkHandle());
@@ -243,7 +243,7 @@ void Swapchain::Destroy() {
     StateObject::Destroy();
 }
 
-void Swapchain::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
+void Swapchain::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
     StateObject::NotifyInvalidate(invalid_nodes, unlink);
     if (unlink) {
         surface = nullptr;
@@ -304,7 +304,7 @@ void Surface::Destroy() {
     StateObject::Destroy();
 }
 
-void Surface::RemoveParent(StateObject *parent_node) {
+void Surface::RemoveParent(StateObject* parent_node) {
     if (swapchain == parent_node) {
         swapchain = nullptr;
     }
@@ -356,14 +356,14 @@ std::vector<VkPresentModeKHR> Surface::GetPresentModes(VkPhysicalDevice phys_dev
     return present_modes;
 }
 
-void Surface::SetFormats(VkPhysicalDevice phys_dev, std::vector<vku::safe_VkSurfaceFormat2KHR> &&fmts) {
+void Surface::SetFormats(VkPhysicalDevice phys_dev, std::vector<vku::safe_VkSurfaceFormat2KHR>&& fmts) {
     auto guard = Lock();
     assert(phys_dev);
     formats_[phys_dev] = std::move(fmts);
 }
 
 vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                                   const void *surface_info2_pnext) const {
+                                                                   const void* surface_info2_pnext) const {
     auto guard = Lock();
 
     // TODO: BUG: format also depends on pNext. Rework this function similar to GetSurfaceCapabilities
@@ -403,7 +403,7 @@ vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surf
         } else {
             result.reserve(count);
             VkSurfaceFormat2KHR format2 = vku::InitStructHelper();
-            for (const auto &format : formats) {
+            for (const auto& format : formats) {
                 format2.surfaceFormat = format;
                 result.emplace_back(&format2);
             }
@@ -413,8 +413,8 @@ vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surf
     return vvl::span<const vku::safe_VkSurfaceFormat2KHR>(formats_[phys_dev]);
 }
 
-const Surface::PresentModeInfo *Surface::PhysDevCache::GetPresentModeInfo(VkPresentModeKHR present_mode) const {
-    for (auto &info : present_mode_infos) {
+const Surface::PresentModeInfo* Surface::PhysDevCache::GetPresentModeInfo(VkPresentModeKHR present_mode) const {
+    for (auto& info : present_mode_infos) {
         if (info.present_mode == present_mode) {
             return &info;
         }
@@ -422,26 +422,26 @@ const Surface::PresentModeInfo *Surface::PhysDevCache::GetPresentModeInfo(VkPres
     return nullptr;
 }
 
-const Surface::PhysDevCache *Surface::GetPhysDevCache(VkPhysicalDevice phys_dev) const {
+const Surface::PhysDevCache* Surface::GetPhysDevCache(VkPhysicalDevice phys_dev) const {
     auto it = cache_.find(phys_dev);
     return (it == cache_.end()) ? nullptr : &it->second;
 }
 
-void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurfaceCapabilitiesKHR &surface_caps) {
+void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurfaceCapabilitiesKHR& surface_caps) {
     auto guard = Lock();
-    PhysDevCache &cache = cache_[phys_dev];
+    PhysDevCache& cache = cache_[phys_dev];
     cache.capabilities = surface_caps;
     cache.last_capability_query_used_present_mode = false;
 }
 
-void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurfaceCapabilities2KHR &surface_caps,
+void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurfaceCapabilities2KHR& surface_caps,
                                       VkPresentModeKHR present_mode) {
     auto guard = Lock();
-    auto &cache = cache_[phys_dev];
+    auto& cache = cache_[phys_dev];
 
     // Get entry for the given presentation mode
-    PresentModeInfo *info = nullptr;
-    for (auto &cur_info : cache.present_mode_infos) {
+    PresentModeInfo* info = nullptr;
+    for (auto& cur_info : cache.present_mode_infos) {
         if (cur_info.present_mode == present_mode) {
             info = &cur_info;
             break;
@@ -455,11 +455,11 @@ void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurface
 
     // Update entry
     info->surface_capabilities = surface_caps.surfaceCapabilities;
-    const auto *present_scaling_caps = vku::FindStructInPNextChain<VkSurfacePresentScalingCapabilitiesKHR>(surface_caps.pNext);
+    const auto* present_scaling_caps = vku::FindStructInPNextChain<VkSurfacePresentScalingCapabilitiesKHR>(surface_caps.pNext);
     if (present_scaling_caps) {
         info->scaling_capabilities = *present_scaling_caps;
     }
-    const auto *compat_modes = vku::FindStructInPNextChain<VkSurfacePresentModeCompatibilityKHR>(surface_caps.pNext);
+    const auto* compat_modes = vku::FindStructInPNextChain<VkSurfacePresentModeCompatibilityKHR>(surface_caps.pNext);
     if (compat_modes && compat_modes->pPresentModes) {
         info->compatible_present_modes.emplace(compat_modes->pPresentModes,
                                                compat_modes->pPresentModes + compat_modes->presentModeCount);
@@ -474,7 +474,7 @@ bool Surface::IsLastCapabilityQueryUsedPresentMode(VkPhysicalDevice phys_dev) co
     return false;
 }
 
-VkSurfaceCapabilitiesKHR Surface::GetSurfaceCapabilities(VkPhysicalDevice phys_dev, const void *surface_info_pnext) const {
+VkSurfaceCapabilitiesKHR Surface::GetSurfaceCapabilities(VkPhysicalDevice phys_dev, const void* surface_info_pnext) const {
     if (!surface_info_pnext) {
         if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
             if (cache->capabilities.has_value()) {
@@ -487,11 +487,11 @@ VkSurfaceCapabilitiesKHR Surface::GetSurfaceCapabilities(VkPhysicalDevice phys_d
     }
 
     // Per present mode caching is supported for a common case when pNext chain is a single VkSurfacePresentModeKHR structure.
-    const auto *surface_present_mode = vku::FindStructInPNextChain<VkSurfacePresentModeKHR>(surface_info_pnext);
-    const bool single_pnext_element = static_cast<const VkBaseInStructure *>(surface_info_pnext)->pNext == nullptr;
+    const auto* surface_present_mode = vku::FindStructInPNextChain<VkSurfacePresentModeKHR>(surface_info_pnext);
+    const bool single_pnext_element = static_cast<const VkBaseInStructure*>(surface_info_pnext)->pNext == nullptr;
     if (surface_present_mode && single_pnext_element) {
         if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
-            const PresentModeInfo *info = cache->GetPresentModeInfo(surface_present_mode->presentMode);
+            const PresentModeInfo* info = cache->GetPresentModeInfo(surface_present_mode->presentMode);
             if (info) {
                 return info->surface_capabilities;
             }
@@ -515,7 +515,7 @@ VkSurfaceCapabilitiesKHR Surface::GetPresentModeSurfaceCapabilities(VkPhysicalDe
 VkSurfacePresentScalingCapabilitiesKHR Surface::GetPresentModeScalingCapabilities(VkPhysicalDevice phys_dev,
                                                                                   VkPresentModeKHR present_mode) const {
     if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
-        const PresentModeInfo *info = cache->GetPresentModeInfo(present_mode);
+        const PresentModeInfo* info = cache->GetPresentModeInfo(present_mode);
         if (info && info->scaling_capabilities.has_value()) {
             return info->scaling_capabilities.value();
         }
@@ -532,7 +532,7 @@ VkSurfacePresentScalingCapabilitiesKHR Surface::GetPresentModeScalingCapabilitie
 
 std::vector<VkPresentModeKHR> Surface::GetCompatibleModes(VkPhysicalDevice phys_dev, VkPresentModeKHR present_mode) const {
     if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
-        const PresentModeInfo *info = cache->GetPresentModeInfo(present_mode);
+        const PresentModeInfo* info = cache->GetPresentModeInfo(present_mode);
         if (info && info->compatible_present_modes.has_value()) {
             return info->compatible_present_modes.value();
         }

--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -26,11 +26,11 @@
 
 namespace stateless {
 
-bool Device::manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
-                                                const stateless::Context &context) const {
+bool Device::manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
+                                                const stateless::Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     skip |= context.ValidateNotZero(pCreateInfo->size == 0, "VUID-VkBufferCreateInfo-size-00912", create_info_loc.dot(Field::size));
@@ -48,7 +48,7 @@ bool Device::manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferC
         }
     }
 
-    const auto *usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pCreateInfo->pNext);
+    const auto* usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pCreateInfo->pNext);
     if (!usage_flags2) {
         skip |= context.ValidateFlags(create_info_loc.dot(Field::usage), vvl::FlagBitmask::VkBufferUsageFlagBits,
                                       AllVkBufferUsageFlagBits, pCreateInfo->usage, kRequiredFlags,
@@ -110,9 +110,9 @@ bool Device::manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferC
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
-                                                    const VkAllocationCallbacks *pAllocator, VkBufferView *pBufferView,
-                                                    const Context &context) const {
+bool Device::manual_PreCallValidateCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
+                                                    const VkAllocationCallbacks* pAllocator, VkBufferView* pBufferView,
+                                                    const Context& context) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_METAL_EXT
     skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT,
@@ -122,7 +122,7 @@ bool Device::manual_PreCallValidateCreateBufferView(VkDevice device, const VkBuf
 
     const Location create_info_loc = context.error_obj.location.dot(Field::pCreateInfo);
 
-    const VkDeviceSize &range = pCreateInfo->range;
+    const VkDeviceSize& range = pCreateInfo->range;
     const VkFormat format = pCreateInfo->format;
 
     if (vkuFormatIsDepthOrStencil(format)) {
@@ -176,7 +176,7 @@ bool Device::manual_PreCallValidateCreateBufferView(VkDevice device, const VkBuf
     return skip;
 }
 
-bool Device::ValidateCreateBufferFlags(const VkBufferCreateFlags flags, const Location &flag_loc) const {
+bool Device::ValidateCreateBufferFlags(const VkBufferCreateFlags flags, const Location& flag_loc) const {
     bool skip = false;
 
     if ((flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!enabled_features.sparseBinding)) {
@@ -216,7 +216,7 @@ bool Device::ValidateCreateBufferFlags(const VkBufferCreateFlags flags, const Lo
     return skip;
 }
 
-bool Device::ValidateCreateBufferBufferDeviceAddress(const VkBufferCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateBufferBufferDeviceAddress(const VkBufferCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
     if (auto chained_devaddr_struct = vku::FindStructInPNextChain<VkBufferDeviceAddressCreateInfoEXT>(create_info.pNext)) {
@@ -249,11 +249,11 @@ bool Device::ValidateCreateBufferBufferDeviceAddress(const VkBufferCreateInfo &c
     return skip;
 }
 
-bool Device::ValidateCreateBufferTileMemory(const VkBufferCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateBufferTileMemory(const VkBufferCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
     const VkBufferCreateFlags flags = create_info.flags;
-    const auto *usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(create_info.pNext);
+    const auto* usage_flags2 = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(create_info.pNext);
     const VkBufferUsageFlags2 usage = usage_flags2 ? usage_flags2->usage : create_info.usage;
 
     if (usage & VK_BUFFER_USAGE_TILE_MEMORY_BIT_QCOM) {

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -32,10 +32,10 @@ ReadLockGuard Device::ReadLock() const { return ReadLockGuard(validation_object_
 WriteLockGuard Device::WriteLock() { return WriteLockGuard(validation_object_mutex, std::defer_lock); }
 
 bool Device::ValidateCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkIndexType indexType,
-                                        const Location &loc) const {
+                                        const Location& loc) const {
     bool skip = false;
     const bool is_2 = loc.function != Func::vkCmdBindIndexBuffer;
-    const char *vuid;
+    const char* vuid;
 
     if (buffer == VK_NULL_HANDLE) {
         if (!enabled_features.maintenance6) {
@@ -62,20 +62,20 @@ bool Device::ValidateCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer 
 }
 
 bool Device::manual_PreCallValidateCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                      VkIndexType indexType, const Context &context) const {
+                                                      VkIndexType indexType, const Context& context) const {
     return ValidateCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, context.error_obj.location);
 }
 
 bool Device::manual_PreCallValidateCmdBindIndexBuffer2(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                       VkDeviceSize size, VkIndexType indexType, const Context &context) const {
+                                                       VkDeviceSize size, VkIndexType indexType, const Context& context) const {
     return ValidateCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType, context.error_obj.location);
 }
 
 bool Device::manual_PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
-                                                        const VkBuffer *pBuffers, const VkDeviceSize *pOffsets,
-                                                        const Context &context) const {
+                                                        const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
+                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (firstBinding > phys_dev_props.limits.maxVertexInputBindings) {
         skip |= LogError("VUID-vkCmdBindVertexBuffers-firstBinding-00624", commandBuffer, error_obj.location,
@@ -112,11 +112,11 @@ bool Device::manual_PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandB
 }
 
 bool Device::manual_PreCallValidateCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                                      uint32_t bindingCount, const VkBuffer *pBuffers,
-                                                                      const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
-                                                                      const Context &context) const {
+                                                                      uint32_t bindingCount, const VkBuffer* pBuffers,
+                                                                      const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
+                                                                      const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.transformFeedback) {
         skip |= LogError("VUID-vkCmdBindTransformFeedbackBuffersEXT-transformFeedback-02355", commandBuffer, error_obj.location,
@@ -150,11 +150,11 @@ bool Device::manual_PreCallValidateCmdBindTransformFeedbackBuffersEXT(VkCommandB
 }
 
 bool Device::manual_PreCallValidateCmdBeginTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                                uint32_t counterBufferCount, const VkBuffer *pCounterBuffers,
-                                                                const VkDeviceSize *pCounterBufferOffsets,
-                                                                const Context &context) const {
+                                                                uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
+                                                                const VkDeviceSize* pCounterBufferOffsets,
+                                                                const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.transformFeedback) {
         skip |= LogError("VUID-vkCmdBeginTransformFeedbackEXT-transformFeedback-02366", commandBuffer, error_obj.location,
                          "transformFeedback feature was not enabled.");
@@ -216,11 +216,11 @@ bool Device::manual_PreCallValidateCmdBeginTransformFeedback2EXT(VkCommandBuffer
 }
 
 bool Device::manual_PreCallValidateCmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t firstCounterBuffer,
-                                                              uint32_t counterBufferCount, const VkBuffer *pCounterBuffers,
-                                                              const VkDeviceSize *pCounterBufferOffsets,
-                                                              const Context &context) const {
+                                                              uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
+                                                              const VkDeviceSize* pCounterBufferOffsets,
+                                                              const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.transformFeedback) {
         skip |= LogError("VUID-vkCmdEndTransformFeedbackEXT-transformFeedback-02374", commandBuffer, error_obj.location,
                          "transformFeedback feature was not enabled.");
@@ -252,11 +252,11 @@ bool Device::manual_PreCallValidateCmdEndTransformFeedbackEXT(VkCommandBuffer co
 }
 
 bool Device::manual_PreCallValidateCmdBindVertexBuffers2(VkCommandBuffer commandBuffer, uint32_t firstBinding,
-                                                         uint32_t bindingCount, const VkBuffer *pBuffers,
-                                                         const VkDeviceSize *pOffsets, const VkDeviceSize *pSizes,
-                                                         const VkDeviceSize *pStrides, const Context &context) const {
+                                                         uint32_t bindingCount, const VkBuffer* pBuffers,
+                                                         const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
+                                                         const VkDeviceSize* pStrides, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     // Check VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength
     // This is a special case and generator currently skips it
@@ -265,7 +265,7 @@ bool Device::manual_PreCallValidateCmdBindVertexBuffers2(VkCommandBuffer command
         const bool vuid_expectation = bindingCount > 0;
         if (vuid_condition) {
             if (!vuid_expectation) {
-                const char *not_null_msg = "";
+                const char* not_null_msg = "";
                 if ((pSizes != nullptr) && (pStrides != nullptr)) {
                     not_null_msg = "pSizes and pStrides are not NULL";
                 } else if (pSizes != nullptr) {
@@ -326,31 +326,31 @@ bool Device::manual_PreCallValidateCmdBindVertexBuffers2(VkCommandBuffer command
     return skip;
 }
 
-bool Device::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, uint32_t offset, uint32_t size, const Location &loc) const {
+bool Device::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, uint32_t offset, uint32_t size, const Location& loc) const {
     bool skip = false;
     const bool is_2 = loc.function != Func::vkCmdPushConstants;
     const uint32_t max_push_constants_size = phys_dev_props.limits.maxPushConstantsSize;
     // Check that offset + size don't exceed the max.
     // Prevent arithetic overflow here by avoiding addition and testing in this order.
     if (offset >= max_push_constants_size) {
-        const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-00370" : "VUID-vkCmdPushConstants-offset-00370";
+        const char* vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-00370" : "VUID-vkCmdPushConstants-offset-00370";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::offset),
                          "(%" PRIu32 ") is greater than maxPushConstantSize (%" PRIu32 ").", offset, max_push_constants_size);
     }
     if (size > max_push_constants_size - offset) {
-        const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-size-00371" : "VUID-vkCmdPushConstants-size-00371";
+        const char* vuid = is_2 ? "VUID-VkPushConstantsInfo-size-00371" : "VUID-vkCmdPushConstants-size-00371";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::offset),
                          "(%" PRIu32 ") plus size (%" PRIu32 ") is greater than maxPushConstantSize (%" PRIu32 ").", offset, size,
                          max_push_constants_size);
     }
 
     if (!IsIntegerMultipleOf(size, 4)) {
-        const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-size-00369" : "VUID-vkCmdPushConstants-size-00369";
+        const char* vuid = is_2 ? "VUID-VkPushConstantsInfo-size-00369" : "VUID-vkCmdPushConstants-size-00369";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::size), "(%" PRIu32 ") must be a multiple of 4.", size);
     }
 
     if (!IsIntegerMultipleOf(offset, 4)) {
-        const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-00368" : "VUID-vkCmdPushConstants-offset-00368";
+        const char* vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-00368" : "VUID-vkCmdPushConstants-offset-00368";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::offset), "(%" PRIu32 ") must be a multiple of 4.", offset);
     }
     return skip;
@@ -358,14 +358,14 @@ bool Device::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, uint32_t of
 
 bool Device::manual_PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                     VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
-                                                    const void *pValues, const Context &context) const {
+                                                    const void* pValues, const Context& context) const {
     return ValidateCmdPushConstants(commandBuffer, offset, size, context.error_obj.location);
 }
 
-bool Device::manual_PreCallValidateCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo *pPushConstantsInfo,
-                                                     const Context &context) const {
+bool Device::manual_PreCallValidateCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo* pPushConstantsInfo,
+                                                     const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= ValidateCmdPushConstants(commandBuffer, pPushConstantsInfo->offset, pPushConstantsInfo->size,
                                      error_obj.location.dot(Field::pPushConstantsInfo));
     if (pPushConstantsInfo->layout == VK_NULL_HANDLE) {
@@ -382,10 +382,10 @@ bool Device::manual_PreCallValidateCmdPushConstants2(VkCommandBuffer commandBuff
 }
 
 bool Device::manual_PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                                      const VkClearColorValue *pColor, uint32_t rangeCount,
-                                                      const VkImageSubresourceRange *pRanges, const Context &context) const {
+                                                      const VkClearColorValue* pColor, uint32_t rangeCount,
+                                                      const VkImageSubresourceRange* pRanges, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!pColor) {
         skip |= LogError("VUID-vkCmdClearColorImage-pColor-04961", commandBuffer, error_obj.location, "pColor must not be null");
     }
@@ -393,10 +393,10 @@ bool Device::manual_PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
 }
 
 bool Device::manual_PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,
-                                                       uint32_t queryCount, size_t dataSize, void *pData, VkDeviceSize stride,
-                                                       VkQueryResultFlags flags, const Context &context) const {
+                                                       uint32_t queryCount, size_t dataSize, void* pData, VkDeviceSize stride,
+                                                       VkQueryResultFlags flags, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if ((flags & VK_QUERY_RESULT_WITH_STATUS_BIT_KHR) && (flags & VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)) {
         skip |= LogError("VUID-vkGetQueryPoolResults-flags-09443", device, error_obj.location.dot(Field::flags),
@@ -408,13 +408,13 @@ bool Device::manual_PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryP
 
 bool Device::manual_PreCallValidateCmdCopyQueryPoolResultsToMemoryKHR(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
                                                                       uint32_t firstQuery, uint32_t queryCount,
-                                                                      const VkStridedDeviceAddressRangeKHR *pDstRange,
+                                                                      const VkStridedDeviceAddressRangeKHR* pDstRange,
                                                                       VkAddressCommandFlagsKHR dstFlags,
                                                                       VkQueryResultFlags queryResultFlags,
-                                                                      const Context &context) const {
+                                                                      const Context& context) const {
     bool skip = false;
 
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= context.ValidateDeviceAddressFlags(error_obj.location.dot(Field::dstFlags), dstFlags);
 
     if (queryCount > 1 && pDstRange->stride == 0) {
@@ -460,10 +460,10 @@ bool Device::manual_PreCallValidateCmdCopyQueryPoolResultsToMemoryKHR(VkCommandB
 }
 
 bool Device::manual_PreCallValidateCmdBeginConditionalRenderingEXT(
-    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT *pConditionalRenderingBegin,
-    const Context &context) const {
+    VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin,
+    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!IsIntegerMultipleOf(pConditionalRenderingBegin->offset, 4)) {
         skip |= LogError("VUID-VkConditionalRenderingBeginInfoEXT-offset-01984", commandBuffer,
@@ -475,10 +475,10 @@ bool Device::manual_PreCallValidateCmdBeginConditionalRenderingEXT(
 }
 
 bool Device::manual_PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                       const VkClearAttachment *pAttachments, uint32_t rectCount,
-                                                       const VkClearRect *pRects, const Context &context) const {
+                                                       const VkClearAttachment* pAttachments, uint32_t rectCount,
+                                                       const VkClearRect* pRects, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     for (uint32_t rect = 0; rect < rectCount; rect++) {
         const VkClearRect& clear_rect = pRects[rect];
         const Location rect_loc = error_obj.location.dot(Field::pRects, rect);
@@ -499,9 +499,9 @@ bool Device::manual_PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
 }
 
 bool Device::manual_PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                                 uint32_t regionCount, const VkBufferCopy *pRegions, const Context &context) const {
+                                                 uint32_t regionCount, const VkBufferCopy* pRegions, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pRegions != nullptr) {
         for (uint32_t i = 0; i < regionCount; i++) {
@@ -514,10 +514,10 @@ bool Device::manual_PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo,
-                                                  const Context &context) const {
+bool Device::manual_PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
+                                                  const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pCopyBufferInfo->pRegions != nullptr) {
         for (uint32_t i = 0; i < pCopyBufferInfo->regionCount; i++) {
@@ -532,9 +532,9 @@ bool Device::manual_PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
 }
 
 bool Device::manual_PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                   VkDeviceSize dataSize, const void *pData, const Context &context) const {
+                                                   VkDeviceSize dataSize, const void* pData, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!IsIntegerMultipleOf(dstOffset, 4)) {
         const LogObjectList objlist(commandBuffer, dstBuffer);
@@ -901,9 +901,9 @@ bool Device::manual_PreCallValidateCmdBindIndexBuffer3KHR(VkCommandBuffer comman
 }
 
 bool Device::manual_PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                 VkDeviceSize size, uint32_t data, const Context &context) const {
+                                                 VkDeviceSize size, uint32_t data, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!IsIntegerMultipleOf(dstOffset, 4)) {
         const LogObjectList objlist(commandBuffer, dstBuffer);
@@ -948,10 +948,10 @@ bool Device::manual_PreCallValidateCmdFillMemoryKHR(VkCommandBuffer commandBuffe
 }
 
 bool Device::manual_PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                                               const VkDescriptorBufferBindingInfoEXT *pBindingInfos,
-                                                               const Context &context) const {
+                                                               const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
+                                                               const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.descriptorBuffer) {
         skip |= LogError("VUID-vkCmdBindDescriptorBuffersEXT-None-08047", commandBuffer, error_obj.location,
                          "descriptorBuffer feature was not enabled.");
@@ -970,10 +970,10 @@ bool Device::manual_PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer c
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceExternalBufferProperties(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalBufferInfo *pExternalBufferInfo,
-    VkExternalBufferProperties *pExternalBufferProperties, const Context &context) const {
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
+    VkExternalBufferProperties* pExternalBufferProperties, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pExternalBufferInfo->pNext)) {
         skip |= context.ValidateFlags(error_obj.location.dot(Field::pExternalBufferInfo).dot(Field::usage),
@@ -987,16 +987,16 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceExternalBufferProperties(
 
 bool Device::manual_PreCallValidateCmdPushDescriptorSet(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                         VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
-                                                        const VkWriteDescriptorSet *pDescriptorWrites,
-                                                        const Context &context) const {
+                                                        const VkWriteDescriptorSet* pDescriptorWrites,
+                                                        const Context& context) const {
     return ValidateWriteDescriptorSet(context, context.error_obj.location, descriptorWriteCount, pDescriptorWrites);
 }
 
 bool Device::manual_PreCallValidateCmdPushDescriptorSet2(VkCommandBuffer commandBuffer,
-                                                         const VkPushDescriptorSetInfo *pPushDescriptorSetInfo,
-                                                         const Context &context) const {
+                                                         const VkPushDescriptorSetInfo* pPushDescriptorSetInfo,
+                                                         const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= ValidateWriteDescriptorSet(context, error_obj.location, pPushDescriptorSetInfo->descriptorWriteCount,
                                        pPushDescriptorSetInfo->pDescriptorWrites);
     if (pPushDescriptorSetInfo->layout == VK_NULL_HANDLE) {
@@ -1012,7 +1012,7 @@ bool Device::manual_PreCallValidateCmdPushDescriptorSet2(VkCommandBuffer command
     return skip;
 }
 
-bool Device::ValidateViewport(const VkViewport &viewport, VkCommandBuffer object, const Location &loc) const {
+bool Device::ValidateViewport(const VkViewport& viewport, VkCommandBuffer object, const Location& loc) const {
     bool skip = false;
 
     // Note: for numerical correctness
@@ -1141,9 +1141,9 @@ bool Device::ValidateViewport(const VkViewport &viewport, VkCommandBuffer object
 }
 
 bool Device::manual_PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
-                                                      const VkCommandBuffer *pCommandBuffers, const Context &context) const {
+                                                      const VkCommandBuffer* pCommandBuffers, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
     // This is an array of handles, where the elements are allowed to be VK_NULL_HANDLE, and does not require any validation beyond
@@ -1176,10 +1176,10 @@ bool Device::manual_PreCallValidateFreeCommandBuffers(VkDevice device, VkCommand
     return skip;
 }
 
-bool Device::manual_PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *pBeginInfo,
-                                                      const Context &context) const {
+bool Device::manual_PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
+                                                      const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     // pBeginInfo->pInheritanceInfo can be a non-null invalid pointer. If not secondary command buffer we need to ignore
     if (!error_obj.handle_data->command_buffer.is_secondary) {
@@ -1187,7 +1187,7 @@ bool Device::manual_PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuf
     }
 
     if (pBeginInfo->pInheritanceInfo) {
-        const VkCommandBufferInheritanceInfo &info = *pBeginInfo->pInheritanceInfo;
+        const VkCommandBufferInheritanceInfo& info = *pBeginInfo->pInheritanceInfo;
         const Location begin_info_loc = error_obj.location.dot(Field::pBeginInfo);
         const Location inheritance_loc = begin_info_loc.dot(Field::pInheritanceInfo);
 
@@ -1219,7 +1219,7 @@ bool Device::manual_PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuf
                                                   "VUID-VkCommandBufferInheritanceInfo-pipelineStatistics-00058");
         }
 
-        if (const auto *conditional_rendering =
+        if (const auto* conditional_rendering =
                 vku::FindStructInPNextChain<VkCommandBufferInheritanceConditionalRenderingInfoEXT>(info.pNext)) {
             if (!enabled_features.inheritedConditionalRendering && conditional_rendering->conditionalRenderingEnable == VK_TRUE) {
                 skip |= LogError("VUID-VkCommandBufferInheritanceConditionalRenderingInfoEXT-conditionalRenderingEnable-01977",
@@ -1284,9 +1284,9 @@ static bool IsFloatComponentType(VkComponentTypeKHR component_type) {
     }
 }
 
-bool Device::ValidateVkConvertCooperativeVectorMatrixInfoNV(const LogObjectList &objlist,
-                                                            const VkConvertCooperativeVectorMatrixInfoNV &info,
-                                                            const Location &info_loc) const {
+bool Device::ValidateVkConvertCooperativeVectorMatrixInfoNV(const LogObjectList& objlist,
+                                                            const VkConvertCooperativeVectorMatrixInfoNV& info,
+                                                            const Location& info_loc) const {
     bool skip = false;
 
     // size_t to match the stride used in the API
@@ -1373,10 +1373,10 @@ static size_t ComputeMinSize(VkComponentTypeKHR component_type, VkCooperativeVec
 }
 
 bool Device::manual_PreCallValidateConvertCooperativeVectorMatrixNV(VkDevice device,
-                                                                    const VkConvertCooperativeVectorMatrixInfoNV *pInfo,
-                                                                    const Context &context) const {
+                                                                    const VkConvertCooperativeVectorMatrixInfoNV* pInfo,
+                                                                    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
@@ -1420,16 +1420,16 @@ bool Device::manual_PreCallValidateConvertCooperativeVectorMatrixNV(VkDevice dev
 }
 
 bool Device::manual_PreCallValidateCmdConvertCooperativeVectorMatrixNV(VkCommandBuffer commandBuffer, uint32_t infoCount,
-                                                                       const VkConvertCooperativeVectorMatrixInfoNV *pInfos,
-                                                                       const Context &context) const {
+                                                                       const VkConvertCooperativeVectorMatrixInfoNV* pInfos,
+                                                                       const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     std::vector<vvl::range<VkDeviceAddress>> src_memory_ranges;
     std::vector<vvl::range<VkDeviceAddress>> dst_memory_ranges;
 
     for (uint32_t i = 0; i < infoCount; ++i) {
-        auto const &info = pInfos[i];
+        auto const& info = pInfos[i];
 
         const Location info_loc = error_obj.location.dot(Field::pInfos, i);
 

--- a/layers/stateless/sl_cmd_buffer_dynamic.cpp
+++ b/layers/stateless/sl_cmd_buffer_dynamic.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,9 +22,9 @@
 namespace stateless {
 
 bool Device::manual_PreCallValidateCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
-                                                           const VkViewport *pViewports, const Context &context) const {
+                                                           const VkViewport* pViewports, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.multiViewport) {
         if (viewportCount != 1) {
@@ -45,7 +45,7 @@ bool Device::manual_PreCallValidateCmdSetViewportWithCount(VkCommandBuffer comma
 
     if (pViewports) {
         for (uint32_t viewport_i = 0; viewport_i < viewportCount; ++viewport_i) {
-            const auto &viewport = pViewports[viewport_i];  // will crash on invalid ptr
+            const auto& viewport = pViewports[viewport_i];  // will crash on invalid ptr
             skip |= ValidateViewport(viewport, commandBuffer, error_obj.location.dot(Field::pViewports, viewport_i));
         }
     }
@@ -54,9 +54,9 @@ bool Device::manual_PreCallValidateCmdSetViewportWithCount(VkCommandBuffer comma
 }
 
 bool Device::manual_PreCallValidateCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
-                                                          const VkRect2D *pScissors, const Context &context) const {
+                                                          const VkRect2D* pScissors, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.multiViewport) {
         if (scissorCount != 1) {
             skip |= LogError("VUID-vkCmdSetScissorWithCount-scissorCount-03398", commandBuffer,
@@ -78,7 +78,7 @@ bool Device::manual_PreCallValidateCmdSetScissorWithCount(VkCommandBuffer comman
     if (pScissors) {
         for (uint32_t scissor_i = 0; scissor_i < scissorCount; ++scissor_i) {
             const Location scissor_loc = error_obj.location.dot(Field::pScissors, scissor_i);
-            const auto &scissor = pScissors[scissor_i];  // will crash on invalid ptr
+            const auto& scissor = pScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
                 skip |= LogError("VUID-vkCmdSetScissorWithCount-x-03399", commandBuffer,
@@ -110,12 +110,12 @@ bool Device::manual_PreCallValidateCmdSetScissorWithCount(VkCommandBuffer comman
 }
 
 bool Device::manual_PreCallValidateCmdSetVertexInputEXT(VkCommandBuffer commandBuffer, uint32_t vertexBindingDescriptionCount,
-                                                        const VkVertexInputBindingDescription2EXT *pVertexBindingDescriptions,
+                                                        const VkVertexInputBindingDescription2EXT* pVertexBindingDescriptions,
                                                         uint32_t vertexAttributeDescriptionCount,
-                                                        const VkVertexInputAttributeDescription2EXT *pVertexAttributeDescriptions,
-                                                        const Context &context) const {
+                                                        const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions,
+                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (vertexBindingDescriptionCount > phys_dev_props.limits.maxVertexInputBindings) {
         skip |= LogError("VUID-vkCmdSetVertexInputEXT-vertexBindingDescriptionCount-04791", commandBuffer,
@@ -151,7 +151,7 @@ bool Device::manual_PreCallValidateCmdSetVertexInputEXT(VkCommandBuffer commandB
         vvl::unordered_set<uint32_t> vertex_bindings(vertexBindingDescriptionCount);
         for (uint32_t i = 0; i < vertexBindingDescriptionCount; ++i) {
             const uint32_t binding = pVertexBindingDescriptions[i].binding;
-            auto const &binding_it = vertex_bindings.find(binding);
+            auto const& binding_it = vertex_bindings.find(binding);
             if (binding_it != vertex_bindings.cend()) {
                 skip |= LogError("VUID-vkCmdSetVertexInputEXT-pVertexBindingDescriptions-04794", commandBuffer,
                                  error_obj.location.dot(Field::pVertexBindingDescriptions, i),
@@ -164,7 +164,7 @@ bool Device::manual_PreCallValidateCmdSetVertexInputEXT(VkCommandBuffer commandB
         vvl::unordered_set<uint32_t> vertex_locations(vertexAttributeDescriptionCount);
         for (uint32_t i = 0; i < vertexAttributeDescriptionCount; ++i) {
             const uint32_t location = pVertexAttributeDescriptions[i].location;
-            auto const &location_it = vertex_locations.find(location);
+            auto const& location_it = vertex_locations.find(location);
             if (location_it != vertex_locations.cend()) {
                 skip |= LogError("VUID-vkCmdSetVertexInputEXT-pVertexAttributeDescriptions-04795", commandBuffer,
                                  error_obj.location.dot(Field::pVertexAttributeDescriptions, i),
@@ -261,10 +261,10 @@ bool Device::manual_PreCallValidateCmdSetVertexInputEXT(VkCommandBuffer commandB
 }
 
 bool Device::manual_PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
-                                                             uint32_t discardRectangleCount, const VkRect2D *pDiscardRectangles,
-                                                             const Context &context) const {
+                                                             uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles,
+                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!pDiscardRectangles) {
         return skip;
@@ -292,9 +292,9 @@ bool Device::manual_PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer com
 }
 
 bool Device::manual_PreCallValidateCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable,
-                                                                   const Context &context) const {
+                                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (discard_rectangles_extension_version < 2) {
         skip |= LogError("VUID-vkCmdSetDiscardRectangleEnableEXT-specVersion-07851", commandBuffer, error_obj.location,
                          "Requires support for version 2 of VK_EXT_discard_rectangles.");
@@ -304,9 +304,9 @@ bool Device::manual_PreCallValidateCmdSetDiscardRectangleEnableEXT(VkCommandBuff
 
 bool Device::manual_PreCallValidateCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
                                                                  VkDiscardRectangleModeEXT discardRectangleMode,
-                                                                 const Context &context) const {
+                                                                 const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (discard_rectangles_extension_version < 2) {
         skip |= LogError("VUID-vkCmdSetDiscardRectangleModeEXT-specVersion-07852", commandBuffer, error_obj.location,
                          "Requires support for version 2 of VK_EXT_discard_rectangles.");
@@ -316,10 +316,10 @@ bool Device::manual_PreCallValidateCmdSetDiscardRectangleModeEXT(VkCommandBuffer
 
 bool Device::manual_PreCallValidateCmdSetExclusiveScissorEnableNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                                   uint32_t exclusiveScissorCount,
-                                                                  const VkBool32 *pExclusiveScissorEnables,
-                                                                  const Context &context) const {
+                                                                  const VkBool32* pExclusiveScissorEnables,
+                                                                  const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (scissor_exclusive_extension_version < 2) {
         skip |= LogError("VUID-vkCmdSetExclusiveScissorEnableNV-exclusiveScissor-07853", commandBuffer, error_obj.location,
                          "Requires support for version 2 of VK_NV_scissor_exclusive.");
@@ -328,10 +328,10 @@ bool Device::manual_PreCallValidateCmdSetExclusiveScissorEnableNV(VkCommandBuffe
 }
 
 bool Device::manual_PreCallValidateCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
-                                                            uint32_t exclusiveScissorCount, const VkRect2D *pExclusiveScissors,
-                                                            const Context &context) const {
+                                                            uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors,
+                                                            const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.multiViewport) {
         if (firstExclusiveScissor != 0) {
@@ -357,7 +357,7 @@ bool Device::manual_PreCallValidateCmdSetExclusiveScissorNV(VkCommandBuffer comm
     if (pExclusiveScissors) {
         for (uint32_t scissor_i = 0; scissor_i < exclusiveScissorCount; ++scissor_i) {
             const Location scissor_loc = error_obj.location.dot(Field::pExclusiveScissors, scissor_i);
-            const auto &scissor = pExclusiveScissors[scissor_i];  // will crash on invalid ptr
+            const auto& scissor = pExclusiveScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
                 skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-x-02037", commandBuffer,
@@ -389,10 +389,10 @@ bool Device::manual_PreCallValidateCmdSetExclusiveScissorNV(VkCommandBuffer comm
 }
 
 bool Device::manual_PreCallValidateCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
-                                                            uint32_t viewportCount, const VkViewportWScalingNV *pViewportWScalings,
-                                                            const Context &context) const {
+                                                            uint32_t viewportCount, const VkViewportWScalingNV* pViewportWScalings,
+                                                            const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const uint64_t sum = static_cast<uint64_t>(firstViewport) + static_cast<uint64_t>(viewportCount);
     if ((sum < 1) || (sum > phys_dev_props.limits.maxViewports)) {
         skip |= LogError("VUID-vkCmdSetViewportWScalingNV-firstViewport-01324", commandBuffer, error_obj.location,
@@ -406,10 +406,10 @@ bool Device::manual_PreCallValidateCmdSetViewportWScalingNV(VkCommandBuffer comm
 
 bool Device::manual_PreCallValidateCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                                       uint32_t viewportCount,
-                                                                      const VkShadingRatePaletteNV *pShadingRatePalettes,
-                                                                      const Context &context) const {
+                                                                      const VkShadingRatePaletteNV* pShadingRatePalettes,
+                                                                      const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.multiViewport) {
         if (firstViewport != 0) {
@@ -438,10 +438,10 @@ bool Device::manual_PreCallValidateCmdSetViewportShadingRatePaletteNV(VkCommandB
 bool Device::manual_PreCallValidateCmdSetCoarseSampleOrderNV(VkCommandBuffer commandBuffer,
                                                              VkCoarseSampleOrderTypeNV sampleOrderType,
                                                              uint32_t customSampleOrderCount,
-                                                             const VkCoarseSampleOrderCustomNV *pCustomSampleOrders,
-                                                             const Context &context) const {
+                                                             const VkCoarseSampleOrderCustomNV* pCustomSampleOrders,
+                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (sampleOrderType != VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV && customSampleOrderCount != 0) {
         skip |= LogError("VUID-vkCmdSetCoarseSampleOrderNV-sampleOrderType-02081", commandBuffer, error_obj.location,
@@ -458,9 +458,9 @@ bool Device::manual_PreCallValidateCmdSetCoarseSampleOrderNV(VkCommandBuffer com
 }
 
 bool Device::manual_PreCallValidateCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
-                                                  const VkViewport *pViewports, const Context &context) const {
+                                                  const VkViewport* pViewports, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.multiViewport) {
         if (firstViewport != 0) {
@@ -485,7 +485,7 @@ bool Device::manual_PreCallValidateCmdSetViewport(VkCommandBuffer commandBuffer,
 
     if (pViewports) {
         for (uint32_t viewport_i = 0; viewport_i < viewportCount; ++viewport_i) {
-            const auto &viewport = pViewports[viewport_i];  // will crash on invalid ptr
+            const auto& viewport = pViewports[viewport_i];  // will crash on invalid ptr
             skip |= ValidateViewport(viewport, commandBuffer, error_obj.location.dot(Field::pViewports, viewport_i));
         }
     }
@@ -494,10 +494,10 @@ bool Device::manual_PreCallValidateCmdSetViewport(VkCommandBuffer commandBuffer,
 }
 
 bool Device::manual_PreCallValidateCmdSetDepthClampRangeEXT(VkCommandBuffer commandBuffer, VkDepthClampModeEXT depthClampMode,
-                                                            const VkDepthClampRangeEXT *pDepthClampRange,
-                                                            const Context &context) const {
+                                                            const VkDepthClampRangeEXT* pDepthClampRange,
+                                                            const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (depthClampMode == VK_DEPTH_CLAMP_MODE_USER_DEFINED_RANGE_EXT) {
         if (!pDepthClampRange) {
             skip |= LogError("VUID-vkCmdSetDepthClampRangeEXT-pDepthClampRange-09647", device,
@@ -510,9 +510,9 @@ bool Device::manual_PreCallValidateCmdSetDepthClampRangeEXT(VkCommandBuffer comm
 }
 
 bool Device::manual_PreCallValidateCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
-                                                 const VkRect2D *pScissors, const Context &context) const {
+                                                 const VkRect2D* pScissors, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.multiViewport) {
         if (firstScissor != 0) {
@@ -536,7 +536,7 @@ bool Device::manual_PreCallValidateCmdSetScissor(VkCommandBuffer commandBuffer, 
     if (pScissors) {
         for (uint32_t scissor_i = 0; scissor_i < scissorCount; ++scissor_i) {
             const Location scissor_loc = error_obj.location.dot(Field::pScissors, scissor_i);
-            const auto &scissor = pScissors[scissor_i];  // will crash on invalid ptr
+            const auto& scissor = pScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
                 skip |= LogError("VUID-vkCmdSetScissor-x-00595", commandBuffer, scissor_loc.dot(Field::offset).dot(Field::x),
@@ -567,9 +567,9 @@ bool Device::manual_PreCallValidateCmdSetScissor(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth, const Context &context) const {
+bool Device::manual_PreCallValidateCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.wideLines && (lineWidth != 1.0f)) {
         skip |= LogError("VUID-vkCmdSetLineWidth-lineWidth-00788", commandBuffer, error_obj.location.dot(Field::lineWidth),
@@ -580,9 +580,9 @@ bool Device::manual_PreCallValidateCmdSetLineWidth(VkCommandBuffer commandBuffer
 }
 
 bool Device::manual_PreCallValidateCmdSetLineStipple(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
-                                                     uint16_t lineStipplePattern, const Context &context) const {
+                                                     uint16_t lineStipplePattern, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (lineStippleFactor < 1 || lineStippleFactor > 256) {
         skip |= LogError("VUID-vkCmdSetLineStipple-lineStippleFactor-02776", commandBuffer,

--- a/layers/stateless/sl_data_graph.cpp
+++ b/layers/stateless/sl_data_graph.cpp
@@ -21,7 +21,7 @@
 
 namespace stateless {
 
-bool Device::ValidateCreateDataGraphPipelinesFlags(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const {
+bool Device::ValidateCreateDataGraphPipelinesFlags(const VkPipelineCreateFlags2 flags, const Location& flags_loc) const {
     bool skip = false;
 
     constexpr VkPipelineCreateFlags2 valid_flag_mask =
@@ -49,11 +49,11 @@ bool Device::ValidateCreateDataGraphPipelinesFlags(const VkPipelineCreateFlags2 
 
 bool Device::manual_PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                               const VkDataGraphPipelineCreateInfoARM *pCreateInfos,
-                                                               const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                               const Context &context) const {
+                                                               const VkDataGraphPipelineCreateInfoARM* pCreateInfos,
+                                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                               const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.dataGraph) {
         skip |= LogError("VUID-vkCreateDataGraphPipelinesARM-dataGraph-09760", device, error_obj.location,
@@ -66,7 +66,7 @@ bool Device::manual_PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, 
 
     for (uint32_t i = 0; i < createInfoCount; i++) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
-        const VkDataGraphPipelineCreateInfoARM &create_info = pCreateInfos[i];
+        const VkDataGraphPipelineCreateInfoARM& create_info = pCreateInfos[i];
 
         skip |= ValidateCreatePipelinesFlagsCommon(create_info.flags, create_info_loc.dot(Field::flags));
 

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -31,7 +31,7 @@
 #include "utils/vk_api_utils.h"
 
 namespace stateless {
-bool Device::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV &order, const Location &order_loc) const {
+bool Device::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV& order, const Location& order_loc) const {
     bool skip = false;
 
     struct SampleOrderInfo {
@@ -50,7 +50,7 @@ bool Device::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV
         SampleOrderInfo{VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X4_PIXELS_NV, 4, 4},
     };
 
-    const SampleOrderInfo *sample_order_info;
+    const SampleOrderInfo* sample_order_info;
     uint32_t info_idx = 0;
     for (sample_order_info = nullptr; info_idx < sample_order_infos.size(); ++info_idx) {
         if (sample_order_infos[info_idx].shadingRate == order.shadingRate) {
@@ -98,7 +98,7 @@ bool Device::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV
     assert(phys_dev_ext_props.shading_rate_image_props.shadingRateMaxCoarseSamples <= 64);
     std::bitset<64> sample_locations_mask = 0;
     for (uint32_t i = 0; i < order.sampleLocationCount; ++i) {
-        const VkCoarseSampleLocationNV *sample_loc = &order.pSampleLocations[i];
+        const VkCoarseSampleLocationNV* sample_loc = &order.pSampleLocations[i];
         if (sample_loc->pixelX >= sample_order_info->width) {
             skip |= LogError("VUID-VkCoarseSampleLocationNV-pixelX-02078", device, order_loc,
                              "pixelX (%" PRIu32 ") must be less than the width (in pixels) of the fragment (%" PRIu32 ").",
@@ -136,9 +136,9 @@ bool Device::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV
 }
 
 // VK_EXT_sampler_filter_minmax
-bool Device::ValidateSamplerFilterMinMax(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateSamplerFilterMinMax(const VkSamplerCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
-    const auto *sampler_reduction = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(create_info.pNext);
+    const auto* sampler_reduction = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(create_info.pNext);
     if (!sampler_reduction) return skip;
 
     if (sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
@@ -190,7 +190,7 @@ bool Device::ValidateSamplerFilterMinMax(const VkSamplerCreateInfo &create_info,
 }
 
 // VK_EXT_custom_border_color
-bool Device::ValidateSamplerCustomBorderColor(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateSamplerCustomBorderColor(const VkSamplerCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
     if (create_info.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT || create_info.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
@@ -242,7 +242,7 @@ bool Device::ValidateSamplerCustomBorderColor(const VkSamplerCreateInfo &create_
 }
 
 // VK_EXT_fragment_density_map
-bool Device::ValidateSamplerSubsampled(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateSamplerSubsampled(const VkSamplerCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     if ((create_info.flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT) == 0) return skip;
 
@@ -295,7 +295,7 @@ bool Device::ValidateSamplerSubsampled(const VkSamplerCreateInfo &create_info, c
 }
 
 // VK_QCOM_image_processing
-bool Device::ValidateSamplerImageProcessingQCOM(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateSamplerImageProcessingQCOM(const VkSamplerCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     if ((create_info.flags & VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM) == 0) return skip;
 
@@ -354,8 +354,8 @@ bool Device::ValidateSamplerImageProcessingQCOM(const VkSamplerCreateInfo &creat
     return skip;
 }
 
-bool Device::ValidateSamplerCreateInfo(const VkSamplerCreateInfo &create_info, const Location &create_info_loc,
-                                       const Context &context) const {
+bool Device::ValidateSamplerCreateInfo(const VkSamplerCreateInfo& create_info, const Location& create_info_loc,
+                                       const Context& context) const {
     bool skip = false;
 
     if (create_info.anisotropyEnable == VK_TRUE) {
@@ -524,19 +524,19 @@ bool Device::ValidateSamplerCreateInfo(const VkSamplerCreateInfo &create_info, c
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkSampler *pSampler,
-                                                 const Context &context) const {
+bool Device::manual_PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
+                                                 const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
+                                                 const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     skip |= ValidateSamplerCreateInfo(*pCreateInfo, create_info_loc, context);
     return skip;
 }
 
-bool Device::ValidateMutableDescriptorTypeCreateInfo(const VkDescriptorSetLayoutCreateInfo &create_info,
-                                                     const VkMutableDescriptorTypeCreateInfoEXT &mutable_create_info,
-                                                     const Location &create_info_loc) const {
+bool Device::ValidateMutableDescriptorTypeCreateInfo(const VkDescriptorSetLayoutCreateInfo& create_info,
+                                                     const VkMutableDescriptorTypeCreateInfoEXT& mutable_create_info,
+                                                     const Location& create_info_loc) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < create_info.bindingCount; ++i) {
@@ -608,15 +608,15 @@ bool Device::ValidateMutableDescriptorTypeCreateInfo(const VkDescriptorSetLayout
     return skip;
 }
 
-bool Device::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCreateInfo &create_info,
-                                                   const Location &create_info_loc) const {
+bool Device::ValidateDescriptorSetLayoutCreateInfo(const VkDescriptorSetLayoutCreateInfo& create_info,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
 
     const bool has_descriptor_buffer_flag = (create_info.flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0;
     const bool has_push_descriptor_flag = (create_info.flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT) != 0;
     // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
     if (create_info.pBindings != nullptr) {
-        const auto *mutable_descriptor_type = vku::FindStructInPNextChain<VkMutableDescriptorTypeCreateInfoEXT>(create_info.pNext);
+        const auto* mutable_descriptor_type = vku::FindStructInPNextChain<VkMutableDescriptorTypeCreateInfoEXT>(create_info.pNext);
         for (const auto [i, binding] : vvl::enumerate(create_info.pBindings, create_info.bindingCount)) {
             if (binding.descriptorCount == 0) {
                 continue;
@@ -774,28 +774,28 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceDescriptorSizeEXT(VkPhysic
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator,
-                                                             VkDescriptorSetLayout *pSetLayout, const Context &context) const {
+bool Device::manual_PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator,
+                                                             VkDescriptorSetLayout* pSetLayout, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= ValidateDescriptorSetLayoutCreateInfo(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
     return skip;
 }
 
 bool Device::manual_PreCallValidateGetDescriptorSetLayoutSupport(VkDevice device,
-                                                                 const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
-                                                                 VkDescriptorSetLayoutSupport *pSupport,
-                                                                 const Context &context) const {
+                                                                 const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
+                                                                 VkDescriptorSetLayoutSupport* pSupport,
+                                                                 const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= ValidateDescriptorSetLayoutCreateInfo(*pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
     return skip;
 }
 
 bool Device::manual_PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t descriptorSetCount,
-                                                      const VkDescriptorSet *pDescriptorSets, const Context &context) const {
-    const auto &error_obj = context.error_obj;
+                                                      const VkDescriptorSet* pDescriptorSets, const Context& context) const {
+    const auto& error_obj = context.error_obj;
     // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
     // This is an array of handles, where the elements are allowed to be VK_NULL_HANDLE, and does not require any validation beyond
     // ValidateArray()
@@ -804,8 +804,8 @@ bool Device::manual_PreCallValidateFreeDescriptorSets(VkDevice device, VkDescrip
                                  "VUID-vkFreeDescriptorSets-pDescriptorSets-00310");
 }
 
-bool Device::ValidateWriteDescriptorSet(const Context &context, const Location &loc, const uint32_t descriptorWriteCount,
-                                        const VkWriteDescriptorSet *pDescriptorWrites) const {
+bool Device::ValidateWriteDescriptorSet(const Context& context, const Location& loc, const uint32_t descriptorWriteCount,
+                                        const VkWriteDescriptorSet* pDescriptorWrites) const {
     bool skip = false;
     if (!pDescriptorWrites) {
         return skip;
@@ -815,7 +815,7 @@ bool Device::ValidateWriteDescriptorSet(const Context &context, const Location &
 
     for (uint32_t i = 0; i < descriptorWriteCount; ++i) {
         const Location writes_loc = loc.dot(Field::pDescriptorWrites, i);
-        const auto &descriptor_writes = pDescriptorWrites[i];
+        const auto& descriptor_writes = pDescriptorWrites[i];
 
         // If called from vkCmdPushDescriptorSetKHR, the dstSet member is ignored.
         if (!is_push_descriptor) {
@@ -835,7 +835,7 @@ bool Device::ValidateWriteDescriptorSet(const Context &context, const Location &
                 }
             }
         }
-        const auto *tensor_struct = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(descriptor_writes.pNext);
+        const auto* tensor_struct = vku::FindStructInPNextChain<VkWriteDescriptorSetTensorARM>(descriptor_writes.pNext);
         if (tensor_struct) {
             for (uint32_t j = 0; j < tensor_struct->tensorViewCount; ++j) {
                 if (!enabled_features.nullDescriptor && tensor_struct->pTensorViews[j] == VK_NULL_HANDLE) {
@@ -850,14 +850,14 @@ bool Device::ValidateWriteDescriptorSet(const Context &context, const Location &
 }
 
 bool Device::manual_PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
-                                                        const VkWriteDescriptorSet *pDescriptorWrites, uint32_t descriptorCopyCount,
-                                                        const VkCopyDescriptorSet *pDescriptorCopies,
-                                                        const Context &context) const {
-    const auto &error_obj = context.error_obj;
+                                                        const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
+                                                        const VkCopyDescriptorSet* pDescriptorCopies,
+                                                        const Context& context) const {
+    const auto& error_obj = context.error_obj;
     return ValidateWriteDescriptorSet(context, error_obj.location, descriptorWriteCount, pDescriptorWrites);
 }
 
-static bool MutableDescriptorTypePartialOverlap(const VkDescriptorPoolCreateInfo *pCreateInfo, uint32_t i, uint32_t j) {
+static bool MutableDescriptorTypePartialOverlap(const VkDescriptorPoolCreateInfo* pCreateInfo, uint32_t i, uint32_t j) {
     bool partial_overlap = false;
 
     constexpr std::array all_descriptor_types = {
@@ -877,13 +877,13 @@ static bool MutableDescriptorTypePartialOverlap(const VkDescriptorPoolCreateInfo
         VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV,
     };
 
-    const auto *mutable_descriptor_type = vku::FindStructInPNextChain<VkMutableDescriptorTypeCreateInfoEXT>(pCreateInfo->pNext);
+    const auto* mutable_descriptor_type = vku::FindStructInPNextChain<VkMutableDescriptorTypeCreateInfoEXT>(pCreateInfo->pNext);
     if (mutable_descriptor_type) {
         vvl::span<const VkDescriptorType> first_types, second_types;
 
         if (mutable_descriptor_type->mutableDescriptorTypeListCount > i) {
             const uint32_t descriptor_type_count = mutable_descriptor_type->pMutableDescriptorTypeLists[i].descriptorTypeCount;
-            auto *descriptor_types = mutable_descriptor_type->pMutableDescriptorTypeLists[i].pDescriptorTypes;
+            auto* descriptor_types = mutable_descriptor_type->pMutableDescriptorTypeLists[i].pDescriptorTypes;
             first_types = vvl::make_span(descriptor_types, descriptor_type_count);
         } else {
             first_types = vvl::make_span(all_descriptor_types.data(), all_descriptor_types.size());
@@ -891,7 +891,7 @@ static bool MutableDescriptorTypePartialOverlap(const VkDescriptorPoolCreateInfo
 
         if (mutable_descriptor_type->mutableDescriptorTypeListCount > j) {
             const uint32_t descriptor_type_count = mutable_descriptor_type->pMutableDescriptorTypeLists[j].descriptorTypeCount;
-            auto *descriptor_types = mutable_descriptor_type->pMutableDescriptorTypeLists[j].pDescriptorTypes;
+            auto* descriptor_types = mutable_descriptor_type->pMutableDescriptorTypeLists[j].pDescriptorTypes;
             second_types = vvl::make_span(descriptor_types, descriptor_type_count);
         } else {
             second_types = vvl::make_span(all_descriptor_types.data(), all_descriptor_types.size());
@@ -922,11 +922,11 @@ static bool MutableDescriptorTypePartialOverlap(const VkDescriptorPoolCreateInfo
     return partial_overlap;
 }
 
-bool Device::manual_PreCallValidateCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
-                                                        const VkAllocationCallbacks *pAllocator, VkDescriptorPool *pDescriptorPool,
-                                                        const Context &context) const {
+bool Device::manual_PreCallValidateCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
+                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     if (pCreateInfo->maxSets == 0 && ((pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_ALLOW_OVERALLOCATION_SETS_BIT_NV) == 0)) {
@@ -934,7 +934,7 @@ bool Device::manual_PreCallValidateCreateDescriptorPool(VkDevice device, const V
                          create_info_loc.dot(Field::maxSets), "is zero.");
     }
 
-    const auto *inline_uniform_info = vku::FindStructInPNextChain<VkDescriptorPoolInlineUniformBlockCreateInfo>(pCreateInfo->pNext);
+    const auto* inline_uniform_info = vku::FindStructInPNextChain<VkDescriptorPoolInlineUniformBlockCreateInfo>(pCreateInfo->pNext);
     const bool non_zero_inline_uniform_count = inline_uniform_info && inline_uniform_info->maxInlineUniformBlockBindings != 0;
 
     if (pCreateInfo->pPoolSizes) {
@@ -992,11 +992,11 @@ bool Device::manual_PreCallValidateCreateDescriptorPool(VkDevice device, const V
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkQueryPool *pQueryPool,
-                                                   const Context &context) const {
+bool Device::manual_PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool,
+                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
 
     switch (pCreateInfo->queryType) {
@@ -1058,12 +1058,12 @@ bool Device::manual_PreCallValidateCreateQueryPool(VkDevice device, const VkQuer
 }
 
 bool Device::manual_PreCallValidateCreateSamplerYcbcrConversion(VkDevice device,
-                                                                const VkSamplerYcbcrConversionCreateInfo *pCreateInfo,
-                                                                const VkAllocationCallbacks *pAllocator,
-                                                                VkSamplerYcbcrConversion *pYcbcrConversion,
-                                                                const Context &context) const {
+                                                                const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
+                                                                const VkAllocationCallbacks* pAllocator,
+                                                                VkSamplerYcbcrConversion* pYcbcrConversion,
+                                                                const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     // Check samplerYcbcrConversion feature is set
     if (!enabled_features.samplerYcbcrConversion) {
@@ -1127,7 +1127,7 @@ bool Device::manual_PreCallValidateCreateSamplerYcbcrConversion(VkDevice device,
 
     if (pCreateInfo->ycbcrModel != VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY) {
         // This VU covers a lot, could have been multiple VUs, so provide a good error message for all cases.
-        const char *vuid = "VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-01655";
+        const char* vuid = "VUID-VkSamplerYcbcrConversionCreateInfo-ycbcrModel-01655";
         if (components.r == VK_COMPONENT_SWIZZLE_ZERO || components.g == VK_COMPONENT_SWIZZLE_ZERO ||
             components.b == VK_COMPONENT_SWIZZLE_ZERO) {
             skip |= LogError(vuid, device, create_info_loc,
@@ -1202,10 +1202,10 @@ bool Device::manual_PreCallValidateCreateSamplerYcbcrConversion(VkDevice device,
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT *pDescriptorInfo, size_t dataSize,
-                                                    void *pDescriptor, const Context &context) const {
+bool Device::manual_PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT* pDescriptorInfo, size_t dataSize,
+                                                    void* pDescriptor, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.descriptorBuffer) {
         skip |=
             LogError("VUID-vkGetDescriptorEXT-None-08015", device, error_obj.location, "descriptorBuffer feature was not enabled.");
@@ -1213,7 +1213,7 @@ bool Device::manual_PreCallValidateGetDescriptorEXT(VkDevice device, const VkDes
 
     const Location descriptor_info_loc = error_obj.location.dot(Field::pDescriptorInfo);
     const Location data_loc = descriptor_info_loc.dot(Field::data);
-    const VkDescriptorAddressInfoEXT *address_info = nullptr;
+    const VkDescriptorAddressInfoEXT* address_info = nullptr;
     Field data_field = Field::Empty;
     switch (pDescriptorInfo->type) {
         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
@@ -1293,7 +1293,7 @@ bool Device::manual_PreCallValidateGetDescriptorEXT(VkDevice device, const VkDes
         }
     }
 
-    const auto *tensor_struct = vku::FindStructInPNextChain<VkDescriptorGetTensorInfoARM>(pDescriptorInfo->pNext);
+    const auto* tensor_struct = vku::FindStructInPNextChain<VkDescriptorGetTensorInfoARM>(pDescriptorInfo->pNext);
     if (tensor_struct) {
         if (!enabled_features.nullDescriptor && tensor_struct->tensorView == VK_NULL_HANDLE) {
             skip |= LogError("VUID-VkDescriptorGetTensorInfoARM-nullDescriptor-09899", device,
@@ -1305,13 +1305,13 @@ bool Device::manual_PreCallValidateGetDescriptorEXT(VkDevice device, const VkDes
 }
 
 bool Device::ValidateCmdSetDescriptorBufferOffsets(VkCommandBuffer commandBuffer, VkPipelineLayout layout, uint32_t setCount,
-                                                   const uint32_t *pBufferIndices, const VkDeviceSize *pOffsets,
-                                                   const Location &loc) const {
+                                                   const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets,
+                                                   const Location& loc) const {
     bool skip = false;
     const bool is_2 = loc.function != Func::vkCmdSetDescriptorBufferOffsetsEXT;
 
     if (!enabled_features.descriptorBuffer) {
-        const char *vuid = is_2 ? "VUID-vkCmdSetDescriptorBufferOffsets2EXT-descriptorBuffer-09470"
+        const char* vuid = is_2 ? "VUID-vkCmdSetDescriptorBufferOffsets2EXT-descriptorBuffer-09470"
                                 : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-None-08060";
         skip |= LogError(vuid, commandBuffer, loc, "descriptorBuffer feature was not enabled.");
     }
@@ -1319,7 +1319,7 @@ bool Device::ValidateCmdSetDescriptorBufferOffsets(VkCommandBuffer commandBuffer
     for (uint32_t i = 0; i < setCount; i++) {
         const uint32_t buffer_index = pBufferIndices[i];
         if (buffer_index >= phys_dev_ext_props.descriptor_buffer_props.maxDescriptorBufferBindings) {
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08064"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08064"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pBufferIndices-08064";
             const LogObjectList objlist(commandBuffer, layout);
             skip |= LogError(vuid, objlist, loc.dot(Field::pBufferIndices, i),
@@ -1329,7 +1329,7 @@ bool Device::ValidateCmdSetDescriptorBufferOffsets(VkCommandBuffer commandBuffer
 
         const VkDeviceAddress offset = pOffsets[i];
         if (!IsIntegerMultipleOf(offset, phys_dev_ext_props.descriptor_buffer_props.descriptorBufferOffsetAlignment)) {
-            const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08061"
+            const char* vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08061"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08061";
             const LogObjectList objlist(commandBuffer, layout);
             skip |= LogError(vuid, objlist, loc.dot(Field::pOffsets, i),
@@ -1346,17 +1346,17 @@ bool Device::ValidateCmdSetDescriptorBufferOffsets(VkCommandBuffer commandBuffer
 bool Device::manual_PreCallValidateCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer,
                                                                     VkPipelineBindPoint pipelineBindPoint, VkPipelineLayout layout,
                                                                     uint32_t firstSet, uint32_t setCount,
-                                                                    const uint32_t *pBufferIndices, const VkDeviceSize *pOffsets,
-                                                                    const Context &context) const {
+                                                                    const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets,
+                                                                    const Context& context) const {
     return ValidateCmdSetDescriptorBufferOffsets(commandBuffer, layout, setCount, pBufferIndices, pOffsets,
                                                  context.error_obj.location);
 }
 
 bool Device::manual_PreCallValidateCmdSetDescriptorBufferOffsets2EXT(
-    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT *pSetDescriptorBufferOffsetsInfo,
-    const Context &context) const {
+    VkCommandBuffer commandBuffer, const VkSetDescriptorBufferOffsetsInfoEXT* pSetDescriptorBufferOffsetsInfo,
+    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= ValidateCmdSetDescriptorBufferOffsets(
         commandBuffer, pSetDescriptorBufferOffsetsInfo->layout, pSetDescriptorBufferOffsetsInfo->setCount,
         pSetDescriptorBufferOffsetsInfo->pBufferIndices, pSetDescriptorBufferOffsetsInfo->pOffsets, error_obj.location);
@@ -1377,10 +1377,10 @@ bool Device::manual_PreCallValidateCmdSetDescriptorBufferOffsets2EXT(
 }
 
 bool Device::manual_PreCallValidateCmdBindDescriptorBufferEmbeddedSamplers2EXT(
-    VkCommandBuffer commandBuffer, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT *pBindDescriptorBufferEmbeddedSamplersInfo,
-    const Context &context) const {
+    VkCommandBuffer commandBuffer, const VkBindDescriptorBufferEmbeddedSamplersInfoEXT* pBindDescriptorBufferEmbeddedSamplersInfo,
+    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pBindDescriptorBufferEmbeddedSamplersInfo->layout == VK_NULL_HANDLE) {
         if (!enabled_features.dynamicPipelineLayout) {
@@ -1398,10 +1398,10 @@ bool Device::manual_PreCallValidateCmdBindDescriptorBufferEmbeddedSamplers2EXT(
 }
 
 bool Device::manual_PreCallValidateCmdPushDescriptorSetWithTemplate2(
-    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfo *pPushDescriptorSetWithTemplateInfo,
-    const Context &context) const {
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfo* pPushDescriptorSetWithTemplateInfo,
+    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pPushDescriptorSetWithTemplateInfo->layout == VK_NULL_HANDLE) {
         if (!enabled_features.dynamicPipelineLayout) {
@@ -1418,10 +1418,10 @@ bool Device::manual_PreCallValidateCmdPushDescriptorSetWithTemplate2(
 }
 
 bool Device::manual_PreCallValidateCmdBindDescriptorSets2(VkCommandBuffer commandBuffer,
-                                                          const VkBindDescriptorSetsInfoKHR *pBindDescriptorSetsInfo,
-                                                          const Context &context) const {
+                                                          const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo,
+                                                          const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pBindDescriptorSetsInfo->layout == VK_NULL_HANDLE) {
         if (!enabled_features.dynamicPipelineLayout) {
             skip |= LogError("VUID-VkBindDescriptorSetsInfo-None-09495", commandBuffer,

--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,11 +24,11 @@
 
 namespace stateless {
 
-bool Device::manual_PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory,
-                                                  const Context &context) const {
+bool Device::manual_PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
+                                                  const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!pAllocateInfo) {
         return skip;
@@ -61,11 +61,11 @@ bool Device::manual_PreCallValidateAllocateMemory(VkDevice device, const VkMemor
     return skip;
 }
 
-bool Device::ValidateDeviceImageMemoryRequirements(VkDevice device, const VkDeviceImageMemoryRequirements &memory_requirements,
-                                                   const Location &loc) const {
+bool Device::ValidateDeviceImageMemoryRequirements(VkDevice device, const VkDeviceImageMemoryRequirements& memory_requirements,
+                                                   const Location& loc) const {
     bool skip = false;
 
-    const auto &create_info = *(memory_requirements.pCreateInfo);
+    const auto& create_info = *(memory_requirements.pCreateInfo);
     if (vku::FindStructInPNextChain<VkImageSwapchainCreateInfoKHR>(create_info.pNext)) {
         skip |= LogError("VUID-VkDeviceImageMemoryRequirements-pCreateInfo-06416", device,
                          loc.dot(Field::pCreateInfo).dot(Field::pNext), "chain contains VkImageSwapchainCreateInfoKHR.\n%s",
@@ -98,11 +98,11 @@ bool Device::ValidateDeviceImageMemoryRequirements(VkDevice device, const VkDevi
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetDeviceImageMemoryRequirements(VkDevice device, const VkDeviceImageMemoryRequirements *pInfo,
-                                                                    VkMemoryRequirements2 *pMemoryRequirements,
-                                                                    const Context &context) const {
+bool Device::manual_PreCallValidateGetDeviceImageMemoryRequirements(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo,
+                                                                    VkMemoryRequirements2* pMemoryRequirements,
+                                                                    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     skip |= ValidateDeviceImageMemoryRequirements(device, *pInfo, error_obj.location.dot(Field::pInfo));
 
@@ -110,10 +110,10 @@ bool Device::manual_PreCallValidateGetDeviceImageMemoryRequirements(VkDevice dev
 }
 
 bool Device::manual_PreCallValidateGetDeviceImageSparseMemoryRequirements(
-    VkDevice device, const VkDeviceImageMemoryRequirements *pInfo, uint32_t *pSparseMemoryRequirementCount,
-    VkSparseImageMemoryRequirements2 *pSparseMemoryRequirements, const Context &context) const {
+    VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, uint32_t* pSparseMemoryRequirementCount,
+    VkSparseImageMemoryRequirements2* pSparseMemoryRequirements, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     skip |= ValidateDeviceImageMemoryRequirements(device, *pInfo, error_obj.location.dot(Field::pInfo));
 
@@ -247,17 +247,17 @@ bool Device::manual_PreCallValidateCmdDecompressMemoryIndirectCountEXT(
     return skip;
 }
 
-bool Device::manual_PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                                   VkFence fence, const Context &context) const {
+bool Device::manual_PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
+                                                   VkFence fence, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     for (uint32_t bind_info_i = 0; bind_info_i < bindInfoCount; ++bind_info_i) {
-        const VkBindSparseInfo &bind_info = pBindInfo[bind_info_i];
+        const VkBindSparseInfo& bind_info = pBindInfo[bind_info_i];
         for (uint32_t image_bind_i = 0; image_bind_i < bind_info.imageBindCount; ++image_bind_i) {
-            const VkSparseImageMemoryBindInfo &image_bind = bind_info.pImageBinds[image_bind_i];
+            const VkSparseImageMemoryBindInfo& image_bind = bind_info.pImageBinds[image_bind_i];
             for (uint32_t bind_i = 0; bind_i < image_bind.bindCount; ++bind_i) {
-                const VkSparseImageMemoryBind &bind = image_bind.pBinds[bind_i];
+                const VkSparseImageMemoryBind& bind = image_bind.pBinds[bind_i];
                 if (bind.extent.width == 0) {
                     const LogObjectList objlist(queue, image_bind.image);
                     skip |= LogError("VUID-VkSparseImageMemoryBind-extent-09388", objlist,
@@ -298,9 +298,9 @@ bool Device::manual_PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
 }
 
 bool Device::manual_PreCallValidateSetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority,
-                                                              const Context &context) const {
+                                                              const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!IsBetweenInclusive(priority, 0.0F, 1.0F)) {
         skip |= LogError("VUID-vkSetDeviceMemoryPriorityEXT-priority-06258", device, error_obj.location.dot(Field::priority),
                          "is %f.", priority);
@@ -308,18 +308,18 @@ bool Device::manual_PreCallValidateSetDeviceMemoryPriorityEXT(VkDevice device, V
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo *pRenderingInfo,
-                                                                         VkTilePropertiesQCOM *pProperties,
-                                                                         const Context &context) const {
+bool Device::manual_PreCallValidateGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo* pRenderingInfo,
+                                                                         VkTilePropertiesQCOM* pProperties,
+                                                                         const Context& context) const {
     bool skip = false;
     if (const auto tile_memory_size = vku::FindStructInPNextChain<VkTileMemorySizeInfoQCOM>(pRenderingInfo->pNext)) {
-        const auto &error_obj = context.error_obj;
+        const auto& error_obj = context.error_obj;
         skip |= ValidateTileMemorySizeInfo(*tile_memory_size, error_obj.location);
     }
     return skip;
 }
 
-bool Device::ValidateTileMemorySizeInfo(const VkTileMemorySizeInfoQCOM &tile_memory_size_info, const Location &loc) const {
+bool Device::ValidateTileMemorySizeInfo(const VkTileMemorySizeInfoQCOM& tile_memory_size_info, const Location& loc) const {
     bool skip = false;
     uint64_t largest_heap_size = 0;
     uint32_t heap_index = 0;
@@ -333,8 +333,8 @@ bool Device::ValidateTileMemorySizeInfo(const VkTileMemorySizeInfoQCOM &tile_mem
     }
     if (tile_memory_size_info.size > largest_heap_size) {
         skip |= LogError("VUID-VkTileMemorySizeInfoQCOM-size-10729", device, loc.dot(Field::size),
-                         "(%" PRIu64
-                         ") must be less than or equal to %" PRIu64 ", found at memoryHeaps[%" PRIu32 "],"
+                         "(%" PRIu64 ") must be less than or equal to %" PRIu64 ", found at memoryHeaps[%" PRIu32
+                         "],"
                          " the largest VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM heap.",
                          tile_memory_size_info.size, largest_heap_size, heap_index);
     }

--- a/layers/stateless/sl_drawdispatch.cpp
+++ b/layers/stateless/sl_drawdispatch.cpp
@@ -44,8 +44,8 @@ bool Device::ValidateDrawIndirect2Info(VkCommandBuffer commandBuffer, const VkDr
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdDrawIndirect2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR *pInfo,
-                                                       const Context &context) const {
+bool Device::manual_PreCallValidateCmdDrawIndirect2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR* pInfo,
+                                                       const Context& context) const {
     bool skip = false;
 
     const Location info_loc = context.error_obj.location.dot(Field::pInfo);
@@ -84,8 +84,8 @@ bool Device::manual_PreCallValidateCmdDrawIndirect2KHR(VkCommandBuffer commandBu
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdDrawIndexedIndirect2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR *pInfo,
-                                                              const Context &context) const {
+bool Device::manual_PreCallValidateCmdDrawIndexedIndirect2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR* pInfo,
+                                                              const Context& context) const {
     bool skip = false;
 
     const Location info_loc = context.error_obj.location.dot(Field::pInfo);
@@ -124,8 +124,8 @@ bool Device::manual_PreCallValidateCmdDrawIndexedIndirect2KHR(VkCommandBuffer co
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdDrawMeshTasksIndirect2EXT(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR *pInfo,
-                                                                const Context &context) const {
+bool Device::manual_PreCallValidateCmdDrawMeshTasksIndirect2EXT(VkCommandBuffer commandBuffer, const VkDrawIndirect2InfoKHR* pInfo,
+                                                                const Context& context) const {
     bool skip = false;
 
     const Location info_loc = context.error_obj.location.dot(Field::pInfo);
@@ -161,8 +161,8 @@ bool Device::ValidateDrawIndirectCount2Info(VkCommandBuffer commandBuffer, const
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdDrawIndirectCount2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirectCount2InfoKHR *pInfo,
-                                                            const Context &context) const {
+bool Device::manual_PreCallValidateCmdDrawIndirectCount2KHR(VkCommandBuffer commandBuffer, const VkDrawIndirectCount2InfoKHR* pInfo,
+                                                            const Context& context) const {
     bool skip = false;
 
     if ((extensions.vk_khr_draw_indirect_count != kEnabledByCreateinfo) &&
@@ -209,8 +209,8 @@ bool Device::manual_PreCallValidateCmdDrawIndirectCount2KHR(VkCommandBuffer comm
 }
 
 bool Device::manual_PreCallValidateCmdDrawIndexedIndirectCount2KHR(VkCommandBuffer commandBuffer,
-                                                                   const VkDrawIndirectCount2InfoKHR *pInfo,
-                                                                   const Context &context) const {
+                                                                   const VkDrawIndirectCount2InfoKHR* pInfo,
+                                                                   const Context& context) const {
     bool skip = false;
 
     if ((extensions.vk_khr_draw_indirect_count != kEnabledByCreateinfo) &&
@@ -258,8 +258,8 @@ bool Device::manual_PreCallValidateCmdDrawIndexedIndirectCount2KHR(VkCommandBuff
     return skip;
 }
 bool Device::manual_PreCallValidateCmdDrawMeshTasksIndirectCount2EXT(VkCommandBuffer commandBuffer,
-                                                                     const VkDrawIndirectCount2InfoKHR *pInfo,
-                                                                     const Context &context) const {
+                                                                     const VkDrawIndirectCount2InfoKHR* pInfo,
+                                                                     const Context& context) const {
     bool skip = false;
 
     if ((extensions.vk_khr_draw_indirect_count != kEnabledByCreateinfo) &&
@@ -276,8 +276,8 @@ bool Device::manual_PreCallValidateCmdDrawMeshTasksIndirectCount2EXT(VkCommandBu
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdDispatchIndirect2KHR(VkCommandBuffer commandBuffer, const VkDispatchIndirect2InfoKHR *pInfo,
-                                                           const Context &context) const {
+bool Device::manual_PreCallValidateCmdDispatchIndirect2KHR(VkCommandBuffer commandBuffer, const VkDispatchIndirect2InfoKHR* pInfo,
+                                                           const Context& context) const {
     bool skip = false;
 
     const Location info_loc = context.error_obj.location.dot(Field::pInfo);

--- a/layers/stateless/sl_external_object.cpp
+++ b/layers/stateless/sl_external_object.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,11 +23,11 @@
 
 namespace stateless {
 
-bool Device::manual_PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                                  const Context &context) const {
+bool Device::manual_PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                                  const Context& context) const {
     constexpr auto allowed_types = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT | VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (0 == (pGetFdInfo->handleType & allowed_types)) {
         skip |= LogError("VUID-VkMemoryGetFdInfoKHR-handleType-00672", pGetFdInfo->memory,
                          error_obj.location.dot(Field::pGetFdInfo).dot(Field::handleType),
@@ -39,10 +39,10 @@ bool Device::manual_PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemor
 }
 
 bool Device::manual_PreCallValidateGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd,
-                                                            VkMemoryFdPropertiesKHR *pMemoryFdProperties,
-                                                            const Context &context) const {
+                                                            VkMemoryFdPropertiesKHR* pMemoryFdProperties,
+                                                            const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (fd < 0) {
         skip |= LogError("VUID-vkGetMemoryFdPropertiesKHR-fd-00673", device, error_obj.location.dot(Field::fd),
                          "handle (%d) is not a valid POSIX file descriptor.", fd);
@@ -54,7 +54,7 @@ bool Device::manual_PreCallValidateGetMemoryFdPropertiesKHR(VkDevice device, VkE
     return skip;
 }
 
-bool Device::ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const char *vuid, const Location &handle_type_loc,
+bool Device::ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const char* vuid, const Location& handle_type_loc,
                                                  VkExternalSemaphoreHandleTypeFlagBits handle_type,
                                                  VkExternalSemaphoreHandleTypeFlags allowed_types) const {
     bool skip = false;
@@ -66,7 +66,7 @@ bool Device::ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const ch
     return skip;
 }
 
-bool Device::ValidateExternalFenceHandleType(VkFence fence, const char *vuid, const Location &handle_type_loc,
+bool Device::ValidateExternalFenceHandleType(VkFence fence, const char* vuid, const Location& handle_type_loc,
                                              VkExternalFenceHandleTypeFlagBits handle_type,
                                              VkExternalFenceHandleTypeFlags allowed_types) const {
     bool skip = false;
@@ -81,18 +81,18 @@ bool Device::ValidateExternalFenceHandleType(VkFence fence, const char *vuid, co
 static constexpr VkExternalSemaphoreHandleTypeFlags kSemFdHandleTypes =
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT | VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
 
-bool Device::manual_PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                                     const Context &context) const {
-    const auto &error_obj = context.error_obj;
+bool Device::manual_PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                                     const Context& context) const {
+    const auto& error_obj = context.error_obj;
     return ValidateExternalSemaphoreHandleType(pGetFdInfo->semaphore, "VUID-VkSemaphoreGetFdInfoKHR-handleType-01136",
                                                error_obj.location.dot(Field::pGetFdInfo).dot(Field::handleType),
                                                pGetFdInfo->handleType, kSemFdHandleTypes);
 }
 
-bool Device::manual_PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR *pImportSemaphoreFdInfo,
-                                                        const Context &context) const {
+bool Device::manual_PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo,
+                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location info_loc = error_obj.location.dot(Field::pImportSemaphoreFdInfo);
     skip |=
         ValidateExternalSemaphoreHandleType(pImportSemaphoreFdInfo->semaphore, "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143",
@@ -112,17 +112,17 @@ bool Device::manual_PreCallValidateImportSemaphoreFdKHR(VkDevice device, const V
 static constexpr VkExternalFenceHandleTypeFlags kFenceFdHandleTypes =
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT | VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT;
 
-bool Device::manual_PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *pGetFdInfo, int *pFd,
-                                                 const Context &context) const {
+bool Device::manual_PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd,
+                                                 const Context& context) const {
     return ValidateExternalFenceHandleType(pGetFdInfo->fence, "VUID-VkFenceGetFdInfoKHR-handleType-01456",
                                            context.error_obj.location.dot(Field::pGetFdInfo).dot(Field::handleType),
                                            pGetFdInfo->handleType, kFenceFdHandleTypes);
 }
 
-bool Device::manual_PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR *pImportFenceFdInfo,
-                                                    const Context &context) const {
+bool Device::manual_PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo,
+                                                    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location info_loc = error_obj.location.dot(Field::pImportFenceFdInfo);
     skip |= ValidateExternalFenceHandleType(pImportFenceFdInfo->fence, "VUID-VkImportFenceFdInfoKHR-handleType-01464",
                                             info_loc.dot(Field::handleType), pImportFenceFdInfo->handleType, kFenceFdHandleTypes);
@@ -138,11 +138,11 @@ bool Device::manual_PreCallValidateImportFenceFdKHR(VkDevice device, const VkImp
 }
 
 bool Device::manual_PreCallValidateGetMemoryHostPointerPropertiesEXT(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
-                                                                     const void *pHostPointer,
-                                                                     VkMemoryHostPointerPropertiesEXT *pMemoryHostPointerProperties,
-                                                                     const Context &context) const {
+                                                                     const void* pHostPointer,
+                                                                     VkMemoryHostPointerPropertiesEXT* pMemoryHostPointerProperties,
+                                                                     const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT &&
         handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_MAPPED_FOREIGN_MEMORY_BIT_EXT) {
         skip |=
@@ -165,8 +165,8 @@ bool Device::manual_PreCallValidateGetMemoryHostPointerPropertiesEXT(VkDevice de
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 bool Device::manual_PreCallValidateGetMemoryWin32HandleKHR(VkDevice device,
-                                                           const VkMemoryGetWin32HandleInfoKHR *pGetWin32HandleInfo,
-                                                           HANDLE *pHandle, const Context &context) const {
+                                                           const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
+                                                           HANDLE* pHandle, const Context& context) const {
     constexpr VkExternalMemoryHandleTypeFlags nt_handles =
         VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT | VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT |
         VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP_BIT | VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE_BIT;
@@ -185,10 +185,10 @@ bool Device::manual_PreCallValidateGetMemoryWin32HandleKHR(VkDevice device,
 
 bool Device::manual_PreCallValidateGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
                                                                      HANDLE handle,
-                                                                     VkMemoryWin32HandlePropertiesKHR *pMemoryWin32HandleProperties,
-                                                                     const Context &context) const {
+                                                                     VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties,
+                                                                     const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (handle == NULL || handle == INVALID_HANDLE_VALUE) {
         static_assert(sizeof(HANDLE) == sizeof(uintptr_t));  // to use PRIxPTR for HANDLE formatting
         skip |= LogError("VUID-vkGetMemoryWin32HandlePropertiesKHR-handle-00665", device, error_obj.location.dot(Field::handle),
@@ -207,10 +207,10 @@ static constexpr VkExternalSemaphoreHandleTypeFlags kSemWin32HandleTypes = VK_EX
                                                                            VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT |
                                                                            VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
 
-bool Device::manual_PreCallValidateImportSemaphoreWin32HandleKHR(VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *info,
-                                                                 const Context &context) const {
+bool Device::manual_PreCallValidateImportSemaphoreWin32HandleKHR(VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* info,
+                                                                 const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     skip |=
         ValidateExternalSemaphoreHandleType(info->semaphore, "VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140",
@@ -222,19 +222,19 @@ bool Device::manual_PreCallValidateImportSemaphoreWin32HandleKHR(VkDevice device
     if ((info->handleType & kNameAllowedTypes) == 0 && info->name) {
         skip |= LogError("VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01466", info->semaphore,
                          error_obj.location.dot(Field::pImportSemaphoreWin32HandleInfo).dot(Field::name),
-                         "(%p) must be NULL if handleType is %s", reinterpret_cast<const void *>(info->name),
+                         "(%p) must be NULL if handleType is %s", reinterpret_cast<const void*>(info->name),
                          string_VkExternalSemaphoreHandleTypeFlagBits(info->handleType));
     }
     if (info->handle && info->name) {
         skip |= LogError("VUID-VkImportSemaphoreWin32HandleInfoKHR-handle-01469", info->semaphore,
                          error_obj.location.dot(Field::pImportSemaphoreWin32HandleInfo),
-                         "both handle (%p) and name (%p) are non-NULL", info->handle, reinterpret_cast<const void *>(info->name));
+                         "both handle (%p) and name (%p) are non-NULL", info->handle, reinterpret_cast<const void*>(info->name));
     }
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR *info,
-                                                              HANDLE *pHandle, const Context &context) const {
+bool Device::manual_PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR* info,
+                                                              HANDLE* pHandle, const Context& context) const {
     return ValidateExternalSemaphoreHandleType(info->semaphore, "VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01131",
                                                context.error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
                                                info->handleType, kSemWin32HandleTypes);
@@ -243,10 +243,10 @@ bool Device::manual_PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device, c
 static constexpr VkExternalFenceHandleTypeFlags kFenceWin32HandleTypes =
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT | VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
 
-bool Device::manual_PreCallValidateImportFenceWin32HandleKHR(VkDevice device, const VkImportFenceWin32HandleInfoKHR *info,
-                                                             const Context &context) const {
+bool Device::manual_PreCallValidateImportFenceWin32HandleKHR(VkDevice device, const VkImportFenceWin32HandleInfoKHR* info,
+                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= ValidateExternalFenceHandleType(info->fence, "VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457",
                                             error_obj.location.dot(Field::pImportFenceWin32HandleInfo).dot(Field::handleType),
                                             info->handleType, kFenceWin32HandleTypes);
@@ -255,20 +255,20 @@ bool Device::manual_PreCallValidateImportFenceWin32HandleKHR(VkDevice device, co
     if ((info->handleType & kNameAllowedTypes) == 0 && info->name) {
         skip |= LogError("VUID-VkImportFenceWin32HandleInfoKHR-handleType-01459", info->fence,
                          error_obj.location.dot(Field::pImportFenceWin32HandleInfo).dot(Field::name),
-                         "(%p) must be NULL if handleType is %s", reinterpret_cast<const void *>(info->name),
+                         "(%p) must be NULL if handleType is %s", reinterpret_cast<const void*>(info->name),
                          string_VkExternalFenceHandleTypeFlagBits(info->handleType));
     }
     if (info->handle && info->name) {
         skip |= LogError("VUID-VkImportFenceWin32HandleInfoKHR-handle-01462", info->fence,
                          error_obj.location.dot(Field::pImportFenceWin32HandleInfo), "both handle (%p) and name (%p) are non-NULL",
-                         info->handle, reinterpret_cast<const void *>(info->name));
+                         info->handle, reinterpret_cast<const void*>(info->name));
     }
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR *info,
-                                                          HANDLE *pHandle, const Context &context) const {
-    const auto &error_obj = context.error_obj;
+bool Device::manual_PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* info,
+                                                          HANDLE* pHandle, const Context& context) const {
+    const auto& error_obj = context.error_obj;
     return ValidateExternalFenceHandleType(info->fence, "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452",
                                            error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
                                            info->handleType, kFenceWin32HandleTypes);
@@ -276,8 +276,8 @@ bool Device::manual_PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const
 #endif
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-bool Device::ExportMetalObjectsPNextUtil(VkExportMetalObjectTypeFlagBitsEXT bit, const char *vuid, const Location &loc,
-                                         const char *sType, const void *pNext) const {
+bool Device::ExportMetalObjectsPNextUtil(VkExportMetalObjectTypeFlagBitsEXT bit, const char* vuid, const Location& loc,
+                                         const char* sType, const void* pNext) const {
     bool skip = false;
     auto export_metal_object_info = vku::FindStructInPNextChain<VkExportMetalObjectCreateInfoEXT>(pNext);
     while (export_metal_object_info) {
@@ -303,18 +303,18 @@ struct ExternalOperationsInfo {
     bool export_info_win32 = false;
     bool export_info_win32_nv = false;
 
-    const VkImportMemoryFdInfoKHR *import_info_fd = nullptr;
-    const VkImportMemoryHostPointerInfoEXT *import_info_host_pointer = nullptr;
+    const VkImportMemoryFdInfoKHR* import_info_fd = nullptr;
+    const VkImportMemoryHostPointerInfoEXT* import_info_host_pointer = nullptr;
 
-    const VkExportMemoryAllocateInfo *export_info = nullptr;
-    const VkExportMemoryAllocateInfoNV *export_info_nv = nullptr;
+    const VkExportMemoryAllocateInfo* export_info = nullptr;
+    const VkExportMemoryAllocateInfoNV* export_info_nv = nullptr;
 
     uint32_t total_import_ops = 0;
     bool has_export = false;
 };
 
 // vkspec.html#memory-import-operation describes all the various ways for import operations
-ExternalOperationsInfo GetExternalOperationsInfo(const void *pNext) {
+ExternalOperationsInfo GetExternalOperationsInfo(const void* pNext) {
     ExternalOperationsInfo ext = {};
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
@@ -376,14 +376,14 @@ ExternalOperationsInfo GetExternalOperationsInfo(const void *pNext) {
     // VK_EXT_external_memory_metal
     auto import_info_metal = vku::FindStructInPNextChain<VkImportMemoryMetalHandleInfoEXT>(pNext);
     ext.total_import_ops += (import_info_metal && import_info_metal->handle);
-#endif // VK_USE_PLATFORM_METAL_EXT
+#endif  // VK_USE_PLATFORM_METAL_EXT
 
     return ext;
 }
 }  // namespace
 
-bool Device::ValidateAllocateMemoryExternal(VkDevice device, const VkMemoryAllocateInfo &allocate_info, VkMemoryAllocateFlags flags,
-                                            const Location &allocate_info_loc) const {
+bool Device::ValidateAllocateMemoryExternal(VkDevice device, const VkMemoryAllocateInfo& allocate_info, VkMemoryAllocateFlags flags,
+                                            const Location& allocate_info_loc) const {
     bool skip = false;
 
     // Used to remove platform ifdef logic below

--- a/layers/stateless/sl_framebuffer.cpp
+++ b/layers/stateless/sl_framebuffer.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,12 +20,12 @@
 
 namespace stateless {
 
-bool Device::manual_PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkFramebuffer *pFramebuffer,
-                                                     const Context &context) const {
+bool Device::manual_PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
+                                                     const Context& context) const {
     // Validation for pAttachments which is excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
 
     if ((pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
@@ -48,7 +48,7 @@ bool Device::manual_PreCallValidateCreateFramebuffer(VkDevice device, const VkFr
                              "includes VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, but the imagelessFramebuffer feature is not enabled.");
         }
 
-        const auto *framebuffer_attachments_create_info =
+        const auto* framebuffer_attachments_create_info =
             vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(pCreateInfo->pNext);
         if (framebuffer_attachments_create_info == nullptr) {
             skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03190", device, create_info_loc.dot(Field::flags),

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -29,11 +29,11 @@
 
 namespace stateless {
 
-bool Device::manual_PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
-                                               const VkAllocationCallbacks *pAllocator, VkImage *pImage,
-                                               const Context &context) const {
+bool Device::manual_PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
+                                               const VkAllocationCallbacks* pAllocator, VkImage* pImage,
+                                               const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pCreateInfo == nullptr) {
         return skip;
@@ -372,7 +372,7 @@ bool Device::manual_PreCallValidateCreateImage(VkDevice device, const VkImageCre
     return skip;
 }
 
-bool Device::ValidateCreateImageSparse(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateImageSparse(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     const VkImageCreateFlags image_flags = create_info.flags;
     const VkImageCreateFlags sparse_flags =
@@ -460,7 +460,7 @@ bool Device::ValidateCreateImageSparse(const VkImageCreateInfo &create_info, con
     return skip;
 }
 
-bool Device::ValidateCreateImageFragmentShadingRate(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateImageFragmentShadingRate(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     // alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV
     if ((create_info.usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) == 0) return skip;
@@ -486,7 +486,7 @@ bool Device::ValidateCreateImageFragmentShadingRate(const VkImageCreateInfo &cre
     return skip;
 }
 
-bool Device::ValidateCreateImageCornerSampled(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateImageCornerSampled(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     if ((create_info.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) == 0) return skip;
 
@@ -520,7 +520,7 @@ bool Device::ValidateCreateImageCornerSampled(const VkImageCreateInfo &create_in
     return skip;
 }
 
-bool Device::ValidateCreateImageStencilUsage(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateImageStencilUsage(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(create_info.pNext);
     if (!image_stencil_struct) return skip;
@@ -602,8 +602,8 @@ bool Device::ValidateCreateImageStencilUsage(const VkImageCreateInfo &create_inf
     return skip;
 }
 
-bool Device::ValidateCreateImageCompressionControl(const Context &context, const VkImageCreateInfo &create_info,
-                                                   const Location &create_info_loc) const {
+bool Device::ValidateCreateImageCompressionControl(const Context& context, const VkImageCreateInfo& create_info,
+                                                   const Location& create_info_loc) const {
     bool skip = false;
     const auto image_compression_control = vku::FindStructInPNextChain<VkImageCompressionControlEXT>(create_info.pNext);
     if (!image_compression_control) return skip;
@@ -644,7 +644,7 @@ bool Device::ValidateCreateImageCompressionControl(const Context &context, const
     return skip;
 }
 
-bool Device::ValidateCreateImageSwapchain(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateImageSwapchain(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     const auto swapchain_create_info = vku::FindStructInPNextChain<VkImageSwapchainCreateInfoKHR>(create_info.pNext);
     if (!swapchain_create_info || swapchain_create_info->swapchain == VK_NULL_HANDLE) return skip;
@@ -652,7 +652,7 @@ bool Device::ValidateCreateImageSwapchain(const VkImageCreateInfo &create_info, 
     // All the following fall under the same VU that checks that the swapchain image uses parameters listed in the
     // #swapchain-wsi-image-create-info table. Breaking up into multiple checks allows for more useful information
     // to be returned when this error occurs. Check for matching Swapchain flags is done later in state tracking validation
-    const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
+    const char* vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
     const Location swapchain_loc = create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain);
 
     if (create_info.imageType != VK_IMAGE_TYPE_2D) {
@@ -689,7 +689,7 @@ bool Device::ValidateCreateImageSwapchain(const VkImageCreateInfo &create_info, 
     return skip;
 }
 
-bool Device::ValidateCreateImageFormatList(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateImageFormatList(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
     const auto format_list_info = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(create_info.pNext);
     if (!format_list_info) return skip;
@@ -766,7 +766,7 @@ bool Device::ValidateCreateImageFormatList(const VkImageCreateInfo &create_info,
     return skip;
 }
 
-bool Device::ValidateCreateImageMetalObject(const VkImageCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateCreateImageMetalObject(const VkImageCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_METAL_EXT
     auto export_metal_object_info = vku::FindStructInPNextChain<VkExportMetalObjectCreateInfoEXT>(create_info.pNext);
@@ -813,8 +813,8 @@ bool Device::ValidateCreateImageMetalObject(const VkImageCreateInfo &create_info
     return skip;
 }
 
-bool Device::ValidateCreateImageDrmFormatModifiers(const VkImageCreateInfo &create_info, const Location &create_info_loc,
-                                                   std::vector<uint64_t> &image_create_drm_format_modifiers) const {
+bool Device::ValidateCreateImageDrmFormatModifiers(const VkImageCreateInfo& create_info, const Location& create_info_loc,
+                                                   std::vector<uint64_t>& image_create_drm_format_modifiers) const {
     bool skip = false;
     if (!IsExtEnabled(extensions.vk_ext_image_drm_format_modifier)) return skip;
 
@@ -895,7 +895,7 @@ bool Device::ValidateCreateImageDrmFormatModifiers(const VkImageCreateInfo &crea
     return skip;
 }
 
-bool Device::ValidateImageViewCreateInfo(const VkImageViewCreateInfo &create_info, const Location &create_info_loc) const {
+bool Device::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create_info, const Location& create_info_loc) const {
     bool skip = false;
 
     if ((create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (!enabled_features.imageCubeArray)) {
@@ -964,11 +964,11 @@ bool Device::ValidateImageViewCreateInfo(const VkImageViewCreateInfo &create_inf
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkImageView *pView,
-                                                   const Context &context) const {
+bool Device::manual_PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkImageView* pView,
+                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pCreateInfo == nullptr) {
         return skip;
@@ -978,16 +978,16 @@ bool Device::manual_PreCallValidateCreateImageView(VkDevice device, const VkImag
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetDeviceImageSubresourceLayout(VkDevice device, const VkDeviceImageSubresourceInfo *pInfo,
-                                                                   VkSubresourceLayout2 *pLayout, const Context &context) const {
+bool Device::manual_PreCallValidateGetDeviceImageSubresourceLayout(VkDevice device, const VkDeviceImageSubresourceInfo* pInfo,
+                                                                   VkSubresourceLayout2* pLayout, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location info_loc = error_obj.location.dot(Field::pInfo);
     const Location create_info_loc = info_loc.dot(Field::pCreateInfo);
     const Location subresource_loc = info_loc.dot(Field::pSubresource);
 
-    const VkImageCreateInfo &create_info = *pInfo->pCreateInfo;
-    const VkImageSubresource &subresource = pInfo->pSubresource->imageSubresource;
+    const VkImageCreateInfo& create_info = *pInfo->pCreateInfo;
+    const VkImageSubresource& subresource = pInfo->pSubresource->imageSubresource;
     const VkImageAspectFlags aspect_mask = subresource.aspectMask;
 
     if (CountSetBits(aspect_mask) != 1) {
@@ -1051,7 +1051,7 @@ bool Device::manual_PreCallValidateGetDeviceImageSubresourceLayout(VkDevice devi
 
 bool Device::manual_PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                    VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                   const VkImageResolve *pRegions, const Context &context) const {
+                                                   const VkImageResolve* pRegions, const Context& context) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < regionCount; i++) {
@@ -1080,15 +1080,15 @@ bool Device::manual_PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
-                                                    const Context &context) const {
+bool Device::manual_PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
+                                                    const Context& context) const {
     bool skip = false;
     const Location resolve_info_loc = context.error_obj.location.dot(Field::pResolveImageInfo);
     for (uint32_t i = 0; i < pResolveImageInfo->regionCount; i++) {
         const Location region_loc = resolve_info_loc.dot(Field::pRegions, i);
         const Location src_subresource_loc = region_loc.dot(Field::srcSubresource);
         const Location dst_subresource_loc = region_loc.dot(Field::dstSubresource);
-        const VkImageResolve2 &region = pResolveImageInfo->pRegions[i];
+        const VkImageResolve2& region = pResolveImageInfo->pRegions[i];
 
         if (enabled_features.maintenance10) {
             if (region.srcSubresource.aspectMask &
@@ -1124,7 +1124,7 @@ bool Device::manual_PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
         }
     }
 
-    if (const auto *resolve_mode_info = vku::FindStructInPNextChain<VkResolveImageModeInfoKHR>(pResolveImageInfo->pNext)) {
+    if (const auto* resolve_mode_info = vku::FindStructInPNextChain<VkResolveImageModeInfoKHR>(pResolveImageInfo->pNext)) {
         const auto both_skip_and_enable_transfer_flags =
             VK_RESOLVE_IMAGE_SKIP_TRANSFER_FUNCTION_BIT_KHR | VK_RESOLVE_IMAGE_ENABLE_TRANSFER_FUNCTION_BIT_KHR;
         if ((resolve_mode_info->flags & both_skip_and_enable_transfer_flags) == both_skip_and_enable_transfer_flags) {

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -26,12 +26,12 @@ namespace stateless {
 // Traits objects to allow string_join to operate on collections of const char *
 template <typename String>
 struct StringJoinSizeTrait {
-    static size_t size(const String &str) { return str.size(); }
+    static size_t size(const String& str) { return str.size(); }
 };
 
 template <>
-struct StringJoinSizeTrait<const char *> {
-    static size_t size(const char *str) {
+struct StringJoinSizeTrait<const char*> {
+    static size_t size(const char* str) {
         if (!str) return 0;
         return strlen(str);
     }
@@ -46,14 +46,14 @@ struct StringJoinSizeTrait<const char *> {
 // Return type based on sep type
 template <typename String = std::string, typename StringCollection = std::vector<String>,
           typename Accessor = StringJoinSizeTrait<typename StringCollection::value_type>>
-static inline String string_join(const String &sep, const StringCollection &strings) {
+static inline String string_join(const String& sep, const StringCollection& strings) {
     String joined;
     const size_t count = strings.size();
     if (!count) return joined;
 
     // Prereserved storage, s.t. we will execute in linear time (avoids reallocation copies)
     size_t reserve = (count - 1) * sep.size();
-    for (const auto &str : strings) {
+    for (const auto& str : strings) {
         reserve += Accessor::size(str);  // abstracted to allow const char * type in StringCollection
     }
     joined.reserve(reserve + 1);
@@ -71,13 +71,13 @@ static inline String string_join(const String &sep, const StringCollection &stri
 
 // Requires StringCollection::value_type has a const char * constructor and is compatible the string_join::String above
 template <typename StringCollection = std::vector<std::string>, typename SepString = std::string>
-static inline SepString string_join(const char *sep, const StringCollection &strings) {
+static inline SepString string_join(const char* sep, const StringCollection& strings) {
     return string_join<SepString, StringCollection>(SepString(sep), strings);
 }
 
 template <typename ExtensionState>
-bool Instance::ValidateExtensionReqs(const ExtensionState &extensions, const char *vuid, const char *extension_type,
-                                     vvl::Extension extension, const Location &extension_loc) const {
+bool Instance::ValidateExtensionReqs(const ExtensionState& extensions, const char* vuid, const char* extension_type,
+                                     vvl::Extension extension, const Location& extension_loc) const {
     bool skip = false;
     if (extension == vvl::Extension::Empty) {
         return skip;
@@ -89,8 +89,8 @@ bool Instance::ValidateExtensionReqs(const ExtensionState &extensions, const cha
     }
 
     // Check against the required list in the info
-    std::vector<const char *> missing;
-    for (const auto &req : info.requirements) {
+    std::vector<const char*> missing;
+    for (const auto& req : info.requirements) {
         if (!IsExtEnabled(extensions.*(req.enabled))) {
             missing.push_back(req.name);
         }
@@ -105,15 +105,15 @@ bool Instance::ValidateExtensionReqs(const ExtensionState &extensions, const cha
     return skip;
 }
 
-ExtEnabled ExtensionStateByName(const DeviceExtensions &extensions, vvl::Extension extension) {
+ExtEnabled ExtensionStateByName(const DeviceExtensions& extensions, vvl::Extension extension) {
     auto info = extensions.GetInfo(extension);
     // unknown extensions can't be enabled in extension struct
     ExtEnabled state = info.state ? extensions.*(info.state) : kNotSupported;
     return state;
 }
 
-bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                             VkInstance *pInstance, const ErrorObject &error_obj) const {
+bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                             VkInstance* pInstance, const ErrorObject& error_obj) const {
     bool skip = false;
     Location loc = error_obj.location;
     // Note: From the spec--
@@ -207,7 +207,7 @@ bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo *pCreate
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
     // avoid redundant pNext-pNext errors from the cases where we have specific VUs by returning early
-    const auto *debug_report_callback = vku::FindStructInPNextChain<VkDebugReportCallbackCreateInfoEXT>(pCreateInfo->pNext);
+    const auto* debug_report_callback = vku::FindStructInPNextChain<VkDebugReportCallbackCreateInfoEXT>(pCreateInfo->pNext);
     if (debug_report_callback && !instance_extensions.vk_ext_debug_report) {
         skip |=
             LogError("VUID-VkInstanceCreateInfo-pNext-04925", instance, create_info_loc.dot(Field::ppEnabledExtensionNames),
@@ -215,7 +215,7 @@ bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo *pCreate
                      PrintPNextChain(Struct::VkInstanceCreateInfo, pCreateInfo->pNext).c_str());
         return skip;
     }
-    const auto *debug_utils_messenger = vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(pCreateInfo->pNext);
+    const auto* debug_utils_messenger = vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(pCreateInfo->pNext);
     if (debug_utils_messenger && !instance_extensions.vk_ext_debug_utils) {
         skip |=
             LogError("VUID-VkInstanceCreateInfo-pNext-04926", instance, create_info_loc.dot(Field::ppEnabledExtensionNames),
@@ -223,7 +223,7 @@ bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo *pCreate
                      PrintPNextChain(Struct::VkInstanceCreateInfo, pCreateInfo->pNext).c_str());
         return skip;
     }
-    const auto *direct_driver_loading_list = vku::FindStructInPNextChain<VkDirectDriverLoadingListLUNARG>(pCreateInfo->pNext);
+    const auto* direct_driver_loading_list = vku::FindStructInPNextChain<VkDirectDriverLoadingListLUNARG>(pCreateInfo->pNext);
     if (direct_driver_loading_list && !instance_extensions.vk_lunarg_direct_driver_loading) {
         skip |= LogError(
             "VUID-VkInstanceCreateInfo-pNext-09400", instance, create_info_loc.dot(Field::ppEnabledExtensionNames),
@@ -232,7 +232,7 @@ bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo *pCreate
         return skip;
     }
 
-    if (const auto *validation_features = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(pCreateInfo->pNext)) {
+    if (const auto* validation_features = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(pCreateInfo->pNext)) {
         bool debug_printf = false;
         bool gpu_assisted = false;
         bool reserve_slot = false;
@@ -277,11 +277,11 @@ bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo *pCreate
     return skip;
 }
 
-void Instance::CommonPostCallRecordEnumeratePhysicalDevice(const VkPhysicalDevice *phys_devices, const int count) {
+void Instance::CommonPostCallRecordEnumeratePhysicalDevice(const VkPhysicalDevice* phys_devices, const int count) {
     // Assume phys_devices is valid
     assert(phys_devices);
     for (int i = 0; i < count; ++i) {
-        const auto &phys_device = phys_devices[i];
+        const auto& phys_device = phys_devices[i];
         if (0 == physical_device_properties_map.count(phys_device)) {
             auto phys_dev_props = new VkPhysicalDeviceProperties;
             DispatchGetPhysicalDeviceProperties(phys_device, phys_dev_props);
@@ -301,8 +301,8 @@ void Instance::CommonPostCallRecordEnumeratePhysicalDevice(const VkPhysicalDevic
     }
 }
 
-void Instance::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
-                                                      VkPhysicalDevice *pPhysicalDevices, const RecordObject &record_obj) {
+void Instance::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
+                                                      VkPhysicalDevice* pPhysicalDevices, const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_INCOMPLETE != record_obj.result)) {
         return;
     }
@@ -312,36 +312,36 @@ void Instance::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint3
     }
 }
 
-void Instance::PostCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t *pPhysicalDeviceGroupCount,
-                                                           VkPhysicalDeviceGroupProperties *pPhysicalDeviceGroupProperties,
-                                                           const RecordObject &record_obj) {
+void Instance::PostCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
+                                                           VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties,
+                                                           const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_INCOMPLETE != record_obj.result)) {
         return;
     }
 
     if (pPhysicalDeviceGroupCount && pPhysicalDeviceGroupProperties) {
         for (uint32_t i = 0; i < *pPhysicalDeviceGroupCount; i++) {
-            const auto &group = pPhysicalDeviceGroupProperties[i];
+            const auto& group = pPhysicalDeviceGroupProperties[i];
             CommonPostCallRecordEnumeratePhysicalDevice(group.physicalDevices, group.physicalDeviceCount);
         }
     }
 }
 
-void Instance::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator,
-                                            const RecordObject &record_obj) {
+void Instance::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator,
+                                            const RecordObject& record_obj) {
     for (auto it = physical_device_properties_map.begin(); it != physical_device_properties_map.end();) {
         delete (it->second);
         it = physical_device_properties_map.erase(it);
     }
 }
 
-void Device::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void Device::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) {
     std::vector<VkExtensionProperties> ext_props{};
     uint32_t ext_count = 0;
     DispatchEnumerateDeviceExtensionProperties(physical_device, nullptr, &ext_count, nullptr);
     ext_props.resize(ext_count);
     DispatchEnumerateDeviceExtensionProperties(physical_device, nullptr, &ext_count, ext_props.data());
-    for (const auto &prop : ext_props) {
+    for (const auto& prop : ext_props) {
         vvl::Extension extension = GetExtension(prop.extensionName);
         if (extension == vvl::Extension::_VK_EXT_discard_rectangles) {
             discard_rectangles_extension_version = prop.specVersion;
@@ -353,29 +353,29 @@ void Device::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Loca
     has_zero_queues = pCreateInfo->queueCreateInfoCount == 0;
 }
 
-bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                                  const Context &context) const {
+bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
+                                                  const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     // VU was removed in 1.4.344
     // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4725
-    skip |= context.ValidateStringArray(create_info_loc.dot(Field::enabledLayerCount),
-                                            create_info_loc.dot(Field::ppEnabledLayerNames), pCreateInfo->enabledLayerCount,
-                                            pCreateInfo->ppEnabledLayerNames, false, true, kVUIDUndefined,
-                                            "VUID-VkDeviceCreateInfo-ppEnabledLayerNames-parameter");
+    skip |=
+        context.ValidateStringArray(create_info_loc.dot(Field::enabledLayerCount), create_info_loc.dot(Field::ppEnabledLayerNames),
+                                    pCreateInfo->enabledLayerCount, pCreateInfo->ppEnabledLayerNames, false, true, kVUIDUndefined,
+                                    "VUID-VkDeviceCreateInfo-ppEnabledLayerNames-parameter");
     if (pCreateInfo->ppEnabledLayerNames) {
         for (size_t i = 0; i < pCreateInfo->enabledLayerCount; i++) {
-            skip |=
-                context.ValidateString(create_info_loc.dot(Field::ppEnabledLayerNames),
-                                    "VUID-VkDeviceCreateInfo-ppEnabledLayerNames-parameter", pCreateInfo->ppEnabledLayerNames[i]);
+            skip |= context.ValidateString(create_info_loc.dot(Field::ppEnabledLayerNames),
+                                           "VUID-VkDeviceCreateInfo-ppEnabledLayerNames-parameter",
+                                           pCreateInfo->ppEnabledLayerNames[i]);
         }
     }
 
     // If this device supports VK_KHR_portability_subset, it must be enabled
-    const auto &exposed_extensions = physical_device_extensions.at(physicalDevice);
+    const auto& exposed_extensions = physical_device_extensions.at(physicalDevice);
     const bool portability_supported = exposed_extensions.vk_khr_portability_subset;
     bool portability_requested = false;
     bool fragmentmask_requested = false;
@@ -421,7 +421,8 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
     }
 
     if (fragmentmask_requested) {
-        const auto *descriptor_buffer_features = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(pCreateInfo->pNext);
+        const auto* descriptor_buffer_features =
+            vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(pCreateInfo->pNext);
         if (descriptor_buffer_features && descriptor_buffer_features->descriptorBuffer) {
             skip |=
                 LogError("VUID-VkDeviceCreateInfo-None-08095", physicalDevice, create_info_loc.dot(Field::ppEnabledExtensionNames),
@@ -450,9 +451,9 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
                          PrintPNextChain(Struct::VkDeviceCreateInfo, pCreateInfo->pNext).c_str());
     }
 
-    const VkPhysicalDeviceFeatures *features = features2 ? &features2->features : pCreateInfo->pEnabledFeatures;
+    const VkPhysicalDeviceFeatures* features = features2 ? &features2->features : pCreateInfo->pEnabledFeatures;
 
-    if (const auto *robustness2_features =
+    if (const auto* robustness2_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(pCreateInfo->pNext)) {
         if (features && robustness2_features->robustBufferAccess2 && !features->robustBufferAccess) {
             skip |= LogError("VUID-VkPhysicalDeviceRobustness2FeaturesKHR-robustBufferAccess2-04000", physicalDevice,
@@ -460,7 +461,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    if (const auto *raytracing_features =
+    if (const auto* raytracing_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(pCreateInfo->pNext)) {
         if (raytracing_features->rayTracingPipelineShaderGroupHandleCaptureReplayMixed &&
             !raytracing_features->rayTracingPipelineShaderGroupHandleCaptureReplay) {
@@ -475,16 +476,16 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
 
     // might be set in Feature12 struct
     bool any_update_after_bind_feature = false;
-    if (const auto *di_features = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(pCreateInfo->pNext)) {
+    if (const auto* di_features = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(pCreateInfo->pNext)) {
         any_update_after_bind_feature = di_features->descriptorBindingUniformBufferUpdateAfterBind ||
                                         di_features->descriptorBindingStorageBufferUpdateAfterBind ||
                                         di_features->descriptorBindingUniformTexelBufferUpdateAfterBind ||
                                         di_features->descriptorBindingStorageTexelBufferUpdateAfterBind;
     }
 
-    const auto *vulkan_11_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(pCreateInfo->pNext);
+    const auto* vulkan_11_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(pCreateInfo->pNext);
     if (vulkan_11_features) {
-        const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(pCreateInfo->pNext);
+        const VkBaseOutStructure* current = reinterpret_cast<const VkBaseOutStructure*>(pCreateInfo->pNext);
         constexpr std::array illegal_feature_structs_with_11 = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES,
                                                                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES,
                                                                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES,
@@ -502,7 +503,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
                                  PrintPNextChain(Struct::VkDeviceCreateInfo, pCreateInfo->pNext).c_str());
                 break;
             }
-            current = reinterpret_cast<const VkBaseOutStructure *>(current->pNext);
+            current = reinterpret_cast<const VkBaseOutStructure*>(current->pNext);
         }
 
         // Check features are enabled if matching extension is passed in as well
@@ -514,9 +515,9 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    const auto *vulkan_12_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(pCreateInfo->pNext);
+    const auto* vulkan_12_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(pCreateInfo->pNext);
     if (vulkan_12_features) {
-        const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(pCreateInfo->pNext);
+        const VkBaseOutStructure* current = reinterpret_cast<const VkBaseOutStructure*>(pCreateInfo->pNext);
         constexpr std::array illegal_feature_structs_with_12 = {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES,
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES,
@@ -542,7 +543,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
                                  PrintPNextChain(Struct::VkDeviceCreateInfo, pCreateInfo->pNext).c_str());
                 break;
             }
-            current = reinterpret_cast<const VkBaseOutStructure *>(current->pNext);
+            current = reinterpret_cast<const VkBaseOutStructure*>(current->pNext);
         }
         // Check features are enabled if matching extension is passed in as well
         if (vulkan_12_features->drawIndirectCount == VK_FALSE &&
@@ -593,9 +594,9 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
                                         vulkan_12_features->descriptorBindingStorageTexelBufferUpdateAfterBind;
     }
 
-    const auto *vulkan_13_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(pCreateInfo->pNext);
+    const auto* vulkan_13_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(pCreateInfo->pNext);
     if (vulkan_13_features) {
-        const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(pCreateInfo->pNext);
+        const VkBaseOutStructure* current = reinterpret_cast<const VkBaseOutStructure*>(pCreateInfo->pNext);
         constexpr std::array illegal_feature_structs_with_13 = {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES,
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES,
@@ -621,14 +622,14 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
                                  PrintPNextChain(Struct::VkDeviceCreateInfo, pCreateInfo->pNext).c_str());
                 break;
             }
-            current = reinterpret_cast<const VkBaseOutStructure *>(current->pNext);
+            current = reinterpret_cast<const VkBaseOutStructure*>(current->pNext);
         }
     }
 
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8969
-    const auto *vulkan_14_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(pCreateInfo->pNext);
+    const auto* vulkan_14_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(pCreateInfo->pNext);
     if (vulkan_14_features) {
-        const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(pCreateInfo->pNext);
+        const VkBaseOutStructure* current = reinterpret_cast<const VkBaseOutStructure*>(pCreateInfo->pNext);
         constexpr std::array illegal_feature_structs_with_14 = {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES,
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES,
@@ -654,7 +655,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
                                  PrintPNextChain(Struct::VkDeviceCreateInfo, pCreateInfo->pNext).c_str());
                 break;
             }
-            current = reinterpret_cast<const VkBaseOutStructure *>(current->pNext);
+            current = reinterpret_cast<const VkBaseOutStructure*>(current->pNext);
         }
         if (vulkan_14_features->pushDescriptor == VK_FALSE &&
             enabled_extensions.find(vvl::Extension::_VK_KHR_push_descriptor) != enabled_extensions.end()) {
@@ -667,7 +668,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
     // Validate pCreateInfo->pQueueCreateInfos
     if (pCreateInfo->pQueueCreateInfos) {
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
-            const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
+            const VkDeviceQueueCreateInfo& queue_create_info = pCreateInfo->pQueueCreateInfos[i];
             const uint32_t requested_queue_family = queue_create_info.queueFamilyIndex;
             if (requested_queue_family == VK_QUEUE_FAMILY_IGNORED) {
                 skip |= LogError("VUID-VkDeviceQueueCreateInfo-queueFamilyIndex-00381", physicalDevice,
@@ -688,7 +689,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
 
             // Need to know if protectedMemory feature is passed in preCall to creating the device
             VkBool32 protected_memory = VK_FALSE;
-            const auto *protected_features =
+            const auto* protected_features =
                 vku::FindStructInPNextChain<VkPhysicalDeviceProtectedMemoryFeatures>(pCreateInfo->pNext);
             if (protected_features) {
                 protected_memory = protected_features->protectedMemory;
@@ -705,7 +706,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
 
     // feature dependencies for VK_KHR_variable_pointers
     {
-        const auto *variable_pointers_features =
+        const auto* variable_pointers_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceVariablePointersFeatures>(pCreateInfo->pNext);
         VkBool32 variable_pointers = VK_FALSE;
         VkBool32 variable_pointers_storage_buffer = VK_FALSE;
@@ -725,7 +726,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
 
     // feature dependencies for VK_KHR_multiview
     {
-        const auto *multiview_features = vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(pCreateInfo->pNext);
+        const auto* multiview_features = vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(pCreateInfo->pNext);
         VkBool32 multiview = VK_FALSE;
         VkBool32 multiview_geometry_shader = VK_FALSE;
         VkBool32 multiview_tessellation_shader = VK_FALSE;
@@ -748,8 +749,8 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
                          error_obj.location, "If multiviewTessellationShader is VK_TRUE then multiview also needs to be VK_TRUE");
         }
 
-        const auto *fsr_features = vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(pCreateInfo->pNext);
-        const auto *mesh_shader_features = vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(pCreateInfo->pNext);
+        const auto* fsr_features = vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(pCreateInfo->pNext);
+        const auto* mesh_shader_features = vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(pCreateInfo->pNext);
         if (mesh_shader_features) {
             if ((multiview == VK_FALSE) && (mesh_shader_features->multiviewMeshShader)) {
                 skip |= LogError("VUID-VkPhysicalDeviceMeshShaderFeaturesEXT-multiviewMeshShader-07032", physicalDevice,
@@ -776,9 +777,9 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    if (const auto *fragment_shading_rate_features =
+    if (const auto* fragment_shading_rate_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(pCreateInfo->pNext)) {
-        const VkPhysicalDeviceShadingRateImageFeaturesNV *shading_rate_image_features =
+        const VkPhysicalDeviceShadingRateImageFeaturesNV* shading_rate_image_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(pCreateInfo->pNext);
 
         if (shading_rate_image_features && shading_rate_image_features->shadingRateImage) {
@@ -797,7 +798,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
             }
         }
 
-        const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *fragment_density_map_features =
+        const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* fragment_density_map_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(pCreateInfo->pNext);
 
         if (fragment_density_map_features && fragment_density_map_features->fragmentDensityMap) {
@@ -832,7 +833,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    if (const auto *shader_image_atomic_int64_features =
+    if (const auto* shader_image_atomic_int64_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(pCreateInfo->pNext)) {
         if (shader_image_atomic_int64_features->sparseImageInt64Atomics &&
             !shader_image_atomic_int64_features->shaderImageInt64Atomics) {
@@ -842,7 +843,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    if (const auto *shader_atomic_float_features =
+    if (const auto* shader_atomic_float_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(pCreateInfo->pNext)) {
         if (shader_atomic_float_features->sparseImageFloat32Atomics && !shader_atomic_float_features->shaderImageFloat32Atomics) {
             skip |= LogError("VUID-VkDeviceCreateInfo-None-04897", physicalDevice, error_obj.location,
@@ -857,7 +858,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    if (const auto *shader_atomic_float2_features =
+    if (const auto* shader_atomic_float2_features =
             vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(pCreateInfo->pNext)) {
         if (shader_atomic_float2_features->sparseImageFloat32AtomicMinMax &&
             !shader_atomic_float2_features->shaderImageFloat32AtomicMinMax) {
@@ -867,7 +868,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    if (const auto *device_group_ci = vku::FindStructInPNextChain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext)) {
+    if (const auto* device_group_ci = vku::FindStructInPNextChain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext)) {
         for (uint32_t i = 0; i < device_group_ci->physicalDeviceCount - 1; ++i) {
             for (uint32_t j = i + 1; j < device_group_ci->physicalDeviceCount; ++j) {
                 if (device_group_ci->pPhysicalDevices[i] == device_group_ci->pPhysicalDevices[j]) {
@@ -881,7 +882,7 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
         }
     }
 
-    const auto *cache_control = vku::FindStructInPNextChain<VkDevicePipelineBinaryInternalCacheControlKHR>(pCreateInfo->pNext);
+    const auto* cache_control = vku::FindStructInPNextChain<VkDevicePipelineBinaryInternalCacheControlKHR>(pCreateInfo->pNext);
     if (cache_control && cache_control->disableInternalCache) {
         VkPhysicalDevicePipelineBinaryPropertiesKHR pipeline_binary_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&pipeline_binary_props);
@@ -897,10 +898,10 @@ bool Instance::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevic
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceImageFormatProperties2(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2 *pImageFormatInfo,
-    VkImageFormatProperties2 *pImageFormatProperties, const Context &context) const {
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pImageFormatInfo != nullptr) {
         const Location format_info_loc = error_obj.location.dot(Field::pImageFormatInfo);
@@ -917,7 +918,8 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceImageFormatProperties2(
                 }
             }
         }
-        const auto image_drm_format = vku::FindStructInPNextChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(pImageFormatInfo->pNext);
+        const auto image_drm_format =
+            vku::FindStructInPNextChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(pImageFormatInfo->pNext);
         if (image_drm_format) {
             if (pImageFormatInfo->tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
                 skip |= LogError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249", physicalDevice,
@@ -993,10 +995,10 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceImageFormatProperties2(
 bool Instance::manual_PreCallValidateGetPhysicalDeviceImageFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                             VkImageType type, VkImageTiling tiling,
                                                                             VkImageUsageFlags usage, VkImageCreateFlags flags,
-                                                                            VkImageFormatProperties *pImageFormatProperties,
-                                                                            const Context &context) const {
+                                                                            VkImageFormatProperties* pImageFormatProperties,
+                                                                            const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
         skip |= LogError("VUID-vkGetPhysicalDeviceImageFormatProperties-tiling-02248", physicalDevice,
@@ -1006,10 +1008,10 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceImageFormatProperties(VkPh
     return skip;
 }
 
-bool Device::manual_PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo,
-                                                              const Context &context) const {
+bool Device::manual_PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo,
+                                                              const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location name_info_loc = error_obj.location.dot(Field::pNameInfo);
     if (pNameInfo->objectType == VK_OBJECT_TYPE_UNKNOWN) {
         skip |= LogError("VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02587", device, name_info_loc.dot(Field::objectType),
@@ -1028,10 +1030,10 @@ bool Device::manual_PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, c
     return skip;
 }
 
-bool Device::manual_PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT *pTagInfo,
-                                                             const Context &context) const {
+bool Device::manual_PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT* pTagInfo,
+                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pTagInfo->objectType == VK_OBJECT_TYPE_UNKNOWN) {
         skip |= LogError("VUID-VkDebugUtilsObjectTagInfoEXT-objectType-01908", device,
                          error_obj.location.dot(Field::pTagInfo).dot(Field::objectType), "cannot be VK_OBJECT_TYPE_UNKNOWN.");
@@ -1040,16 +1042,16 @@ bool Device::manual_PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device, co
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
-                                                                  VkPhysicalDeviceProperties2 *pProperties,
-                                                                  const Context &context) const {
+                                                                  VkPhysicalDeviceProperties2* pProperties,
+                                                                  const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
-    const auto *api_props_lists = vku::FindStructInPNextChain<VkPhysicalDeviceLayeredApiPropertiesListKHR>(pProperties->pNext);
+    const auto& error_obj = context.error_obj;
+    const auto* api_props_lists = vku::FindStructInPNextChain<VkPhysicalDeviceLayeredApiPropertiesListKHR>(pProperties->pNext);
     if (api_props_lists && api_props_lists->pLayeredApis) {
         for (uint32_t i = 0; i < api_props_lists->layeredApiCount; i++) {
-            if (const auto *api_vulkan_props = vku::FindStructInPNextChain<VkPhysicalDeviceLayeredApiVulkanPropertiesKHR>(
+            if (const auto* api_vulkan_props = vku::FindStructInPNextChain<VkPhysicalDeviceLayeredApiVulkanPropertiesKHR>(
                     api_props_lists->pLayeredApis[i].pNext)) {
-                const VkBaseOutStructure *current = static_cast<const VkBaseOutStructure *>(api_vulkan_props->properties.pNext);
+                const VkBaseOutStructure* current = static_cast<const VkBaseOutStructure*>(api_vulkan_props->properties.pNext);
                 while (current) {
                     // only VkPhysicalDeviceDriverProperties and VkPhysicalDeviceIDProperties allowed
                     if (current->sType != VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES &&
@@ -1070,16 +1072,16 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceProperties2(VkPhysicalDevi
 }
 
 bool Instance::ValidateGetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                          VkFormatProperties2 *pFormatProperties, const Context &context) const {
+                                                          VkFormatProperties2* pFormatProperties, const Context& context) const {
     bool skip = false;
 
     if (IsValueIn(format, {VK_FORMAT_G8_B8R8_2PLANE_444_UNORM, VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16,
                            VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, VK_FORMAT_G16_B16R16_2PLANE_444_UNORM})) {
-        const auto &exposed_extensions = physical_device_extensions.at(physicalDevice);
+        const auto& exposed_extensions = physical_device_extensions.at(physicalDevice);
 
         if (api_version < VK_API_VERSION_1_3 && !exposed_extensions.vk_khr_maintenance5 &&
             !exposed_extensions.vk_ext_ycbcr_2plane_444_formats) {
-            const char *vuid = context.error_obj.location.function == Func::vkGetPhysicalDeviceFormatProperties
+            const char* vuid = context.error_obj.location.function == Func::vkGetPhysicalDeviceFormatProperties
                                    ? "VUID-vkGetPhysicalDeviceFormatProperties-None-12272"
                                    : "VUID-vkGetPhysicalDeviceFormatProperties2-None-12273";
             skip |=
@@ -1091,8 +1093,8 @@ bool Instance::ValidateGetPhysicalDeviceFormatProperties2(VkPhysicalDevice physi
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                                       VkFormatProperties *pFormatProperties,
-                                                                       const Context &context) const {
+                                                                       VkFormatProperties* pFormatProperties,
+                                                                       const Context& context) const {
     if (!pFormatProperties) {
         return false;
     }
@@ -1102,8 +1104,8 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceFormatProperties(VkPhysica
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                                        VkFormatProperties2 *pFormatProperties,
-                                                                        const Context &context) const {
+                                                                        VkFormatProperties2* pFormatProperties,
+                                                                        const Context& context) const {
     return ValidateGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties, context);
 }
 

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -29,11 +29,11 @@
 
 namespace stateless {
 
-bool Device::manual_PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                                      const Context &context) const {
+bool Device::manual_PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
+                                                      const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     constexpr std::array allowed_structs = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT,
                                             VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT,
@@ -46,11 +46,11 @@ bool Device::manual_PreCallValidateCreateShaderModule(VkDevice device, const VkS
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
-                                                        const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
-                                                        const Context &context) const {
+bool Device::manual_PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
+                                                        const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
+                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     if (pCreateInfo->setLayoutCount > phys_dev_props.limits.maxBoundDescriptorSets) {
         skip |= LogError("VUID-VkPipelineLayoutCreateInfo-setLayoutCount-00286", device, create_info_loc.dot(Field::setLayoutCount),
@@ -74,8 +74,8 @@ bool Device::manual_PreCallValidateCreatePipelineLayout(VkDevice device, const V
     return skip;
 }
 
-bool Device::ValidatePushConstantRange(uint32_t push_constant_range_count, const VkPushConstantRange *push_constant_ranges,
-                                       const Location &loc) const {
+bool Device::ValidatePushConstantRange(uint32_t push_constant_range_count, const VkPushConstantRange* push_constant_ranges,
+                                       const Location& loc) const {
     bool skip = false;
 
     if (!push_constant_ranges) {
@@ -117,7 +117,7 @@ bool Device::ValidatePushConstantRange(uint32_t push_constant_range_count, const
     for (uint32_t i = 0; i < push_constant_range_count; ++i) {
         for (uint32_t j = i + 1; j < push_constant_range_count; ++j) {
             if (0 != (push_constant_ranges[i].stageFlags & push_constant_ranges[j].stageFlags)) {
-                const char *vuid = loc.function == Func::vkCreatePipelineLayout
+                const char* vuid = loc.function == Func::vkCreatePipelineLayout
                                        ? "VUID-VkPipelineLayoutCreateInfo-pPushConstantRanges-00292"
                                        : "VUID-VkShaderCreateInfoEXT-pPushConstantRanges-10063";
                 skip |= LogError(vuid, device, loc,
@@ -493,8 +493,8 @@ bool Device::ValidateShaderDescriptorSetAndBindingMappingInfo(const VkShaderDesc
 }
 
 // Called from graphics, compute, raytracing, etc
-bool Device::ValidatePipelineShaderStageCreateInfoCommon(const Context &context, const VkPipelineShaderStageCreateInfo &create_info,
-                                                         const Location &loc) const {
+bool Device::ValidatePipelineShaderStageCreateInfoCommon(const Context& context, const VkPipelineShaderStageCreateInfo& create_info,
+                                                         const Location& loc) const {
     bool skip = false;
 
     if (create_info.pName) {
@@ -523,7 +523,7 @@ bool Device::ValidatePipelineShaderStageCreateInfoCommon(const Context &context,
 bool Device::ValidatePipelineBinaryInfo(const void* next, VkPipelineCreateFlags flags, VkPipelineCache pipelineCache,
                                         VkPipelineLayout layout, const Location& loc) const {
     bool skip = false;
-    const auto *temp_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(next);
+    const auto* temp_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(next);
     const VkPipelineCreateFlags2 create_flags_2 = temp_flags_2 ? temp_flags_2->flags : static_cast<VkPipelineCreateFlags2>(flags);
     const Location flag_loc =
         temp_flags_2 ? loc.pNext(Struct::VkPipelineCreateFlags2CreateInfo, Field::flags) : loc.dot(Field::flags);
@@ -594,8 +594,8 @@ bool Device::ValidatePipelineBinaryInfo(const void* next, VkPipelineCreateFlags 
     return skip;
 }
 
-bool Device::ValidatePipelineRenderingCreateInfo(const Context &context, const VkPipelineRenderingCreateInfo &rendering_struct,
-                                                 const Location &loc) const {
+bool Device::ValidatePipelineRenderingCreateInfo(const Context& context, const VkPipelineRenderingCreateInfo& rendering_struct,
+                                                 const Location& loc) const {
     bool skip = false;
 
     if ((rendering_struct.depthAttachmentFormat != VK_FORMAT_UNDEFINED)) {
@@ -649,7 +649,7 @@ bool Device::ValidatePipelineRenderingCreateInfo(const Context &context, const V
 }
 
 bool Device::ValidateCreatePipelinesFlags2(const VkPipelineCreateFlags flags1, const VkPipelineCreateFlags2 flags2,
-                                           const Location &flags1_loc) const {
+                                           const Location& flags1_loc) const {
     bool skip = false;
     // Discussed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7607
     // Some wrappers include empty pNext structs which might be undesired here
@@ -662,7 +662,7 @@ bool Device::ValidateCreatePipelinesFlags2(const VkPipelineCreateFlags flags1, c
     return skip;
 }
 
-bool Device::ValidateCreateGraphicsPipelinesFlags(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const {
+bool Device::ValidateCreateGraphicsPipelinesFlags(const VkPipelineCreateFlags2 flags, const Location& flags_loc) const {
     bool skip = false;
     if ((flags & VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT) != 0 &&
         (flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
@@ -756,7 +756,7 @@ bool Device::ValidateCreateGraphicsPipelinesFlags(const VkPipelineCreateFlags2 f
     return skip;
 }
 
-bool Device::ValidateCreatePipelinesFlagsCommon(VkPipelineCreateFlags2 flags, const Location &flags_loc) const {
+bool Device::ValidateCreatePipelinesFlagsCommon(VkPipelineCreateFlags2 flags, const Location& flags_loc) const {
     bool skip = false;
 
     if (flags_loc.function == Func::vkCreateGraphicsPipelines) {
@@ -806,11 +806,11 @@ bool Device::ValidateCreatePipelinesFlagsCommon(VkPipelineCreateFlags2 flags, co
 }
 
 bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                           const VkGraphicsPipelineCreateInfo *pCreateInfos,
-                                                           const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                           const Context &context) const {
+                                                           const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                           const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                           const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!pCreateInfos) {
         return skip;
@@ -822,7 +822,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
         // Create a copy of create_info and set non-included sub-state to null
         VkGraphicsPipelineCreateInfo create_info = pCreateInfos[i];
 
-        const auto *create_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(create_info.pNext);
+        const auto* create_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(create_info.pNext);
         const VkPipelineCreateFlags2 flags =
             create_flags_2 ? create_flags_2->flags : static_cast<VkPipelineCreateFlags2>(create_info.flags);
         const Location flags_loc = create_flags_2 ? create_info_loc.pNext(Struct::VkPipelineCreateFlags2CreateInfo, Field::flags)
@@ -835,7 +835,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
         }
         skip |= ValidateCreatePipelinesFlagsCommon(flags, flags_loc);
 
-        const auto *graphics_lib_info = vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(create_info.pNext);
+        const auto* graphics_lib_info = vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(create_info.pNext);
         if (graphics_lib_info) {
             if (!(graphics_lib_info->flags & VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT)) {
                 create_info.pVertexInputState = nullptr;
@@ -923,7 +923,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
         vvl::unordered_map<VkDynamicState, uint32_t, vvl::hash<int>> dynamic_state_map;
         // TODO probably should check dynamic state from graphics libraries, at least when creating an "executable pipeline"
         if (create_info.pDynamicState != nullptr) {
-            const auto &dynamic_state_info = *create_info.pDynamicState;
+            const auto& dynamic_state_info = *create_info.pDynamicState;
             for (uint32_t state_index = 0; state_index < dynamic_state_info.dynamicStateCount; ++state_index) {
                 const VkDynamicState dynamic_state = dynamic_state_info.pDynamicStates[state_index];
 
@@ -1053,7 +1053,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
         const bool has_dynamic_vertex_input = vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
         if (!has_dynamic_vertex_input && !(active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT) &&
             (create_info.pVertexInputState != nullptr)) {
-            auto const &vertex_input_state = create_info.pVertexInputState;
+            auto const& vertex_input_state = create_info.pVertexInputState;
             const Location vertex_loc = create_info_loc.dot(Field::pVertexInputState);
             skip |= ValidatePipelineVertexInputStateCreateInfo(context, *vertex_input_state, vertex_loc);
 
@@ -1076,8 +1076,8 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
             vvl::unordered_set<uint32_t> vertex_bindings(vertex_input_state->vertexBindingDescriptionCount);
             for (uint32_t d = 0; d < vertex_input_state->vertexBindingDescriptionCount; ++d) {
                 const Location binding_loc = vertex_loc.dot(Field::pVertexBindingDescriptions);
-                auto const &vertex_bind_desc = vertex_input_state->pVertexBindingDescriptions[d];
-                auto const &binding_it = vertex_bindings.find(vertex_bind_desc.binding);
+                auto const& vertex_bind_desc = vertex_input_state->pVertexBindingDescriptions[d];
+                auto const& binding_it = vertex_bindings.find(vertex_bind_desc.binding);
                 if (binding_it != vertex_bindings.cend()) {
                     skip |= LogError("VUID-VkPipelineVertexInputStateCreateInfo-pVertexBindingDescriptions-00616", device,
                                      binding_loc.dot(Field::binding),
@@ -1105,8 +1105,8 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
             vvl::unordered_set<uint32_t> attribute_locations(vertex_input_state->vertexAttributeDescriptionCount);
             for (uint32_t d = 0; d < vertex_input_state->vertexAttributeDescriptionCount; ++d) {
                 const Location attribute_loc = vertex_loc.dot(Field::pVertexAttributeDescriptions);
-                auto const &vertex_attrib_desc = vertex_input_state->pVertexAttributeDescriptions[d];
-                auto const &location_it = attribute_locations.find(vertex_attrib_desc.location);
+                auto const& vertex_attrib_desc = vertex_input_state->pVertexAttributeDescriptions[d];
+                auto const& location_it = attribute_locations.find(vertex_attrib_desc.location);
                 if (location_it != attribute_locations.cend()) {
                     skip |= LogError("VUID-VkPipelineVertexInputStateCreateInfo-pVertexAttributeDescriptions-00617", device,
                                      attribute_loc.dot(Field::location),
@@ -1115,7 +1115,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                 }
                 attribute_locations.insert(vertex_attrib_desc.location);
 
-                auto const &binding_it = vertex_bindings.find(vertex_attrib_desc.binding);
+                auto const& binding_it = vertex_bindings.find(vertex_attrib_desc.binding);
                 if (binding_it == vertex_bindings.cend()) {
                     skip |= LogError("VUID-VkPipelineVertexInputStateCreateInfo-binding-00615", device,
                                      attribute_loc.dot(Field::binding),
@@ -1171,23 +1171,23 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
             (create_info.pRasterizationState->rasterizerDiscardEnable == VK_FALSE)) {
             // Everything in here has a pre-rasterization shader state
             if (create_info.pViewportState) {
-                const auto &viewport_state = *create_info.pViewportState;
+                const auto& viewport_state = *create_info.pViewportState;
                 const Location viewport_loc = create_info_loc.dot(Field::pViewportState);
                 skip |= ValidatePipelineViewportStateCreateInfo(context, *create_info.pViewportState, viewport_loc);
 
-                const auto *exclusive_scissor_struct =
+                const auto* exclusive_scissor_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportExclusiveScissorStateCreateInfoNV>(viewport_state.pNext);
-                const auto *shading_rate_image_struct =
+                const auto* shading_rate_image_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportShadingRateImageStateCreateInfoNV>(viewport_state.pNext);
-                const auto *coarse_sample_order_struct =
+                const auto* coarse_sample_order_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportCoarseSampleOrderStateCreateInfoNV>(viewport_state.pNext);
-                const auto *vp_swizzle_struct =
+                const auto* vp_swizzle_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportSwizzleStateCreateInfoNV>(viewport_state.pNext);
-                const auto *vp_w_scaling_struct =
+                const auto* vp_w_scaling_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportWScalingStateCreateInfoNV>(viewport_state.pNext);
-                const auto *depth_clip_control_struct =
+                const auto* depth_clip_control_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportDepthClipControlCreateInfoEXT>(viewport_state.pNext);
-                const auto *depth_clamp_control_struct =
+                const auto* depth_clamp_control_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportDepthClampControlCreateInfoEXT>(viewport_state.pNext);
 
                 if (!enabled_features.multiViewport) {
@@ -1268,8 +1268,8 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
 
                 if (!has_dynamic_scissor && viewport_state.pScissors) {
                     for (uint32_t scissor_i = 0; scissor_i < viewport_state.scissorCount; ++scissor_i) {
-                        const Location &scissor_loc = create_info_loc.dot(Field::pScissors, scissor_i);
-                        const auto &scissor = viewport_state.pScissors[scissor_i];
+                        const Location& scissor_loc = create_info_loc.dot(Field::pScissors, scissor_i);
+                        const auto& scissor = viewport_state.pScissors[scissor_i];
 
                         if (scissor.offset.x < 0) {
                             skip |= LogError("VUID-VkPipelineViewportStateCreateInfo-x-02821", device,
@@ -1392,7 +1392,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                 // validate the VkViewports
                 if (!has_dynamic_viewport && viewport_state.pViewports) {
                     for (uint32_t viewport_i = 0; viewport_i < viewport_state.viewportCount; ++viewport_i) {
-                        const auto &viewport = viewport_state.pViewports[viewport_i];  // will crash on invalid ptr
+                        const auto& viewport = viewport_state.pViewports[viewport_i];  // will crash on invalid ptr
                         skip |= ValidateViewport(viewport, VkCommandBuffer(0), viewport_loc.dot(Field::pViewports, viewport_i));
                     }
                 }
@@ -1497,7 +1497,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                 std::unique_lock<std::mutex> lock(renderpass_map_mutex);
                 const auto subpasses_uses_it = renderpasses_states.find(create_info.renderPass);
                 if (subpasses_uses_it != renderpasses_states.end()) {
-                    const auto &subpasses_uses = subpasses_uses_it->second;
+                    const auto& subpasses_uses = subpasses_uses_it->second;
                     if (subpasses_uses.subpasses_using_color_attachment.count(create_info.subpass)) {
                         uses_color_attachment = true;
                     }
@@ -1510,13 +1510,13 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
 
             if (create_info.pDepthStencilState != nullptr && uses_depthstencil_attachment) {
                 const Location ds_loc = create_info_loc.dot(Field::pDepthStencilState);
-                auto const &ds_state = *create_info.pDepthStencilState;
+                auto const& ds_state = *create_info.pDepthStencilState;
                 skip |= ValidatePipelineDepthStencilStateCreateInfo(context, ds_state, ds_loc);
             }
 
             if (create_info.pColorBlendState != nullptr && uses_color_attachment) {
                 const Location color_loc = create_info_loc.dot(Field::pColorBlendState);
-                auto const &color_blend_state = *create_info.pColorBlendState;
+                auto const& color_blend_state = *create_info.pColorBlendState;
                 skip |= ValidatePipelineColorBlendStateCreateInfo(context, color_blend_state, color_loc);
 
                 // If logicOpEnable is VK_TRUE, logicOp must be a valid VkLogicOp value
@@ -1579,7 +1579,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                                  create_info.pRasterizationState->lineWidth, i);
             }
 
-            const auto *line_state =
+            const auto* line_state =
                 vku::FindStructInPNextChain<VkPipelineRasterizationLineStateCreateInfo>(create_info.pRasterizationState->pNext);
             const bool dynamic_line_raster_mode = vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT);
             const bool dynamic_line_stipple_enable = vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT);
@@ -1705,7 +1705,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
     return skip;
 }
 
-bool Device::ValidateCreateComputePipelinesFlags(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const {
+bool Device::ValidateCreateComputePipelinesFlags(const VkPipelineCreateFlags2 flags, const Location& flags_loc) const {
     bool skip = false;
     if ((flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) != 0) {
         if (!enabled_features.shaderEnqueue) {
@@ -1784,15 +1784,15 @@ bool Device::ValidateCreateComputePipelinesFlags(const VkPipelineCreateFlags2 fl
 }
 
 bool Device::manual_PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                          const VkComputePipelineCreateInfo *pCreateInfos,
-                                                          const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                          const Context &context) const {
+                                                          const VkComputePipelineCreateInfo* pCreateInfos,
+                                                          const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                          const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     for (uint32_t i = 0; i < createInfoCount; i++) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
-        const VkComputePipelineCreateInfo &create_info = pCreateInfos[i];
+        const VkComputePipelineCreateInfo& create_info = pCreateInfos[i];
 
         auto feedback_struct = vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfo>(create_info.pNext);
         if (feedback_struct) {
@@ -1805,7 +1805,7 @@ bool Device::manual_PreCallValidateCreateComputePipelines(VkDevice device, VkPip
             }
         }
 
-        const auto *create_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(create_info.pNext);
+        const auto* create_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(create_info.pNext);
         const VkPipelineCreateFlags2 flags =
             create_flags_2 ? create_flags_2->flags : static_cast<VkPipelineCreateFlags2>(create_info.flags);
         const Location flags_loc = create_flags_2 ? create_info_loc.pNext(Struct::VkPipelineCreateFlags2CreateInfo, Field::flags)
@@ -1850,7 +1850,7 @@ bool Device::manual_PreCallValidateCreateComputePipelines(VkDevice device, VkPip
     return skip;
 }
 
-bool Device::ValidateDepthClampRange(const VkDepthClampRangeEXT &depth_clamp_range, const Location &loc) const {
+bool Device::ValidateDepthClampRange(const VkDepthClampRangeEXT& depth_clamp_range, const Location& loc) const {
     bool skip = false;
     if (depth_clamp_range.minDepthClamp > depth_clamp_range.maxDepthClamp) {
         skip |=
@@ -1873,11 +1873,11 @@ bool Device::ValidateDepthClampRange(const VkDepthClampRangeEXT &depth_clamp_ran
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
-                                                       const VkAllocationCallbacks *pAllocator, VkPipelineCache *pPipelineCache,
-                                                       const Context &context) const {
+bool Device::manual_PreCallValidateCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
+                                                       const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
+                                                       const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const bool has_externally_sync = (pCreateInfo->flags & VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT) != 0;
     const bool has_internally_sync = (pCreateInfo->flags & VK_PIPELINE_CACHE_CREATE_INTERNALLY_SYNCHRONIZED_MERGE_BIT_KHR) != 0;
 
@@ -1904,9 +1904,9 @@ bool Device::manual_PreCallValidateCreatePipelineCache(VkDevice device, const Vk
 }
 
 bool Device::manual_PreCallValidateMergePipelineCaches(VkDevice device, VkPipelineCache dstCache, uint32_t srcCacheCount,
-                                                       const VkPipelineCache *pSrcCaches, const Context &context) const {
+                                                       const VkPipelineCache* pSrcCaches, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pSrcCaches) {
         for (uint32_t index0 = 0; index0 < srcCacheCount; ++index0) {
             if (pSrcCaches[index0] == dstCache) {
@@ -1919,17 +1919,17 @@ bool Device::manual_PreCallValidateMergePipelineCaches(VkDevice device, VkPipeli
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT *pPipelineInfo,
-                                                            VkBaseOutStructure *pPipelineProperties, const Context &context) const {
+bool Device::manual_PreCallValidateGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT* pPipelineInfo,
+                                                            VkBaseOutStructure* pPipelineProperties, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.pipelinePropertiesIdentifier) {
         skip |= LogError("VUID-vkGetPipelinePropertiesEXT-None-06766", device, error_obj.location,
                          "the pipelinePropertiesIdentifier feature was not enabled.");
     }
 
-    const Location &pipeline_properties_loc = error_obj.location.dot(Field::pPipelineProperties);
+    const Location& pipeline_properties_loc = error_obj.location.dot(Field::pPipelineProperties);
     if (pPipelineProperties) {
         if (pPipelineProperties->sType != VK_STRUCTURE_TYPE_PIPELINE_PROPERTIES_IDENTIFIER_EXT) {
             skip |=

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -68,12 +68,12 @@ bool Device::ValidateCreateAccelerationStructure(const VkAccelerationStructureCr
 }
 
 bool Device::manual_PreCallValidateCreateAccelerationStructureKHR(VkDevice device,
-                                                                  const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
-                                                                  const VkAllocationCallbacks *pAllocator,
-                                                                  VkAccelerationStructureKHR *pAccelerationStructure,
-                                                                  const Context &context) const {
+                                                                  const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  VkAccelerationStructureKHR* pAccelerationStructure,
+                                                                  const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkCreateAccelerationStructureKHR-accelerationStructure-03611", device, error_obj.location,
@@ -105,12 +105,12 @@ bool Device::manual_PreCallValidateCreateAccelerationStructureKHR(VkDevice devic
 }
 
 bool Device::manual_PreCallValidateCreateAccelerationStructure2KHR(VkDevice device,
-                                                                   const VkAccelerationStructureCreateInfo2KHR *pCreateInfo,
-                                                                   const VkAllocationCallbacks *pAllocator,
-                                                                   VkAccelerationStructureKHR *pAccelerationStructure,
-                                                                   const Context &context) const {
+                                                                   const VkAccelerationStructureCreateInfo2KHR* pCreateInfo,
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   VkAccelerationStructureKHR* pAccelerationStructure,
+                                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkCreateAccelerationStructure2KHR-accelerationStructure-03611", device, error_obj.location,
@@ -144,10 +144,10 @@ bool Device::manual_PreCallValidateCreateAccelerationStructure2KHR(VkDevice devi
 
 bool Device::manual_PreCallValidateDestroyAccelerationStructureKHR(VkDevice device,
                                                                    VkAccelerationStructureKHR accelerationStructure,
-                                                                   const VkAllocationCallbacks *pAllocator,
-                                                                   const Context &context) const {
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-08934", device, error_obj.location,
                          "accelerationStructure feature was not enabled.");
@@ -155,7 +155,7 @@ bool Device::manual_PreCallValidateDestroyAccelerationStructureKHR(VkDevice devi
     return skip;
 }
 
-bool Device::ValidateCreateRayTracingPipelinesFlagsKHR(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const {
+bool Device::ValidateCreateRayTracingPipelinesFlagsKHR(const VkPipelineCreateFlags2 flags, const Location& flags_loc) const {
     bool skip = false;
 
     if (flags & VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV) {
@@ -200,11 +200,11 @@ bool Device::ValidateCreateRayTracingPipelinesFlagsKHR(const VkPipelineCreateFla
 
 bool Device::manual_PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                 VkPipelineCache pipelineCache, uint32_t createInfoCount,
-                                                                const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
-                                                                const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                                const Context &context) const {
+                                                                const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                                const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.rayTracingPipeline) {
         skip |= LogError("VUID-vkCreateRayTracingPipelinesKHR-rayTracingPipeline-03586", device, error_obj.location,
@@ -212,9 +212,9 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device,
     }
     for (uint32_t i = 0; i < createInfoCount; i++) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
-        const VkRayTracingPipelineCreateInfoKHR &create_info = pCreateInfos[i];
+        const VkRayTracingPipelineCreateInfoKHR& create_info = pCreateInfos[i];
 
-        const auto *create_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(create_info.pNext);
+        const auto* create_flags_2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(create_info.pNext);
         const VkPipelineCreateFlags2 flags =
             create_flags_2 ? create_flags_2->flags : static_cast<VkPipelineCreateFlags2>(create_info.flags);
         const Location flags_loc = create_flags_2 ? create_info_loc.pNext(Struct::VkPipelineCreateFlags2CreateInfo, Field::flags)
@@ -391,10 +391,10 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device,
 }
 
 bool Device::manual_PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
-                                                                        const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
-                                                                        const Context &context) const {
+                                                                        const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
+                                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
     if (pInfo->mode != VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR) {
@@ -416,10 +416,10 @@ bool Device::manual_PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice
 }
 
 bool Device::manual_PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
-                                                                           const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
-                                                                           const Context &context) const {
+                                                                           const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
+                                                                           const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-accelerationStructure-08926", device, error_obj.location,
@@ -440,8 +440,8 @@ bool Device::manual_PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCom
     return skip;
 }
 
-bool Device::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerationStructureInfoKHR &as_info,
-                                                      const VulkanTypedHandle &handle, const Location &info_loc) const {
+bool Device::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerationStructureInfoKHR& as_info,
+                                                      const VulkanTypedHandle& handle, const Location& info_loc) const {
     bool skip = false;
     if (!(as_info.mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR ||
           as_info.mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR)) {
@@ -453,10 +453,10 @@ bool Device::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerationSt
 }
 
 bool Device::manual_PreCallValidateCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
-                                                                const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                                const Context &context) const {
+                                                                const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                                const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     skip |= ValidateCopyAccelerationStructureInfoKHR(*pInfo, error_obj.handle, error_obj.location.dot(Field::pInfo));
     if (!enabled_features.accelerationStructureHostCommands) {
         skip |= LogError("VUID-vkCopyAccelerationStructureKHR-accelerationStructureHostCommands-03582", device, error_obj.location,
@@ -466,10 +466,10 @@ bool Device::manual_PreCallValidateCopyAccelerationStructureKHR(VkDevice device,
 }
 
 bool Device::manual_PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                   const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                                   const Context &context) const {
+                                                                   const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkCmdCopyAccelerationStructureKHR-accelerationStructure-08925", device, error_obj.location,
@@ -480,8 +480,8 @@ bool Device::manual_PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
     return skip;
 }
 
-bool Device::ValidateCopyMemoryToAccelerationStructureInfoKHR(const VkCopyMemoryToAccelerationStructureInfoKHR &as_info,
-                                                              const VulkanTypedHandle &handle, const Location &loc) const {
+bool Device::ValidateCopyMemoryToAccelerationStructureInfoKHR(const VkCopyMemoryToAccelerationStructureInfoKHR& as_info,
+                                                              const VulkanTypedHandle& handle, const Location& loc) const {
     bool skip = false;
     if (as_info.mode != VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR) {
         const LogObjectList objlist(handle);
@@ -492,10 +492,10 @@ bool Device::ValidateCopyMemoryToAccelerationStructureInfoKHR(const VkCopyMemory
 }
 
 bool Device::manual_PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
-                                                                        const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
-                                                                        const Context &context) const {
+                                                                        const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
+                                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
     skip |= ValidateCopyMemoryToAccelerationStructureInfoKHR(*pInfo, error_obj.handle, info_loc);
@@ -517,10 +517,10 @@ bool Device::manual_PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevice
 }
 
 bool Device::manual_PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                           const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
-                                                                           const Context &context) const {
+                                                                           const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
+                                                                           const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkCmdCopyMemoryToAccelerationStructureKHR-accelerationStructure-08927", device, error_obj.location,
@@ -538,10 +538,10 @@ bool Device::manual_PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCom
 }
 
 bool Device::manual_PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
-    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR *pAccelerationStructures,
-    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const Context &context) const {
+    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures,
+    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructure-08924", commandBuffer,
@@ -559,10 +559,10 @@ bool Device::manual_PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
 }
 
 bool Device::manual_PreCallValidateWriteAccelerationStructuresPropertiesKHR(
-    VkDevice device, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR *pAccelerationStructures,
-    VkQueryType queryType, size_t dataSize, void *pData, size_t stride, const Context &context) const {
+    VkDevice device, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures,
+    VkQueryType queryType, size_t dataSize, void* pData, size_t stride, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.accelerationStructureHostCommands) {
         skip |= LogError("VUID-vkWriteAccelerationStructuresPropertiesKHR-accelerationStructureHostCommands-03585", device,
                          error_obj.location, "accelerationStructureHostCommands feature was not enabled.");
@@ -630,10 +630,10 @@ bool Device::manual_PreCallValidateWriteAccelerationStructuresPropertiesKHR(
 
 bool Device::manual_PreCallValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline,
                                                                                    uint32_t firstGroup, uint32_t groupCount,
-                                                                                   size_t dataSize, void *pData,
-                                                                                   const Context &context) const {
+                                                                                   size_t dataSize, void* pData,
+                                                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.rayTracingPipelineShaderGroupHandleCaptureReplay) {
         skip |= LogError(
             "VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-rayTracingPipelineShaderGroupHandleCaptureReplay-03606", device,
@@ -643,10 +643,10 @@ bool Device::manual_PreCallValidateGetRayTracingCaptureReplayShaderGroupHandlesK
 }
 
 bool Device::manual_PreCallValidateGetDeviceAccelerationStructureCompatibilityKHR(
-    VkDevice device, const VkAccelerationStructureVersionInfoKHR *pVersionInfo,
-    VkAccelerationStructureCompatibilityKHR *pCompatibility, const Context &context) const {
+    VkDevice device, const VkAccelerationStructureVersionInfoKHR* pVersionInfo,
+    VkAccelerationStructureCompatibilityKHR* pCompatibility, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-accelerationStructure-08928", device,
                          error_obj.location, "accelerationStructure feature was not enabled.");
@@ -655,7 +655,7 @@ bool Device::manual_PreCallValidateGetDeviceAccelerationStructureCompatibilityKH
 }
 
 bool Device::ValidateTotalPrimitivesCount(uint64_t total_triangles_count, uint64_t total_aabbs_count,
-                                          const VulkanTypedHandle &handle, const Location &loc) const {
+                                          const VulkanTypedHandle& handle, const Location& loc) const {
     bool skip = false;
 
     if (total_triangles_count > phys_dev_ext_props.acc_structure_props.maxPrimitiveCount) {
@@ -1086,9 +1086,9 @@ bool Device::ValidateAccelerationStructureBuildRangeInfo(const Context& context,
 }
 
 static void ComputeTotalPrimitiveCountWithBuildRanges(uint32_t info_count,
-                                                      const VkAccelerationStructureBuildGeometryInfoKHR *build_geometry_infos,
-                                                      const VkAccelerationStructureBuildRangeInfoKHR *const *build_ranges,
-                                                      uint64_t *out_total_triangles_count, uint64_t *out_total_aabbs_count) {
+                                                      const VkAccelerationStructureBuildGeometryInfoKHR* build_geometry_infos,
+                                                      const VkAccelerationStructureBuildRangeInfoKHR* const* build_ranges,
+                                                      uint64_t* out_total_triangles_count, uint64_t* out_total_aabbs_count) {
     *out_total_triangles_count = 0;
     *out_total_aabbs_count = 0;
 
@@ -1100,7 +1100,7 @@ static void ComputeTotalPrimitiveCountWithBuildRanges(uint32_t info_count,
         }
 
         for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
-            const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
+            const VkAccelerationStructureGeometryKHR& geom = rt::GetGeometry(info, geom_i);
             if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
                 *out_total_triangles_count += build_ranges[info_i][geom_i].primitiveCount;
             } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
@@ -1113,8 +1113,8 @@ static void ComputeTotalPrimitiveCountWithBuildRanges(uint32_t info_count,
 }
 
 static void ComputeTotalPrimitiveCountWithMaxPrimitivesCount(
-    uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR *build_geometry_infos,
-    const uint32_t *const *max_primitives, uint64_t *out_total_triangles_count, uint64_t *out_total_aabbs_count) {
+    uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR* build_geometry_infos,
+    const uint32_t* const* max_primitives, uint64_t* out_total_triangles_count, uint64_t* out_total_aabbs_count) {
     *out_total_triangles_count = 0;
     *out_total_aabbs_count = 0;
 
@@ -1126,7 +1126,7 @@ static void ComputeTotalPrimitiveCountWithMaxPrimitivesCount(
         }
 
         for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
-            const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
+            const VkAccelerationStructureGeometryKHR& geom = rt::GetGeometry(info, geom_i);
             if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
                 *out_total_triangles_count += max_primitives[info_i][geom_i];
             } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
@@ -1139,10 +1139,10 @@ static void ComputeTotalPrimitiveCountWithMaxPrimitivesCount(
 }
 
 bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const Context &context) const {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-accelerationStructure-08923", commandBuffer, error_obj.location,
@@ -1218,11 +1218,11 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
 }
 
 bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkDeviceAddress *pIndirectDeviceAddresses, const uint32_t *pIndirectStrides, const uint32_t *const *ppMaxPrimitiveCounts,
-    const Context &context) const {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkDeviceAddress* pIndirectDeviceAddresses, const uint32_t* pIndirectStrides, const uint32_t* const* ppMaxPrimitiveCounts,
+    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructureIndirectBuild) {
         skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-accelerationStructureIndirectBuild-03650", commandBuffer,
@@ -1303,10 +1303,10 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(
 
 bool Device::manual_PreCallValidateBuildAccelerationStructuresKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
-    const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const Context &context) const {
+    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructureHostCommands) {
         skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-accelerationStructureHostCommands-03581", device,
@@ -1380,11 +1380,11 @@ bool Device::manual_PreCallValidateBuildAccelerationStructuresKHR(
 }
 
 bool Device::manual_PreCallValidateGetAccelerationStructureBuildSizesKHR(
-    VkDevice device, VkAccelerationStructureBuildTypeKHR buildType, const VkAccelerationStructureBuildGeometryInfoKHR *pBuildInfo,
-    const uint32_t *pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR *pSizeInfo, const Context &context) const {
+    VkDevice device, VkAccelerationStructureBuildTypeKHR buildType, const VkAccelerationStructureBuildGeometryInfoKHR* pBuildInfo,
+    const uint32_t* pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo, const Context& context) const {
     bool skip = false;
 
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (!enabled_features.accelerationStructure) {
         skip |= LogError("VUID-vkGetAccelerationStructureBuildSizesKHR-accelerationStructure-08933", device, error_obj.location,
@@ -1437,20 +1437,20 @@ bool Device::manual_PreCallValidateGetAccelerationStructureBuildSizesKHR(
 }
 
 bool Device::ValidateTraceRaysRaygenShaderBindingTable(VkCommandBuffer commandBuffer,
-                                                       const VkStridedDeviceAddressRegionKHR &raygen_shader_binding_table,
-                                                       const Location &table_loc) const {
+                                                       const VkStridedDeviceAddressRegionKHR& raygen_shader_binding_table,
+                                                       const Location& table_loc) const {
     bool skip = false;
     const bool indirect = table_loc.function == vvl::Func::vkCmdTraceRaysIndirectKHR;
 
     if (raygen_shader_binding_table.size != raygen_shader_binding_table.stride) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-size-04023" : "VUID-vkCmdTraceRaysKHR-size-04023";
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-size-04023" : "VUID-vkCmdTraceRaysKHR-size-04023";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::size), "(%" PRIu64 ") is not equal to stride (%" PRIu64 ").",
                          raygen_shader_binding_table.size, raygen_shader_binding_table.stride);
     }
 
     if (!IsPointerAligned(raygen_shader_binding_table.deviceAddress,
                           phys_dev_ext_props.ray_tracing_props_khr.shaderGroupBaseAlignment)) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pRayGenShaderBindingTable-03682"
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pRayGenShaderBindingTable-03682"
                                     : "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03682";
         skip |=
             LogError(vuid, commandBuffer, table_loc.dot(Field::deviceAddress),
@@ -1464,14 +1464,14 @@ bool Device::ValidateTraceRaysRaygenShaderBindingTable(VkCommandBuffer commandBu
 }
 
 bool Device::ValidateTraceRaysMissShaderBindingTable(VkCommandBuffer commandBuffer,
-                                                     const VkStridedDeviceAddressRegionKHR &miss_shader_binding_table,
-                                                     const Location &table_loc) const {
+                                                     const VkStridedDeviceAddressRegionKHR& miss_shader_binding_table,
+                                                     const Location& table_loc) const {
     bool skip = false;
     const bool indirect = table_loc.function == vvl::Func::vkCmdTraceRaysIndirectKHR;
-    auto &props = phys_dev_ext_props.ray_tracing_props_khr;
+    auto& props = phys_dev_ext_props.ray_tracing_props_khr;
 
     if (!IsIntegerMultipleOf(miss_shader_binding_table.stride, props.shaderGroupHandleAlignment)) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-03686" : "VUID-vkCmdTraceRaysKHR-stride-03686";
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-03686" : "VUID-vkCmdTraceRaysKHR-stride-03686";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::stride),
                          "(%" PRIu64
                          ") must be a multiple of "
@@ -1479,7 +1479,7 @@ bool Device::ValidateTraceRaysMissShaderBindingTable(VkCommandBuffer commandBuff
                          miss_shader_binding_table.stride, props.shaderGroupHandleAlignment);
     }
     if (miss_shader_binding_table.stride > props.maxShaderGroupStride) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-04029" : "VUID-vkCmdTraceRaysKHR-stride-04029";
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-04029" : "VUID-vkCmdTraceRaysKHR-stride-04029";
         skip |=
             LogError(vuid, commandBuffer, table_loc.dot(Field::stride),
                      "(%" PRIu64
@@ -1488,7 +1488,7 @@ bool Device::ValidateTraceRaysMissShaderBindingTable(VkCommandBuffer commandBuff
                      miss_shader_binding_table.stride, props.maxShaderGroupStride);
     }
     if (!IsPointerAligned(miss_shader_binding_table.deviceAddress, props.shaderGroupBaseAlignment)) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pMissShaderBindingTable-03685"
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pMissShaderBindingTable-03685"
                                     : "VUID-vkCmdTraceRaysKHR-pMissShaderBindingTable-03685";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::deviceAddress),
                          "(0x%" PRIx64
@@ -1501,14 +1501,14 @@ bool Device::ValidateTraceRaysMissShaderBindingTable(VkCommandBuffer commandBuff
 }
 
 bool Device::ValidateTraceRaysHitShaderBindingTable(VkCommandBuffer commandBuffer,
-                                                    const VkStridedDeviceAddressRegionKHR &hit_shader_binding_table,
-                                                    const Location &table_loc) const {
+                                                    const VkStridedDeviceAddressRegionKHR& hit_shader_binding_table,
+                                                    const Location& table_loc) const {
     bool skip = false;
     const bool indirect = table_loc.function == vvl::Func::vkCmdTraceRaysIndirectKHR;
-    auto &props = phys_dev_ext_props.ray_tracing_props_khr;
+    auto& props = phys_dev_ext_props.ray_tracing_props_khr;
 
     if (!IsIntegerMultipleOf(hit_shader_binding_table.stride, props.shaderGroupHandleAlignment)) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-03690" : "VUID-vkCmdTraceRaysKHR-stride-03690";
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-03690" : "VUID-vkCmdTraceRaysKHR-stride-03690";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::stride),
                          "(%" PRIu64
                          ") must be a multiple of "
@@ -1516,7 +1516,7 @@ bool Device::ValidateTraceRaysHitShaderBindingTable(VkCommandBuffer commandBuffe
                          hit_shader_binding_table.stride, props.shaderGroupHandleAlignment);
     }
     if (hit_shader_binding_table.stride > props.maxShaderGroupStride) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-04035" : "VUID-vkCmdTraceRaysKHR-stride-04035";
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-04035" : "VUID-vkCmdTraceRaysKHR-stride-04035";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::stride),
                          "(%" PRIu64
                          ") must be less than or equal to "
@@ -1524,7 +1524,7 @@ bool Device::ValidateTraceRaysHitShaderBindingTable(VkCommandBuffer commandBuffe
                          hit_shader_binding_table.stride, props.maxShaderGroupStride);
     }
     if (!IsPointerAligned(hit_shader_binding_table.deviceAddress, props.shaderGroupBaseAlignment)) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pHitShaderBindingTable-03689"
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pHitShaderBindingTable-03689"
                                     : "VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03689";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::deviceAddress),
                          "(0x%" PRIx64
@@ -1537,14 +1537,14 @@ bool Device::ValidateTraceRaysHitShaderBindingTable(VkCommandBuffer commandBuffe
 }
 
 bool Device::ValidateTraceRaysCallableShaderBindingTable(VkCommandBuffer commandBuffer,
-                                                         const VkStridedDeviceAddressRegionKHR &callable_shader_binding_table,
-                                                         const Location &table_loc) const {
+                                                         const VkStridedDeviceAddressRegionKHR& callable_shader_binding_table,
+                                                         const Location& table_loc) const {
     bool skip = false;
     const bool indirect = table_loc.function == vvl::Func::vkCmdTraceRaysIndirectKHR;
-    auto &props = phys_dev_ext_props.ray_tracing_props_khr;
+    auto& props = phys_dev_ext_props.ray_tracing_props_khr;
 
     if (!IsIntegerMultipleOf(callable_shader_binding_table.stride, props.shaderGroupHandleAlignment)) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-03694" : "VUID-vkCmdTraceRaysKHR-stride-03694";
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-03694" : "VUID-vkCmdTraceRaysKHR-stride-03694";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::stride),
                          "(%" PRIu64
                          ") must be a multiple of "
@@ -1553,7 +1553,7 @@ bool Device::ValidateTraceRaysCallableShaderBindingTable(VkCommandBuffer command
     }
 
     if (callable_shader_binding_table.stride > props.maxShaderGroupStride) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-04041" : "VUID-vkCmdTraceRaysKHR-stride-04041";
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-stride-04041" : "VUID-vkCmdTraceRaysKHR-stride-04041";
         skip |= LogError(
             vuid, commandBuffer, table_loc.dot(Field::stride),
             "(%" PRIu64
@@ -1562,7 +1562,7 @@ bool Device::ValidateTraceRaysCallableShaderBindingTable(VkCommandBuffer command
     }
 
     if (!IsPointerAligned(callable_shader_binding_table.deviceAddress, props.shaderGroupBaseAlignment)) {
-        const char *vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pCallableShaderBindingTable-03693"
+        const char* vuid = indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pCallableShaderBindingTable-03693"
                                     : "VUID-vkCmdTraceRaysKHR-pCallableShaderBindingTable-03693";
         skip |= LogError(vuid, commandBuffer, table_loc.dot(Field::deviceAddress),
                          "(0x%" PRIx64
@@ -1575,13 +1575,13 @@ bool Device::ValidateTraceRaysCallableShaderBindingTable(VkCommandBuffer command
 }
 
 bool Device::manual_PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                                   const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                   const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                   const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                   const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                   uint32_t width, uint32_t height, uint32_t depth, const Context &context) const {
+                                                   const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                   const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                   const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                   const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                   uint32_t width, uint32_t height, uint32_t depth, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pRaygenShaderBindingTable) {
         skip |= ValidateTraceRaysRaygenShaderBindingTable(commandBuffer, *pRaygenShaderBindingTable,
                                                           error_obj.location.dot(Field::pRaygenShaderBindingTable));
@@ -1642,13 +1642,13 @@ bool Device::manual_PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer
 }
 
 bool Device::manual_PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                           const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                           const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                           const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                           const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                           VkDeviceAddress indirectDeviceAddress, const Context &context) const {
+                                                           const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                           VkDeviceAddress indirectDeviceAddress, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.rayTracingPipelineTraceRaysIndirect) {
         skip |= LogError("VUID-vkCmdTraceRaysIndirectKHR-rayTracingPipelineTraceRaysIndirect-03637", commandBuffer,
                          error_obj.location, "rayTracingPipelineTraceRaysIndirect feature must be enabled.");
@@ -1681,9 +1681,9 @@ bool Device::manual_PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer comma
 }
 
 bool Device::manual_PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
-                                                            const Context &context) const {
+                                                            const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (!enabled_features.rayTracingPipelineTraceRaysIndirect2) {
         skip |= LogError("VUID-vkCmdTraceRaysIndirect2KHR-rayTracingPipelineTraceRaysIndirect2-03637", commandBuffer,
                          error_obj.location, "rayTracingPipelineTraceRaysIndirect2 feature was not enabled.");

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -29,8 +29,8 @@
 
 namespace stateless {
 
-bool Device::ValidateSubpassGraphicsFlags(const VkRenderPassCreateInfo2 &create_info, uint32_t subpass,
-                                          VkPipelineStageFlags2 stages, const char *vuid, const Location &loc) const {
+bool Device::ValidateSubpassGraphicsFlags(const VkRenderPassCreateInfo2& create_info, uint32_t subpass,
+                                          VkPipelineStageFlags2 stages, const char* vuid, const Location& loc) const {
     bool skip = false;
     if (subpass == VK_SUBPASS_EXTERNAL || subpass >= create_info.subpassCount) {
         return skip;
@@ -63,10 +63,10 @@ bool Device::ValidateSubpassGraphicsFlags(const VkRenderPassCreateInfo2 &create_
     return skip;
 }
 
-bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_info, const ErrorObject &error_obj) const {
+bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info, const ErrorObject& error_obj) const {
     bool skip = false;
     const bool use_rp2 = error_obj.location.function != Func::vkCreateRenderPass;
-    const char *vuid = nullptr;
+    const char* vuid = nullptr;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
 
     VkBool32 android_external_format_resolve_feature = false;
@@ -75,15 +75,15 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_info
 #endif
 
     for (uint32_t i = 0; i < create_info.attachmentCount; ++i) {
-        const Location &attachment_loc = create_info_loc.dot(Field::pAttachments, i);
+        const Location& attachment_loc = create_info_loc.dot(Field::pAttachments, i);
 
         // if not null, also confirms rp2 is being used
-        const void *pNext =
-            (use_rp2) ? reinterpret_cast<VkAttachmentDescription2 const *>(&create_info.pAttachments[i])->pNext : nullptr;
-        const auto *attachment_description_stencil_layout =
+        const void* pNext =
+            (use_rp2) ? reinterpret_cast<VkAttachmentDescription2 const*>(&create_info.pAttachments[i])->pNext : nullptr;
+        const auto* attachment_description_stencil_layout =
             (use_rp2) ? vku::FindStructInPNextChain<VkAttachmentDescriptionStencilLayout>(pNext) : nullptr;
 
-        const VkAttachmentDescription2 &attachment = create_info.pAttachments[i];
+        const VkAttachmentDescription2& attachment = create_info.pAttachments[i];
         if (attachment.format == VK_FORMAT_UNDEFINED) {
             if (use_rp2 && android_external_format_resolve_feature) {
                 if (GetExternalFormat(pNext) == 0) {
@@ -367,7 +367,7 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_info
     }
 
     for (uint32_t i = 0; i < create_info.subpassCount; ++i) {
-        const VkSubpassDescription2 &subpass_desc = create_info.pSubpasses[i];
+        const VkSubpassDescription2& subpass_desc = create_info.pSubpasses[i];
         if (subpass_desc.colorAttachmentCount > phys_dev_props.limits.maxColorAttachments) {
             vuid = use_rp2 ? "VUID-VkSubpassDescription2-colorAttachmentCount-00845"
                            : "VUID-VkSubpassDescription-colorAttachmentCount-00845";
@@ -386,7 +386,7 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_info
     }
 
     for (uint32_t i = 0; i < create_info.dependencyCount; ++i) {
-        const VkSubpassDependency2 &dependency = create_info.pDependencies[i];
+        const VkSubpassDependency2& dependency = create_info.pDependencies[i];
         const Location dependency_loc = create_info_loc.dot(Field::pDependencies, i);
 
         // Need to check first so layer doesn't segfault from out of bound array access
@@ -439,27 +439,27 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_info
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                                    const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                    const Context &context) const {
+bool Device::manual_PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
+                                                    const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                    const Context& context) const {
     vku::safe_VkRenderPassCreateInfo2 create_info_2 = ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo);
     return ValidateCreateRenderPass(*create_info_2.ptr(), context.error_obj);
 }
 
-bool Device::manual_PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                     const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                     const Context &context) const {
+bool Device::manual_PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                                     const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                     const Context& context) const {
     vku::safe_VkRenderPassCreateInfo2 create_info_2(pCreateInfo);
     return ValidateCreateRenderPass(*create_info_2.ptr(), context.error_obj);
 }
 
-void Device::RecordRenderPass(VkRenderPass renderPass, const VkRenderPassCreateInfo2 &create_info) {
+void Device::RecordRenderPass(VkRenderPass renderPass, const VkRenderPassCreateInfo2& create_info) {
     std::unique_lock<std::mutex> lock(renderpass_map_mutex);
-    auto &renderpass_state = renderpasses_states[renderPass];
+    auto& renderpass_state = renderpasses_states[renderPass];
     lock.unlock();
 
     for (uint32_t subpass = 0; subpass < create_info.subpassCount; ++subpass) {
-        const VkSubpassDescription2 &subpass_desc = create_info.pSubpasses[subpass];
+        const VkSubpassDescription2& subpass_desc = create_info.pSubpasses[subpass];
 
         for (uint32_t i = 0; i < subpass_desc.colorAttachmentCount; ++i) {
             if (subpass_desc.pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) {
@@ -473,9 +473,9 @@ void Device::RecordRenderPass(VkRenderPass renderPass, const VkRenderPassCreateI
         }
     }
 }
-void Device::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                            const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                            const RecordObject &record_obj) {
+void Device::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
+                                            const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                            const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -483,9 +483,9 @@ void Device::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassC
     RecordRenderPass(*pRenderPass, *create_info_2.ptr());
 }
 
-void Device::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                                const RecordObject &record_obj) {
+void Device::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
+                                                const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                const RecordObject& record_obj) {
     // Track the state necessary for checking vkCreateGraphicsPipeline (subpass usage of depth and color attachments)
     if (record_obj.result != VK_SUCCESS) {
         return;
@@ -494,15 +494,15 @@ void Device::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderP
     RecordRenderPass(*pRenderPass, *create_info_2.ptr());
 }
 
-void Device::PostCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator,
-                                             const RecordObject &record_obj) {
+void Device::PostCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator,
+                                             const RecordObject& record_obj) {
     // Track the state necessary for checking vkCreateGraphicsPipeline (subpass usage of depth and color attachments)
     std::unique_lock<std::mutex> lock(renderpass_map_mutex);
     renderpasses_states.erase(renderPass);
 }
 
-bool Device::ValidateRenderPassStripeBeginInfo(VkCommandBuffer commandBuffer, const void *pNext, const VkRect2D render_area,
-                                               const Location &loc) const {
+bool Device::ValidateRenderPassStripeBeginInfo(VkCommandBuffer commandBuffer, const void* pNext, const VkRect2D render_area,
+                                               const Location& loc) const {
     bool skip = false;
     const auto rp_stripe_begin = vku::FindStructInPNextChain<VkRenderPassStripeBeginInfoARM>(pNext);
     if (!rp_stripe_begin) {
@@ -523,7 +523,7 @@ bool Device::ValidateRenderPassStripeBeginInfo(VkCommandBuffer commandBuffer, co
     bool has_overlapping_stripes = false;
 
     for (uint32_t i = 0; i < rp_stripe_begin->stripeInfoCount; ++i) {
-        const Location &stripe_info_loc = loc.pNext(Struct::VkRenderPassStripeBeginInfoARM, Field::pStripeInfos, i);
+        const Location& stripe_info_loc = loc.pNext(Struct::VkRenderPassStripeBeginInfoARM, Field::pStripeInfos, i);
         const VkRect2D stripe_area = rp_stripe_begin->pStripeInfos[i].stripeArea;
         total_stripe_area += (stripe_area.extent.width * stripe_area.extent.height);
 
@@ -664,8 +664,8 @@ bool Device::ValidateMultiviewPerViewRenderAreasRenderPassBeginInfo(
     return skip;
 }
 
-bool Device::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *const rp_begin,
-                                        const ErrorObject &error_obj) const {
+bool Device::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* const rp_begin,
+                                        const ErrorObject& error_obj) const {
     bool skip = false;
     if ((rp_begin->clearValueCount != 0) && !rp_begin->pClearValues) {
         const LogObjectList objlist(commandBuffer, rp_begin->renderPass);
@@ -686,17 +686,17 @@ bool Device::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkR
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                      VkSubpassContents, const Context &context) const {
+bool Device::manual_PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                      VkSubpassContents, const Context& context) const {
     return ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, context.error_obj);
 }
 
-bool Device::manual_PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                       const VkSubpassBeginInfo *, const Context &context) const {
+bool Device::manual_PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                       const VkSubpassBeginInfo*, const Context& context) const {
     return ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, context.error_obj);
 }
 
-static bool UniqueRenderingInfoImageViews(const VkRenderingInfo &rendering_info, VkImageView image_view) {
+static bool UniqueRenderingInfoImageViews(const VkRenderingInfo& rendering_info, VkImageView image_view) {
     bool unique_views = true;
     for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
         if (rendering_info.pColorAttachments[i].imageView == image_view) {
@@ -730,10 +730,10 @@ static bool UniqueRenderingInfoImageViews(const VkRenderingInfo &rendering_info,
     return unique_views;
 }
 
-bool Device::manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo,
-                                                     const Context &context) const {
+bool Device::manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
+                                                     const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     const Location rendering_info_loc = error_obj.location.dot(Field::pRenderingInfo);
 
     if (!enabled_features.dynamicRendering) {
@@ -840,8 +840,8 @@ bool Device::manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
     return skip;
 }
 
-bool Device::ValidateRenderingAttachmentLayout(VkCommandBuffer commandBuffer, const VkRenderingAttachmentInfo &attachment_info,
-                                               const Location &attachment_loc) const {
+bool Device::ValidateRenderingAttachmentLayout(VkCommandBuffer commandBuffer, const VkRenderingAttachmentInfo& attachment_info,
+                                               const Location& attachment_loc) const {
     bool skip = false;
 
     if (attachment_info.imageLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
@@ -858,7 +858,7 @@ bool Device::ValidateRenderingAttachmentLayout(VkCommandBuffer commandBuffer, co
 
     if (attachment_info.imageLayout == VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR) {
         const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-        const char *vuid = IsExtEnabled(extensions.vk_khr_fragment_shading_rate) ? "VUID-VkRenderingAttachmentInfo-imageView-06143"
+        const char* vuid = IsExtEnabled(extensions.vk_khr_fragment_shading_rate) ? "VUID-VkRenderingAttachmentInfo-imageView-06143"
                                                                                  : "VUID-VkRenderingAttachmentInfo-imageView-06138";
         skip |= LogError(vuid, objlist, attachment_loc.dot(Field::imageLayout),
                          "must not be VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR (or the alias "
@@ -875,8 +875,8 @@ bool Device::ValidateRenderingAttachmentLayout(VkCommandBuffer commandBuffer, co
 }
 
 bool Device::ValidateRenderingAttachmentFeedbackLoopInfo(VkCommandBuffer commandBuffer,
-                                                         const VkRenderingAttachmentInfo &attachment_info,
-                                                         const Location &attachment_loc) const {
+                                                         const VkRenderingAttachmentInfo& attachment_info,
+                                                         const Location& attachment_loc) const {
     bool skip = false;
 
     const auto attachment_feedback_loop_info = vku::FindStructInPNextChain<VkAttachmentFeedbackLoopInfoEXT>(attachment_info.pNext);
@@ -892,7 +892,7 @@ bool Device::ValidateRenderingAttachmentFeedbackLoopInfo(VkCommandBuffer command
 }
 
 bool Device::ValidateRenderingCustomResolve(VkCommandBuffer commandBuffer, VkRenderingFlags rendering_flags,
-                                            VkResolveModeFlagBits resolve_mode, const Location &attachment_loc) const {
+                                            VkResolveModeFlagBits resolve_mode, const Location& attachment_loc) const {
     bool skip = false;
 
     if (rendering_flags & VK_RENDERING_CUSTOM_RESOLVE_BIT_EXT) {
@@ -911,11 +911,11 @@ bool Device::ValidateRenderingCustomResolve(VkCommandBuffer commandBuffer, VkRen
     return skip;
 }
 
-bool Device::ValidateBeginRenderingColorAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                   const Location &rendering_info_loc) const {
+bool Device::ValidateBeginRenderingColorAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                   const Location& rendering_info_loc) const {
     bool skip = false;
     for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
-        const VkRenderingAttachmentInfo &color_attachment = rendering_info.pColorAttachments[i];
+        const VkRenderingAttachmentInfo& color_attachment = rendering_info.pColorAttachments[i];
         if (color_attachment.imageView == VK_NULL_HANDLE) continue;
         const Location color_attachment_loc = rendering_info_loc.dot(Field::pColorAttachments, i);
 
@@ -976,12 +976,12 @@ bool Device::ValidateBeginRenderingColorAttachment(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool Device::ValidateBeginRenderingDepthAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                   const Location &rendering_info_loc) const {
+bool Device::ValidateBeginRenderingDepthAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                   const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pDepthAttachment || rendering_info.pDepthAttachment->imageView == VK_NULL_HANDLE) return skip;
 
-    const VkRenderingAttachmentInfo &depth_attachment = *rendering_info.pDepthAttachment;
+    const VkRenderingAttachmentInfo& depth_attachment = *rendering_info.pDepthAttachment;
     const Location attachment_loc = rendering_info_loc.dot(Field::pDepthAttachment);
 
     skip |= ValidateRenderingAttachmentFeedbackLoopInfo(commandBuffer, depth_attachment, attachment_loc);
@@ -1027,12 +1027,12 @@ bool Device::ValidateBeginRenderingDepthAttachment(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool Device::ValidateBeginRenderingStencilAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                     const Location &rendering_info_loc) const {
+bool Device::ValidateBeginRenderingStencilAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                     const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pStencilAttachment || rendering_info.pStencilAttachment->imageView == VK_NULL_HANDLE) return skip;
 
-    const VkRenderingAttachmentInfo &stencil_attachment = *rendering_info.pStencilAttachment;
+    const VkRenderingAttachmentInfo& stencil_attachment = *rendering_info.pStencilAttachment;
     const Location attachment_loc = rendering_info_loc.dot(Field::pStencilAttachment);
 
     skip |= ValidateRenderingAttachmentFeedbackLoopInfo(commandBuffer, stencil_attachment, attachment_loc);
@@ -1078,8 +1078,8 @@ bool Device::ValidateBeginRenderingStencilAttachment(VkCommandBuffer commandBuff
     return skip;
 }
 
-bool Device::ValidateBeginRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-                                                       const Location &rendering_info_loc) const {
+bool Device::ValidateBeginRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+                                                       const Location& rendering_info_loc) const {
     bool skip = false;
     if (rendering_info.flags & VK_RENDERING_LOCAL_READ_CONCURRENT_ACCESS_CONTROL_BIT_KHR) {
         if (!enabled_features.maintenance10) {
@@ -1089,7 +1089,7 @@ bool Device::ValidateBeginRenderingAttachmentFlagsInfo(VkCommandBuffer commandBu
         }
     } else {
         for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
-            const VkRenderingAttachmentInfo &attachment_info = rendering_info.pColorAttachments[i];
+            const VkRenderingAttachmentInfo& attachment_info = rendering_info.pColorAttachments[i];
             if (const auto flags_info = vku::FindStructInPNextChain<VkRenderingAttachmentFlagsInfoKHR>(attachment_info.pNext)) {
                 if (flags_info->flags & VK_RENDERING_ATTACHMENT_INPUT_ATTACHMENT_FEEDBACK_BIT_KHR) {
                     skip |= LogError("VUID-vkCmdBeginRendering-pRenderingInfo-11751", commandBuffer,
@@ -1127,9 +1127,9 @@ bool Device::ValidateBeginRenderingAttachmentFlagsInfo(VkCommandBuffer commandBu
 }
 
 bool Device::ValidateBeginRenderingFragmentShadingRateAttachment(
-    VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
-    const VkRenderingFragmentShadingRateAttachmentInfoKHR &rendering_fsr_attachment_info,
-    const Location &rendering_info_loc) const {
+    VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+    const VkRenderingFragmentShadingRateAttachmentInfoKHR& rendering_fsr_attachment_info,
+    const Location& rendering_info_loc) const {
     bool skip = false;
     if (rendering_fsr_attachment_info.imageView == VK_NULL_HANDLE) return skip;
 

--- a/layers/stateless/sl_shader_object.cpp
+++ b/layers/stateless/sl_shader_object.cpp
@@ -21,7 +21,7 @@
 
 namespace stateless {
 
-bool Device::ValidateCreateShadersFlags(VkShaderCreateFlagsEXT flags, VkShaderStageFlagBits stage, const Location &flag_loc) const {
+bool Device::ValidateCreateShadersFlags(VkShaderCreateFlagsEXT flags, VkShaderStageFlagBits stage, const Location& flag_loc) const {
     bool skip = false;
     if ((flags & VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT) != 0 &&
         enabled_features.attachmentFragmentShadingRate == VK_FALSE) {
@@ -92,11 +92,11 @@ bool Device::ValidateCreateShadersFlags(VkShaderCreateFlagsEXT flags, VkShaderSt
 }
 
 bool Device::manual_PreCallValidateCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
-                                                    const VkShaderCreateInfoEXT *pCreateInfos,
-                                                    const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
-                                                    const Context &context) const {
+                                                    const VkShaderCreateInfoEXT* pCreateInfos,
+                                                    const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
+                                                    const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     uint32_t linked_heap_stage = createInfoCount;
     uint32_t linked_non_heap_stage = createInfoCount;
@@ -117,7 +117,7 @@ bool Device::manual_PreCallValidateCreateShadersEXT(VkDevice device, uint32_t cr
                                  static_cast<uint64_t>(create_info.codeSize));
             } else {
                 // Can't cast this until we know it is aligned to 4 bytes or USAN will catch it
-                const uint32_t first_dword = ((uint32_t *)create_info.pCode)[0];
+                const uint32_t first_dword = ((uint32_t*)create_info.pCode)[0];
                 if (first_dword != spv::MagicNumber) {
                     skip |= LogError("VUID-VkShaderCreateInfoEXT-pCode-08738", device, create_info_loc.dot(Field::pCode),
                                      "doesn't point to a SPIR-V module. The first dword (0x%" PRIx32
@@ -260,10 +260,10 @@ bool Device::manual_PreCallValidateCreateShadersEXT(VkDevice device, uint32_t cr
     return skip;
 }
 
-bool Device::manual_PreCallValidateGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t *pDataSize, void *pData,
-                                                          const Context &context) const {
+bool Device::manual_PreCallValidateGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData,
+                                                          const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pData) {
         if (!IsPointerAligned(pData, 16)) {

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -39,7 +39,7 @@ struct VariableInstInfo {
 };
 
 // easier to use recursion to traverse the OpTypeStruct
-static void GetVariableInfo(const spirv::Module &module_state, const spirv::Instruction *insn, VariableInstInfo &info) {
+static void GetVariableInfo(const spirv::Module& module_state, const spirv::Instruction* insn, VariableInstInfo& info) {
     if (!insn) {
         return;
     } else if (insn->Opcode() == spv::OpTypePointer || insn->Opcode() == spv::OpTypeUntypedPointerKHR) {
@@ -50,18 +50,18 @@ static void GetVariableInfo(const spirv::Module &module_state, const spirv::Inst
         info.has_16bit |= (bit_width == 16);
     } else if (insn->Opcode() == spv::OpTypeStruct) {
         for (uint32_t i = 2; i < insn->Length(); i++) {
-            const spirv::Instruction *member_insn = module_state.FindDef(insn->Word(i));
+            const spirv::Instruction* member_insn = module_state.FindDef(insn->Word(i));
             if (member_insn->StorageClass() == spv::StorageClassPhysicalStorageBuffer) {
                 continue;  // a uint8 pointer is not a 8-bit element
             }
             const uint32_t base_insn_id = module_state.GetBaseType(member_insn);
-            const spirv::Instruction *base_insn = module_state.FindDef(base_insn_id);
+            const spirv::Instruction* base_insn = module_state.FindDef(base_insn_id);
             GetVariableInfo(module_state, base_insn, info);
         }
     }
 }
 
-SpirvValidator::SpirvValidator(DebugReport *debug_report, const vvl::StatelessDeviceData &stateless_device_data, bool disabled)
+SpirvValidator::SpirvValidator(DebugReport* debug_report, const vvl::StatelessDeviceData& stateless_device_data, bool disabled)
     : Logger(debug_report),
       disabled(disabled),
       api_version(stateless_device_data.api_version),
@@ -79,8 +79,8 @@ SpirvValidator::SpirvValidator(DebugReport *debug_report, const vvl::StatelessDe
 // Originally the goal was to move more validation to vkCreateShaderModule time in case the driver decided to parse an invalid
 // SPIR-V here, while that is likely not the case anymore, a bigger reason for checking here is to save on memory. There is a lot of
 // state saved in the Module that is only checked once later and could be reduced if not saved.
-bool SpirvValidator::Validate(const spirv::Module &module_state, const spirv::StatelessData &stateless_data,
-                              const Location &loc) const {
+bool SpirvValidator::Validate(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,
+                              const Location& loc) const {
     bool skip = false;
     if (!module_state.valid_spirv || disabled) {
         return skip;
@@ -101,7 +101,7 @@ bool SpirvValidator::Validate(const spirv::Module &module_state, const spirv::St
 
     // The following tries to limit the number of passes through the shader module.
     // It save a good amount of memory and complex state tracking to just check these in a 2nd pass
-    for (const spirv::Instruction &insn : module_state.GetInstructions()) {
+    for (const spirv::Instruction& insn : module_state.GetInstructions()) {
         skip |= ValidateShaderCapabilitiesAndExtensions(module_state, insn, loc);
         skip |= ValidateTexelOffsetLimits(module_state, insn, loc);
         skip |= ValidateMemoryScope(module_state, insn, loc);
@@ -124,13 +124,13 @@ bool SpirvValidator::Validate(const spirv::Module &module_state, const spirv::St
     return skip;
 }
 
-bool SpirvValidator::ValidateShaderClock(const spirv::Module &module_state, const spirv::StatelessData &stateless_data,
-                                         const Location &loc) const {
+bool SpirvValidator::ValidateShaderClock(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,
+                                         const Location& loc) const {
     bool skip = false;
 
-    for (const spirv::Instruction *clock_inst : stateless_data.read_clock_inst) {
-        const spirv::Instruction &insn = *clock_inst;
-        const spirv::Instruction *scope_id = module_state.FindDef(insn.Word(3));
+    for (const spirv::Instruction* clock_inst : stateless_data.read_clock_inst) {
+        const spirv::Instruction& insn = *clock_inst;
+        const spirv::Instruction* scope_id = module_state.FindDef(insn.Word(3));
         auto scope_type = scope_id->Word(3);
         // if scope isn't Subgroup or Device, spirv-val will catch
         if ((scope_type == spv::ScopeSubgroup) && (enabled_features.shaderSubgroupClock == VK_FALSE)) {
@@ -146,8 +146,8 @@ bool SpirvValidator::ValidateShaderClock(const spirv::Module &module_state, cons
     return skip;
 }
 
-bool SpirvValidator::ValidateAtomicsTypes(const spirv::Module &module_state, const spirv::StatelessData &stateless_data,
-                                          const Location &loc) const {
+bool SpirvValidator::ValidateAtomicsTypes(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,
+                                          const Location& loc) const {
     bool skip = false;
 
     // "If sparseImageInt64Atomics is enabled, shaderImageInt64Atomics must be enabled"
@@ -196,9 +196,9 @@ bool SpirvValidator::ValidateAtomicsTypes(const spirv::Module &module_state, con
     const bool valid_16_float_vector = (enabled_features.shaderFloat16VectorAtomics == VK_TRUE);
     // clang-format on
 
-    for (const spirv::Instruction *atomic_def_ptr : stateless_data.atomic_inst) {
-        const spirv::Instruction &atomic_def = *atomic_def_ptr;
-        const spirv::AtomicInstructionInfo &atomic = module_state.GetAtomicInfo(atomic_def);
+    for (const spirv::Instruction* atomic_def_ptr : stateless_data.atomic_inst) {
+        const spirv::Instruction& atomic_def = *atomic_def_ptr;
+        const spirv::AtomicInstructionInfo& atomic = module_state.GetAtomicInfo(atomic_def);
         const uint32_t opcode = atomic_def.Opcode();
 
         if (atomic.type == spv::OpTypeFloat && (atomic.vector_size == 2 || atomic.vector_size == 4)) {
@@ -376,12 +376,12 @@ bool SpirvValidator::ValidateAtomicsTypes(const spirv::Module &module_state, con
     return skip;
 }
 
-bool SpirvValidator::ValidateFma(const spirv::Module &module_state, const spirv::StatelessData &stateless_data,
-                                 const Location &loc) const {
+bool SpirvValidator::ValidateFma(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,
+                                 const Location& loc) const {
     bool skip = false;
 
     // spirv-val enforces the Result Type must be a scalar or vector of floats
-    for (const spirv::Instruction *fma_inst : stateless_data.fma_inst) {
+    for (const spirv::Instruction* fma_inst : stateless_data.fma_inst) {
         const spirv::Instruction* type_insn = module_state.FindDef(fma_inst->TypeId());
         const uint32_t bit_width = module_state.GetBaseTypeInstruction(type_insn)->GetBitWidth();
         if (bit_width == 16 && !enabled_features.shaderFmaFloat16) {
@@ -402,10 +402,10 @@ bool SpirvValidator::ValidateFma(const spirv::Module &module_state, const spirv:
     return skip;
 }
 
-bool SpirvValidator::ValidateVariables(const spirv::Module &module_state, const Location &loc) const {
+bool SpirvValidator::ValidateVariables(const spirv::Module& module_state, const Location& loc) const {
     bool skip = false;
 
-    for (const spirv::Instruction *insn : module_state.static_data_.explicit_memory_inst) {
+    for (const spirv::Instruction* insn : module_state.static_data_.explicit_memory_inst) {
         const uint32_t opcode = insn->Opcode();
         if (opcode == spv::OpVariable || opcode == spv::OpUntypedVariableKHR) {
             const uint32_t storage_class = insn->StorageClass();
@@ -442,8 +442,8 @@ bool SpirvValidator::ValidateVariables(const spirv::Module &module_state, const 
 }
 
 // This is to validate the VK_KHR_8bit_storage and VK_KHR_16bit_storage extensions
-bool SpirvValidator::Validate8And16BitStorage(const spirv::Module &module_state, const spirv::Instruction &insn,
-                                              const Location &loc) const {
+bool SpirvValidator::Validate8And16BitStorage(const spirv::Module& module_state, const spirv::Instruction& insn,
+                                              const Location& loc) const {
     bool skip = false;
 
     const bool variable = insn.Opcode() == spv::OpVariable;
@@ -508,14 +508,14 @@ bool SpirvValidator::Validate8And16BitStorage(const spirv::Module &module_state,
             // TODO: This doesn't capture explicitly laid out workgroup variables
             // that use typed pointers.
             const uint32_t ptr_type_id = module_state.GetTypeId(pointer_id);
-            const spirv::Instruction *ptr_insn = module_state.FindDef(ptr_type_id);
+            const spirv::Instruction* ptr_insn = module_state.FindDef(ptr_type_id);
             if (ptr_insn->Opcode() != spv::OpTypeUntypedPointerKHR) {
                 return skip;
             }
         }
 
         uint32_t byte_size = 0;
-        const spirv::Instruction *type_insn = module_state.FindDef(type_id);
+        const spirv::Instruction* type_insn = module_state.FindDef(type_id);
         byte_size = module_state.GetTypeBytesSize(type_insn);
 
         // If 8-bit storage is not enabled, accesses must be at least 16-bit
@@ -526,7 +526,7 @@ bool SpirvValidator::Validate8And16BitStorage(const spirv::Module &module_state,
         untyped_access = true;
     } else if (variable) {
         // type will either be a float, int, or struct and if struct need to traverse it
-        const spirv::Instruction *type = module_state.GetVariablePointerType(insn);
+        const spirv::Instruction* type = module_state.GetVariablePointerType(insn);
         std::shared_ptr<const spirv::TypeStructInfo> struct_info = module_state.GetTypeStructInfo(type);
         // Only check block-deocrated workgroup variables.
         if (storage_class != spv::StorageClassWorkgroup ||
@@ -612,8 +612,8 @@ bool SpirvValidator::Validate8And16BitStorage(const spirv::Module &module_state,
     return skip;
 }
 
-bool SpirvValidator::ValidateShaderStorageImageFormatsVariables(const spirv::Module &module_state, const spirv::Instruction &insn,
-                                                                const Location &loc) const {
+bool SpirvValidator::ValidateShaderStorageImageFormatsVariables(const spirv::Module& module_state, const spirv::Instruction& insn,
+                                                                const Location& loc) const {
     bool skip = false;
 
     // Go through all variables for images and check decorations
@@ -621,11 +621,11 @@ bool SpirvValidator::ValidateShaderStorageImageFormatsVariables(const spirv::Mod
     // to trigger the error.
     assert(insn.Opcode() == spv::OpVariable || insn.Opcode() == spv::OpUntypedVariableKHR);
     // spirv-val validates this is an OpTypePointer
-    const spirv::Instruction *pointer_def = module_state.FindDef(insn.TypeId());
+    const spirv::Instruction* pointer_def = module_state.FindDef(insn.TypeId());
     if (pointer_def->Word(2) != spv::StorageClassUniformConstant) {
         return skip;  // Vulkan Spec says storage image must be UniformConstant
     }
-    const spirv::Instruction *type_def = module_state.FindDef(pointer_def->Word(3));
+    const spirv::Instruction* type_def = module_state.FindDef(pointer_def->Word(3));
 
     // Unpack an optional level of arraying
     if (type_def && type_def->IsArray()) {
@@ -665,18 +665,18 @@ bool SpirvValidator::ValidateShaderStorageImageFormatsVariables(const spirv::Mod
     return skip;
 }
 
-bool SpirvValidator::ValidateTransformFeedbackDecorations(const spirv::Module &module_state, const Location &loc) const {
+bool SpirvValidator::ValidateTransformFeedbackDecorations(const spirv::Module& module_state, const Location& loc) const {
     bool skip = false;
 
     if (!enabled_features.transformFeedback) {
         return skip;
     }
 
-    std::vector<const spirv::Instruction *> xfb_streams;
-    std::vector<const spirv::Instruction *> xfb_buffers;
-    std::vector<const spirv::Instruction *> xfb_offsets;
+    std::vector<const spirv::Instruction*> xfb_streams;
+    std::vector<const spirv::Instruction*> xfb_buffers;
+    std::vector<const spirv::Instruction*> xfb_offsets;
 
-    for (const spirv::Instruction *op_decorate : module_state.static_data_.decoration_inst) {
+    for (const spirv::Instruction* op_decorate : module_state.static_data_.decoration_inst) {
         uint32_t decoration = op_decorate->Word(2);
         if (decoration == spv::DecorationXfbStride) {
             uint32_t stride = op_decorate->Word(3);
@@ -707,11 +707,11 @@ bool SpirvValidator::ValidateTransformFeedbackDecorations(const spirv::Module &m
 
     // XfbBuffer, buffer data size
     std::vector<std::pair<uint32_t, uint32_t>> buffer_data_sizes;
-    for (const spirv::Instruction *op_decorate : xfb_offsets) {
-        for (const spirv::Instruction *xfb_buffer : xfb_buffers) {
+    for (const spirv::Instruction* op_decorate : xfb_offsets) {
+        for (const spirv::Instruction* xfb_buffer : xfb_buffers) {
             if (xfb_buffer->Word(1) == op_decorate->Word(1)) {
                 const auto offset = op_decorate->Word(3);
-                const spirv::Instruction *def = module_state.FindDef(xfb_buffer->Word(1));
+                const spirv::Instruction* def = module_state.FindDef(xfb_buffer->Word(1));
                 const auto size = module_state.GetTypeBytesSize(def);
                 const uint32_t buffer_data_size = offset + size;
                 if (buffer_data_size > phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataSize) {
@@ -724,7 +724,7 @@ bool SpirvValidator::ValidateTransformFeedbackDecorations(const spirv::Module &m
                 }
 
                 bool found = false;
-                for (auto &bds : buffer_data_sizes) {
+                for (auto& bds : buffer_data_sizes) {
                     if (bds.first == xfb_buffer->Word(1)) {
                         bds.second = std::max(bds.second, buffer_data_size);
                         found = true;
@@ -741,8 +741,8 @@ bool SpirvValidator::ValidateTransformFeedbackDecorations(const spirv::Module &m
     }
 
     vvl::unordered_map<uint32_t, uint32_t> stream_data_size;
-    for (const spirv::Instruction *xfb_stream : xfb_streams) {
-        for (const auto &bds : buffer_data_sizes) {
+    for (const spirv::Instruction* xfb_stream : xfb_streams) {
+        for (const auto& bds : buffer_data_sizes) {
             if (xfb_stream->Word(1) == bds.first) {
                 uint32_t stream = xfb_stream->Word(3);
                 const auto itr = stream_data_size.find(stream);
@@ -755,7 +755,7 @@ bool SpirvValidator::ValidateTransformFeedbackDecorations(const spirv::Module &m
         }
     }
 
-    for (const auto &stream : stream_data_size) {
+    for (const auto& stream : stream_data_size) {
         if (stream.second > phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackStreamDataSize) {
             skip |= LogError(
                 "VUID-RuntimeSpirv-XfbBuffer-06309", module_state.handle(), loc,
@@ -769,15 +769,15 @@ bool SpirvValidator::ValidateTransformFeedbackDecorations(const spirv::Module &m
     return skip;
 }
 
-bool SpirvValidator::ValidateTransformFeedbackEmitStreams(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                          const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateTransformFeedbackEmitStreams(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                          const spirv::StatelessData& stateless_data, const Location& loc) const {
     bool skip = false;
     if (!enabled_features.transformFeedback || entrypoint.stage != VK_SHADER_STAGE_GEOMETRY_BIT) {
         return skip;  // GeometryStreams are only used in Geomtry Shaders
     }
 
     vvl::unordered_set<uint32_t> emitted_streams;
-    for (const spirv::Instruction *insn : stateless_data.transform_feedback_stream_inst) {
+    for (const spirv::Instruction* insn : stateless_data.transform_feedback_stream_inst) {
         const uint32_t opcode = insn->Opcode();
         if (opcode == spv::OpEmitStreamVertex) {
             emitted_streams.emplace(module_state.GetConstantValueById(insn->Word(1)));
@@ -808,8 +808,8 @@ bool SpirvValidator::ValidateTransformFeedbackEmitStreams(const spirv::Module &m
     return skip;
 }
 
-bool SpirvValidator::ValidateRelaxedExtendedInstruction(const spirv::Module &module_state,
-                                                        const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateRelaxedExtendedInstruction(const spirv::Module& module_state,
+                                                        const spirv::StatelessData& stateless_data, const Location& loc) const {
     bool skip = false;
     if (!enabled_features.shaderRelaxedExtendedInstruction && stateless_data.has_ext_inst_with_forward_refs) {
         skip |= LogError("VUID-RuntimeSpirv-shaderRelaxedExtendedInstruction-10773", module_state.handle(), loc,
@@ -821,8 +821,8 @@ bool SpirvValidator::ValidateRelaxedExtendedInstruction(const spirv::Module &mod
 }
 
 // Checks for both TexelOffset and TexelGatherOffset limits
-bool SpirvValidator::ValidateTexelOffsetLimits(const spirv::Module &module_state, const spirv::Instruction &insn,
-                                               const Location &loc) const {
+bool SpirvValidator::ValidateTexelOffsetLimits(const spirv::Module& module_state, const spirv::Instruction& insn,
+                                               const Location& loc) const {
     bool skip = false;
 
     const uint32_t opcode = insn.Opcode();
@@ -859,13 +859,13 @@ bool SpirvValidator::ValidateTexelOffsetLimits(const spirv::Module &module_state
         // If the bit is set, consume operand
         if (insn.Length() > index && (i & offset_bits)) {
             uint32_t constant_id = insn.Word(index);
-            const spirv::Instruction *constant = module_state.FindDef(constant_id);
+            const spirv::Instruction* constant = module_state.FindDef(constant_id);
             const bool is_dynamic_offset = constant == nullptr;
             if (!is_dynamic_offset && constant->Opcode() == spv::OpConstantComposite) {
                 for (uint32_t j = 3; j < constant->Length(); ++j) {
                     uint32_t comp_id = constant->Word(j);
-                    const spirv::Instruction *comp = module_state.FindDef(comp_id);
-                    const spirv::Instruction *comp_type = module_state.FindDef(comp->Word(1));
+                    const spirv::Instruction* comp = module_state.FindDef(comp_id);
+                    const spirv::Instruction* comp_type = module_state.FindDef(comp->Word(1));
                     // Get operand value
                     const uint32_t offset = comp->Word(3);
                     // spec requires minTexelGatherOffset/minTexelOffset to be -8 or less so never can compare if
@@ -919,14 +919,14 @@ bool SpirvValidator::ValidateTexelOffsetLimits(const spirv::Module &module_state
     return skip;
 }
 
-bool SpirvValidator::ValidateMemoryScope(const spirv::Module &module_state, const spirv::Instruction &insn,
-                                         const Location &loc) const {
+bool SpirvValidator::ValidateMemoryScope(const spirv::Module& module_state, const spirv::Instruction& insn,
+                                         const Location& loc) const {
     bool skip = false;
 
-    const auto &entry = OpcodeMemoryScopePosition(insn.Opcode());
+    const auto& entry = OpcodeMemoryScopePosition(insn.Opcode());
     if (entry > 0) {
         const uint32_t scope_id = insn.Word(entry);
-        const spirv::Instruction *scope_def = module_state.GetAnyConstantDef(scope_id);
+        const spirv::Instruction* scope_def = module_state.GetAnyConstantDef(scope_id);
         // Very very low chance using spec constant to set memory scope
         if (scope_def && scope_def->Opcode() == spv::OpConstant) {
             const spv::Scope scope_type = spv::Scope(scope_def->GetConstantValue());
@@ -947,8 +947,8 @@ bool SpirvValidator::ValidateMemoryScope(const spirv::Module &module_state, cons
     return skip;
 }
 
-bool SpirvValidator::ValidateSubgroupRotateClustered(const spirv::Module &module_state, const spirv::Instruction &insn,
-                                                     const Location &loc) const {
+bool SpirvValidator::ValidateSubgroupRotateClustered(const spirv::Module& module_state, const spirv::Instruction& insn,
+                                                     const Location& loc) const {
     bool skip = false;
     if (!enabled_features.shaderSubgroupRotateClustered && insn.Opcode() == spv::OpGroupNonUniformRotateKHR && insn.Length() == 7) {
         skip |= LogError("VUID-RuntimeSpirv-shaderSubgroupRotateClustered-09566", module_state.handle(), loc,
@@ -985,8 +985,8 @@ bool SpirvValidator::ValidateShaderStageGroupNonUniform(const spirv::Module& mod
 
     const VkShaderStageFlagBits stage = entrypoint.stage;
     // Check anything using a group operation (which currently is only OpGroupNonUnifrom* operations)
-    for (const spirv::Instruction *group_inst : stateless_data.group_inst) {
-        const spirv::Instruction &insn = *group_inst;
+    for (const spirv::Instruction* group_inst : stateless_data.group_inst) {
+        const spirv::Instruction& insn = *group_inst;
         // Check the quad operations.
         if ((insn.Opcode() == spv::OpGroupNonUniformQuadBroadcast) || (insn.Opcode() == spv::OpGroupNonUniformQuadSwap)) {
             if ((stage != VK_SHADER_STAGE_FRAGMENT_BIT) && (stage != VK_SHADER_STAGE_COMPUTE_BIT)) {
@@ -1005,7 +1005,7 @@ bool SpirvValidator::ValidateShaderStageGroupNonUniform(const spirv::Module& mod
             scope_type = spv::ScopeSubgroup;
         } else {
             // "All <id> used for Scope <id> must be of an OpConstant"
-            const spirv::Instruction *scope_id = module_state.FindDef(insn.Word(3));
+            const spirv::Instruction* scope_id = module_state.FindDef(insn.Word(3));
             scope_type = scope_id->Word(3);
         }
 
@@ -1021,7 +1021,7 @@ bool SpirvValidator::ValidateShaderStageGroupNonUniform(const spirv::Module& mod
         }
 
         if (!enabled_features.shaderSubgroupExtendedTypes) {
-            const spirv::Instruction *type = module_state.FindDef(insn.Word(1));
+            const spirv::Instruction* type = module_state.FindDef(insn.Word(1));
 
             const bool is_vector = type->IsVector();
             if (is_vector) {
@@ -1050,15 +1050,15 @@ bool SpirvValidator::ValidateShaderStageGroupNonUniform(const spirv::Module& mod
     return skip;
 }
 
-bool SpirvValidator::ValidateShaderStageInputOutputLimits(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                          const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateShaderStageInputOutputLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                          const spirv::StatelessData& stateless_data, const Location& loc) const {
     const VkShaderStageFlagBits stage = entrypoint.stage;
     if (stage == VK_SHADER_STAGE_COMPUTE_BIT || stage == VK_SHADER_STAGE_ALL_GRAPHICS || stage == VK_SHADER_STAGE_ALL) {
         return false;
     }
 
     bool skip = false;
-    auto const &limits = phys_dev_props.limits;
+    auto const& limits = phys_dev_props.limits;
 
     const uint32_t num_vertices = entrypoint.execution_mode.output_vertices;
     const uint32_t num_primitives = entrypoint.execution_mode.output_primitives;
@@ -1250,7 +1250,7 @@ bool SpirvValidator::ValidateShaderStageInputOutputLimits(const spirv::Module &m
     if (stage == VK_SHADER_STAGE_FRAGMENT_BIT && !IsExtEnabled(extensions.vk_ext_descriptor_indexing)) {
         // Variables can be aliased, so use Location to mark things as unique
         vvl::unordered_set<uint32_t> color_attachments;
-        for (const auto *variable : entrypoint.user_defined_interface_variables) {
+        for (const auto* variable : entrypoint.user_defined_interface_variables) {
             if (variable->storage_class == spv::StorageClassOutput && variable->decorations.location != spirv::kInvalidValue) {
                 // even if using an array of attachments in the shader, each used variable of the array is represented by a single
                 // variable
@@ -1261,7 +1261,7 @@ bool SpirvValidator::ValidateShaderStageInputOutputLimits(const spirv::Module &m
         // unordered_set requires to define hashing, and these should be very small and cheap as is
         std::set<std::pair<uint32_t, uint32_t>> storage_buffers;
         std::set<std::pair<uint32_t, uint32_t>> storage_images;
-        for (const auto &variable : entrypoint.resource_interface_variables) {
+        for (const auto& variable : entrypoint.resource_interface_variables) {
             if (!variable.IsAccessed()) continue;
             if (variable.is_storage_buffer) {
                 storage_buffers.insert(std::make_pair(variable.decorations.set, variable.decorations.binding));
@@ -1282,8 +1282,8 @@ bool SpirvValidator::ValidateShaderStageInputOutputLimits(const spirv::Module &m
     return skip;
 }
 
-bool SpirvValidator::ValidateShaderStageInterfaceVariables(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                           const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateShaderStageInterfaceVariables(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                           const spirv::StatelessData& stateless_data, const Location& loc) const {
     bool skip = false;
 
     if (entrypoint.stage == VK_SHADER_STAGE_MESH_BIT_EXT && !enabled_features.primitiveFragmentShadingRateMeshShader &&
@@ -1297,8 +1297,8 @@ bool SpirvValidator::ValidateShaderStageInterfaceVariables(const spirv::Module &
     return skip;
 }
 
-bool SpirvValidator::ValidateShaderFloatControl(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateShaderFloatControl(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                const spirv::StatelessData& stateless_data, const Location& loc) const {
     bool skip = false;
 
     // Need to wrap otherwise phys_dev_props_core12 can be junk
@@ -1395,7 +1395,7 @@ bool SpirvValidator::ValidateShaderFloatControl(const spirv::Module &module_stat
     }
 
     auto get_float_width = [&module_state](uint32_t id) {
-        const auto *insn = module_state.FindDef(id);
+        const auto* insn = module_state.FindDef(id);
         if (!insn || insn->Opcode() != spv::OpTypeFloat) {
             return 0u;
         } else {
@@ -1405,14 +1405,14 @@ bool SpirvValidator::ValidateShaderFloatControl(const spirv::Module &module_stat
 
     const uint32_t mask = spv::FPFastMathModeNotNaNMask | spv::FPFastMathModeNotInfMask | spv::FPFastMathModeNSZMask;
     if (entrypoint.execution_mode.Has(spirv::ExecutionModeSet::fp_fast_math_default)) {
-        for (const spirv::Instruction *insn : stateless_data.execution_mode_id_inst) {
+        for (const spirv::Instruction* insn : stateless_data.execution_mode_id_inst) {
             const uint32_t mode = insn->Word(2);
             if (mode != spv::ExecutionModeFPFastMathDefault) {
                 continue;
             }
 
             // spirv-val will catch if this is not a constant
-            const auto *fast_math_mode = module_state.FindDef(insn->Word(4));
+            const auto* fast_math_mode = module_state.FindDef(insn->Word(4));
             const bool has_mask = (fast_math_mode->GetConstantValue() & mask) == mask;
             if (has_mask) {
                 continue;  // nothing to validate
@@ -1439,7 +1439,7 @@ bool SpirvValidator::ValidateShaderFloatControl(const spirv::Module &module_stat
         }
     }
 
-    for (const spirv::Instruction *insn : module_state.static_data_.decoration_inst) {
+    for (const spirv::Instruction* insn : module_state.static_data_.decoration_inst) {
         uint32_t decoration = insn->Word(2);
         if (decoration != spv::DecorationFPFastMathMode) {
             continue;
@@ -1456,7 +1456,7 @@ bool SpirvValidator::ValidateShaderFloatControl(const spirv::Module &module_stat
         bool float_64 = false;
         uint32_t operand_index = 2;  // if using OpDecoration, this instruction must have a ResultId
 
-        const auto *target_insn = module_state.FindDef(insn->Word(1));
+        const auto* target_insn = module_state.FindDef(insn->Word(1));
         if (target_insn->TypeId() != 0) {
             operand_index++;
             const uint32_t bit_width = get_float_width(target_insn->TypeId());
@@ -1493,8 +1493,8 @@ bool SpirvValidator::ValidateShaderFloatControl(const spirv::Module &module_stat
     return skip;
 }
 
-bool SpirvValidator::ValidateExecutionModes(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                            const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateExecutionModes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                            const spirv::StatelessData& stateless_data, const Location& loc) const {
     bool skip = false;
     const VkShaderStageFlagBits stage = entrypoint.stage;
 
@@ -1548,8 +1548,8 @@ bool SpirvValidator::ValidateExecutionModes(const spirv::Module &module_state, c
     return skip;
 }
 
-bool SpirvValidator::ValidateConservativeRasterization(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
-                                                       const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateConservativeRasterization(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                       const spirv::StatelessData& stateless_data, const Location& loc) const {
     bool skip = false;
 
     // only new to validate if property is not enabled
@@ -1568,7 +1568,8 @@ bool SpirvValidator::ValidateConservativeRasterization(const spirv::Module &modu
     return skip;
 }
 
-bool SpirvValidator::ValidateShaderTensor(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint, const spirv::StatelessData &stateless_data, const Location &loc) const {
+bool SpirvValidator::ValidateShaderTensor(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                          const spirv::StatelessData& stateless_data, const Location& loc) const {
     bool skip = false;
 
     // check only shaders
@@ -1582,7 +1583,7 @@ bool SpirvValidator::ValidateShaderTensor(const spirv::Module &module_state, con
                          string_VkShaderStageFlagBits(entrypoint.stage));
     }
 
-    for (auto &instruction : stateless_data.tensor_inst) {
+    for (auto& instruction : stateless_data.tensor_inst) {
         if ((entrypoint.stage & phys_dev_ext_props.tensor_properties.shaderTensorSupportedStages) == 0) {
             skip |= LogError("VUID-RuntimeSpirv-shaderTensorSupportedStages-09901", module_state.handle(), loc,
                              "'%s' is a tensor instruction but not supported in %s; supported stages are %s.",
@@ -1605,10 +1606,10 @@ bool SpirvValidator::ValidateShaderTensor(const spirv::Module &module_state, con
         if (instruction->Opcode() == spv::OpTensorReadARM || instruction->Opcode() == spv::OpTensorWriteARM) {
             // for read, the size to copy is defined as a type in the OpTensorReadARM instruction itself;
             // for write it's defined with an object, whose type is defined in a previous instruction
-            const spirv::Instruction *copy_definition_instr =
+            const spirv::Instruction* copy_definition_instr =
                 (instruction->Opcode() == spv::OpTensorReadARM) ? instruction : module_state.FindDef(instruction->Word(3));
-            const spirv::Instruction *copy_object_type = module_state.FindDef(copy_definition_instr->Word(1));
-            const spirv::Instruction *element_type = module_state.FindDef(module_state.GetBaseType(copy_object_type));
+            const spirv::Instruction* copy_object_type = module_state.FindDef(copy_definition_instr->Word(1));
+            const spirv::Instruction* element_type = module_state.FindDef(module_state.GetBaseType(copy_object_type));
             // the type can be an OpTypeArray or a scalar type: computing array_elements this way works for both cases
             uint32_t copy_object_type_bytes = module_state.GetTypeBytesSize(copy_object_type);
             uint32_t element_bytes = module_state.GetTypeBytesSize(element_type);

--- a/layers/stateless/sl_synchronization.cpp
+++ b/layers/stateless/sl_synchronization.cpp
@@ -20,9 +20,9 @@
 #include "generated/enum_flag_bits.h"
 
 namespace stateless {
-bool Device::manual_PreCallValidateCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
-                                                   const Context &context) const {
+bool Device::manual_PreCallValidateCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
+                                                   const Context& context) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_METAL_EXT
     skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT,
@@ -31,9 +31,9 @@ bool Device::manual_PreCallValidateCreateSemaphore(VkDevice device, const VkSema
 #endif  // VK_USE_PLATFORM_METAL_EXT
     return skip;
 }
-bool Device::manual_PreCallValidateCreateEvent(VkDevice device, const VkEventCreateInfo *pCreateInfo,
-                                               const VkAllocationCallbacks *pAllocator, VkEvent *pEvent,
-                                               const Context &context) const {
+bool Device::manual_PreCallValidateCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
+                                               const VkAllocationCallbacks* pAllocator, VkEvent* pEvent,
+                                               const Context& context) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_METAL_EXT
     skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT,
@@ -43,7 +43,7 @@ bool Device::manual_PreCallValidateCreateEvent(VkDevice device, const VkEventCre
     return skip;
 }
 
-bool Device::ValidateDependencyInfo(const Context &context, const VkDependencyInfo &dep_info, const Location &loc) const {
+bool Device::ValidateDependencyInfo(const Context& context, const VkDependencyInfo& dep_info, const Location& loc) const {
     bool skip = false;
 
     constexpr std::array allowed_structs = {VK_STRUCTURE_TYPE_MEMORY_BARRIER_ACCESS_FLAGS_3_KHR};
@@ -68,8 +68,8 @@ bool Device::ValidateDependencyInfo(const Context &context, const VkDependencyIn
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,
-                                                       const Context &context) const {
+bool Device::manual_PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
+                                                       const Context& context) const {
     bool skip = false;
 
     skip |= ValidateDependencyInfo(context, *pDependencyInfo, context.error_obj.location.dot(Field::pDependencyInfo));
@@ -78,7 +78,7 @@ bool Device::manual_PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBu
 }
 
 bool Device::manual_PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
-                                                const VkDependencyInfo *pDependencyInfo, const Context &context) const {
+                                                const VkDependencyInfo* pDependencyInfo, const Context& context) const {
     bool skip = false;
 
     skip |= ValidateDependencyInfo(context, *pDependencyInfo, context.error_obj.location.dot(Field::pDependencyInfo));
@@ -86,8 +86,8 @@ bool Device::manual_PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, V
     return skip;
 }
 
-bool Device::manual_PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                  const VkDependencyInfo *pDependencyInfos, const Context &context) const {
+bool Device::manual_PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                  const VkDependencyInfo* pDependencyInfos, const Context& context) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < eventCount; ++i) {

--- a/layers/stateless/sl_tensor.cpp
+++ b/layers/stateless/sl_tensor.cpp
@@ -21,7 +21,7 @@
 
 namespace stateless {
 
-bool Device::ValidateTensorDescriptionARM(const VkTensorDescriptionARM &description, const Location &description_loc) const {
+bool Device::ValidateTensorDescriptionARM(const VkTensorDescriptionARM& description, const Location& description_loc) const {
     bool skip = false;
 
     if (description.format == VK_FORMAT_UNDEFINED) {
@@ -37,7 +37,7 @@ bool Device::ValidateTensorDescriptionARM(const VkTensorDescriptionARM &descript
     }
 
     // pStrides can be null
-    if (const auto *strides = description.pStrides) {
+    if (const auto* strides = description.pStrides) {
         if (description.tiling == VK_TENSOR_TILING_OPTIMAL_ARM) {
             skip |= LogError("VUID-VkTensorCreateInfoARM-pDescription-09720", device, description_loc.dot(Field::tiling),
                              "is VK_TENSOR_TILING_OPTIMAL_ARM, but pDescription::pStrides (%p) is not null", description.pStrides);
@@ -110,7 +110,7 @@ bool Device::ValidateTensorDescriptionARM(const VkTensorDescriptionARM &descript
 
     {
         int64_t total_elements = 1;
-        auto *dims = description.pDimensions;
+        auto* dims = description.pDimensions;
         auto would_overflow = false;
         for (uint32_t i = 0; i < description.dimensionCount; i++) {
             if (INT64_MAX / total_elements >= dims[i]) {
@@ -130,8 +130,8 @@ bool Device::ValidateTensorDescriptionARM(const VkTensorDescriptionARM &descript
         }
         if (static_cast<uint64_t>(total_elements) > phys_dev_ext_props.tensor_properties.maxTensorElements || would_overflow) {
             skip |= LogError("VUID-VkTensorCreateInfoARM-tensorElements-09721", device, description_loc.dot(Field::pDimensions),
-                             "the total number of elements (%" PRIi64 ") is greater than maxTensorElements (%" PRIu64 ")", total_elements,
-                             phys_dev_ext_props.tensor_properties.maxTensorElements);
+                             "the total number of elements (%" PRIi64 ") is greater than maxTensorElements (%" PRIu64 ")",
+                             total_elements, phys_dev_ext_props.tensor_properties.maxTensorElements);
         }
     }
 
@@ -153,9 +153,9 @@ bool Device::ValidateTensorDescriptionARM(const VkTensorDescriptionARM &descript
     return skip;
 }
 
-bool Device::manual_PreCallValidateCreateTensorARM(VkDevice device, const VkTensorCreateInfoARM *pCreateInfo,
-                                                   const VkAllocationCallbacks *pAllocator, VkTensorARM *pTensor,
-                                                   const Context &context) const {
+bool Device::manual_PreCallValidateCreateTensorARM(VkDevice device, const VkTensorCreateInfoARM* pCreateInfo,
+                                                   const VkAllocationCallbacks* pAllocator, VkTensorARM* pTensor,
+                                                   const Context& context) const {
     bool skip = false;
 
     if (!enabled_features.tensors) {

--- a/layers/stateless/sl_utils.cpp
+++ b/layers/stateless/sl_utils.cpp
@@ -21,7 +21,7 @@
 #include "sl_vuid_maps.h"
 
 namespace stateless {
-bool Instance::CheckPromotedApiAgainstVulkanVersion(VkInstance instance, const Location &loc,
+bool Instance::CheckPromotedApiAgainstVulkanVersion(VkInstance instance, const Location& loc,
                                                     const uint32_t promoted_version) const {
     bool skip = false;
     if (api_version < promoted_version) {
@@ -33,10 +33,10 @@ bool Instance::CheckPromotedApiAgainstVulkanVersion(VkInstance instance, const L
     return skip;
 }
 
-bool Instance::CheckPromotedApiAgainstVulkanVersion(VkPhysicalDevice pdev, const Location &loc,
+bool Instance::CheckPromotedApiAgainstVulkanVersion(VkPhysicalDevice pdev, const Location& loc,
                                                     const uint32_t promoted_version) const {
     bool skip = false;
-    const auto &target_pdev = physical_device_properties_map.find(pdev);
+    const auto& target_pdev = physical_device_properties_map.find(pdev);
     if (target_pdev != physical_device_properties_map.end()) {
         auto effective_api_version = std::min(APIVersion(target_pdev->second->apiVersion), api_version);
         if (effective_api_version < promoted_version) {
@@ -52,11 +52,11 @@ bool Instance::CheckPromotedApiAgainstVulkanVersion(VkPhysicalDevice pdev, const
     return skip;
 }
 
-bool Instance::OutputExtensionError(const Location &loc, const vvl::Extensions &extensions) const {
+bool Instance::OutputExtensionError(const Location& loc, const vvl::Extensions& extensions) const {
     return LogError("UNASSIGNED-GeneralParameterError-ExtensionNotEnabled", instance, loc,
                     "function required extension %s which has not been enabled.\n", String(extensions).c_str());
 }
-bool Device::OutputExtensionError(const Location &loc, const vvl::Extensions &extensions) const {
+bool Device::OutputExtensionError(const Location& loc, const vvl::Extensions& extensions) const {
     return LogError("UNASSIGNED-GeneralParameterError-ExtensionNotEnabled", device, loc,
                     "function required extension %s which has not been enabled.\n", String(extensions).c_str());
 }
@@ -77,7 +77,7 @@ typedef enum VkStringErrorFlagBits {
 } VkStringErrorFlagBits;
 typedef VkFlags VkStringErrorFlags;
 
-static VkStringErrorFlags ValidateVkString(const int max_length, const char *utf8) {
+static VkStringErrorFlags ValidateVkString(const int max_length, const char* utf8) {
     VkStringErrorFlags result = VK_STRING_ERROR_NONE;
     int num_char_bytes = 0;
     int i, j;
@@ -118,7 +118,7 @@ static VkStringErrorFlags ValidateVkString(const int max_length, const char *utf
 }
 
 static const int kMaxParamCheckerStringLength = 256;
-bool Context::ValidateString(const Location &loc, const char *vuid, const char *validate_string) const {
+bool Context::ValidateString(const Location& loc, const char* vuid, const char* validate_string) const {
     bool skip = false;
 
     VkStringErrorFlags result = ValidateVkString(kMaxParamCheckerStringLength, validate_string);
@@ -133,7 +133,7 @@ bool Context::ValidateString(const Location &loc, const char *vuid, const char *
     return skip;
 }
 
-bool Context::ValidateNotZero(bool is_zero, const char *vuid, const Location &loc) const {
+bool Context::ValidateNotZero(bool is_zero, const char* vuid, const Location& loc) const {
     bool skip = false;
     if (is_zero) {
         skip |= log.LogError(vuid, error_obj.handle, loc, "is zero.");
@@ -141,7 +141,7 @@ bool Context::ValidateNotZero(bool is_zero, const char *vuid, const Location &lo
     return skip;
 }
 
-bool Context::ValidateRequiredPointer(const Location &loc, const void *value, const char *vuid) const {
+bool Context::ValidateRequiredPointer(const Location& loc, const void* value, const char* vuid) const {
     bool skip = false;
     if (value == nullptr) {
         skip |= log.LogError(vuid, error_obj.handle, loc, "is NULL.");
@@ -149,34 +149,34 @@ bool Context::ValidateRequiredPointer(const Location &loc, const void *value, co
     return skip;
 }
 
-bool Context::ValidateAllocationCallbacks(const VkAllocationCallbacks &callback, const Location &loc) const {
+bool Context::ValidateAllocationCallbacks(const VkAllocationCallbacks& callback, const Location& loc) const {
     bool skip = false;
-    skip |= ValidateRequiredPointer(loc.dot(Field::pfnAllocation), reinterpret_cast<const void *>(callback.pfnAllocation),
+    skip |= ValidateRequiredPointer(loc.dot(Field::pfnAllocation), reinterpret_cast<const void*>(callback.pfnAllocation),
                                     "VUID-VkAllocationCallbacks-pfnAllocation-00632");
 
-    skip |= ValidateRequiredPointer(loc.dot(Field::pfnReallocation), reinterpret_cast<const void *>(callback.pfnReallocation),
+    skip |= ValidateRequiredPointer(loc.dot(Field::pfnReallocation), reinterpret_cast<const void*>(callback.pfnReallocation),
                                     "VUID-VkAllocationCallbacks-pfnReallocation-00633");
 
-    skip |= ValidateRequiredPointer(loc.dot(Field::pfnFree), reinterpret_cast<const void *>(callback.pfnFree),
+    skip |= ValidateRequiredPointer(loc.dot(Field::pfnFree), reinterpret_cast<const void*>(callback.pfnFree),
                                     "VUID-VkAllocationCallbacks-pfnFree-00634");
 
     if (callback.pfnInternalAllocation) {
         skip |=
-            ValidateRequiredPointer(loc.dot(Field::pfnInternalAllocation), reinterpret_cast<const void *>(callback.pfnInternalFree),
+            ValidateRequiredPointer(loc.dot(Field::pfnInternalAllocation), reinterpret_cast<const void*>(callback.pfnInternalFree),
                                     "VUID-VkAllocationCallbacks-pfnInternalAllocation-00635");
     }
 
     if (callback.pfnInternalFree) {
         skip |=
-            ValidateRequiredPointer(loc.dot(Field::pfnInternalFree), reinterpret_cast<const void *>(callback.pfnInternalAllocation),
+            ValidateRequiredPointer(loc.dot(Field::pfnInternalFree), reinterpret_cast<const void*>(callback.pfnInternalAllocation),
                                     "VUID-VkAllocationCallbacks-pfnInternalAllocation-00635");
     }
     return skip;
 }
 
-bool Context::ValidateStringArray(const Location &count_loc, const Location &array_loc, uint32_t count, const char *const *array,
-                                  bool count_required, bool array_required, const char *count_required_vuid,
-                                  const char *array_required_vuid) const {
+bool Context::ValidateStringArray(const Location& count_loc, const Location& array_loc, uint32_t count, const char* const* array,
+                                  bool count_required, bool array_required, const char* count_required_vuid,
+                                  const char* array_required_vuid) const {
     bool skip = false;
 
     if ((array == nullptr) || (count == 0)) {
@@ -200,11 +200,11 @@ bool Context::ValidateStringArray(const Location &count_loc, const Location &arr
 //
 // However.. some structs we determined to warn the user because it might produce subtle effects, but this is the edge case, not the
 // normal case.
-bool Context::ValidatePnextStructExtension(const Location &loc, const VkBaseOutStructure *header) const {
+bool Context::ValidatePnextStructExtension(const Location& loc, const VkBaseOutStructure* header) const {
     bool skip = false;
     switch (header->sType) {
         case VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO: {
-            auto buffer_flags2_ci = (const VkBufferUsageFlags2CreateInfo *)header;
+            auto buffer_flags2_ci = (const VkBufferUsageFlags2CreateInfo*)header;
             if (buffer_flags2_ci->usage != 0 && !IsExtEnabled(extensions.vk_khr_maintenance5)) {
                 skip |= log.LogWarning(
                     "WARNING-VkBufferUsageFlags2CreateInfo-Extension", error_obj.handle, loc.dot(Field::pNext),
@@ -215,7 +215,7 @@ bool Context::ValidatePnextStructExtension(const Location &loc, const VkBaseOutS
         } break;
 
         case VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO: {
-            auto pipeline_flags2_ci = (const VkPipelineCreateFlags2CreateInfo *)header;
+            auto pipeline_flags2_ci = (const VkPipelineCreateFlags2CreateInfo*)header;
             if (pipeline_flags2_ci->flags != 0 && !IsExtEnabled(extensions.vk_khr_maintenance5)) {
                 skip |= log.LogWarning(
                     "WARNING-VkPipelineCreateFlags2CreateInfo-Extension", error_obj.handle, loc.dot(Field::pNext),
@@ -231,15 +231,15 @@ bool Context::ValidatePnextStructExtension(const Location &loc, const VkBaseOutS
     return skip;
 }
 
-bool Context::ValidateStructPnext(const Location &loc, const void *next, size_t allowed_type_count,
-                                  const VkStructureType *allowed_types, uint32_t header_version, const char *pnext_vuid,
-                                  const char *stype_vuid, const bool is_const_param) const {
+bool Context::ValidateStructPnext(const Location& loc, const void* next, size_t allowed_type_count,
+                                  const VkStructureType* allowed_types, uint32_t header_version, const char* pnext_vuid,
+                                  const char* stype_vuid, const bool is_const_param) const {
     bool skip = false;
 
     if (next != nullptr) {
-        vvl::unordered_set<const void *> cycle_check;
+        vvl::unordered_set<const void*> cycle_check;
         vvl::unordered_set<VkStructureType, vvl::hash<int>> unique_stype_check;
-        const char *disclaimer =
+        const char* disclaimer =
             "This error is based on the Valid Usage documentation for version %" PRIu32
             " of the Vulkan header.  It is possible that "
             "you are using a struct from a private extension or an extension that was added to a later version of the Vulkan "
@@ -252,9 +252,9 @@ bool Context::ValidateStructPnext(const Location &loc, const void *next, size_t 
             skip |=
                 log.LogError(pnext_vuid, error_obj.handle, pNext_loc, message.c_str(), header_version, pNext_loc.Fields().c_str());
         } else {
-            const VkStructureType *start = allowed_types;
-            const VkStructureType *end = allowed_types + allowed_type_count;
-            const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(next);
+            const VkStructureType* start = allowed_types;
+            const VkStructureType* end = allowed_types + allowed_type_count;
+            const VkBaseOutStructure* current = reinterpret_cast<const VkBaseOutStructure*>(next);
 
             while (current != nullptr) {
                 if ((loc.function != Func::vkCreateInstance || (current->sType != VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO)) &&
@@ -270,7 +270,7 @@ bool Context::ValidateStructPnext(const Location &loc, const void *next, size_t 
 
                     // Search custom stype list -- if sType found, skip this entirely
                     bool custom = false;
-                    for (const auto &item : GetCustomStypeInfo()) {
+                    for (const auto& item : GetCustomStypeInfo()) {
                         if (item.first == current->sType) {
                             custom = true;
                             break;
@@ -304,7 +304,7 @@ bool Context::ValidateStructPnext(const Location &loc, const void *next, size_t 
                         }
                     }
                 }
-                current = reinterpret_cast<const VkBaseOutStructure *>(current->pNext);
+                current = reinterpret_cast<const VkBaseOutStructure*>(current->pNext);
             }
         }
     }
@@ -312,7 +312,7 @@ bool Context::ValidateStructPnext(const Location &loc, const void *next, size_t 
     return skip;
 }
 
-bool Context::ValidateBool32(const Location &loc, VkBool32 value) const {
+bool Context::ValidateBool32(const Location& loc, VkBool32 value) const {
     bool skip = false;
     if ((value != VK_TRUE) && (value != VK_FALSE)) {
         skip |= log.LogError("UNASSIGNED-GeneralParameterError-UnrecognizedBool32", error_obj.handle, loc,
@@ -324,9 +324,9 @@ bool Context::ValidateBool32(const Location &loc, VkBool32 value) const {
     return skip;
 }
 
-bool Context::ValidateBool32Array(const Location &count_loc, const Location &array_loc, uint32_t count, const VkBool32 *array,
-                                  bool count_required, bool array_required, const char *count_required_vuid,
-                                  const char *array_required_vuid) const {
+bool Context::ValidateBool32Array(const Location& count_loc, const Location& array_loc, uint32_t count, const VkBool32* array,
+                                  bool count_required, bool array_required, const char* count_required_vuid,
+                                  const char* array_required_vuid) const {
     bool skip = false;
 
     if ((array == nullptr) || (count == 0)) {
@@ -347,7 +347,7 @@ bool Context::ValidateBool32Array(const Location &count_loc, const Location &arr
     return skip;
 }
 
-bool Context::ValidateReservedFlags(const Location &loc, VkFlags value, const char *vuid) const {
+bool Context::ValidateReservedFlags(const Location& loc, VkFlags value, const char* vuid) const {
     bool skip = false;
     if (value != 0) {
         skip |= log.LogError(vuid, error_obj.handle, loc, "is %" PRIu32 ", but must be 0.", value);
@@ -355,7 +355,7 @@ bool Context::ValidateReservedFlags(const Location &loc, VkFlags value, const ch
     return skip;
 }
 
-bool Context::ValidateReservedFlags(const Location &loc, VkFlags64 value, const char *vuid) const {
+bool Context::ValidateReservedFlags(const Location& loc, VkFlags64 value, const char* vuid) const {
     bool skip = false;
     if (value != 0) {
         skip |= log.LogError(vuid, error_obj.handle, loc, "is %" PRIu64 ", but must be 0.", value);
@@ -365,13 +365,13 @@ bool Context::ValidateReservedFlags(const Location &loc, VkFlags64 value, const 
 
 // helper to implement validation of both 32 bit and 64 bit flags.
 template <typename FlagTypedef>
-bool Context::ValidateFlagsImplementation(const Location &loc, vvl::FlagBitmask flag_bitmask, FlagTypedef all_flags,
-                                          FlagTypedef value, const FlagType flag_type, const char *vuid,
-                                          const char *flags_zero_vuid) const {
+bool Context::ValidateFlagsImplementation(const Location& loc, vvl::FlagBitmask flag_bitmask, FlagTypedef all_flags,
+                                          FlagTypedef value, const FlagType flag_type, const char* vuid,
+                                          const char* flags_zero_vuid) const {
     bool skip = false;
 
     const bool required = flag_type == kRequiredFlags || flag_type == kRequiredSingleBit;
-    const char *zero_vuid = flag_type == kRequiredFlags ? flags_zero_vuid : vuid;
+    const char* zero_vuid = flag_type == kRequiredFlags ? flags_zero_vuid : vuid;
     if (required && value == 0) {
         skip |= log.LogError(zero_vuid, error_obj.handle, loc, "is zero.");
     }
@@ -391,8 +391,8 @@ bool Context::ValidateFlagsImplementation(const Location &loc, vvl::FlagBitmask 
     return skip;
 }
 
-bool Context::ValidateFlags(const Location &loc, vvl::FlagBitmask flag_bitmask, VkFlags all_flags, VkFlags value,
-                            const FlagType flag_type, const char *vuid, const char *flags_zero_vuid, bool instance_function) const {
+bool Context::ValidateFlags(const Location& loc, vvl::FlagBitmask flag_bitmask, VkFlags all_flags, VkFlags value,
+                            const FlagType flag_type, const char* vuid, const char* flags_zero_vuid, bool instance_function) const {
     bool skip = false;
     skip |= ValidateFlagsImplementation<VkFlags>(loc, flag_bitmask, all_flags, value, flag_type, vuid, flags_zero_vuid);
 
@@ -424,8 +424,8 @@ bool Context::ValidateFlags(const Location &loc, vvl::FlagBitmask flag_bitmask, 
     return skip;
 }
 
-bool Context::ValidateFlags(const Location &loc, vvl::FlagBitmask flag_bitmask, VkFlags64 all_flags, VkFlags64 value,
-                            const FlagType flag_type, const char *vuid, const char *flags_zero_vuid, bool instance_function) const {
+bool Context::ValidateFlags(const Location& loc, vvl::FlagBitmask flag_bitmask, VkFlags64 all_flags, VkFlags64 value,
+                            const FlagType flag_type, const char* vuid, const char* flags_zero_vuid, bool instance_function) const {
     bool skip = false;
     skip |= ValidateFlagsImplementation<VkFlags64>(loc, flag_bitmask, all_flags, value, flag_type, vuid, flags_zero_vuid);
 
@@ -450,9 +450,9 @@ bool Context::ValidateFlags(const Location &loc, vvl::FlagBitmask flag_bitmask, 
     return skip;
 }
 
-bool Context::ValidateFlagsArray(const Location &count_loc, const Location &array_loc, vvl::FlagBitmask flag_bitmask,
-                                 VkFlags all_flags, uint32_t count, const VkFlags *array, bool count_required,
-                                 const char *count_required_vuid, const char *array_required_vuid) const {
+bool Context::ValidateFlagsArray(const Location& count_loc, const Location& array_loc, vvl::FlagBitmask flag_bitmask,
+                                 VkFlags all_flags, uint32_t count, const VkFlags* array, bool count_required,
+                                 const char* count_required_vuid, const char* array_required_vuid) const {
     bool skip = false;
 
     if ((array == nullptr) || (count == 0)) {

--- a/layers/stateless/sl_vuid_maps.cpp
+++ b/layers/stateless/sl_vuid_maps.cpp
@@ -20,7 +20,7 @@
 
 namespace vvl {
 
-const std::string &GetPipelineBinaryInfoVUID(const Location &loc, PipelineBinaryInfoError error) {
+const std::string& GetPipelineBinaryInfoVUID(const Location& loc, PipelineBinaryInfoError error) {
     static const std::map<PipelineBinaryInfoError, std::array<Entry, 5>> errors{
         {PipelineBinaryInfoError::PNext_09616,
          {{
@@ -80,7 +80,7 @@ const std::string &GetPipelineBinaryInfoVUID(const Location &loc, PipelineBinary
          }}},
     };
 
-    const auto &result = FindVUID(error, loc, errors);
+    const auto& result = FindVUID(error, loc, errors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-Stateless-unhandled-pipelinebinaryinfo-error");

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -27,10 +27,10 @@
 
 namespace stateless {
 bool Device::manual_PreCallValidateAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
-                                                       VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
-                                                       const Context &context) const {
+                                                       VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
+                                                       const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (semaphore == VK_NULL_HANDLE && fence == VK_NULL_HANDLE) {
         skip |= LogError("VUID-vkAcquireNextImageKHR-semaphore-01780", swapchain, error_obj.location,
@@ -40,10 +40,10 @@ bool Device::manual_PreCallValidateAcquireNextImageKHR(VkDevice device, VkSwapch
     return skip;
 }
 
-bool Device::manual_PreCallValidateAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
-                                                        uint32_t *pImageIndex, const Context &context) const {
+bool Device::manual_PreCallValidateAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
+                                                        uint32_t* pImageIndex, const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pAcquireInfo->semaphore == VK_NULL_HANDLE && pAcquireInfo->fence == VK_NULL_HANDLE) {
         skip |= LogError("VUID-VkAcquireNextImageInfoKHR-semaphore-01782", pAcquireInfo->swapchain,
@@ -53,7 +53,7 @@ bool Device::manual_PreCallValidateAcquireNextImage2KHR(VkDevice device, const V
     return skip;
 }
 
-bool Device::ValidateSwapchainCreateInfoMaintenance1(const VkSwapchainCreateInfoKHR &create_info, const Location &loc) const {
+bool Device::ValidateSwapchainCreateInfoMaintenance1(const VkSwapchainCreateInfoKHR& create_info, const Location& loc) const {
     bool skip = false;
 
     if (enabled_features.swapchainMaintenance1) {
@@ -65,7 +65,7 @@ bool Device::ValidateSwapchainCreateInfoMaintenance1(const VkSwapchainCreateInfo
                          "contains VkSwapchainPresentModesCreateInfoKHR, but swapchainMaintenance1 is not enabled");
     }
 
-    if (const auto *present_scaling_create_info =
+    if (const auto* present_scaling_create_info =
             vku::FindStructInPNextChain<VkSwapchainPresentScalingCreateInfoKHR>(create_info.pNext)) {
         if (present_scaling_create_info->scalingBehavior != 0) {
             skip |= LogError("VUID-VkSwapchainPresentScalingCreateInfoKHR-swapchainMaintenance1-10154", device,
@@ -94,8 +94,8 @@ bool Device::ValidateSwapchainCreateInfoMaintenance1(const VkSwapchainCreateInfo
     return skip;
 }
 
-bool Device::ValidateSwapchainCreateInfo(const Context &context, const VkSwapchainCreateInfoKHR &create_info,
-                                         const Location &loc) const {
+bool Device::ValidateSwapchainCreateInfo(const Context& context, const VkSwapchainCreateInfoKHR& create_info,
+                                         const Location& loc) const {
     bool skip = false;
 
     // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
@@ -172,14 +172,14 @@ bool Device::ValidateSwapchainCreateInfo(const Context &context, const VkSwapcha
     }
 
     if (create_info.presentMode == VK_PRESENT_MODE_FIFO_LATEST_READY_KHR && !enabled_features.presentModeFifoLatestReady) {
-        skip |=
-            LogError("VUID-VkSwapchainCreateInfoKHR-presentModeFifoLatestReady-10161", device, loc.dot(Field::presentMode),
-                     "is %s, but feature presentModeFifoLatestReady is not enabled", string_VkPresentModeKHR(create_info.presentMode));
+        skip |= LogError("VUID-VkSwapchainCreateInfoKHR-presentModeFifoLatestReady-10161", device, loc.dot(Field::presentMode),
+                         "is %s, but feature presentModeFifoLatestReady is not enabled",
+                         string_VkPresentModeKHR(create_info.presentMode));
     }
 
     if (create_info.flags & VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR) {
-        auto stateless_instance = static_cast<Instance *>(dispatch_instance_->GetValidationObject(container_type));
-        const auto &physdev_extensions = stateless_instance->physical_device_extensions.at(physical_device);
+        auto stateless_instance = static_cast<Instance*>(dispatch_instance_->GetValidationObject(container_type));
+        const auto& physdev_extensions = stateless_instance->physical_device_extensions.at(physical_device);
         const bool is_required_ext_supported = IsExtEnabled(physdev_extensions.vk_khr_surface_protected_capabilities);
         const bool is_required_ext_enabled = IsExtEnabled(extensions.vk_khr_surface_protected_capabilities);
 
@@ -217,8 +217,8 @@ bool Device::ValidateSwapchainCreateInfo(const Context &context, const VkSwapcha
     return skip;
 }
 
-bool Device::manual_PreCallValidateReleaseSwapchainImagesKHR(VkDevice device, const VkReleaseSwapchainImagesInfoKHR *pReleaseInfo,
-                                                     const Context &context) const {
+bool Device::manual_PreCallValidateReleaseSwapchainImagesKHR(VkDevice device, const VkReleaseSwapchainImagesInfoKHR* pReleaseInfo,
+                                                             const Context& context) const {
     bool skip = false;
 
     if (!enabled_features.swapchainMaintenance1) {
@@ -229,27 +229,27 @@ bool Device::manual_PreCallValidateReleaseSwapchainImagesKHR(VkDevice device, co
     return skip;
 }
 
-bool Device::manual_PreCallValidateReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT *pReleaseInfo,
-                                                             const Context &context) const {
+bool Device::manual_PreCallValidateReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo,
+                                                             const Context& context) const {
     return manual_PreCallValidateReleaseSwapchainImagesKHR(device, pReleaseInfo, context);
 }
 
-bool Device::manual_PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchain,
-                                                      const Context &context) const {
+bool Device::manual_PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                                      const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
+                                                      const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     skip |= ValidateSwapchainCreateInfo(context, *pCreateInfo, error_obj.location.dot(Field::pCreateInfo));
     return skip;
 }
 
 bool Device::manual_PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
-                                                             const VkSwapchainCreateInfoKHR *pCreateInfos,
-                                                             const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchains,
-                                                             const Context &context) const {
+                                                             const VkSwapchainCreateInfoKHR* pCreateInfos,
+                                                             const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains,
+                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pCreateInfos) {
         for (uint32_t i = 0; i < swapchainCount; i++) {
             skip |= ValidateSwapchainCreateInfo(context, pCreateInfos[i], error_obj.location.dot(Field::pCreateInfos, i));
@@ -258,10 +258,10 @@ bool Device::manual_PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, ui
     return skip;
 }
 
-bool Device::manual_PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
-                                                   const Context &context) const {
+bool Device::manual_PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
+                                                   const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     ASSERT_AND_RETURN_SKIP(pPresentInfo);
 
     const Location present_info_loc = error_obj.location.dot(Field::pPresentInfo);
@@ -298,8 +298,8 @@ bool Device::manual_PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresen
 }
 
 bool Device::manual_PreCallValidateGetSwapchainTimeDomainPropertiesEXT(
-    VkDevice device, VkSwapchainKHR swapchain, VkSwapchainTimeDomainPropertiesEXT *pSwapchainTimeDomainProperties,
-    uint64_t *pTimeDomainsCounter, const Context &context) const {
+    VkDevice device, VkSwapchainKHR swapchain, VkSwapchainTimeDomainPropertiesEXT* pSwapchainTimeDomainProperties,
+    uint64_t* pTimeDomainsCounter, const Context& context) const {
     bool skip = false;
 
     const bool time_domains = pSwapchainTimeDomainProperties->pTimeDomains != nullptr;
@@ -310,7 +310,7 @@ bool Device::manual_PreCallValidateGetSwapchainTimeDomainPropertiesEXT(
                              "pTimeDomains and pTimeDomainIds are not null, but timeDomainCount is 0.");
         }
     } else if (time_domains || time_domain_ids) {
-        const char *msg = time_domains ? "pTimeDomains is not null, but pTimeDomainIds is null"
+        const char* msg = time_domains ? "pTimeDomains is not null, but pTimeDomainIds is null"
                                        : "pTimeDomainIds is not null, but pTimeDomains is null";
         skip |= LogError("VUID-VkSwapchainTimeDomainPropertiesEXT-pTimeDomains-12370", swapchain, context.error_obj.location, "%s",
                          msg);
@@ -320,11 +320,11 @@ bool Device::manual_PreCallValidateGetSwapchainTimeDomainPropertiesEXT(
 }
 
 bool Instance::manual_PreCallValidateCreateDisplayModeKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
-                                                          const VkDisplayModeCreateInfoKHR *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator, VkDisplayModeKHR *pMode,
-                                                          const Context &context) const {
+                                                          const VkDisplayModeCreateInfoKHR* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode,
+                                                          const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const VkDisplayModeParametersKHR display_mode_parameters = pCreateInfo->parameters;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -342,11 +342,11 @@ bool Instance::manual_PreCallValidateCreateDisplayModeKHR(VkPhysicalDevice physi
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                        uint32_t *pSurfaceFormatCount,
-                                                                        VkSurfaceFormatKHR *pSurfaceFormats,
-                                                                        const Context &context) const {
+                                                                        uint32_t* pSurfaceFormatCount,
+                                                                        VkSurfaceFormatKHR* pSurfaceFormats,
+                                                                        const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (surface == VK_NULL_HANDLE && !IsExtEnabled(extensions.vk_google_surfaceless_query)) {
         skip |=
             LogError("VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-surface-06524", physicalDevice,
@@ -356,11 +356,11 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(VkPhysic
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
-                                                                             uint32_t *pPresentModeCount,
-                                                                             VkPresentModeKHR *pPresentModes,
-                                                                             const Context &context) const {
+                                                                             uint32_t* pPresentModeCount,
+                                                                             VkPresentModeKHR* pPresentModes,
+                                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (surface == VK_NULL_HANDLE && !IsExtEnabled(extensions.vk_google_surfaceless_query)) {
         skip |=
             LogError("VUID-vkGetPhysicalDeviceSurfacePresentModesKHR-surface-06524", physicalDevice,
@@ -370,21 +370,21 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfacePresentModesKHR(VkP
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysicalDevice physicalDevice,
-                                                                              const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                              VkSurfaceCapabilities2KHR *pSurfaceCapabilities,
-                                                                              const Context &context) const {
+                                                                              const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                              VkSurfaceCapabilities2KHR* pSurfaceCapabilities,
+                                                                              const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pSurfaceInfo && pSurfaceInfo->surface == VK_NULL_HANDLE && !IsExtEnabled(extensions.vk_google_surfaceless_query)) {
         skip |= LogError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pSurfaceInfo-06521", physicalDevice,
                          error_obj.location.dot(Field::pSurfaceInfo).dot(Field::surface),
                          "is VK_NULL_HANDLE and VK_GOOGLE_surfaceless_query is not enabled.");
     }
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    const auto *capabilities_full_screen_exclusive =
+    const auto* capabilities_full_screen_exclusive =
         vku::FindStructInPNextChain<VkSurfaceCapabilitiesFullScreenExclusiveEXT>(pSurfaceCapabilities->pNext);
     if (capabilities_full_screen_exclusive) {
-        const auto *full_screen_exclusive_win32_info =
+        const auto* full_screen_exclusive_win32_info =
             vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveWin32InfoEXT>(pSurfaceInfo->pNext);
         if (!full_screen_exclusive_win32_info) {
             skip |= LogError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-02671", physicalDevice,
@@ -396,9 +396,9 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(Vk
     }
 #endif
 
-    const auto *surface_present_mode_compatibility =
+    const auto* surface_present_mode_compatibility =
         vku::FindStructInPNextChain<VkSurfacePresentModeCompatibilityKHR>(pSurfaceCapabilities->pNext);
-    const auto *surface_present_scaling_compatibilities =
+    const auto* surface_present_scaling_compatibilities =
         vku::FindStructInPNextChain<VkSurfacePresentScalingCapabilitiesKHR>(pSurfaceCapabilities->pNext);
 
     if (!(vku::FindStructInPNextChain<VkSurfacePresentModeKHR>(pSurfaceInfo->pNext))) {
@@ -440,12 +440,12 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(Vk
 }
 
 bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice,
-                                                                         const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                         uint32_t *pSurfaceFormatCount,
-                                                                         VkSurfaceFormat2KHR *pSurfaceFormats,
-                                                                         const Context &context) const {
+                                                                         const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                         uint32_t* pSurfaceFormatCount,
+                                                                         VkSurfaceFormat2KHR* pSurfaceFormats,
+                                                                         const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pSurfaceInfo && pSurfaceInfo->surface == VK_NULL_HANDLE && !IsExtEnabled(extensions.vk_google_surfaceless_query)) {
         skip |= LogError("VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceInfo-06521", physicalDevice,
                          error_obj.location.dot(Field::pSurfaceInfo).dot(Field::surface),
@@ -453,7 +453,7 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(VkPhysi
     }
     if (pSurfaceFormats) {
         if (vku::FindStructInPNextChain<VkImageCompressionPropertiesEXT>(pSurfaceFormats->pNext)) {
-            const auto &physdev_extensions = physical_device_extensions.at(physicalDevice);
+            const auto& physdev_extensions = physical_device_extensions.at(physicalDevice);
             if (!IsExtEnabled(physdev_extensions.vk_ext_image_compression_control_swapchain)) {
                 skip |= LogError("VUID-VkSurfaceFormat2KHR-pNext-06750", physicalDevice,
                                  error_obj.location.dot(Field::pSurfaceFormats).dot(Field::pNext),
@@ -467,12 +467,12 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(VkPhysi
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfacePresentModes2EXT(VkPhysicalDevice physicalDevice,
-                                                                              const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                              uint32_t *pPresentModeCount,
-                                                                              VkPresentModeKHR *pPresentModes,
-                                                                              const Context &context) const {
+                                                                              const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                              uint32_t* pPresentModeCount,
+                                                                              VkPresentModeKHR* pPresentModes,
+                                                                              const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pSurfaceInfo && pSurfaceInfo->surface == VK_NULL_HANDLE && !IsExtEnabled(extensions.vk_google_surfaceless_query)) {
         skip |= LogError("VUID-vkGetPhysicalDeviceSurfacePresentModes2EXT-pSurfaceInfo-06521", physicalDevice,
                          error_obj.location.dot(Field::pSurfaceInfo).dot(Field::surface),
@@ -481,11 +481,11 @@ bool Instance::manual_PreCallValidateGetPhysicalDeviceSurfacePresentModes2EXT(Vk
     return skip;
 }
 
-bool Instance::manual_PreCallValidateCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR *pCreateInfo,
-                                                           const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                           const Context &context) const {
+bool Instance::manual_PreCallValidateCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
+                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                           const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     if (pCreateInfo->hwnd == nullptr) {
         skip |= LogError("VUID-VkWin32SurfaceCreateInfoKHR-hwnd-01308", instance, error_obj.location, "pCreateInfo->hwnd is NULL.");
@@ -495,9 +495,9 @@ bool Instance::manual_PreCallValidateCreateWin32SurfaceKHR(VkInstance instance, 
 }
 
 bool Device::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(VkDevice device,
-                                                                  const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,
-                                                                  VkDeviceGroupPresentModeFlagsKHR *pModes,
-                                                                  const ErrorObject &error_obj) const {
+                                                                  const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
+                                                                  VkDeviceGroupPresentModeFlagsKHR* pModes,
+                                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     Context context(*this, error_obj, extensions);
     if (!IsExtEnabled(extensions.vk_khr_swapchain))
@@ -542,11 +542,11 @@ bool Device::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(VkDevice devic
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-bool Instance::manual_PreCallValidateCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                             const Context &context) const {
+bool Instance::manual_PreCallValidateCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const auto display = pCreateInfo->display;
     const auto surface = pCreateInfo->surface;
@@ -566,11 +566,11 @@ bool Instance::manual_PreCallValidateCreateWaylandSurfaceKHR(VkInstance instance
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-bool Instance::manual_PreCallValidateCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR *pCreateInfo,
-                                                         const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                         const Context &context) const {
+bool Instance::manual_PreCallValidateCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
+                                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                         const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const auto connection = pCreateInfo->connection;
     const auto window = pCreateInfo->window;
@@ -588,11 +588,11 @@ bool Instance::manual_PreCallValidateCreateXcbSurfaceKHR(VkInstance instance, co
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-bool Instance::manual_PreCallValidateCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR *pCreateInfo,
-                                                          const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                          const Context &context) const {
+bool Instance::manual_PreCallValidateCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
+                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                          const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
 
     const auto display = pCreateInfo->dpy;
     const auto window = pCreateInfo->window;
@@ -610,11 +610,11 @@ bool Instance::manual_PreCallValidateCreateXlibSurfaceKHR(VkInstance instance, c
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-bool Instance::manual_PreCallValidateCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR *pCreateInfo,
-                                                             const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
-                                                             const Context &context) const {
+bool Instance::manual_PreCallValidateCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
+                                                             const Context& context) const {
     bool skip = false;
-    const auto &error_obj = context.error_obj;
+    const auto& error_obj = context.error_obj;
     if (pCreateInfo->window == nullptr) {
         skip |= LogError("VUID-VkAndroidSurfaceCreateInfoKHR-window-01248", instance,
                          error_obj.location.dot(Field::pCreateInfo).dot(Field::window), "is NULL.");
@@ -642,15 +642,15 @@ bool Device::manual_PreCallValidateCreateDirectFBSurfaceEXT(VkInstance instance,
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 
 bool Device::manual_PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint32_t timestampCount,
-                                                              const VkCalibratedTimestampInfoKHR *pTimestampInfos,
-                                                              uint64_t *pTimestamps, uint64_t *pMaxDeviation,
-                                                              const Context &context) const {
+                                                              const VkCalibratedTimestampInfoKHR* pTimestampInfos,
+                                                              uint64_t* pTimestamps, uint64_t* pMaxDeviation,
+                                                              const Context& context) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < timestampCount; ++i) {
         if (pTimestampInfos[i].timeDomain == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT ||
             pTimestampInfos[i].timeDomain == VK_TIME_DOMAIN_SWAPCHAIN_LOCAL_EXT) {
-            const auto *swapchain_calibrated_timestamp_info =
+            const auto* swapchain_calibrated_timestamp_info =
                 vku::FindStructInPNextChain<VkSwapchainCalibratedTimestampInfoEXT>(pTimestampInfos[i].pNext);
             if (!swapchain_calibrated_timestamp_info) {
                 skip |= LogError("VUID-VkCalibratedTimestampInfoKHR-timeDomain-12227", device,
@@ -676,9 +676,9 @@ bool Device::manual_PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, u
 }
 
 bool Device::manual_PreCallValidateGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount,
-                                                              const VkCalibratedTimestampInfoKHR *pTimestampInfos,
-                                                              uint64_t *pTimestamps, uint64_t *pMaxDeviation,
-                                                              const Context &context) const {
+                                                              const VkCalibratedTimestampInfoKHR* pTimestampInfos,
+                                                              uint64_t* pTimestamps, uint64_t* pMaxDeviation,
+                                                              const Context& context) const {
     return manual_PreCallValidateGetCalibratedTimestampsKHR(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation,
                                                             context);
 }

--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -25,13 +25,13 @@
 
 namespace syncval {
 
-bool SimpleBinding(const vvl::Bindable &bindable) { return !bindable.sparse && bindable.Binding(); }
-VkDeviceSize ResourceBaseAddress(const vvl::Buffer &buffer) { return buffer.GetFakeBaseAddress(); }
+bool SimpleBinding(const vvl::Bindable& bindable) { return !bindable.sparse && bindable.Binding(); }
+VkDeviceSize ResourceBaseAddress(const vvl::Buffer& buffer) { return buffer.GetFakeBaseAddress(); }
 
 void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags,
-                             const std::vector<SubpassDependencyInfo> &subpass_dependency_infos, const AccessContext *contexts,
-                             const AccessContext &external_context) {
-    const SubpassDependencyInfo &info = subpass_dependency_infos[subpass];
+                             const std::vector<SubpassDependencyInfo>& subpass_dependency_infos, const AccessContext* contexts,
+                             const AccessContext& external_context) {
+    const SubpassDependencyInfo& info = subpass_dependency_infos[subpass];
     async_.reserve(info.async.size());
     for (const uint32_t async_subpass : info.async) {
         // Start tags are not known at creation time (as it's done at BeginRenderpass)
@@ -42,7 +42,7 @@ void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags,
     // To resolve contexts, we usually need regular subpass contexts and the external
     // src context, so the corresponding barriers are stored together.
     subpass_barriers_.resize(subpass + 1);
-    for (const auto &[src_subpass, subpass_dependencies] : info.dependencies) {
+    for (const auto& [src_subpass, subpass_dependencies] : info.dependencies) {
         subpass_barriers_[src_subpass] = SubpassBarrier(contexts[src_subpass], queue_flags, subpass_dependencies);
     }
     subpass_barriers_[subpass] = SubpassBarrier(external_context, queue_flags, info.barrier_from_external);
@@ -51,26 +51,26 @@ void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags,
     dst_external_ = SubpassBarrier(*this, queue_flags, info.barrier_to_external);
 }
 
-ApplySingleBufferBarrierFunctor::ApplySingleBufferBarrierFunctor(const AccessContext &access_context,
-                                                                 const BarrierScope &barrier_scope, const SyncBarrier &barrier)
+ApplySingleBufferBarrierFunctor::ApplySingleBufferBarrierFunctor(const AccessContext& access_context,
+                                                                 const BarrierScope& barrier_scope, const SyncBarrier& barrier)
     : access_context(access_context), barrier_scope(barrier_scope), barrier(barrier) {}
 
-AccessMap::iterator ApplySingleBufferBarrierFunctor::Infill(AccessMap *accesses, const Iterator &pos_hint,
-                                                            const AccessRange &range) const {
+AccessMap::iterator ApplySingleBufferBarrierFunctor::Infill(AccessMap* accesses, const Iterator& pos_hint,
+                                                            const AccessRange& range) const {
     // The buffer barrier does not need to fill the gaps because barrier
     // application to a range without accesses is a no-op.
     // Return the pos iterator unchanged to indicate that no entry was created.
     return pos_hint;
 }
 
-void ApplySingleBufferBarrierFunctor::operator()(const Iterator &pos) const {
-    AccessState &access_state = pos->second;
+void ApplySingleBufferBarrierFunctor::operator()(const Iterator& pos) const {
+    AccessState& access_state = pos->second;
     access_context.ApplyGlobalBarriers(access_state);
     access_state.ApplyBarrier(barrier_scope, barrier);
 }
 
-ApplySingleImageBarrierFunctor::ApplySingleImageBarrierFunctor(const AccessContext &access_context,
-                                                               const BarrierScope &barrier_scope, const SyncBarrier &barrier,
+ApplySingleImageBarrierFunctor::ApplySingleImageBarrierFunctor(const AccessContext& access_context,
+                                                               const BarrierScope& barrier_scope, const SyncBarrier& barrier,
                                                                bool layout_transition, uint32_t layout_transition_handle_index,
                                                                ResourceUsageTag exec_tag)
     : access_context(access_context),
@@ -87,8 +87,8 @@ ApplySingleImageBarrierFunctor::ApplySingleImageBarrierFunctor(const AccessConte
     }
 }
 
-AccessMap::iterator ApplySingleImageBarrierFunctor::Infill(AccessMap *accesses, const Iterator &pos_hint,
-                                                           const AccessRange &range) const {
+AccessMap::iterator ApplySingleImageBarrierFunctor::Infill(AccessMap* accesses, const Iterator& pos_hint,
+                                                           const AccessRange& range) const {
     if (!layout_transition) {
         // Do not create a new range if this is not a layout transition
         return pos_hint;
@@ -98,20 +98,20 @@ AccessMap::iterator ApplySingleImageBarrierFunctor::Infill(AccessMap *accesses, 
     return inserted;
 }
 
-void ApplySingleImageBarrierFunctor::operator()(const Iterator &pos) const {
-    AccessState &access_state = pos->second;
+void ApplySingleImageBarrierFunctor::operator()(const Iterator& pos) const {
+    AccessState& access_state = pos->second;
     access_context.ApplyGlobalBarriers(access_state);
     access_state.ApplyBarrier(barrier_scope, barrier, layout_transition, layout_transition_handle_index, exec_tag);
 }
 
-void CollectBarriersFunctor::operator()(const Iterator &pos) const {
-    AccessState &access_state = pos->second;
+void CollectBarriersFunctor::operator()(const Iterator& pos) const {
+    AccessState& access_state = pos->second;
     access_context.ApplyGlobalBarriers(access_state);
     access_state.CollectPendingBarriers(barrier_scope, barrier, layout_transition, layout_transition_handle_index,
                                         pending_barriers);
 }
 
-void AccessContext::InitFrom(const AccessContext &other) {
+void AccessContext::InitFrom(const AccessContext& other) {
     access_state_map_.Assign(other.access_state_map_);
 
     async_ = other.async_;
@@ -153,7 +153,7 @@ void AccessContext::Finalize() {
     finalized_ = true;
 }
 
-void AccessContext::RegisterGlobalBarrier(const SyncBarrier &barrier, QueueId queue_id) {
+void AccessContext::RegisterGlobalBarrier(const SyncBarrier& barrier, QueueId queue_id) {
     assert(global_barriers_.empty() || global_barriers_queue_ == queue_id);
 
     // Search for existing def
@@ -167,7 +167,7 @@ void AccessContext::RegisterGlobalBarrier(const SyncBarrier &barrier, QueueId qu
     if (def_index == global_barrier_def_count_) {
         // Flush global barriers if all def slots are in use
         if (global_barrier_def_count_ == kMaxGlobaBarrierDefCount) {
-            for (auto &[_, access] : access_state_map_) {
+            for (auto& [_, access] : access_state_map_) {
                 ApplyGlobalBarriers(access);
                 access.next_global_barrier_index = 0;  // to match state after reset
             }
@@ -175,13 +175,13 @@ void AccessContext::RegisterGlobalBarrier(const SyncBarrier &barrier, QueueId qu
             def_index = 0;
         }
 
-        GlobalBarrierDef &new_def = global_barrier_defs_[global_barrier_def_count_++];
+        GlobalBarrierDef& new_def = global_barrier_defs_[global_barrier_def_count_++];
         new_def.barrier = barrier;
         new_def.chain_mask = 0;
 
         // Update chain masks
         for (uint32_t i = 0; i < global_barrier_def_count_ - 1; i++) {
-            GlobalBarrierDef &def = global_barrier_defs_[i];
+            GlobalBarrierDef& def = global_barrier_defs_[i];
             if ((new_def.barrier.src_exec_scope.exec_scope & def.barrier.dst_exec_scope.exec_scope) != 0) {
                 new_def.chain_mask |= 1u << i;
             }
@@ -195,7 +195,7 @@ void AccessContext::RegisterGlobalBarrier(const SyncBarrier &barrier, QueueId qu
     global_barriers_queue_ = queue_id;
 }
 
-void AccessContext::ApplyGlobalBarriers(AccessState &access_state) const {
+void AccessContext::ApplyGlobalBarriers(AccessState& access_state) const {
     const uint32_t global_barrier_count = GetGlobalBarrierCount();
     assert(access_state.next_global_barrier_index <= global_barrier_count);
     if (access_state.next_global_barrier_index == global_barrier_count) {
@@ -210,7 +210,7 @@ void AccessContext::ApplyGlobalBarriers(AccessState &access_state) const {
         const uint32_t def_mask = 1u << def_index;
         assert(def_index < global_barrier_def_count_);
 
-        const GlobalBarrierDef &def = global_barrier_defs_[def_index];
+        const GlobalBarrierDef& def = global_barrier_defs_[def_index];
 
         // Skip barriers that were already applied
         if ((def_mask & applied_barrier_mask) != 0) {
@@ -250,20 +250,20 @@ void AccessContext::ResetGlobalBarriers() {
 
 void AccessContext::TrimAndClearFirstAccess() {
     assert(!finalized_);
-    for (auto &[range, access] : access_state_map_) {
+    for (auto& [range, access] : access_state_map_) {
         access.Normalize();
     }
     Consolidate(access_state_map_);
 }
 
-void AccessContext::AddReferencedTags(ResourceUsageTagSet &used) const {
+void AccessContext::AddReferencedTags(ResourceUsageTagSet& used) const {
     assert(!finalized_);
-    for (const auto &[range, access] : access_state_map_) {
+    for (const auto& [range, access] : access_state_map_) {
         access.GatherReferencedTags(used);
     }
 }
 
-const SubpassBarrier &AccessContext::GetSubpassBarrier(uint32_t src_subpass) const {
+const SubpassBarrier& AccessContext::GetSubpassBarrier(uint32_t src_subpass) const {
     if (src_subpass == VK_SUBPASS_EXTERNAL) {
         return subpass_barriers_.back();
     } else {
@@ -272,14 +272,14 @@ const SubpassBarrier &AccessContext::GetSubpassBarrier(uint32_t src_subpass) con
     }
 }
 
-void AccessContext::ResolveFromContext(const AccessContext &from) {
+void AccessContext::ResolveFromContext(const AccessContext& from) {
     assert(!finalized_);
-    auto noop_action = [](AccessState *access) {};
+    auto noop_action = [](AccessState* access) {};
     from.ResolveAccessRangeRecursePrev(kFullRange, noop_action, *this, false);
 }
 
-void AccessContext::ResolveFromSubpassContext(const ApplySubpassTransitionBarrierAction &subpass_transition_action,
-                                              const AccessContext &from_context,
+void AccessContext::ResolveFromSubpassContext(const ApplySubpassTransitionBarrierAction& subpass_transition_action,
+                                              const AccessContext& from_context,
                                               subresource_adapter::ImageRangeGenerator attachment_range_gen) {
     assert(!finalized_);
     for (; attachment_range_gen->non_empty(); ++attachment_range_gen) {
@@ -292,9 +292,9 @@ void AccessContext::ResolveAllSubpassDependencies() {
     ResolveSubpassDependencies(kFullRange, *this, true);
 }
 
-void AccessContext::ResolveSubpassDependencies(const AccessRange &range, AccessContext &resolve_context, bool infill,
-                                               const AccessStateFunction *previous_barrier_action) const {
-    for (const SubpassBarrier &subpass_barrier : subpass_barriers_) {
+void AccessContext::ResolveSubpassDependencies(const AccessRange& range, AccessContext& resolve_context, bool infill,
+                                               const AccessStateFunction* previous_barrier_action) const {
+    for (const SubpassBarrier& subpass_barrier : subpass_barriers_) {
         if (subpass_barrier.src_subpass_context) {
             const ApplySubpassBarrierAction barrier_action(subpass_barrier, previous_barrier_action);
             subpass_barrier.src_subpass_context->ResolveAccessRangeRecursePrev(range, barrier_action, resolve_context, infill);
@@ -302,18 +302,18 @@ void AccessContext::ResolveSubpassDependencies(const AccessRange &range, AccessC
     }
 }
 
-void AccessContext::ResolveAccessRange(const AccessRange &range, const AccessStateFunction &barrier_action,
-                                       AccessContext &resolve_context) const {
+void AccessContext::ResolveAccessRange(const AccessRange& range, const AccessStateFunction& barrier_action,
+                                       AccessContext& resolve_context) const {
     if (!range.non_empty()) {
         return;
     }
-    AccessMap &resolve_map = resolve_context.access_state_map_;
+    AccessMap& resolve_map = resolve_context.access_state_map_;
 
     ParallelIterator current(resolve_map, access_state_map_, range.begin);
     while (current.range.non_empty() && range.includes(current.range.begin)) {
         const auto current_range = current.range & range;
         if (current.pos_B.inside_lower_bound_range) {
-            const auto &src_pos = current.pos_B.lower_bound;
+            const auto& src_pos = current.pos_B.lower_bound;
 
             // Create a copy of the source access state (source is this context, destination is the resolve context).
             // Then do the following steps:
@@ -327,7 +327,7 @@ void AccessContext::ResolveAccessRange(const AccessRange &range, const AccessSta
 
             if (current.pos_A.inside_lower_bound_range) {
                 const auto trimmed = Split(current.pos_A.lower_bound, resolve_map, current_range);
-                AccessState &dst_state = trimmed->second;
+                AccessState& dst_state = trimmed->second;
                 resolve_context.ApplyGlobalBarriers(dst_state);
                 dst_state.Resolve(src_access);
                 current.OnCurrentRangeModified(trimmed);
@@ -342,18 +342,18 @@ void AccessContext::ResolveAccessRange(const AccessRange &range, const AccessSta
     }
 }
 
-void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange &range, const AccessStateFunction &barrier_action,
-                                                  AccessContext &resolve_context, bool infill) const {
+void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange& range, const AccessStateFunction& barrier_action,
+                                                  AccessContext& resolve_context, bool infill) const {
     if (!range.non_empty()) {
         return;
     }
-    AccessMap &resolve_map = resolve_context.access_state_map_;
+    AccessMap& resolve_map = resolve_context.access_state_map_;
 
     ParallelIterator current(resolve_map, access_state_map_, range.begin);
     while (current.range.non_empty() && range.includes(current.range.begin)) {
         const auto current_range = current.range & range;
         if (current.pos_B.inside_lower_bound_range) {
-            const auto &src_pos = current.pos_B.lower_bound;
+            const auto& src_pos = current.pos_B.lower_bound;
 
             // Create a copy of the source access state (source is this context, destination is the resolve context).
             // Then do the following steps:
@@ -367,7 +367,7 @@ void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange &range, cons
 
             if (current.pos_A.inside_lower_bound_range) {
                 const auto trimmed = Split(current.pos_A.lower_bound, resolve_map, current_range);
-                AccessState &dst_state = trimmed->second;
+                AccessState& dst_state = trimmed->second;
                 resolve_context.ApplyGlobalBarriers(dst_state);
                 dst_state.Resolve(src_access);
                 current.OnCurrentRangeModified(trimmed);
@@ -413,8 +413,8 @@ void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange &range, cons
     }
 }
 
-void AccessContext::ResolveGapsRecursePrev(const AccessRange &range, AccessContext &descent_context, bool infill,
-                                           const AccessStateFunction &previous_barrier_action) const {
+void AccessContext::ResolveGapsRecursePrev(const AccessRange& range, AccessContext& descent_context, bool infill,
+                                           const AccessStateFunction& previous_barrier_action) const {
     assert(range.non_empty());
     if (!subpass_barriers_.empty()) {
         ResolveSubpassDependencies(range, descent_context, infill, &previous_barrier_action);
@@ -432,7 +432,7 @@ void AccessContext::ResolveGapsRecursePrev(const AccessRange &range, AccessConte
     }
 }
 
-AccessMap::iterator AccessContext::ResolveGapRecursePrev(const AccessRange &gap_range, AccessMap::iterator pos_hint) {
+AccessMap::iterator AccessContext::ResolveGapRecursePrev(const AccessRange& gap_range, AccessMap::iterator pos_hint) {
     assert(gap_range.non_empty());
     if (!subpass_barriers_.empty()) {
         ResolveSubpassDependencies(gap_range, *this, true);
@@ -451,11 +451,11 @@ AccessMap::iterator AccessContext::ResolveGapRecursePrev(const AccessRange &gap_
 // This inserts new accesses for empty regions and updates existing accesses.
 // The passed pos must either be a lower bound (can be the end iterator) or be strictly less than the range.
 // Map entries that intersect range.begin or range.end are split at the intersection point.
-AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, const AccessRange &range,
-                                                       SyncAccessIndex access_index, const AttachmentAccess &attachment_access,
+AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, const AccessRange& range,
+                                                       SyncAccessIndex access_index, const AttachmentAccess& attachment_access,
                                                        ResourceUsageTagEx tag_ex, SyncFlags flags) {
     assert(range.non_empty());
-    const SyncAccessInfo &access_info = GetAccessInfo(access_index);
+    const SyncAccessInfo& access_info = GetAccessInfo(access_index);
 
     const auto end = access_state_map_.end();
     assert(pos == access_state_map_.LowerBound(range.begin) || pos->first.strictly_less(range));
@@ -488,7 +488,7 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
             AccessMap::iterator infilled_it = ResolveGapRecursePrev(gap_range, pos);
 
             // Update
-            AccessState &new_access_state = infilled_it->second;
+            AccessState& new_access_state = infilled_it->second;
             ApplyGlobalBarriers(new_access_state);
             new_access_state.Update(access_info, attachment_access, tag_ex, flags);
 
@@ -505,7 +505,7 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
             }
 
             // Update
-            AccessState &access_state = pos->second;
+            AccessState& access_state = pos->second;
             ApplyGlobalBarriers(access_state);
             access_state.Update(access_info, attachment_access, tag_ex, flags);
 
@@ -521,14 +521,14 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
         AccessMap::iterator infilled_it = ResolveGapRecursePrev(gap_range, pos);
 
         // Update
-        AccessState &new_access_state = infilled_it->second;
+        AccessState& new_access_state = infilled_it->second;
         ApplyGlobalBarriers(new_access_state);
         new_access_state.Update(access_info, attachment_access, tag_ex, flags);
     }
     return pos;
 }
 
-void AccessContext::UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex current_usage, const AccessRange &range,
+void AccessContext::UpdateAccessState(const vvl::Buffer& buffer, SyncAccessIndex current_usage, const AccessRange& range,
                                       ResourceUsageTagEx tag_ex, SyncFlags flags) {
     assert(range.valid());
     assert(!finalized_);
@@ -550,7 +550,7 @@ void AccessContext::UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex
     DoUpdateAccessState(pos, buffer_range, current_usage, AttachmentAccess::NonAttachment(), tag_ex, flags);
 }
 
-void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex,
+void AccessContext::UpdateAccessState(ImageRangeGen& range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex,
                                       SyncFlags flags) {
     assert(!finalized_);
     if (current_usage == SYNC_ACCESS_INDEX_NONE) {
@@ -562,8 +562,8 @@ void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex 
     }
 }
 
-void AccessContext::UpdateAttachmentAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage,
-                                                const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex) {
+void AccessContext::UpdateAttachmentAccessState(ImageRangeGen& range_gen, SyncAccessIndex current_usage,
+                                                const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex) {
     assert(!finalized_);
     if (current_usage == SYNC_ACCESS_INDEX_NONE) {
         return;
@@ -574,8 +574,8 @@ void AccessContext::UpdateAttachmentAccessState(ImageRangeGen &range_gen, SyncAc
     }
 }
 
-void AccessContext::UpdateAttachmentAccessState(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
-                                                SyncAccessIndex current_usage, const AttachmentAccess &attachment_access,
+void AccessContext::UpdateAttachmentAccessState(const AttachmentViewGen& view_gen, AttachmentViewGen::Gen gen_type,
+                                                SyncAccessIndex current_usage, const AttachmentAccess& attachment_access,
                                                 ResourceUsageTagEx tag_ex, uint32_t view_mask) {
     if (view_mask == 0) {
         ImageRangeGen range_gen = view_gen.GetRangeGen(gen_type);
@@ -596,26 +596,26 @@ void AccessContext::UpdateAttachmentAccessState(const AttachmentViewGen &view_ge
 void AccessContext::ResolveChildContexts(vvl::span<AccessContext> subpass_contexts) {
     assert(!finalized_);
 
-    for (AccessContext &context : subpass_contexts) {
+    for (AccessContext& context : subpass_contexts) {
         ApplySubpassBarrierAction barrier_action(context.GetDstExternalSubpassBarrier());
         context.ResolveAccessRange(kFullRange, barrier_action, *this);
     }
 }
 
 // Caller must ensure that lifespan of this is less than the lifespan of from
-void AccessContext::ImportAsyncContexts(const AccessContext &from) {
+void AccessContext::ImportAsyncContexts(const AccessContext& from) {
     async_.insert(async_.end(), from.async_.begin(), from.async_.end());
 }
 
-void AccessContext::AddAsyncContext(const AccessContext *context, ResourceUsageTag tag, QueueId queue_id) {
+void AccessContext::AddAsyncContext(const AccessContext* context, ResourceUsageTag tag, QueueId queue_id) {
     if (context) {
         async_.emplace_back(*context, tag, queue_id);
     }
 }
 
-void SortedFirstAccesses::Init(const AccessMap &finalized_access_map) {
-    for (const auto &entry : finalized_access_map) {
-        const AccessState &access = entry.second;
+void SortedFirstAccesses::Init(const AccessMap& finalized_access_map) {
+    for (const auto& entry : finalized_access_map) {
+        const AccessState& access = entry.second;
         const ResourceUsageRange range = access.GetFirstAccessRange();
         if (range.empty()) {
             continue;
@@ -628,9 +628,9 @@ void SortedFirstAccesses::Init(const AccessMap &finalized_access_map) {
         }
     }
     std::sort(sorted_single_tags.begin(), sorted_single_tags.end(),
-              [](const SingleTag &a, const SingleTag &b) { return a.tag < b.tag; });
+              [](const SingleTag& a, const SingleTag& b) { return a.tag < b.tag; });
     std::sort(sorted_multi_tags.begin(), sorted_multi_tags.end(),
-              [](const auto &a, const auto &b) { return a.range.begin < b.range.begin; });
+              [](const auto& a, const auto& b) { return a.range.begin < b.range.begin; });
 }
 
 void SortedFirstAccesses::Clear() {
@@ -640,15 +640,15 @@ void SortedFirstAccesses::Clear() {
 
 std::vector<SortedFirstAccesses::SingleTag>::const_iterator SortedFirstAccesses::SingleTagRange::begin() {
     return std::lower_bound(sorted_single_tags.begin(), sorted_single_tags.end(), tag_range.begin,
-                            [](const SingleTag &single_tag, ResourceUsageTag tag) { return single_tag.tag < tag; });
+                            [](const SingleTag& single_tag, ResourceUsageTag tag) { return single_tag.tag < tag; });
 }
 
 std::vector<SortedFirstAccesses::SingleTag>::const_iterator SortedFirstAccesses::SingleTagRange::end() {
     return std::lower_bound(sorted_single_tags.begin(), sorted_single_tags.end(), tag_range.end,
-                            [](const SingleTag &single_tag, ResourceUsageTag tag) { return single_tag.tag < tag; });
+                            [](const SingleTag& single_tag, ResourceUsageTag tag) { return single_tag.tag < tag; });
 }
 
-SortedFirstAccesses::SingleTagRange SortedFirstAccesses::IterateSingleTagFirstAccesses(const ResourceUsageRange &tag_range) const {
+SortedFirstAccesses::SingleTagRange SortedFirstAccesses::IterateSingleTagFirstAccesses(const ResourceUsageRange& tag_range) const {
     return SingleTagRange{this->sorted_single_tags, tag_range};
 }
 
@@ -658,10 +658,10 @@ std::vector<SortedFirstAccesses::MultiTag>::const_iterator SortedFirstAccesses::
 
 std::vector<SortedFirstAccesses::MultiTag>::const_iterator SortedFirstAccesses::MultiTagRange::end() {
     return std::lower_bound(sorted_multi_tags.begin(), sorted_multi_tags.end(), tag_range.end,
-                            [](const MultiTag &multi_tag, ResourceUsageTag tag) { return multi_tag.range.begin < tag; });
+                            [](const MultiTag& multi_tag, ResourceUsageTag tag) { return multi_tag.range.begin < tag; });
 }
 
-SortedFirstAccesses::MultiTagRange SortedFirstAccesses::IterateMultiTagFirstAccesses(const ResourceUsageRange &tag_range) const {
+SortedFirstAccesses::MultiTagRange SortedFirstAccesses::IterateMultiTagFirstAccesses(const ResourceUsageRange& tag_range) const {
     return MultiTagRange{this->sorted_multi_tags, tag_range};
 }
 
@@ -669,7 +669,7 @@ SortedFirstAccesses::MultiTagRange SortedFirstAccesses::IterateMultiTagFirstAcce
 // unsynchronized tag for the Queue being tested against (max synchrononous + 1, perhaps)
 ResourceUsageTag AccessContext::AsyncReference::StartTag() const { return (tag_ == kInvalidTag) ? context_->StartTag() : tag_; }
 
-AttachmentViewGen::AttachmentViewGen(const vvl::ImageView *image_view, const VkOffset3D &offset, const VkExtent3D &extent)
+AttachmentViewGen::AttachmentViewGen(const vvl::ImageView* image_view, const VkOffset3D& offset, const VkExtent3D& extent)
     : view_(image_view) {
     gen_store_[Gen::kViewSubresource].emplace(MakeImageRangeGen(*image_view));
 
@@ -740,11 +740,11 @@ AttachmentViewGen::Gen AttachmentViewGen::GetDepthStencilRenderAreaGenType(bool 
     return kRenderArea;
 }
 
-SubpassBarrier::SubpassBarrier(const AccessContext &src_subpass_context, VkQueueFlags queue_flags,
-                               const std::vector<const VkSubpassDependency2 *> &subpass_dependencies)
+SubpassBarrier::SubpassBarrier(const AccessContext& src_subpass_context, VkQueueFlags queue_flags,
+                               const std::vector<const VkSubpassDependency2*>& subpass_dependencies)
     : src_subpass_context(&src_subpass_context) {
     barriers.reserve(subpass_dependencies.size());
-    for (const VkSubpassDependency2 *dependency : subpass_dependencies) {
+    for (const VkSubpassDependency2* dependency : subpass_dependencies) {
         barriers.emplace_back(queue_flags, *dependency);
     }
 }

--- a/layers/sync/sync_access_map.cpp
+++ b/layers/sync/sync_access_map.cpp
@@ -19,7 +19,7 @@
 
 namespace syncval {
 
-void AccessMap::Assign(const AccessMap &other) {
+void AccessMap::Assign(const AccessMap& other) {
     auto temp_copy(other.impl_map_);
     impl_map_.swap(temp_copy);
 }
@@ -34,7 +34,7 @@ AccessMap::const_iterator AccessMap::LowerBound(ResourceAddress range_begin) con
     return it;
 }
 
-AccessMap::iterator AccessMap::Erase(const iterator &pos) {
+AccessMap::iterator AccessMap::Erase(const iterator& pos) {
     assert(pos != end());
     return impl_map_.erase(pos);
 }
@@ -47,7 +47,7 @@ void AccessMap::Erase(iterator first, iterator last) {
     }
 }
 
-AccessMap::iterator AccessMap::Insert(const_iterator hint, const AccessRange &range, const AccessState &access_state) {
+AccessMap::iterator AccessMap::Insert(const_iterator hint, const AccessRange& range, const AccessState& access_state) {
     assert(range.non_empty());
     bool hint_open;
     const_iterator impl_next = hint;
@@ -75,7 +75,7 @@ AccessMap::iterator AccessMap::Insert(const_iterator hint, const AccessRange &ra
     return iterator(impl_insert);
 }
 
-std::pair<AccessMap::iterator, bool> AccessMap::Insert(const AccessRange &range, const AccessState &access_state) {
+std::pair<AccessMap::iterator, bool> AccessMap::Insert(const AccessRange& range, const AccessState& access_state) {
     assert(range.non_empty());
 
     // Look for range conflicts (and an insertion point, which makes the lower_bound *not* wasted work)
@@ -89,14 +89,14 @@ std::pair<AccessMap::iterator, bool> AccessMap::Insert(const AccessRange &range,
     return {lower, false};
 }
 
-AccessMap::iterator AccessMap::InfillGap(const_iterator range_lower_bound, const AccessRange &range,
-                                         const AccessState &access_state) {
+AccessMap::iterator AccessMap::InfillGap(const_iterator range_lower_bound, const AccessRange& range,
+                                         const AccessState& access_state) {
     assert(LowerBound(range.begin) == range_lower_bound);
     assert(range_lower_bound == end() || range.strictly_less(range_lower_bound->first));
     return impl_map_.insert(range_lower_bound, {range, access_state});
 }
 
-void AccessMap::InfillGaps(const AccessRange &range, const AccessState &access_state) {
+void AccessMap::InfillGaps(const AccessRange& range, const AccessState& access_state) {
     AccessMapLocator pos(*this, range.begin);
     while (range.includes(pos.index)) {
         if (!pos.inside_lower_bound_range) {
@@ -115,7 +115,7 @@ void AccessMap::InfillGaps(const AccessRange &range, const AccessState &access_s
     }
 }
 
-AccessMap::iterator AccessMap::Split(const iterator split_it, const index_type &index) {
+AccessMap::iterator AccessMap::Split(const iterator split_it, const index_type& index) {
     const auto range = split_it->first;
 
     if (!range.includes(index)) {
@@ -149,7 +149,7 @@ AccessMap::iterator AccessMap::Split(const iterator split_it, const index_type &
     return next_it;
 }
 
-AccessMap::iterator Split(AccessMap::iterator in, AccessMap &map, const AccessRange &range) {
+AccessMap::iterator Split(AccessMap::iterator in, AccessMap& map, const AccessRange& range) {
     assert(in != map.end());  // Not designed for use with invalid iterators...
     const AccessRange in_range = in->first;
     const AccessRange split_range = in_range & range;
@@ -168,14 +168,14 @@ AccessMap::iterator Split(AccessMap::iterator in, AccessMap &map, const AccessRa
     return pos;
 }
 
-void Consolidate(AccessMap &map) {
+void Consolidate(AccessMap& map) {
     using It = AccessMap::iterator;
 
     It current = map.begin();
     const It map_end = map.end();
 
     // To be included in a merge range there must be no gap in the AccessRange space, and the mapped_type values must match
-    auto can_merge = [](const It &last, const It &cur) {
+    auto can_merge = [](const It& last, const It& cur) {
         return cur->first.begin == last->first.end && cur->second == last->second;
     };
 
@@ -208,13 +208,13 @@ void Consolidate(AccessMap &map) {
 }
 
 template <typename TAccessMap>
-TAccessMapLocator<TAccessMap>::TAccessMapLocator(TAccessMap &map, index_type index) : map_(&map), index(index) {
+TAccessMapLocator<TAccessMap>::TAccessMapLocator(TAccessMap& map, index_type index) : map_(&map), index(index) {
     lower_bound = LowerBoundForIndex(index);
     inside_lower_bound_range = InsideLowerBoundRange();
 }
 
 template <typename TAccessMap>
-TAccessMapLocator<TAccessMap>::TAccessMapLocator(TAccessMap &map, index_type index, const iterator &index_lower_bound)
+TAccessMapLocator<TAccessMap>::TAccessMapLocator(TAccessMap& map, index_type index, const iterator& index_lower_bound)
     : map_(&map), index(index), lower_bound(index_lower_bound) {
     assert(LowerBoundForIndex(index) == index_lower_bound);
     inside_lower_bound_range = InsideLowerBoundRange();
@@ -232,7 +232,7 @@ void TAccessMapLocator<TAccessMap>::Seek(index_type seek_to) {
 
 template <typename TAccessMap>
 bool TAccessMapLocator<TAccessMap>::TrySeekLocal(index_type seek_to) {
-    auto is_lower_than = [this](AccessMap::index_type index, const auto &it) { return it == map_->end() || index < it->first.end; };
+    auto is_lower_than = [this](AccessMap::index_type index, const auto& it) { return it == map_->end() || index < it->first.end; };
 
     // Already here
     if (index == seek_to) {
@@ -274,7 +274,7 @@ AccessMap::index_type TAccessMapLocator<TAccessMap>::DistanceToEdge() const {
 template class TAccessMapLocator<AccessMap>;
 template class TAccessMapLocator<const AccessMap>;
 
-void ParallelIterator::OnCurrentRangeModified(const iterator &new_lower_bound) {
+void ParallelIterator::OnCurrentRangeModified(const iterator& new_lower_bound) {
     // Only map A can be modified, map B is constant
     pos_A = AccessMapLocator(map_A_, range.begin, new_lower_bound);
     range.end = range.begin + ComputeDelta();

--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -29,17 +29,17 @@ static const std::array<OrderingBarrier, static_cast<size_t>(SyncOrdering::kNumO
      {kDepthStencilAttachmentExecScope, kDepthStencilAttachmentAccessScope},
      {kRasterAttachmentExecScope, kRasterAttachmentAccessScope}}};
 
-const OrderingBarrier &GetOrderingRules(SyncOrdering ordering_enum) { return kOrderingRules[static_cast<size_t>(ordering_enum)]; }
+const OrderingBarrier& GetOrderingRules(SyncOrdering ordering_enum) { return kOrderingRules[static_cast<size_t>(ordering_enum)]; }
 
 static ThreadSafeLookupTable<OrderingBarrier> layout_ordering_barrier_lookup;
-ThreadSafeLookupTable<OrderingBarrier> &GetLayoutOrderingBarrierLookup() { return layout_ordering_barrier_lookup; }
+ThreadSafeLookupTable<OrderingBarrier>& GetLayoutOrderingBarrierLookup() { return layout_ordering_barrier_lookup; }
 
-bool AttachmentAccess::operator==(const AttachmentAccess &other) const {
+bool AttachmentAccess::operator==(const AttachmentAccess& other) const {
     return type == other.type && ordering == other.ordering && render_pass_instance_id == other.render_pass_instance_id &&
            subpass == other.subpass;
 }
 
-bool OrderingBarrier::operator==(const OrderingBarrier &rhs) const {
+bool OrderingBarrier::operator==(const OrderingBarrier& rhs) const {
     return exec_scope == rhs.exec_scope && access_scope == rhs.access_scope;
 }
 
@@ -50,8 +50,8 @@ size_t OrderingBarrier::Hash() const {
     return hc.Value();
 }
 
-HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info) const {
-    const auto &usage_stage = usage_info.stage_mask;
+HazardResult AccessState::DetectHazard(const SyncAccessInfo& usage_info) const {
+    const auto& usage_stage = usage_info.stage_mask;
     if (IsRead(usage_info.access_index)) {
         if (IsRAWHazard(usage_info)) {
             return HazardResult::HazardVsPriorWrite(this, usage_info, READ_AFTER_WRITE, *last_write);
@@ -67,7 +67,7 @@ HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info) const {
         //
         // Look for casus belli for WAR
         if (HasReads()) {
-            for (const auto &read_access : GetReads()) {
+            for (const auto& read_access : GetReads()) {
                 if (IsReadHazard(usage_stage, read_access)) {
                     return HazardResult::HazardVsPriorRead(this, usage_info, WRITE_AFTER_READ, read_access);
                 }
@@ -88,12 +88,12 @@ HazardResult AccessState::DetectMarkerHazard() const {
     }
 
     // Go back to regular hazard detection
-    const SyncAccessInfo &marker_access_info = GetAccessInfo(SYNC_COPY_TRANSFER_WRITE);
+    const SyncAccessInfo& marker_access_info = GetAccessInfo(SYNC_COPY_TRANSFER_WRITE);
     return DetectHazard(marker_access_info);
 }
 
-HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const OrderingBarrier &ordering,
-                                       const AttachmentAccess &attachment_access, SyncFlags flags, QueueId queue_id,
+HazardResult AccessState::DetectHazard(const SyncAccessInfo& usage_info, const OrderingBarrier& ordering,
+                                       const AttachmentAccess& attachment_access, SyncFlags flags, QueueId queue_id,
                                        bool detect_load_op_after_store_op_hazards) const {
     const VkPipelineStageFlagBits2 access_stage = usage_info.stage_mask;
     const SyncAccessIndex access_index = usage_info.access_index;
@@ -161,7 +161,7 @@ HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const O
         }
         // If we're tracking any reads that aren't ordered against the current write, got to check 'em all.
         if ((ordered_stages & last_read_stages) != last_read_stages) {
-            for (const auto &read_access : GetReads()) {
+            for (const auto& read_access : GetReads()) {
                 if (read_access.stage & ordered_stages) continue;  // but we can skip the ordered ones
                 if (IsReadHazard(access_stage, read_access)) {
                     return HazardResult::HazardVsPriorRead(this, usage_info, WRITE_AFTER_READ, read_access);
@@ -199,10 +199,10 @@ HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const O
     return {};
 }
 
-HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId queue_id, const ResourceUsageRange &tag_range,
+HazardResult AccessState::DetectHazard(const AccessState& recorded_use, QueueId queue_id, const ResourceUsageRange& tag_range,
                                        bool detect_load_op_after_store_op_hazards) const {
     HazardResult hazard;
-    const auto &recorded_accesses = recorded_use.first_accesses_;
+    const auto& recorded_accesses = recorded_use.first_accesses_;
     uint32_t count = recorded_accesses.size();
     if (count) {
         // First access is only closed if the last is a write
@@ -213,7 +213,7 @@ HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId 
         }
 
         for (uint32_t i = 0; i < count; ++i) {
-            const auto &first = recorded_accesses[i];
+            const auto& first = recorded_accesses[i];
             // Skip and quit logic
             if (first.tag < tag_range.begin) continue;
             if (first.tag >= tag_range.end) {
@@ -221,7 +221,7 @@ HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId 
                 break;
             }
 
-            const auto &first_ordering = GetOrderingRules(first.attachment_access.ordering);
+            const auto& first_ordering = GetOrderingRules(first.attachment_access.ordering);
             hazard = DetectHazard(*first.usage_info, first_ordering, first.attachment_access, first.flags, queue_id,
                                   detect_load_op_after_store_op_hazards);
             if (hazard.IsHazard()) {
@@ -232,14 +232,14 @@ HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId 
 
         if (do_write_last) {
             // Writes are a bit special... both for the "most recent" access logic, and layout transition specific logic
-            const auto &last_access = recorded_accesses.back();
+            const auto& last_access = recorded_accesses.back();
             if (tag_range.includes(last_access.tag)) {
                 OrderingBarrier barrier = GetOrderingRules(last_access.attachment_access.ordering);
                 if (last_access.usage_info->access_index == SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION) {
                     // Or in the layout first access scope as a barrier... IFF the usage is an ILT
                     // this was saved off in the "apply barriers" logic to simplify ILT access checks as they straddle
                     // the barrier that applies them
-                    const auto &layout_ordering_lookup = GetLayoutOrderingBarrierLookup();
+                    const auto& layout_ordering_lookup = GetLayoutOrderingBarrierLookup();
                     const OrderingBarrier layout_ordering =
                         layout_ordering_lookup.GetObject(recorded_use.first_write_layout_ordering_index);
 
@@ -270,7 +270,7 @@ HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId 
 }
 
 // Asynchronous Hazards occur between subpasses with no connection through the DAG
-HazardResult AccessState::DetectAsyncHazard(const SyncAccessInfo &usage_info, const ResourceUsageTag start_tag,
+HazardResult AccessState::DetectAsyncHazard(const SyncAccessInfo& usage_info, const ResourceUsageTag start_tag,
                                             QueueId queue_id) const {
     // Async checks need to not go back further than the start of the subpass, as we only want to find hazards between the async
     // subpasses.  Anything older than that should have been checked at the start of each subpass, taking into account all of
@@ -284,7 +284,7 @@ HazardResult AccessState::DetectAsyncHazard(const SyncAccessInfo &usage_info, co
             return HazardResult::HazardVsPriorWrite(this, usage_info, WRITE_RACING_WRITE, *last_write);
         } else if (HasReads()) {
             // Any reads during the other subpass will conflict with this write, so we need to check them all.
-            for (const auto &read_access : GetReads()) {
+            for (const auto& read_access : GetReads()) {
                 if (read_access.queue == queue_id && read_access.tag >= start_tag) {
                     return HazardResult::HazardVsPriorRead(this, usage_info, WRITE_RACING_READ, read_access);
                 }
@@ -294,9 +294,9 @@ HazardResult AccessState::DetectAsyncHazard(const SyncAccessInfo &usage_info, co
     return {};
 }
 
-HazardResult AccessState::DetectAsyncHazard(const AccessState &recorded_use, const ResourceUsageRange &tag_range,
+HazardResult AccessState::DetectAsyncHazard(const AccessState& recorded_use, const ResourceUsageRange& tag_range,
                                             ResourceUsageTag start_tag, QueueId queue_id) const {
-    for (const auto &first : recorded_use.first_accesses_) {
+    for (const auto& first : recorded_use.first_accesses_) {
         // Skip and quit logic
         if (first.tag < tag_range.begin) continue;
         if (first.tag >= tag_range.end) break;
@@ -310,8 +310,8 @@ HazardResult AccessState::DetectAsyncHazard(const AccessState &recorded_use, con
     return {};
 }
 
-HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo &usage_info, QueueId queue_id,
-                                              VkPipelineStageFlags2 src_exec_scope, const SyncAccessFlags &src_access_scope) const {
+HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo& usage_info, QueueId queue_id,
+                                              VkPipelineStageFlags2 src_exec_scope, const SyncAccessFlags& src_access_scope) const {
     // Only supporting image layout transitions for now
     assert(usage_info.access_index == SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
 
@@ -319,7 +319,7 @@ HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo &usage_info, 
     // See DetectHazard(SyncStagetAccessIndex) above for more details.
     if (HasReads()) {
         // Look at the reads if any
-        for (const auto &read_access : GetReads()) {
+        for (const auto& read_access : GetReads()) {
             if (read_access.IsReadBarrierHazard(queue_id, src_exec_scope, src_access_scope)) {
                 return HazardResult::HazardVsPriorRead(this, usage_info, WRITE_AFTER_READ, read_access);
             }
@@ -330,8 +330,8 @@ HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo &usage_info, 
     return {};
 }
 
-HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo &usage_info, const AccessState &scope_state,
-                                              VkPipelineStageFlags2 src_exec_scope, const SyncAccessFlags &src_access_scope,
+HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo& usage_info, const AccessState& scope_state,
+                                              VkPipelineStageFlags2 src_exec_scope, const SyncAccessFlags& src_access_scope,
                                               QueueId event_queue, ResourceUsageTag event_tag) const {
     // Only supporting image layout transitions for now
     assert(usage_info.access_index == SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
@@ -351,8 +351,8 @@ HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo &usage_info, 
             //  * The stage order is the same.
             assert(last_read_count >= scope_read_count);
             for (uint32_t read_idx = 0; read_idx < scope_read_count; ++read_idx) {
-                const ReadState &scope_read = scope_state.last_reads[read_idx];
-                const ReadState &current_read = last_reads[read_idx];
+                const ReadState& scope_read = scope_state.last_reads[read_idx];
+                const ReadState& current_read = last_reads[read_idx];
                 assert(scope_read.stage == current_read.stage);
                 if (current_read.tag > event_tag) {
                     // The read is more recent than the set event scope, thus no barrier from the wait/ILT.
@@ -368,7 +368,7 @@ HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo &usage_info, 
                 }
             }
             if (last_read_count > scope_read_count) {
-                const ReadState &current_read = last_reads[scope_read_count];
+                const ReadState& current_read = last_reads[scope_read_count];
                 return HazardResult::HazardVsPriorRead(this, usage_info, WRITE_AFTER_READ, current_read);
             }
         } else if (last_write.has_value()) {
@@ -383,7 +383,7 @@ HazardResult AccessState::DetectBarrierHazard(const SyncAccessInfo &usage_info, 
     return {};
 }
 
-void AccessState::AddRead(const ReadState &read) {
+void AccessState::AddRead(const ReadState& read) {
     if (last_read_count == 0) {
         single_last_read = read;
         last_reads = &single_last_read;
@@ -400,18 +400,18 @@ void AccessState::AddRead(const ReadState &read) {
     }
 }
 
-void AccessState::MergeReads(const AccessState &other) {
+void AccessState::MergeReads(const AccessState& other) {
     // Merge the read states
     const uint32_t pre_merge_count = last_read_count;
     const auto pre_merge_stages = last_read_stages;
     for (uint32_t other_read_index = 0; other_read_index < other.last_read_count; other_read_index++) {
-        auto &other_read = other.last_reads[other_read_index];
+        auto& other_read = other.last_reads[other_read_index];
         if (pre_merge_stages & other_read.stage) {
             // Merge in the barriers for read stages that exist in *both* this and other
             // TODO: This is N^2 with stages... perhaps the ReadStates should be sorted by stage index.
             //       but we should wait on profiling data for that.
             for (uint32_t my_read_index = 0; my_read_index < pre_merge_count; my_read_index++) {
-                auto &my_read = last_reads[my_read_index];
+                auto& my_read = last_reads[my_read_index];
                 if (other_read.stage == my_read.stage) {
                     if (my_read.tag < other_read.tag) {
                         // Other is more recent, copy in the state
@@ -452,7 +452,7 @@ void AccessState::MergeReads(const AccessState &other) {
 // The logic behind resolves is the same as update, we assume that earlier hazards have be reported, and that no
 // tranistive hazard can exists with a hazard between the earlier operations.  Yes, an early hazard can mask that another
 // exists, but if you fix *that* hazard it either fixes or unmasks the subsequent ones.
-void AccessState::Resolve(const AccessState &other) {
+void AccessState::Resolve(const AccessState& other) {
     bool skip_first = false;
     if (last_write.has_value()) {
         if (other.last_write.has_value()) {
@@ -508,7 +508,7 @@ void AccessState::Resolve(const AccessState &other) {
 
         auto a = firsts.begin();
         auto a_end = firsts.end();
-        for (auto &b : other.first_accesses_) {
+        for (auto& b : other.first_accesses_) {
             // TODO: Determine whether some tag offset will be needed for PHASE II
             while ((a != a_end) && (a->tag < b.tag)) {
                 UpdateFirst(a->TagEx(), *a->usage_info, a->attachment_access, a->flags);
@@ -522,7 +522,7 @@ void AccessState::Resolve(const AccessState &other) {
     }
 }
 
-void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
+void AccessState::Update(const SyncAccessInfo& usage_info, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
                          SyncFlags flags) {
     const VkPipelineStageFlagBits2 usage_stage = usage_info.stage_mask;
     if (IsRead(usage_info.access_index)) {
@@ -530,7 +530,7 @@ void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAcces
         // However, for purposes of barrier tracking, only one read per pipeline stage matters
         if (usage_stage & last_read_stages) {
             const auto not_usage_stage = ~usage_stage;
-            for (auto &read_access : GetReads()) {
+            for (auto& read_access : GetReads()) {
                 if (read_access.stage == usage_stage) {
                     read_access.Set(usage_stage, usage_info.access_index, attachment_access, tag_ex);
                 } else if (read_access.barriers & usage_stage) {
@@ -544,7 +544,7 @@ void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAcces
                 }
             }
         } else {
-            for (auto &read_access : GetReads()) {
+            for (auto& read_access : GetReads()) {
                 if (read_access.barriers & usage_stage) {
                     read_access.sync_stages |= usage_stage;
                 }
@@ -566,22 +566,22 @@ void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAcces
     UpdateFirst(tag_ex, usage_info, attachment_access, flags);
 }
 
-HazardResult HazardResult::HazardVsPriorWrite(const AccessState *access_state, const SyncAccessInfo &usage_info, SyncHazard hazard,
-                                              const WriteState &prior_write) {
+HazardResult HazardResult::HazardVsPriorWrite(const AccessState* access_state, const SyncAccessInfo& usage_info, SyncHazard hazard,
+                                              const WriteState& prior_write) {
     HazardResult result;
     result.state_.emplace(access_state, usage_info, hazard, prior_write.access_index, prior_write.TagEx());
     return result;
 }
 
-HazardResult HazardResult::HazardVsPriorRead(const AccessState *access_state, const SyncAccessInfo &usage_info, SyncHazard hazard,
-                                             const ReadState &prior_read) {
+HazardResult HazardResult::HazardVsPriorRead(const AccessState* access_state, const SyncAccessInfo& usage_info, SyncHazard hazard,
+                                             const ReadState& prior_read) {
     assert(prior_read.access_index != SYNC_ACCESS_INDEX_NONE);
     HazardResult result;
     result.state_.emplace(access_state, usage_info, hazard, prior_read.access_index, prior_read.TagEx());
     return result;
 }
 
-void HazardResult::AddRecordedAccess(const FirstAccess &first_access) {
+void HazardResult::AddRecordedAccess(const FirstAccess& first_access) {
     assert(state_.has_value());
     state_->recorded_access = std::make_unique<const FirstAccess>(first_access);
 }
@@ -594,7 +594,7 @@ bool HazardResult::IsWAWHazard() const {
 // Clobber last read and all barriers... because all we have is DANGER, DANGER, WILL ROBINSON!!!
 // if the last_reads/last_write were unsafe, we've reported them, in either case the prior access is irrelevant.
 // We can overwrite them as *this* write is now after them.
-void AccessState::SetWrite(SyncAccessIndex access_index, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
+void AccessState::SetWrite(SyncAccessIndex access_index, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
                            SyncFlags flags) {
     ClearRead();
     if (!last_write.has_value()) {
@@ -627,11 +627,11 @@ void AccessState::ClearFirstUse() {
     first_access_closed_ = false;
 }
 
-bool AccessState::ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarrier &barrier, bool layout_transition,
+bool AccessState::ApplyBarrier(const BarrierScope& barrier_scope, const SyncBarrier& barrier, bool layout_transition,
                                uint32_t layout_transition_handle_index, ResourceUsageTag layout_transition_tag) {
     // Dedicated layout transition barrier logic
     if (layout_transition) {
-        const SyncAccessInfo &layout_transition_access_info = GetAccessInfo(SYNC_IMAGE_LAYOUT_TRANSITION);
+        const SyncAccessInfo& layout_transition_access_info = GetAccessInfo(SYNC_IMAGE_LAYOUT_TRANSITION);
         const ResourceUsageTagEx tag_ex = ResourceUsageTagEx{layout_transition_tag, layout_transition_handle_index};
         const OrderingBarrier layout_ordering{barrier.src_exec_scope.exec_scope, barrier.src_access_scope};
 
@@ -655,7 +655,7 @@ bool AccessState::ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarr
     }
     // Apply barriers over read accesses
     VkPipelineStageFlags2 stages_in_scope = VK_PIPELINE_STAGE_2_NONE;
-    for (ReadState &read_access : GetReads()) {
+    for (ReadState& read_access : GetReads()) {
         // The | implements the "dependency chain" logic for this access,
         // as the barriers field stores the second sync scope
         if (read_access.InBarrierSourceScope(barrier_scope)) {
@@ -663,7 +663,7 @@ bool AccessState::ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarr
             stages_in_scope |= read_access.stage;
         }
     }
-    for (ReadState &read_access : GetReads()) {
+    for (ReadState& read_access : GetReads()) {
         if ((read_access.stage | read_access.sync_stages) & stages_in_scope) {
             // If this stage, or any stage known to be synchronized after it are in scope, apply the barrier to this read.
             // NOTE: Forwarding barriers to known prior stages changes the sync_stages from shallow to deep, because the
@@ -676,8 +676,8 @@ bool AccessState::ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarr
     return barrier_applied;
 }
 
-void AccessState::CollectPendingBarriers(const BarrierScope &barrier_scope, const SyncBarrier &barrier, bool layout_transition,
-                                         uint32_t layout_transition_handle_index, PendingBarriers &pending_barriers) {
+void AccessState::CollectPendingBarriers(const BarrierScope& barrier_scope, const SyncBarrier& barrier, bool layout_transition,
+                                         uint32_t layout_transition_handle_index, PendingBarriers& pending_barriers) {
     if (layout_transition) {
         // Schedule layout transition first: layout transition creates WriteState if necessary
         const OrderingBarrier layout_transition_ordering_barrier{barrier.src_exec_scope.exec_scope, barrier.src_access_scope};
@@ -695,7 +695,7 @@ void AccessState::CollectPendingBarriers(const BarrierScope &barrier_scope, cons
 
     // Collect barriers over read accesses
     VkPipelineStageFlags2 stages_in_scope = VK_PIPELINE_STAGE_2_NONE;
-    for (ReadState &read_access : GetReads()) {
+    for (ReadState& read_access : GetReads()) {
         // The | implements the "dependency chain" logic for this access,
         // as the barriers field stores the second sync scope
         if (read_access.InBarrierSourceScope(barrier_scope)) {
@@ -703,7 +703,7 @@ void AccessState::CollectPendingBarriers(const BarrierScope &barrier_scope, cons
             stages_in_scope |= read_access.stage;
         }
     }
-    for (ReadState &read_access : GetReads()) {
+    for (ReadState& read_access : GetReads()) {
         if ((read_access.stage | read_access.sync_stages) & stages_in_scope) {
             // If this stage, or any stage known to be synchronized after it are in scope, apply the barrier to this read.
             // NOTE: Forwarding barriers to known prior stages changes the sync_stages from shallow to deep, because the
@@ -713,76 +713,76 @@ void AccessState::CollectPendingBarriers(const BarrierScope &barrier_scope, cons
     }
 }
 
-void PendingBarriers::AddReadBarrier(AccessState *access_state, uint32_t last_reads_index, const SyncBarrier &barrier) {
+void PendingBarriers::AddReadBarrier(AccessState* access_state, uint32_t last_reads_index, const SyncBarrier& barrier) {
     size_t barrier_index = 0;
     for (; barrier_index < read_barriers.size(); barrier_index++) {
-        const PendingReadBarrier &pending = read_barriers[barrier_index];
+        const PendingReadBarrier& pending = read_barriers[barrier_index];
         if (pending.barriers == barrier.dst_exec_scope.exec_scope && pending.last_reads_index == last_reads_index) {
             break;
         }
     }
     if (barrier_index == read_barriers.size()) {
-        PendingReadBarrier &pending = read_barriers.emplace_back();
+        PendingReadBarrier& pending = read_barriers.emplace_back();
         pending.barriers = barrier.dst_exec_scope.exec_scope;
         pending.last_reads_index = last_reads_index;
     }
-    PendingBarrierInfo &info = infos.emplace_back();
+    PendingBarrierInfo& info = infos.emplace_back();
     info.type = PendingBarrierType::ReadAccessBarrier;
     info.index = (uint32_t)barrier_index;
     info.access_state = access_state;
 }
 
-void PendingBarriers::AddWriteBarrier(AccessState *access_state, const SyncBarrier &barrier) {
+void PendingBarriers::AddWriteBarrier(AccessState* access_state, const SyncBarrier& barrier) {
     size_t barrier_index = 0;
     for (; barrier_index < write_barriers.size(); barrier_index++) {
-        const PendingWriteBarrier &pending = write_barriers[barrier_index];
+        const PendingWriteBarrier& pending = write_barriers[barrier_index];
         if (pending.barriers == barrier.dst_access_scope && pending.dependency_chain == barrier.dst_exec_scope.exec_scope) {
             break;
         }
     }
     if (barrier_index == write_barriers.size()) {
-        PendingWriteBarrier &pending = write_barriers.emplace_back();
+        PendingWriteBarrier& pending = write_barriers.emplace_back();
         pending.barriers = barrier.dst_access_scope;
         pending.dependency_chain = barrier.dst_exec_scope.exec_scope;
     }
-    PendingBarrierInfo &info = infos.emplace_back();
+    PendingBarrierInfo& info = infos.emplace_back();
     info.type = PendingBarrierType::WriteAccessBarrier;
     info.index = (uint32_t)barrier_index;
     info.access_state = access_state;
 }
 
-void PendingBarriers::AddLayoutTransition(AccessState *access_state, const OrderingBarrier &layout_transition_ordering_barrier,
+void PendingBarriers::AddLayoutTransition(AccessState* access_state, const OrderingBarrier& layout_transition_ordering_barrier,
                                           uint32_t layout_transition_handle_index) {
     // NOTE: in contrast to read/write barriers, we don't do reuse search here,
     // mostly because we didn't see a beneficial use case yet.
     // Storing handle index can be a hint it would be harder to find duplicates.
-    PendingBarrierInfo &info = infos.emplace_back();
+    PendingBarrierInfo& info = infos.emplace_back();
     info.type = PendingBarrierType::LayoutTransition;
     info.index = (uint32_t)layout_transitions.size();
     info.access_state = access_state;
 
-    PendingLayoutTransition &layout_transition = layout_transitions.emplace_back();
+    PendingLayoutTransition& layout_transition = layout_transitions.emplace_back();
     layout_transition.ordering = layout_transition_ordering_barrier;
     layout_transition.handle_index = layout_transition_handle_index;
 }
 
 void PendingBarriers::Apply(const ResourceUsageTag exec_tag) {
-    for (const PendingBarrierInfo &info : infos) {
+    for (const PendingBarrierInfo& info : infos) {
         if (info.type == PendingBarrierType::ReadAccessBarrier) {
-            const PendingReadBarrier &read_barrier = read_barriers[info.index];
+            const PendingReadBarrier& read_barrier = read_barriers[info.index];
             info.access_state->ApplyPendingReadBarrier(read_barrier, exec_tag);
         } else if (info.type == PendingBarrierType::WriteAccessBarrier) {
-            const PendingWriteBarrier &write_barrier = write_barriers[info.index];
+            const PendingWriteBarrier& write_barrier = write_barriers[info.index];
             info.access_state->ApplyPendingWriteBarrier(write_barrier);
         } else {
             assert(info.type == PendingBarrierType::LayoutTransition);
-            const PendingLayoutTransition &layout_transition = layout_transitions[info.index];
+            const PendingLayoutTransition& layout_transition = layout_transitions[info.index];
             info.access_state->ApplyPendingLayoutTransition(layout_transition, exec_tag);
         }
     }
 }
 
-void ApplyBarriers(AccessState &access_state, const std::vector<SyncBarrier> &barriers, bool layout_transition,
+void ApplyBarriers(AccessState& access_state, const std::vector<SyncBarrier>& barriers, bool layout_transition,
                    ResourceUsageTag layout_transition_tag) {
     // The common case of a single barrier.
     // The pending barrier helper is unnecessary because there are no independent barriers to track.
@@ -802,13 +802,13 @@ void ApplyBarriers(AccessState &access_state, const std::vector<SyncBarrier> &ba
         // NOTE: CollectPendingBarriers works correctly for a common case when layout transition is defined
         // by a single barrier
         OrderingBarrier layout_ordering_barrier;
-        for (const SyncBarrier &barrier : barriers) {
+        for (const SyncBarrier& barrier : barriers) {
             layout_ordering_barrier.exec_scope |= barrier.src_exec_scope.exec_scope;
             layout_ordering_barrier.access_scope |= barrier.src_access_scope;
         }
         pending_barriers.AddLayoutTransition(&access_state, layout_ordering_barrier, vvl::kNoIndex32);
 
-        for (const SyncBarrier &barrier : barriers) {
+        for (const SyncBarrier& barrier : barriers) {
             pending_barriers.AddWriteBarrier(&access_state, barrier);
         }
     } else {
@@ -816,20 +816,20 @@ void ApplyBarriers(AccessState &access_state, const std::vector<SyncBarrier> &ba
         // between themselves (result of the previous barrier might affect application of the next barrier).
         // The APIs we are dealing require that the barriers in a set of barriers are applied independently.
         // That's the intended use case of PendingBarriers helper.
-        for (const SyncBarrier &barrier : barriers) {
+        for (const SyncBarrier& barrier : barriers) {
             access_state.CollectPendingBarriers(BarrierScope(barrier), barrier, false, vvl::kNoIndex32, pending_barriers);
         }
     }
     pending_barriers.Apply(layout_transition_tag);
 }
 
-BarrierScope::BarrierScope(const SyncBarrier &barrier, QueueId scope_queue, ResourceUsageTag scope_tag)
+BarrierScope::BarrierScope(const SyncBarrier& barrier, QueueId scope_queue, ResourceUsageTag scope_tag)
     : src_exec_scope(barrier.src_exec_scope.exec_scope),
       src_access_scope(barrier.src_access_scope),
       scope_queue(scope_queue),
       scope_tag(scope_tag) {}
 
-void AccessState::ApplyPendingReadBarrier(const PendingReadBarrier &read_barrier, ResourceUsageTag tag) {
+void AccessState::ApplyPendingReadBarrier(const PendingReadBarrier& read_barrier, ResourceUsageTag tag) {
     // Do not register read barriers if layout transition has been registered for the same barrier API command.
     // The layout transition resets the read state (if any) and sets a write instead. By definition of our
     // implementation the read barriers are the barriers we apply to read accesses, so without read accesses we
@@ -838,20 +838,20 @@ void AccessState::ApplyPendingReadBarrier(const PendingReadBarrier &read_barrier
         return;
     }
 
-    ReadState &read_state = last_reads[read_barrier.last_reads_index];
+    ReadState& read_state = last_reads[read_barrier.last_reads_index];
     read_state.barriers |= read_barrier.barriers;
     read_execution_barriers |= read_barrier.barriers;
 }
 
-void AccessState::ApplyPendingWriteBarrier(const PendingWriteBarrier &write_barrier) {
+void AccessState::ApplyPendingWriteBarrier(const PendingWriteBarrier& write_barrier) {
     if (last_write.has_value()) {
         last_write->dependency_chain |= write_barrier.dependency_chain;
         last_write->barriers |= write_barrier.barriers;
     }
 }
 
-void AccessState::ApplyPendingLayoutTransition(const PendingLayoutTransition &layout_transition, ResourceUsageTag tag) {
-    const SyncAccessInfo &layout_usage_info = GetAccessInfo(SYNC_IMAGE_LAYOUT_TRANSITION);
+void AccessState::ApplyPendingLayoutTransition(const PendingLayoutTransition& layout_transition, ResourceUsageTag tag) {
+    const SyncAccessInfo& layout_usage_info = GetAccessInfo(SYNC_IMAGE_LAYOUT_TRANSITION);
     const ResourceUsageTagEx tag_ex = ResourceUsageTagEx{tag, layout_transition.handle_index};
     SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, AttachmentAccess::NonAttachment(), tag_ex);
     UpdateFirst(tag_ex, layout_usage_info, AttachmentAccess::NonAttachment());
@@ -859,11 +859,11 @@ void AccessState::ApplyPendingLayoutTransition(const PendingLayoutTransition &la
 }
 
 // Assumes signal queue != wait queue
-void AccessState::ApplySemaphore(const SemaphoreScope &signal, const SemaphoreScope &wait) {
+void AccessState::ApplySemaphore(const SemaphoreScope& signal, const SemaphoreScope& wait) {
     // Semaphores only guarantee the first scope of the signal is before the second scope of the wait.
     // If any access isn't in the first scope, there are no guarantees, thus those barriers are cleared
     assert(signal.queue != wait.queue);
-    for (auto &read_access : GetReads()) {
+    for (auto& read_access : GetReads()) {
         if (read_access.ReadOrDependencyChainInSourceScope(signal.queue, signal.exec_scope)) {
             // Deflects WAR on wait queue
             read_access.barriers = wait.exec_scope;
@@ -891,7 +891,7 @@ ResourceUsageRange AccessState::GetFirstAccessRange() const {
     return ResourceUsageRange(first_accesses_.front().tag, first_accesses_.back().tag + 1);
 }
 
-bool AccessState::FirstAccessInTagRange(const ResourceUsageRange &tag_range) const {
+bool AccessState::FirstAccessInTagRange(const ResourceUsageRange& tag_range) const {
     if (first_accesses_.empty()) {
         return false;
     }
@@ -903,16 +903,16 @@ void AccessState::OffsetTag(ResourceUsageTag offset) {
     if (last_write.has_value()) {
         last_write->tag += offset;
     }
-    for (auto &read_access : GetReads()) {
+    for (auto& read_access : GetReads()) {
         read_access.tag += offset;
     }
-    for (auto &first : first_accesses_) {
+    for (auto& first : first_accesses_) {
         first.tag += offset;
     }
 }
 
 // Copies everything except read states which need custom logic
-void AccessState::CopySimpleMembers(const AccessState &other) {
+void AccessState::CopySimpleMembers(const AccessState& other) {
     next_global_barrier_index = other.next_global_barrier_index;
 
     last_write = other.last_write;
@@ -928,19 +928,19 @@ void AccessState::CopySimpleMembers(const AccessState &other) {
     input_attachment_read = other.input_attachment_read;
 }
 
-AccessState::AccessState(const AccessState &other) { Assign(other); }
+AccessState::AccessState(const AccessState& other) { Assign(other); }
 
-void AccessState::Assign(const AccessState &other) {
+void AccessState::Assign(const AccessState& other) {
     CopySimpleMembers(other);
     ClearReadStates();
-    for (const ReadState &read : other.GetReads()) {
+    for (const ReadState& read : other.GetReads()) {
         AddRead(read);
     }
 }
 
-AccessState::AccessState(AccessState &&other) { Assign(std::move(other)); }
+AccessState::AccessState(AccessState&& other) { Assign(std::move(other)); }
 
-void AccessState::Assign(AccessState &&other) {
+void AccessState::Assign(AccessState&& other) {
     CopySimpleMembers(other);
 
     last_read_count = other.last_read_count;
@@ -960,7 +960,7 @@ AccessState ::~AccessState() {
 }
 
 VkPipelineStageFlags2 AccessState::GetReadBarriers(SyncAccessIndex access_index) const {
-    for (const auto &read_access : GetReads()) {
+    for (const auto& read_access : GetReads()) {
         if (read_access.access_index == access_index) {
             return read_access.barriers;
         }
@@ -969,7 +969,7 @@ VkPipelineStageFlags2 AccessState::GetReadBarriers(SyncAccessIndex access_index)
 }
 
 void AccessState::SetQueueId(QueueId id) {
-    for (auto &read_access : GetReads()) {
+    for (auto& read_access : GetReads()) {
         if (read_access.queue == kQueueIdInvalid) {
             read_access.queue = id;
         }
@@ -980,34 +980,34 @@ void AccessState::SetQueueId(QueueId id) {
 }
 
 bool AccessState::IsWriteBarrierHazard(QueueId queue_id, VkPipelineStageFlags2 src_exec_scope,
-                                       const SyncAccessFlags &src_access_scope) const {
+                                       const SyncAccessFlags& src_access_scope) const {
     return last_write.has_value() && last_write->IsWriteBarrierHazard(queue_id, src_exec_scope, src_access_scope);
 }
 
 // As ReadStates must be unique by stage, this is as good a sort as needed
-bool operator<(const ReadState &lhs, const ReadState &rhs) { return lhs.stage < rhs.stage; }
+bool operator<(const ReadState& lhs, const ReadState& rhs) { return lhs.stage < rhs.stage; }
 
 void AccessState::Normalize() {
     std::sort(last_reads, last_reads + last_read_count);
     ClearFirstUse();
 }
 
-void AccessState::GatherReferencedTags(ResourceUsageTagSet &used) const {
+void AccessState::GatherReferencedTags(ResourceUsageTagSet& used) const {
     if (last_write.has_value()) {
         used.CachedInsert(last_write->tag);
     }
 
-    for (const auto &read_access : GetReads()) {
+    for (const auto& read_access : GetReads()) {
         used.CachedInsert(read_access.tag);
     }
 }
 
-const WriteState &AccessState::LastWrite() const {
+const WriteState& AccessState::LastWrite() const {
     assert(last_write.has_value());
     return *last_write;
 }
 
-void AccessState::UpdateStats(AccessContextStats &stats) const {
+void AccessState::UpdateStats(AccessContextStats& stats) const {
 #if VVL_ENABLE_SYNCVAL_STATS != 0
     stats.read_states += last_read_count;
     stats.write_states += last_write.has_value();
@@ -1032,7 +1032,7 @@ void AccessState::UpdateStats(AccessContextStats &stats) const {
 #endif
 }
 
-bool AccessState::IsRAWHazard(const SyncAccessInfo &usage_info) const {
+bool AccessState::IsRAWHazard(const SyncAccessInfo& usage_info) const {
     assert(IsRead(usage_info.access_index));
     // Only RAW vs. last_write if it doesn't happen-after any other read because either:
     //    * the previous reads are not hazards, and thus last_write must be visible and available to
@@ -1043,12 +1043,12 @@ bool AccessState::IsRAWHazard(const SyncAccessInfo &usage_info) const {
            last_write->IsWriteHazard(usage_info);
 }
 
-VkPipelineStageFlags2 AccessState::GetOrderedStages(QueueId queue_id, const OrderingBarrier &ordering,
+VkPipelineStageFlags2 AccessState::GetOrderedStages(QueueId queue_id, const OrderingBarrier& ordering,
                                                     AttachmentAccessType attachment_access_type) const {
     // At apply queue submission order limits on the effect of ordering
     VkPipelineStageFlags2 non_qso_stages = VK_PIPELINE_STAGE_2_NONE;
     if (queue_id != kQueueIdInvalid) {
-        for (const auto &read_access : GetReads()) {
+        for (const auto& read_access : GetReads()) {
             if (read_access.queue != queue_id) {
                 non_qso_stages |= read_access.stage;
             }
@@ -1067,8 +1067,8 @@ VkPipelineStageFlags2 AccessState::GetOrderedStages(QueueId queue_id, const Orde
     return ordered_stages;
 }
 
-void AccessState::UpdateFirst(const ResourceUsageTagEx tag_ex, const SyncAccessInfo &usage_info,
-                              const AttachmentAccess &attachment_access, SyncFlags flags) {
+void AccessState::UpdateFirst(const ResourceUsageTagEx tag_ex, const SyncAccessInfo& usage_info,
+                              const AttachmentAccess& attachment_access, SyncFlags flags) {
     // Only record until we record a write.
     if (!first_access_closed_) {
         const bool is_read = IsRead(usage_info.access_index);
@@ -1086,18 +1086,18 @@ void AccessState::UpdateFirst(const ResourceUsageTagEx tag_ex, const SyncAccessI
     }
 }
 
-void AccessState::TouchupFirstForLayoutTransition(ResourceUsageTag tag, const OrderingBarrier &layout_ordering) {
+void AccessState::TouchupFirstForLayoutTransition(ResourceUsageTag tag, const OrderingBarrier& layout_ordering) {
     // Only call this after recording an image layout transition
     assert(first_accesses_.size());
     if (first_accesses_.back().tag == tag) {
         // If this layout transition is the the first write, add the additional ordering rules that guard the ILT
         assert(first_accesses_.back().usage_info->access_index == SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
-        auto &layout_ordering_lookup = GetLayoutOrderingBarrierLookup();
+        auto& layout_ordering_lookup = GetLayoutOrderingBarrierLookup();
         first_write_layout_ordering_index = layout_ordering_lookup.GetIndexAndMaybeInsert(layout_ordering);
     }
 }
 
-void ReadState::Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, const AttachmentAccess &attachment_access,
+void ReadState::Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, const AttachmentAccess& attachment_access,
                     ResourceUsageTagEx tag_ex) {
     assert(access_index != SYNC_ACCESS_INDEX_NONE);
     this->stage = stage;
@@ -1128,7 +1128,7 @@ bool ReadState::ReadOrDependencyChainInSourceScope(QueueId scope_queue, VkPipeli
     return (src_exec_scope & effective_stages) != 0;
 }
 
-bool ReadState::InBarrierSourceScope(const BarrierScope &barrier_scope) const {
+bool ReadState::InBarrierSourceScope(const BarrierScope& barrier_scope) const {
     // TODO: the following comment is from the initial implementation. Check it during Event rework.
     // NOTE: That's not really correct... this read stage might *not* have been included in the SetEvent,
     // and the barriers representing the chain might have changed since then (that would be an odd usage),
@@ -1143,7 +1143,7 @@ bool ReadState::InBarrierSourceScope(const BarrierScope &barrier_scope) const {
     return ReadOrDependencyChainInSourceScope(barrier_scope.scope_queue, barrier_scope.src_exec_scope);
 }
 
-void WriteState::Set(SyncAccessIndex access_index, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
+void WriteState::Set(SyncAccessIndex access_index, const AttachmentAccess& attachment_access, ResourceUsageTagEx tag_ex,
                      SyncFlags flags) {
     this->access_index = access_index;
     this->attachment_access = attachment_access;
@@ -1165,19 +1165,19 @@ void WriteState::SetQueueId(QueueId id) {
     }
 }
 
-bool WriteState::operator==(const WriteState &rhs) const {
+bool WriteState::operator==(const WriteState& rhs) const {
     return (access_index == rhs.access_index) && (barriers == rhs.barriers) && (tag == rhs.tag) && (queue == rhs.queue) &&
            (dependency_chain == rhs.dependency_chain);
 }
 
-bool WriteState::IsWriteHazard(const SyncAccessInfo &usage_info) const { return !barriers[usage_info.access_index]; }
+bool WriteState::IsWriteHazard(const SyncAccessInfo& usage_info) const { return !barriers[usage_info.access_index]; }
 
-bool WriteState::IsOrdered(const OrderingBarrier &ordering, QueueId queue_id) const {
+bool WriteState::IsOrdered(const OrderingBarrier& ordering, QueueId queue_id) const {
     return (queue == queue_id) && ordering.access_scope[access_index];
 }
 
 bool WriteState::IsWriteBarrierHazard(QueueId queue_id, VkPipelineStageFlags2 src_exec_scope,
-                                      const SyncAccessFlags &src_access_scope) const {
+                                      const SyncAccessFlags& src_access_scope) const {
     // Current implementation relies on TOP_OF_PIPE constant due to the fact that it's non-zero value
     // and AND-ing with it can create execution dependency when necessary. One example, it allows the
     // ALL_COMMANDS stage to guard all accesses even if NONE/TOP_OF_PIPE is used. When NONE constant is
@@ -1211,7 +1211,7 @@ bool WriteState::IsWriteBarrierHazard(QueueId queue_id, VkPipelineStageFlags2 sr
     return !WriteInSourceScope(src_access_scope);
 }
 
-void WriteState::MergeBarriers(const WriteState &other) {
+void WriteState::MergeBarriers(const WriteState& other) {
     barriers |= other.barriers;
     dependency_chain |= other.dependency_chain;
 }
@@ -1220,14 +1220,14 @@ bool WriteState::DependencyChainInSourceScope(VkPipelineStageFlags2 src_exec_sco
     return (dependency_chain & src_exec_scope) != 0;
 }
 
-bool WriteState::WriteInSourceScope(const SyncAccessFlags &src_access_scope) const { return src_access_scope[access_index]; }
+bool WriteState::WriteInSourceScope(const SyncAccessFlags& src_access_scope) const { return src_access_scope[access_index]; }
 
 bool WriteState::WriteOrDependencyChainInSourceScope(QueueId queue_id, VkPipelineStageFlags2 src_exec_scope,
-                                                     const SyncAccessFlags &src_access_scope) const {
+                                                     const SyncAccessFlags& src_access_scope) const {
     return DependencyChainInSourceScope(src_exec_scope) || (queue == queue_id && WriteInSourceScope(src_access_scope));
 }
 
-bool WriteState::InBarrierSourceScope(const BarrierScope &barrier_scope) const {
+bool WriteState::InBarrierSourceScope(const BarrierScope& barrier_scope) const {
     if (tag > barrier_scope.scope_tag) {
         return false;
     }
@@ -1242,7 +1242,7 @@ bool WriteState::InBarrierSourceScope(const BarrierScope &barrier_scope) const {
     return WriteOrDependencyChainInSourceScope(scope_queue, barrier_scope.src_exec_scope, barrier_scope.src_access_scope);
 }
 
-HazardResult::HazardState::HazardState(const AccessState *access_state_, const SyncAccessInfo &access_info_, SyncHazard hazard_,
+HazardResult::HazardState::HazardState(const AccessState* access_state_, const SyncAccessInfo& access_info_, SyncHazard hazard_,
                                        SyncAccessIndex prior_access_index, ResourceUsageTagEx tag_ex)
     : access_state(std::make_unique<const AccessState>(*access_state_)),
       recorded_access(),
@@ -1269,7 +1269,7 @@ HazardResult::HazardState::HazardState(const AccessState *access_state_, const S
     }
 }
 
-const char *string_SyncHazardVUID(SyncHazard hazard) {
+const char* string_SyncHazardVUID(SyncHazard hazard) {
     switch (hazard) {
         case SyncHazard::NONE:
             return "SYNC-HAZARD-NONE";

--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,9 @@ static VkAccessFlags2 ExpandAccessFlags(VkAccessFlags2 access_mask) {
 }
 
 template <typename Flags, typename Map>
-static SyncAccessFlags AccessScopeImpl(Flags flag_mask, const Map &map) {
+static SyncAccessFlags AccessScopeImpl(Flags flag_mask, const Map& map) {
     SyncAccessFlags scope;
-    for (const auto &[flag_bits2, sync_access_flags] : map) {
+    for (const auto& [flag_bits2, sync_access_flags] : map) {
         if (flag_mask < flag_bits2) {
             break;
         }
@@ -70,10 +70,10 @@ static SyncAccessFlags AccessScopeByAccess(VkAccessFlags2 accesses) {
 
 static VkPipelineStageFlags2 RelatedPipelineStages(
     VkPipelineStageFlags2 stage_mask,
-    const vvl::unordered_map<VkPipelineStageFlagBits2, VkPipelineStageFlags2> &earlier_or_later_stages) {
+    const vvl::unordered_map<VkPipelineStageFlagBits2, VkPipelineStageFlags2>& earlier_or_later_stages) {
     VkPipelineStageFlags2 unscanned = stage_mask;
     VkPipelineStageFlags2 related = 0;
-    for (const auto &[stage, related_stages] : earlier_or_later_stages) {
+    for (const auto& [stage, related_stages] : earlier_or_later_stages) {
         if (stage & unscanned) {
             related |= related_stages;
             unscanned &= ~stage;
@@ -93,7 +93,7 @@ static VkPipelineStageFlags2 WithLaterPipelineStages(VkPipelineStageFlags2 stage
     return stage_mask | RelatedPipelineStages(stage_mask, syncLogicallyLaterStages());
 }
 
-static SyncAccessFlags AccessScope(const SyncAccessFlags &stage_scope, VkAccessFlags2 accesses) {
+static SyncAccessFlags AccessScope(const SyncAccessFlags& stage_scope, VkAccessFlags2 accesses) {
     SyncAccessFlags access_scope = stage_scope & AccessScopeByAccess(accesses);
 
     // Special case. AS copy operations (e.g., vkCmdCopyAccelerationStructureKHR) can be synchronized using
@@ -143,7 +143,7 @@ SyncExecScope SyncExecScope::MakeDst(VkQueueFlags queue_flags, VkPipelineStageFl
     return result;
 }
 
-bool SyncExecScope::operator==(const SyncExecScope &other) const {
+bool SyncExecScope::operator==(const SyncExecScope& other) const {
     return mask_param == other.mask_param && exec_scope == other.exec_scope && valid_accesses == other.valid_accesses;
 }
 
@@ -155,16 +155,16 @@ size_t SyncExecScope::Hash() const {
     return hc.Value();
 }
 
-SyncBarrier::SyncBarrier(const SyncExecScope &src_exec, const SyncExecScope &dst_exec)
+SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst_exec)
     : src_exec_scope(src_exec), dst_exec_scope(dst_exec) {}
 
-SyncBarrier::SyncBarrier(const SyncExecScope &src_exec, const SyncExecScope &dst_exec, const SyncBarrier::AllAccess &)
+SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst_exec, const SyncBarrier::AllAccess&)
     : src_exec_scope(src_exec),
       src_access_scope(src_exec.valid_accesses),
       dst_exec_scope(dst_exec),
       dst_access_scope(dst_exec.valid_accesses) {}
 
-SyncBarrier::SyncBarrier(const SyncExecScope &src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope &dst_exec,
+SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope& dst_exec,
                          VkAccessFlags2 dst_access_mask)
     : src_exec_scope(src_exec),
       src_access_scope(AccessScope(src_exec.valid_accesses, src_access_mask)),
@@ -173,7 +173,7 @@ SyncBarrier::SyncBarrier(const SyncExecScope &src_exec, VkAccessFlags2 src_acces
       dst_access_scope(AccessScope(dst_exec.valid_accesses, dst_access_mask)),
       original_dst_access(dst_access_mask) {}
 
-SyncBarrier::SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2 &subpass) {
+SyncBarrier::SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2& subpass) {
     const auto barrier = vku::FindStructInPNextChain<VkMemoryBarrier2>(subpass.pNext);
     if (barrier) {
         auto src = SyncExecScope::MakeSrc(queue_flags, barrier->srcStageMask);
@@ -198,9 +198,9 @@ SyncBarrier::SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2 &s
     }
 }
 
-SyncBarrier::SyncBarrier(const std::vector<SyncBarrier> &barriers) {
+SyncBarrier::SyncBarrier(const std::vector<SyncBarrier>& barriers) {
     // Merge each barrier
-    for (const SyncBarrier &barrier : barriers) {
+    for (const SyncBarrier& barrier : barriers) {
         // Note that after merge, only the exec_scope and access_scope fields are fully valid
         // TODO: Do we need to update any of the other fields?  Merging has limited application.
         src_exec_scope.exec_scope |= barrier.src_exec_scope.exec_scope;
@@ -210,7 +210,7 @@ SyncBarrier::SyncBarrier(const std::vector<SyncBarrier> &barriers) {
     }
 }
 
-bool SyncBarrier::operator==(const SyncBarrier &other) const {
+bool SyncBarrier::operator==(const SyncBarrier& other) const {
     return (src_exec_scope == other.src_exec_scope) && (src_access_scope == other.src_access_scope) &&
            (dst_exec_scope == other.dst_exec_scope) && (dst_access_scope == other.dst_access_scope);
 }

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -156,9 +156,9 @@ static ShaderStageAccesses GetShaderStageAccesses(VkShaderStageFlagBits shader_s
 }
 
 static AccessRange MakeRangeForVertexData(VkDeviceSize offset, uint32_t first_vertex, uint32_t vertex_count,
-                                          const VertexBindingState &vertex_binding) {
+                                          const VertexBindingState& vertex_binding) {
     uint32_t element_size = 0;
-    for (const auto &[_, vertex_attrib] : vertex_binding.locations) {
+    for (const auto& [_, vertex_attrib] : vertex_binding.locations) {
         element_size = std::max(element_size, vertex_attrib.desc.offset + GetVertexInputFormatSize(vertex_attrib.desc.format));
     }
     const VkDeviceSize range_start = offset + (first_vertex * vertex_binding.desc.stride);
@@ -176,12 +176,12 @@ static AccessRange MakeRangeForIndexData(VkDeviceSize offset, uint32_t first_ind
     return MakeRange(range_start, range_size);
 }
 
-static AccessRange MakeRange(const vvl::BufferView &buf_view_state) {
+static AccessRange MakeRange(const vvl::BufferView& buf_view_state) {
     return MakeRange(*buf_view_state.buffer_state.get(), buf_view_state.create_info.offset, buf_view_state.create_info.range);
 }
 
 static SyncAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType descriptor_type,
-                                                               const spirv::ResourceInterfaceVariable &variable,
+                                                               const spirv::ResourceInterfaceVariable& variable,
                                                                VkShaderStageFlagBits stage_flag) {
     if (!variable.IsAccessed()) {
         return SYNC_ACCESS_INDEX_NONE;
@@ -219,32 +219,32 @@ static SyncAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType 
     }
 }
 
-static void UpdateImageAccessState(AccessContext &access_context, const vvl::Image &image, SyncAccessIndex current_usage,
-                                   const VkImageSubresourceRange &subresource_range, const ResourceUsageTag &tag) {
-    const auto &sub_state = SubState(image);
+static void UpdateImageAccessState(AccessContext& access_context, const vvl::Image& image, SyncAccessIndex current_usage,
+                                   const VkImageSubresourceRange& subresource_range, const ResourceUsageTag& tag) {
+    const auto& sub_state = SubState(image);
     ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, false);
     access_context.UpdateAccessState(range_gen, current_usage, ResourceUsageTagEx{tag});
 }
 
-static void UpdateImageAccessState(AccessContext &access_context, const vvl::Image &image, SyncAccessIndex current_usage,
-                                   const VkImageSubresourceRange &subresource_range, const VkOffset3D &offset,
-                                   const VkExtent3D &extent, ResourceUsageTagEx tag_ex) {
-    const auto &sub_state = SubState(image);
+static void UpdateImageAccessState(AccessContext& access_context, const vvl::Image& image, SyncAccessIndex current_usage,
+                                   const VkImageSubresourceRange& subresource_range, const VkOffset3D& offset,
+                                   const VkExtent3D& extent, ResourceUsageTagEx tag_ex) {
+    const auto& sub_state = SubState(image);
     ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, offset, extent, false);
     access_context.UpdateAccessState(range_gen, current_usage, tag_ex);
 }
 
-static void UpdateVideoAccessState(AccessContext &access_context, const vvl::VideoSession &vs_state,
-                                   const vvl::VideoPictureResource &resource, SyncAccessIndex current_usage, ResourceUsageTag tag) {
-    const auto image = static_cast<const vvl::Image *>(resource.image_state.get());
+static void UpdateVideoAccessState(AccessContext& access_context, const vvl::VideoSession& vs_state,
+                                   const vvl::VideoPictureResource& resource, SyncAccessIndex current_usage, ResourceUsageTag tag) {
+    const auto image = static_cast<const vvl::Image*>(resource.image_state.get());
     const auto offset = resource.GetEffectiveImageOffset(vs_state);
     const auto extent = resource.GetEffectiveImageExtent(vs_state);
-    const auto &sub_state = SubState(*image);
+    const auto& sub_state = SubState(*image);
     ImageRangeGen range_gen(sub_state.MakeImageRangeGen(resource.range, offset, extent, false));
     access_context.UpdateAccessState(range_gen, current_usage, ResourceUsageTagEx{tag});
 }
 
-CommandExecutionContext::CommandExecutionContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags)
+CommandExecutionContext::CommandExecutionContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags)
     : sync_state_(sync_validator), error_messages_(sync_validator.error_messages_), queue_flags_(queue_flags) {}
 
 bool CommandExecutionContext::ValidForSyncOps() const {
@@ -253,7 +253,7 @@ bool CommandExecutionContext::ValidForSyncOps() const {
     return valid;
 }
 
-CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags)
+CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags)
     : CommandExecutionContext(sync_validator, queue_flags),
       cb_state_(),
       access_log_(std::make_shared<AccessLog>()),
@@ -267,14 +267,14 @@ CommandBufferAccessContext::CommandBufferAccessContext(const SyncValidator &sync
       current_renderpass_context_(),
       sync_ops_() {}
 
-CommandBufferAccessContext::CommandBufferAccessContext(SyncValidator &sync_validator, vvl::CommandBuffer *cb_state)
+CommandBufferAccessContext::CommandBufferAccessContext(SyncValidator& sync_validator, vvl::CommandBuffer* cb_state)
     : CommandBufferAccessContext(sync_validator, cb_state->GetQueueFlags()) {
     cb_state_ = cb_state;
     sync_state_.stats.AddCommandBufferContext();
 }
 
 // NOTE: Make sure the proxy doesn't outlive from, as the proxy is pointing directly to access contexts owned by from.
-CommandBufferAccessContext::CommandBufferAccessContext(const CommandBufferAccessContext &from, AsProxyContext dummy)
+CommandBufferAccessContext::CommandBufferAccessContext(const CommandBufferAccessContext& from, AsProxyContext dummy)
     : CommandBufferAccessContext(from.sync_state_, from.cb_state_->GetQueueFlags()) {
     // Copy only the needed fields out of from for a temporary, proxy command buffer context
     cb_state_ = from.cb_state_;
@@ -285,7 +285,7 @@ CommandBufferAccessContext::CommandBufferAccessContext(const CommandBufferAccess
     handles_ = from.handles_;
     sync_state_.stats.AddHandleRecord((uint32_t)from.handles_.size());
 
-    const auto *from_context = from.GetCurrentAccessContext();
+    const auto* from_context = from.GetCurrentAccessContext();
     assert(from_context);
 
     // Construct a fully resolved single access context out of from
@@ -326,9 +326,9 @@ void CommandBufferAccessContext::Reset() {
     dynamic_rendering_info_.reset();
 }
 
-bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error_obj, BeginRenderingCmdState &cmd_state) const {
+bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject& error_obj, BeginRenderingCmdState& cmd_state) const {
     bool skip = false;
-    const DynamicRenderingInfo &info = cmd_state.GetRenderingInfo();
+    const DynamicRenderingInfo& info = cmd_state.GetRenderingInfo();
 
     // Load operations do not happen when resuming
     if (info.info.flags & VK_RENDERING_RESUMING_BIT) {
@@ -337,7 +337,7 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
 
     // Need to hazard detect load operations vs. the attachment views
     for (size_t i = 0; i < info.attachments.size(); i++) {
-        const auto &attachment = info.attachments[i];
+        const auto& attachment = info.attachments[i];
         const SyncAccessIndex load_index = attachment.GetLoadUsage();
         if (load_index == SYNC_ACCESS_INDEX_NONE) {
             continue;
@@ -367,13 +367,13 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
     return skip;
 }
 
-void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState &cmd_state, const Location &loc) {
+void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState& cmd_state, const Location& loc) {
     const auto tag = NextCommandTag(loc.function);
 
-    const DynamicRenderingInfo &info = cmd_state.GetRenderingInfo();
+    const DynamicRenderingInfo& info = cmd_state.GetRenderingInfo();
     if ((info.info.flags & VK_RENDERING_RESUMING_BIT) == 0) {
         for (size_t i = 0; i < info.attachments.size(); i++) {
-            const DynamicRenderingInfo::Attachment &attachment = info.attachments[i];
+            const DynamicRenderingInfo::Attachment& attachment = info.attachments[i];
             const SyncAccessIndex load_index = attachment.GetLoadUsage();
             if (load_index == SYNC_ACCESS_INDEX_NONE) {
                 continue;
@@ -387,7 +387,7 @@ void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState &cm
     dynamic_rendering_info_ = std::move(cmd_state.info);
 }
 
-bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_obj) const {
+bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject& error_obj) const {
     bool skip = false;
 
     // Only validate resolve and store if not suspending (as specified by BeginRendering)
@@ -396,9 +396,9 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
     }
 
     for (uint32_t i = 0; i < (uint32_t)dynamic_rendering_info_->attachments.size(); i++) {
-        const auto &attachment = dynamic_rendering_info_->attachments[i];
+        const auto& attachment = dynamic_rendering_info_->attachments[i];
 
-        auto attachment_description = [this, &error_obj, &attachment, i](const auto &view, std::ostringstream &ss) {
+        auto attachment_description = [this, &error_obj, &attachment, i](const auto& view, std::ostringstream& ss) {
             ss << vvl::String(vvl::Field::pRenderingInfo) << ".";
             ss << attachment.GetLocation(error_obj.location, uint32_t(i)).Fields();
             ss << " (" << sync_state_.FormatHandle(view->Handle());
@@ -474,7 +474,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
     return skip;
 }
 
-void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_obj) {
+void CommandBufferAccessContext::RecordEndRendering(const RecordObject& record_obj) {
     if (!dynamic_rendering_info_) {
         return;
     }
@@ -484,9 +484,9 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
     }
 
     auto store_tag = NextCommandTag(record_obj.location.function, SubCommandType::kStoreOp);
-    AccessContext &access_context = *GetCurrentAccessContext();
+    AccessContext& access_context = *GetCurrentAccessContext();
 
-    for (const auto &attachment : dynamic_rendering_info_->attachments) {
+    for (const auto& attachment : dynamic_rendering_info_->attachments) {
         if (attachment.resolve_gen) {
             const bool is_color = attachment.type == AttachmentType::kColor;
             const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
@@ -513,14 +513,14 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
 }
 
 bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint,
-                                                                   const Location &loc) const {
+                                                                   const Location& loc) const {
     bool skip = false;
     if (!sync_state_.syncval_settings.shader_accesses_heuristic) {
         return skip;
     }
-    const auto &last_bound_state = cb_state_->lastBound[ConvertToVvlBindPoint(pipelineBindPoint)];
-    const vvl::Pipeline *pipe = last_bound_state.pipeline_state;
-    const std::vector<LastBound::DescriptorSetSlot> &ds_slots = last_bound_state.ds_slots;
+    const auto& last_bound_state = cb_state_->lastBound[ConvertToVvlBindPoint(pipelineBindPoint)];
+    const vvl::Pipeline* pipe = last_bound_state.pipeline_state;
+    const std::vector<LastBound::DescriptorSetSlot>& ds_slots = last_bound_state.ds_slots;
     if (!pipe) {
         return skip;
     }
@@ -530,19 +530,19 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
     using ImageDescriptor = vvl::ImageDescriptor;
     using TexelDescriptor = vvl::TexelDescriptor;
 
-    for (const auto &stage_state : pipe->stage_states) {
+    for (const auto& stage_state : pipe->stage_states) {
         if (stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT && pipe->RasterizationDisabled()) {
             continue;
         } else if (!stage_state.HasSpirv()) {
             continue;
         }
-        for (const auto &variable : stage_state.entrypoint->resource_interface_variables) {
+        for (const auto& variable : stage_state.entrypoint->resource_interface_variables) {
             if (variable.decorations.set >= ds_slots.size()) {
                 // This should be caught by Core validation, but if core checks are disabled SyncVal should not crash.
                 continue;
             }
-            const auto &ds_slot = ds_slots[variable.decorations.set];
-            const auto *descriptor_set = ds_slot.ds_state.get();
+            const auto& ds_slot = ds_slots[variable.decorations.set];
+            const auto* descriptor_set = ds_slot.ds_state.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);
             if (!binding) continue;
@@ -560,7 +560,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
             }
 
             for (uint32_t index = 0; index < binding->count; index++) {
-                const auto *descriptor = binding->GetDescriptor(index);
+                const auto* descriptor = binding->GetDescriptor(index);
                 switch (descriptor->GetClass()) {
                     case DescriptorClass::ImageSampler:
                     case DescriptorClass::Image: {
@@ -569,8 +569,8 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         }
 
                         // NOTE: ImageSamplerDescriptor inherits from ImageDescriptor, so this cast works for both types.
-                        const auto *image_descriptor = static_cast<const ImageDescriptor *>(descriptor);
-                        const auto *img_view_state = image_descriptor->GetImageViewState();
+                        const auto* image_descriptor = static_cast<const ImageDescriptor*>(descriptor);
+                        const auto* img_view_state = image_descriptor->GetImageViewState();
                         VkImageLayout image_layout = image_descriptor->GetImageLayout();
 
                         if (img_view_state->is_depth_sliced) {
@@ -603,12 +603,12 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         break;
                     }
                     case DescriptorClass::TexelBuffer: {
-                        const auto *texel_descriptor = static_cast<const TexelDescriptor *>(descriptor);
+                        const auto* texel_descriptor = static_cast<const TexelDescriptor*>(descriptor);
                         if (texel_descriptor->Invalid()) {
                             continue;
                         }
-                        const auto *buf_view_state = texel_descriptor->GetBufferViewState();
-                        const auto *buf_state = buf_view_state->buffer_state.get();
+                        const auto* buf_view_state = texel_descriptor->GetBufferViewState();
+                        const auto* buf_state = buf_view_state->buffer_state.get();
                         const AccessRange range = MakeRange(*buf_view_state);
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
                         if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
@@ -622,7 +622,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         break;
                     }
                     case DescriptorClass::GeneralBuffer: {
-                        const auto *buffer_descriptor = static_cast<const BufferDescriptor *>(descriptor);
+                        const auto* buffer_descriptor = static_cast<const BufferDescriptor*>(descriptor);
                         if (buffer_descriptor->Invalid()) {
                             continue;
                         }
@@ -635,7 +635,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                             }
                             offset += ds_slot.dynamic_offsets[dynamic_offset_index];
                         }
-                        const auto *buf_state = buffer_descriptor->GetBufferState();
+                        const auto* buf_state = buffer_descriptor->GetBufferState();
                         const AccessRange range = MakeRange(*buf_state, offset, buffer_descriptor->GetRange());
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
                         if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
@@ -648,11 +648,11 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         break;
                     }
                     case DescriptorClass::AccelerationStructure: {
-                        const auto *accel_descriptor = static_cast<const vvl::AccelerationStructureDescriptor *>(descriptor);
+                        const auto* accel_descriptor = static_cast<const vvl::AccelerationStructureDescriptor*>(descriptor);
                         if (accel_descriptor->Invalid()) {
                             continue;
                         }
-                        const vvl::AccelerationStructureKHR *accel = accel_descriptor->GetAccelerationStructureStateKHR();
+                        const vvl::AccelerationStructureKHR* accel = accel_descriptor->GetAccelerationStructureStateKHR();
                         if (!accel || !accel->buffer_state) {
                             continue;
                         }
@@ -686,9 +686,9 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
         return;
     }
 
-    const auto &last_bound_state = cb_state_->lastBound[ConvertToVvlBindPoint(pipelineBindPoint)];
-    const vvl::Pipeline *pipe = last_bound_state.pipeline_state;
-    const std::vector<LastBound::DescriptorSetSlot> &ds_slots = last_bound_state.ds_slots;
+    const auto& last_bound_state = cb_state_->lastBound[ConvertToVvlBindPoint(pipelineBindPoint)];
+    const vvl::Pipeline* pipe = last_bound_state.pipeline_state;
+    const std::vector<LastBound::DescriptorSetSlot>& ds_slots = last_bound_state.ds_slots;
     if (!pipe) {
         return;
     }
@@ -698,19 +698,19 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
     using ImageDescriptor = vvl::ImageDescriptor;
     using TexelDescriptor = vvl::TexelDescriptor;
 
-    for (const auto &stage_state : pipe->stage_states) {
+    for (const auto& stage_state : pipe->stage_states) {
         if (stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT && pipe->RasterizationDisabled()) {
             continue;
         } else if (!stage_state.HasSpirv()) {
             continue;
         }
-        for (const auto &variable : stage_state.entrypoint->resource_interface_variables) {
+        for (const auto& variable : stage_state.entrypoint->resource_interface_variables) {
             if (variable.decorations.set >= ds_slots.size()) {
                 // This should be caught by Core validation, but if core checks are disabled SyncVal should not crash.
                 continue;
             }
-            const auto &ds_slot = ds_slots[variable.decorations.set];
-            const auto *descriptor_set = ds_slot.ds_state.get();
+            const auto& ds_slot = ds_slots[variable.decorations.set];
+            const auto* descriptor_set = ds_slot.ds_state.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);
             if (!binding) continue;
@@ -723,16 +723,16 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
             }
 
             for (uint32_t i = 0; i < binding->count; i++) {
-                const auto *descriptor = binding->GetDescriptor(i);
+                const auto* descriptor = binding->GetDescriptor(i);
                 switch (descriptor->GetClass()) {
                     case DescriptorClass::ImageSampler:
                     case DescriptorClass::Image: {
                         // NOTE: ImageSamplerDescriptor inherits from ImageDescriptor, so this cast works for both types.
-                        const auto *image_descriptor = static_cast<const ImageDescriptor *>(descriptor);
+                        const auto* image_descriptor = static_cast<const ImageDescriptor*>(descriptor);
                         if (image_descriptor->Invalid()) {
                             continue;
                         }
-                        const auto *img_view_state = image_descriptor->GetImageViewState();
+                        const auto* img_view_state = image_descriptor->GetImageViewState();
                         if (img_view_state->is_depth_sliced) {
                             // NOTE: 2D ImageViews of VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT Images are not allowed in
                             // Descriptors, unless VK_EXT_image_2d_view_of_3d is supported, which it isn't at the moment.
@@ -755,19 +755,19 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         break;
                     }
                     case DescriptorClass::TexelBuffer: {
-                        const auto *texel_descriptor = static_cast<const TexelDescriptor *>(descriptor);
+                        const auto* texel_descriptor = static_cast<const TexelDescriptor*>(descriptor);
                         if (texel_descriptor->Invalid()) {
                             continue;
                         }
-                        const auto *buf_view_state = texel_descriptor->GetBufferViewState();
-                        const auto *buf_state = buf_view_state->buffer_state.get();
+                        const auto* buf_view_state = texel_descriptor->GetBufferViewState();
+                        const auto* buf_state = buf_view_state->buffer_state.get();
                         const AccessRange range = MakeRange(*buf_view_state);
                         const ResourceUsageTagEx tag_ex = AddCommandHandle(tag, buf_view_state->Handle());
                         current_context_->UpdateAccessState(*buf_state, sync_index, range, tag_ex);
                         break;
                     }
                     case DescriptorClass::GeneralBuffer: {
-                        const auto *buffer_descriptor = static_cast<const BufferDescriptor *>(descriptor);
+                        const auto* buffer_descriptor = static_cast<const BufferDescriptor*>(descriptor);
                         if (buffer_descriptor->Invalid()) {
                             continue;
                         }
@@ -780,18 +780,18 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                             }
                             offset += ds_slot.dynamic_offsets[dynamic_offset_index];
                         }
-                        const auto *buf_state = buffer_descriptor->GetBufferState();
+                        const auto* buf_state = buffer_descriptor->GetBufferState();
                         const AccessRange range = MakeRange(*buf_state, offset, buffer_descriptor->GetRange());
                         const ResourceUsageTagEx tag_ex = AddCommandHandle(tag, buf_state->Handle());
                         current_context_->UpdateAccessState(*buf_state, sync_index, range, tag_ex);
                         break;
                     }
                     case DescriptorClass::AccelerationStructure: {
-                        const auto *accel_descriptor = static_cast<const vvl::AccelerationStructureDescriptor *>(descriptor);
+                        const auto* accel_descriptor = static_cast<const vvl::AccelerationStructureDescriptor*>(descriptor);
                         if (accel_descriptor->Invalid()) {
                             continue;
                         }
-                        const vvl::AccelerationStructureKHR *accel = accel_descriptor->GetAccelerationStructureStateKHR();
+                        const vvl::AccelerationStructureKHR* accel = accel_descriptor->GetAccelerationStructureStateKHR();
                         if (!accel || !accel->buffer_state) {
                             continue;
                         }
@@ -809,25 +809,25 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
     }
 }
 
-bool CommandBufferAccessContext::ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const Location &loc) const {
+bool CommandBufferAccessContext::ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const Location& loc) const {
     bool skip = false;
-    const auto *pipe = cb_state_->GetLastBoundGraphics().pipeline_state;
+    const auto* pipe = cb_state_->GetLastBoundGraphics().pipeline_state;
     if (!pipe) {
         return skip;
     }
 
-    const auto &binding_buffers = cb_state_->current_vertex_buffer_binding_info;
-    const auto &vertex_bindings = pipe->IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT)
+    const auto& binding_buffers = cb_state_->current_vertex_buffer_binding_info;
+    const auto& vertex_bindings = pipe->IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT)
                                       ? cb_state_->dynamic_state_value.vertex_bindings
                                       : pipe->vertex_input_state->bindings;
 
-    for (const auto &[_, binding_state] : vertex_bindings) {
-        const auto &binding_desc = binding_state.desc;
+    for (const auto& [_, binding_state] : vertex_bindings) {
+        const auto& binding_desc = binding_state.desc;
         if (binding_desc.inputRate != VK_VERTEX_INPUT_RATE_VERTEX) {
             // TODO: add support to determine range of instance level attributes
             continue;
         }
-        if (const vvl::VertexBufferBinding *vertex_buffer = vvl::Find(binding_buffers, binding_desc.binding)) {
+        if (const vvl::VertexBufferBinding* vertex_buffer = vvl::Find(binding_buffers, binding_desc.binding)) {
             // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
             const auto buf_state = sync_state_.Get<vvl::Buffer>(vertex_buffer->Buffer());
             if (!buf_state) continue;  // also skips if using nullDescriptor
@@ -847,22 +847,22 @@ bool CommandBufferAccessContext::ValidateDrawVertex(uint32_t vertexCount, uint32
 }
 
 void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const ResourceUsageTag tag) {
-    const auto *pipe = cb_state_->GetLastBoundGraphics().pipeline_state;
+    const auto* pipe = cb_state_->GetLastBoundGraphics().pipeline_state;
     if (!pipe) {
         return;
     }
-    const auto &binding_buffers = cb_state_->current_vertex_buffer_binding_info;
-    const auto &vertex_bindings = pipe->IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT)
+    const auto& binding_buffers = cb_state_->current_vertex_buffer_binding_info;
+    const auto& vertex_bindings = pipe->IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT)
                                       ? cb_state_->dynamic_state_value.vertex_bindings
                                       : pipe->vertex_input_state->bindings;
 
-    for (const auto &[_, binding_state] : vertex_bindings) {
-        const auto &binding_desc = binding_state.desc;
+    for (const auto& [_, binding_state] : vertex_bindings) {
+        const auto& binding_desc = binding_state.desc;
         if (binding_desc.inputRate != VK_VERTEX_INPUT_RATE_VERTEX) {
             // TODO: add support to determine range of instance level attributes
             continue;
         }
-        if (const auto *vertex_buffer = vvl::Find(binding_buffers, binding_desc.binding)) {
+        if (const auto* vertex_buffer = vvl::Find(binding_buffers, binding_desc.binding)) {
             // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
             const auto buf_state = sync_state_.Get<vvl::Buffer>(vertex_buffer->Buffer());
             if (!buf_state) continue;  // also skips if using nullDescriptor
@@ -875,9 +875,9 @@ void CommandBufferAccessContext::RecordDrawVertex(uint32_t vertexCount, uint32_t
     }
 }
 
-bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t index_count, uint32_t firstIndex, const Location &loc) const {
+bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t index_count, uint32_t firstIndex, const Location& loc) const {
     bool skip = false;
-    const auto &index_binding = cb_state_->index_buffer_binding;
+    const auto& index_binding = cb_state_->index_buffer_binding;
     // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
     const auto index_buf_state = sync_state_.Get<vvl::Buffer>(index_binding.Buffer());
     if (!index_buf_state) return skip;
@@ -888,7 +888,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t index_count, u
     auto hazard = current_context_->DetectHazard(*index_buf_state, SYNC_INDEX_INPUT_INDEX_READ, range);
     if (hazard.IsHazard()) {
         LogObjectList objlist(cb_state_->Handle(), index_buf_state->Handle());
-        if (const auto *pipe = cb_state_->GetLastBoundGraphics().pipeline_state) {
+        if (const auto* pipe = cb_state_->GetLastBoundGraphics().pipeline_state) {
             objlist.add(pipe->Handle());
         }
         const std::string resource_description = "index " + sync_state_.FormatHandle(*index_buf_state);
@@ -907,7 +907,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t index_count, u
 }
 
 void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const ResourceUsageTag tag) {
-    const auto &index_binding = cb_state_->index_buffer_binding;
+    const auto& index_binding = cb_state_->index_buffer_binding;
     // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
     const auto index_buf_state = sync_state_.Get<vvl::Buffer>(index_binding.Buffer());
     if (!index_buf_state) return;
@@ -925,7 +925,7 @@ void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint
     // RecordDrawVertex(?, ?, tag);
 }
 
-bool CommandBufferAccessContext::ValidateDrawAttachment(const Location &loc) const {
+bool CommandBufferAccessContext::ValidateDrawAttachment(const Location& loc) const {
     bool skip = false;
     if (current_renderpass_context_) {
         skip |= current_renderpass_context_->ValidateDrawSubpassAttachment(*this, loc.function);
@@ -935,21 +935,21 @@ bool CommandBufferAccessContext::ValidateDrawAttachment(const Location &loc) con
     return skip;
 }
 
-bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Location &location) const {
+bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Location& location) const {
     bool skip = false;
-    const auto &last_bound_state = cb_state_->GetLastBoundGraphics();
-    const auto *pipe = last_bound_state.pipeline_state;
+    const auto& last_bound_state = cb_state_->GetLastBoundGraphics();
+    const auto* pipe = last_bound_state.pipeline_state;
     if (!pipe || pipe->RasterizationDisabled()) return skip;
 
     const auto& list = pipe->fs_writable_output_location_list;
-    const auto &access_context = *GetCurrentAccessContext();
+    const auto& access_context = *GetCurrentAccessContext();
 
-    const DynamicRenderingInfo &info = *dynamic_rendering_info_;
+    const DynamicRenderingInfo& info = *dynamic_rendering_info_;
     for (const auto output_location : list) {
         if (output_location >= info.info.colorAttachmentCount) {
             continue;
         }
-        const auto &attachment = info.attachments[output_location];
+        const auto& attachment = info.attachments[output_location];
         if (!attachment.IsWriteable(last_bound_state)) {
             continue;
         }
@@ -972,7 +972,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
     // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
     // PHASE1 TODO: Add EARLY stage detection based on ExecutionMode.
     for (size_t i = info.info.colorAttachmentCount; i < info.attachments.size(); i++) {
-        const auto &attachment = info.attachments[i];
+        const auto& attachment = info.attachments[i];
         bool writeable = attachment.IsWriteable(last_bound_state);
 
         if (writeable) {
@@ -1004,19 +1004,19 @@ void CommandBufferAccessContext::RecordDrawAttachment(const ResourceUsageTag tag
 }
 
 void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUsageTag tag) {
-    const auto &last_bound_state = cb_state_->GetLastBoundGraphics();
-    const auto *pipe = last_bound_state.pipeline_state;
+    const auto& last_bound_state = cb_state_->GetLastBoundGraphics();
+    const auto* pipe = last_bound_state.pipeline_state;
     if (!pipe || pipe->RasterizationDisabled()) return;
 
     const auto& list = pipe->fs_writable_output_location_list;
-    auto &access_context = *GetCurrentAccessContext();
+    auto& access_context = *GetCurrentAccessContext();
 
-    const DynamicRenderingInfo &info = *dynamic_rendering_info_;
+    const DynamicRenderingInfo& info = *dynamic_rendering_info_;
     for (const auto output_location : list) {
         if (output_location >= info.info.colorAttachmentCount) {
             continue;
         }
-        const auto &attachment = info.attachments[output_location];
+        const auto& attachment = info.attachments[output_location];
         if (!attachment.IsWriteable(last_bound_state)) {
             continue;
         }
@@ -1033,7 +1033,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
 
     const uint32_t attachment_count = static_cast<uint32_t>(info.attachments.size());
     for (uint32_t i = info.info.colorAttachmentCount; i < attachment_count; i++) {
-        const auto &attachment = info.attachments[i];
+        const auto& attachment = info.attachments[i];
         bool writeable = attachment.IsWriteable(last_bound_state);
 
         if (writeable) {
@@ -1045,8 +1045,8 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
     }
 }
 
-static VkImageAspectFlags GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask, const vvl::ImageView &attachment_view,
-                                            bool separate_depth_stencil_attachment_access) {
+static VkImageAspectFlags GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask, const vvl::ImageView& attachment_view,
+                                                      bool separate_depth_stencil_attachment_access) {
     // Check if clear request is valid.
     const bool clear_color = (clear_aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) != 0;
     const bool clear_depth = (clear_aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0;
@@ -1084,7 +1084,7 @@ static VkImageAspectFlags GetAttachmentAspectsToClear(VkImageAspectFlags clear_a
 }
 
 static std::optional<VkImageSubresourceRange> RestrictSubresourceRangeToClearLayers(
-    const VkImageSubresourceRange &normalized_subresource_range, uint32_t clear_first_layer, uint32_t clear_layer_count) {
+    const VkImageSubresourceRange& normalized_subresource_range, uint32_t clear_first_layer, uint32_t clear_layer_count) {
     // Contract of this function
     assert(normalized_subresource_range.layerCount != VK_REMAINING_ARRAY_LAYERS);
     // According to spec
@@ -1106,8 +1106,8 @@ static std::optional<VkImageSubresourceRange> RestrictSubresourceRangeToClearLay
 }
 
 std::optional<CommandBufferAccessContext::ClearAttachmentInfo> CommandBufferAccessContext::GetClearAttachmentInfo(
-    const VkClearAttachment &clear_attachment, uint32_t clear_first_layer, uint32_t clear_layer_count) const {
-    const vvl::ImageView *attachment_view = nullptr;
+    const VkClearAttachment& clear_attachment, uint32_t clear_first_layer, uint32_t clear_layer_count) const {
+    const vvl::ImageView* attachment_view = nullptr;
     if (current_renderpass_context_) {
         attachment_view = current_renderpass_context_->GetClearAttachmentView(clear_attachment);
     } else if (dynamic_rendering_info_) {
@@ -1132,25 +1132,25 @@ std::optional<CommandBufferAccessContext::ClearAttachmentInfo> CommandBufferAcce
     return ClearAttachmentInfo{*attachment_view, *subresource_range};
 }
 
-bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, const VkClearAttachment &clear_attachment,
-                                                         uint32_t clear_rect_index, const VkClearRect &clear_rect) const {
+bool CommandBufferAccessContext::ValidateClearAttachment(const Location& loc, const VkClearAttachment& clear_attachment,
+                                                         uint32_t clear_rect_index, const VkClearRect& clear_rect) const {
     bool skip = false;
 
     const auto optional_info = GetClearAttachmentInfo(clear_attachment, clear_rect.baseArrayLayer, clear_rect.layerCount);
     if (!optional_info) {
         return skip;
     }
-    const ClearAttachmentInfo &info = *optional_info;
+    const ClearAttachmentInfo& info = *optional_info;
     const VkImageSubresourceRange subresource_range = info.subresource_range;
     const VkImageAspectFlags aspects_to_clear = subresource_range.aspectMask;
     const uint32_t view_mask = GetViewMask();
-    const ImageSubState &sub_state = SubState(*info.attachment_view.image_state);
+    const ImageSubState& sub_state = SubState(*info.attachment_view.image_state);
 
     // NOTE: when we teach ImageRangeGen to work with view masks all logic will be much simplified
 
     // Validate Color clear
-    auto report_color_hazard = [this, &skip, &loc, &info](const HazardResult &hazard, const VkClearAttachment &clear_attachment,
-                                                          uint32_t clear_rect_index, const VkClearRect &clear_rect) {
+    auto report_color_hazard = [this, &skip, &loc, &info](const HazardResult& hazard, const VkClearAttachment& clear_attachment,
+                                                          uint32_t clear_rect_index, const VkClearRect& clear_rect) {
         std::ostringstream ss;
         ss << string_VkImageAspectFlags(clear_attachment.aspectMask);
         ss << " aspect of color attachment " << clear_attachment.colorAttachment;
@@ -1179,7 +1179,7 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
             }
         } else {
             const auto view_indices = GetSetBitIndices(view_mask);
-            const VkImageSubresourceRange &attachment_subresource = info.attachment_view.normalized_subresource_range;
+            const VkImageSubresourceRange& attachment_subresource = info.attachment_view.normalized_subresource_range;
             for (uint32_t view_index : view_indices) {
                 if (view_index < attachment_subresource.layerCount) {
                     VkImageSubresourceRange view_subresource = attachment_subresource;
@@ -1198,9 +1198,9 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
     }
 
     // Validate Depth-Stencil clear
-    auto report_depth_stencil_hazard = [this, &skip, &loc, &info](const HazardResult &hazard,
-                                                                  const VkClearAttachment &clear_attachment,
-                                                                  uint32_t clear_rect_index, const VkClearRect &clear_rect) {
+    auto report_depth_stencil_hazard = [this, &skip, &loc, &info](const HazardResult& hazard,
+                                                                  const VkClearAttachment& clear_attachment,
+                                                                  uint32_t clear_rect_index, const VkClearRect& clear_rect) {
         std::ostringstream ss;
         ss << string_VkImageAspectFlags(clear_attachment.aspectMask);
         ss << " aspect(s) of depth-stencil attachment (";
@@ -1228,7 +1228,7 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
             }
         } else {
             const auto view_indices = GetSetBitIndices(view_mask);
-            const VkImageSubresourceRange &attachment_subresource = info.attachment_view.normalized_subresource_range;
+            const VkImageSubresourceRange& attachment_subresource = info.attachment_view.normalized_subresource_range;
             for (uint32_t view_index : view_indices) {
                 if (view_index < attachment_subresource.layerCount) {
                     VkImageSubresourceRange view_subresource = attachment_subresource;
@@ -1248,19 +1248,19 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
     return skip;
 }
 
-void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, const VkClearAttachment &clear_attachment,
-                                                       const VkClearRect &rect) {
+void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, const VkClearAttachment& clear_attachment,
+                                                       const VkClearRect& rect) {
     const auto optional_info = GetClearAttachmentInfo(clear_attachment, rect.baseArrayLayer, rect.layerCount);
     if (!optional_info) {
         return;
     }
-    const ClearAttachmentInfo &info = *optional_info;
+    const ClearAttachmentInfo& info = *optional_info;
     const VkImageSubresourceRange subresource_range = info.subresource_range;
     const VkImageAspectFlags aspects_to_clear = subresource_range.aspectMask;
     const uint32_t view_mask = GetViewMask();
-    const ImageSubState &sub_state = SubState(*info.attachment_view.image_state);
+    const ImageSubState& sub_state = SubState(*info.attachment_view.image_state);
 
-    auto update_access_state = [this, aspects_to_clear, tag](ImageRangeGen &range_gen) {
+    auto update_access_state = [this, aspects_to_clear, tag](ImageRangeGen& range_gen) {
         if (aspects_to_clear & kColorAspects) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
             current_context_->UpdateAttachmentAccessState(range_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
@@ -1277,7 +1277,7 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
         update_access_state(range_gen);
     } else {
         const auto view_indices = GetSetBitIndices(view_mask);
-        const VkImageSubresourceRange &attachment_subresource = info.attachment_view.normalized_subresource_range;
+        const VkImageSubresourceRange& attachment_subresource = info.attachment_view.normalized_subresource_range;
         for (uint32_t view_index : view_indices) {
             if (view_index < attachment_subresource.layerCount) {
                 VkImageSubresourceRange view_subresource = attachment_subresource;
@@ -1292,9 +1292,9 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
 
 QueueId CommandBufferAccessContext::GetQueueId() const { return kQueueIdInvalid; }
 
-ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(vvl::Func command, const vvl::RenderPass &rp_state,
-                                                                   const VkRect2D &render_area,
-                                                                   const std::vector<const vvl::ImageView *> &attachment_views) {
+ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(vvl::Func command, const vvl::RenderPass& rp_state,
+                                                                   const VkRect2D& render_area,
+                                                                   const std::vector<const vvl::ImageView*>& attachment_views) {
     // Create an access context the current renderpass.
     const auto barrier_tag = NextCommandTag(command, SubCommandType::kSubpassTransition, 0);
     AddCommandHandle(barrier_tag, rp_state.Handle());
@@ -1344,15 +1344,15 @@ ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func comma
     return barrier_tag;
 }
 
-void CommandBufferAccessContext::RecordDestroyEvent(vvl::Event *event_state) { GetCurrentEventsContext()->Destroy(event_state); }
+void CommandBufferAccessContext::RecordDestroyEvent(vvl::Event* event_state) { GetCurrentEventsContext()->Destroy(event_state); }
 
-void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBufferAccessContext &recorded_cb_context) {
-    const AccessContext *recorded_context = recorded_cb_context.GetCurrentAccessContext();
+void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBufferAccessContext& recorded_cb_context) {
+    const AccessContext* recorded_context = recorded_cb_context.GetCurrentAccessContext();
     assert(recorded_context);
 
     // Just run through the barriers ignoring the usage from the recorded context, as Resolve will overwrite outdated state
     const ResourceUsageTag base_tag = GetTagCount();
-    for (const auto &sync_op : recorded_cb_context.GetSyncOps()) {
+    for (const auto& sync_op : recorded_cb_context.GetSyncOps()) {
         // we update the range to any include layout transition first use writes,
         // as they are stored along with the source scope (as effective barrier) when recorded
         sync_op.sync_op->ReplayRecord(*this, base_tag + sync_op.tag);
@@ -1362,19 +1362,19 @@ void CommandBufferAccessContext::RecordExecutedCommandBuffer(const CommandBuffer
     ResolveExecutedCommandBuffer(*recorded_context, base_tag);
 }
 
-void CommandBufferAccessContext::ResolveExecutedCommandBuffer(const AccessContext &recorded_context, ResourceUsageTag offset) {
-    auto tag_offset = [offset](AccessState *access) { access->OffsetTag(offset); };
+void CommandBufferAccessContext::ResolveExecutedCommandBuffer(const AccessContext& recorded_context, ResourceUsageTag offset) {
+    auto tag_offset = [offset](AccessState* access) { access->OffsetTag(offset); };
     GetCurrentAccessContext()->ResolveFromContext(tag_offset, recorded_context);
 }
 
-void CommandBufferAccessContext::ImportRecordedAccessLog(const CommandBufferAccessContext &recorded_context) {
+void CommandBufferAccessContext::ImportRecordedAccessLog(const CommandBufferAccessContext& recorded_context) {
     cbs_referenced_->emplace_back(recorded_context.GetCBStateShared());
     access_log_->insert(access_log_->end(), recorded_context.access_log_->cbegin(), recorded_context.access_log_->cend());
 
     // Adjust command indices for the log records added from recorded_context.
-    const auto &recorded_label_commands = recorded_context.cb_state_->GetLabelCommands();
+    const auto& recorded_label_commands = recorded_context.cb_state_->GetLabelCommands();
     const bool use_proxy = !proxy_label_commands_.empty();
-    const auto &label_commands = use_proxy ? proxy_label_commands_ : cb_state_->GetLabelCommands();
+    const auto& label_commands = use_proxy ? proxy_label_commands_ : cb_state_->GetLabelCommands();
     if (!label_commands.empty()) {
         assert(label_commands.size() >= recorded_label_commands.size());
         const uint32_t command_offset = static_cast<uint32_t>(label_commands.size() - recorded_label_commands.size());
@@ -1390,7 +1390,7 @@ ResourceUsageTag CommandBufferAccessContext::NextCommandTag(vvl::Func command, S
     command_number_++;
     current_command_tag_ = access_log_->size();
 
-    ResourceUsageRecord &record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_, subpass);
+    ResourceUsageRecord& record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_, subpass);
 
     if (!cb_state_->GetLabelCommands().empty()) {
         record.label_command_index = static_cast<uint32_t>(cb_state_->GetLabelCommands().size() - 1);
@@ -1401,10 +1401,10 @@ ResourceUsageTag CommandBufferAccessContext::NextCommandTag(vvl::Func command, S
 
 ResourceUsageTag CommandBufferAccessContext::NextSubCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass) {
     const ResourceUsageTag tag = access_log_->size();
-    ResourceUsageRecord &record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_, subpass);
+    ResourceUsageRecord& record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_, subpass);
 
     // By default copy handle range from the main command, but can be overwritten with AddSubcommandHandle.
-    const auto &main_command_record = (*access_log_)[current_command_tag_];
+    const auto& main_command_record = (*access_log_)[current_command_tag_];
     record.first_handle_index = main_command_record.first_handle_index;
     record.handle_count = main_command_record.handle_count;
 
@@ -1414,24 +1414,24 @@ ResourceUsageTag CommandBufferAccessContext::NextSubCommandTag(vvl::Func command
     return tag;
 }
 
-uint32_t CommandBufferAccessContext::AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index) {
+uint32_t CommandBufferAccessContext::AddHandle(const VulkanTypedHandle& typed_handle, uint32_t index) {
     const uint32_t handle_index = static_cast<uint32_t>(handles_.size());
     handles_.emplace_back(HandleRecord(typed_handle, index));
     sync_state_.stats.AddHandleRecord();
     return handle_index;
 }
 
-ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle) {
+ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle) {
     return AddCommandHandleIndexed(tag, typed_handle, vvl::kNoIndex32);
 }
 
-ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle,
+ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle,
                                                                        uint32_t index) {
     assert(tag < access_log_->size());
     const uint32_t handle_index = AddHandle(typed_handle, index);
     // TODO: the following range check is not needed. Test and remove.
     if (tag < access_log_->size()) {
-        auto &record = (*access_log_)[tag];
+        auto& record = (*access_log_)[tag];
         if (record.first_handle_index == vvl::kNoIndex32) {
             record.first_handle_index = handle_index;
             record.handle_count = 1;
@@ -1444,14 +1444,14 @@ ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandleIndexed(ResourceU
     return {tag, handle_index};
 }
 
-void CommandBufferAccessContext::AddSubcommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle,
+void CommandBufferAccessContext::AddSubcommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle& typed_handle,
                                                             uint32_t index) {
     assert(tag < access_log_->size());
     const uint32_t handle_index = AddHandle(typed_handle, index);
     // TODO: the following range check is not needed. Test and remove.
     if (tag < access_log_->size()) {
-        auto &record = (*access_log_)[tag];
-        const auto &main_command_record = (*access_log_)[current_command_tag_];
+        auto& record = (*access_log_)[tag];
+        const auto& main_command_record = (*access_log_)[current_command_tag_];
         if (record.first_handle_index == main_command_record.first_handle_index) {
             // override default behavior that subcommand references the same handles as the main command
             record.first_handle_index = handle_index;
@@ -1464,13 +1464,13 @@ void CommandBufferAccessContext::AddSubcommandHandleIndexed(ResourceUsageTag tag
     }
 }
 
-std::string CommandBufferAccessContext::GetDebugRegionName(const ResourceUsageRecord &record) const {
+std::string CommandBufferAccessContext::GetDebugRegionName(const ResourceUsageRecord& record) const {
     const bool use_proxy = !proxy_label_commands_.empty();
-    const auto &label_commands = use_proxy ? proxy_label_commands_ : cb_state_->GetLabelCommands();
+    const auto& label_commands = use_proxy ? proxy_label_commands_ : cb_state_->GetLabelCommands();
     return vvl::CommandBuffer::GetDebugRegionName(label_commands, record.label_command_index);
 }
 
-void CommandBufferAccessContext::RecordSyncOp(SyncOpPointer &&sync_op) {
+void CommandBufferAccessContext::RecordSyncOp(SyncOpPointer&& sync_op) {
     auto tag = sync_op->Record(this);
     // As renderpass operations can have side effects on the command buffer access context,
     // update the sync operation to record these if any.
@@ -1490,7 +1490,7 @@ uint32_t CommandBufferAccessContext::GetViewMask() const {
     if (dynamic_rendering_info_) {
         return dynamic_rendering_info_->info.viewMask;
     } else if (current_renderpass_context_) {
-        const auto &render_pass_ci = current_renderpass_context_->GetRenderPassState()->create_info;
+        const auto& render_pass_ci = current_renderpass_context_->GetRenderPassState()->create_info;
         const uint32_t subpass = current_renderpass_context_->GetCurrentSubpass();
         return render_pass_ci.pSubpasses[subpass].viewMask;
     } else {
@@ -1510,7 +1510,7 @@ uint32_t CommandBufferAccessContext::GetViewMask() const {
 // VK_SYNCVAL_DEBUG_RESET_COUNT: (optional, default value is 1) command buffer reset count
 // VK_SYNCVAL_DEBUG_CMDBUF_PATTERN: (optional, empty string by default) pattern to match command buffer debug name
 void CommandBufferAccessContext::CheckCommandTagDebugCheckpoint() {
-    auto get_cmdbuf_name = [](const DebugReport &debug_report, uint64_t cmdbuf_handle) {
+    auto get_cmdbuf_name = [](const DebugReport& debug_report, uint64_t cmdbuf_handle) {
         std::unique_lock<std::mutex> lock(debug_report.debug_output_mutex);
         std::string object_name = debug_report.GetUtilsObjectNameNoLock(cmdbuf_handle);
         if (object_name.empty()) {
@@ -1521,7 +1521,7 @@ void CommandBufferAccessContext::CheckCommandTagDebugCheckpoint() {
     };
     if (sync_state_.debug_command_number == command_number_ && sync_state_.debug_reset_count == reset_count_) {
         const auto cmdbuf_name = get_cmdbuf_name(*sync_state_.debug_report, cb_state_->Handle().handle);
-        const auto &pattern = sync_state_.debug_cmdbuf_pattern;
+        const auto& pattern = sync_state_.debug_cmdbuf_pattern;
         const bool cmdbuf_match = pattern.empty() || (cmdbuf_name.find(pattern) != std::string::npos);
         if (cmdbuf_match) {
             sync_state_.LogInfo("SYNCVAL_DEBUG_COMMAND", LogObjectList(), Location(access_log_->back().command),
@@ -1532,21 +1532,21 @@ void CommandBufferAccessContext::CheckCommandTagDebugCheckpoint() {
     }
 }
 
-void UpdateAccessMapStats(const AccessMap &access_map, AccessContextStats &stats);
+void UpdateAccessMapStats(const AccessMap& access_map, AccessContextStats& stats);
 
-void CommandBufferAccessContext::UpdateStats(AccessStats &access_stats) const {
+void CommandBufferAccessContext::UpdateStats(AccessStats& access_stats) const {
 #if VVL_ENABLE_SYNCVAL_STATS != 0
     UpdateAccessMapStats(cb_access_context_.GetAccessMap(), access_stats.cb_access_stats);
 
-    for (const auto &render_pass_context : render_pass_contexts_) {
-        for (const AccessContext &subpass_access_context : render_pass_context->GetSubpassContexts()) {
+    for (const auto& render_pass_context : render_pass_contexts_) {
+        for (const AccessContext& subpass_access_context : render_pass_context->GetSubpassContexts()) {
             UpdateAccessMapStats(subpass_access_context.GetAccessMap(), access_stats.subpass_access_stats);
         }
     }
 #endif
 }
 
-CommandBufferSubState::CommandBufferSubState(SyncValidator &dev, vvl::CommandBuffer &cb)
+CommandBufferSubState::CommandBufferSubState(SyncValidator& dev, vvl::CommandBuffer& cb)
     : vvl::CommandBufferSubState(cb), access_context(dev, &cb) {
     access_context.SetSelfReference();
 }
@@ -1563,13 +1563,13 @@ void CommandBufferSubState::Destroy() {
     access_context.Destroy();  // must be first to clean up self references correctly.
 }
 
-void CommandBufferSubState::Reset(const Location &loc) { access_context.Reset(); }
+void CommandBufferSubState::Reset(const Location& loc) { access_context.Reset(); }
 
-void CommandBufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &obj : invalid_nodes) {
+void CommandBufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) {
+    for (auto& obj : invalid_nodes) {
         switch (obj->Type()) {
             case kVulkanObjectTypeEvent:
-                access_context.RecordDestroyEvent(static_cast<vvl::Event *>(obj.get()));
+                access_context.RecordDestroyEvent(static_cast<vvl::Event*>(obj.get()));
                 break;
             default:
                 break;
@@ -1577,15 +1577,15 @@ void CommandBufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList &i
     }
 }
 
-void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer &src_buffer_state, vvl::Buffer &dst_buffer_state, uint32_t region_count,
-                                             const VkBufferCopy *regions, const Location &loc) {
+void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
+                                             const VkBufferCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         const AccessRange src_range = MakeRange(src_buffer_state, copy_region.srcOffset, copy_region.size);
         context->UpdateAccessState(src_buffer_state, SYNC_COPY_TRANSFER_READ, src_range, src_tag_ex);
 
@@ -1594,15 +1594,15 @@ void CommandBufferSubState::RecordCopyBuffer(vvl::Buffer &src_buffer_state, vvl:
     }
 }
 
-void CommandBufferSubState::RecordCopyBuffer2(vvl::Buffer &src_buffer_state, vvl::Buffer &dst_buffer_state, uint32_t region_count,
-                                              const VkBufferCopy2 *regions, const Location &loc) {
+void CommandBufferSubState::RecordCopyBuffer2(vvl::Buffer& src_buffer_state, vvl::Buffer& dst_buffer_state, uint32_t region_count,
+                                              const VkBufferCopy2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         const AccessRange src_range = MakeRange(src_buffer_state, copy_region.srcOffset, copy_region.size);
         context->UpdateAccessState(src_buffer_state, SYNC_COPY_TRANSFER_READ, src_range, src_tag_ex);
 
@@ -1611,16 +1611,16 @@ void CommandBufferSubState::RecordCopyBuffer2(vvl::Buffer &src_buffer_state, vvl
     }
 }
 
-void CommandBufferSubState::RecordCopyImage(vvl::Image &src_image_state, vvl::Image &dst_image_state,
+void CommandBufferSubState::RecordCopyImage(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                             VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
-                                            const VkImageCopy *regions, const Location &loc) {
+                                            const VkImageCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(*context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.srcSubresource),
                                copy_region.srcOffset, copy_region.extent, src_tag_ex);
         UpdateImageAccessState(*context, dst_image_state, SYNC_COPY_TRANSFER_WRITE, RangeFromLayers(copy_region.dstSubresource),
@@ -1628,16 +1628,16 @@ void CommandBufferSubState::RecordCopyImage(vvl::Image &src_image_state, vvl::Im
     }
 }
 
-void CommandBufferSubState::RecordCopyImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state,
+void CommandBufferSubState::RecordCopyImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                              VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
-                                             const VkImageCopy2 *regions, const Location &loc) {
+                                             const VkImageCopy2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(*context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.srcSubresource),
                                copy_region.srcOffset, copy_region.extent, src_tag_ex);
         UpdateImageAccessState(*context, dst_image_state, SYNC_COPY_TRANSFER_WRITE, RangeFromLayers(copy_region.dstSubresource),
@@ -1645,15 +1645,15 @@ void CommandBufferSubState::RecordCopyImage2(vvl::Image &src_image_state, vvl::I
     }
 }
 
-void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout,
-                                                    uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) {
+void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state, VkImageLayout,
+                                                    uint32_t region_count, const VkBufferImageCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         AccessRange src_range = MakeRange(copy_region.bufferOffset, dst_image_state.GetBufferSizeFromCopyImage(copy_region));
         context->UpdateAccessState(src_buffer_state, SYNC_COPY_TRANSFER_READ, src_range, src_tag_ex);
 
@@ -1662,16 +1662,16 @@ void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer &src_buffer_stat
     }
 }
 
-void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout,
-                                                     uint32_t region_count, const VkBufferImageCopy2 *regions,
-                                                     const Location &loc) {
+void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state, VkImageLayout,
+                                                     uint32_t region_count, const VkBufferImageCopy2* regions,
+                                                     const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_buffer_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         AccessRange src_range = MakeRange(copy_region.bufferOffset, dst_image_state.GetBufferSizeFromCopyImage(copy_region));
         context->UpdateAccessState(src_buffer_state, SYNC_COPY_TRANSFER_READ, src_range, src_tag_ex);
 
@@ -1680,16 +1680,16 @@ void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer &src_buffer_sta
     }
 }
 
-void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state,
+void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state,
                                                     VkImageLayout src_image_layout, uint32_t region_count,
-                                                    const VkBufferImageCopy *regions, const Location &loc) {
+                                                    const VkBufferImageCopy* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(*context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.imageSubresource),
                                copy_region.imageOffset, copy_region.imageExtent, src_tag_ex);
 
@@ -1698,16 +1698,16 @@ void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image &src_image_state,
     }
 }
 
-void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state,
+void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state,
                                                      VkImageLayout src_image_layout, uint32_t region_count,
-                                                     const VkBufferImageCopy2 *regions, const Location &loc) {
+                                                     const VkBufferImageCopy2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_buffer_state.Handle());
 
-    for (const auto &copy_region : vvl::make_span(regions, region_count)) {
+    for (const auto& copy_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(*context, src_image_state, SYNC_COPY_TRANSFER_READ, RangeFromLayers(copy_region.imageSubresource),
                                copy_region.imageOffset, copy_region.imageExtent, src_tag_ex);
 
@@ -1716,16 +1716,16 @@ void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image &src_image_state
     }
 }
 
-void CommandBufferSubState::RecordBlitImage(vvl::Image &src_image_state, vvl::Image &dst_image_state,
+void CommandBufferSubState::RecordBlitImage(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                             VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
-                                            const VkImageBlit *regions, const Location &loc) {
+                                            const VkImageBlit* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &blit_region : vvl::make_span(regions, region_count)) {
+    for (const auto& blit_region : vvl::make_span(regions, region_count)) {
         VkOffset3D offset = {std::min(blit_region.srcOffsets[0].x, blit_region.srcOffsets[1].x),
                              std::min(blit_region.srcOffsets[0].y, blit_region.srcOffsets[1].y),
                              std::min(blit_region.srcOffsets[0].z, blit_region.srcOffsets[1].z)};
@@ -1746,16 +1746,16 @@ void CommandBufferSubState::RecordBlitImage(vvl::Image &src_image_state, vvl::Im
     }
 }
 
-void CommandBufferSubState::RecordBlitImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state,
+void CommandBufferSubState::RecordBlitImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state,
                                              VkImageLayout src_image_layout, VkImageLayout dst_image_layout, uint32_t region_count,
-                                             const VkImageBlit2 *regions, const Location &loc) {
+                                             const VkImageBlit2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &blit_region : vvl::make_span(regions, region_count)) {
+    for (const auto& blit_region : vvl::make_span(regions, region_count)) {
         VkOffset3D offset = {std::min(blit_region.srcOffsets[0].x, blit_region.srcOffsets[1].x),
                              std::min(blit_region.srcOffsets[0].y, blit_region.srcOffsets[1].y),
                              std::min(blit_region.srcOffsets[0].z, blit_region.srcOffsets[1].z)};
@@ -1776,15 +1776,15 @@ void CommandBufferSubState::RecordBlitImage2(vvl::Image &src_image_state, vvl::I
     }
 }
 
-void CommandBufferSubState::RecordResolveImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, uint32_t region_count,
-                                               const VkImageResolve *regions, const Location &loc) {
+void CommandBufferSubState::RecordResolveImage(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
+                                               const VkImageResolve* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &resolve_region : vvl::make_span(regions, region_count)) {
+    for (const auto& resolve_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(*context, src_image_state, SYNC_RESOLVE_TRANSFER_READ,
                                RangeFromLayers(resolve_region.srcSubresource), resolve_region.srcOffset, resolve_region.extent,
                                src_tag_ex);
@@ -1794,15 +1794,15 @@ void CommandBufferSubState::RecordResolveImage(vvl::Image &src_image_state, vvl:
     }
 }
 
-void CommandBufferSubState::RecordResolveImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, uint32_t region_count,
-                                                const VkImageResolve2 *regions, const Location &loc) {
+void CommandBufferSubState::RecordResolveImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state, uint32_t region_count,
+                                                const VkImageResolve2* regions, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     auto src_tag_ex = access_context.AddCommandHandle(tag, src_image_state.Handle());
     auto dst_tag_ex = access_context.AddCommandHandle(tag, dst_image_state.Handle());
 
-    for (const auto &resolve_region : vvl::make_span(regions, region_count)) {
+    for (const auto& resolve_region : vvl::make_span(regions, region_count)) {
         UpdateImageAccessState(*context, src_image_state, SYNC_RESOLVE_TRANSFER_READ,
                                RangeFromLayers(resolve_region.srcSubresource), resolve_region.srcOffset, resolve_region.extent,
                                src_tag_ex);
@@ -1812,51 +1812,51 @@ void CommandBufferSubState::RecordResolveImage2(vvl::Image &src_image_state, vvl
     }
 }
 
-void CommandBufferSubState::RecordClearColorImage(vvl::Image &image_state, VkImageLayout, const VkClearColorValue *,
-                                                  uint32_t range_count, const VkImageSubresourceRange *ranges,
-                                                  const Location &loc) {
+void CommandBufferSubState::RecordClearColorImage(vvl::Image& image_state, VkImageLayout, const VkClearColorValue*,
+                                                  uint32_t range_count, const VkImageSubresourceRange* ranges,
+                                                  const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
     assert(context);
 
     access_context.AddCommandHandle(tag, image_state.Handle());
 
     for (uint32_t index = 0; index < range_count; index++) {
-        const auto &range = ranges[index];
+        const auto& range = ranges[index];
         UpdateImageAccessState(*context, image_state, SYNC_CLEAR_TRANSFER_WRITE, range, tag);
     }
 }
 
-void CommandBufferSubState::RecordClearDepthStencilImage(vvl::Image &image_state, VkImageLayout, const VkClearDepthStencilValue *,
-                                                         uint32_t range_count, const VkImageSubresourceRange *ranges,
-                                                         const Location &loc) {
+void CommandBufferSubState::RecordClearDepthStencilImage(vvl::Image& image_state, VkImageLayout, const VkClearDepthStencilValue*,
+                                                         uint32_t range_count, const VkImageSubresourceRange* ranges,
+                                                         const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
     assert(context);
 
     access_context.AddCommandHandle(tag, image_state.Handle());
 
     for (uint32_t index = 0; index < range_count; index++) {
-        const auto &range = ranges[index];
+        const auto& range = ranges[index];
         UpdateImageAccessState(*context, image_state, SYNC_CLEAR_TRANSFER_WRITE, range, tag);
     }
 }
 
-void CommandBufferSubState::RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment *pAttachments,
-                                                   uint32_t rect_count, const VkClearRect *pRects, const Location &loc) {
+void CommandBufferSubState::RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment* pAttachments,
+                                                   uint32_t rect_count, const VkClearRect* pRects, const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
 
-    for (const auto &attachment : vvl::make_span(pAttachments, attachment_count)) {
-        for (const auto &rect : vvl::make_span(pRects, rect_count)) {
+    for (const auto& attachment : vvl::make_span(pAttachments, attachment_count)) {
+        for (const auto& rect : vvl::make_span(pRects, rect_count)) {
             access_context.RecordClearAttachment(tag, attachment, rect);
         }
     }
 }
 
-void CommandBufferSubState::RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size,
-                                             const Location &loc) {
+void CommandBufferSubState::RecordFillBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size,
+                                             const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
     assert(context);
 
     const AccessRange range = MakeRange(buffer_state, offset, size);
@@ -1864,10 +1864,10 @@ void CommandBufferSubState::RecordFillBuffer(vvl::Buffer &buffer_state, VkDevice
     context->UpdateAccessState(buffer_state, SYNC_CLEAR_TRANSFER_WRITE, range, tag_ex);
 }
 
-void CommandBufferSubState::RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size,
-                                               const Location &loc) {
+void CommandBufferSubState::RecordUpdateBuffer(vvl::Buffer& buffer_state, VkDeviceSize offset, VkDeviceSize size,
+                                               const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
     assert(context);
 
     // VK_WHOLE_SIZE not allowed
@@ -1876,10 +1876,10 @@ void CommandBufferSubState::RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDevi
     context->UpdateAccessState(buffer_state, SYNC_CLEAR_TRANSFER_WRITE, range, tag_ex);
 }
 
-void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession &vs_state, const VkVideoDecodeInfoKHR &decode_info,
-                                              const Location &loc) {
+void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession& vs_state, const VkVideoDecodeInfoKHR& decode_info,
+                                              const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     if (auto src_buffer = base.dev_data.Get<vvl::Buffer>(decode_info.srcBuffer)) {
         const AccessRange src_range = MakeRange(*src_buffer, decode_info.srcBufferOffset, decode_info.srcBufferRange);
@@ -1887,7 +1887,7 @@ void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession &vs_state, const
         context->UpdateAccessState(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range, src_tag_ex);
     }
 
-    const auto *device_state = access_context.GetSyncState().device_state;
+    const auto* device_state = access_context.GetSyncState().device_state;
     auto dst_resource = vvl::VideoPictureResource(*device_state, decode_info.dstPictureResource);
     if (dst_resource) {
         UpdateVideoAccessState(*context, vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE, tag);
@@ -1910,10 +1910,10 @@ void CommandBufferSubState::RecordDecodeVideo(vvl::VideoSession &vs_state, const
     }
 }
 
-void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession &vs_state, const VkVideoEncodeInfoKHR &encode_info,
-                                              const Location &loc) {
+void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession& vs_state, const VkVideoEncodeInfoKHR& encode_info,
+                                              const Location& loc) {
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     if (auto src_buffer = base.dev_data.Get<vvl::Buffer>(encode_info.dstBuffer)) {
         const AccessRange src_range = MakeRange(*src_buffer, encode_info.dstBufferOffset, encode_info.dstBufferRange);
@@ -1921,7 +1921,7 @@ void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession &vs_state, const
         context->UpdateAccessState(*src_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, src_range, src_tag_ex);
     }
 
-    const auto *device_state = access_context.GetSyncState().device_state;
+    const auto* device_state = access_context.GetSyncState().device_state;
     auto src_resource = vvl::VideoPictureResource(*device_state, encode_info.srcPictureResource);
     if (src_resource) {
         UpdateVideoAccessState(*context, vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, tag);
@@ -1958,14 +1958,14 @@ void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession &vs_state, const
     }
 }
 
-void CommandBufferSubState::RecordCopyQueryPoolResults(vvl::QueryPool &pool_state, vvl::Buffer &dst_buffer_state,
+void CommandBufferSubState::RecordCopyQueryPoolResults(vvl::QueryPool& pool_state, vvl::Buffer& dst_buffer_state,
                                                        uint32_t first_query, uint32_t query_count, VkDeviceSize dst_offset,
-                                                       VkDeviceSize stride, VkQueryResultFlags flags, const Location &loc) {
+                                                       VkDeviceSize stride, VkQueryResultFlags flags, const Location& loc) {
     if (query_count == 0) {
         return;
     }
     const auto tag = access_context.NextCommandTag(loc.function);
-    auto *context = access_context.GetCurrentAccessContext();
+    auto* context = access_context.GetCurrentAccessContext();
 
     const uint32_t query_size = (flags & VK_QUERY_RESULT_64_BIT) ? 8 : 4;
     const VkDeviceSize range_size = (query_count - 1) * stride + query_size;
@@ -1976,8 +1976,8 @@ void CommandBufferSubState::RecordCopyQueryPoolResults(vvl::QueryPool &pool_stat
     // TODO:Track VkQueryPool
 }
 
-void CommandBufferSubState::RecordBeginRenderPass(const VkRenderPassBeginInfo &render_pass_begin,
-                                                  const VkSubpassBeginInfo &subpass_begin_info, const Location &loc) {
+void CommandBufferSubState::RecordBeginRenderPass(const VkRenderPassBeginInfo& render_pass_begin,
+                                                  const VkSubpassBeginInfo& subpass_begin_info, const Location& loc) {
     if (!base.IsPrimary()) {
         return;  // [core validation check]: only primary command buffer can begin render pass
     }
@@ -1985,8 +1985,8 @@ void CommandBufferSubState::RecordBeginRenderPass(const VkRenderPassBeginInfo &r
                                                        &subpass_begin_info);
 }
 
-void CommandBufferSubState::RecordNextSubpass(const VkSubpassBeginInfo &subpass_begin_info,
-                                              const VkSubpassEndInfo *subpass_end_info, const Location &loc) {
+void CommandBufferSubState::RecordNextSubpass(const VkSubpassBeginInfo& subpass_begin_info,
+                                              const VkSubpassEndInfo* subpass_end_info, const Location& loc) {
     if (!base.IsPrimary()) {
         return;  // [core validation check]: only primary command buffer can start next subpass
     }
@@ -1994,7 +1994,7 @@ void CommandBufferSubState::RecordNextSubpass(const VkSubpassBeginInfo &subpass_
                                                    subpass_end_info);
 }
 
-void CommandBufferSubState::RecordEndRenderPass(const VkSubpassEndInfo *subpass_end_info, const Location &loc) {
+void CommandBufferSubState::RecordEndRenderPass(const VkSubpassEndInfo* subpass_end_info, const Location& loc) {
     if (!base.IsPrimary()) {
         return;  // [core validation check]: only primary command buffer can end render pass
     }
@@ -2002,8 +2002,8 @@ void CommandBufferSubState::RecordEndRenderPass(const VkSubpassEndInfo *subpass_
     access_context.RecordSyncOp<SyncOpEndRenderPass>(loc.function, access_context.GetSyncState(), subpass_end_info);
 }
 
-void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer &secondary_command_buffer, uint32_t cmd_index,
-                                                 const Location &loc) {
+void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_command_buffer, uint32_t cmd_index,
+                                                 const Location& loc) {
     if (cmd_index == 0) {
         ResourceUsageTag cb_tag = access_context.NextCommandTag(loc.function, SubCommandType::kIndex);
         access_context.AddCommandHandleIndexed(cb_tag, secondary_command_buffer.Handle(), cmd_index);

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -128,9 +128,9 @@ std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard,
 }
 
 std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                                      vvl::Func command, const std::string& resource_description,
-                                                      uint32_t subresource_range_index,
-                                                      const VkImageSubresourceRange& subresource_range) const {
+                                           vvl::Func command, const std::string& resource_description,
+                                           uint32_t subresource_range_index,
+                                           const VkImageSubresourceRange& subresource_range) const {
     std::ostringstream ss;
     ss << "\nImage clear subresource range " << subresource_range_index << ": {\n";
     ss << "  " << string_VkImageSubresourceRange(subresource_range) << "\n";

--- a/layers/sync/sync_hazard_detection.cpp
+++ b/layers/sync/sync_hazard_detection.cpp
@@ -33,7 +33,7 @@ namespace syncval {
 // Note: If Action invocations are heavyweight and inter-entry (gap) calls are not needed
 //       add a template or function parameter to skip them. TBD.
 template <typename Action>
-bool ForEachEntryInRangesUntil(const AccessMap &map, ImageRangeGen &range_gen, Action &action) {
+bool ForEachEntryInRangesUntil(const AccessMap& map, ImageRangeGen& range_gen, Action& action) {
     using RangeType = ImageRangeGen::RangeType;
     using IndexType = RangeType::index_type;
     auto pos = map.LowerBound((*range_gen).begin);
@@ -81,7 +81,7 @@ bool ForEachEntryInRangesUntil(const AccessMap &map, ImageRangeGen &range_gen, A
 }
 
 template <typename DetectorRunner>
-HazardResult DoDetect(const AccessContext &access_context, const AccessState &access_state, DetectorRunner detector_runner) {
+HazardResult DoDetect(const AccessContext& access_context, const AccessState& access_state, DetectorRunner detector_runner) {
     if (access_state.next_global_barrier_index < access_context.GetGlobalBarrierCount()) {
         AccessState new_access_state = AccessState::DefaultAccessState();
         new_access_state.Assign(access_state);
@@ -94,126 +94,126 @@ HazardResult DoDetect(const AccessContext &access_context, const AccessState &ac
 
 class HazardDetector {
   public:
-    HazardDetector(SyncAccessIndex access_index, const AccessContext &access_context)
+    HazardDetector(SyncAccessIndex access_index, const AccessContext& access_context)
         : access_info_(GetAccessInfo(access_index)), access_context_(access_context) {}
 
-    HazardResult Detect(const AccessMap::const_iterator &pos) const {
+    HazardResult Detect(const AccessMap::const_iterator& pos) const {
         return DoDetect(access_context_, pos->second,
-                        [this](const AccessState &access_state) { return access_state.DetectHazard(access_info_); });
+                        [this](const AccessState& access_state) { return access_state.DetectHazard(access_info_); });
     }
 
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+    HazardResult DetectAsync(const AccessMap::const_iterator& pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState& access_state) {
             return access_state.DetectAsyncHazard(access_info_, start_tag, queue_id);
         });
     }
 
   private:
-    const SyncAccessInfo &access_info_;
-    const AccessContext &access_context_;
+    const SyncAccessInfo& access_info_;
+    const AccessContext& access_context_;
 };
 
 class HazardDetectorAttachment {
   public:
-    HazardDetectorAttachment(SyncAccessIndex access_index, const AttachmentAccess &attachment_access,
-                             const AccessContext &access_context, bool detect_load_op_after_store_op_hazards)
+    HazardDetectorAttachment(SyncAccessIndex access_index, const AttachmentAccess& attachment_access,
+                             const AccessContext& access_context, bool detect_load_op_after_store_op_hazards)
         : access_info_(GetAccessInfo(access_index)),
           attachment_access_(attachment_access),
           access_context_(access_context),
           detect_load_op_after_store_op_hazards(detect_load_op_after_store_op_hazards) {}
 
-    HazardResult Detect(const AccessMap::const_iterator &pos) const {
-        const OrderingBarrier &ordering = GetOrderingRules(attachment_access_.ordering);
-        return DoDetect(access_context_, pos->second, [this, &ordering](const AccessState &access_state) {
+    HazardResult Detect(const AccessMap::const_iterator& pos) const {
+        const OrderingBarrier& ordering = GetOrderingRules(attachment_access_.ordering);
+        return DoDetect(access_context_, pos->second, [this, &ordering](const AccessState& access_state) {
             return access_state.DetectHazard(access_info_, ordering, attachment_access_, 0, kQueueIdInvalid,
                                              detect_load_op_after_store_op_hazards);
         });
     }
 
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+    HazardResult DetectAsync(const AccessMap::const_iterator& pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState& access_state) {
             return access_state.DetectAsyncHazard(access_info_, start_tag, queue_id);
         });
     }
 
   private:
-    const SyncAccessInfo &access_info_;
+    const SyncAccessInfo& access_info_;
     const AttachmentAccess attachment_access_;
-    const AccessContext &access_context_;
+    const AccessContext& access_context_;
     const bool detect_load_op_after_store_op_hazards;
 };
 
 class HazardDetectFirstUse {
   public:
-    HazardDetectFirstUse(const AccessState &recorded_use, QueueId queue_id, const ResourceUsageRange &tag_range,
-                         const AccessContext &access_context, bool detect_load_op_after_store_op_hazards)
+    HazardDetectFirstUse(const AccessState& recorded_use, QueueId queue_id, const ResourceUsageRange& tag_range,
+                         const AccessContext& access_context, bool detect_load_op_after_store_op_hazards)
         : recorded_use_(recorded_use),
           queue_id_(queue_id),
           tag_range_(tag_range),
           access_context_(access_context),
           detect_load_op_after_store_op_hazards(detect_load_op_after_store_op_hazards) {}
 
-    HazardResult Detect(const AccessMap::const_iterator &pos) const {
-        return DoDetect(access_context_, pos->second, [this](const AccessState &access_state) {
+    HazardResult Detect(const AccessMap::const_iterator& pos) const {
+        return DoDetect(access_context_, pos->second, [this](const AccessState& access_state) {
             return access_state.DetectHazard(recorded_use_, queue_id_, tag_range_, detect_load_op_after_store_op_hazards);
         });
     }
 
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+    HazardResult DetectAsync(const AccessMap::const_iterator& pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState& access_state) {
             return access_state.DetectAsyncHazard(recorded_use_, tag_range_, start_tag, queue_id);
         });
     }
 
   private:
-    const AccessState &recorded_use_;
+    const AccessState& recorded_use_;
     const QueueId queue_id_;
-    const ResourceUsageRange &tag_range_;
-    const AccessContext &access_context_;
+    const ResourceUsageRange& tag_range_;
+    const AccessContext& access_context_;
     const bool detect_load_op_after_store_op_hazards;
 };
 
 struct HazardDetectorMarker {
-    HazardDetectorMarker(const AccessContext &access_context) : access_context(access_context) {}
+    HazardDetectorMarker(const AccessContext& access_context) : access_context(access_context) {}
 
-    HazardResult Detect(const AccessMap::const_iterator &pos) const {
+    HazardResult Detect(const AccessMap::const_iterator& pos) const {
         return DoDetect(access_context, pos->second,
-                        [](const AccessState &access_state) { return access_state.DetectMarkerHazard(); });
+                        [](const AccessState& access_state) { return access_state.DetectMarkerHazard(); });
     }
 
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return DoDetect(access_context, pos->second, [start_tag, queue_id](const AccessState &access_state) {
+    HazardResult DetectAsync(const AccessMap::const_iterator& pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context, pos->second, [start_tag, queue_id](const AccessState& access_state) {
             return access_state.DetectAsyncHazard(GetAccessInfo(SYNC_COPY_TRANSFER_WRITE), start_tag, queue_id);
         });
     }
 
-    const AccessContext &access_context;
+    const AccessContext& access_context;
 };
 
 class BarrierHazardDetector {
   public:
-    BarrierHazardDetector(const AccessContext &access_context, SyncAccessIndex access_index, VkPipelineStageFlags2 src_exec_scope,
+    BarrierHazardDetector(const AccessContext& access_context, SyncAccessIndex access_index, VkPipelineStageFlags2 src_exec_scope,
                           SyncAccessFlags src_access_scope)
         : access_context_(access_context),
           access_info_(GetAccessInfo(access_index)),
           src_exec_scope_(src_exec_scope),
           src_access_scope_(src_access_scope) {}
 
-    HazardResult Detect(const AccessMap::const_iterator &pos) const {
-        return DoDetect(access_context_, pos->second, [this](const AccessState &access_state) {
+    HazardResult Detect(const AccessMap::const_iterator& pos) const {
+        return DoDetect(access_context_, pos->second, [this](const AccessState& access_state) {
             return access_state.DetectBarrierHazard(access_info_, kQueueIdInvalid, src_exec_scope_, src_access_scope_);
         });
     }
 
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+    HazardResult DetectAsync(const AccessMap::const_iterator& pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState& access_state) {
             return access_state.DetectAsyncHazard(access_info_, start_tag, queue_id);
         });
     }
 
   private:
-    const AccessContext &access_context_;
-    const SyncAccessInfo &access_info_;
+    const AccessContext& access_context_;
+    const SyncAccessInfo& access_info_;
     VkPipelineStageFlags2 src_exec_scope_;
     SyncAccessFlags src_access_scope_;
 };
@@ -221,7 +221,7 @@ class BarrierHazardDetector {
 class EventBarrierHazardDetector {
   public:
     EventBarrierHazardDetector(SyncAccessIndex access_index, VkPipelineStageFlags2 src_exec_scope, SyncAccessFlags src_access_scope,
-                               const AccessContext::ScopeMap &event_scope, QueueId queue_id, ResourceUsageTag scope_tag)
+                               const AccessContext::ScopeMap& event_scope, QueueId queue_id, ResourceUsageTag scope_tag)
         : access_info_(GetAccessInfo(access_index)),
           src_exec_scope_(src_exec_scope),
           src_access_scope_(src_access_scope),
@@ -231,11 +231,11 @@ class EventBarrierHazardDetector {
           scope_pos_(event_scope.begin()),
           scope_end_(event_scope.end()) {}
 
-    HazardResult Detect(const AccessMap::const_iterator &pos) {
+    HazardResult Detect(const AccessMap::const_iterator& pos) {
         // Need to piece together coverage of pos->first range:
         // Copy the range as we'll be chopping it up as needed
         AccessRange range = pos->first;
-        const AccessState &access = pos->second;
+        const AccessState& access = pos->second;
         HazardResult hazard;
 
         bool in_scope = AdvanceScope(range);
@@ -264,7 +264,7 @@ class EventBarrierHazardDetector {
         return hazard;
     }
 
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+    HazardResult DetectAsync(const AccessMap::const_iterator& pos, ResourceUsageTag start_tag, QueueId queue_id) const {
         // Async barrier hazard detection can use the same path as the usage index is not IsRead, but is IsWrite
         return pos->second.DetectAsyncHazard(access_info_, start_tag, queue_id);
     }
@@ -272,15 +272,15 @@ class EventBarrierHazardDetector {
   private:
     bool ScopeInvalid() const { return scope_pos_ == scope_end_; }
     bool ScopeValid() const { return !ScopeInvalid(); }
-    void ScopeSeek(const AccessRange &range) { scope_pos_ = event_scope_.LowerBound(range.begin); }
+    void ScopeSeek(const AccessRange& range) { scope_pos_ = event_scope_.LowerBound(range.begin); }
 
     // Hiding away the std::pair grunge...
     ResourceAddress ScopeBegin() const { return scope_pos_->first.begin; }
     ResourceAddress ScopeEnd() const { return scope_pos_->first.end; }
-    const AccessRange &ScopeRange() const { return scope_pos_->first; }
-    const AccessState &ScopeState() const { return scope_pos_->second; }
+    const AccessRange& ScopeRange() const { return scope_pos_->first; }
+    const AccessState& ScopeState() const { return scope_pos_->second; }
 
-    bool AdvanceScope(const AccessRange &range) {
+    bool AdvanceScope(const AccessRange& range) {
         // Note: non_empty is (valid && !empty), so don't change !non_empty to empty...
         if (!range.non_empty()) return false;
         if (ScopeInvalid()) return false;
@@ -295,14 +295,14 @@ class EventBarrierHazardDetector {
     const SyncAccessInfo access_info_;
     VkPipelineStageFlags2 src_exec_scope_;
     SyncAccessFlags src_access_scope_;
-    const AccessContext::ScopeMap &event_scope_;
+    const AccessContext::ScopeMap& event_scope_;
     QueueId scope_queue_id_;
     const ResourceUsageTag scope_tag_;
     AccessContext::ScopeMap::const_iterator scope_pos_;
     AccessContext::ScopeMap::const_iterator scope_end_;
 };
 
-HazardResult AccessContext::DetectHazard(const vvl::Buffer &buffer, SyncAccessIndex access_index, const AccessRange &range) const {
+HazardResult AccessContext::DetectHazard(const vvl::Buffer& buffer, SyncAccessIndex access_index, const AccessRange& range) const {
     if (!SimpleBinding(buffer)) {
         return {};
     }
@@ -311,49 +311,49 @@ HazardResult AccessContext::DetectHazard(const vvl::Buffer &buffer, SyncAccessIn
     return DetectHazardRange(detector, (range + base_address), DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(ImageRangeGen &range_gen, SyncAccessIndex current_usage) const {
+HazardResult AccessContext::DetectHazard(ImageRangeGen& range_gen, SyncAccessIndex current_usage) const {
     HazardDetector detector(current_usage, *this);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
+HazardResult AccessContext::DetectHazard(const vvl::Image& image, const VkImageSubresourceRange& subresource_range,
                                          SyncAccessIndex current_usage) const {
-    const auto &sub_state = SubState(image);
+    const auto& sub_state = SubState(image);
     HazardDetector detector(current_usage, *this);
     ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, false);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
-                                         const VkOffset3D &offset, const VkExtent3D &extent, SyncAccessIndex current_usage) const {
-    const auto &sub_state = SubState(image);
+HazardResult AccessContext::DetectHazard(const vvl::Image& image, const VkImageSubresourceRange& subresource_range,
+                                         const VkOffset3D& offset, const VkExtent3D& extent, SyncAccessIndex current_usage) const {
+    const auto& sub_state = SubState(image);
     HazardDetector detector(current_usage, *this);
     ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, offset, extent, false);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(const vvl::ImageView &image_view, SyncAccessIndex current_usage) const {
+HazardResult AccessContext::DetectHazard(const vvl::ImageView& image_view, SyncAccessIndex current_usage) const {
     HazardDetector detector(current_usage, *this);
     ImageRangeGen range_gen = MakeImageRangeGen(image_view);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(const vvl::ImageView &image_view, const VkOffset3D &offset, const VkExtent3D &extent,
+HazardResult AccessContext::DetectHazard(const vvl::ImageView& image_view, const VkOffset3D& offset, const VkExtent3D& extent,
                                          SyncAccessIndex current_usage) const {
     HazardDetector detector(current_usage, *this);
     ImageRangeGen range_gen(MakeImageRangeGen(image_view, offset, extent));
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectAttachmentHazard(ImageRangeGen &range_gen, SyncAccessIndex current_usage,
-                                                   const AttachmentAccess &attachment_access) const {
+HazardResult AccessContext::DetectAttachmentHazard(ImageRangeGen& range_gen, SyncAccessIndex current_usage,
+                                                   const AttachmentAccess& attachment_access) const {
     HazardDetectorAttachment detector(current_usage, attachment_access, *this,
                                       validator->syncval_settings.load_op_after_store_op_validation);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectAttachmentHazard(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
-                                                   SyncAccessIndex current_usage, const AttachmentAccess &attachment_access,
+HazardResult AccessContext::DetectAttachmentHazard(const AttachmentViewGen& view_gen, AttachmentViewGen::Gen gen_type,
+                                                   SyncAccessIndex current_usage, const AttachmentAccess& attachment_access,
                                                    uint32_t view_mask) const {
     if (view_mask == 0) {
         ImageRangeGen range_gen = view_gen.GetRangeGen(gen_type);
@@ -375,27 +375,27 @@ HazardResult AccessContext::DetectAttachmentHazard(const AttachmentViewGen &view
     }
 }
 
-HazardResult AccessContext::DetectAttachmentHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
+HazardResult AccessContext::DetectAttachmentHazard(const vvl::Image& image, const VkImageSubresourceRange& subresource_range,
                                                    bool is_depth_sliced, SyncAccessIndex current_usage,
-                                                   const AttachmentAccess &attachment_access) const {
-    const auto &sub_state = SubState(image);
+                                                   const AttachmentAccess& attachment_access) const {
+    const auto& sub_state = SubState(image);
     HazardDetectorAttachment detector(current_usage, attachment_access, *this, false);
     ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, is_depth_sliced);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectAttachmentHazard(const vvl::ImageView &image_view, const VkOffset3D &offset,
-                                                   const VkExtent3D &extent, SyncAccessIndex current_usage,
-                                                   const AttachmentAccess &attachment_access) const {
+HazardResult AccessContext::DetectAttachmentHazard(const vvl::ImageView& image_view, const VkOffset3D& offset,
+                                                   const VkExtent3D& extent, SyncAccessIndex current_usage,
+                                                   const AttachmentAccess& attachment_access) const {
     HazardDetectorAttachment detector(current_usage, attachment_access, *this,
                                       validator->syncval_settings.load_op_after_store_op_validation);
     ImageRangeGen range_gen(MakeImageRangeGen(image_view, offset, extent));
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
-                                                     VkPipelineStageFlags2 src_exec_scope, const SyncAccessFlags &src_access_scope,
-                                                     QueueId queue_id, const ScopeMap &scope_map, const ResourceUsageTag scope_tag,
+HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image& image, const VkImageSubresourceRange& subresource_range,
+                                                     VkPipelineStageFlags2 src_exec_scope, const SyncAccessFlags& src_access_scope,
+                                                     QueueId queue_id, const ScopeMap& scope_map, const ResourceUsageTag scope_tag,
                                                      AccessContext::DetectOptions options) const {
     EventBarrierHazardDetector detector(SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, src_exec_scope, src_access_scope, scope_map,
                                         queue_id, scope_tag);
@@ -403,16 +403,16 @@ HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image &image, co
     return DetectHazardGeneratedRangeGen(detector, range_gen, options);
 }
 
-HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image &image, VkPipelineStageFlags2 src_exec_scope,
-                                                     const SyncAccessFlags &src_access_scope,
-                                                     const VkImageSubresourceRange &subresource_range, bool is_depth_sliced,
+HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image& image, VkPipelineStageFlags2 src_exec_scope,
+                                                     const SyncAccessFlags& src_access_scope,
+                                                     const VkImageSubresourceRange& subresource_range, bool is_depth_sliced,
                                                      const DetectOptions options) const {
     BarrierHazardDetector detector(*this, SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, src_exec_scope, src_access_scope);
     ImageRangeGen range_gen = SubState(image).MakeImageRangeGen(subresource_range, is_depth_sliced);
     return DetectHazardGeneratedRangeGen(detector, range_gen, options);
 }
 
-HazardResult AccessContext::DetectImageBarrierHazard(const AttachmentViewGen &view_gen, const SyncBarrier &barrier,
+HazardResult AccessContext::DetectImageBarrierHazard(const AttachmentViewGen& view_gen, const SyncBarrier& barrier,
                                                      DetectOptions options) const {
     BarrierHazardDetector detector(*this, SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, barrier.src_exec_scope.exec_scope,
                                    barrier.src_access_scope);
@@ -420,12 +420,12 @@ HazardResult AccessContext::DetectImageBarrierHazard(const AttachmentViewGen &vi
     return DetectHazardGeneratedRangeGen(detector, range_gen, options);
 }
 
-HazardResult AccessContext::DetectSubpassTransitionHazard(const SubpassBarrier &subpass_barrier,
-                                                          const AttachmentViewGen &attach_view) const {
+HazardResult AccessContext::DetectSubpassTransitionHazard(const SubpassBarrier& subpass_barrier,
+                                                          const AttachmentViewGen& attach_view) const {
     // Do the detection against the specific prior context independent of other contexts.  (Synchronous only)
     // Hazard detection for the transition can be against the merged of the barriers (it only uses src_...)
     const SyncBarrier merged_barrier(subpass_barrier.barriers);
-    const AccessContext &src_subpass_context = *subpass_barrier.src_subpass_context;
+    const AccessContext& src_subpass_context = *subpass_barrier.src_subpass_context;
     HazardResult hazard = src_subpass_context.DetectImageBarrierHazard(attach_view, merged_barrier, kDetectPrevious);
     if (!hazard.IsHazard()) {
         // The Async hazard check is against the current context's async set.
@@ -438,13 +438,13 @@ HazardResult AccessContext::DetectSubpassTransitionHazard(const SubpassBarrier &
 
 // This is called with the *recorded* command buffers access context, with the
 // *active* access context pass in, againsts which hazards will be detected
-HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const ResourceUsageRange &tag_range,
-                                                 const AccessContext &access_context) const {
+HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const ResourceUsageRange& tag_range,
+                                                 const AccessContext& access_context) const {
     // If the context is finalized we have a fast path to find first accesses within a range
     if (finalized_) {
-        for (const auto &single_tag : sorted_first_accesses_.IterateSingleTagFirstAccesses(tag_range)) {
+        for (const auto& single_tag : sorted_first_accesses_.IterateSingleTagFirstAccesses(tag_range)) {
             const AccessRange access_range = single_tag.p_key_value->first;
-            const AccessState &access = single_tag.p_key_value->second;
+            const AccessState& access = single_tag.p_key_value->second;
 
             // For single tag first accesses we have exact search and can assert the find
             assert(access.FirstAccessInTagRange(tag_range));
@@ -456,9 +456,9 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
                 return hazard;
             }
         }
-        for (const auto &multi_tag : sorted_first_accesses_.IterateMultiTagFirstAccesses(tag_range)) {
+        for (const auto& multi_tag : sorted_first_accesses_.IterateMultiTagFirstAccesses(tag_range)) {
             const AccessRange access_range = multi_tag.p_key_value->first;
-            const AccessState &access = multi_tag.p_key_value->second;
+            const AccessState& access = multi_tag.p_key_value->second;
 
             // For multi tag first accesses the search is not exact, so we need to check for range inclusion
             // (on average multi tag search is faster than going over the entire access map)
@@ -476,7 +476,7 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
     }
     // The context is not finalized. We have to iterate over the entire access map
     else {
-        for (const auto &recorded_access : access_state_map_) {
+        for (const auto& recorded_access : access_state_map_) {
             // Cull any entries not in the current tag range
             if (!recorded_access.second.FirstAccessInTagRange(tag_range)) {
                 continue;
@@ -492,10 +492,10 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
     return {};
 }
 
-HazardResult AccessContext::DetectVideoHazard(const vvl::VideoSession &vs_state, const vvl::VideoPictureResource &resource,
+HazardResult AccessContext::DetectVideoHazard(const vvl::VideoSession& vs_state, const vvl::VideoPictureResource& resource,
                                               SyncAccessIndex current_usage) const {
-    const vvl::Image &image = *resource.image_state.get();
-    const auto &sub_state = SubState(image);
+    const vvl::Image& image = *resource.image_state.get();
+    const auto& sub_state = SubState(image);
     const auto offset = resource.GetEffectiveImageOffset(vs_state);
     const auto extent = resource.GetEffectiveImageExtent(vs_state);
     ImageRangeGen range_gen(sub_state.MakeImageRangeGen(resource.range, offset, extent, false));
@@ -503,7 +503,7 @@ HazardResult AccessContext::DetectVideoHazard(const vvl::VideoSession &vs_state,
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectMarkerHazard(const vvl::Buffer &buffer, const AccessRange &range) const {
+HazardResult AccessContext::DetectMarkerHazard(const vvl::Buffer& buffer, const AccessRange& range) const {
     if (!SimpleBinding(buffer)) {
         return HazardResult();
     }
@@ -513,7 +513,7 @@ HazardResult AccessContext::DetectMarkerHazard(const vvl::Buffer &buffer, const 
 }
 
 template <typename Detector>
-HazardResult AccessContext::DetectHazardRange(Detector &detector, const AccessRange &range, DetectOptions options) const {
+HazardResult AccessContext::DetectHazardRange(Detector& detector, const AccessRange& range, DetectOptions options) const {
     if (!range.non_empty()) {
         return {};
     }
@@ -523,7 +523,7 @@ HazardResult AccessContext::DetectHazardRange(Detector &detector, const AccessRa
     if (static_cast<uint32_t>(options) & DetectOptions::kDetectAsync) {
         // Async checks don't require recursive lookups, as the async lists are
         // exhaustive for the top-level context so we'll check these first
-        for (const auto &async_ref : async_) {
+        for (const auto& async_ref : async_) {
             hazard = async_ref.Context().DetectAsyncHazard(detector, range, async_ref.StartTag(), async_ref.GetQueueId());
             if (hazard.IsHazard()) {
                 return hazard;
@@ -537,14 +537,14 @@ HazardResult AccessContext::DetectHazardRange(Detector &detector, const AccessRa
 }
 
 template <typename Detector>
-HazardResult AccessContext::DetectHazardGeneratedRangeGen(Detector &detector, ImageRangeGen &range_gen,
+HazardResult AccessContext::DetectHazardGeneratedRangeGen(Detector& detector, ImageRangeGen& range_gen,
                                                           DetectOptions options) const {
     HazardResult hazard;
 
     if ((options & DetectOptions::kDetectAsync) != 0) {
         // Async checks don't require recursive lookups, as the async lists are
         // exhaustive for the top-level context so we'll check these first
-        for (const auto &async_ref : async_) {
+        for (const auto& async_ref : async_) {
             ImageRangeGen range_gen_copy(range_gen);  // original range gen is needed later
             hazard = async_ref.Context().DetectAsyncHazard(detector, range_gen_copy, async_ref.StartTag(), async_ref.GetQueueId());
             if (hazard.IsHazard()) return hazard;
@@ -553,8 +553,8 @@ HazardResult AccessContext::DetectHazardGeneratedRangeGen(Detector &detector, Im
 
     const bool detect_prev = (options & DetectOptions::kDetectPrevious) != 0;
     using ConstIterator = AccessMap::const_iterator;
-    auto do_detect_hazard_range = [this, &detector, &hazard, detect_prev](const ImageRangeGen::RangeType &range,
-                                                                          const ConstIterator &end, ConstIterator &pos) {
+    auto do_detect_hazard_range = [this, &detector, &hazard, detect_prev](const ImageRangeGen::RangeType& range,
+                                                                          const ConstIterator& end, ConstIterator& pos) {
         hazard = DetectHazardOneRange(detector, detect_prev, pos, end, range);
         return hazard.IsHazard();
     };
@@ -563,7 +563,7 @@ HazardResult AccessContext::DetectHazardGeneratedRangeGen(Detector &detector, Im
 }
 
 template <typename Detector>
-HazardResult AccessContext::DetectAsyncHazard(const Detector &detector, const AccessRange &range, ResourceUsageTag async_tag,
+HazardResult AccessContext::DetectAsyncHazard(const Detector& detector, const AccessRange& range, ResourceUsageTag async_tag,
                                               QueueId async_queue_id) const {
     assert(range.non_empty());
     HazardResult hazard;
@@ -575,13 +575,13 @@ HazardResult AccessContext::DetectAsyncHazard(const Detector &detector, const Ac
 }
 
 template <typename Detector>
-HazardResult AccessContext::DetectAsyncHazard(const Detector &detector, ImageRangeGen &range_gen, ResourceUsageTag async_tag,
+HazardResult AccessContext::DetectAsyncHazard(const Detector& detector, ImageRangeGen& range_gen, ResourceUsageTag async_tag,
                                               QueueId async_queue_id) const {
     using ConstIterator = AccessMap::const_iterator;
     HazardResult hazard;
 
-    auto do_async_hazard_check = [&detector, async_tag, async_queue_id, &hazard](const ImageRangeGen::RangeType &range,
-                                                                                 const ConstIterator &end, ConstIterator &pos) {
+    auto do_async_hazard_check = [&detector, async_tag, async_queue_id, &hazard](const ImageRangeGen::RangeType& range,
+                                                                                 const ConstIterator& end, ConstIterator& pos) {
         while (pos != end && pos->first.begin < range.end) {
             hazard = detector.DetectAsync(pos, async_tag, async_queue_id);
             if (hazard.IsHazard()) return true;
@@ -594,8 +594,8 @@ HazardResult AccessContext::DetectAsyncHazard(const Detector &detector, ImageRan
 }
 
 template <typename Detector>
-HazardResult AccessContext::DetectHazardOneRange(Detector &detector, bool detect_prev, AccessMap::const_iterator &pos,
-                                                 const AccessMap::const_iterator &the_end, const AccessRange &range) const {
+HazardResult AccessContext::DetectHazardOneRange(Detector& detector, bool detect_prev, AccessMap::const_iterator& pos,
+                                                 const AccessMap::const_iterator& the_end, const AccessRange& range) const {
     HazardResult hazard;
     AccessRange gap = {range.begin, range.begin};
 
@@ -631,14 +631,14 @@ HazardResult AccessContext::DetectHazardOneRange(Detector &detector, bool detect
 }
 
 template <typename Detector>
-HazardResult AccessContext::DetectPreviousHazard(Detector &detector, const AccessRange &range) const {
+HazardResult AccessContext::DetectPreviousHazard(Detector& detector, const AccessRange& range) const {
     if (subpass_barriers_.empty()) {
         return {};
     }
     AccessContext descent_context;
     ResolveSubpassDependencies(range, descent_context, false);
 
-    AccessMap &descent_map = descent_context.access_state_map_;
+    AccessMap& descent_map = descent_context.access_state_map_;
     for (auto prev = descent_map.begin(); prev != descent_map.end(); ++prev) {
         HazardResult hazard = detector.Detect(prev);
         if (hazard.IsHazard()) {

--- a/layers/sync/sync_image.cpp
+++ b/layers/sync/sync_image.cpp
@@ -19,16 +19,16 @@
 
 namespace syncval {
 
-ImageSubState::ImageSubState(vvl::Image &image) : vvl::ImageSubState(image), fragment_encoder(image) {}
+ImageSubState::ImageSubState(vvl::Image& image) : vvl::ImageSubState(image), fragment_encoder(image) {}
 
-void ImageSubState::SetSwapchain(vvl::Swapchain &swapchain) { SetOpaqueBaseAddress(swapchain.dev_data); }
+void ImageSubState::SetSwapchain(vvl::Swapchain& swapchain) { SetOpaqueBaseAddress(swapchain.dev_data); }
 
 bool ImageSubState::IsSimplyBound() const {
     bool simple = SimpleBinding(base) || base.IsSwapchainImage() || base.bind_swapchain;
     return simple;
 }
 
-void ImageSubState::SetOpaqueBaseAddress(vvl::DeviceState &dev_data) {
+void ImageSubState::SetOpaqueBaseAddress(vvl::DeviceState& dev_data) {
     // This is safe to call if already called to simplify caller logic
     // NOTE: Not asserting IsTiled, as there could in future be other reasons for opaque representations
     if (opaque_base_address_) {
@@ -36,8 +36,8 @@ void ImageSubState::SetOpaqueBaseAddress(vvl::DeviceState &dev_data) {
     }
 
     VkDeviceSize opaque_base = 0U;  // Fakespace Allocator starts > 0
-    auto get_opaque_base = [&opaque_base](const vvl::Image &other) {
-        const auto &other_sync = SubState(other);
+    auto get_opaque_base = [&opaque_base](const vvl::Image& other) {
+        const auto& other_sync = SubState(other);
         opaque_base = other_sync.opaque_base_address_;
         return true;
     };
@@ -62,8 +62,7 @@ VkDeviceSize ImageSubState::GetResourceBaseAddress() const {
     return base.GetFakeBaseAddress();
 }
 
-ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &subresource_range,
-                                                              bool is_depth_sliced) const {
+ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange& subresource_range, bool is_depth_sliced) const {
     if (!IsSimplyBound()) {
         return ImageRangeGen();  // default range generators have an empty position (generator "end")
     }
@@ -73,7 +72,7 @@ ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &su
     return range_gen;
 }
 
-ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &subresource_range, bool is_depth_sliced,
+ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange& subresource_range, bool is_depth_sliced,
                                                uint32_t view_mask) const {
     if (!IsSimplyBound()) {
         return {};
@@ -83,9 +82,8 @@ ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &su
     return range_gen;
 }
 
-ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &subresource_range,
-                                                              const VkOffset3D &offset, const VkExtent3D &extent,
-                                                              bool is_depth_sliced) const {
+ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange& subresource_range, const VkOffset3D& offset,
+                                               const VkExtent3D& extent, bool is_depth_sliced) const {
     if (!IsSimplyBound()) {
         return ImageRangeGen();  // default range generators have an empty position (generator "end")
     }
@@ -96,23 +94,23 @@ ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &su
     return range_gen;
 }
 
-ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view) {
-    const auto &sub_state = SubState(*view.image_state);
+ImageRangeGen MakeImageRangeGen(const vvl::ImageView& view) {
+    const auto& sub_state = SubState(*view.image_state);
     return sub_state.MakeImageRangeGen(view.normalized_subresource_range, view.is_depth_sliced);
 }
 
-ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view, uint32_t view_mask,
+ImageRangeGen MakeImageRangeGen(const vvl::ImageView& view, uint32_t view_mask,
                                 VkImageAspectFlags override_depth_stencil_aspect_mask) {
     VkImageSubresourceRange subresource_range = view.normalized_subresource_range;
     if (override_depth_stencil_aspect_mask != 0) {
         assert((override_depth_stencil_aspect_mask & kDepthStencilAspects) == override_depth_stencil_aspect_mask);
         subresource_range.aspectMask = override_depth_stencil_aspect_mask;
     }
-    const auto &sub_state = SubState(*view.image_state);
+    const auto& sub_state = SubState(*view.image_state);
     return sub_state.MakeImageRangeGen(subresource_range, view.is_depth_sliced, view_mask);
 }
 
-ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view, const VkOffset3D &offset, const VkExtent3D &extent,
+ImageRangeGen MakeImageRangeGen(const vvl::ImageView& view, const VkOffset3D& offset, const VkExtent3D& extent,
                                 VkImageAspectFlags override_depth_stencil_aspect_mask) {
     if (view.Invalid()) ImageRangeGen();
 
@@ -121,7 +119,7 @@ ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view, const VkOffset3D &of
         assert((override_depth_stencil_aspect_mask & kDepthStencilAspects) == override_depth_stencil_aspect_mask);
         subresource_range.aspectMask = override_depth_stencil_aspect_mask;
     }
-    const auto &sub_state = SubState(*view.image_state);
+    const auto& sub_state = SubState(*view.image_state);
     return sub_state.MakeImageRangeGen(subresource_range, offset, extent, view.is_depth_sliced);
 }
 

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -48,21 +48,21 @@ class MapRangesRangeGenerator {
         // Default construction *must* be empty range
         assert(current_.empty());
     }
-    MapRangesRangeGenerator(const AccessMap &filter, const AccessRange &range)
+    MapRangesRangeGenerator(const AccessMap& filter, const AccessRange& range)
         : range_(range), map_(&filter), map_pos_(), current_() {
         SeekBegin();
     }
-    MapRangesRangeGenerator(const MapRangesRangeGenerator &from) = default;
+    MapRangesRangeGenerator(const MapRangesRangeGenerator& from) = default;
 
-    const AccessRange &operator*() const { return current_; }
-    const AccessRange *operator->() const { return &current_; }
-    MapRangesRangeGenerator &operator++() {
+    const AccessRange& operator*() const { return current_; }
+    const AccessRange* operator->() const { return &current_; }
+    MapRangesRangeGenerator& operator++() {
         ++map_pos_;
         UpdateCurrent();
         return *this;
     }
 
-    bool operator==(const MapRangesRangeGenerator &other) const { return current_ == other.current_; }
+    bool operator==(const MapRangesRangeGenerator& other) const { return current_ == other.current_; }
 
   protected:
     void UpdateCurrent() {
@@ -80,7 +80,7 @@ class MapRangesRangeGenerator {
     // Adding this functionality here, to avoid gratuitous Base:: qualifiers in the derived class
     // Note: Not exposed in this classes public interface to encourage using a consistent ++/empty generator semantic
     template <typename Pred>
-    MapRangesRangeGenerator &PredicatedIncrement(Pred &pred) {
+    MapRangesRangeGenerator& PredicatedIncrement(Pred& pred) {
         do {
             ++map_pos_;
         } while (map_pos_ != map_->end() && map_pos_->first.intersects(range_) && !pred(map_pos_));
@@ -89,7 +89,7 @@ class MapRangesRangeGenerator {
     }
 
     const AccessRange range_;
-    const AccessMap *map_ = nullptr;
+    const AccessMap* map_ = nullptr;
     AccessMap::const_iterator map_pos_;
     AccessRange current_;
 };
@@ -104,13 +104,13 @@ class FilteredGeneratorGenerator {
         // Default construction for KeyType *must* be empty range
         assert(current_.empty());
     }
-    FilteredGeneratorGenerator(const AccessMap &filter, RangeGen &gen) : filter_(&filter), gen_(gen), filter_pos_(), current_() {
+    FilteredGeneratorGenerator(const AccessMap& filter, RangeGen& gen) : filter_(&filter), gen_(gen), filter_pos_(), current_() {
         SeekBegin();
     }
-    FilteredGeneratorGenerator(const FilteredGeneratorGenerator &from) = default;
-    const AccessRange &operator*() const { return current_; }
-    const AccessRange *operator->() const { return &current_; }
-    FilteredGeneratorGenerator &operator++() {
+    FilteredGeneratorGenerator(const FilteredGeneratorGenerator& from) = default;
+    const AccessRange& operator*() const { return current_; }
+    const AccessRange* operator->() const { return &current_; }
+    FilteredGeneratorGenerator& operator++() {
         AccessRange gen_range = GenRange();
         AccessRange filter_range = FilterRange();
         current_ = {};
@@ -126,7 +126,7 @@ class FilteredGeneratorGenerator {
         return *this;
     }
 
-    bool operator==(const FilteredGeneratorGenerator &other) const { return current_ == other.current_; }
+    bool operator==(const FilteredGeneratorGenerator& other) const { return current_ == other.current_; }
 
   private:
     AccessRange AdvanceFilter() {
@@ -150,7 +150,7 @@ class FilteredGeneratorGenerator {
     AccessRange FilterRange() const { return (filter_pos_ != filter_->end()) ? filter_pos_->first : AccessRange{}; }
     AccessRange GenRange() const { return *gen_; }
 
-    AccessRange FastForwardFilter(const AccessRange &range) {
+    AccessRange FastForwardFilter(const AccessRange& range) {
         auto filter_range = FilterRange();
         int retry_count = 0;
         const static int kRetryLimit = 2;  // TODO -- determine whether this limit is optimal
@@ -170,7 +170,7 @@ class FilteredGeneratorGenerator {
 
     // TODO: Consider adding "seek" (or an absolute bound "get" to range generators to make this walk
     // faster.
-    AccessRange FastForwardGen(const AccessRange &range) {
+    AccessRange FastForwardGen(const AccessRange& range) {
         auto gen_range = GenRange();
         while (!gen_range.empty() && (gen_range.end <= range.begin)) {
             ++gen_;
@@ -190,7 +190,7 @@ class FilteredGeneratorGenerator {
         }
     }
 
-    const AccessMap *filter_ = nullptr;
+    const AccessMap* filter_ = nullptr;
     RangeGen gen_;
     AccessMap::const_iterator filter_pos_;
     AccessRange current_;
@@ -198,10 +198,10 @@ class FilteredGeneratorGenerator {
 
 using EventImageRangeGenerator = FilteredGeneratorGenerator<subresource_adapter::ImageRangeGenerator>;
 
-void BarrierSet::MakeMemoryBarriers(const SyncExecScope &src, const SyncExecScope &dst, uint32_t barrier_count,
-                                    const VkMemoryBarrier *barriers) {
+void BarrierSet::MakeMemoryBarriers(const SyncExecScope& src, const SyncExecScope& dst, uint32_t barrier_count,
+                                    const VkMemoryBarrier* barriers) {
     memory_barriers.reserve(std::max<uint32_t>(1, barrier_count));
-    for (const VkMemoryBarrier &barrier : vvl::make_span(barriers, barrier_count)) {
+    for (const VkMemoryBarrier& barrier : vvl::make_span(barriers, barrier_count)) {
         SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
         memory_barriers.emplace_back(sync_barrier);
     }
@@ -217,7 +217,7 @@ void BarrierSet::MakeMemoryBarriers(const SyncExecScope &src, const SyncExecScop
     execution_dependency_barrier_count = (barrier_count == 0) ? 1 : 0;
 }
 
-void BarrierSet::MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo &dep_info) {
+void BarrierSet::MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo& dep_info) {
     // Collect unique execution dependencies from buffer and image barriers.
     //
     // NOTE: the reason to collect execution dependencies in addition to original buffer/image
@@ -227,14 +227,14 @@ void BarrierSet::MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependency
     // all READ accesses that are in scope. To emulate this behavior we collect unique
     // execution dependencies and apply them to all memory accesses (don't specify access mask).
     small_vector<std::pair<VkPipelineStageFlags2, VkPipelineStageFlags2>, 4> buffer_image_barrier_exec_deps;
-    for (const VkBufferMemoryBarrier2 &buffer_barrier :
+    for (const VkBufferMemoryBarrier2& buffer_barrier :
          vvl::make_span(dep_info.pBufferMemoryBarriers, dep_info.bufferMemoryBarrierCount)) {
         const auto src_dst = std::make_pair(buffer_barrier.srcStageMask, buffer_barrier.dstStageMask);
         if (!buffer_image_barrier_exec_deps.Contains(src_dst)) {
             buffer_image_barrier_exec_deps.emplace_back(src_dst);
         }
     }
-    for (const VkImageMemoryBarrier2 &image_barrier :
+    for (const VkImageMemoryBarrier2& image_barrier :
          vvl::make_span(dep_info.pImageMemoryBarriers, dep_info.imageMemoryBarrierCount)) {
         const auto src_dst = std::make_pair(image_barrier.srcStageMask, image_barrier.dstStageMask);
         if (!buffer_image_barrier_exec_deps.Contains(src_dst)) {
@@ -245,13 +245,13 @@ void BarrierSet::MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependency
     memory_barriers.reserve(dep_info.memoryBarrierCount + buffer_image_barrier_exec_deps.size());
 
     // Add global memory barriers specified in VkDependencyInfo
-    for (const VkMemoryBarrier2 &barrier : vvl::make_span(dep_info.pMemoryBarriers, dep_info.memoryBarrierCount)) {
+    for (const VkMemoryBarrier2& barrier : vvl::make_span(dep_info.pMemoryBarriers, dep_info.memoryBarrierCount)) {
         auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
         auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
         memory_barriers.emplace_back(SyncBarrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask));
     }
     // Add execution dependencies from buffer and image barriers
-    for (const auto &src_dst : buffer_image_barrier_exec_deps) {
+    for (const auto& src_dst : buffer_image_barrier_exec_deps) {
         auto src = SyncExecScope::MakeSrc(queue_flags, src_dst.first);
         auto dst = SyncExecScope::MakeDst(queue_flags, src_dst.second);
         memory_barriers.emplace_back(SyncBarrier(src, dst));
@@ -260,10 +260,10 @@ void BarrierSet::MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependency
     execution_dependency_barrier_count = (uint32_t)buffer_image_barrier_exec_deps.size();
 }
 
-void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator &sync_state, const SyncExecScope &src, const SyncExecScope &dst,
-                                          uint32_t barrier_count, const VkBufferMemoryBarrier *barriers) {
+void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                          uint32_t barrier_count, const VkBufferMemoryBarrier* barriers) {
     buffer_barriers.reserve(barrier_count);
-    for (const VkBufferMemoryBarrier &barrier : vvl::make_span(barriers, barrier_count)) {
+    for (const VkBufferMemoryBarrier& barrier : vvl::make_span(barriers, barrier_count)) {
         if (auto buffer = sync_state.Get<vvl::Buffer>(barrier.buffer)) {
             const auto range = MakeRange(*buffer, barrier.offset, barrier.size);
             const SyncBarrier sync_barrier(src, barrier.srcAccessMask, dst, barrier.dstAccessMask);
@@ -272,10 +272,10 @@ void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator &sync_state, const
     }
 }
 
-void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                          const VkBufferMemoryBarrier2 *barriers) {
+void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                          const VkBufferMemoryBarrier2* barriers) {
     buffer_barriers.reserve(barrier_count);
-    for (const VkBufferMemoryBarrier2 &barrier : vvl::make_span(barriers, barrier_count)) {
+    for (const VkBufferMemoryBarrier2& barrier : vvl::make_span(barriers, barrier_count)) {
         auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
         auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
         if (auto buffer = sync_state.Get<vvl::Buffer>(barrier.buffer)) {
@@ -286,9 +286,9 @@ void BarrierSet::MakeBufferMemoryBarriers(const SyncValidator &sync_state, VkQue
     }
 }
 
-void BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sync_state, const SyncExecScope &src, const SyncExecScope &dst,
-                                         uint32_t barrier_count, const VkImageMemoryBarrier *barriers,
-                                         const DeviceExtensions &extensions) {
+void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                         uint32_t barrier_count, const VkImageMemoryBarrier* barriers,
+                                         const DeviceExtensions& extensions) {
     image_barriers.reserve(barrier_count);
     for (const auto [index, barrier] : vvl::enumerate(barriers, barrier_count)) {
         if (auto image = sync_state.Get<vvl::Image>(barrier.image)) {
@@ -307,8 +307,8 @@ void BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sync_state, const 
     }
 }
 
-void BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                         const VkImageMemoryBarrier2 *barriers, const DeviceExtensions &extensions) {
+void BarrierSet::MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                         const VkImageMemoryBarrier2* barriers, const DeviceExtensions& extensions) {
     image_barriers.reserve(barrier_count);
     for (const auto [index, barrier] : vvl::enumerate(barriers, barrier_count)) {
         auto src = SyncExecScope::MakeSrc(queue_flags, barrier.srcStageMask);
@@ -330,11 +330,11 @@ void BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sync_state, VkQueu
     }
 }
 
-SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags,
+SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags,
                                              VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
-                                             uint32_t memory_barrier_count, const VkMemoryBarrier *memory_barriers,
-                                             uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers,
-                                             uint32_t image_barrier_count, const VkImageMemoryBarrier *image_barriers)
+                                             uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers,
+                                             uint32_t buffer_barrier_count, const VkBufferMemoryBarrier* buffer_barriers,
+                                             uint32_t image_barrier_count, const VkImageMemoryBarrier* image_barriers)
     : SyncOpBase(command) {
     const auto src_exec_scope = SyncExecScope::MakeSrc(queue_flags, src_stage_mask);
     const auto dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dst_stage_mask);
@@ -348,8 +348,8 @@ SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValida
                                          sync_state.device_state->extensions);
 }
 
-SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags,
-                                             const VkDependencyInfo &dep_info)
+SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags,
+                                             const VkDependencyInfo& dep_info)
     : SyncOpBase(command) {
     const ExecScopes stage_masks = sync_utils::GetExecScopes(dep_info);
 
@@ -363,18 +363,18 @@ SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValida
                                          sync_state.device_state->extensions);
 }
 
-bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext &cb_context) const {
+bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext& cb_context) const {
     bool skip = false;
-    const auto *context = cb_context.GetCurrentAccessContext();
+    const auto* context = cb_context.GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
     // Validate Image Layout transitions
-    for (const auto &image_barrier : barrier_set_.image_barriers) {
+    for (const auto& image_barrier : barrier_set_.image_barriers) {
         if (!image_barrier.layout_transition) {
             continue;
         }
-        const vvl::Image &image_state = *image_barrier.image;
+        const vvl::Image& image_state = *image_barrier.image;
         const bool can_transition_depth_slices =
             CanTransitionDepthSlices(cb_context.GetSyncState().extensions, image_state.create_info);
         const auto hazard = context->DetectImageBarrierHazard(
@@ -383,7 +383,7 @@ bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext &cb_contex
         if (hazard.IsHazard()) {
             LogObjectList objlist(cb_context.GetCBState().Handle(), image_state.Handle());
             const Location loc(command_);
-            const SyncValidator &sync_state = cb_context.GetSyncState();
+            const SyncValidator& sync_state = cb_context.GetSyncState();
             const std::string resource_description = sync_state.FormatHandle(image_state.Handle());
             const std::string error =
                 sync_state.error_messages_.ImageBarrierError(hazard, cb_context, command_, resource_description, image_barrier);
@@ -393,12 +393,12 @@ bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext &cb_contex
     return skip;
 }
 
-ResourceUsageTag SyncOpPipelineBarrier::Record(CommandBufferAccessContext *cb_context) {
+ResourceUsageTag SyncOpPipelineBarrier::Record(CommandBufferAccessContext* cb_context) {
     const auto tag = cb_context->NextCommandTag(command_);
-    for (const auto &buffer_barrier : barrier_set_.buffer_barriers) {
+    for (const auto& buffer_barrier : barrier_set_.buffer_barriers) {
         cb_context->AddCommandHandle(tag, buffer_barrier.buffer->Handle());
     }
-    for (auto &image_barrier : barrier_set_.image_barriers) {
+    for (auto& image_barrier : barrier_set_.image_barriers) {
         if (image_barrier.layout_transition) {
             const auto tag_ex = cb_context->AddCommandHandle(tag, image_barrier.image->Handle());
             image_barrier.handle_index = tag_ex.handle_index;
@@ -408,9 +408,9 @@ ResourceUsageTag SyncOpPipelineBarrier::Record(CommandBufferAccessContext *cb_co
     return tag;
 }
 
-void SyncOpPipelineBarrier::ApplySingleBufferBarrier(CommandExecutionContext &exec_context, const SyncBufferBarrier &buffer_barrier,
-                                                     const SyncBarrier &exec_dep_barrier) const {
-    AccessContext *access_context = exec_context.GetCurrentAccessContext();
+void SyncOpPipelineBarrier::ApplySingleBufferBarrier(CommandExecutionContext& exec_context, const SyncBufferBarrier& buffer_barrier,
+                                                     const SyncBarrier& exec_dep_barrier) const {
+    AccessContext* access_context = exec_context.GetCurrentAccessContext();
     const QueueId queue_id = exec_context.GetQueueId();
 
     if (SimpleBinding(*buffer_barrier.buffer)) {
@@ -425,16 +425,16 @@ void SyncOpPipelineBarrier::ApplySingleBufferBarrier(CommandExecutionContext &ex
     access_context->RegisterGlobalBarrier(exec_dep_barrier, queue_id);
 }
 
-void SyncOpPipelineBarrier::ApplySingleImageBarrier(CommandExecutionContext &exec_context, const SyncImageBarrier &image_barrier,
-                                                    const SyncBarrier &exec_dep_barrier, const ResourceUsageTag exec_tag) const {
-    AccessContext *access_context = exec_context.GetCurrentAccessContext();
+void SyncOpPipelineBarrier::ApplySingleImageBarrier(CommandExecutionContext& exec_context, const SyncImageBarrier& image_barrier,
+                                                    const SyncBarrier& exec_dep_barrier, const ResourceUsageTag exec_tag) const {
+    AccessContext* access_context = exec_context.GetCurrentAccessContext();
     const QueueId queue_id = exec_context.GetQueueId();
 
     const BarrierScope barrier_scope(image_barrier.barrier, queue_id);
     ApplySingleImageBarrierFunctor apply_barrier(*access_context, barrier_scope, image_barrier.barrier,
                                                  image_barrier.layout_transition, image_barrier.handle_index, exec_tag);
 
-    const auto &sub_state = SubState(*image_barrier.image);
+    const auto& sub_state = SubState(*image_barrier.image);
     const bool can_transition_depth_slices =
         CanTransitionDepthSlices(exec_context.GetSyncState().extensions, sub_state.base.create_info);
     auto range_gen = sub_state.MakeImageRangeGen(image_barrier.subresource_range, can_transition_depth_slices);
@@ -443,15 +443,15 @@ void SyncOpPipelineBarrier::ApplySingleImageBarrier(CommandExecutionContext &exe
     access_context->RegisterGlobalBarrier(exec_dep_barrier, queue_id);
 }
 
-void SyncOpPipelineBarrier::ApplySingleMemoryBarrier(CommandExecutionContext &exec_context,
-                                                     const SyncBarrier &memory_barrier) const {
-    AccessContext *access_context = exec_context.GetCurrentAccessContext();
+void SyncOpPipelineBarrier::ApplySingleMemoryBarrier(CommandExecutionContext& exec_context,
+                                                     const SyncBarrier& memory_barrier) const {
+    AccessContext* access_context = exec_context.GetCurrentAccessContext();
     const QueueId queue_id = exec_context.GetQueueId();
     access_context->RegisterGlobalBarrier(memory_barrier, queue_id);
 }
 
-void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const {
-    AccessContext *access_context = exec_context.GetCurrentAccessContext();
+void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
+    AccessContext* access_context = exec_context.GetCurrentAccessContext();
     const QueueId queue_id = exec_context.GetQueueId();
 
     // Apply markup action.
@@ -463,7 +463,7 @@ void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext &exec_
     // NOTE: it is enough to apply markup action to buffer and image barriers. The global barriers
     // do not use infill operations (no layout transitions) and also do not split access map ranges
     // because global barriers are applied to the full range.
-    for (const SyncBufferBarrier &barrier : barrier_set_.buffer_barriers) {
+    for (const SyncBufferBarrier& barrier : barrier_set_.buffer_barriers) {
         if (SimpleBinding(*barrier.buffer)) {
             const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
             const AccessRange range = barrier.range + base_address;
@@ -471,8 +471,8 @@ void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext &exec_
             access_context->UpdateMemoryAccessState(markup_action, range);
         }
     }
-    for (const SyncImageBarrier &barrier : barrier_set_.image_barriers) {
-        const auto &sub_state = SubState(*barrier.image);
+    for (const SyncImageBarrier& barrier : barrier_set_.image_barriers) {
+        const auto& sub_state = SubState(*barrier.image);
         const bool can_transition_depth_slices =
             CanTransitionDepthSlices(exec_context.GetSyncState().extensions, sub_state.base.create_info);
         auto range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
@@ -483,7 +483,7 @@ void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext &exec_
 
     // Use PendingBarriers to collect barriers that must be applied independently
     PendingBarriers pending_barriers;
-    for (const SyncBufferBarrier &barrier : barrier_set_.buffer_barriers) {
+    for (const SyncBufferBarrier& barrier : barrier_set_.buffer_barriers) {
         if (SimpleBinding(*barrier.buffer)) {
             const BarrierScope barrier_scope(barrier.barrier, queue_id);
             CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, barrier.barrier, false, vvl::kNoIndex32,
@@ -495,12 +495,12 @@ void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext &exec_
             access_context->UpdateMemoryAccessState(collect_barriers, range);
         }
     }
-    for (const SyncImageBarrier &barrier : barrier_set_.image_barriers) {
+    for (const SyncImageBarrier& barrier : barrier_set_.image_barriers) {
         const BarrierScope barrier_scope(barrier.barrier, queue_id);
         CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, barrier.barrier, barrier.layout_transition,
                                                 barrier.handle_index, pending_barriers);
 
-        const auto &sub_state = SubState(*barrier.image);
+        const auto& sub_state = SubState(*barrier.image);
         const bool can_transition_depth_slices =
             CanTransitionDepthSlices(exec_context.GetSyncState().extensions, sub_state.base.create_info);
         auto range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
@@ -511,7 +511,7 @@ void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext &exec_
     // Do kFullRange update only when there is multiple memory barriers.
     // For a single barrier we can use global barrier functionality.
     if (barrier_set_.memory_barriers.size() > 1) {
-        for (const SyncBarrier &barrier : barrier_set_.memory_barriers) {
+        for (const SyncBarrier& barrier : barrier_set_.memory_barriers) {
             const BarrierScope barrier_scope(barrier, queue_id);
             CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, barrier, false, vvl::kNoIndex32,
                                                     pending_barriers);
@@ -528,7 +528,7 @@ void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext &exec_
     }
 }
 
-void SyncOpPipelineBarrier::ReplayRecord(CommandExecutionContext &exec_context, const ResourceUsageTag exec_tag) const {
+void SyncOpPipelineBarrier::ReplayRecord(CommandExecutionContext& exec_context, const ResourceUsageTag exec_tag) const {
     if (!exec_context.ValidForSyncOps()) {
         return;
     }
@@ -556,30 +556,30 @@ void SyncOpPipelineBarrier::ReplayRecord(CommandExecutionContext &exec_context, 
         ApplyMultipleBarriers(exec_context, exec_tag);
     }
 
-    SyncEventsContext *events_context = exec_context.GetCurrentEventsContext();
+    SyncEventsContext* events_context = exec_context.GetCurrentEventsContext();
     if (barrier_set_.single_exec_scope) {
         events_context->ApplyBarrier(barrier_set_.src_exec_scope, barrier_set_.dst_exec_scope, exec_tag);
     } else {
-        for (const auto &barrier : barrier_set_.memory_barriers) {
+        for (const auto& barrier : barrier_set_.memory_barriers) {
             events_context->ApplyBarrier(barrier.src_exec_scope, barrier.dst_exec_scope, exec_tag);
         }
     }
 }
 
-bool SyncOpPipelineBarrier::ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const {
+bool SyncOpPipelineBarrier::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     // The layout transitions happen at the replay tag
     ResourceUsageRange first_use_range = {recorded_tag, recorded_tag + 1};
     return replay.DetectFirstUseHazard(first_use_range);
 }
 
-SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags,
-                                   uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags srcStageMask,
+SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags,
+                                   uint32_t eventCount, const VkEvent* pEvents, VkPipelineStageFlags srcStageMask,
                                    VkPipelineStageFlags dstStageMask, uint32_t memoryBarrierCount,
-                                   const VkMemoryBarrier *pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
-                                   const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-                                   const VkImageMemoryBarrier *pImageMemoryBarriers)
+                                   const VkMemoryBarrier* pMemoryBarriers, uint32_t bufferMemoryBarrierCount,
+                                   const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+                                   const VkImageMemoryBarrier* pImageMemoryBarriers)
     : SyncOpBase(command), barrier_sets_(1) {
-    auto &barrier_set = barrier_sets_[0];
+    auto& barrier_set = barrier_sets_[0];
     const auto src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
     const auto dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
 
@@ -595,12 +595,12 @@ SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator &sync_
     MakeEventsList(sync_state, eventCount, pEvents);
 }
 
-SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags,
-                                   uint32_t eventCount, const VkEvent *pEvents, const VkDependencyInfo *pDependencyInfo)
+SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags,
+                                   uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfo)
     : SyncOpBase(command), barrier_sets_(eventCount) {
     for (uint32_t i = 0; i < eventCount; i++) {
-        const auto &dep_info = pDependencyInfo[i];
-        auto &barrier_set = barrier_sets_[i];
+        const auto& dep_info = pDependencyInfo[i];
+        auto& barrier_set = barrier_sets_[i];
         auto stage_masks = sync_utils::GetExecScopes(dep_info);
 
         barrier_set.src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stage_masks.src);
@@ -615,16 +615,16 @@ SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator &sync_
     MakeEventsList(sync_state, eventCount, pEvents);
 }
 
-const char *const SyncOpWaitEvents::kIgnored = "Wait operation is ignored for this event.";
+const char* const SyncOpWaitEvents::kIgnored = "Wait operation is ignored for this event.";
 
-bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext &cb_context) const {
+bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext& cb_context) const {
     bool skip = false;
-    const auto &sync_state = cb_context.GetSyncState();
+    const auto& sync_state = cb_context.GetSyncState();
     const VkCommandBuffer command_buffer_handle = cb_context.GetCBState().VkHandle();
 
     // This is only interesting at record and not replay (Execute/Submit) time.
     for (size_t barrier_set_index = 0; barrier_set_index < barrier_sets_.size(); barrier_set_index++) {
-        const auto &barrier_set = barrier_sets_[barrier_set_index];
+        const auto& barrier_set = barrier_sets_[barrier_set_index];
         if (barrier_set.single_exec_scope) {
             const Location loc(command_);
             if (barrier_set.src_exec_scope.mask_param & VK_PIPELINE_STAGE_HOST_BIT) {
@@ -633,9 +633,9 @@ bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext &cb_context) co
                                    "srcStageMask includes %s, unsupported by synchronization validation.",
                                    string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
             } else {
-                const auto &barriers = barrier_set.memory_barriers;
+                const auto& barriers = barrier_set.memory_barriers;
                 for (size_t barrier_index = 0; barrier_index < barriers.size(); barrier_index++) {
-                    const auto &barrier = barriers[barrier_index];
+                    const auto& barrier = barriers[barrier_index];
                     if (barrier.src_exec_scope.mask_param & VK_PIPELINE_STAGE_HOST_BIT) {
                         const std::string vuid =
                             std::string("SYNC-") + std::string(CmdName()) + std::string("-hostevent-unsupported");
@@ -655,22 +655,22 @@ bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext &cb_context) co
     return skip;
 }
 
-bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, const ResourceUsageTag base_tag) const {
+bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext& exec_context, const ResourceUsageTag base_tag) const {
     bool skip = false;
-    const auto &sync_state = exec_context.GetSyncState();
+    const auto& sync_state = exec_context.GetSyncState();
     const QueueId queue_id = exec_context.GetQueueId();
 
     VkPipelineStageFlags2 event_stage_masks = 0U;
     VkPipelineStageFlags2 barrier_mask_params = 0U;
     bool events_not_found = false;
-    const auto *events_context = exec_context.GetCurrentEventsContext();
+    const auto* events_context = exec_context.GetCurrentEventsContext();
     assert(events_context);
     size_t barrier_set_index = 0;
     size_t barrier_set_incr = (barrier_sets_.size() == 1) ? 0 : 1;
     const Location loc(command_);
-    for (const auto &event : events_) {
-        const auto *sync_event = events_context->Get(event.get());
-        const auto &barrier_set = barrier_sets_[barrier_set_index];
+    for (const auto& event : events_) {
+        const auto* sync_event = events_context->Get(event.get());
+        const auto& barrier_set = barrier_sets_[barrier_set_index];
         if (!sync_event) {
             // NOTE PHASE2: This is where we'll need queue submit time validation to come back and check the srcStageMask bits
             //              or solve this with replay creating the SyncEventState in the queue context... also this will be a
@@ -692,7 +692,7 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
             event_stage_masks |= sync_event->scope.mask_param;
         }
 
-        const auto &src_exec_scope = barrier_set.src_exec_scope;
+        const auto& src_exec_scope = barrier_set.src_exec_scope;
 
         const auto ignore_reason = sync_event->IsIgnoredByWait(command_, src_exec_scope.mask_param);
         if (ignore_reason) {
@@ -700,13 +700,13 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
                 case SyncEventState::ResetWaitRace:
                 case SyncEventState::Reset2WaitRace: {
                     // Four permuations of Reset and Wait calls...
-                    const char *vuid = (command_ == vvl::Func::vkCmdWaitEvents) ? "VUID-vkCmdResetEvent-event-03834"
+                    const char* vuid = (command_ == vvl::Func::vkCmdWaitEvents) ? "VUID-vkCmdResetEvent-event-03834"
                                                                                 : "VUID-vkCmdResetEvent-event-03835";
                     if (ignore_reason == SyncEventState::Reset2WaitRace) {
                         vuid = (command_ == vvl::Func::vkCmdWaitEvents) ? "VUID-vkCmdResetEvent2-event-03831"
                                                                         : "VUID-vkCmdResetEvent2-event-03832";
                     }
-                    const char *const message =
+                    const char* const message =
                         "%s %s operation following %s without intervening execution barrier, may cause race condition. %s";
                     skip |= sync_state.LogError(vuid, event_handle, loc, message, sync_state.FormatHandle(event_handle).c_str(),
                                                 CmdName(), vvl::String(sync_event->last_command), kIgnored);
@@ -715,10 +715,10 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
                 case SyncEventState::SetRace: {
                     // Issue error message that Wait is waiting on an signal subject to race condition, and is thus ignored for
                     // this event
-                    const char *const vuid = "SYNC-vkCmdWaitEvents-unsynchronized-setops";
-                    const char *const message =
+                    const char* const vuid = "SYNC-vkCmdWaitEvents-unsynchronized-setops";
+                    const char* const message =
                         "%s Unsychronized %s calls result in race conditions w.r.t. event signalling, %s %s";
-                    const char *const reason = "First synchronization scope is undefined.";
+                    const char* const reason = "First synchronization scope is undefined.";
                     skip |= sync_state.LogError(vuid, event_handle, loc, message, sync_state.FormatHandle(event_handle).c_str(),
                                                 vvl::String(sync_event->last_command), reason, kIgnored);
                     break;
@@ -726,8 +726,8 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
                 case SyncEventState::MissingStageBits: {
                     const auto missing_bits = sync_event->scope.mask_param & ~src_exec_scope.mask_param;
                     // Issue error message that event waited for is not in wait events scope
-                    const char *const vuid = "VUID-vkCmdWaitEvents-srcStageMask-01158";
-                    const char *const message =
+                    const char* const vuid = "VUID-vkCmdWaitEvents-srcStageMask-01158";
+                    const char* const message =
                         "%s stageMask %s includes stages not present in srcStageMask %s. Stages missing from srcStageMask: %s. %s";
                     skip |= sync_state.LogError(vuid, event_handle, loc, message, sync_state.FormatHandle(event_handle).c_str(),
                                                 sync_utils::StringPipelineStageFlags(sync_event->scope.mask_param).c_str(),
@@ -750,15 +750,15 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
                     assert(ignore_reason == SyncEventState::NotIgnored);
             }
         } else if (barrier_set.image_barriers.size()) {
-            const auto &image_memory_barriers = barrier_set.image_barriers;
-            const auto *context = exec_context.GetCurrentAccessContext();
+            const auto& image_memory_barriers = barrier_set.image_barriers;
+            const auto* context = exec_context.GetCurrentAccessContext();
             assert(context);
-            for (const auto &image_memory_barrier : image_memory_barriers) {
+            for (const auto& image_memory_barrier : image_memory_barriers) {
                 if (!image_memory_barrier.layout_transition) continue;
-                const auto *image_state = image_memory_barrier.image.get();
+                const auto* image_state = image_memory_barrier.image.get();
                 if (!image_state) continue;
-                const auto &subresource_range = image_memory_barrier.subresource_range;
-                const auto &src_access_scope = image_memory_barrier.barrier.src_access_scope;
+                const auto& subresource_range = image_memory_barrier.subresource_range;
+                const auto& src_access_scope = image_memory_barrier.barrier.src_access_scope;
                 const auto hazard = context->DetectImageBarrierHazard(
                     *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, queue_id,
                     sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
@@ -782,7 +782,7 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
     if (extra_stage_bits) {
         assert(vvl::Func::vkCmdWaitEvents == command_);
         // Issue error message that event waited for is not in wait events scope
-        const char *const message =
+        const char* const message =
             "srcStageMask 0x%" PRIx64 " contains stages not present in pEvents stageMask. Extra stages are %s.%s";
         const auto handle = exec_context.Handle();
         if (!events_not_found) {
@@ -793,7 +793,7 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
     return skip;
 }
 
-ResourceUsageTag SyncOpWaitEvents::Record(CommandBufferAccessContext *cb_context) {
+ResourceUsageTag SyncOpWaitEvents::Record(CommandBufferAccessContext* cb_context) {
     const auto tag = cb_context->NextCommandTag(command_);
 
     ReplayRecord(*cb_context, tag);
@@ -801,20 +801,20 @@ ResourceUsageTag SyncOpWaitEvents::Record(CommandBufferAccessContext *cb_context
 }
 
 // Need to restrict to only valid exec and access scope for this event
-static SyncBarrier RestrictToEvent(const SyncBarrier &barrier, const SyncEventState &sync_event) {
+static SyncBarrier RestrictToEvent(const SyncBarrier& barrier, const SyncEventState& sync_event) {
     SyncBarrier result = barrier;
     result.src_exec_scope.exec_scope = sync_event.scope.exec_scope & barrier.src_exec_scope.exec_scope;
     result.src_access_scope = sync_event.scope.valid_accesses & barrier.src_access_scope;
     return result;
 }
 
-void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const {
+void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
     // Unlike PipelineBarrier, WaitEvent is *not* limited to accesses within the current subpass (if any) and thus needs to import
     // all accesses. Can instead import for all first_scopes, or a union of them, if this becomes a performance/memory issue,
     // but with no idea of the performance of the union, nor of whether it even matters... take the simplest approach here,
     if (!exec_context.ValidForSyncOps()) return;
-    AccessContext *access_context = exec_context.GetCurrentAccessContext();
-    SyncEventsContext *events_context = exec_context.GetCurrentEventsContext();
+    AccessContext* access_context = exec_context.GetCurrentAccessContext();
+    SyncEventsContext* events_context = exec_context.GetCurrentEventsContext();
     const QueueId queue_id = exec_context.GetQueueId();
 
     access_context->ResolveAllSubpassDependencies();
@@ -833,16 +833,16 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, Resou
     // TODO: need a test that demonstrates this (when doing some work on syncval events)
     size_t barrier_set_index = 0;
     size_t barrier_set_incr = (barrier_sets_.size() == 1) ? 0 : 1;
-    for (auto &event_shared : events_) {
+    for (auto& event_shared : events_) {
         if (!event_shared.get()) continue;
-        auto *sync_event = events_context->GetFromShared(event_shared);
+        auto* sync_event = events_context->GetFromShared(event_shared);
 
         sync_event->last_command = command_;
         sync_event->last_command_tag = exec_tag;
 
-        const auto &barrier_set = barrier_sets_[barrier_set_index];
+        const auto& barrier_set = barrier_sets_[barrier_set_index];
         if (!sync_event->IsIgnoredByWait(command_, barrier_set.src_exec_scope.mask_param)) {
-            for (const SyncBufferBarrier &barrier : barrier_set.buffer_barriers) {
+            for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
                 if (SimpleBinding(*barrier.buffer)) {
                     const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
                     const AccessRange range = barrier.range + base_address;
@@ -851,8 +851,8 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, Resou
                     access_context->UpdateMemoryAccessState(markup_action, filtered_range_gen);
                 }
             }
-            for (const SyncImageBarrier &barrier : barrier_set.image_barriers) {
-                const auto &sub_state = SubState(*barrier.image);
+            for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
+                const auto& sub_state = SubState(*barrier.image);
                 const bool can_transition_depth_slices =
                     CanTransitionDepthSlices(exec_context.GetSyncState().extensions, sub_state.base.create_info);
                 ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
@@ -871,18 +871,18 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, Resou
     PendingBarriers pending_barriers;
     barrier_set_index = 0;
     barrier_set_incr = (barrier_sets_.size() == 1) ? 0 : 1;
-    for (auto &event_shared : events_) {
+    for (auto& event_shared : events_) {
         if (!event_shared.get()) continue;
-        auto *sync_event = events_context->GetFromShared(event_shared);
+        auto* sync_event = events_context->GetFromShared(event_shared);
 
-        const auto &barrier_set = barrier_sets_[barrier_set_index];
-        const auto &dst = barrier_set.dst_exec_scope;
+        const auto& barrier_set = barrier_sets_[barrier_set_index];
+        const auto& dst = barrier_set.dst_exec_scope;
         if (!sync_event->IsIgnoredByWait(command_, barrier_set.src_exec_scope.mask_param)) {
             // These apply barriers one at a time as the are restricted to the resource ranges specified per each barrier,
             // but do not update the dependency chain information (but set the "pending" state) // s.t. the order independence
             // of the barriers is maintained.
 
-            for (const SyncBufferBarrier &barrier : barrier_set.buffer_barriers) {
+            for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
                 if (SimpleBinding(*barrier.buffer)) {
                     const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
                     const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
@@ -896,13 +896,13 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, Resou
                     access_context->UpdateMemoryAccessState(collect_barriers, range_gen);
                 }
             }
-            for (const SyncImageBarrier &barrier : barrier_set.image_barriers) {
+            for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
                 const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
                 const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
                 CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, event_barrier, barrier.layout_transition,
                                                         barrier.handle_index, pending_barriers);
 
-                const auto &sub_state = SubState(*barrier.image);
+                const auto& sub_state = SubState(*barrier.image);
                 const bool can_transition_depth_slices =
                     CanTransitionDepthSlices(exec_context.GetSyncState().extensions, sub_state.base.create_info);
                 ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
@@ -913,7 +913,7 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, Resou
             // TODO: because each iteration applies functor to the same range, investigate if it is
             // beneficial for the functor to support multiple barriers, so we traverse access map once.
             auto global_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
-            for (const auto &barrier : barrier_set.memory_barriers) {
+            for (const auto& barrier : barrier_set.memory_barriers) {
                 const SyncBarrier event_barrier = RestrictToEvent(barrier, *sync_event);
                 const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
                 CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
@@ -938,43 +938,43 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, Resou
     pending_barriers.Apply(exec_tag);
 }
 
-bool SyncOpWaitEvents::ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const {
+bool SyncOpWaitEvents::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     return DoValidate(replay.GetExecutionContext(), replay.GetBaseTag() + recorded_tag);
 }
 
-void SyncOpWaitEvents::MakeEventsList(const SyncValidator &sync_state, uint32_t event_count, const VkEvent *events) {
+void SyncOpWaitEvents::MakeEventsList(const SyncValidator& sync_state, uint32_t event_count, const VkEvent* events) {
     events_.reserve(event_count);
     for (uint32_t event_index = 0; event_index < event_count; event_index++) {
         events_.emplace_back(sync_state.Get<vvl::Event>(events[event_index]));
     }
 }
 
-SyncOpResetEvent::SyncOpResetEvent(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, VkEvent event,
+SyncOpResetEvent::SyncOpResetEvent(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags, VkEvent event,
                                    VkPipelineStageFlags2 stageMask)
     : SyncOpBase(command), event_(sync_state.Get<vvl::Event>(event)), exec_scope_(SyncExecScope::MakeSrc(queue_flags, stageMask)) {}
 
-bool SyncOpResetEvent::Validate(const CommandBufferAccessContext &cb_context) const {
+bool SyncOpResetEvent::Validate(const CommandBufferAccessContext& cb_context) const {
     return DoValidate(cb_context, ResourceUsageRecord::kMaxIndex);
 }
 
-bool SyncOpResetEvent::DoValidate(const CommandExecutionContext &exec_context, const ResourceUsageTag base_tag) const {
-    auto *events_context = exec_context.GetCurrentEventsContext();
+bool SyncOpResetEvent::DoValidate(const CommandExecutionContext& exec_context, const ResourceUsageTag base_tag) const {
+    auto* events_context = exec_context.GetCurrentEventsContext();
     assert(events_context);
     bool skip = false;
     if (!events_context) return skip;
 
-    const auto &sync_state = exec_context.GetSyncState();
-    const auto *sync_event = events_context->Get(event_);
+    const auto& sync_state = exec_context.GetSyncState();
+    const auto* sync_event = events_context->Get(event_);
     if (!sync_event) return skip;  // Core, Lifetimes, or Param check needs to catch invalid events.
 
     if (sync_event->last_command_tag > base_tag) return skip;  // if we validated this in recording of the secondary, don't repeat
 
-    const char *const set_wait =
+    const char* const set_wait =
         "%s %s operation following %s without intervening execution barrier, is a race condition and may result in data "
         "hazards.";
-    const char *message = set_wait;  // Only one message this call.
+    const char* message = set_wait;  // Only one message this call.
     if (!sync_event->HasBarrier(exec_scope_.mask_param, exec_scope_.exec_scope)) {
-        const char *vuid = nullptr;
+        const char* vuid = nullptr;
         switch (sync_event->last_command) {
             case vvl::Func::vkCmdSetEvent:
             case vvl::Func::vkCmdSetEvent2KHR:
@@ -1007,21 +1007,21 @@ bool SyncOpResetEvent::DoValidate(const CommandExecutionContext &exec_context, c
     return skip;
 }
 
-ResourceUsageTag SyncOpResetEvent::Record(CommandBufferAccessContext *cb_context) {
+ResourceUsageTag SyncOpResetEvent::Record(CommandBufferAccessContext* cb_context) {
     const auto tag = cb_context->NextCommandTag(command_);
     ReplayRecord(*cb_context, tag);
     return tag;
 }
 
-bool SyncOpResetEvent::ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const {
+bool SyncOpResetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     return DoValidate(replay.GetExecutionContext(), replay.GetBaseTag() + recorded_tag);
 }
 
-void SyncOpResetEvent::ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const {
+void SyncOpResetEvent::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
     if (!exec_context.ValidForSyncOps()) return;
-    SyncEventsContext *events_context = exec_context.GetCurrentEventsContext();
+    SyncEventsContext* events_context = exec_context.GetCurrentEventsContext();
 
-    auto *sync_event = events_context->GetFromShared(event_);
+    auto* sync_event = events_context->GetFromShared(event_);
     if (!sync_event) return;  // Core, Lifetimes, or Param check needs to catch invalid events.
 
     // Update the event state
@@ -1032,8 +1032,8 @@ void SyncOpResetEvent::ReplayRecord(CommandExecutionContext &exec_context, Resou
     sync_event->barriers = 0U;
 }
 
-SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, VkEvent event,
-                               VkPipelineStageFlags2 stageMask, const AccessContext *access_context)
+SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags, VkEvent event,
+                               VkPipelineStageFlags2 stageMask, const AccessContext* access_context)
     : SyncOpBase(command),
       event_(sync_state.Get<vvl::Event>(event)),
       src_exec_scope_(SyncExecScope::MakeSrc(queue_flags, stageMask)),
@@ -1049,8 +1049,8 @@ SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator &sync_stat
     }
 }
 
-SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator &sync_state, VkQueueFlags queue_flags, VkEvent event,
-                               const VkDependencyInfo &dep_info, const AccessContext *access_context)
+SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags, VkEvent event,
+                               const VkDependencyInfo& dep_info, const AccessContext* access_context)
     : SyncOpBase(command),
       event_(sync_state.Get<vvl::Event>(event)),
       src_exec_scope_(SyncExecScope::MakeSrc(queue_flags, sync_utils::GetExecScopes(dep_info).src)),
@@ -1062,35 +1062,35 @@ SyncOpSetEvent::SyncOpSetEvent(vvl::Func command, const SyncValidator &sync_stat
     }
 }
 
-bool SyncOpSetEvent::Validate(const CommandBufferAccessContext &cb_context) const {
+bool SyncOpSetEvent::Validate(const CommandBufferAccessContext& cb_context) const {
     return DoValidate(cb_context, ResourceUsageRecord::kMaxIndex);
 }
-bool SyncOpSetEvent::ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const {
+bool SyncOpSetEvent::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     return DoValidate(replay.GetExecutionContext(), replay.GetBaseTag() + recorded_tag);
 }
 
-bool SyncOpSetEvent::DoValidate(const CommandExecutionContext &exec_context, const ResourceUsageTag base_tag) const {
+bool SyncOpSetEvent::DoValidate(const CommandExecutionContext& exec_context, const ResourceUsageTag base_tag) const {
     bool skip = false;
 
-    const auto &sync_state = exec_context.GetSyncState();
-    auto *events_context = exec_context.GetCurrentEventsContext();
+    const auto& sync_state = exec_context.GetSyncState();
+    auto* events_context = exec_context.GetCurrentEventsContext();
     assert(events_context);
     if (!events_context) return skip;
 
-    const auto *sync_event = events_context->Get(event_);
+    const auto* sync_event = events_context->Get(event_);
     if (!sync_event) return skip;  // Core, Lifetimes, or Param check needs to catch invalid events.
 
     if (sync_event->last_command_tag >= base_tag) return skip;  // for replay we don't want to revalidate internal "last commmand"
 
-    const char *const reset_set =
+    const char* const reset_set =
         "%s %s operation following %s without intervening execution barrier, is a race condition and may result in data "
         "hazards.";
-    const char *const wait =
+    const char* const wait =
         "%s %s operation following %s without intervening vkCmdResetEvent, may result in data hazard and is ignored.";
 
     if (!sync_event->HasBarrier(src_exec_scope_.mask_param, src_exec_scope_.exec_scope)) {
-        const char *vuid_stem = nullptr;
-        const char *message = nullptr;
+        const char* vuid_stem = nullptr;
+        const char* message = nullptr;
         switch (sync_event->last_command) {
             case vvl::Func::vkCmdResetEvent:
             case vvl::Func::vkCmdResetEvent2KHR:
@@ -1132,9 +1132,9 @@ bool SyncOpSetEvent::DoValidate(const CommandExecutionContext &exec_context, con
     return skip;
 }
 
-ResourceUsageTag SyncOpSetEvent::Record(CommandBufferAccessContext *cb_context) {
+ResourceUsageTag SyncOpSetEvent::Record(CommandBufferAccessContext* cb_context) {
     const auto tag = cb_context->NextCommandTag(command_);
-    auto *events_context = cb_context->GetCurrentEventsContext();
+    auto* events_context = cb_context->GetCurrentEventsContext();
     const QueueId queue_id = cb_context->GetQueueId();
     assert(recorded_context_);
     if (recorded_context_ && events_context) {
@@ -1143,12 +1143,12 @@ ResourceUsageTag SyncOpSetEvent::Record(CommandBufferAccessContext *cb_context) 
     return tag;
 }
 
-void SyncOpSetEvent::ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const {
+void SyncOpSetEvent::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
     // Create a copy of the current context, and merge in the state snapshot at record set event time
     // Note: we mustn't change the recorded context copy, as a given CB could be submitted more than once (in generaL)
     if (!exec_context.ValidForSyncOps()) return;
-    SyncEventsContext *events_context = exec_context.GetCurrentEventsContext();
-    AccessContext *access_context = exec_context.GetCurrentAccessContext();
+    SyncEventsContext* events_context = exec_context.GetCurrentEventsContext();
+    AccessContext* access_context = exec_context.GetCurrentAccessContext();
     const QueueId queue_id = exec_context.GetQueueId();
 
     // Note: merged_context is a copy of the access_context, combined with the recorded context
@@ -1159,9 +1159,9 @@ void SyncOpSetEvent::ReplayRecord(CommandExecutionContext &exec_context, Resourc
     DoRecord(queue_id, exec_tag, merged_context, events_context);
 }
 
-void SyncOpSetEvent::DoRecord(QueueId queue_id, ResourceUsageTag tag, const std::shared_ptr<const AccessContext> &access_context,
-                              SyncEventsContext *events_context) const {
-    auto *sync_event = events_context->GetFromShared(event_);
+void SyncOpSetEvent::DoRecord(QueueId queue_id, ResourceUsageTag tag, const std::shared_ptr<const AccessContext>& access_context,
+                              SyncEventsContext* events_context) const {
+    auto* sync_event = events_context->GetFromShared(event_);
     if (!sync_event) return;  // Core, Lifetimes, or Param check needs to catch invalid events.
 
     // NOTE: We're going to simply record the sync scope here, as anything else would be implementation defined/undefined
@@ -1191,9 +1191,9 @@ void SyncOpSetEvent::DoRecord(QueueId queue_id, ResourceUsageTag tag, const std:
     sync_event->barriers = 0U;
 }
 
-SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValidator &sync_state,
-                                             const VkRenderPassBeginInfo *pRenderPassBegin,
-                                             const VkSubpassBeginInfo *pSubpassBeginInfo)
+SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValidator& sync_state,
+                                             const VkRenderPassBeginInfo* pRenderPassBegin,
+                                             const VkSubpassBeginInfo* pSubpassBeginInfo)
     : SyncOpBase(command), rp_context_(nullptr) {
     if (pRenderPassBegin) {
         rp_state_ = sync_state.Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
@@ -1204,7 +1204,7 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValida
             // TODO: Revisit this when all attachment validation is through SyncOps to see if we can discard the plain pointer copy
             // Note that this a safe to presist as long as shared_attachments is not cleared
             attachments_.reserve(shared_attachments_.size());
-            for (const auto &attachment : shared_attachments_) {
+            for (const auto& attachment : shared_attachments_) {
                 attachments_.emplace_back(attachment.get());
             }
         }
@@ -1214,13 +1214,13 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValida
     }
 }
 
-bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_context) const {
+bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext& cb_context) const {
     // Check if any of the layout transitions are hazardous.... but we don't have the renderpass context to work with, so we
     bool skip = false;
 
     assert(rp_state_.get());
     if (nullptr == rp_state_.get()) return skip;
-    auto &rp_state = *rp_state_.get();
+    auto& rp_state = *rp_state_.get();
 
     const uint32_t subpass = 0;
     const uint32_t view_mask = rp_state_->create_info.pSubpasses[0].viewMask;
@@ -1235,7 +1235,7 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
 
     // Validate attachment operations
     if (attachments_.empty()) return skip;
-    const auto &render_area = renderpass_begin_info_.renderArea;
+    const auto& render_area = renderpass_begin_info_.renderArea;
     const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
 
     // Since the isn't a valid RenderPassAccessContext until Record, needs to create the view/generator list... we could limit this
@@ -1256,7 +1256,7 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
     return skip;
 }
 
-ResourceUsageTag SyncOpBeginRenderPass::Record(CommandBufferAccessContext *cb_context) {
+ResourceUsageTag SyncOpBeginRenderPass::Record(CommandBufferAccessContext* cb_context) {
     assert(rp_state_.get());
     if (nullptr == rp_state_.get()) return cb_context->NextCommandTag(command_);
     const ResourceUsageTag begin_tag =
@@ -1268,11 +1268,11 @@ ResourceUsageTag SyncOpBeginRenderPass::Record(CommandBufferAccessContext *cb_co
     return begin_tag;
 }
 
-bool SyncOpBeginRenderPass::ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const {
-    CommandExecutionContext &exec_context = replay.GetExecutionContext();
+bool SyncOpBeginRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
+    CommandExecutionContext& exec_context = replay.GetExecutionContext();
     // this operation is not allowed in secondary command buffers
     assert(exec_context.Handle().type == kVulkanObjectTypeQueue);
-    auto &batch_context = static_cast<QueueBatchContext &>(exec_context);
+    auto& batch_context = static_cast<QueueBatchContext&>(exec_context);
     batch_context.BeginRenderPassReplaySetup(replay, *this);
 
     // Only the layout transitions happen at the replay tag, loadOp's happen at a subsequent tag
@@ -1280,12 +1280,12 @@ bool SyncOpBeginRenderPass::ReplayValidate(ReplayState &replay, ResourceUsageTag
     return replay.DetectFirstUseHazard(first_use_range);
 }
 
-void SyncOpBeginRenderPass::ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const {
+void SyncOpBeginRenderPass::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
     // All the needed replay state changes (for the layout transition, and context update) have to happen in ReplayValidate
 }
 
-SyncOpNextSubpass::SyncOpNextSubpass(vvl::Func command, const SyncValidator &sync_state,
-                                     const VkSubpassBeginInfo *pSubpassBeginInfo, const VkSubpassEndInfo *pSubpassEndInfo)
+SyncOpNextSubpass::SyncOpNextSubpass(vvl::Func command, const SyncValidator& sync_state,
+                                     const VkSubpassBeginInfo* pSubpassBeginInfo, const VkSubpassEndInfo* pSubpassEndInfo)
     : SyncOpBase(command) {
     if (pSubpassBeginInfo) {
         subpass_begin_info_.initialize(pSubpassBeginInfo);
@@ -1295,25 +1295,25 @@ SyncOpNextSubpass::SyncOpNextSubpass(vvl::Func command, const SyncValidator &syn
     }
 }
 
-bool SyncOpNextSubpass::Validate(const CommandBufferAccessContext &cb_context) const {
+bool SyncOpNextSubpass::Validate(const CommandBufferAccessContext& cb_context) const {
     bool skip = false;
-    const auto *renderpass_context = cb_context.GetCurrentRenderPassContext();
+    const auto* renderpass_context = cb_context.GetCurrentRenderPassContext();
     if (!renderpass_context) return skip;
 
     skip |= renderpass_context->ValidateNextSubpass(cb_context, command_);
     return skip;
 }
 
-ResourceUsageTag SyncOpNextSubpass::Record(CommandBufferAccessContext *cb_context) {
+ResourceUsageTag SyncOpNextSubpass::Record(CommandBufferAccessContext* cb_context) {
     return cb_context->RecordNextSubpass(command_);
 }
 
-bool SyncOpNextSubpass::ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const {
+bool SyncOpNextSubpass::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     // Any store/resolve operations happen before the NextSubpass tag so we can advance to the next subpass state
-    CommandExecutionContext &exec_context = replay.GetExecutionContext();
+    CommandExecutionContext& exec_context = replay.GetExecutionContext();
     // this operation is not allowed in secondary command buffers
     assert(exec_context.Handle().type == kVulkanObjectTypeQueue);
-    auto &batch_context = static_cast<QueueBatchContext &>(exec_context);
+    auto& batch_context = static_cast<QueueBatchContext&>(exec_context);
     batch_context.NextSubpassReplaySetup(replay);
 
     // Only the layout transitions happen at the replay tag, loadOp's happen at a subsequent tag
@@ -1321,31 +1321,31 @@ bool SyncOpNextSubpass::ReplayValidate(ReplayState &replay, ResourceUsageTag rec
     return replay.DetectFirstUseHazard(first_use_range);
 }
 
-void SyncOpNextSubpass::ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const {
+void SyncOpNextSubpass::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {
     // All the needed replay state changes (for the layout transition, and context update) have to happen in ReplayValidate
 }
-SyncOpEndRenderPass::SyncOpEndRenderPass(vvl::Func command, const SyncValidator &sync_state,
-                                         const VkSubpassEndInfo *pSubpassEndInfo)
+SyncOpEndRenderPass::SyncOpEndRenderPass(vvl::Func command, const SyncValidator& sync_state,
+                                         const VkSubpassEndInfo* pSubpassEndInfo)
     : SyncOpBase(command) {
     if (pSubpassEndInfo) {
         subpass_end_info_.initialize(pSubpassEndInfo);
     }
 }
 
-bool SyncOpEndRenderPass::Validate(const CommandBufferAccessContext &cb_context) const {
+bool SyncOpEndRenderPass::Validate(const CommandBufferAccessContext& cb_context) const {
     bool skip = false;
-    const auto *renderpass_context = cb_context.GetCurrentRenderPassContext();
+    const auto* renderpass_context = cb_context.GetCurrentRenderPassContext();
 
     if (!renderpass_context) return skip;
     skip |= renderpass_context->ValidateEndRenderPass(cb_context, command_);
     return skip;
 }
 
-ResourceUsageTag SyncOpEndRenderPass::Record(CommandBufferAccessContext *cb_context) {
+ResourceUsageTag SyncOpEndRenderPass::Record(CommandBufferAccessContext* cb_context) {
     return cb_context->RecordEndRenderPass(command_);
 }
 
-bool SyncOpEndRenderPass::ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const {
+bool SyncOpEndRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
     // Any store/resolve operations happen before the EndRenderPass tag so we can ignore them
     // Only the layout transitions happen at the replay tag
     ResourceUsageRange first_use_range = {recorded_tag, recorded_tag + 1};
@@ -1353,48 +1353,48 @@ bool SyncOpEndRenderPass::ReplayValidate(ReplayState &replay, ResourceUsageTag r
     skip |= replay.DetectFirstUseHazard(first_use_range);
 
     // We can cleanup here as the recorded tag represents the final layout transition (which is the last operation or the RP)
-    CommandExecutionContext &exec_context = replay.GetExecutionContext();
+    CommandExecutionContext& exec_context = replay.GetExecutionContext();
     // this operation is not allowed in secondary command buffers
     assert(exec_context.Handle().type == kVulkanObjectTypeQueue);
-    auto &batch_context = static_cast<QueueBatchContext &>(exec_context);
+    auto& batch_context = static_cast<QueueBatchContext&>(exec_context);
     batch_context.EndRenderPassReplayCleanup(replay);
 
     return skip;
 }
 
-void SyncOpEndRenderPass::ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const {}
+void SyncOpEndRenderPass::ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const {}
 
-ReplayState::ReplayState(CommandExecutionContext &exec_context, const CommandBufferAccessContext &recorded_context,
-                         const ErrorObject &error_obj, uint32_t index, ResourceUsageTag base_tag)
+ReplayState::ReplayState(CommandExecutionContext& exec_context, const CommandBufferAccessContext& recorded_context,
+                         const ErrorObject& error_obj, uint32_t index, ResourceUsageTag base_tag)
     : exec_context_(exec_context), recorded_context_(recorded_context), error_obj_(error_obj), index_(index), base_tag_(base_tag) {}
 
-AccessContext *ReplayState::ReplayStateRenderPassBegin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass &begin_op,
-                                                       const AccessContext &external_context) {
+AccessContext* ReplayState::ReplayStateRenderPassBegin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass& begin_op,
+                                                       const AccessContext& external_context) {
     return rp_replay_.Begin(queue_flags, begin_op, external_context);
 }
 
-AccessContext *ReplayState::ReplayStateRenderPassNext() { return rp_replay_.Next(); }
+AccessContext* ReplayState::ReplayStateRenderPassNext() { return rp_replay_.Next(); }
 
-void ReplayState::ReplayStateRenderPassEnd(AccessContext &external_context) { rp_replay_.End(external_context); }
+void ReplayState::ReplayStateRenderPassEnd(AccessContext& external_context) { rp_replay_.End(external_context); }
 
-const AccessContext *ReplayState::GetRecordedAccessContext() const {
+const AccessContext* ReplayState::GetRecordedAccessContext() const {
     if (rp_replay_.begin_op) {
         return rp_replay_.replay_context;
     }
     return recorded_context_.GetCurrentAccessContext();
 }
 
-bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange &first_use_range) const {
+bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange& first_use_range) const {
     bool skip = false;
     if (first_use_range.non_empty()) {
         // We're allowing for the Replay(Validate|Record) to modify the exec_context (e.g. for Renderpass operations), so
         // we need to fetch the current access context each time
-        const AccessContext *access_context = GetRecordedAccessContext();
+        const AccessContext* access_context = GetRecordedAccessContext();
 
         const HazardResult hazard = access_context->DetectFirstUseHazard(exec_context_.GetQueueId(), first_use_range,
                                                                          *exec_context_.GetCurrentAccessContext());
         if (hazard.IsHazard()) {
-            const SyncValidator &sync_state = exec_context_.GetSyncState();
+            const SyncValidator& sync_state = exec_context_.GetSyncState();
             LogObjectList objlist(exec_context_.Handle(), recorded_context_.Handle());
             const std::string error = sync_state.error_messages_.FirstUseError(hazard, exec_context_, recorded_context_, index_);
             skip |= sync_state.SyncError(hazard.Hazard(), objlist, error_obj_.location, error);
@@ -1409,7 +1409,7 @@ bool ReplayState::ValidateFirstUse() {
     bool skip = false;
     ResourceUsageRange first_use_range = {0, 0};
 
-    for (const auto &sync_op : recorded_context_.GetSyncOps()) {
+    for (const auto& sync_op : recorded_context_.GetSyncOps()) {
         // Set the range to cover all accesses until the next sync_op, and validate
         first_use_range.end = sync_op.tag;
         skip |= DetectFirstUseHazard(first_use_range);
@@ -1428,9 +1428,9 @@ bool ReplayState::ValidateFirstUse() {
 
     return skip;
 }
-AccessContext *ReplayState::RenderPassReplayState::Begin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass &begin_op_,
-                                                         const AccessContext &external_context) {
-    const RenderPassAccessContext *rp_context = begin_op_.GetRenderPassAccessContext();
+AccessContext* ReplayState::RenderPassReplayState::Begin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass& begin_op_,
+                                                         const AccessContext& external_context) {
+    const RenderPassAccessContext* rp_context = begin_op_.GetRenderPassAccessContext();
     assert(rp_context);
 
     begin_op = &begin_op_;
@@ -1440,7 +1440,7 @@ AccessContext *ReplayState::RenderPassReplayState::Begin(VkQueueFlags queue_flag
 
     // Replace the Async contexts with the the async context of the "external" context
     // For replay we don't care about async subpasses, just async queue batches
-    for (AccessContext &context : GetSubpassContexts()) {
+    for (AccessContext& context : GetSubpassContexts()) {
         context.ClearAsyncContexts();
         context.ImportAsyncContexts(external_context);
     }
@@ -1448,16 +1448,16 @@ AccessContext *ReplayState::RenderPassReplayState::Begin(VkQueueFlags queue_flag
     return &subpass_contexts[0];
 }
 
-AccessContext *ReplayState::RenderPassReplayState::Next() {
+AccessContext* ReplayState::RenderPassReplayState::Next() {
     subpass++;
 
-    const RenderPassAccessContext *rp_context = begin_op->GetRenderPassAccessContext();
+    const RenderPassAccessContext* rp_context = begin_op->GetRenderPassAccessContext();
 
     replay_context = &rp_context->GetSubpassContexts()[subpass];
     return &subpass_contexts[subpass];
 }
 
-void ReplayState::RenderPassReplayState::End(AccessContext &external_context) {
+void ReplayState::RenderPassReplayState::End(AccessContext& external_context) {
     external_context.ResolveChildContexts(GetSubpassContexts());
     *this = RenderPassReplayState{};
 }
@@ -1467,11 +1467,11 @@ vvl::span<AccessContext> ReplayState::RenderPassReplayState::GetSubpassContexts(
                           begin_op->GetRenderPassAccessContext()->GetRenderPassState()->create_info.subpassCount);
 }
 
-void SyncEventsContext::ApplyBarrier(const SyncExecScope &src, const SyncExecScope &dst, ResourceUsageTag tag) {
+void SyncEventsContext::ApplyBarrier(const SyncExecScope& src, const SyncExecScope& dst, ResourceUsageTag tag) {
     const bool all_commands_bit = 0 != (src.mask_param & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-    for (auto &event_pair : map_) {
+    for (auto& event_pair : map_) {
         assert(event_pair.second);  // Shouldn't be storing empty
-        auto &sync_event = *event_pair.second;
+        auto& sync_event = *event_pair.second;
         // Events don't happen at a stage, so we need to check and store the unexpanded ALL_COMMANDS if set for inter-event-calls
         // But only if occuring before the tag
         if (((sync_event.barriers & src.exec_scope) || all_commands_bit) && (sync_event.last_command_tag <= tag)) {
@@ -1488,24 +1488,24 @@ void SyncEventsContext::ApplyTaggedWait(VkQueueFlags queue_flags, ResourceUsageT
     ApplyBarrier(src_scope, dst_scope, tag);
 }
 
-SyncEventsContext &SyncEventsContext::DeepCopy(const SyncEventsContext &from) {
+SyncEventsContext& SyncEventsContext::DeepCopy(const SyncEventsContext& from) {
     // We need a deep copy of the const context to update during validation phase
-    for (const auto &event : from.map_) {
+    for (const auto& event : from.map_) {
         map_.emplace(event.first, std::make_shared<SyncEventState>(*event.second));
     }
     return *this;
 }
 
-void SyncEventsContext::AddReferencedTags(ResourceUsageTagSet &referenced) const {
-    for (const auto &event : map_) {
-        const std::shared_ptr<const SyncEventState> &event_state = event.second;
+void SyncEventsContext::AddReferencedTags(ResourceUsageTagSet& referenced) const {
+    for (const auto& event : map_) {
+        const std::shared_ptr<const SyncEventState>& event_state = event.second;
         if (event_state) {
             event_state->AddReferencedTags(referenced);
         }
     }
 }
 
-SyncEventState::SyncEventState(const SyncEventState::EventPointer &event_state) : SyncEventState() {
+SyncEventState::SyncEventState(const SyncEventState::EventPointer& event_state) : SyncEventState() {
     event = event_state;
     destroyed = (event.get() == nullptr) || event_state->Destroyed();
 }
@@ -1544,7 +1544,7 @@ bool SyncEventState::HasBarrier(VkPipelineStageFlags2 stageMask, VkPipelineStage
            (barriers & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 }
 
-void SyncEventState::AddReferencedTags(ResourceUsageTagSet &referenced) const {
+void SyncEventState::AddReferencedTags(ResourceUsageTagSet& referenced) const {
     if (first_scope) {
         first_scope->AddReferencedTags(referenced);
     }

--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -28,8 +28,8 @@ namespace syncval {
 
 class ValidateResolveAction {
   public:
-    ValidateResolveAction(VkRenderPass render_pass, uint32_t subpass, uint32_t view_mask, const AccessContext &context,
-                          const CommandBufferAccessContext &cb_context, vvl::Func command)
+    ValidateResolveAction(VkRenderPass render_pass, uint32_t subpass, uint32_t view_mask, const AccessContext& context,
+                          const CommandBufferAccessContext& cb_context, vvl::Func command)
         : render_pass_(render_pass),
           subpass_(subpass),
           view_mask_(view_mask),
@@ -38,15 +38,15 @@ class ValidateResolveAction {
           command_(command),
           skip_(false) {}
 
-    void operator()(const char *aspect_name, const char *resolve_action_name, uint32_t src_at, uint32_t dst_at,
-                    const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
-                    const AttachmentAccess &attachment_access) {
+    void operator()(const char* aspect_name, const char* resolve_action_name, uint32_t src_at, uint32_t dst_at,
+                    const AttachmentViewGen& view_gen, AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
+                    const AttachmentAccess& attachment_access) {
         const HazardResult hazard =
             context_.DetectAttachmentHazard(view_gen, gen_type, current_usage, attachment_access, view_mask_);
         if (hazard.IsHazard()) {
             const Location loc(command_);
 
-            const SyncValidator &validator = cb_context_.GetSyncState();
+            const SyncValidator& validator = cb_context_.GetSyncState();
 
             std::ostringstream ss;
             ss << validator.FormatHandle(view_gen.GetViewState()->Handle());
@@ -65,30 +65,30 @@ class ValidateResolveAction {
     VkRenderPass render_pass_;
     const uint32_t subpass_;
     const uint32_t view_mask_;
-    const AccessContext &context_;
-    const CommandBufferAccessContext &cb_context_;
+    const AccessContext& context_;
+    const CommandBufferAccessContext& cb_context_;
     vvl::Func command_;
     bool skip_;
 };
 
 class UpdateStateResolveAction {
   public:
-    UpdateStateResolveAction(AccessContext &context, uint32_t view_mask, ResourceUsageTag tag)
+    UpdateStateResolveAction(AccessContext& context, uint32_t view_mask, ResourceUsageTag tag)
         : context_(context), view_mask_(view_mask), tag_(tag) {}
-    void operator()(const char *, const char *, uint32_t, uint32_t, const AttachmentViewGen &view_gen,
-                    AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage, const AttachmentAccess &attachment_access) {
+    void operator()(const char*, const char*, uint32_t, uint32_t, const AttachmentViewGen& view_gen,
+                    AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage, const AttachmentAccess& attachment_access) {
         context_.UpdateAttachmentAccessState(view_gen, gen_type, current_usage, attachment_access, ResourceUsageTagEx{tag_},
                                              view_mask_);
     }
 
   private:
-    AccessContext &context_;
+    AccessContext& context_;
     const uint32_t view_mask_;
     const ResourceUsageTag tag_;
 };
 
-std::unique_ptr<AccessContext[]> InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state,
-                                                     const AccessContext &external_context) {
+std::unique_ptr<AccessContext[]> InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass& rp_state,
+                                                     const AccessContext& external_context) {
     const uint32_t subpass_count = rp_state.create_info.subpassCount;
     auto subpass_contexts = std::make_unique<AccessContext[]>(subpass_count);
     // Add this for all subpasses here so that they exsist during next subpass validation
@@ -126,16 +126,14 @@ static SyncAccessIndex GetStoreOpUsageIndex(VkAttachmentStoreOp store_op, Attach
     return access_index;
 }
 
-static SyncAccessIndex ColorLoadUsage(VkAttachmentLoadOp load_op) {
-    return GetLoadOpUsageIndex(load_op, AttachmentType::kColor);
-}
+static SyncAccessIndex ColorLoadUsage(VkAttachmentLoadOp load_op) { return GetLoadOpUsageIndex(load_op, AttachmentType::kColor); }
 static SyncAccessIndex DepthStencilLoadUsage(VkAttachmentLoadOp load_op) {
     return GetLoadOpUsageIndex(load_op, AttachmentType::kDepth);
 }
 
 // Keeps only those bits in view_mask for which subpass is "enabled" based on subpass_per_view.
 static std::optional<uint32_t> FilterViewMask(uint32_t view_mask, uint32_t subpass,
-                                              const vvl::RenderPass::SubpassPerView &subpass_per_view) {
+                                              const vvl::RenderPass::SubpassPerView& subpass_per_view) {
     // Special case when multiview is disabled to unify caller code
     if (view_mask == 0) {
         return (subpass_per_view[0] == subpass) ? std::optional<uint32_t>(0) : std::nullopt;
@@ -152,10 +150,10 @@ static std::optional<uint32_t> FilterViewMask(uint32_t view_mask, uint32_t subpa
 }
 
 // Caller must manage returned pointer
-static AccessContext *CreateStoreResolveProxyContext(const AccessContext &context, const vvl::RenderPass &rp_state,
+static AccessContext* CreateStoreResolveProxyContext(const AccessContext& context, const vvl::RenderPass& rp_state,
                                                      uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
-                                                     const AttachmentViewGenVector &attachment_views) {
-    auto *proxy = new AccessContext(*context.validator);
+                                                     const AttachmentViewGenVector& attachment_views) {
+    auto* proxy = new AccessContext(*context.validator);
     proxy->InitFrom(context);
     RenderPassAccessContext::UpdateAttachmentResolveAccess(rp_state, attachment_views, render_pass_instance_id, subpass, view_mask,
                                                            kInvalidTag, *proxy);
@@ -165,11 +163,11 @@ static AccessContext *CreateStoreResolveProxyContext(const AccessContext &contex
 }
 
 // Layout transitions are handled as if the were occuring in the beginning of the next subpass
-bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAccessContext &cb_context,
-                                                        const AccessContext &access_context, const vvl::RenderPass &rp_state,
-                                                        const VkRect2D &render_area, uint32_t render_pass_instance_id,
+bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAccessContext& cb_context,
+                                                        const AccessContext& access_context, const vvl::RenderPass& rp_state,
+                                                        const VkRect2D& render_area, uint32_t render_pass_instance_id,
                                                         uint32_t subpass, uint32_t view_mask,
-                                                        const AttachmentViewGenVector &attachment_views, vvl::Func command) {
+                                                        const AttachmentViewGenVector& attachment_views, vvl::Func command) {
     bool skip = false;
     // As validation methods are const and precede the record/update phase, for any tranistions from the immediately
     // previous subpass, we have to validate them against a copy of the AccessContext, with resolve operations applied, as
@@ -180,10 +178,10 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
     std::unique_ptr<AccessContext> src_context_proxy;
     SubpassBarrier proxy_subpass_barrier;
 
-    const auto &transitions = rp_state.subpass_transitions[subpass];
-    for (const auto &transition : transitions) {
-        const SubpassBarrier &subpass_barrier = access_context.GetSubpassBarrier(transition.src_subpass);
-        const SubpassBarrier *p_subpass_barrier = &subpass_barrier;
+    const auto& transitions = rp_state.subpass_transitions[subpass];
+    for (const auto& transition : transitions) {
+        const SubpassBarrier& subpass_barrier = access_context.GetSubpassBarrier(transition.src_subpass);
+        const SubpassBarrier* p_subpass_barrier = &subpass_barrier;
 
         const bool src_context_needs_proxy =
             transition.src_subpass != VK_SUBPASS_EXTERNAL && (transition.src_subpass + 1 == subpass);
@@ -203,10 +201,10 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
         }
         auto hazard = access_context.DetectSubpassTransitionHazard(*p_subpass_barrier, attachment_views[transition.attachment]);
         if (hazard.IsHazard()) {
-            const SyncValidator &sync_state = cb_context.GetSyncState();
+            const SyncValidator& sync_state = cb_context.GetSyncState();
             const Location loc(command);
 
-            const vvl::ImageView *attachment_view = attachment_views[transition.attachment].GetViewState();
+            const vvl::ImageView* attachment_view = attachment_views[transition.attachment].GetViewState();
             std::ostringstream ss;
             ss << "in subpass " << subpass << " of " << sync_state.FormatHandle(rp_state.Handle());
             ss << " on attachment " << transition.attachment << " (";
@@ -232,10 +230,10 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
     return skip;
 }
 
-bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessContext &cb_context,
-                                                    const AccessContext &access_context, const vvl::RenderPass &rp_state,
-                                                    const VkRect2D &render_area, uint32_t render_pass_instance_id, uint32_t subpass,
-                                                    uint32_t view_mask, const AttachmentViewGenVector &attachment_views,
+bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessContext& cb_context,
+                                                    const AccessContext& access_context, const vvl::RenderPass& rp_state,
+                                                    const VkRect2D& render_area, uint32_t render_pass_instance_id, uint32_t subpass,
+                                                    uint32_t view_mask, const AttachmentViewGenVector& attachment_views,
                                                     vvl::Func command) {
     bool skip = false;
 
@@ -246,8 +244,8 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
 
     for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
         if (auto filtered_view_mask = FilterViewMask(view_mask, subpass, rp_state.attachment_first_subpass[i])) {
-            const auto &view_gen = attachment_views[i];
-            const auto &ci = rp_state.create_info.pAttachments[i];
+            const auto& view_gen = attachment_views[i];
+            const auto& ci = rp_state.create_info.pAttachments[i];
 
             // Need check in the following way
             // 1) if the usage bit isn't in the dest_access_scope, and there is layout traniition for initial use, report hazard
@@ -263,7 +261,7 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
             const SyncAccessIndex stencil_load_index = has_stencil ? DepthStencilLoadUsage(ci.stencilLoadOp) : load_index;
 
             HazardResult hazard;
-            const char *aspect = nullptr;
+            const char* aspect = nullptr;
 
             bool checked_stencil = false;
             if (is_color && (load_index != SYNC_ACCESS_INDEX_NONE)) {
@@ -289,7 +287,7 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
 
             if (hazard.IsHazard()) {
                 const VkAttachmentLoadOp load_op = checked_stencil ? ci.stencilLoadOp : ci.loadOp;
-                const SyncValidator &sync_state = cb_context.GetSyncState();
+                const SyncValidator& sync_state = cb_context.GetSyncState();
                 const Location loc(command);
 
                 std::ostringstream ss;
@@ -319,7 +317,7 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
 // because of the ordering guarantees w.r.t. sample access and that the resolve validation hasn't altered the state, because
 // store is part of the same Next/End operation.
 // The latter is handled in layout transistion validation directly
-bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessContext &cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
     bool skip = false;
 
     const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kRaster, AttachmentAccessType::StoreOp);
@@ -327,8 +325,8 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
 
     for (uint32_t i = 0; i < rp_state_->create_info.attachmentCount; i++) {
         if (auto filtered_view_mask = FilterViewMask(view_mask, current_subpass_, rp_state_->attachment_last_subpass[i])) {
-            const AttachmentViewGen &view_gen = attachment_views_[i];
-            const auto &ci = rp_state_->create_info.pAttachments[i];
+            const AttachmentViewGen& view_gen = attachment_views_[i];
+            const auto& ci = rp_state_->create_info.pAttachments[i];
 
             // The spec states that "don't care" is an operation with VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
             // so we assume that an implementation is *free* to write in that case, meaning that for correctness
@@ -340,7 +338,7 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
             if (!has_stencil && !store_op_stores) continue;
 
             HazardResult hazard;
-            const char *aspect = nullptr;
+            const char* aspect = nullptr;
             bool checked_stencil = false;
             if (is_color) {
                 hazard = CurrentContext().DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
@@ -365,8 +363,8 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
             }
 
             if (hazard.IsHazard()) {
-                const SyncValidator &sync_state = cb_context.GetSyncState();
-                const char *const op_type_string = checked_stencil ? "stencilStoreOp" : "storeOp";
+                const SyncValidator& sync_state = cb_context.GetSyncState();
+                const char* const op_type_string = checked_stencil ? "stencilStoreOp" : "storeOp";
                 const VkAttachmentStoreOp store_op = checked_stencil ? ci.stencilStoreOp : ci.storeOp;
                 const Location loc(command);
 
@@ -387,19 +385,19 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
     return skip;
 }
 
-static bool IsDepthAttachmentWriteable(const LastBound &last_bound_state, const VkFormat format) {
+static bool IsDepthAttachmentWriteable(const LastBound& last_bound_state, const VkFormat format) {
     const bool depth_write_enable = last_bound_state.IsDepthWriteEnable();
     return (vkuFormatIsDepthAndStencil(format) || vkuFormatIsDepthOnly(format)) && depth_write_enable;
 }
 
-static bool IsStencilAttachmentWriteable(const LastBound &last_bound_state, const VkFormat format) {
+static bool IsStencilAttachmentWriteable(const LastBound& last_bound_state, const VkFormat format) {
     if (!vkuFormatIsDepthAndStencil(format) && !vkuFormatIsStencilOnly(format)) {
         return false;
     }
     if (!last_bound_state.IsStencilTestEnable()) {
         return false;
     }
-    auto is_writable = [&last_bound_state](const VkStencilOpState &ops) -> bool {
+    auto is_writable = [&last_bound_state](const VkStencilOpState& ops) -> bool {
         if (ops.writeMask == 0) {
             return false;
         }
@@ -428,11 +426,11 @@ static bool IsStencilAttachmentWriteable(const LastBound &last_bound_state, cons
 //
 // The signature for Action() reflect the needs of both uses.
 template <typename Action>
-void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
+void ResolveOperation(Action& action, const vvl::RenderPass& rp_state, const AttachmentViewGenVector& attachment_views,
                       uint32_t render_pass_instance_id, uint32_t subpass) {
-    const auto &rp_ci = rp_state.create_info;
-    const auto *attachment_ci = rp_ci.pAttachments;
-    const auto &subpass_ci = rp_ci.pSubpasses[subpass];
+    const auto& rp_ci = rp_state.create_info;
+    const auto* attachment_ci = rp_ci.pAttachments;
+    const auto& subpass_ci = rp_ci.pSubpasses[subpass];
 
     AttachmentAccess attachment_access;
     attachment_access.render_pass_instance_id = render_pass_instance_id;
@@ -445,7 +443,7 @@ void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const Att
             const uint32_t color_attach = subpass_ci.pColorAttachments[i].attachment;
             const uint32_t resolve_attach = subpass_ci.pResolveAttachments[i].attachment;
             if (color_attach != VK_ATTACHMENT_UNUSED && resolve_attach != VK_ATTACHMENT_UNUSED) {
-                attachment_access.type  = AttachmentAccessType::ResolveRead;
+                attachment_access.type = AttachmentAccessType::ResolveRead;
                 action("color", "resolve read", color_attach, resolve_attach, attachment_views[color_attach],
                        AttachmentViewGen::Gen::kRenderArea, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, attachment_access);
 
@@ -469,7 +467,7 @@ void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const Att
         const auto dst_at = ds_resolve->pDepthStencilResolveAttachment->attachment;
 
         // Figure out which aspects are actually touched during resolve operations
-        const char *aspect_string = nullptr;
+        const char* aspect_string = nullptr;
         AttachmentViewGen::Gen gen_type = AttachmentViewGen::Gen::kRenderArea;
         if (resolve_depth && resolve_stencil) {
             aspect_string = "depth/stencil";
@@ -497,7 +495,7 @@ void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const Att
     }
 }
 
-bool RenderPassAccessContext::ValidateResolveOperations(const CommandBufferAccessContext &cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateResolveOperations(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
     const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
     ValidateResolveAction validate_action(rp_state_->VkHandle(), current_subpass_, view_mask, CurrentContext(), cb_context,
                                           command);
@@ -505,18 +503,18 @@ bool RenderPassAccessContext::ValidateResolveOperations(const CommandBufferAcces
     return validate_action.GetSkip();
 }
 
-void RenderPassAccessContext::UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state,
-                                                            const AttachmentViewGenVector &attachment_views,
+void RenderPassAccessContext::UpdateAttachmentResolveAccess(const vvl::RenderPass& rp_state,
+                                                            const AttachmentViewGenVector& attachment_views,
                                                             uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
-                                                            const ResourceUsageTag tag, AccessContext &access_context) {
+                                                            const ResourceUsageTag tag, AccessContext& access_context) {
     UpdateStateResolveAction update(access_context, view_mask, tag);
     ResolveOperation(update, rp_state, attachment_views, render_pass_instance_id, subpass);
 }
 
-void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state,
-                                                          const AttachmentViewGenVector &attachment_views,
+void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass& rp_state,
+                                                          const AttachmentViewGenVector& attachment_views,
                                                           uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
-                                                          const ResourceUsageTag tag, AccessContext &access_context) {
+                                                          const ResourceUsageTag tag, AccessContext& access_context) {
     AttachmentAccess attachment_access;
     attachment_access.type = AttachmentAccessType::StoreOp;
     attachment_access.ordering = SyncOrdering::kRaster;
@@ -525,9 +523,9 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass 
 
     for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
         if (auto filtered_view_mask = FilterViewMask(view_mask, subpass, rp_state.attachment_last_subpass[i])) {
-            const auto &view_gen = attachment_views[i];
+            const auto& view_gen = attachment_views[i];
 
-            const auto &ci = rp_state.create_info.pAttachments[i];
+            const auto& ci = rp_state.create_info.pAttachments[i];
             const bool has_depth = vkuFormatHasDepth(ci.format);
             const bool has_stencil = vkuFormatHasStencil(ci.format);
             const bool is_color = !(has_depth || has_stencil);
@@ -554,14 +552,14 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass 
     }
 }
 
-void RenderPassAccessContext::RecordLayoutTransitions(const vvl::RenderPass &rp_state, uint32_t subpass,
-                                                      const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,
-                                                      AccessContext &access_context) {
-    const auto &transitions = rp_state.subpass_transitions[subpass];
-    for (const auto &transition : transitions) {
-        const auto &view_gen = attachment_views[transition.attachment];
-        const SubpassBarrier &subpass_barrier = access_context.GetSubpassBarrier(transition.src_subpass);
-        const AccessContext &src_subpass_context = *subpass_barrier.src_subpass_context;
+void RenderPassAccessContext::RecordLayoutTransitions(const vvl::RenderPass& rp_state, uint32_t subpass,
+                                                      const AttachmentViewGenVector& attachment_views, const ResourceUsageTag tag,
+                                                      AccessContext& access_context) {
+    const auto& transitions = rp_state.subpass_transitions[subpass];
+    for (const auto& transition : transitions) {
+        const auto& view_gen = attachment_views[transition.attachment];
+        const SubpassBarrier& subpass_barrier = access_context.GetSubpassBarrier(transition.src_subpass);
+        const AccessContext& src_subpass_context = *subpass_barrier.src_subpass_context;
 
         // Import the attachments into the current context
         ApplySubpassTransitionBarrierAction barrier_action(subpass_barrier, tag);
@@ -570,25 +568,25 @@ void RenderPassAccessContext::RecordLayoutTransitions(const vvl::RenderPass &rp_
     }
 }
 
-bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferAccessContext &cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
     bool skip = false;
-    const vvl::CommandBuffer &cmd_buffer = cb_context.GetCBState();
-    const auto &last_bound_state = cmd_buffer.GetLastBoundGraphics();
-    const auto *pipe = last_bound_state.pipeline_state;
+    const vvl::CommandBuffer& cmd_buffer = cb_context.GetCBState();
+    const auto& last_bound_state = cmd_buffer.GetLastBoundGraphics();
+    const auto* pipe = last_bound_state.pipeline_state;
 
     if (!pipe || pipe->RasterizationDisabled()) {
         return skip;
     }
 
     const auto& list = pipe->fs_writable_output_location_list;
-    const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
-    const auto &current_context = CurrentContext();
-    const SyncValidator &sync_state = cb_context.GetSyncState();
+    const auto& subpass = rp_state_->create_info.pSubpasses[current_subpass_];
+    const auto& current_context = CurrentContext();
+    const SyncValidator& sync_state = cb_context.GetSyncState();
 
-    auto report_atachment_hazard = [&sync_state, &cb_context, command](const HazardResult &hazard,
-                                                                       const vvl::ImageView &attachment_view,
+    auto report_atachment_hazard = [&sync_state, &cb_context, command](const HazardResult& hazard,
+                                                                       const vvl::ImageView& attachment_view,
                                                                        std::string_view attachment_description) {
-        const vvl::Image &attachment_image = *attachment_view.image_state;
+        const vvl::Image& attachment_image = *attachment_view.image_state;
         LogObjectList objlist(cb_context.GetCBState().Handle(), attachment_view.Handle(), attachment_image.Handle());
         const Location loc(command);
 
@@ -611,7 +609,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
                 continue;
             }
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
-            const AttachmentViewGen &view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
+            const AttachmentViewGen& view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
             HazardResult hazard = current_context.DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                                                          SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
                                                                          attachment_access, subpass.viewMask);
@@ -629,8 +627,8 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
     const uint32_t depth_stencil_attachment = GetSubpassDepthStencilAttachmentIndex(ds_state, subpass.pDepthStencilAttachment);
 
     if (depth_stencil_attachment != VK_ATTACHMENT_UNUSED) {
-        const AttachmentViewGen &view_gen = attachment_views_[depth_stencil_attachment];
-        const vvl::ImageView &view_state = *view_gen.GetViewState();
+        const AttachmentViewGen& view_gen = attachment_views_[depth_stencil_attachment];
+        const vvl::ImageView& view_state = *view_gen.GetViewState();
         const VkFormat ds_format = view_state.create_info.format;
         const bool depth_write = IsDepthAttachmentWriteable(last_bound_state, ds_format);
         const bool stencil_write = IsStencilAttachmentWriteable(last_bound_state, ds_format);
@@ -663,15 +661,15 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
     return skip;
 }
 
-void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuffer &cmd_buffer, const ResourceUsageTag tag) {
-    const auto &last_bound_state = cmd_buffer.GetLastBoundGraphics();
-    const auto *pipe = last_bound_state.pipeline_state;
+void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuffer& cmd_buffer, const ResourceUsageTag tag) {
+    const auto& last_bound_state = cmd_buffer.GetLastBoundGraphics();
+    const auto* pipe = last_bound_state.pipeline_state;
     if (!pipe || pipe->RasterizationDisabled()) return;
 
-    const auto &list = pipe->fs_writable_output_location_list;
-    const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
+    const auto& list = pipe->fs_writable_output_location_list;
+    const auto& subpass = rp_state_->create_info.pSubpasses[current_subpass_];
 
-    auto &current_context = CurrentContext();
+    auto& current_context = CurrentContext();
     // Subpass's inputAttachment has been done in RecordDispatchDrawDescriptorSet
     if (subpass.pColorAttachments && subpass.colorAttachmentCount && !list.empty()) {
         for (const auto location : list) {
@@ -680,7 +678,7 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
                 continue;
             }
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
-            const AttachmentViewGen &view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
+            const AttachmentViewGen& view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
             current_context.UpdateAttachmentAccessState(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                                         SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
                                                         ResourceUsageTagEx{tag}, subpass.viewMask);
@@ -688,11 +686,11 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
     }
 
     // PHASE1 TODO: Read operations for both depth and stencil are possible in the future.
-    const auto *ds_state = pipe->DepthStencilState();
+    const auto* ds_state = pipe->DepthStencilState();
     const uint32_t depth_stencil_attachment = GetSubpassDepthStencilAttachmentIndex(ds_state, subpass.pDepthStencilAttachment);
     if (depth_stencil_attachment != VK_ATTACHMENT_UNUSED) {
-        const AttachmentViewGen &view_gen = attachment_views_[depth_stencil_attachment];
-        const vvl::ImageView &view_state = *view_gen.GetViewState();
+        const AttachmentViewGen& view_gen = attachment_views_[depth_stencil_attachment];
+        const vvl::ImageView& view_state = *view_gen.GetViewState();
         const VkFormat ds_format = view_state.create_info.format;
         const bool depth_write = IsDepthAttachmentWriteable(last_bound_state, ds_format);
         const bool stencil_write = IsStencilAttachmentWriteable(last_bound_state, ds_format);
@@ -707,8 +705,8 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
     }
 }
 
-const vvl::ImageView *RenderPassAccessContext::GetClearAttachmentView(const VkClearAttachment &clear_attachment) const {
-    const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
+const vvl::ImageView* RenderPassAccessContext::GetClearAttachmentView(const VkClearAttachment& clear_attachment) const {
+    const auto& subpass = rp_state_->create_info.pSubpasses[current_subpass_];
     uint32_t attachment_index = VK_ATTACHMENT_UNUSED;
     if (clear_attachment.aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
         if (clear_attachment.colorAttachment < subpass.colorAttachmentCount) {
@@ -726,7 +724,7 @@ const vvl::ImageView *RenderPassAccessContext::GetClearAttachmentView(const VkCl
     return attachment_views_[attachment_index].GetViewState();
 }
 
-bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessContext &cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
     // PHASE1 TODO: Add Validate Preserve attachments
     bool skip = false;
     skip |= ValidateResolveOperations(cb_context, command);
@@ -737,7 +735,7 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
         return skip;
     }
     const uint32_t next_subpass_view_mask = rp_state_->create_info.pSubpasses[next_subpass].viewMask;
-    const auto &next_context = subpass_contexts_[next_subpass];
+    const auto& next_context = subpass_contexts_[next_subpass];
     skip |= ValidateLayoutTransitions(cb_context, next_context, *rp_state_, render_area_, render_pass_instance_id_, next_subpass,
                                       next_subpass_view_mask, attachment_views_, command);
     if (!skip) {
@@ -752,7 +750,7 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
     }
     return skip;
 }
-bool RenderPassAccessContext::ValidateEndRenderPass(const CommandBufferAccessContext &cb_context, vvl::Func command) const {
+bool RenderPassAccessContext::ValidateEndRenderPass(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
     // PHASE1 TODO: Validate Preserve
     bool skip = false;
     skip |= ValidateResolveOperations(cb_context, command);
@@ -761,12 +759,12 @@ bool RenderPassAccessContext::ValidateEndRenderPass(const CommandBufferAccessCon
     return skip;
 }
 
-AccessContext *RenderPassAccessContext::CreateStoreResolveProxy() const {
+AccessContext* RenderPassAccessContext::CreateStoreResolveProxy() const {
     return CreateStoreResolveProxyContext(CurrentContext(), *rp_state_, render_pass_instance_id_, current_subpass_,
                                           rp_state_->create_info.pSubpasses[current_subpass_].viewMask, attachment_views_);
 }
 
-bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const CommandBufferAccessContext &cb_context,
+bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const CommandBufferAccessContext& cb_context,
                                                                     vvl::Func command) const {
     bool skip = false;
 
@@ -778,11 +776,11 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
 
     // Validate the "finalLayout" transitions to external
     // Get them from where there we're hidding in the extra entry.
-    const auto &final_transitions = rp_state_->subpass_transitions.back();
-    for (const auto &transition : final_transitions) {
-        const auto &view_gen = attachment_views_[transition.attachment];
-        const SubpassBarrier &subpass_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
-        const AccessContext *context = subpass_barrier.src_subpass_context;
+    const auto& final_transitions = rp_state_->subpass_transitions.back();
+    for (const auto& transition : final_transitions) {
+        const auto& view_gen = attachment_views_[transition.attachment];
+        const SubpassBarrier& subpass_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
+        const AccessContext* context = subpass_barrier.src_subpass_context;
 
         if (transition.src_subpass == current_subpass_) {
             if (!proxy_for_current) {
@@ -796,7 +794,7 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
         const SyncBarrier merged_barrier(subpass_barrier.barriers);
         auto hazard = context->DetectImageBarrierHazard(view_gen, merged_barrier, AccessContext::DetectOptions::kDetectPrevious);
         if (hazard.IsHazard()) {
-            const SyncValidator &sync_state = cb_context.GetSyncState();
+            const SyncValidator& sync_state = cb_context.GetSyncState();
             const Location loc(command);
 
             std::ostringstream ss;
@@ -829,15 +827,15 @@ void RenderPassAccessContext::RecordLayoutTransitions(const ResourceUsageTag tag
 }
 
 void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
-    const auto *attachment_ci = rp_state_->create_info.pAttachments;
-    auto &subpass_context = CurrentContext();
+    const auto* attachment_ci = rp_state_->create_info.pAttachments;
+    auto& subpass_context = CurrentContext();
     const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
 
     for (uint32_t i = 0; i < rp_state_->create_info.attachmentCount; i++) {
         if (auto filtered_view_mask = FilterViewMask(view_mask, current_subpass_, rp_state_->attachment_first_subpass[i])) {
-            const AttachmentViewGen &view_gen = attachment_views_[i];
+            const AttachmentViewGen& view_gen = attachment_views_[i];
 
-            const VkAttachmentDescription2 &ci = *attachment_ci[i].ptr();
+            const VkAttachmentDescription2& ci = *attachment_ci[i].ptr();
             const bool has_depth = vkuFormatHasDepth(ci.format);
             const bool has_stencil = vkuFormatHasStencil(ci.format);
             const bool is_color = !(has_depth || has_stencil);
@@ -881,21 +879,21 @@ void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
 }
 
 AttachmentViewGenVector RenderPassAccessContext::CreateAttachmentViewGen(
-    const VkRect2D &render_area, const std::vector<const vvl::ImageView *> &attachment_views) {
+    const VkRect2D& render_area, const std::vector<const vvl::ImageView*>& attachment_views) {
     AttachmentViewGenVector view_gens;
     VkExtent3D extent = CastTo3D(render_area.extent);
     VkOffset3D offset = CastTo3D(render_area.offset);
     view_gens.reserve(attachment_views.size());
-    for (const auto *view : attachment_views) {
+    for (const auto* view : attachment_views) {
         view_gens.emplace_back(view, offset, extent);
     }
     return view_gens;
 }
 
-RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass &rp_state, const VkRect2D &render_area,
+RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass& rp_state, const VkRect2D& render_area,
                                                  VkQueueFlags queue_flags,
-                                                 const std::vector<const vvl::ImageView *> &attachment_views,
-                                                 const AccessContext &external_context, uint32_t render_pass_instance_id)
+                                                 const std::vector<const vvl::ImageView*>& attachment_views,
+                                                 const AccessContext& external_context, uint32_t render_pass_instance_id)
     : rp_state_(&rp_state),
       render_area_(render_area),
       attachment_views_(CreateAttachmentViewGen(render_area, attachment_views)),
@@ -905,7 +903,7 @@ RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass &rp_state
 
 void RenderPassAccessContext::RecordBeginRenderPass(const ResourceUsageTag barrier_tag, const ResourceUsageTag load_tag) {
     assert(0 == current_subpass_);
-    AccessContext &current_context = CurrentContext();
+    AccessContext& current_context = CurrentContext();
     current_context.SetStartTag(barrier_tag);
 
     RecordLayoutTransitions(barrier_tag);
@@ -928,14 +926,14 @@ void RenderPassAccessContext::RecordNextSubpass(ResourceUsageTag resolve_tag, co
     // Move to the next sub-command for the new subpass. The resolve and store are logically part of the previous
     // subpass, so their tag needs to be different from the layout and load operations below.
     current_subpass_++;
-    AccessContext &current_context = CurrentContext();
+    AccessContext& current_context = CurrentContext();
     current_context.SetStartTag(transition_tag);
 
     RecordLayoutTransitions(transition_tag);
     RecordLoadOperations(load_tag);
 }
 
-void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_context, const ResourceUsageTag store_tag,
+void RenderPassAccessContext::RecordEndRenderPass(AccessContext* external_context, const ResourceUsageTag store_tag,
                                                   const ResourceUsageTag transition_tag) {
     const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
 
@@ -953,10 +951,10 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
     // Not that since *final* always comes from *one* subpass per view, we don't have to accumulate the barriers
     // TODO Aliasing we may need to reconsider barrier accumulation... though I don't know that it would be valid for aliasing
     //      that had mulitple final layout transistions from mulitple final subpasses.
-    const auto &final_transitions = rp_state_->subpass_transitions.back();
-    for (const auto &transition : final_transitions) {
-        const AttachmentViewGen &view_gen = attachment_views_[transition.attachment];
-        const SubpassBarrier &dst_external_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
+    const auto& final_transitions = rp_state_->subpass_transitions.back();
+    for (const auto& transition : final_transitions) {
+        const AttachmentViewGen& view_gen = attachment_views_[transition.attachment];
+        const SubpassBarrier& dst_external_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
         assert(&subpass_contexts_[transition.src_subpass] == dst_external_barrier.src_subpass_context);
 
         ImageRangeGen range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kViewSubresource);
@@ -966,7 +964,7 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
         external_context->UpdateMemoryAccessState(markup_action, markup_range_gen);
 
         PendingBarriers pending_barriers;
-        for (const auto &barrier : dst_external_barrier.barriers) {
+        for (const auto& barrier : dst_external_barrier.barriers) {
             const BarrierScope barrier_scope(barrier);
             CollectBarriersFunctor collect_barriers(*external_context, barrier_scope, barrier, true, vvl::kNoIndex32,
                                                     pending_barriers);
@@ -976,12 +974,12 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
     }
 }
 
-AccessContext &RenderPassAccessContext::CurrentContext() {
+AccessContext& RenderPassAccessContext::CurrentContext() {
     assert(current_subpass_ < rp_state_->create_info.subpassCount);
     return subpass_contexts_[current_subpass_];
 }
 
-const AccessContext &RenderPassAccessContext::CurrentContext() const {
+const AccessContext& RenderPassAccessContext::CurrentContext() const {
     assert(current_subpass_ < rp_state_->create_info.subpassCount);
     return subpass_contexts_[current_subpass_];
 }
@@ -1003,15 +1001,15 @@ AttachmentAccess RenderPassAccessContext::GetAttachmentAccess(SyncOrdering order
     return attachment_access;
 }
 
-void BeginRenderingCmdState::AddRenderingInfo(const SyncValidator &state, const VkRenderingInfo &rendering_info) {
+void BeginRenderingCmdState::AddRenderingInfo(const SyncValidator& state, const VkRenderingInfo& rendering_info) {
     info = std::make_unique<DynamicRenderingInfo>(state, rendering_info);
 }
 
-const DynamicRenderingInfo &BeginRenderingCmdState::GetRenderingInfo() const {
+const DynamicRenderingInfo& BeginRenderingCmdState::GetRenderingInfo() const {
     assert(info);
     return *info;
 }
-DynamicRenderingInfo::DynamicRenderingInfo(const SyncValidator &state, const VkRenderingInfo &rendering_info)
+DynamicRenderingInfo::DynamicRenderingInfo(const SyncValidator& state, const VkRenderingInfo& rendering_info)
     : info(&rendering_info) {
     uint32_t attachment_count = info.colorAttachmentCount + (info.pDepthAttachment ? 1 : 0) + (info.pStencilAttachment ? 1 : 0);
 
@@ -1032,8 +1030,8 @@ DynamicRenderingInfo::DynamicRenderingInfo(const SyncValidator &state, const VkR
     }
 }
 
-const vvl::ImageView *DynamicRenderingInfo::GetClearAttachmentView(const VkClearAttachment &clear_attachment) const {
-    const vvl::ImageView *attachment_view = nullptr;
+const vvl::ImageView* DynamicRenderingInfo::GetClearAttachmentView(const VkClearAttachment& clear_attachment) const {
+    const vvl::ImageView* attachment_view = nullptr;
     if (clear_attachment.aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
         if (clear_attachment.colorAttachment < info.colorAttachmentCount) {
             attachment_view = attachments[clear_attachment.colorAttachment].view.get();
@@ -1047,8 +1045,8 @@ const vvl::ImageView *DynamicRenderingInfo::GetClearAttachmentView(const VkClear
     return attachment_view;
 }
 
-DynamicRenderingInfo::Attachment::Attachment(const SyncValidator &state, const vku::safe_VkRenderingAttachmentInfo &attachment_info,
-                                             AttachmentType type_, const VkOffset3D &offset, const VkExtent3D &extent)
+DynamicRenderingInfo::Attachment::Attachment(const SyncValidator& state, const vku::safe_VkRenderingAttachmentInfo& attachment_info,
+                                             AttachmentType type_, const VkOffset3D& offset, const VkExtent3D& extent)
     : info(attachment_info), view(state.Get<vvl::ImageView>(attachment_info.imageView)), view_gen(), type(type_) {
     if (view) {
         if (type == AttachmentType::kColor) {
@@ -1089,19 +1087,15 @@ ImageRangeGen DynamicRenderingInfo::Attachment::GetRangeGen(uint32_t view_mask) 
     }
 }
 
-SyncAccessIndex DynamicRenderingInfo::Attachment::GetLoadUsage() const {
-    return GetLoadOpUsageIndex(info.loadOp, type);
-}
+SyncAccessIndex DynamicRenderingInfo::Attachment::GetLoadUsage() const { return GetLoadOpUsageIndex(info.loadOp, type); }
 
-SyncAccessIndex DynamicRenderingInfo::Attachment::GetStoreUsage() const {
-    return GetStoreOpUsageIndex(info.storeOp, type);
-}
+SyncAccessIndex DynamicRenderingInfo::Attachment::GetStoreUsage() const { return GetStoreOpUsageIndex(info.storeOp, type); }
 
 SyncOrdering DynamicRenderingInfo::Attachment::GetOrdering() const {
     return (type == AttachmentType::kColor) ? SyncOrdering::kColorAttachment : SyncOrdering::kDepthStencilAttachment;
 }
 
-Location DynamicRenderingInfo::Attachment::GetLocation(const Location &loc, uint32_t attachment_index) const {
+Location DynamicRenderingInfo::Attachment::GetLocation(const Location& loc, uint32_t attachment_index) const {
     if (type == AttachmentType::kColor) {
         return loc.dot(vvl::Struct::VkRenderingAttachmentInfo, vvl::Field::pColorAttachments, attachment_index);
     } else if (type == AttachmentType::kDepth) {
@@ -1112,7 +1106,7 @@ Location DynamicRenderingInfo::Attachment::GetLocation(const Location &loc, uint
     }
 }
 
-bool DynamicRenderingInfo::Attachment::IsWriteable(const LastBound &last_bound_state) const {
+bool DynamicRenderingInfo::Attachment::IsWriteable(const LastBound& last_bound_state) const {
     bool writeable = IsValid();
     if (writeable) {
         //  Depth and Stencil have additional criteria

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -26,7 +26,7 @@ namespace syncval {
 
 constexpr VkAccessFlags2 kAllAccesses = VK_ACCESS_2_MEMORY_READ_BIT | VK_ACCESS_2_MEMORY_WRITE_BIT;
 
-static const char *string_SyncHazard(SyncHazard hazard) {
+static const char* string_SyncHazard(SyncHazard hazard) {
     switch (hazard) {
         case SyncHazard::NONE:
             return "NONE";
@@ -67,14 +67,14 @@ static bool IsHazardVsRead(SyncHazard hazard) {
     }
 }
 
-static auto SortKeyValues(const std::vector<ReportProperties::NameValue> &name_values) {
+static auto SortKeyValues(const std::vector<ReportProperties::NameValue>& name_values) {
     const std::vector<std::string> std_properties = {
         kPropertyMessageType,   kPropertyHazardType, kPropertyAccess,       kPropertyPriorAccess, kPropertyReadBarriers,
         kPropertyWriteBarriers, kPropertyCommand,    kPropertyPriorCommand, kPropertyDebugRegion, kPropertyPriorDebugRegion};
     const uint32_t other_properties_order = uint32_t(std_properties.size());
     const uint32_t debug_properties_order = other_properties_order + 1;
 
-    auto get_sort_order = [&](const std::string &key) -> uint32_t {
+    auto get_sort_order = [&](const std::string& key) -> uint32_t {
         // at first put standard properties
         auto std_it = std::find(std_properties.begin(), std_properties.end(), key);
         if (std_it != std_properties.end()) {
@@ -82,14 +82,14 @@ static auto SortKeyValues(const std::vector<ReportProperties::NameValue> &name_v
             return std_order;
         }
         // debug properties are at the end
-        const char *debug_properties[] = {kPropertySeqNo, kPropertyResetNo, kPropertyBatchTag};
+        const char* debug_properties[] = {kPropertySeqNo, kPropertyResetNo, kPropertyBatchTag};
         if (IsValueIn(key, debug_properties)) {
             return debug_properties_order;
         }
         return other_properties_order;
     };
     auto sorted = name_values;
-    std::stable_sort(sorted.begin(), sorted.end(), [&get_sort_order](const auto &a, const auto &b) {
+    std::stable_sort(sorted.begin(), sorted.end(), [&get_sort_order](const auto& a, const auto& b) {
         const uint32_t a_order = get_sort_order(a.name);
         const uint32_t b_order = get_sort_order(b.name);
         // Sort ordering groups
@@ -103,7 +103,7 @@ static auto SortKeyValues(const std::vector<ReportProperties::NameValue> &name_v
     return sorted;
 }
 
-static std::string FormatAccessProperty(const SyncAccessInfo &access) {
+static std::string FormatAccessProperty(const SyncAccessInfo& access) {
     constexpr std::array special_accesses = {SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_ACQUIRE_READ_SYNCVAL,
                                              SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL, SYNC_IMAGE_LAYOUT_TRANSITION,
                                              SYNC_QUEUE_FAMILY_OWNERSHIP_TRANSFER};
@@ -119,11 +119,11 @@ static std::string FormatAccessProperty(const SyncAccessInfo &access) {
     return ss.str();
 }
 
-static void GetAccessProperties(const HazardResult &hazard_result, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
-                                ReportProperties &properties) {
-    const HazardResult::HazardState &hazard = hazard_result.State();
-    const SyncAccessInfo &access_info = GetAccessInfo(hazard.access_index);
-    const SyncAccessInfo &prior_access_info = GetAccessInfo(hazard.prior_access_index);
+static void GetAccessProperties(const HazardResult& hazard_result, const SyncValidator& device, VkQueueFlags allowed_queue_flags,
+                                ReportProperties& properties) {
+    const HazardResult::HazardState& hazard = hazard_result.State();
+    const SyncAccessInfo& access_info = GetAccessInfo(hazard.access_index);
+    const SyncAccessInfo& prior_access_info = GetAccessInfo(hazard.prior_access_index);
 
     if (!hazard.recorded_access.get()) {
         properties.Add(kPropertyAccess, FormatAccessProperty(access_info));
@@ -141,7 +141,7 @@ static void GetAccessProperties(const HazardResult &hazard_result, const SyncVal
     }
 }
 
-static void GetPriorUsageProperties(const ResourceUsageInfo &prior_usage_info, ReportProperties &properties) {
+static void GetPriorUsageProperties(const ResourceUsageInfo& prior_usage_info, ReportProperties& properties) {
     properties.Add(kPropertyPriorCommand, vvl::String(prior_usage_info.command));
 
     if (!prior_usage_info.debug_region_name.empty()) {
@@ -165,7 +165,7 @@ static void GetPriorUsageProperties(const ResourceUsageInfo &prior_usage_info, R
 
 static VkPipelineStageFlags2 GetAllowedStages(VkQueueFlags queue_flags, VkPipelineStageFlagBits2 disabled_stages) {
     VkPipelineStageFlags2 allowed_stages = 0;
-    for (const auto &[queue_flag, stages] : syncAllCommandStagesByQueueFlags()) {
+    for (const auto& [queue_flag, stages] : syncAllCommandStagesByQueueFlags()) {
         if (queue_flag & queue_flags) {
             allowed_stages |= (stages & ~disabled_stages);
         }
@@ -173,12 +173,12 @@ static VkPipelineStageFlags2 GetAllowedStages(VkQueueFlags queue_flags, VkPipeli
     return allowed_stages;
 }
 
-static SyncAccessFlags FilterSyncAccessesByAllowedVkStages(const SyncAccessFlags &accesses, VkPipelineStageFlags2 allowed_stages,
+static SyncAccessFlags FilterSyncAccessesByAllowedVkStages(const SyncAccessFlags& accesses, VkPipelineStageFlags2 allowed_stages,
                                                            VkAccessFlags2 disabled_accesses) {
     SyncAccessFlags filtered_accesses = accesses;
-    const auto &access_infos = GetSyncAccessInfos();
+    const auto& access_infos = GetSyncAccessInfos();
     for (size_t i = 0; i < access_infos.size(); i++) {
-        const SyncAccessInfo &access_info = access_infos[i];
+        const SyncAccessInfo& access_info = access_infos[i];
         const bool is_stage_allowed = (access_info.stage_mask & allowed_stages) != 0;
         const bool is_access_allowed = (access_info.access_mask & disabled_accesses) == 0;
         if (!is_stage_allowed || !is_access_allowed) {
@@ -188,11 +188,11 @@ static SyncAccessFlags FilterSyncAccessesByAllowedVkStages(const SyncAccessFlags
     return filtered_accesses;
 }
 
-static SyncAccessFlags FilterSyncAccessesByAllowedVkAccesses(const SyncAccessFlags &accesses, VkAccessFlags2 allowed_vk_accesses) {
+static SyncAccessFlags FilterSyncAccessesByAllowedVkAccesses(const SyncAccessFlags& accesses, VkAccessFlags2 allowed_vk_accesses) {
     SyncAccessFlags filtered_accesses = accesses;
-    const auto &access_infos = GetSyncAccessInfos();
+    const auto& access_infos = GetSyncAccessInfos();
     for (size_t i = 0; i < access_infos.size(); i++) {
-        const SyncAccessInfo &access_info = access_infos[i];
+        const SyncAccessInfo& access_info = access_infos[i];
         if (filtered_accesses[i]) {
             const bool is_access_allowed = (access_info.access_mask & allowed_vk_accesses) != 0;
             if (!is_access_allowed) {
@@ -204,7 +204,7 @@ static SyncAccessFlags FilterSyncAccessesByAllowedVkAccesses(const SyncAccessFla
 }
 
 // If mask contains ALL of expand_bits, then clear these bits and add a meta_mask
-static void ReplaceExpandBitsWithMetaMask(VkFlags64 &mask, VkFlags64 expand_bits, VkFlags64 meta_mask) {
+static void ReplaceExpandBitsWithMetaMask(VkFlags64& mask, VkFlags64 expand_bits, VkFlags64 meta_mask) {
     if (expand_bits && (mask & expand_bits) == expand_bits) {
         mask &= ~expand_bits;
         mask |= meta_mask;
@@ -212,7 +212,7 @@ static void ReplaceExpandBitsWithMetaMask(VkFlags64 &mask, VkFlags64 expand_bits
 }
 
 static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSyncAccessesToCompactVkForm(
-    const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags) {
+    const SyncAccessFlags& sync_accesses, const SyncValidator& device, VkQueueFlags allowed_queue_flags) {
     if (sync_accesses.none()) {
         return {};
     }
@@ -248,7 +248,7 @@ static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSync
         } else {
             for (size_t i = 0; i < filtered_accesses.size(); i++) {
                 if (filtered_accesses[i]) {
-                    const SyncAccessInfo &info = GetSyncAccessInfos()[i];
+                    const SyncAccessInfo& info = GetSyncAccessInfos()[i];
                     stage_to_accesses[info.stage_mask] |= info.access_mask;
                 }
             }
@@ -266,7 +266,7 @@ static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSync
     VkPipelineStageFlags2 stages_with_all_supported_accesses = 0;
     VkAccessFlags2 all_accesses = 0;  // accesses for the above stages
 
-    for (const auto &entry : accesses_to_stages) {
+    for (const auto& entry : accesses_to_stages) {
         VkAccessFlags2 accesses = entry.first;
         VkPipelineStageFlags2 stages = entry.second;
 
@@ -314,13 +314,13 @@ static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSync
 // Given that access is hazardous, we check if at least stage or access part of it is covered
 // by the synchronization. If applied synchronization covers at least stage or access component
 // then we can provide more precise message by focusing on the other component.
-static std::pair<bool, bool> GetPartialProtectedInfo(const SyncAccessInfo &access, const SyncAccessFlags &write_barriers,
-                                                     const CommandExecutionContext &context) {
+static std::pair<bool, bool> GetPartialProtectedInfo(const SyncAccessInfo& access, const SyncAccessFlags& write_barriers,
+                                                     const CommandExecutionContext& context) {
     const auto protected_stage_access_pairs =
         ConvertSyncAccessesToCompactVkForm(write_barriers, context.GetSyncState(), context.GetQueueFlags());
     bool is_stage_protected = false;
     bool is_access_protected = false;
-    for (const auto &protected_stage_access : protected_stage_access_pairs) {
+    for (const auto& protected_stage_access : protected_stage_access_pairs) {
         if (protected_stage_access.first & access.stage_mask) {
             is_stage_protected = true;
         }
@@ -331,7 +331,7 @@ static std::pair<bool, bool> GetPartialProtectedInfo(const SyncAccessInfo &acces
     return std::make_pair(is_stage_protected, is_access_protected);
 }
 
-static void ReportLayoutTransitionSynchronizationInsight(std::ostringstream &ss, bool needs_execution_dependency,
+static void ReportLayoutTransitionSynchronizationInsight(std::ostringstream& ss, bool needs_execution_dependency,
                                                          VkPipelineStageFlags2 read_barriers = 0) {
     // TODO: analyse exact form of API is used (render pass layout transition, image barrier layout transition) and
     // print instructions for specific situation. Now we describe all possibilities.
@@ -350,7 +350,7 @@ static void ReportLayoutTransitionSynchronizationInsight(std::ostringstream &ss,
     }
 }
 
-static void ReportAcquireImageSynchronizationInsight(std::ostringstream &ss) {
+static void ReportAcquireImageSynchronizationInsight(std::ostringstream& ss) {
     ss << "\nHint: If a submit command waits on a semaphore signaled by AcquireNextImage command at specific pipeline stages, this "
           "error can occur if the layout transition barrier does not create an execution dependency with those stages (for "
           "example, by including them in the barrier's srcStageMask).";
@@ -372,7 +372,7 @@ std::string ReportProperties::FormatExtraPropertiesSection() const {
     std::ostringstream ss;
     ss << "[Extra properties]\n";
     bool first = true;
-    for (const NameValue &property : sorted) {
+    for (const NameValue& property : sorted) {
         if (!first) {
             ss << "\n";
         }
@@ -382,8 +382,8 @@ std::string ReportProperties::FormatExtraPropertiesSection() const {
     return ss.str();
 }
 
-ReportProperties GetErrorMessageProperties(const HazardResult &hazard, const CommandExecutionContext &context, vvl::Func command,
-                                           const char *message_type, const AdditionalMessageInfo &additional_info) {
+ReportProperties GetErrorMessageProperties(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+                                           const char* message_type, const AdditionalMessageInfo& additional_info) {
     ReportProperties properties;
     properties.Add(kPropertyMessageType, message_type);
     properties.Add(kPropertyHazardType, string_SyncHazard(hazard.Hazard()));
@@ -395,19 +395,19 @@ ReportProperties GetErrorMessageProperties(const HazardResult &hazard, const Com
         ResourceUsageInfo prior_usage_info = context.GetResourceUsageInfo(hazard.TagEx());
         GetPriorUsageProperties(prior_usage_info, properties);
     }
-    for (const auto &property : additional_info.properties.name_values) {
+    for (const auto& property : additional_info.properties.name_values) {
         properties.Add(property.name, property.value);
     }
     return properties;
 }
 
-std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutionContext &context, vvl::Func command,
-                               const std::string &resouce_description, const AdditionalMessageInfo &additional_info) {
+std::string FormatErrorMessage(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+                               const std::string& resouce_description, const AdditionalMessageInfo& additional_info) {
     const SyncHazard hazard_type = hazard.Hazard();
     const SyncHazardInfo hazard_info = GetSyncHazardInfo(hazard_type);
 
-    const SyncAccessInfo &access = GetAccessInfo(hazard.State().access_index);
-    const SyncAccessInfo &prior_access = GetAccessInfo(hazard.State().prior_access_index);
+    const SyncAccessInfo& access = GetAccessInfo(hazard.State().access_index);
+    const SyncAccessInfo& prior_access = GetAccessInfo(hazard.State().prior_access_index);
 
     const SyncAccessFlags write_barriers = hazard.State().access_state->GetWriteBarriers();
     VkPipelineStageFlags2 read_barriers = hazard.State().access_state->GetReadBarriers(hazard.State().prior_access_index);
@@ -504,10 +504,10 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
     // Synchronization information
     ss << "\n";
     if (missing_synchronization) {
-        const char *access_type = hazard_info.IsWrite() ? "write" : "read";
-        const char *prior_access_type = hazard_info.IsPriorWrite() ? "write" : "read";
+        const char* access_type = hazard_info.IsWrite() ? "write" : "read";
+        const char* prior_access_type = hazard_info.IsPriorWrite() ? "write" : "read";
 
-        auto get_special_access_name = [](SyncAccessIndex access) -> const char * {
+        auto get_special_access_name = [](SyncAccessIndex access) -> const char* {
             if (access == SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_ACQUIRE_READ_SYNCVAL) {
                 return "swapchain image acquire operation";
             } else if (access == SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL) {
@@ -521,7 +521,7 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
         };
 
         ss << "No sufficient synchronization is present to ensure that a ";
-        if (const char *special_access_name = get_special_access_name(access.access_index)) {
+        if (const char* special_access_name = get_special_access_name(access.access_index)) {
             ss << special_access_name;
         } else {
             assert(access.access_mask != VK_ACCESS_2_NONE);
@@ -531,7 +531,7 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
         }
 
         ss << " does not conflict with a prior ";
-        if (const char *special_access_name = get_special_access_name(prior_access.access_index)) {
+        if (const char* special_access_name = get_special_access_name(prior_access.access_index)) {
             ss << special_access_name;
         } else {
             assert(prior_access.access_mask != VK_ACCESS_2_NONE);
@@ -605,7 +605,7 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
     return ss.str();
 }
 
-std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
+std::string FormatSyncAccesses(const SyncAccessFlags& sync_accesses, const SyncValidator& device, VkQueueFlags allowed_queue_flags,
                                bool format_as_extra_property) {
     const auto report_accesses = ConvertSyncAccessesToCompactVkForm(sync_accesses, device, allowed_queue_flags);
     if (report_accesses.empty()) {
@@ -613,7 +613,7 @@ std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncV
     }
     std::ostringstream out;
     bool first = true;
-    for (const auto &[stages, accesses] : report_accesses) {
+    for (const auto& [stages, accesses] : report_accesses) {
         if (!first) {
             out << (format_as_extra_property ? ":" : ", ");
         }
@@ -635,7 +635,7 @@ std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncV
     return out.str();
 }
 
-void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::ostringstream &ss) {
+void FormatVideoPictureResouce(const Logger& logger, const VkVideoPictureResourceInfoKHR& video_picture, std::ostringstream& ss) {
     ss << "{";
     ss << logger.FormatHandle(video_picture.imageViewBinding);
     ss << ", codedOffset (" << string_VkOffset2D(video_picture.codedOffset) << ")";
@@ -644,16 +644,16 @@ void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourc
     ss << "}";
 }
 
-void FormatVideoQuantizationMap(const Logger &logger, const VkVideoEncodeQuantizationMapInfoKHR &quantization_map,
-                                std::ostringstream &ss) {
+void FormatVideoQuantizationMap(const Logger& logger, const VkVideoEncodeQuantizationMapInfoKHR& quantization_map,
+                                std::ostringstream& ss) {
     ss << "{";
     ss << logger.FormatHandle(quantization_map.quantizationMap);
     ss << ", quantizationMapExtent (" << string_VkExtent2D(quantization_map.quantizationMapExtent) << ")";
     ss << "}";
 }
 
-static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_ex, const ResourceUsageRecord &record,
-                                                        const DebugNameProvider *debug_name_provider) {
+static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_ex, const ResourceUsageRecord& record,
+                                                        const DebugNameProvider* debug_name_provider) {
     ResourceUsageInfo info;
     if (record.alt_usage) {
         info.command = record.alt_usage.GetCommand();
@@ -666,8 +666,8 @@ static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_e
 
         // Associated resource
         if (tag_ex.handle_index != vvl::kNoIndex32) {
-            auto &cb_context = SubState(*record.cb_state);
-            const auto &handle_records = cb_context.access_context.GetHandleRecords();
+            auto& cb_context = SubState(*record.cb_state);
+            const auto& handle_records = cb_context.access_context.GetHandleRecords();
 
             // Command buffer can be in inconsistent state due to unhandled core validation error (core validation is disabled).
             // In this case the goal is not to crash, no guarantees that reported information (handle index) makes sense.
@@ -687,7 +687,7 @@ static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_e
 }
 
 ResourceUsageInfo CommandBufferAccessContext::GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const {
-    const ResourceUsageRecord &record = (*access_log_)[tag_ex.tag];
+    const ResourceUsageRecord& record = (*access_log_)[tag_ex.tag];
     const auto debug_name_provider = (record.label_command_index == vvl::kNoIndex32) ? nullptr : this;
     return GetResourceUsageInfoFromRecord(tag_ex, record, debug_name_provider);
 }
@@ -697,10 +697,10 @@ ResourceUsageInfo QueueBatchContext::GetResourceUsageInfo(ResourceUsageTagEx tag
     if (!access.IsValid()) {
         return {};
     }
-    const ResourceUsageRecord &record = *access.record;
+    const ResourceUsageRecord& record = *access.record;
     ResourceUsageInfo info = GetResourceUsageInfoFromRecord(tag_ex, record, access.debug_name_provider);
 
-    const BatchAccessLog::BatchRecord &batch = *access.batch;
+    const BatchAccessLog::BatchRecord& batch = *access.batch;
     if (batch.queue) {
         info.queue = batch.queue->GetQueueState();
         info.submit_index = batch.submit_index;

--- a/layers/sync/sync_stats.cpp
+++ b/layers/sync/sync_stats.cpp
@@ -29,10 +29,9 @@ namespace vvl {
 // https://en.cppreference.com/w/cpp/atomic/atomic/fetch_max
 // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0493r5.pdf
 template <typename T>
-inline T atomic_fetch_max(std::atomic<T> &current_max, const T &value) noexcept {
+inline T atomic_fetch_max(std::atomic<T>& current_max, const T& value) noexcept {
     T t = current_max.load();
-    while (!current_max.compare_exchange_weak(t, std::max(t, value)))
-        ;
+    while (!current_max.compare_exchange_weak(t, std::max(t, value)));
     return t;
 }
 }  // namespace vvl

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -39,7 +39,7 @@ static bool GetShowStatsEnvVar() {
     return !show_stats_str.empty() && std::atoi(show_stats_str.c_str()) != 0;
 }
 
-SyncValidator::SyncValidator(vvl::dispatch::Device *dev, syncval::Instance *instance_vo)
+SyncValidator::SyncValidator(vvl::dispatch::Device* dev, syncval::Instance* instance_vo)
     : BaseClass(dev, instance_vo, LayerObjectTypeSyncValidation), error_messages_(*this), report_stats_(GetShowStatsEnvVar()) {}
 
 SyncValidator::~SyncValidator() {
@@ -68,8 +68,8 @@ void SyncValidator::DebugCapture() {
     }
 }
 
-bool SyncValidator::SyncError(SyncHazard hazard, const LogObjectList &objlist, const Location &loc,
-                              const std::string &error_message) const {
+bool SyncValidator::SyncError(SyncHazard hazard, const LogObjectList& objlist, const Location& loc,
+                              const std::string& error_message) const {
     return LogError(string_SyncHazardVUID(hazard), objlist, loc, "%s", error_message.c_str());
 }
 
@@ -81,10 +81,10 @@ ResourceUsageRange SyncValidator::ReserveGlobalTagRange(size_t tag_count) const 
 }
 
 void SyncValidator::EnsureTimelineSignalsLimit(uint32_t signals_per_queue_limit, QueueId queue) {
-    for (auto &[_, signals] : timeline_signals_) {
+    for (auto& [_, signals] : timeline_signals_) {
         const size_t initial_signal_count = signals.size();
         vvl::unordered_map<QueueId, uint32_t> signals_per_queue;
-        for (const SignalInfo &signal : signals) {
+        for (const SignalInfo& signal : signals) {
             ++signals_per_queue[signal.first_scope.queue];
         }
         const bool filter_queue = queue != kQueueIdInvalid;
@@ -93,7 +93,7 @@ void SyncValidator::EnsureTimelineSignalsLimit(uint32_t signals_per_queue_limit,
                 ++it;
                 continue;
             }
-            auto &counter = signals_per_queue[it->first_scope.queue];
+            auto& counter = signals_per_queue[it->first_scope.queue];
             if (counter > signals_per_queue_limit) {
                 it = signals.erase(it);
                 --counter;
@@ -105,12 +105,12 @@ void SyncValidator::EnsureTimelineSignalsLimit(uint32_t signals_per_queue_limit,
     }
 }
 
-void SyncValidator::ApplySignalsUpdate(SignalsUpdate &update, const QueueBatchContext::Ptr &last_batch) {
+void SyncValidator::ApplySignalsUpdate(SignalsUpdate& update, const QueueBatchContext::Ptr& last_batch) {
     // NOTE: All conserved QueueBatchContexts need to have their access logs reset to use the global
     // logger and the only conserved QBCs are those referenced by unwaited signals and the last batch.
 
-    for (auto &signal_entry : update.binary_signal_requests) {
-        auto &signal_batch = signal_entry.second.batch;
+    for (auto& signal_entry : update.binary_signal_requests) {
+        auto& signal_batch = signal_entry.second.batch;
         // Batches retained for signalled semaphore don't need to retain
         // event data, unless it's the last batch in the submit
         if (signal_batch != last_batch) {
@@ -120,20 +120,20 @@ void SyncValidator::ApplySignalsUpdate(SignalsUpdate &update, const QueueBatchCo
             signal_batch->Trim();
         }
         const VkSemaphore semaphore = signal_entry.first;
-        SignalInfo &signal_info = signal_entry.second;
+        SignalInfo& signal_info = signal_entry.second;
         binary_signals_.insert_or_assign(semaphore, std::move(signal_info));
     }
     for (VkSemaphore semaphore : update.binary_unsignal_requests) {
         binary_signals_.erase(semaphore);
     }
-    for (auto &[semaphore, new_signals] : update.timeline_signals) {
-        std::vector<SignalInfo> &signals = timeline_signals_[semaphore];
+    for (auto& [semaphore, new_signals] : update.timeline_signals) {
+        std::vector<SignalInfo>& signals = timeline_signals_[semaphore];
         vvl::Append(signals, new_signals);
         stats.AddTimelineSignals((uint32_t)new_signals.size());
 
         // Update host sync points
-        std::deque<TimelineHostSyncPoint> &host_sync_points = host_waitable_semaphores_[semaphore];
-        for (SignalInfo &new_signal : new_signals) {
+        std::deque<TimelineHostSyncPoint>& host_sync_points = host_waitable_semaphores_[semaphore];
+        for (SignalInfo& new_signal : new_signals) {
             if (new_signal.batch) {
                 // The lifetimes of the semaphore host sync points are managed by vkWaitSemaphores.
                 // kMaxTimelineHostSyncPoints limit is used when the program does not use vkWaitSemaphores.
@@ -155,10 +155,10 @@ void SyncValidator::ApplySignalsUpdate(SignalsUpdate &update, const QueueBatchCo
             }
         }
     }
-    for (const auto &remove_signals_request : update.remove_timeline_signals_requests) {
-        auto &signals = timeline_signals_[remove_signals_request.semaphore];
+    for (const auto& remove_signals_request : update.remove_timeline_signals_requests) {
+        auto& signals = timeline_signals_[remove_signals_request.semaphore];
         for (auto it = signals.begin(); it != signals.end();) {
-            const SignalInfo &signal = *it;
+            const SignalInfo& signal = *it;
             if (signal.first_scope.queue == remove_signals_request.queue &&
                 signal.timeline_value < remove_signals_request.signal_threshold_value) {
                 it = signals.erase(it);
@@ -176,8 +176,8 @@ void SyncValidator::ApplySignalsUpdate(SignalsUpdate &update, const QueueBatchCo
 }
 
 void SyncValidator::ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag,
-                                    const LastSynchronizedPresent &last_synchronized_present,
-                                    const std::vector<ResourceUsageTag> &queue_sync_tags) {
+                                    const LastSynchronizedPresent& last_synchronized_present,
+                                    const std::vector<ResourceUsageTag>& queue_sync_tags) {
     assert(queue_id < queue_id_limit_);
     assert(queue_sync_tags.empty() || queue_sync_tags.size() == queue_id_limit_);
     assert(queue_sync_tags.empty() || queue_sync_tags[queue_id] == tag);
@@ -199,8 +199,8 @@ void SyncValidator::ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag,
     }
 
     const auto all_batches = GetAllQueueBatchContexts();
-    for (const auto &batch : all_batches) {
-        for (const auto &[sync_queue, sync_tag] : sync_points) {
+    for (const auto& batch : all_batches) {
+        for (const auto& [sync_queue, sync_tag] : sync_points) {
             batch->ApplyTaggedWait(sync_queue, sync_tag, last_synchronized_present);
         }
         batch->Trim();
@@ -212,7 +212,7 @@ void SyncValidator::ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag,
         auto batch_queue_state = batch->GetQueueSyncState();
         auto pending_batch = batch_queue_state ? batch_queue_state->PendingLastBatch() : nullptr;
         if (pending_batch) {
-            for (const auto &[sync_queue, sync_tag] : sync_points) {
+            for (const auto& [sync_queue, sync_tag] : sync_points) {
                 pending_batch->ApplyTaggedWait(sync_queue, sync_tag, last_synchronized_present);
             }
             pending_batch->Trim();
@@ -220,8 +220,8 @@ void SyncValidator::ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag,
     }
 }
 
-void SyncValidator::ApplyAcquireWait(const AcquiredImage &acquired) {
-    for (const auto &batch : GetAllQueueBatchContexts()) {
+void SyncValidator::ApplyAcquireWait(const AcquiredImage& acquired) {
+    for (const auto& batch : GetAllQueueBatchContexts()) {
         batch->ApplyAcquireWait(acquired);
         batch->Trim();
     }
@@ -232,29 +232,29 @@ std::vector<QueueBatchContext::Ptr> SyncValidator::GetAllQueueBatchContexts() {
     std::vector<QueueBatchContext::Ptr> batch_contexts = GetLastBatches([](auto) { return true; });
 
     // Get batches from binary signals
-    for (auto &[_, signal] : binary_signals_) {
+    for (auto& [_, signal] : binary_signals_) {
         if (!vvl::Contains(batch_contexts, signal.batch)) {
             batch_contexts.emplace_back(signal.batch);
         }
     }
     // Get batches from timeline signals
-    for (auto &[_, signals] : timeline_signals_) {
-        for (const auto &signal : signals) {
+    for (auto& [_, signals] : timeline_signals_) {
+        for (const auto& signal : signals) {
             if (signal.batch && !vvl::Contains(batch_contexts, signal.batch)) {
                 batch_contexts.emplace_back(signal.batch);
             }
         }
     }
     // Get present batches
-    device_state->ForEachShared<vvl::Swapchain>([&batch_contexts](const std::shared_ptr<vvl::Swapchain> &swapchain) {
-        auto &sync_swapchain = SubState(*swapchain);
+    device_state->ForEachShared<vvl::Swapchain>([&batch_contexts](const std::shared_ptr<vvl::Swapchain>& swapchain) {
+        auto& sync_swapchain = SubState(*swapchain);
         sync_swapchain.GetPresentBatches(batch_contexts);
     });
 
     return batch_contexts;
 }
 
-void SyncValidator::UpdateFenceHostSyncPoint(VkFence fence, FenceHostSyncPoint &&sync_point) {
+void SyncValidator::UpdateFenceHostSyncPoint(VkFence fence, FenceHostSyncPoint&& sync_point) {
     std::shared_ptr<const vvl::Fence> fence_state = Get<vvl::Fence>(fence);
     if (!vvl::StateObject::Invalid(fence_state)) {
         waitable_fences_[fence_state->VkHandle()] = std::move(sync_point);
@@ -265,7 +265,7 @@ void SyncValidator::WaitForFence(VkFence fence) {
     auto fence_it = waitable_fences_.find(fence);
     if (fence_it != waitable_fences_.end()) {
         // The fence may no longer be waitable for several valid reasons.
-        FenceHostSyncPoint &wait_for = fence_it->second;
+        FenceHostSyncPoint& wait_for = fence_it->second;
         if (wait_for.acquired.Invalid()) {
             // This is just a normal fence wait
             ApplyTaggedWait(wait_for.queue_id, wait_for.tag, {}, wait_for.queue_sync_tags);
@@ -278,26 +278,26 @@ void SyncValidator::WaitForFence(VkFence fence) {
 }
 
 void SyncValidator::WaitForSemaphore(VkSemaphore semaphore, uint64_t value) {
-    std::deque<TimelineHostSyncPoint> *sync_points = vvl::Find(host_waitable_semaphores_, semaphore);
+    std::deque<TimelineHostSyncPoint>* sync_points = vvl::Find(host_waitable_semaphores_, semaphore);
     if (!sync_points) {
         return;
     }
-    auto matching_sync_point = [value](const TimelineHostSyncPoint &sync_point) { return sync_point.timeline_value >= value; };
+    auto matching_sync_point = [value](const TimelineHostSyncPoint& sync_point) { return sync_point.timeline_value >= value; };
     auto sync_point_it = std::find_if(sync_points->begin(), sync_points->end(), matching_sync_point);
     if (sync_point_it == sync_points->end()) {
         return;
     }
 
-    const TimelineHostSyncPoint &sync_point = *sync_point_it;
+    const TimelineHostSyncPoint& sync_point = *sync_point_it;
     const auto queue_state = GetQueueSyncStateShared(sync_point.queue_id);
 
     // TODO: specify queue sync tags argument similar to WaitForFence
     ApplyTaggedWait(sync_point.queue_id, sync_point.tag, queue_state->GetLastSynchronizedPresent(), {});
 
     // Remove signals before the resolving one (keep the resolving signal).
-    std::vector<SignalInfo> &signals = timeline_signals_[semaphore];
+    std::vector<SignalInfo>& signals = timeline_signals_[semaphore];
     const size_t initial_signal_count = signals.size();
-    vvl::erase_if(signals, [&sync_point](SignalInfo &signal) {
+    vvl::erase_if(signals, [&sync_point](SignalInfo& signal) {
         return signal.first_scope.queue == sync_point.queue_id && signal.timeline_value < sync_point.timeline_value;
     });
     stats.RemoveTimelineSignals(uint32_t(initial_signal_count - signals.size()));
@@ -308,15 +308,15 @@ void SyncValidator::WaitForSemaphore(VkSemaphore semaphore, uint64_t value) {
     sync_points->erase(sync_points->begin(), sync_point_it + 1 /* include resolving sync point too*/);
 }
 
-void SyncValidator::UpdateSyncImageMemoryBindState(uint32_t count, const VkBindImageMemoryInfo *infos) {
-    for (const auto &info : vvl::make_span(infos, count)) {
+void SyncValidator::UpdateSyncImageMemoryBindState(uint32_t count, const VkBindImageMemoryInfo* infos) {
+    for (const auto& info : vvl::make_span(infos, count)) {
         if (VK_NULL_HANDLE == info.image) continue;
         auto image_state = Get<vvl::Image>(info.image);
 
         // Need to protect if some VkBindMemoryStatus are not VK_SUCCESS
         if (!image_state->HasBeenBound()) continue;
 
-        auto &sub_state = SubState(*image_state);
+        auto& sub_state = SubState(*image_state);
         if (sub_state.IsTiled()) {
             sub_state.SetOpaqueBaseAddress(*device_state);
         }
@@ -324,7 +324,7 @@ void SyncValidator::UpdateSyncImageMemoryBindState(uint32_t count, const VkBindI
 }
 
 std::shared_ptr<const QueueSyncState> SyncValidator::GetQueueSyncStateShared(VkQueue queue) const {
-    for (const auto &queue_sync_state : queue_sync_states_) {
+    for (const auto& queue_sync_state : queue_sync_states_) {
         if (queue_sync_state->GetQueueState()->VkHandle() == queue) {
             return queue_sync_state;
         }
@@ -333,7 +333,7 @@ std::shared_ptr<const QueueSyncState> SyncValidator::GetQueueSyncStateShared(VkQ
 }
 
 std::shared_ptr<const QueueSyncState> SyncValidator::GetQueueSyncStateShared(QueueId queue_id) const {
-    for (const auto &queue_sync_state : queue_sync_states_) {
+    for (const auto& queue_sync_state : queue_sync_states_) {
         if (queue_sync_state->GetQueueId() == queue_id) {
             return queue_sync_state;
         }
@@ -341,35 +341,35 @@ std::shared_ptr<const QueueSyncState> SyncValidator::GetQueueSyncStateShared(Que
     return {};
 }
 
-void SyncValidator::Created(vvl::CommandBuffer &cb_state) {
+void SyncValidator::Created(vvl::CommandBuffer& cb_state) {
     cb_state.SetSubState(container_type, std::make_unique<CommandBufferSubState>(*this, cb_state));
 }
 
-void SyncValidator::Created(vvl::Swapchain &swapchain_state) {
+void SyncValidator::Created(vvl::Swapchain& swapchain_state) {
     swapchain_state.SetSubState(container_type, std::make_unique<SwapchainSubState>(swapchain_state));
 }
 
-void SyncValidator::Created(vvl::Image &image_state) {
+void SyncValidator::Created(vvl::Image& image_state) {
     image_state.SetSubState(container_type, std::make_unique<ImageSubState>(image_state));
 }
 
-void SyncValidator::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
-                                               const RecordObject &record_obj) {
+void SyncValidator::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
+                                               const RecordObject& record_obj) {
     if (const auto buffer_state = Get<vvl::Buffer>(buffer)) {
         const VkDeviceSize base_address = ResourceBaseAddress(*buffer_state);
         const AccessRange buffer_range(base_address, base_address + buffer_state->create_info.size);
-        for (const auto &batch : GetAllQueueBatchContexts()) {
+        for (const auto& batch : GetAllQueueBatchContexts()) {
             batch->OnResourceDestroyed(buffer_range);
             batch->Trim();
         }
     }
 }
 
-void SyncValidator::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,
-                                              const RecordObject &record_obj) {
+void SyncValidator::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
+                                              const RecordObject& record_obj) {
     if (const auto image_state = Get<vvl::Image>(image)) {
-        for (const auto &batch : GetAllQueueBatchContexts()) {
-            const auto &sub_state = SubState(*image_state);
+        for (const auto& batch : GetAllQueueBatchContexts()) {
+            const auto& sub_state = SubState(*image_state);
             ImageRangeGen range_gen = sub_state.MakeImageRangeGen(image_state->full_range, false);
             for (; range_gen->non_empty(); ++range_gen) {
                 const AccessRange subresource_range = *range_gen;
@@ -381,20 +381,20 @@ void SyncValidator::PreCallRecordDestroyImage(VkDevice device, VkImage image, co
 }
 
 void SyncValidator::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
-                                                     const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
-    for (const auto &batch : GetAllQueueBatchContexts()) {
+                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
+    for (const auto& batch : GetAllQueueBatchContexts()) {
         batch->last_synchronized_present.OnDestroySwapchain(swapchain);
     }
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                                 uint32_t regionCount, const VkBufferCopy *pRegions,
-                                                 const ErrorObject &error_obj) const {
+                                                 uint32_t regionCount, const VkBufferCopy* pRegions,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
 
-    const auto *cb_context = GetAccessContext(*cb_state);
-    const auto *context = cb_context->GetCurrentAccessContext();
+    const auto* cb_context = GetAccessContext(*cb_state);
+    const auto* context = cb_context->GetCurrentAccessContext();
 
     // If we have no previous accesses, we have no hazards
     auto src_buffer = Get<vvl::Buffer>(srcBuffer);
@@ -428,12 +428,12 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo,
-                                                  const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
-    const auto *context = cb_context->GetCurrentAccessContext();
+    const auto* cb_context = GetAccessContext(*cb_state);
+    const auto* context = cb_context->GetCurrentAccessContext();
 
     // If we have no previous accesses, we have no hazards
     auto src_buffer = Get<vvl::Buffer>(pCopyBufferInfo->srcBuffer);
@@ -470,19 +470,19 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfo,
-                                                     const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR* pCopyBufferInfo,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyBuffer2(commandBuffer, pCopyBufferInfo, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                const VkImageCopy *pRegions, const ErrorObject &error_obj) const {
+                                                const VkImageCopy* pRegions, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -520,13 +520,13 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
-                                                 const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo,
+                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -564,19 +564,19 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR *pCopyImageInfo,
-                                                    const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR* pCopyImageInfo,
+                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyImage2(commandBuffer, pCopyImageInfo, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdPipelineBarrier(
     VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-    const VkImageMemoryBarrier *pImageMemoryBarriers, const ErrorObject &error_obj) const {
+    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+    const VkImageMemoryBarrier* pImageMemoryBarriers, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
     SyncOpPipelineBarrier pipeline_barrier(error_obj.location.function, *this, cb_access_context->GetQueueFlags(), srcStageMask,
                                            dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount,
@@ -589,27 +589,27 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier(
 
 void SyncValidator::PostCallRecordCmdPipelineBarrier(
     VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
-    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
-    const VkImageMemoryBarrier *pImageMemoryBarriers, const RecordObject &record_obj) {
+    VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
+    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
+    const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
 
     cb_access_context->RecordSyncOp<SyncOpPipelineBarrier>(
         record_obj.location.function, *this, cb_access_context->GetQueueFlags(), srcStageMask, dstStageMask, memoryBarrierCount,
         pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 }
 
-bool SyncValidator::PreCallValidateCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR *pDependencyInfo,
-                                                          const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR* pDependencyInfo,
+                                                          const ErrorObject& error_obj) const {
     return PreCallValidateCmdPipelineBarrier2(commandBuffer, pDependencyInfo, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,
-                                                       const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
     SyncOpPipelineBarrier pipeline_barrier(error_obj.location.function, *this, cb_access_context->GetQueueFlags(),
                                            *pDependencyInfo);
@@ -619,21 +619,21 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBu
     return skip;
 }
 
-void SyncValidator::PostCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR *pDependencyInfo,
-                                                         const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR* pDependencyInfo,
+                                                         const RecordObject& record_obj) {
     PostCallRecordCmdPipelineBarrier2(commandBuffer, pDependencyInfo, record_obj);
 }
 
-void SyncValidator::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,
-                                                      const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
+                                                      const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
 
     cb_access_context->RecordSyncOp<SyncOpPipelineBarrier>(record_obj.location.function, *this, cb_access_context->GetQueueFlags(),
                                                            *pDependencyInfo);
 }
 
-void SyncValidator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void SyncValidator::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) {
     // The state tracker sets up the device state
     BaseClass::FinishDeviceSetup(pCreateInfo, loc);
 
@@ -642,15 +642,15 @@ void SyncValidator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, con
     auto get_sorted_queues = [this]() {
         std::vector<std::shared_ptr<vvl::Queue>> queues;
         device_state->ForEachShared<vvl::Queue>(
-            [&queues](const std::shared_ptr<vvl::Queue> &queue) { queues.emplace_back(queue); });
-        std::sort(queues.begin(), queues.end(), [](const auto &q1, const auto &q2) {
+            [&queues](const std::shared_ptr<vvl::Queue>& queue) { queues.emplace_back(queue); });
+        std::sort(queues.begin(), queues.end(), [](const auto& q1, const auto& q2) {
             return (q1->queue_family_index < q2->queue_family_index) ||
                    (q1->queue_family_index == q2->queue_family_index && q1->queue_index < q2->queue_index);
         });
         return queues;
     };
     queue_sync_states_.reserve(device_state->Count<vvl::Queue>());
-    for (const auto &queue : get_sorted_queues()) {
+    for (const auto& queue : get_sorted_queues()) {
         queue_sync_states_.emplace_back(std::make_shared<QueueSyncState>(queue, queue_id_limit_++));
     }
 
@@ -666,8 +666,8 @@ void SyncValidator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, con
     text::ToLower(debug_cmdbuf_pattern);
 }
 
-void SyncValidator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
-                                               const RecordObject &record_obj) {
+void SyncValidator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
+                                               const RecordObject& record_obj) {
     queue_sync_states_.clear();
     binary_signals_.clear();
     timeline_signals_.clear();
@@ -675,17 +675,17 @@ void SyncValidator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocati
     host_waitable_semaphores_.clear();
 }
 
-void SyncValidator::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
-                                                  const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                                  const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
     assert(!vvl::Contains(timeline_signals_, *pSemaphore));
 }
 
-void SyncValidator::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks *pAllocator,
-                                                  const RecordObject &record_obj) {
+void SyncValidator::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
+                                                  const RecordObject& record_obj) {
     if (auto sem_state = Get<vvl::Semaphore>(semaphore); sem_state && (sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE)) {
         if (auto it = timeline_signals_.find(semaphore); it != timeline_signals_.end()) {
             stats.RemoveTimelineSignals((uint32_t)it->second.size());
@@ -694,8 +694,8 @@ void SyncValidator::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore s
     }
 }
 
-bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                            const VkSubpassBeginInfo *pSubpassBeginInfo, const ErrorObject &error_obj) const {
+bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                            const VkSubpassBeginInfo* pSubpassBeginInfo, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     SyncOpBeginRenderPass sync_op(error_obj.location.function, *this, pRenderPassBegin, pSubpassBeginInfo);
@@ -703,36 +703,36 @@ bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                      VkSubpassContents contents, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                      VkSubpassContents contents, const ErrorObject& error_obj) const {
     VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     return ValidateBeginRenderPass(commandBuffer, pRenderPassBegin, &subpass_begin_info, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                       const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                       const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                       const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                       const ErrorObject& error_obj) const {
     return ValidateBeginRenderPass(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
-                                                          const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                          const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                          const ErrorObject &error_obj) const {
+                                                          const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                          const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                          const ErrorObject& error_obj) const {
     return PreCallValidateCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, error_obj);
 }
 
 bool SyncValidator::ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                            const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
     SyncOpNextSubpass sync_op(error_obj.location.function, *this, pSubpassBeginInfo, pSubpassEndInfo);
     return sync_op.Validate(*cb_context);
 }
 
 bool SyncValidator::PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
-                                                  const ErrorObject &error_obj) const {
+                                                  const ErrorObject& error_obj) const {
     // Convert to a NextSubpass2
     VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
@@ -740,39 +740,39 @@ bool SyncValidator::PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer,
     return ValidateCmdNextSubpass(commandBuffer, &subpass_begin_info, &subpass_end_info, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                      const VkSubpassEndInfo *pSubpassEndInfo, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                      const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
     return PreCallValidateCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
-                                                   const VkSubpassEndInfo *pSubpassEndInfo, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
+                                                   const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
     return ValidateCmdNextSubpass(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, error_obj);
 }
 
-bool SyncValidator::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                             const ErrorObject &error_obj) const {
+bool SyncValidator::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                             const ErrorObject& error_obj) const {
     bool skip = false;
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_context = GetAccessContext(*cb_state);
+    auto* cb_context = GetAccessContext(*cb_state);
 
     SyncOpEndRenderPass sync_op(error_obj.location.function, *this, pSubpassEndInfo);
     skip |= sync_op.Validate(*cb_context);
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     return ValidateCmdEndRenderPass(commandBuffer, nullptr, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                                     const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                                     const ErrorObject& error_obj) const {
     return ValidateCmdEndRenderPass(commandBuffer, pSubpassEndInfo, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
-                                                        const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                                        const ErrorObject& error_obj) const {
     return PreCallValidateCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, error_obj);
 }
 
@@ -780,18 +780,18 @@ bool SyncValidator::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandB
 // updates to a resource which do not conflict at the byte level.
 // TODO: Revisit this rule to see if it needs to be tighter or looser
 // TODO: Add programatic control over suppression heuristics
-bool SyncValidator::SuppressedBoundDescriptorWAW(const HazardResult &hazard) const {
+bool SyncValidator::SuppressedBoundDescriptorWAW(const HazardResult& hazard) const {
     assert(hazard.IsHazard());
     return hazard.IsWAWHazard();
 }
 
-bool SyncValidator::PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR *pRenderingInfo,
-                                                        const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,
+                                                        const ErrorObject& error_obj) const {
     return PreCallValidateCmdBeginRendering(commandBuffer, pRenderingInfo, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo,
-                                                     const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
+                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     if (!pRenderingInfo) return skip;
@@ -804,13 +804,13 @@ bool SyncValidator::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
     return skip;
 }
 
-void SyncValidator::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR *pRenderingInfo,
-                                                       const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,
+                                                       const RecordObject& record_obj) {
     PostCallRecordCmdBeginRendering(commandBuffer, pRenderingInfo, record_obj);
 }
 
-void SyncValidator::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo,
-                                                    const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
+                                                    const RecordObject& record_obj) {
     vvl::TlsGuard<BeginRenderingCmdState> cmd_state;
 
     assert(cmd_state && cmd_state->cb_state && (cmd_state->cb_state->VkHandle() == commandBuffer));
@@ -819,35 +819,35 @@ void SyncValidator::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffe
     GetAccessContext(*cb_state)->RecordBeginRendering(*cmd_state, record_obj.location);
 }
 
-bool SyncValidator::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     return PreCallValidateCmdEndRendering(commandBuffer, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     skip |= GetAccessContext(*cb_state)->ValidateEndRendering(error_obj);
     return skip;
 }
 
-void SyncValidator::PreCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void SyncValidator::PreCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     PreCallRecordCmdEndRendering(commandBuffer, record_obj);
 }
 
-void SyncValidator::PreCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+void SyncValidator::PreCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     GetAccessContext(*cb_state)->RecordEndRendering(record_obj);
 }
 
 template <typename RegionType>
 bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
-                                                 VkImageLayout dstImageLayout, uint32_t regionCount, const RegionType *pRegions,
-                                                 const Location &loc) const {
+                                                 VkImageLayout dstImageLayout, uint32_t regionCount, const RegionType* pRegions,
+                                                 const Location& loc) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -887,20 +887,20 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
 
 bool SyncValidator::PreCallValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                         VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                        const VkBufferImageCopy *pRegions, const ErrorObject &error_obj) const {
+                                                        const VkBufferImageCopy* pRegions, const ErrorObject& error_obj) const {
     return ValidateCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions,
                                         error_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                                            const VkCopyBufferToImageInfo2KHR *pCopyBufferToImageInfo,
-                                                            const ErrorObject &error_obj) const {
+                                                            const VkCopyBufferToImageInfo2KHR* pCopyBufferToImageInfo,
+                                                            const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
-                                                         const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
+                                                         const ErrorObject& error_obj) const {
     return ValidateCmdCopyBufferToImage(commandBuffer, pCopyBufferToImageInfo->srcBuffer, pCopyBufferToImageInfo->dstImage,
                                         pCopyBufferToImageInfo->dstImageLayout, pCopyBufferToImageInfo->regionCount,
                                         pCopyBufferToImageInfo->pRegions, error_obj.location.dot(Field::pCopyBufferToImageInfo));
@@ -908,13 +908,13 @@ bool SyncValidator::PreCallValidateCmdCopyBufferToImage2(VkCommandBuffer command
 
 template <typename RegionType>
 bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                                 VkBuffer dstBuffer, uint32_t regionCount, const RegionType *pRegions,
-                                                 const Location &loc) const {
+                                                 VkBuffer dstBuffer, uint32_t regionCount, const RegionType* pRegions,
+                                                 const Location& loc) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -950,20 +950,20 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
 
 bool SyncValidator::PreCallValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                         VkImageLayout srcImageLayout, VkBuffer dstBuffer, uint32_t regionCount,
-                                                        const VkBufferImageCopy *pRegions, const ErrorObject &error_obj) const {
+                                                        const VkBufferImageCopy* pRegions, const ErrorObject& error_obj) const {
     return ValidateCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions,
                                         error_obj.location);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
-                                                            const VkCopyImageToBufferInfo2KHR *pCopyImageToBufferInfo,
-                                                            const ErrorObject &error_obj) const {
+                                                            const VkCopyImageToBufferInfo2KHR* pCopyImageToBufferInfo,
+                                                            const ErrorObject& error_obj) const {
     return PreCallValidateCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
-                                                         const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
-                                                         const ErrorObject &error_obj) const {
+                                                         const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo,
+                                                         const ErrorObject& error_obj) const {
     return ValidateCmdCopyImageToBuffer(commandBuffer, pCopyImageToBufferInfo->srcImage, pCopyImageToBufferInfo->srcImageLayout,
                                         pCopyImageToBufferInfo->dstBuffer, pCopyImageToBufferInfo->regionCount,
                                         pCopyImageToBufferInfo->pRegions, error_obj.location.dot(Field::pCopyImageToBufferInfo));
@@ -972,12 +972,12 @@ bool SyncValidator::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer command
 template <typename RegionType>
 bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                          VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                         const RegionType *pRegions, VkFilter filter, const Location &loc) const {
+                                         const RegionType* pRegions, VkFilter filter, const Location& loc) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1028,26 +1028,26 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
 
 bool SyncValidator::PreCallValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                const VkImageBlit *pRegions, VkFilter filter, const ErrorObject &error_obj) const {
+                                                const VkImageBlit* pRegions, VkFilter filter, const ErrorObject& error_obj) const {
     return ValidateCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter,
                                 error_obj.location);
 }
 
-bool SyncValidator::PreCallValidateCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR *pBlitImageInfo,
-                                                    const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR* pBlitImageInfo,
+                                                    const ErrorObject& error_obj) const {
     return PreCallValidateCmdBlitImage2(commandBuffer, pBlitImageInfo, error_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo,
-                                                 const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
+                                                 const ErrorObject& error_obj) const {
     return ValidateCmdBlitImage(commandBuffer, pBlitImageInfo->srcImage, pBlitImageInfo->srcImageLayout, pBlitImageInfo->dstImage,
                                 pBlitImageInfo->dstImageLayout, pBlitImageInfo->regionCount, pBlitImageInfo->pRegions,
                                 pBlitImageInfo->filter, error_obj.location.dot(Field::pBlitImageInfo));
 }
 
-bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext &cb_context, const AccessContext &context,
+bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext& cb_context, const AccessContext& context,
                                            const VkDeviceSize struct_size, const VkBuffer buffer, const VkDeviceSize offset,
-                                           const uint32_t drawCount, const uint32_t stride, const Location &loc) const {
+                                           const uint32_t drawCount, const uint32_t stride, const Location& loc) const {
     bool skip = false;
     if (drawCount == 0) return skip;
 
@@ -1079,14 +1079,14 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext &cb_
     return skip;
 }
 
-void SyncValidator::RecordIndirectBuffer(CommandBufferAccessContext &cb_context, const ResourceUsageTag tag,
+void SyncValidator::RecordIndirectBuffer(CommandBufferAccessContext& cb_context, const ResourceUsageTag tag,
                                          const VkDeviceSize struct_size, const VkBuffer buffer, const VkDeviceSize offset,
                                          const uint32_t drawCount, uint32_t stride) {
     auto buf_state = Get<vvl::Buffer>(buffer);
     auto tag_ex = buf_state ? cb_context.AddCommandHandle(tag, buf_state->Handle()) : ResourceUsageTagEx{tag};
 
     VkDeviceSize size = struct_size;
-    AccessContext &context = *cb_context.GetCurrentAccessContext();
+    AccessContext& context = *cb_context.GetCurrentAccessContext();
     if (drawCount == 1 || stride == size) {
         if (drawCount > 1) size *= drawCount;
         const AccessRange range = MakeRange(offset, size);
@@ -1099,8 +1099,8 @@ void SyncValidator::RecordIndirectBuffer(CommandBufferAccessContext &cb_context,
     }
 }
 
-bool SyncValidator::ValidateCountBuffer(const CommandBufferAccessContext &cb_context, const AccessContext &context, VkBuffer buffer,
-                                        VkDeviceSize offset, const Location &loc) const {
+bool SyncValidator::ValidateCountBuffer(const CommandBufferAccessContext& cb_context, const AccessContext& context, VkBuffer buffer,
+                                        VkDeviceSize offset, const Location& loc) const {
     bool skip = false;
 
     auto count_buf_state = Get<vvl::Buffer>(buffer);
@@ -1115,40 +1115,39 @@ bool SyncValidator::ValidateCountBuffer(const CommandBufferAccessContext &cb_con
     return skip;
 }
 
-void SyncValidator::RecordCountBuffer(CommandBufferAccessContext &cb_context, const ResourceUsageTag tag, VkBuffer buffer,
+void SyncValidator::RecordCountBuffer(CommandBufferAccessContext& cb_context, const ResourceUsageTag tag, VkBuffer buffer,
                                       VkDeviceSize offset) {
     auto count_buf_state = Get<vvl::Buffer>(buffer);
     const AccessRange range = MakeRange(offset, 4);
     const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, count_buf_state->Handle());
-    AccessContext &context = *cb_context.GetCurrentAccessContext();
+    AccessContext& context = *cb_context.GetCurrentAccessContext();
     context.UpdateAccessState(*count_buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range, tag_ex);
 }
 
 bool SyncValidator::PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
-                                               const ErrorObject &error_obj) const {
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    skip |= GetAccessContext(*cb_state)->ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE,
-                                                                                       error_obj.location);
+    skip |= GetAccessContext(*cb_state)->ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
     return skip;
 }
 
 void SyncValidator::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
-                                              const RecordObject &record_obj) {
+                                              const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                       const ErrorObject &error_obj) const {
+                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_context->GetCurrentAccessContext();
+    const auto* context = cb_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1159,9 +1158,9 @@ bool SyncValidator::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBu
 }
 
 void SyncValidator::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                      const RecordObject &record_obj) {
+                                                      const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, tag);
@@ -1171,7 +1170,7 @@ void SyncValidator::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuf
 
 bool SyncValidator::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                    uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                   uint32_t groupCountZ, const ErrorObject &error_obj) const {
+                                                   uint32_t groupCountZ, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     skip |= GetAccessContext(*cb_state)->ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
@@ -1180,14 +1179,14 @@ bool SyncValidator::PreCallValidateCmdDispatchBase(VkCommandBuffer commandBuffer
 
 bool SyncValidator::PreCallValidateCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                       uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                      uint32_t groupCountZ, const ErrorObject &error_obj) const {
+                                                      uint32_t groupCountZ, const ErrorObject& error_obj) const {
     return PreCallValidateCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ,
                                           error_obj);
 }
 
 void SyncValidator::PostCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                   uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                  uint32_t groupCountZ, const RecordObject &record_obj) {
+                                                  uint32_t groupCountZ, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     auto cb_access_context = GetAccessContext(*cb_state);
     const ResourceUsageTag tag = cb_access_context->NextCommandTag(record_obj.location.function);
@@ -1196,16 +1195,16 @@ void SyncValidator::PostCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer,
 
 void SyncValidator::PostCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                      uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                     uint32_t groupCountZ, const RecordObject &record_obj) {
+                                                     uint32_t groupCountZ, const RecordObject& record_obj) {
     PostCallRecordCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ,
                                   record_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                           uint32_t firstVertex, uint32_t firstInstance, const ErrorObject &error_obj) const {
+                                           uint32_t firstVertex, uint32_t firstInstance, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
     skip |= cb_access_context->ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= cb_access_context->ValidateDrawVertex(vertexCount, firstVertex, error_obj.location);
@@ -1214,9 +1213,9 @@ bool SyncValidator::PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32
 }
 
 void SyncValidator::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                          uint32_t firstVertex, uint32_t firstInstance, const RecordObject &record_obj) {
+                                          uint32_t firstVertex, uint32_t firstInstance, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1226,10 +1225,10 @@ void SyncValidator::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_
 
 bool SyncValidator::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                   uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
-                                                  const ErrorObject &error_obj) const {
+                                                  const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
     skip |= cb_access_context->ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= cb_access_context->ValidateDrawVertexIndex(indexCount, firstIndex, error_obj.location);
@@ -1239,9 +1238,9 @@ bool SyncValidator::PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer,
 
 void SyncValidator::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                  uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
-                                                 const RecordObject &record_obj) {
+                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1250,14 +1249,14 @@ void SyncValidator::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, 
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                   uint32_t drawCount, uint32_t stride, const ErrorObject &error_obj) const {
+                                                   uint32_t drawCount, uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
     if (drawCount == 0) return skip;
 
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1271,10 +1270,10 @@ bool SyncValidator::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer
 }
 
 void SyncValidator::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                  uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                  uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
     if (drawCount == 0) return;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1286,13 +1285,13 @@ void SyncValidator::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer,
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                          uint32_t drawCount, uint32_t stride, const ErrorObject &error_obj) const {
+                                                          uint32_t drawCount, uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
     if (drawCount == 0) return skip;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1307,9 +1306,9 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer comman
 }
 
 void SyncValidator::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                         uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                         uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1322,12 +1321,12 @@ void SyncValidator::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer command
 
 bool SyncValidator::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                        uint32_t stride, const ErrorObject &error_obj) const {
+                                                        uint32_t stride, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1346,7 +1345,7 @@ void SyncValidator::RecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, Vk
                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                uint32_t stride, Func command) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(command);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1360,21 +1359,21 @@ void SyncValidator::RecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, Vk
 
 void SyncValidator::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                        VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                       uint32_t stride, const RecordObject &record_obj) {
+                                                       uint32_t stride, const RecordObject& record_obj) {
     RecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                record_obj.location.function);
 }
 bool SyncValidator::PreCallValidateCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                            VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                            uint32_t maxDrawCount, uint32_t stride,
-                                                           const ErrorObject &error_obj) const {
+                                                           const ErrorObject& error_obj) const {
     return PreCallValidateCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                                error_obj);
 }
 
 void SyncValidator::PostCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                           VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                          uint32_t maxDrawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                          uint32_t maxDrawCount, uint32_t stride, const RecordObject& record_obj) {
     PostCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                        record_obj);
 }
@@ -1382,14 +1381,14 @@ void SyncValidator::PostCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer comman
 bool SyncValidator::PreCallValidateCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                            VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                            uint32_t maxDrawCount, uint32_t stride,
-                                                           const ErrorObject &error_obj) const {
+                                                           const ErrorObject& error_obj) const {
     return PreCallValidateCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                                error_obj);
 }
 
 void SyncValidator::PostCallRecordCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                           VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                          uint32_t maxDrawCount, uint32_t stride, const RecordObject &record_obj) {
+                                                          uint32_t maxDrawCount, uint32_t stride, const RecordObject& record_obj) {
     PostCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                        record_obj);
 }
@@ -1397,12 +1396,12 @@ void SyncValidator::PostCallRecordCmdDrawIndirectCountAMD(VkCommandBuffer comman
 bool SyncValidator::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride,
-                                                               const ErrorObject &error_obj) const {
+                                                               const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1421,7 +1420,7 @@ void SyncValidator::RecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuf
                                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                       uint32_t stride, Func command) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(command);
 
     cb_access_context->RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, tag);
@@ -1436,7 +1435,7 @@ void SyncValidator::RecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuf
 void SyncValidator::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride,
-                                                              const RecordObject &record_obj) {
+                                                              const RecordObject& record_obj) {
     RecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                       record_obj.location.function);
 }
@@ -1444,7 +1443,7 @@ void SyncValidator::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer co
 bool SyncValidator::PreCallValidateCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                   VkDeviceSize offset, VkBuffer countBuffer,
                                                                   VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                                  uint32_t stride, const ErrorObject &error_obj) const {
+                                                                  uint32_t stride, const ErrorObject& error_obj) const {
     return PreCallValidateCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount,
                                                       stride, error_obj);
 }
@@ -1452,7 +1451,7 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirectCountKHR(VkCommandBuffe
 void SyncValidator::PostCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                  VkDeviceSize offset, VkBuffer countBuffer,
                                                                  VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                                 uint32_t stride, const RecordObject &record_obj) {
+                                                                 uint32_t stride, const RecordObject& record_obj) {
     PostCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                               record_obj);
 }
@@ -1460,7 +1459,7 @@ void SyncValidator::PostCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer
 bool SyncValidator::PreCallValidateCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                   VkDeviceSize offset, VkBuffer countBuffer,
                                                                   VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                                  uint32_t stride, const ErrorObject &error_obj) const {
+                                                                  uint32_t stride, const ErrorObject& error_obj) const {
     return PreCallValidateCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount,
                                                       stride, error_obj);
 }
@@ -1468,19 +1467,19 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirectCountAMD(VkCommandBuffe
 void SyncValidator::PostCallRecordCmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer,
                                                                  VkDeviceSize offset, VkBuffer countBuffer,
                                                                  VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                                 uint32_t stride, const RecordObject &record_obj) {
+                                                                 uint32_t stride, const RecordObject& record_obj) {
     PostCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                               record_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
-                                                      const VkClearColorValue *pColor, uint32_t rangeCount,
-                                                      const VkImageSubresourceRange *pRanges, const ErrorObject &error_obj) const {
+                                                      const VkClearColorValue* pColor, uint32_t rangeCount,
+                                                      const VkImageSubresourceRange* pRanges, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1500,14 +1499,14 @@ bool SyncValidator::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
 
 bool SyncValidator::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image,
                                                              VkImageLayout imageLayout,
-                                                             const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount,
-                                                             const VkImageSubresourceRange *pRanges,
-                                                             const ErrorObject &error_obj) const {
+                                                             const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
+                                                             const VkImageSubresourceRange* pRanges,
+                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1526,12 +1525,12 @@ bool SyncValidator::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer com
 }
 
 bool SyncValidator::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
-                                                       const VkClearAttachment *pAttachments, uint32_t rectCount,
-                                                       const VkClearRect *pRects, const ErrorObject &error_obj) const {
+                                                       const VkClearAttachment* pAttachments, uint32_t rectCount,
+                                                       const VkClearRect* pRects, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
 
-    for (const VkClearAttachment &attachment : vvl::make_span(pAttachments, attachmentCount)) {
+    for (const VkClearAttachment& attachment : vvl::make_span(pAttachments, attachmentCount)) {
         for (const auto [rect_index, rect] : vvl::enumerate(pRects, rectCount)) {
             skip |= GetAccessContext(*cb_state)->ValidateClearAttachment(error_obj.location, attachment, rect_index, rect);
         }
@@ -1542,12 +1541,12 @@ bool SyncValidator::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
 bool SyncValidator::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
                                                            uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer,
                                                            VkDeviceSize dstOffset, VkDeviceSize stride, VkQueryResultFlags flags,
-                                                           const ErrorObject &error_obj) const {
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1572,12 +1571,12 @@ bool SyncValidator::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer comma
 }
 
 bool SyncValidator::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                 VkDeviceSize size, uint32_t data, const ErrorObject &error_obj) const {
+                                                 VkDeviceSize size, uint32_t data, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1599,12 +1598,12 @@ bool SyncValidator::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, 
 
 bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                    VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                                   const VkImageResolve *pRegions, const ErrorObject &error_obj) const {
+                                                   const VkImageResolve* pRegions, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1641,13 +1640,13 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
-                                                    const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
+                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1689,18 +1688,18 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
 }
 
 bool SyncValidator::PreCallValidateCmdResolveImage2KHR(VkCommandBuffer commandBuffer,
-                                                       const VkResolveImageInfo2KHR *pResolveImageInfo,
-                                                       const ErrorObject &error_obj) const {
+                                                       const VkResolveImageInfo2KHR* pResolveImageInfo,
+                                                       const ErrorObject& error_obj) const {
     return PreCallValidateCmdResolveImage2(commandBuffer, pResolveImageInfo, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                   VkDeviceSize dataSize, const void *pData, const ErrorObject &error_obj) const {
+                                                   VkDeviceSize dataSize, const void* pData, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1723,11 +1722,11 @@ bool SyncValidator::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer
 
 bool SyncValidator::PreCallValidateCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                            VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
-                                                           const ErrorObject &error_obj) const {
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
-    const AccessContext &context = *cb_access_context->GetCurrentAccessContext();
+    const auto* cb_access_context = GetAccessContext(*cb_state);
+    const AccessContext& context = *cb_access_context->GetCurrentAccessContext();
 
     if (auto dst_buffer = Get<vvl::Buffer>(dstBuffer)) {
         const AccessRange range = MakeRange(dstOffset, 4);
@@ -1744,11 +1743,11 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarkerAMD(VkCommandBuffer comma
 
 void SyncValidator::PostCallRecordCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                           VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
-                                                          const RecordObject &record_obj) {
+                                                          const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
-    AccessContext &context = *cb_access_context->GetCurrentAccessContext();
+    AccessContext& context = *cb_access_context->GetCurrentAccessContext();
 
     if (auto dst_buffer = Get<vvl::Buffer>(dstBuffer)) {
         const AccessRange range = MakeRange(dstOffset, 4);
@@ -1757,13 +1756,13 @@ void SyncValidator::PostCallRecordCmdWriteBufferMarkerAMD(VkCommandBuffer comman
     }
 }
 
-bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR *pDecodeInfo,
-                                                     const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo,
+                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1800,7 +1799,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     }
 
     if (pDecodeInfo->pSetupReferenceSlot != nullptr && pDecodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-        const VkVideoPictureResourceInfoKHR &video_picture = *pDecodeInfo->pSetupReferenceSlot->pPictureResource;
+        const VkVideoPictureResourceInfoKHR& video_picture = *pDecodeInfo->pSetupReferenceSlot->pPictureResource;
         auto setup_resource = vvl::VideoPictureResource(*device_state, video_picture);
         if (setup_resource && (setup_resource != dst_resource)) {
             auto hazard = context->DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
@@ -1823,7 +1822,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
 
     for (uint32_t i = 0; i < pDecodeInfo->referenceSlotCount; ++i) {
         if (pDecodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-            const VkVideoPictureResourceInfoKHR &video_picture = *pDecodeInfo->pReferenceSlots[i].pPictureResource;
+            const VkVideoPictureResourceInfoKHR& video_picture = *pDecodeInfo->pReferenceSlots[i].pPictureResource;
             auto reference_resource = vvl::VideoPictureResource(*device_state, video_picture);
             if (reference_resource) {
                 auto hazard = context->DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
@@ -1848,13 +1847,13 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     return skip;
 }
 
-bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR *pEncodeInfo,
-                                                     const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo,
+                                                     const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -1890,7 +1889,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
     }
 
     if (pEncodeInfo->pSetupReferenceSlot != nullptr && pEncodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-        const VkVideoPictureResourceInfoKHR &video_picture = *pEncodeInfo->pSetupReferenceSlot->pPictureResource;
+        const VkVideoPictureResourceInfoKHR& video_picture = *pEncodeInfo->pSetupReferenceSlot->pPictureResource;
         auto setup_resource = vvl::VideoPictureResource(*device_state, video_picture);
         if (setup_resource) {
             auto hazard = context->DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
@@ -1913,7 +1912,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
 
     for (uint32_t i = 0; i < pEncodeInfo->referenceSlotCount; ++i) {
         if (pEncodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-            const VkVideoPictureResourceInfoKHR &video_picture = *pEncodeInfo->pReferenceSlots[i].pPictureResource;
+            const VkVideoPictureResourceInfoKHR& video_picture = *pEncodeInfo->pReferenceSlots[i].pPictureResource;
             auto reference_resource = vvl::VideoPictureResource(*device_state, video_picture);
             if (reference_resource) {
                 auto hazard = context->DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
@@ -1963,11 +1962,11 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
 }
 
 bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                               const ErrorObject &error_obj) const {
+                                               const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
-    const auto *access_context = cb_context->GetCurrentAccessContext();
+    const auto* cb_context = GetAccessContext(*cb_state);
+    const auto* access_context = cb_context->GetCurrentAccessContext();
     assert(access_context);
     if (!access_context) return skip;
 
@@ -1976,27 +1975,27 @@ bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, Vk
 }
 
 void SyncValidator::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                              const RecordObject &record_obj) {
+                                              const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_context = GetAccessContext(*cb_state);
+    auto* cb_context = GetAccessContext(*cb_state);
 
     cb_context->RecordSyncOp<SyncOpSetEvent>(record_obj.location.function, *this, cb_context->GetQueueFlags(), event, stageMask,
                                              cb_context->GetCurrentAccessContext());
 }
 
 bool SyncValidator::PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                                   const VkDependencyInfoKHR *pDependencyInfo, const ErrorObject &error_obj) const {
+                                                   const VkDependencyInfoKHR* pDependencyInfo, const ErrorObject& error_obj) const {
     return PreCallValidateCmdSetEvent2(commandBuffer, event, pDependencyInfo, error_obj);
 }
 
 bool SyncValidator::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
-                                                const VkDependencyInfo *pDependencyInfo, const ErrorObject &error_obj) const {
+                                                const VkDependencyInfo* pDependencyInfo, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
     if (!pDependencyInfo) return skip;
 
-    const auto *access_context = cb_context->GetCurrentAccessContext();
+    const auto* access_context = cb_context->GetCurrentAccessContext();
     assert(access_context);
     if (!access_context) return skip;
 
@@ -2005,14 +2004,14 @@ bool SyncValidator::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, V
 }
 
 void SyncValidator::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                                  const VkDependencyInfoKHR *pDependencyInfo, const RecordObject &record_obj) {
+                                                  const VkDependencyInfoKHR* pDependencyInfo, const RecordObject& record_obj) {
     PostCallRecordCmdSetEvent2(commandBuffer, event, pDependencyInfo, record_obj);
 }
 
 void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
-                                               const VkDependencyInfo *pDependencyInfo, const RecordObject &record_obj) {
+                                               const VkDependencyInfo* pDependencyInfo, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_context = GetAccessContext(*cb_state);
+    auto* cb_context = GetAccessContext(*cb_state);
     if (!pDependencyInfo) return;
 
     cb_context->RecordSyncOp<SyncOpSetEvent>(record_obj.location.function, *this, cb_context->GetQueueFlags(), event,
@@ -2022,18 +2021,18 @@ void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, Vk
 bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                  const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
 
     SyncOpResetEvent reset_event_op(error_obj.location.function, *this, cb_context->GetQueueFlags(), event, stageMask);
     return reset_event_op.Validate(*cb_context);
 }
 
 void SyncValidator::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
-                                                const RecordObject &record_obj) {
+                                                const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
-    auto *cb_context = GetAccessContext(*cb_state);
+    auto* cb_context = GetAccessContext(*cb_state);
 
     cb_context->RecordSyncOp<SyncOpResetEvent>(record_obj.location.function, *this, cb_context->GetQueueFlags(), event, stageMask);
 }
@@ -2041,26 +2040,26 @@ void SyncValidator::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, V
 bool SyncValidator::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                   const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
 
     SyncOpResetEvent reset_event_op(error_obj.location.function, *this, cb_context->GetQueueFlags(), event, stageMask);
     return reset_event_op.Validate(*cb_context);
 }
 
 bool SyncValidator::PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                                     VkPipelineStageFlags2KHR stageMask, const ErrorObject &error_obj) const {
+                                                     VkPipelineStageFlags2KHR stageMask, const ErrorObject& error_obj) const {
     return PreCallValidateCmdResetEvent2(commandBuffer, event, stageMask, error_obj);
 }
 
 void SyncValidator::PostCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
-                                                    VkPipelineStageFlags2KHR stageMask, const RecordObject &record_obj) {
+                                                    VkPipelineStageFlags2KHR stageMask, const RecordObject& record_obj) {
     PostCallRecordCmdResetEvent2(commandBuffer, event, stageMask, record_obj);
 }
 
 void SyncValidator::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
-                                                 const RecordObject &record_obj) {
+                                                 const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_context = GetAccessContext(*cb_state);
+    auto* cb_context = GetAccessContext(*cb_state);
 
     cb_context->RecordSyncOp<SyncOpResetEvent>(record_obj.location.function, *this, cb_context->GetQueueFlags(), event, stageMask);
 }
@@ -2073,7 +2072,7 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
                                                  uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
                                                  const ErrorObject& error_obj) const {
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
 
     SyncOpWaitEvents wait_events_op(error_obj.location.function, *this, cb_context->GetQueueFlags(), eventCount, pEvents,
                                     srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount,
@@ -2081,15 +2080,15 @@ bool SyncValidator::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, 
     return wait_events_op.Validate(*cb_context);
 }
 
-void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
+void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                 VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-                                                uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
+                                                uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
                                                 uint32_t bufferMemoryBarrierCount,
-                                                const VkBufferMemoryBarrier *pBufferMemoryBarriers,
-                                                uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
-                                                const RecordObject &record_obj) {
+                                                const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                                uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
+                                                const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_context = GetAccessContext(*cb_state);
+    auto* cb_context = GetAccessContext(*cb_state);
 
     cb_context->RecordSyncOp<SyncOpWaitEvents>(record_obj.location.function, *this, cb_context->GetQueueFlags(), eventCount,
                                                pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers,
@@ -2097,22 +2096,22 @@ void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, u
                                                pImageMemoryBarriers);
 }
 
-bool SyncValidator::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                     const VkDependencyInfoKHR *pDependencyInfos,
-                                                     const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                     const VkDependencyInfoKHR* pDependencyInfos,
+                                                     const ErrorObject& error_obj) const {
     return PreCallValidateCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, error_obj);
 }
 
-void SyncValidator::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                    const VkDependencyInfoKHR *pDependencyInfos, const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                    const VkDependencyInfoKHR* pDependencyInfos, const RecordObject& record_obj) {
     PostCallRecordCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, record_obj);
 }
 
-bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                  const VkDependencyInfo *pDependencyInfos, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                  const VkDependencyInfo* pDependencyInfos, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
 
     SyncOpWaitEvents wait_events_op(error_obj.location.function, *this, cb_context->GetQueueFlags(), eventCount, pEvents,
                                     pDependencyInfos);
@@ -2120,10 +2119,10 @@ bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer,
     return skip;
 }
 
-void SyncValidator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
-                                                 const VkDependencyInfo *pDependencyInfos, const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
+                                                 const VkDependencyInfo* pDependencyInfos, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_context = GetAccessContext(*cb_state);
+    auto* cb_context = GetAccessContext(*cb_state);
 
     cb_context->RecordSyncOp<SyncOpWaitEvents>(record_obj.location.function, *this, cb_context->GetQueueFlags(), eventCount,
                                                pEvents, pDependencyInfos);
@@ -2131,12 +2130,12 @@ void SyncValidator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, 
 
 bool SyncValidator::PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR pipelineStage,
                                                             VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
-                                                            const ErrorObject &error_obj) const {
+                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_access_context = GetAccessContext(*cb_state);
+    const auto* cb_access_context = GetAccessContext(*cb_state);
 
-    const auto *context = cb_access_context->GetCurrentAccessContext();
+    const auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
     if (!context) return skip;
 
@@ -2158,11 +2157,11 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer comm
 
 void SyncValidator::PostCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR pipelineStage,
                                                            VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
-                                                           const RecordObject &record_obj) {
+                                                           const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto *cb_access_context = GetAccessContext(*cb_state);
+    auto* cb_access_context = GetAccessContext(*cb_state);
     const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
-    auto *context = cb_access_context->GetCurrentAccessContext();
+    auto* context = cb_access_context->GetCurrentAccessContext();
     assert(context);
 
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
@@ -2175,15 +2174,15 @@ void SyncValidator::PostCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer comma
 }
 
 bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
-                                                      const VkCommandBuffer *pCommandBuffers, const ErrorObject &error_obj) const {
+                                                      const VkCommandBuffer* pCommandBuffers, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    const auto *cb_context = GetAccessContext(*cb_state);
+    const auto* cb_context = GetAccessContext(*cb_state);
 
     // Heavyweight, but we need a proxy copy of the active command buffer access context
     CommandBufferAccessContext proxy_cb_context(*cb_context, CommandBufferAccessContext::AsProxyContext());
 
-    auto &proxy_label_commands = proxy_cb_context.GetProxyLabelCommands();
+    auto& proxy_label_commands = proxy_cb_context.GetProxyLabelCommands();
     proxy_label_commands = cb_state->GetLabelCommands();
 
     // Make working copies of the access and events contexts
@@ -2196,14 +2195,14 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
 
         const auto recorded_cb = Get<vvl::CommandBuffer>(pCommandBuffers[cb_index]);
         if (!recorded_cb) continue;
-        const auto *recorded_cb_context = GetAccessContext(*recorded_cb);
+        const auto* recorded_cb_context = GetAccessContext(*recorded_cb);
         assert(recorded_cb_context);
 
         const ResourceUsageTag base_tag = proxy_cb_context.GetTagCount();
         skip |= ReplayState(proxy_cb_context, *recorded_cb_context, error_obj, cb_index, base_tag).ValidateFirstUse();
 
         // Update proxy label commands so they can be used by ImportRecordedAccessLog
-        const auto &recorded_label_commands = recorded_cb->GetLabelCommands();
+        const auto& recorded_label_commands = recorded_cb->GetLabelCommands();
         proxy_label_commands.insert(proxy_label_commands.end(), recorded_label_commands.begin(), recorded_label_commands.end());
 
         // The barriers have already been applied in ValidatFirstUse
@@ -2216,7 +2215,7 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
 }
 
 void SyncValidator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
-                                                  const RecordObject &record_obj) {
+                                                  const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -2227,18 +2226,18 @@ void SyncValidator::PostCallRecordBindImageMemory(VkDevice device, VkImage image
     UpdateSyncImageMemoryBindState(1, &bind_info);
 }
 
-void SyncValidator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
-                                                   const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
+                                                   const RecordObject& record_obj) {
     // Don't check |record_obj.result| as some binds might still be valid
     UpdateSyncImageMemoryBindState(bindInfoCount, pBindInfos);
 }
 
 void SyncValidator::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount,
-                                                      const VkBindImageMemoryInfo *pBindInfos, const RecordObject &record_obj) {
+                                                      const VkBindImageMemoryInfo* pBindInfos, const RecordObject& record_obj) {
     PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 }
 
-void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS || !syncval_settings.submit_time_validation || queue == VK_NULL_HANDLE) {
         return;
     }
@@ -2252,23 +2251,23 @@ void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObjec
     EnsureTimelineSignalsLimit(1, waited_queue);
 
     // Eliminate host waitable objects from the current queue.
-    vvl::EraseIf(waitable_fences_, [waited_queue](const auto &sf) { return sf.second.queue_id == waited_queue; });
-    for (auto &[semaphore, sync_points] : host_waitable_semaphores_) {
-        vvl::EraseIf(sync_points, [waited_queue](const auto &sync_point) { return sync_point.queue_id == waited_queue; });
+    vvl::EraseIf(waitable_fences_, [waited_queue](const auto& sf) { return sf.second.queue_id == waited_queue; });
+    for (auto& [semaphore, sync_points] : host_waitable_semaphores_) {
+        vvl::EraseIf(sync_points, [waited_queue](const auto& sync_point) { return sync_point.queue_id == waited_queue; });
     }
 }
 
-void SyncValidator::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject& record_obj) {
     const auto batches = GetAllQueueBatchContexts();
 
     // Collect information about last synchronized present over all queues
     LastSynchronizedPresent global_last_synchronized_present;
-    for (const auto &batch : batches) {
+    for (const auto& batch : batches) {
         global_last_synchronized_present.Merge(batch->last_synchronized_present);
     }
 
     // Device wait will preserve unsynchronized present operations.
-    for (const auto &batch : batches) {
+    for (const auto& batch : batches) {
         batch->ApplyDeviceWait(global_last_synchronized_present);
     }
 
@@ -2277,7 +2276,7 @@ void SyncValidator::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordOb
     EnsureTimelineSignalsLimit(1);
 
     // As we we've waited for everything on device, any waits are mooted. (except for acquires)
-    vvl::EraseIf(waitable_fences_, [](const auto &waitable) { return waitable.second.acquired.Invalid(); });
+    vvl::EraseIf(waitable_fences_, [](const auto& waitable) { return waitable.second.acquired.Invalid(); });
     host_waitable_semaphores_.clear();
 }
 
@@ -2285,11 +2284,11 @@ struct QueuePresentCmdState {
     std::shared_ptr<const QueueSyncState> queue;
     SignalsUpdate signals_update;
     PresentedImages presented_images;
-    QueuePresentCmdState(const SyncValidator &sync_validator) : signals_update(sync_validator) {}
+    QueuePresentCmdState(const SyncValidator& sync_validator) : signals_update(sync_validator) {}
 };
 
-bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
-                                                   const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
+                                                   const ErrorObject& error_obj) const {
     bool skip = false;
 
     // Since this early return is above the TlsGuard, the Record phase must also be.
@@ -2327,7 +2326,7 @@ bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresen
 
     const ResourceUsageTag global_range_start = batch->SetupBatchTags(present_tag_count);
     // Update the present tags (convert to global range)
-    for (auto &presented : cmd_state->presented_images) {
+    for (auto& presented : cmd_state->presented_images) {
         presented.tag += global_range_start;
     }
 
@@ -2341,10 +2340,10 @@ bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresen
     return skip;
 }
 
-uint32_t SyncValidator::SetupPresentInfo(const VkPresentInfoKHR &present_info, QueueBatchContext::Ptr &batch,
-                                         PresentedImages &presented_images) const {
-    const VkSwapchainKHR *const swapchains = present_info.pSwapchains;
-    const uint32_t *const image_indices = present_info.pImageIndices;
+uint32_t SyncValidator::SetupPresentInfo(const VkPresentInfoKHR& present_info, QueueBatchContext::Ptr& batch,
+                                         PresentedImages& presented_images) const {
+    const VkSwapchainKHR* const swapchains = present_info.pSwapchains;
+    const uint32_t* const image_indices = present_info.pImageIndices;
     const uint32_t swapchain_count = present_info.swapchainCount;
 
     // Create the working list of presented images
@@ -2352,7 +2351,7 @@ uint32_t SyncValidator::SetupPresentInfo(const VkPresentInfoKHR &present_info, Q
     for (uint32_t present_index = 0; present_index < swapchain_count; present_index++) {
         // Note: Given the "EraseIf" implementation for acquire fence waits, each presentation needs a unique tag.
         const ResourceUsageTag tag = presented_images.size();
-        presented_images.emplace_back(const_cast<SyncValidator &>(*this), batch, swapchains[present_index],
+        presented_images.emplace_back(const_cast<SyncValidator&>(*this), batch, swapchains[present_index],
                                       image_indices[present_index], present_index, tag);
         if (presented_images.back().Invalid()) {
             presented_images.pop_back();
@@ -2362,8 +2361,8 @@ uint32_t SyncValidator::SetupPresentInfo(const VkPresentInfoKHR &present_info, Q
     return static_cast<uint32_t>(presented_images.size());
 }
 
-void SyncValidator::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
-                                                  const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
+                                                  const RecordObject& record_obj) {
     stats.UpdateAccessStats(*this);
     stats.UpdateMemoryStats();
 
@@ -2385,35 +2384,35 @@ void SyncValidator::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresent
     std::shared_ptr<QueueSyncState> queue_state = std::const_pointer_cast<QueueSyncState>(std::move(cmd_state->queue));
     if (!queue_state) return;  // Invalid Queue
     ApplySignalsUpdate(cmd_state->signals_update, queue_state->PendingLastBatch());
-    for (auto &presented : cmd_state->presented_images) {
+    for (auto& presented : cmd_state->presented_images) {
         presented.ExportToSwapchain(*this);
     }
     queue_state->ApplyPendingLastBatch();
 }
 
 void SyncValidator::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
-                                                      VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
-                                                      const RecordObject &record_obj) {
+                                                      VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
+                                                      const RecordObject& record_obj) {
     if (!syncval_settings.submit_time_validation) return;
     RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex, record_obj);
 }
 
-void SyncValidator::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
-                                                       uint32_t *pImageIndex, const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
+                                                       uint32_t* pImageIndex, const RecordObject& record_obj) {
     if (!syncval_settings.submit_time_validation) return;
     RecordAcquireNextImageState(device, pAcquireInfo->swapchain, pAcquireInfo->timeout, pAcquireInfo->semaphore,
                                 pAcquireInfo->fence, pImageIndex, record_obj);
 }
 
 void SyncValidator::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
-                                                VkFence fence, uint32_t *pImageIndex, const RecordObject &record_obj) {
+                                                VkFence fence, uint32_t* pImageIndex, const RecordObject& record_obj) {
     if ((VK_SUCCESS != record_obj.result) && (VK_SUBOPTIMAL_KHR != record_obj.result)) return;
 
     // Get the image out of the presented list and create apppropriate fences/semaphores.
     auto swapchain_base = Get<vvl::Swapchain>(swapchain);
     if (vvl::StateObject::Invalid(swapchain_base)) return;  // Invalid acquire calls to be caught in CoreCheck/Parameter validation
 
-    auto &swapchain_state = SubState(*swapchain_base);
+    auto& swapchain_state = SubState(*swapchain_base);
 
     PresentedImage presented = swapchain_state.MovePresentedImage(*pImageIndex);
     if (presented.Invalid()) return;
@@ -2452,26 +2451,26 @@ void SyncValidator::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR 
     }
 }
 
-bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
-                                               const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
+                                               const ErrorObject& error_obj) const {
     SubmitInfoConverter submit_info(pSubmits, submitCount);
     return ValidateQueueSubmit(queue, submitCount, submit_info.submit_infos2.data(), fence, error_obj);
 }
 
-static std::vector<CommandBufferConstPtr> GetCommandBuffers(const vvl::DeviceState &device_state,
-                                                            const VkSubmitInfo2 &submit_info) {
+static std::vector<CommandBufferConstPtr> GetCommandBuffers(const vvl::DeviceState& device_state,
+                                                            const VkSubmitInfo2& submit_info) {
     // Collected command buffers have the same indexing as in the input VkSubmitInfo2 for reporting purposes.
     // If Get query returns null, it is stored in the result array to keep original indexing.
     std::vector<CommandBufferConstPtr> command_buffers;
     command_buffers.reserve(submit_info.commandBufferInfoCount);
-    for (const auto &cb_info : vvl::make_span(submit_info.pCommandBufferInfos, submit_info.commandBufferInfoCount)) {
+    for (const auto& cb_info : vvl::make_span(submit_info.pCommandBufferInfos, submit_info.commandBufferInfoCount)) {
         command_buffers.emplace_back(device_state.Get<vvl::CommandBuffer>(cb_info.commandBuffer));
     }
     return command_buffers;
 }
 
-bool SyncValidator::ValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                        const ErrorObject &error_obj) const {
+bool SyncValidator::ValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                        const ErrorObject& error_obj) const {
     bool skip = false;
 
     // Since this early return is above the TlsGuard, the Record phase must also be.
@@ -2487,8 +2486,8 @@ bool SyncValidator::ValidateQueueSubmit(VkQueue queue, uint32_t submitCount, con
     cmd_state->queue = GetQueueSyncStateShared(queue);
     if (!cmd_state->queue) return skip;  // Invalid Queue
 
-    auto &queue_sync_state = cmd_state->queue;
-    SignalsUpdate &signals_update = cmd_state->signals_update;
+    auto& queue_sync_state = cmd_state->queue;
+    SignalsUpdate& signals_update = cmd_state->signals_update;
 
     // The submit id is a mutable automic which is not recoverable on a skip == true condition
     uint64_t submit_id = queue_sync_state->ReserveSubmitId();
@@ -2504,7 +2503,7 @@ bool SyncValidator::ValidateQueueSubmit(VkQueue queue, uint32_t submitCount, con
     bool new_timeline_signals = false;
 
     for (uint32_t batch_idx = 0; batch_idx < submitCount; batch_idx++) {
-        const VkSubmitInfo2 &submit = pSubmits[batch_idx];
+        const VkSubmitInfo2& submit = pSubmits[batch_idx];
         auto batch = std::make_shared<QueueBatchContext>(*this, *queue_sync_state);
 
         const auto wait_semaphores = vvl::make_span(submit.pWaitSemaphoreInfos, submit.waitSemaphoreInfoCount);
@@ -2570,18 +2569,18 @@ bool SyncValidator::ValidateQueueSubmit(VkQueue queue, uint32_t submitCount, con
     }
 
     if (!skip) {
-        const_cast<SyncValidator *>(this)->RecordQueueSubmit(queue, fence, cmd_state);
+        const_cast<SyncValidator*>(this)->RecordQueueSubmit(queue, fence, cmd_state);
     }
 
     // Note that if we skip, guard cleans up for us, but cannot release the reserved tag range
     return skip;
 }
 
-bool SyncValidator::PropagateTimelineSignals(SignalsUpdate &signals_update, const ErrorObject &error_obj) const {
+bool SyncValidator::PropagateTimelineSignals(SignalsUpdate& signals_update, const ErrorObject& error_obj) const {
     bool skip = false;
     // Initialize per-queue unresolved batches state.
     std::vector<UnresolvedQueue> queues;
-    for (const auto &queue_state : queue_sync_states_) {
+    for (const auto& queue_state : queue_sync_states_) {
         if (!queue_state->PendingUnresolvedBatches().empty()) {
             // Pending request defines the final unresolved list (current + new unresolved batches)
             queues.emplace_back(UnresolvedQueue{queue_state, queue_state->PendingUnresolvedBatches()});
@@ -2598,7 +2597,7 @@ bool SyncValidator::PropagateTimelineSignals(SignalsUpdate &signals_update, cons
     }
 
     // Schedule unresolved state update
-    for (UnresolvedQueue &queue : queues) {
+    for (UnresolvedQueue& queue : queues) {
         if (queue.update_unresolved) {
             queue.queue_state->SetPendingUnresolvedBatches(std::move(queue.unresolved_batches));
         }
@@ -2606,10 +2605,10 @@ bool SyncValidator::PropagateTimelineSignals(SignalsUpdate &signals_update, cons
     return skip;
 }
 
-bool SyncValidator::PropagateTimelineSignalsIteration(std::vector<UnresolvedQueue> &queues, SignalsUpdate &signals_update,
-                                                      bool &skip, const ErrorObject &error_obj) const {
+bool SyncValidator::PropagateTimelineSignalsIteration(std::vector<UnresolvedQueue>& queues, SignalsUpdate& signals_update,
+                                                      bool& skip, const ErrorObject& error_obj) const {
     bool has_new_timeline_signals = false;
-    for (auto &queue : queues) {
+    for (auto& queue : queues) {
         if (queue.unresolved_batches.empty()) {
             continue;  // all batches for this queue were resolved by previous iterations
         }
@@ -2619,7 +2618,7 @@ bool SyncValidator::PropagateTimelineSignalsIteration(std::vector<UnresolvedQueu
         const BatchContextPtr initial_last_batch = last_batch;
 
         while (!queue.unresolved_batches.empty()) {
-            auto &unresolved_batch = queue.unresolved_batches.front();
+            auto& unresolved_batch = queue.unresolved_batches.front();
 
             has_new_timeline_signals |= ProcessUnresolvedBatch(unresolved_batch, signals_update, last_batch, skip, error_obj);
 
@@ -2638,12 +2637,12 @@ bool SyncValidator::PropagateTimelineSignalsIteration(std::vector<UnresolvedQueu
     return has_new_timeline_signals;
 }
 
-bool SyncValidator::ProcessUnresolvedBatch(UnresolvedBatch &unresolved_batch, SignalsUpdate &signals_update,
-                                           BatchContextPtr &last_batch, bool &skip, const ErrorObject &error_obj) const {
+bool SyncValidator::ProcessUnresolvedBatch(UnresolvedBatch& unresolved_batch, SignalsUpdate& signals_update,
+                                           BatchContextPtr& last_batch, bool& skip, const ErrorObject& error_obj) const {
     // Resolve waits that have matching signal
     auto it = unresolved_batch.unresolved_waits.begin();
     while (it != unresolved_batch.unresolved_waits.end()) {
-        const VkSemaphoreSubmitInfo &wait_info = *it;
+        const VkSemaphoreSubmitInfo& wait_info = *it;
         auto resolving_signal = signals_update.OnTimelineWait(wait_info.semaphore, wait_info.value);
         if (!resolving_signal.has_value()) {
             ++it;
@@ -2663,7 +2662,7 @@ bool SyncValidator::ProcessUnresolvedBatch(UnresolvedBatch &unresolved_batch, Si
     }
 
     // Process fully resolved batch
-    UnresolvedBatch &ready_batch = unresolved_batch;
+    UnresolvedBatch& ready_batch = unresolved_batch;
     if (last_batch && !vvl::Contains(ready_batch.resolved_dependencies, last_batch)) {
         ready_batch.batch->ResolveLastBatch(last_batch);
         ready_batch.resolved_dependencies.emplace_back(std::move(last_batch));
@@ -2679,7 +2678,7 @@ bool SyncValidator::ProcessUnresolvedBatch(UnresolvedBatch &unresolved_batch, Si
     return signals_update.RegisterSignals(ready_batch.batch, submit_signals);
 }
 
-void SyncValidator::RecordQueueSubmit(VkQueue queue, VkFence fence, QueueSubmitCmdState *cmd_state) {
+void SyncValidator::RecordQueueSubmit(VkQueue queue, VkFence fence, QueueSubmitCmdState* cmd_state) {
     stats.UpdateMemoryStats();
 
     // If this return is above the TlsGuard, then the Validate phase return must also be.
@@ -2697,7 +2696,7 @@ void SyncValidator::RecordQueueSubmit(VkQueue queue, VkFence fence, QueueSubmitC
 
     // Apply the pending state from the validation phase. Check all queues because timeline signals
     // on the current queue can resolve wait-before-signal batches on other queues.
-    for (const auto &qs : queue_sync_states_) {
+    for (const auto& qs : queue_sync_states_) {
         qs->ApplyPendingLastBatch();
         qs->ApplyPendingUnresolvedBatches();
     }
@@ -2712,17 +2711,17 @@ void SyncValidator::RecordQueueSubmit(VkQueue queue, VkFence fence, QueueSubmitC
     UpdateFenceHostSyncPoint(fence, std::move(sync_point));
 }
 
-bool SyncValidator::PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits,
-                                                   VkFence fence, const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits,
+                                                   VkFence fence, const ErrorObject& error_obj) const {
     return PreCallValidateQueueSubmit2(queue, submitCount, pSubmits, fence, error_obj);
 }
 
-bool SyncValidator::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                                const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                                const ErrorObject& error_obj) const {
     return ValidateQueueSubmit(queue, submitCount, pSubmits, fence, error_obj);
 }
 
-void SyncValidator::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject& record_obj) {
     if (!syncval_settings.submit_time_validation) return;
     if (record_obj.result == VK_SUCCESS) {
         // fence is signalled, mark it as waited for
@@ -2730,8 +2729,8 @@ void SyncValidator::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence,
     }
 }
 
-void SyncValidator::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences, VkBool32 waitAll,
-                                                uint64_t timeout, const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
+                                                uint64_t timeout, const RecordObject& record_obj) {
     if (!syncval_settings.submit_time_validation) return;
     if ((record_obj.result == VK_SUCCESS) && ((VK_TRUE == waitAll) || (1 == fenceCount))) {
         // We can only know the pFences have signal if we waited for all of them, or there was only one of them
@@ -2741,22 +2740,22 @@ void SyncValidator::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceC
     }
 }
 
-bool SyncValidator::PreCallValidateSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                                   const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     if (!syncval_settings.submit_time_validation) {
         return skip;
     }
     ClearPending();
     vvl::TlsGuard<QueueSubmitCmdState> cmd_state(&skip, *this);
-    SignalsUpdate &signals_update = cmd_state->signals_update;
+    SignalsUpdate& signals_update = cmd_state->signals_update;
 
     auto semaphore_state = Get<vvl::Semaphore>(pSignalInfo->semaphore);
     if (!semaphore_state) {
         return skip;
     }
 
-    std::vector<SignalInfo> &signals = signals_update.timeline_signals[pSignalInfo->semaphore];
+    std::vector<SignalInfo>& signals = signals_update.timeline_signals[pSignalInfo->semaphore];
 
     // Reject invalid signal
     if (!signals.empty() && pSignalInfo->value <= signals.back().timeline_value) {
@@ -2768,13 +2767,13 @@ bool SyncValidator::PreCallValidateSignalSemaphore(VkDevice device, const VkSema
     return skip;
 }
 
-bool SyncValidator::PreCallValidateSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                                      const ErrorObject &error_obj) const {
+bool SyncValidator::PreCallValidateSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                                      const ErrorObject& error_obj) const {
     return PreCallValidateSignalSemaphore(device, pSignalInfo, error_obj);
 }
 
-void SyncValidator::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                                  const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                                  const RecordObject& record_obj) {
     if (!syncval_settings.submit_time_validation) {
         return;
     }
@@ -2787,19 +2786,19 @@ void SyncValidator::PostCallRecordSignalSemaphore(VkDevice device, const VkSemap
         return;
     }
     ApplySignalsUpdate(cmd_state->signals_update, nullptr);
-    for (const auto &qs : queue_sync_states_) {
+    for (const auto& qs : queue_sync_states_) {
         qs->ApplyPendingLastBatch();
         qs->ApplyPendingUnresolvedBatches();
     }
 }
 
-void SyncValidator::PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                                     const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
+                                                     const RecordObject& record_obj) {
     PostCallRecordSignalSemaphore(device, pSignalInfo, record_obj);
 }
 
-void SyncValidator::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                                 const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                                 const RecordObject& record_obj) {
     if (!syncval_settings.submit_time_validation) {
         return;
     }
@@ -2811,13 +2810,13 @@ void SyncValidator::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaph
     }
 }
 
-void SyncValidator::PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
-                                                    const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
+                                                    const RecordObject& record_obj) {
     PostCallRecordWaitSemaphores(device, pWaitInfo, timeout, record_obj);
 }
 
-void SyncValidator::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
-                                                           const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
+                                                           const RecordObject& record_obj) {
     if (!syncval_settings.submit_time_validation) {
         return;
     }
@@ -2826,16 +2825,16 @@ void SyncValidator::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSe
     }
 }
 
-void SyncValidator::PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
-                                                              const RecordObject &record_obj) {
+void SyncValidator::PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
+                                                              const RecordObject& record_obj) {
     PostCallRecordGetSemaphoreCounterValue(device, semaphore, pValue, record_obj);
 }
 
 // Returns null when device address is asssociated with no buffers or more than one buffer.
 // Otherwise returns a valid buffer (device address is associated with a single buffer).
 // When syncval adds memory aliasing support the need of this function can be revisited.
-static const vvl::Buffer *GetSingleBufferFromDeviceAddress(const vvl::DeviceState &device, VkDeviceAddress device_address) {
-    vvl::span<vvl::Buffer *const> buffers = device.GetBuffersByAddress(device_address);
+static const vvl::Buffer* GetSingleBufferFromDeviceAddress(const vvl::DeviceState& device, VkDeviceAddress device_address) {
+    vvl::span<vvl::Buffer* const> buffers = device.GetBuffersByAddress(device_address);
     if (buffers.empty()) {
         return nullptr;
     }
@@ -2846,30 +2845,30 @@ static const vvl::Buffer *GetSingleBufferFromDeviceAddress(const vvl::DeviceStat
 }
 
 struct AccelerationStructureGeometryInfo {
-    const vvl::Buffer *vertex_data = nullptr;
+    const vvl::Buffer* vertex_data = nullptr;
     AccessRange vertex_range;
-    const vvl::Buffer *index_data = nullptr;
+    const vvl::Buffer* index_data = nullptr;
     AccessRange index_range;
-    const vvl::Buffer *transform_data = nullptr;
+    const vvl::Buffer* transform_data = nullptr;
     AccessRange transform_range;
-    const vvl::Buffer *aabb_data = nullptr;
+    const vvl::Buffer* aabb_data = nullptr;
     AccessRange aabb_range;
-    const vvl::Buffer *instance_data = nullptr;
+    const vvl::Buffer* instance_data = nullptr;
     AccessRange instance_range;
 };
 
 static std::optional<AccelerationStructureGeometryInfo> GetValidGeometryInfo(
-    const vvl::DeviceState &device, const VkAccelerationStructureGeometryKHR &geometry,
-    const VkAccelerationStructureBuildRangeInfoKHR &range_info) {
+    const vvl::DeviceState& device, const VkAccelerationStructureGeometryKHR& geometry,
+    const VkAccelerationStructureBuildRangeInfoKHR& range_info) {
     if (geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
-        const VkAccelerationStructureGeometryTrianglesDataKHR &triangles = geometry.geometry.triangles;
+        const VkAccelerationStructureGeometryTrianglesDataKHR& triangles = geometry.geometry.triangles;
         AccelerationStructureGeometryInfo geometry_info;
 
         // Assume that synchronization ranges cover the entire vertex struct,
         // even if positional data is strided (i.e., interleaved with other attributes).
         // That is, the application does not attempt to synchronize each position variable
         // with a separate buffer barrier range.
-        const vvl::Buffer *p_vertex_data = GetSingleBufferFromDeviceAddress(device, triangles.vertexData.deviceAddress);
+        const vvl::Buffer* p_vertex_data = GetSingleBufferFromDeviceAddress(device, triangles.vertexData.deviceAddress);
 
         if (triangles.indexType == VK_INDEX_TYPE_NONE_KHR) {
             // Vertex data
@@ -2904,7 +2903,7 @@ static std::optional<AccelerationStructureGeometryInfo> GetValidGeometryInfo(
             }
         }
         // Transform data
-        if (const vvl::Buffer *p_transform_data = GetSingleBufferFromDeviceAddress(device, triangles.transformData.deviceAddress)) {
+        if (const vvl::Buffer* p_transform_data = GetSingleBufferFromDeviceAddress(device, triangles.transformData.deviceAddress)) {
             const VkDeviceSize base_offset = triangles.transformData.deviceAddress - p_transform_data->deviceAddress;
             const VkDeviceSize offset = base_offset + range_info.transformOffset;
             geometry_info.transform_data = p_transform_data;
@@ -2913,8 +2912,8 @@ static std::optional<AccelerationStructureGeometryInfo> GetValidGeometryInfo(
         return geometry_info;
     } else if (geometry.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
         // Make a similar assumption for strided aabb data as for vertex data - synchronization ranges themselves are not strided.
-        const VkAccelerationStructureGeometryAabbsDataKHR &aabbs = geometry.geometry.aabbs;
-        if (const vvl::Buffer *p_aabbs = GetSingleBufferFromDeviceAddress(device, aabbs.data.deviceAddress)) {
+        const VkAccelerationStructureGeometryAabbsDataKHR& aabbs = geometry.geometry.aabbs;
+        if (const vvl::Buffer* p_aabbs = GetSingleBufferFromDeviceAddress(device, aabbs.data.deviceAddress)) {
             AccelerationStructureGeometryInfo geometry_info;
             geometry_info.aabb_data = p_aabbs;
             const VkDeviceSize base_offset = aabbs.data.deviceAddress - p_aabbs->deviceAddress;
@@ -2924,8 +2923,8 @@ static std::optional<AccelerationStructureGeometryInfo> GetValidGeometryInfo(
             return geometry_info;
         }
     } else if (geometry.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-        const VkAccelerationStructureGeometryInstancesDataKHR &instances = geometry.geometry.instances;
-        if (const vvl::Buffer *p_instances = GetSingleBufferFromDeviceAddress(device, instances.data.deviceAddress)) {
+        const VkAccelerationStructureGeometryInstancesDataKHR& instances = geometry.geometry.instances;
+        if (const vvl::Buffer* p_instances = GetSingleBufferFromDeviceAddress(device, instances.data.deviceAddress)) {
             AccelerationStructureGeometryInfo geometry_info;
             geometry_info.instance_data = p_instances;
             const VkDeviceSize base_offset = instances.data.deviceAddress - p_instances->deviceAddress;
@@ -2941,18 +2940,18 @@ static std::optional<AccelerationStructureGeometryInfo> GetValidGeometryInfo(
 }
 
 bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const ErrorObject &error_obj) const {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     for (const auto [i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, i);
         // Validate scratch buffer
-        if (const vvl::Buffer *p_scratch_buffer = GetSingleBufferFromDeviceAddress(*device_state, info.scratchData.deviceAddress)) {
-            const vvl::Buffer &scratch_buffer = *p_scratch_buffer;
+        if (const vvl::Buffer* p_scratch_buffer = GetSingleBufferFromDeviceAddress(*device_state, info.scratchData.deviceAddress)) {
+            const vvl::Buffer& scratch_buffer = *p_scratch_buffer;
             const VkDeviceSize scratch_size = rt::ComputeScratchSize(rt::BuildType::Device, device, info, ppBuildRangeInfos[i]);
             const VkDeviceSize offset = info.scratchData.deviceAddress - scratch_buffer.deviceAddress;
             const AccessRange range = MakeRange(scratch_buffer, offset, scratch_size);
@@ -2995,12 +2994,12 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
             }
         }
         // Validate geometry buffers
-        const VkAccelerationStructureBuildRangeInfoKHR *p_range_infos = ppBuildRangeInfos[i];
+        const VkAccelerationStructureBuildRangeInfoKHR* p_range_infos = ppBuildRangeInfos[i];
         if (!p_range_infos) {
             continue;  // [core validation check]: range pointers should be valid
         }
         for (uint32_t k = 0; k < info.geometryCount; k++) {
-            const auto *p_geometry = info.pGeometries ? &info.pGeometries[k] : info.ppGeometries[k];
+            const auto* p_geometry = info.pGeometries ? &info.pGeometries[k] : info.ppGeometries[k];
             if (!p_geometry) {
                 continue;  // [core validation check]: null pointer in ppGeometries
             }
@@ -3009,8 +3008,8 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 continue;
             }
             auto validate_accel_input_geometry = [this, &context, &cb_context, &commandBuffer, &error_obj](
-                                                     const vvl::Buffer &geometry_data, const AccessRange &geometry_range,
-                                                     const char *data_description) {
+                                                     const vvl::Buffer& geometry_data, const AccessRange& geometry_range,
+                                                     const char* data_description) {
                 auto hazard = context.DetectHazard(geometry_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ, geometry_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, geometry_data.Handle());
@@ -3047,18 +3046,18 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
 }
 
 void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
-    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const RecordObject &record_obj) {
+    VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
     for (const auto [i, info] : vvl::enumerate(pInfos, infoCount)) {
         // Record scratch buffer access
-        if (const vvl::Buffer *p_scratch_buffer = GetSingleBufferFromDeviceAddress(*device_state, info.scratchData.deviceAddress)) {
-            const vvl::Buffer &scratch_buffer = *p_scratch_buffer;
+        if (const vvl::Buffer* p_scratch_buffer = GetSingleBufferFromDeviceAddress(*device_state, info.scratchData.deviceAddress)) {
+            const vvl::Buffer& scratch_buffer = *p_scratch_buffer;
             const VkDeviceSize scratch_size = rt::ComputeScratchSize(rt::BuildType::Device, device, info, ppBuildRangeInfos[i]);
             const VkDeviceSize offset = info.scratchData.deviceAddress - scratch_buffer.deviceAddress;
             const AccessRange scratch_range = MakeRange(scratch_buffer, offset, scratch_size);
@@ -3087,12 +3086,12 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
                                       dst_range, dst_tag_ex);
         }
         // Record geometry buffer acceses (READ)
-        const VkAccelerationStructureBuildRangeInfoKHR *p_range_infos = ppBuildRangeInfos[i];
+        const VkAccelerationStructureBuildRangeInfoKHR* p_range_infos = ppBuildRangeInfos[i];
         if (!p_range_infos) {
             continue;  // [core validation check]: range pointers should be valid
         }
         for (uint32_t k = 0; k < info.geometryCount; k++) {
-            const auto *p_geometry = info.pGeometries ? &info.pGeometries[k] : info.ppGeometries[k];
+            const auto* p_geometry = info.pGeometries ? &info.pGeometries[k] : info.ppGeometries[k];
             if (!p_geometry) {
                 continue;  // [core validation check]: null pointer in ppGeometries
             }
@@ -3131,12 +3130,12 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
 }
 
 bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                   const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                                   const ErrorObject &error_obj) const {
+                                                                   const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
@@ -3168,11 +3167,11 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
 }
 
 void SyncValidator::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                  const VkCopyAccelerationStructureInfoKHR *pInfo,
-                                                                  const RecordObject &record_obj) {
+                                                                  const VkCopyAccelerationStructureInfoKHR* pInfo,
+                                                                  const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3191,12 +3190,12 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffe
 }
 
 bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
-                                                                           const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
-                                                                           const ErrorObject &error_obj) const {
+                                                                           const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
+                                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
@@ -3222,11 +3221,11 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCom
 }
 
 void SyncValidator::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
-                                                                          const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
-                                                                          const RecordObject &record_obj) {
+                                                                          const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
+                                                                          const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3239,12 +3238,12 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkComm
 }
 
 bool SyncValidator::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                           const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
-                                                                           const ErrorObject &error_obj) const {
+                                                                           const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
+                                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
@@ -3270,11 +3269,11 @@ bool SyncValidator::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCom
 }
 
 void SyncValidator::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
-                                                                          const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
-                                                                          const RecordObject &record_obj) {
+                                                                          const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
+                                                                          const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& context = *cb_context.GetCurrentAccessContext();
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
@@ -3287,48 +3286,48 @@ void SyncValidator::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkComm
 }
 
 bool SyncValidator::PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                                   const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                   const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                   const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                   const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
+                                                   const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                   const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                   const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                   const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                    uint32_t width, uint32_t height, uint32_t depth,
-                                                   const ErrorObject &error_obj) const {
+                                                   const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
+    auto& cb_context = *GetAccessContext(*cb_state);
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
     return skip;
 }
 
 void SyncValidator::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                                  const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                  const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                  const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                  const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                  uint32_t width, uint32_t height, uint32_t depth, const RecordObject &record_obj) {
+                                                  const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                  const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                  const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                  const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                  uint32_t width, uint32_t height, uint32_t depth, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
+    auto& cb_context = *GetAccessContext(*cb_state);
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                           const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                           const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                           const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                           const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                            VkDeviceAddress indirectDeviceAddress,
-                                                           const ErrorObject &error_obj) const {
+                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &access_context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& access_context = *cb_context.GetCurrentAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
 
-    if (const vvl::Buffer *indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
+    if (const vvl::Buffer* indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
         skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkTraceRaysIndirectCommandKHR),
                                        indirect_buffer->VkHandle(), 0, 1, 0, error_obj.location);
     }
@@ -3336,32 +3335,32 @@ bool SyncValidator::PreCallValidateCmdTraceRaysIndirectKHR(VkCommandBuffer comma
 }
 
 void SyncValidator::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                          const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                          const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                          const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                          const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                          VkDeviceAddress indirectDeviceAddress, const RecordObject &record_obj) {
+                                                          const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                                          const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                                          const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                                          const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                                          VkDeviceAddress indirectDeviceAddress, const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
+    auto& cb_context = *GetAccessContext(*cb_state);
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, tag);
 
-    if (const vvl::Buffer *indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
+    if (const vvl::Buffer* indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
         RecordIndirectBuffer(cb_context, tag, sizeof(VkTraceRaysIndirectCommandKHR), indirect_buffer->VkHandle(), 0, 1, 0);
     }
 }
 
 bool SyncValidator::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
-                                                            const ErrorObject &error_obj) const {
+                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
-    auto &access_context = *cb_context.GetCurrentAccessContext();
+    auto& cb_context = *GetAccessContext(*cb_state);
+    auto& access_context = *cb_context.GetCurrentAccessContext();
 
     skip |= cb_context.ValidateDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
 
-    if (const vvl::Buffer *indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
+    if (const vvl::Buffer* indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
         skip |= ValidateIndirectBuffer(cb_context, access_context, sizeof(VkTraceRaysIndirectCommand2KHR),
                                        indirect_buffer->VkHandle(), 0, 1, 0, error_obj.location);
     }
@@ -3369,14 +3368,14 @@ bool SyncValidator::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer comm
 }
 
 void SyncValidator::PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
-                                                           const RecordObject &record_obj) {
+                                                           const RecordObject& record_obj) {
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    auto &cb_context = *GetAccessContext(*cb_state);
+    auto& cb_context = *GetAccessContext(*cb_state);
 
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
     cb_context.RecordDispatchDrawDescriptorSet(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, tag);
 
-    if (const vvl::Buffer *indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
+    if (const vvl::Buffer* indirect_buffer = GetSingleBufferFromDeviceAddress(*device_state, indirectDeviceAddress)) {
         RecordIndirectBuffer(cb_context, tag, sizeof(VkTraceRaysIndirectCommand2KHR), indirect_buffer->VkHandle(), 0, 1, 0);
     }
 }

--- a/layers/utils/convert_utils.cpp
+++ b/layers/utils/convert_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,9 +53,9 @@ static vku::safe_VkAttachmentReference2 ToV2KHR(const VkAttachmentReference& in_
 }
 
 static vku::safe_VkSubpassDescription2 ToV2KHR(const VkSubpassDescription& in_struct, const uint32_t viewMask,
-                                              const VkImageAspectFlags* color_attachment_aspect_masks,
-                                              const VkImageAspectFlags ds_attachment_aspect_mask,
-                                              const VkImageAspectFlags* input_attachment_aspect_masks) {
+                                               const VkImageAspectFlags* color_attachment_aspect_masks,
+                                               const VkImageAspectFlags ds_attachment_aspect_mask,
+                                               const VkImageAspectFlags* input_attachment_aspect_masks) {
     vku::safe_VkSubpassDescription2 v2;
     v2.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
     v2.pNext = nullptr;
@@ -123,8 +123,10 @@ static vku::safe_VkSubpassDependency2 ToV2KHR(const VkSubpassDependency& in_stru
 vku::safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkRenderPassCreateInfo& create_info) {
     vku::safe_VkRenderPassCreateInfo2 out_struct;
     const auto multiview_info = vku::FindStructInPNextChain<VkRenderPassMultiviewCreateInfo>(create_info.pNext);
-    const auto* input_attachment_aspect_info = vku::FindStructInPNextChain<VkRenderPassInputAttachmentAspectCreateInfo>(create_info.pNext);
-    const auto fragment_density_map_info = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
+    const auto* input_attachment_aspect_info =
+        vku::FindStructInPNextChain<VkRenderPassInputAttachmentAspectCreateInfo>(create_info.pNext);
+    const auto fragment_density_map_info =
+        vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
     const auto tile_memory_size_info = vku::FindStructInPNextChain<VkTileMemorySizeInfoQCOM>(create_info.pNext);
 
     out_struct.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
@@ -273,8 +275,8 @@ vku::safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkR
 }
 
 vku::safe_VkImageMemoryBarrier2 ConvertVkImageMemoryBarrierToV2(const VkImageMemoryBarrier& barrier,
-                                                               VkPipelineStageFlags2 srcStageMask,
-                                                               VkPipelineStageFlags2 dstStageMask) {
+                                                                VkPipelineStageFlags2 srcStageMask,
+                                                                VkPipelineStageFlags2 dstStageMask) {
     VkImageMemoryBarrier2 barrier2 = vku::InitStructHelper();
 
     // As of Vulkan 1.3.153, the VkImageMemoryBarrier2 supports the same pNext structs as VkImageMemoryBarrier

--- a/layers/utils/dispatch_utils.cpp
+++ b/layers/utils/dispatch_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2016, 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2016, 2020-2025 Valve Corporation
- * Copyright (c) 2015-2016, 2020-2025 LunarG, Inc.
+/* Copyright (c) 2015-2016, 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2016, 2020-2026 Valve Corporation
+ * Copyright (c) 2015-2016, 2020-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,19 @@
 #include <cassert>
 #include "dispatch_utils.h"
 
-VkLayerInstanceCreateInfo *GetChainInfo(const VkInstanceCreateInfo *pCreateInfo, VkLayerFunction func) {
-    VkLayerInstanceCreateInfo *chain_info = (VkLayerInstanceCreateInfo *)pCreateInfo->pNext;
+VkLayerInstanceCreateInfo* GetChainInfo(const VkInstanceCreateInfo* pCreateInfo, VkLayerFunction func) {
+    VkLayerInstanceCreateInfo* chain_info = (VkLayerInstanceCreateInfo*)pCreateInfo->pNext;
     while (chain_info && !(chain_info->sType == VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO && chain_info->function == func)) {
-        chain_info = (VkLayerInstanceCreateInfo *)chain_info->pNext;
+        chain_info = (VkLayerInstanceCreateInfo*)chain_info->pNext;
     }
     assert(chain_info != NULL);
     return chain_info;
 }
 
-VkLayerDeviceCreateInfo *GetChainInfo(const VkDeviceCreateInfo *pCreateInfo, VkLayerFunction func) {
-    VkLayerDeviceCreateInfo *chain_info = (VkLayerDeviceCreateInfo *)pCreateInfo->pNext;
+VkLayerDeviceCreateInfo* GetChainInfo(const VkDeviceCreateInfo* pCreateInfo, VkLayerFunction func) {
+    VkLayerDeviceCreateInfo* chain_info = (VkLayerDeviceCreateInfo*)pCreateInfo->pNext;
     while (chain_info && !(chain_info->sType == VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO && chain_info->function == func)) {
-        chain_info = (VkLayerDeviceCreateInfo *)chain_info->pNext;
+        chain_info = (VkLayerDeviceCreateInfo*)chain_info->pNext;
     }
     assert(chain_info != NULL);
     return chain_info;

--- a/layers/utils/hash_util.cpp
+++ b/layers/utils/hash_util.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+/* Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ uint32_t VuidHash(std::string_view vuid) {
     return XXH32(vuid.data(), vuid.size(), seed);
 }
 
-uint32_t Hash32(const void *info, const size_t info_size) {
+uint32_t Hash32(const void* info, const size_t info_size) {
     constexpr uint32_t seed = 0;
     return XXH32(info, info_size, seed);
 }
 
-uint64_t Hash64(const void *info, const size_t info_size) {
+uint64_t Hash64(const void* info, const size_t info_size) {
     constexpr uint64_t seed = 0;
     return XXH64(info, info_size, seed);
 }

--- a/layers/utils/image_utils.cpp
+++ b/layers/utils/image_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
+/* Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
-uint32_t GetEffectiveLevelCount(const VkImageSubresourceRange &subresource_range, uint32_t total_level_count) {
+uint32_t GetEffectiveLevelCount(const VkImageSubresourceRange& subresource_range, uint32_t total_level_count) {
     uint32_t level_count = subresource_range.levelCount;
     if (level_count == VK_REMAINING_MIP_LEVELS) {
         if (total_level_count > subresource_range.baseMipLevel) {
@@ -40,7 +40,7 @@ uint32_t GetEffectiveLevelCount(const VkImageSubresourceRange &subresource_range
     return level_count;
 }
 
-uint32_t GetEffectiveLayerCount(const VkImageSubresourceRange &subresource_range, uint32_t total_layer_count) {
+uint32_t GetEffectiveLayerCount(const VkImageSubresourceRange& subresource_range, uint32_t total_layer_count) {
     uint32_t layer_count = subresource_range.layerCount;
     if (layer_count == VK_REMAINING_ARRAY_LAYERS) {
         if (total_layer_count > subresource_range.baseArrayLayer) {
@@ -53,7 +53,7 @@ uint32_t GetEffectiveLayerCount(const VkImageSubresourceRange &subresource_range
 }
 
 // Returns the effective extent of an image subresource, adjusted for mip level and array depth.
-VkExtent3D GetEffectiveExtent(const VkImageCreateInfo &ci, const VkImageAspectFlags aspect_mask, const uint32_t mip_level) {
+VkExtent3D GetEffectiveExtent(const VkImageCreateInfo& ci, const VkImageAspectFlags aspect_mask, const uint32_t mip_level) {
     // Return zero extent if mip level doesn't exist
     if (mip_level >= ci.mipLevels) {
         return VkExtent3D{0, 0, 0};
@@ -170,10 +170,10 @@ uint32_t GetTexelBufferFormatSize(VkFormat format) {
 
 // Used to get the VkExternalFormatANDROID without having to use ifdef in logic
 // Result of zero is same of not having pNext struct
-uint64_t GetExternalFormat(const void *pNext) {
+uint64_t GetExternalFormat(const void* pNext) {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     if (pNext) {
-        const auto *external_format = vku::FindStructInPNextChain<VkExternalFormatANDROID>(pNext);
+        const auto* external_format = vku::FindStructInPNextChain<VkExternalFormatANDROID>(pNext);
         if (external_format) {
             return external_format->externalFormat;
         }
@@ -279,7 +279,7 @@ bool IsImageLayoutStencilReadOnly(VkImageLayout layout) {
                        [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
 }
 
-bool IsDepthSliceView(const VkImageCreateInfo &image_create_info, VkImageViewType view_type) {
+bool IsDepthSliceView(const VkImageCreateInfo& image_create_info, VkImageViewType view_type) {
     constexpr VkImageCreateFlags depth_slice_view_flags =
         VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
 
@@ -289,7 +289,7 @@ bool IsDepthSliceView(const VkImageCreateInfo &image_create_info, VkImageViewTyp
     return image_supports_depth_slice_view && (view_type == VK_IMAGE_VIEW_TYPE_2D || view_type == VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 }
 
-bool CanTransitionDepthSlices(const DeviceExtensions &extensions, const VkImageCreateInfo &create_info) {
+bool CanTransitionDepthSlices(const DeviceExtensions& extensions, const VkImageCreateInfo& create_info) {
     return IsExtEnabled(extensions.vk_khr_maintenance9) && create_info.imageType == VK_IMAGE_TYPE_3D &&
            (create_info.flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) != 0;
 }

--- a/layers/utils/ray_tracing_utils.cpp
+++ b/layers/utils/ray_tracing_utils.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2026 Valve Corporation
- * Copyright (c) 2026 LunarG, Inc.
+/* Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ namespace rt {
 
 static VkAccelerationStructureBuildSizesInfoKHR ComputeBuildSizes(const VkDevice device,
                                                                   const VkAccelerationStructureBuildTypeKHR build_type,
-                                                                  const VkAccelerationStructureBuildGeometryInfoKHR &build_info,
-                                                                  const VkAccelerationStructureBuildRangeInfoKHR *range_infos) {
+                                                                  const VkAccelerationStructureBuildGeometryInfoKHR& build_info,
+                                                                  const VkAccelerationStructureBuildRangeInfoKHR* range_infos) {
     std::vector<uint32_t> primitive_counts(build_info.geometryCount);
     for (const auto [i, build_range] : vvl::enumerate(range_infos, build_info.geometryCount)) {
         primitive_counts[i] = build_range.primitiveCount;
@@ -40,8 +40,8 @@ static VkAccelerationStructureBuildSizesInfoKHR ComputeBuildSizes(const VkDevice
 }
 
 VkDeviceSize ComputeScratchSize(BuildType build_type, const VkDevice device,
-                                const VkAccelerationStructureBuildGeometryInfoKHR &build_info,
-                                const VkAccelerationStructureBuildRangeInfoKHR *range_infos) {
+                                const VkAccelerationStructureBuildGeometryInfoKHR& build_info,
+                                const VkAccelerationStructureBuildRangeInfoKHR* range_infos) {
     const VkAccelerationStructureBuildSizesInfoKHR size_info =
         ComputeBuildSizes(device,
                           build_type == BuildType::Device ? VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR
@@ -60,8 +60,8 @@ VkDeviceSize ComputeScratchSize(BuildType build_type, const VkDevice device,
 }
 
 VkDeviceSize ComputeAccelerationStructureSize(BuildType build_type, const VkDevice device,
-                                              const VkAccelerationStructureBuildGeometryInfoKHR &build_info,
-                                              const VkAccelerationStructureBuildRangeInfoKHR *range_infos) {
+                                              const VkAccelerationStructureBuildGeometryInfoKHR& build_info,
+                                              const VkAccelerationStructureBuildRangeInfoKHR* range_infos) {
     const VkAccelerationStructureBuildSizesInfoKHR size_info =
         ComputeBuildSizes(device,
                           build_type == BuildType::Device ? VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -28,8 +28,8 @@
 #include <sstream>
 #include <string>
 
-void ValidationCache::GetUUID(uint8_t *uuid) {
-    const char *sha1_str = SPIRV_TOOLS_COMMIT_ID;
+void ValidationCache::GetUUID(uint8_t* uuid) {
+    const char* sha1_str = SPIRV_TOOLS_COMMIT_ID;
     // Convert sha1_str from a hex string to binary. We only need VK_UUID_SIZE bytes of
     // output, so pad with zeroes if the input string is shorter than that, and truncate
     // if it's longer.
@@ -51,19 +51,19 @@ void ValidationCache::GetUUID(uint8_t *uuid) {
     std::memcpy(uuid + (VK_UUID_SIZE - sizeof(uint32_t)), &spirv_val_option_hash_, sizeof(uint32_t));
 }
 
-void ValidationCache::Load(VkValidationCacheCreateInfoEXT const *pCreateInfo) {
+void ValidationCache::Load(VkValidationCacheCreateInfoEXT const* pCreateInfo) {
     const auto headerSize = 2 * sizeof(uint32_t) + VK_UUID_SIZE;
     auto size = headerSize;
     if (!pCreateInfo->pInitialData || pCreateInfo->initialDataSize < size) return;
 
-    uint32_t const *data = (uint32_t const *)pCreateInfo->pInitialData;
+    uint32_t const* data = (uint32_t const*)pCreateInfo->pInitialData;
     if (data[0] != size) return;
     if (data[1] != VK_VALIDATION_CACHE_HEADER_VERSION_ONE_EXT) return;
     uint8_t expected_uuid[VK_UUID_SIZE];
     GetUUID(expected_uuid);
     if (memcmp(&data[2], expected_uuid, VK_UUID_SIZE) != 0) return;  // different version
 
-    data = (uint32_t const *)(reinterpret_cast<uint8_t const *>(data) + headerSize);
+    data = (uint32_t const*)(reinterpret_cast<uint8_t const*>(data) + headerSize);
 
     auto guard = WriteLock();
     for (; size < pCreateInfo->initialDataSize; data++, size += sizeof(uint32_t)) {
@@ -71,7 +71,7 @@ void ValidationCache::Load(VkValidationCacheCreateInfoEXT const *pCreateInfo) {
     }
 }
 
-void ValidationCache::Write(size_t *pDataSize, void *pData) {
+void ValidationCache::Write(size_t* pDataSize, void* pData) {
     const auto header_size = 2 * sizeof(uint32_t) + VK_UUID_SIZE;  // 4 bytes for header size + 4 bytes for version number + UUID
     if (!pData) {
         *pDataSize = header_size + good_shader_hashes_.size() * sizeof(uint32_t);
@@ -83,14 +83,14 @@ void ValidationCache::Write(size_t *pDataSize, void *pData) {
         return;  // Too small for even the header!
     }
 
-    uint32_t *out = (uint32_t *)pData;
+    uint32_t* out = (uint32_t*)pData;
     size_t actual_size = header_size;
 
     // Write the header
     *out++ = header_size;
     *out++ = VK_VALIDATION_CACHE_HEADER_VERSION_ONE_EXT;
-    GetUUID(reinterpret_cast<uint8_t *>(out));
-    out = (uint32_t *)(reinterpret_cast<uint8_t *>(out) + VK_UUID_SIZE);
+    GetUUID(reinterpret_cast<uint8_t*>(out));
+    out = (uint32_t*)(reinterpret_cast<uint8_t*>(out) + VK_UUID_SIZE);
 
     {
         auto guard = ReadLock();
@@ -103,7 +103,7 @@ void ValidationCache::Write(size_t *pDataSize, void *pData) {
     *pDataSize = actual_size;
 }
 
-void ValidationCache::Merge(ValidationCache const *other) {
+void ValidationCache::Merge(ValidationCache const* other) {
     // self-merging is invalid, but avoid deadlock below just in case.
     if (other == this) {
         return;
@@ -156,9 +156,9 @@ VkShaderStageFlagBits ExecutionModelToShaderStageFlagBits(uint32_t mode) {
 }
 
 // This is used to help dump SPIR-V while debugging intermediate phases of any altercations to the SPIR-V
-void DumpSpirvToFile(const std::string &file_path, const uint32_t *spirv, size_t spirv_dwords_count) {
+void DumpSpirvToFile(const std::string& file_path, const uint32_t* spirv, size_t spirv_dwords_count) {
     std::ofstream debug_file(file_path, std::ios::out | std::ios::binary);
-    debug_file.write(reinterpret_cast<const char *>(spirv), spirv_dwords_count * sizeof(uint32_t));
+    debug_file.write(reinterpret_cast<const char*>(spirv), spirv_dwords_count * sizeof(uint32_t));
 }
 
 bool ResourceTypeMatchesBinding(VkSpirvResourceTypeFlagsEXT resource_type,

--- a/layers/utils/spirv_tools_utils.cpp
+++ b/layers/utils/spirv_tools_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -26,7 +26,7 @@
 
 #include <sstream>
 
-spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4) {
+spv_target_env PickSpirvEnv(const APIVersion& api_version, bool spirv_1_4) {
     if (api_version >= VK_API_VERSION_1_4) {
         return SPV_ENV_VULKAN_1_4;
     } else if (api_version >= VK_API_VERSION_1_3) {
@@ -44,9 +44,9 @@ spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4) {
 }
 
 // Some Vulkan extensions/features are just all done in spirv-val behind optional settings
-void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
-                            spv_target_env spirv_environment, spvtools::ValidatorOptions &out_options, uint32_t *out_hash,
-                            std::string &out_command) {
+void AdjustValidatorOptions(const DeviceExtensions& device_extensions, const DeviceFeatures& enabled_features,
+                            spv_target_env spirv_environment, spvtools::ValidatorOptions& out_options, uint32_t* out_hash,
+                            std::string& out_command) {
     struct Settings {
         bool relax_block_layout;
         bool uniform_buffer_standard_layout;

--- a/layers/utils/sync_utils.cpp
+++ b/layers/utils/sync_utils.cpp
@@ -37,7 +37,7 @@ size_t QFOImageTransferBarrier::hash() const {
     return hc.Value();
 }
 
-bool QFOImageTransferBarrier::operator==(const QFOImageTransferBarrier &rhs) const {
+bool QFOImageTransferBarrier::operator==(const QFOImageTransferBarrier& rhs) const {
     // Ignoring layout w.r.t. equality. See comment in hash above.
     return (static_cast<BaseType>(*this) == static_cast<BaseType>(rhs)) && (subresourceRange == rhs.subresourceRange);
 }
@@ -47,13 +47,13 @@ size_t QFOBufferTransferBarrier::hash() const {
     return hc.Value();
 }
 
-bool QFOBufferTransferBarrier::operator==(const QFOBufferTransferBarrier &rhs) const {
+bool QFOBufferTransferBarrier::operator==(const QFOBufferTransferBarrier& rhs) const {
     return (static_cast<BaseType>(*this) == static_cast<BaseType>(rhs)) && (offset == rhs.offset) && (size == rhs.size);
 }
 
 namespace sync_utils {
 // IMPORTANT: the features listed here should also be reflected in GetFeatureNameMap()
-VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures &features, const DeviceExtensions &device_extensions) {
+VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures& features, const DeviceExtensions& device_extensions) {
     VkPipelineStageFlags2 result = 0;
     if (!features.geometryShader) {
         result |= VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT;
@@ -101,7 +101,7 @@ VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures &features, con
     return result;
 }
 
-VkAccessFlags2 DisabledAccesses(const DeviceExtensions &device_extensions) {
+VkAccessFlags2 DisabledAccesses(const DeviceExtensions& device_extensions) {
     VkAccessFlags2 result = 0;
     if (!IsExtEnabled(device_extensions.vk_qcom_tile_shading)) {
         result |= VK_ACCESS_2_SHADER_TILE_ATTACHMENT_READ_BIT_QCOM | VK_ACCESS_2_SHADER_TILE_ATTACHMENT_WRITE_BIT_QCOM;
@@ -129,7 +129,7 @@ VkPipelineStageFlags2 ExpandPipelineStages(VkPipelineStageFlags2 stage_mask, VkQ
 
     if (VK_PIPELINE_STAGE_ALL_COMMANDS_BIT & stage_mask) {
         expanded &= ~VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-        for (const auto &all_commands : syncAllCommandStagesByQueueFlags()) {
+        for (const auto& all_commands : syncAllCommandStagesByQueueFlags()) {
             if (all_commands.first & queue_flags) {
                 expanded |= all_commands.second & ~disabled_feature_mask;
             }
@@ -192,7 +192,7 @@ std::string StringAccessFlags(VkAccessFlags2 mask, bool sync1) {
     return string_VkAccessFlags2(mask);
 }
 
-ExecScopes GetExecScopes(const VkDependencyInfo &dep_info) {
+ExecScopes GetExecScopes(const VkDependencyInfo& dep_info) {
     ExecScopes result{};
     for (uint32_t i = 0; i < dep_info.memoryBarrierCount; i++) {
         result.src |= dep_info.pMemoryBarriers[i].srcStageMask;

--- a/layers/utils/text_utils.cpp
+++ b/layers/utils/text_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 namespace text {
 
-std::string VFormat(const char *format, va_list argptr) {
+std::string VFormat(const char* format, va_list argptr) {
     // Counts actual characters. Null terminator is accounted separately.
     const int initial_max_symbol_count = 1024;
 
@@ -49,7 +49,7 @@ std::string VFormat(const char *format, va_list argptr) {
     return str;
 }
 
-std::string Format(const char *format, ...) {
+std::string Format(const char* format, ...) {
     va_list argptr;
     va_start(argptr, format);
     std::string str = VFormat(format, argptr);
@@ -57,12 +57,12 @@ std::string Format(const char *format, ...) {
     return str;
 }
 
-void ToLower(std::string &str) {
+void ToLower(std::string& str) {
     // std::tolower() returns int which can cause compiler warnings
     std::transform(str.begin(), str.end(), str.begin(), [](char c) { return static_cast<char>(std::tolower(c)); });
 }
 
-void ToUpper(std::string &str) {
+void ToUpper(std::string& str) {
     // std::toupper() returns int which can cause compiler warnings
     std::transform(str.begin(), str.end(), str.begin(), [](char c) { return static_cast<char>(std::toupper(c)); });
 }

--- a/layers/utils/vk_layer_extension_utils.cpp
+++ b/layers/utils/vk_layer_extension_utils.cpp
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@
 #include <cstring>
 #include "vk_layer_extension_utils.h"
 
-VkResult util_GetExtensionProperties(const uint32_t count, const VkExtensionProperties *layer_extensions, uint32_t *pCount,
-                                     VkExtensionProperties *pProperties) {
+VkResult util_GetExtensionProperties(const uint32_t count, const VkExtensionProperties* layer_extensions, uint32_t* pCount,
+                                     VkExtensionProperties* pProperties) {
     if (pProperties == nullptr || layer_extensions == nullptr) {
         *pCount = count;
         return VK_SUCCESS;
@@ -35,8 +35,8 @@ VkResult util_GetExtensionProperties(const uint32_t count, const VkExtensionProp
     return VK_SUCCESS;
 }
 
-VkResult util_GetLayerProperties(const uint32_t count, const VkLayerProperties *layer_properties, uint32_t *pCount,
-                                 VkLayerProperties *pProperties) {
+VkResult util_GetLayerProperties(const uint32_t count, const VkLayerProperties* layer_properties, uint32_t* pCount,
+                                 VkLayerProperties* pProperties) {
     if (pProperties == nullptr || layer_properties == nullptr) {
         *pCount = count;
         return VK_SUCCESS;

--- a/layers/utils/vk_struct_compare.cpp
+++ b/layers/utils/vk_struct_compare.cpp
@@ -20,8 +20,8 @@
 #include <vulkan/utility/vk_struct_helper.hpp>
 #include <cstring>
 
-static inline bool ComparePipelineSampleLocationsStateCreateInfo(const VkPipelineSampleLocationsStateCreateInfoEXT &a,
-                                                                 const VkPipelineSampleLocationsStateCreateInfoEXT &b) {
+static inline bool ComparePipelineSampleLocationsStateCreateInfo(const VkPipelineSampleLocationsStateCreateInfoEXT& a,
+                                                                 const VkPipelineSampleLocationsStateCreateInfoEXT& b) {
     // Having VkSampleLocationEXT not confirmed to matter for the VU this is being used for, so just check the Count is good enough
     return (a.sampleLocationsEnable == b.sampleLocationsEnable) &&
            (a.sampleLocationsInfo.sampleLocationsPerPixel == b.sampleLocationsInfo.sampleLocationsPerPixel) &&
@@ -30,8 +30,8 @@ static inline bool ComparePipelineSampleLocationsStateCreateInfo(const VkPipelin
            (a.sampleLocationsInfo.sampleLocationsCount == b.sampleLocationsInfo.sampleLocationsCount);
 }
 
-bool ComparePipelineMultisampleStateCreateInfo(const VkPipelineMultisampleStateCreateInfo &a,
-                                               const VkPipelineMultisampleStateCreateInfo &b) {
+bool ComparePipelineMultisampleStateCreateInfo(const VkPipelineMultisampleStateCreateInfo& a,
+                                               const VkPipelineMultisampleStateCreateInfo& b) {
     bool valid_mask = true;
     if (a.pSampleMask && b.pSampleMask && (a.rasterizationSamples == b.rasterizationSamples)) {
         uint32_t length = (SampleCountSize(a.rasterizationSamples) + 31) / 32;
@@ -47,8 +47,8 @@ bool ComparePipelineMultisampleStateCreateInfo(const VkPipelineMultisampleStateC
 
     bool valid_pNext = true;
     if (a.pNext && b.pNext) {
-        auto *a_sample_location = vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(a.pNext);
-        auto *b_sample_location = vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(b.pNext);
+        auto* a_sample_location = vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(a.pNext);
+        auto* b_sample_location = vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(b.pNext);
         if (a_sample_location && b_sample_location) {
             if (!ComparePipelineSampleLocationsStateCreateInfo(*a_sample_location, *b_sample_location)) {
                 valid_pNext = false;
@@ -65,38 +65,38 @@ bool ComparePipelineMultisampleStateCreateInfo(const VkPipelineMultisampleStateC
            (a.alphaToCoverageEnable == b.alphaToCoverageEnable) && (a.alphaToOneEnable == b.alphaToOneEnable);
 }
 
-bool CompareDescriptorSetLayoutBinding(const VkDescriptorSetLayoutBinding &a, const VkDescriptorSetLayoutBinding &b) {
+bool CompareDescriptorSetLayoutBinding(const VkDescriptorSetLayoutBinding& a, const VkDescriptorSetLayoutBinding& b) {
     return (a.binding == b.binding) && (a.descriptorType == b.descriptorType) && (a.descriptorCount == b.descriptorCount) &&
            (a.stageFlags == b.stageFlags) && (a.pImmutableSamplers == b.pImmutableSamplers);
 }
 
-bool ComparePipelineColorBlendAttachmentState(const VkPipelineColorBlendAttachmentState &a,
-                                              const VkPipelineColorBlendAttachmentState &b) {
+bool ComparePipelineColorBlendAttachmentState(const VkPipelineColorBlendAttachmentState& a,
+                                              const VkPipelineColorBlendAttachmentState& b) {
     return (a.blendEnable == b.blendEnable) && (a.srcColorBlendFactor == b.srcColorBlendFactor) &&
            (a.dstColorBlendFactor == b.dstColorBlendFactor) && (a.colorBlendOp == b.colorBlendOp) &&
            (a.srcAlphaBlendFactor == b.srcAlphaBlendFactor) && (a.dstAlphaBlendFactor == b.dstAlphaBlendFactor) &&
            (a.alphaBlendOp == b.alphaBlendOp) && (a.colorWriteMask == b.colorWriteMask);
 }
 
-bool ComparePipelineFragmentShadingRateStateCreateInfo(const VkPipelineFragmentShadingRateStateCreateInfoKHR &a,
-                                                       const VkPipelineFragmentShadingRateStateCreateInfoKHR &b) {
+bool ComparePipelineFragmentShadingRateStateCreateInfo(const VkPipelineFragmentShadingRateStateCreateInfoKHR& a,
+                                                       const VkPipelineFragmentShadingRateStateCreateInfoKHR& b) {
     // Since this is chained in a pnext, we don't want to check the pNext/sType
     return (a.fragmentSize.width == b.fragmentSize.width) && (a.fragmentSize.height == b.fragmentSize.height) &&
            (a.combinerOps[0] == b.combinerOps[0]) && (a.combinerOps[1] == b.combinerOps[1]);
 }
 
-static inline bool CompareSamplerYcbcrConversionInfo(const VkSamplerYcbcrConversionInfo &a, const VkSamplerYcbcrConversionInfo &b) {
+static inline bool CompareSamplerYcbcrConversionInfo(const VkSamplerYcbcrConversionInfo& a, const VkSamplerYcbcrConversionInfo& b) {
     return a.conversion == b.conversion;
 }
 
-static inline bool CompareSamplerBorderColorComponentMappingCreateInfo(const VkSamplerBorderColorComponentMappingCreateInfoEXT &a,
-                                                                       const VkSamplerBorderColorComponentMappingCreateInfoEXT &b) {
+static inline bool CompareSamplerBorderColorComponentMappingCreateInfo(const VkSamplerBorderColorComponentMappingCreateInfoEXT& a,
+                                                                       const VkSamplerBorderColorComponentMappingCreateInfoEXT& b) {
     return (a.components.r == b.components.r) && (a.components.g == b.components.g) && (a.components.b == b.components.b) &&
            (a.components.a == b.components.a) && (a.srgb == b.srgb);
 }
 
-static inline bool CompareSamplerCustomBorderColorCreateInfo(const VkSamplerCustomBorderColorCreateInfoEXT &a,
-                                                             const VkSamplerCustomBorderColorCreateInfoEXT &b) {
+static inline bool CompareSamplerCustomBorderColorCreateInfo(const VkSamplerCustomBorderColorCreateInfoEXT& a,
+                                                             const VkSamplerCustomBorderColorCreateInfoEXT& b) {
     return (memcmp(a.customBorderColor.uint32, b.customBorderColor.uint32,
                    sizeof(VkSamplerCustomBorderColorCreateInfoEXT::customBorderColor)) == 0 &&
             a.format == b.format);
@@ -104,10 +104,10 @@ static inline bool CompareSamplerCustomBorderColorCreateInfo(const VkSamplerCust
 // to be sure there are gaps between fields and its safe to use memcmp
 static_assert(sizeof(VkSamplerCustomBorderColorCreateInfoEXT::customBorderColor) == 16);
 
-bool CompareSamplerCreateInfo(const VkSamplerCreateInfo &a, const VkSamplerCreateInfo &b) {
+bool CompareSamplerCreateInfo(const VkSamplerCreateInfo& a, const VkSamplerCreateInfo& b) {
     // VkSamplerYcbcrConversionInfo
-    auto *a_ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(a.pNext);
-    auto *b_ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(b.pNext);
+    auto* a_ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(a.pNext);
+    auto* b_ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(b.pNext);
     if (a_ycbcr_conversion || b_ycbcr_conversion) {  // at least one not null
         if (!a_ycbcr_conversion || !b_ycbcr_conversion) {
             return false;  // one null, other not null
@@ -117,8 +117,8 @@ bool CompareSamplerCreateInfo(const VkSamplerCreateInfo &a, const VkSamplerCreat
         }
     }
     // VkSamplerBorderColorComponentMappingCreateInfoEXT
-    auto *a_component_mapping = vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(a.pNext);
-    auto *b_component_mapping = vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(b.pNext);
+    auto* a_component_mapping = vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(a.pNext);
+    auto* b_component_mapping = vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(b.pNext);
     if (a_component_mapping || b_component_mapping) {  // at least one not null
         if (!a_component_mapping || !b_component_mapping) {
             return false;  // one null, other not null
@@ -128,8 +128,8 @@ bool CompareSamplerCreateInfo(const VkSamplerCreateInfo &a, const VkSamplerCreat
         }
     }
     // VkSamplerCustomBorderColorCreateInfoEXT
-    auto *a_border_color = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(a.pNext);
-    auto *b_border_color = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(b.pNext);
+    auto* a_border_color = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(a.pNext);
+    auto* b_border_color = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(b.pNext);
     if (a_border_color || b_border_color) {  // at least one not null
         if (!a_border_color || !b_border_color) {
             return false;  // one null, other not null
@@ -139,8 +139,8 @@ bool CompareSamplerCreateInfo(const VkSamplerCreateInfo &a, const VkSamplerCreat
         }
     }
     // VkSamplerReductionModeCreateInfo
-    auto get_reduction_mode = [](const VkSamplerCreateInfo &ci) {
-        if (auto *reduction_mode_ci = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(ci.pNext)) {
+    auto get_reduction_mode = [](const VkSamplerCreateInfo& ci) {
+        if (auto* reduction_mode_ci = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(ci.pNext)) {
             return reduction_mode_ci->reductionMode;
         }
         // AVERAGE is default reduction mode (used when pNext does not specify VkSamplerReductionModeCreateInfo)
@@ -159,7 +159,7 @@ bool CompareSamplerCreateInfo(const VkSamplerCreateInfo &a, const VkSamplerCreat
            (a.maxLod == b.maxLod) && (a.borderColor == b.borderColor) && (a.unnormalizedCoordinates == b.unnormalizedCoordinates);
 }
 
-bool CompareDependencyInfo(const VkDependencyInfo &a, const VkDependencyInfo &b) {
+bool CompareDependencyInfo(const VkDependencyInfo& a, const VkDependencyInfo& b) {
     if (a.dependencyFlags != b.dependencyFlags || a.memoryBarrierCount != b.memoryBarrierCount ||
         a.bufferMemoryBarrierCount != b.bufferMemoryBarrierCount || a.imageMemoryBarrierCount != b.imageMemoryBarrierCount) {
         return false;

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -1,8 +1,8 @@
 /**************************************************************************
  *
- * Copyright 2014-2024 Valve Software
- * Copyright 2015-2024 Google Inc.
- * Copyright 2019-2024 LunarG, Inc.
+ * Copyright 2014-2026 Valve Software
+ * Copyright 2015-2026 Google Inc.
+ * Copyright 2019-2026 LunarG, Inc.
  * All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,22 +43,22 @@
 #endif
 
 #if defined(__ANDROID__)
-static void PropCallback(void *cookie, [[maybe_unused]] const char *name, const char *value, [[maybe_unused]] uint32_t serial) {
-    std::string *property = static_cast<std::string *>(cookie);
+static void PropCallback(void* cookie, [[maybe_unused]] const char* name, const char* value, [[maybe_unused]] uint32_t serial) {
+    std::string* property = static_cast<std::string*>(cookie);
     *property = value;
 }
 #endif
 
-std::string GetEnvironment(const char *variable) {
+std::string GetEnvironment(const char* variable) {
 #if !defined(__ANDROID__) && !defined(_WIN32)
-    const char *output = getenv(variable);
+    const char* output = getenv(variable);
     return output == NULL ? "" : output;
 #elif defined(_WIN32)
     int size = GetEnvironmentVariable(variable, NULL, 0);
     if (size == 0) {
         return "";
     }
-    char *buffer = new char[size];
+    char* buffer = new char[size];
     GetEnvironmentVariable(variable, buffer, size);
     std::string output = buffer;
     delete[] buffer;
@@ -73,7 +73,7 @@ std::string GetEnvironment(const char *variable) {
         var = "debug.vvl." + var;
     }
 
-    const prop_info *prop_info = __system_property_find(var.data());
+    const prop_info* prop_info = __system_property_find(var.data());
 
     if (prop_info) {
         std::string property;
@@ -87,7 +87,7 @@ std::string GetEnvironment(const char *variable) {
 #endif
 }
 
-void SetEnvironment(const char *variable, const char *value) {
+void SetEnvironment(const char* variable, const char* value) {
 #if !defined(__ANDROID__) && !defined(_WIN32)
     setenv(variable, value, 1);
 #elif defined(_WIN32)
@@ -109,7 +109,7 @@ static inline bool IsHighIntegrity() {
         DWORD buffer_size;
         if (GetTokenInformation(process_token, TokenIntegrityLevel, mandatory_label_buffer, sizeof(mandatory_label_buffer),
                                 &buffer_size) != 0) {
-            const TOKEN_MANDATORY_LABEL *mandatory_label = (const TOKEN_MANDATORY_LABEL *)mandatory_label_buffer;
+            const TOKEN_MANDATORY_LABEL* mandatory_label = (const TOKEN_MANDATORY_LABEL*)mandatory_label_buffer;
             const DWORD sub_authority_count = *GetSidSubAuthorityCount(mandatory_label->Label.Sid);
             const DWORD integrity_level = *GetSidSubAuthority(mandatory_label->Label.Sid, sub_authority_count - 1);
 

--- a/layers/vulkan/generated/command_validation.cpp
+++ b/layers/vulkan/generated/command_validation.cpp
@@ -24,7 +24,7 @@
 #include "command_validation.h"
 #include "containers/custom_containers.h"
 
-extern const char *kVUIDUndefined;
+extern const char* kVUIDUndefined;
 
 using Func = vvl::Func;
 // clang-format off
@@ -2816,7 +2816,7 @@ return kCommandValidationTable;
 }
 // clang-format on
 
-const CommandValidationInfo &GetCommandValidationInfo(vvl::Func command) {
+const CommandValidationInfo& GetCommandValidationInfo(vvl::Func command) {
     auto info_it = GetCommandValidationTable().find(command);
     assert(info_it != GetCommandValidationTable().end());
     return info_it->second;

--- a/layers/vulkan/generated/device_features.cpp
+++ b/layers/vulkan/generated/device_features.cpp
@@ -26,15 +26,15 @@
 #include "generated/vk_extension_helper.h"
 #include <vulkan/utility/vk_struct_helper.hpp>
 
-void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatures *features, const APIVersion &api_version) {
+void GetEnabledDeviceFeatures(const VkDeviceCreateInfo* pCreateInfo, DeviceFeatures* features, const APIVersion& api_version) {
     // Initialize all to false
     *features = {};
 
     // handle VkPhysicalDeviceFeatures specially as it is not part of the pNext chain,
     // and when it is (through VkPhysicalDeviceFeatures2), it requires an extra indirection.
-    const VkPhysicalDeviceFeatures *core_features = pCreateInfo->pEnabledFeatures;
+    const VkPhysicalDeviceFeatures* core_features = pCreateInfo->pEnabledFeatures;
     if (core_features == nullptr) {
-        const VkPhysicalDeviceFeatures2 *features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
+        const VkPhysicalDeviceFeatures2* features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
         if (features2 != nullptr) {
             core_features = &features2->features;
         }
@@ -97,18 +97,18 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
         features->inheritedQueries = core_features->inheritedQueries == VK_TRUE;
     }
 
-    for (const VkBaseInStructure *pNext = reinterpret_cast<const VkBaseInStructure *>(pCreateInfo->pNext); pNext != nullptr;
+    for (const VkBaseInStructure* pNext = reinterpret_cast<const VkBaseInStructure*>(pCreateInfo->pNext); pNext != nullptr;
          pNext = pNext->pNext) {
         switch (pNext->sType) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES: {
-                const VkPhysicalDeviceProtectedMemoryFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures *>(pNext);
+                const VkPhysicalDeviceProtectedMemoryFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(pNext);
                 features->protectedMemory |= enabled->protectedMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES: {
-                const VkPhysicalDevice16BitStorageFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures *>(pNext);
+                const VkPhysicalDevice16BitStorageFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(pNext);
                 features->storageBuffer16BitAccess |= enabled->storageBuffer16BitAccess == VK_TRUE;
                 features->uniformAndStorageBuffer16BitAccess |= enabled->uniformAndStorageBuffer16BitAccess == VK_TRUE;
                 features->storagePushConstant16 |= enabled->storagePushConstant16 == VK_TRUE;
@@ -116,34 +116,34 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES: {
-                const VkPhysicalDeviceVariablePointersFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures *>(pNext);
+                const VkPhysicalDeviceVariablePointersFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(pNext);
                 features->variablePointersStorageBuffer |= enabled->variablePointersStorageBuffer == VK_TRUE;
                 features->variablePointers |= enabled->variablePointers == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES: {
-                const VkPhysicalDeviceSamplerYcbcrConversionFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(pNext);
+                const VkPhysicalDeviceSamplerYcbcrConversionFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(pNext);
                 features->samplerYcbcrConversion |= enabled->samplerYcbcrConversion == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES: {
-                const VkPhysicalDeviceMultiviewFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures *>(pNext);
+                const VkPhysicalDeviceMultiviewFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(pNext);
                 features->multiview |= enabled->multiview == VK_TRUE;
                 features->multiviewGeometryShader |= enabled->multiviewGeometryShader == VK_TRUE;
                 features->multiviewTessellationShader |= enabled->multiviewTessellationShader == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES: {
-                const VkPhysicalDeviceShaderDrawParametersFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures *>(pNext);
+                const VkPhysicalDeviceShaderDrawParametersFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(pNext);
                 features->shaderDrawParameters |= enabled->shaderDrawParameters == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES: {
-                const VkPhysicalDeviceVulkan11Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan11Features *>(pNext);
+                const VkPhysicalDeviceVulkan11Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(pNext);
                 features->storageBuffer16BitAccess |= enabled->storageBuffer16BitAccess == VK_TRUE;
                 features->uniformAndStorageBuffer16BitAccess |= enabled->uniformAndStorageBuffer16BitAccess == VK_TRUE;
                 features->storagePushConstant16 |= enabled->storagePushConstant16 == VK_TRUE;
@@ -159,7 +159,7 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: {
-                const VkPhysicalDeviceVulkan12Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan12Features *>(pNext);
+                const VkPhysicalDeviceVulkan12Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(pNext);
                 features->samplerMirrorClampToEdge |= enabled->samplerMirrorClampToEdge == VK_TRUE;
                 features->drawIndirectCount |= enabled->drawIndirectCount == VK_TRUE;
                 features->storageBuffer8BitAccess |= enabled->storageBuffer8BitAccess == VK_TRUE;
@@ -228,8 +228,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES: {
-                const VkPhysicalDeviceVulkanMemoryModelFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures *>(pNext);
+                const VkPhysicalDeviceVulkanMemoryModelFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(pNext);
                 features->vulkanMemoryModel |= enabled->vulkanMemoryModel == VK_TRUE;
                 features->vulkanMemoryModelDeviceScope |= enabled->vulkanMemoryModelDeviceScope == VK_TRUE;
                 features->vulkanMemoryModelAvailabilityVisibilityChains |=
@@ -237,50 +237,50 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES: {
-                const VkPhysicalDeviceHostQueryResetFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures *>(pNext);
+                const VkPhysicalDeviceHostQueryResetFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(pNext);
                 features->hostQueryReset |= enabled->hostQueryReset == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES: {
-                const VkPhysicalDeviceTimelineSemaphoreFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures *>(pNext);
+                const VkPhysicalDeviceTimelineSemaphoreFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(pNext);
                 features->timelineSemaphore |= enabled->timelineSemaphore == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES: {
-                const VkPhysicalDeviceBufferDeviceAddressFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures *>(pNext);
+                const VkPhysicalDeviceBufferDeviceAddressFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(pNext);
                 features->bufferDeviceAddress |= enabled->bufferDeviceAddress == VK_TRUE;
                 features->bufferDeviceAddressCaptureReplay |= enabled->bufferDeviceAddressCaptureReplay == VK_TRUE;
                 features->bufferDeviceAddressMultiDevice |= enabled->bufferDeviceAddressMultiDevice == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES: {
-                const VkPhysicalDevice8BitStorageFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures *>(pNext);
+                const VkPhysicalDevice8BitStorageFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(pNext);
                 features->storageBuffer8BitAccess |= enabled->storageBuffer8BitAccess == VK_TRUE;
                 features->uniformAndStorageBuffer8BitAccess |= enabled->uniformAndStorageBuffer8BitAccess == VK_TRUE;
                 features->storagePushConstant8 |= enabled->storagePushConstant8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES: {
-                const VkPhysicalDeviceShaderAtomicInt64Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features *>(pNext);
+                const VkPhysicalDeviceShaderAtomicInt64Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(pNext);
                 features->shaderBufferInt64Atomics |= enabled->shaderBufferInt64Atomics == VK_TRUE;
                 features->shaderSharedInt64Atomics |= enabled->shaderSharedInt64Atomics == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES: {
-                const VkPhysicalDeviceShaderFloat16Int8Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features *>(pNext);
+                const VkPhysicalDeviceShaderFloat16Int8Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(pNext);
                 features->shaderFloat16 |= enabled->shaderFloat16 == VK_TRUE;
                 features->shaderInt8 |= enabled->shaderInt8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES: {
-                const VkPhysicalDeviceDescriptorIndexingFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures *>(pNext);
+                const VkPhysicalDeviceDescriptorIndexingFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(pNext);
                 features->shaderInputAttachmentArrayDynamicIndexing |=
                     enabled->shaderInputAttachmentArrayDynamicIndexing == VK_TRUE;
                 features->shaderUniformTexelBufferArrayDynamicIndexing |=
@@ -321,37 +321,37 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES: {
-                const VkPhysicalDeviceScalarBlockLayoutFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures *>(pNext);
+                const VkPhysicalDeviceScalarBlockLayoutFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(pNext);
                 features->scalarBlockLayout |= enabled->scalarBlockLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES: {
-                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(pNext);
+                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(pNext);
                 features->uniformBufferStandardLayout |= enabled->uniformBufferStandardLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES: {
-                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(pNext);
+                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(pNext);
                 features->shaderSubgroupExtendedTypes |= enabled->shaderSubgroupExtendedTypes == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES: {
-                const VkPhysicalDeviceImagelessFramebufferFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures *>(pNext);
+                const VkPhysicalDeviceImagelessFramebufferFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(pNext);
                 features->imagelessFramebuffer |= enabled->imagelessFramebuffer == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES: {
-                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(pNext);
+                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(pNext);
                 features->separateDepthStencilLayouts |= enabled->separateDepthStencilLayouts == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES: {
-                const VkPhysicalDeviceVulkan13Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan13Features *>(pNext);
+                const VkPhysicalDeviceVulkan13Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan13Features*>(pNext);
                 features->robustImageAccess |= enabled->robustImageAccess == VK_TRUE;
                 features->inlineUniformBlock |= enabled->inlineUniformBlock == VK_TRUE;
                 features->descriptorBindingInlineUniformBlockUpdateAfterBind |=
@@ -371,88 +371,88 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES: {
-                const VkPhysicalDevicePrivateDataFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures *>(pNext);
+                const VkPhysicalDevicePrivateDataFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures*>(pNext);
                 features->privateData |= enabled->privateData == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES: {
-                const VkPhysicalDeviceSynchronization2Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features *>(pNext);
+                const VkPhysicalDeviceSynchronization2Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(pNext);
                 features->synchronization2 |= enabled->synchronization2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES: {
-                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(pNext);
+                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(pNext);
                 features->textureCompressionASTC_HDR |= enabled->textureCompressionASTC_HDR == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES: {
-                const VkPhysicalDeviceMaintenance4Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features *>(pNext);
+                const VkPhysicalDeviceMaintenance4Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features*>(pNext);
                 features->maintenance4 |= enabled->maintenance4 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES: {
-                const VkPhysicalDeviceShaderTerminateInvocationFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures *>(pNext);
+                const VkPhysicalDeviceShaderTerminateInvocationFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures*>(pNext);
                 features->shaderTerminateInvocation |= enabled->shaderTerminateInvocation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES: {
-                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(pNext);
+                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(pNext);
                 features->shaderDemoteToHelperInvocation |= enabled->shaderDemoteToHelperInvocation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES: {
-                const VkPhysicalDevicePipelineCreationCacheControlFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures *>(pNext);
+                const VkPhysicalDevicePipelineCreationCacheControlFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures*>(pNext);
                 features->pipelineCreationCacheControl |= enabled->pipelineCreationCacheControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES: {
-                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(pNext);
+                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(pNext);
                 features->shaderZeroInitializeWorkgroupMemory |= enabled->shaderZeroInitializeWorkgroupMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES: {
-                const VkPhysicalDeviceImageRobustnessFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures *>(pNext);
+                const VkPhysicalDeviceImageRobustnessFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(pNext);
                 features->robustImageAccess |= enabled->robustImageAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES: {
-                const VkPhysicalDeviceSubgroupSizeControlFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures *>(pNext);
+                const VkPhysicalDeviceSubgroupSizeControlFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(pNext);
                 features->subgroupSizeControl |= enabled->subgroupSizeControl == VK_TRUE;
                 features->computeFullSubgroups |= enabled->computeFullSubgroups == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES: {
-                const VkPhysicalDeviceInlineUniformBlockFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures *>(pNext);
+                const VkPhysicalDeviceInlineUniformBlockFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures*>(pNext);
                 features->inlineUniformBlock |= enabled->inlineUniformBlock == VK_TRUE;
                 features->descriptorBindingInlineUniformBlockUpdateAfterBind |=
                     enabled->descriptorBindingInlineUniformBlockUpdateAfterBind == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES: {
-                const VkPhysicalDeviceShaderIntegerDotProductFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures *>(pNext);
+                const VkPhysicalDeviceShaderIntegerDotProductFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures*>(pNext);
                 features->shaderIntegerDotProduct |= enabled->shaderIntegerDotProduct == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES: {
-                const VkPhysicalDeviceDynamicRenderingFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures *>(pNext);
+                const VkPhysicalDeviceDynamicRenderingFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures*>(pNext);
                 features->dynamicRendering |= enabled->dynamicRendering == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES: {
-                const VkPhysicalDeviceVulkan14Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan14Features *>(pNext);
+                const VkPhysicalDeviceVulkan14Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan14Features*>(pNext);
                 features->globalPriorityQuery |= enabled->globalPriorityQuery == VK_TRUE;
                 features->shaderSubgroupRotate |= enabled->shaderSubgroupRotate == VK_TRUE;
                 features->shaderSubgroupRotateClustered |= enabled->shaderSubgroupRotateClustered == VK_TRUE;
@@ -477,69 +477,69 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES: {
-                const VkPhysicalDeviceGlobalPriorityQueryFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures *>(pNext);
+                const VkPhysicalDeviceGlobalPriorityQueryFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures*>(pNext);
                 features->globalPriorityQuery |= enabled->globalPriorityQuery == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES: {
-                const VkPhysicalDeviceIndexTypeUint8Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features *>(pNext);
+                const VkPhysicalDeviceIndexTypeUint8Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features*>(pNext);
                 features->indexTypeUint8 |= enabled->indexTypeUint8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES: {
-                const VkPhysicalDeviceMaintenance5Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features *>(pNext);
+                const VkPhysicalDeviceMaintenance5Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features*>(pNext);
                 features->maintenance5 |= enabled->maintenance5 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES: {
-                const VkPhysicalDeviceMaintenance6Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features *>(pNext);
+                const VkPhysicalDeviceMaintenance6Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features*>(pNext);
                 features->maintenance6 |= enabled->maintenance6 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES: {
-                const VkPhysicalDeviceHostImageCopyFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures *>(pNext);
+                const VkPhysicalDeviceHostImageCopyFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures*>(pNext);
                 features->hostImageCopy |= enabled->hostImageCopy == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES: {
-                const VkPhysicalDeviceShaderSubgroupRotateFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures *>(pNext);
+                const VkPhysicalDeviceShaderSubgroupRotateFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures*>(pNext);
                 features->shaderSubgroupRotate |= enabled->shaderSubgroupRotate == VK_TRUE;
                 features->shaderSubgroupRotateClustered |= enabled->shaderSubgroupRotateClustered == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT_CONTROLS_2_FEATURES: {
-                const VkPhysicalDeviceShaderFloatControls2Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features *>(pNext);
+                const VkPhysicalDeviceShaderFloatControls2Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features*>(pNext);
                 features->shaderFloatControls2 |= enabled->shaderFloatControls2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES: {
-                const VkPhysicalDeviceShaderExpectAssumeFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures *>(pNext);
+                const VkPhysicalDeviceShaderExpectAssumeFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures*>(pNext);
                 features->shaderExpectAssume |= enabled->shaderExpectAssume == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES: {
-                const VkPhysicalDevicePipelineProtectedAccessFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures *>(pNext);
+                const VkPhysicalDevicePipelineProtectedAccessFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures*>(pNext);
                 features->pipelineProtectedAccess |= enabled->pipelineProtectedAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES: {
-                const VkPhysicalDevicePipelineRobustnessFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures *>(pNext);
+                const VkPhysicalDevicePipelineRobustnessFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures*>(pNext);
                 features->pipelineRobustness |= enabled->pipelineRobustness == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES: {
-                const VkPhysicalDeviceLineRasterizationFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures *>(pNext);
+                const VkPhysicalDeviceLineRasterizationFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures*>(pNext);
                 features->rectangularLines |= enabled->rectangularLines == VK_TRUE;
                 features->bresenhamLines |= enabled->bresenhamLines == VK_TRUE;
                 features->smoothLines |= enabled->smoothLines == VK_TRUE;
@@ -549,28 +549,28 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES: {
-                const VkPhysicalDeviceVertexAttributeDivisorFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures *>(pNext);
+                const VkPhysicalDeviceVertexAttributeDivisorFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures*>(pNext);
                 features->vertexAttributeInstanceRateDivisor |= enabled->vertexAttributeInstanceRateDivisor == VK_TRUE;
                 features->vertexAttributeInstanceRateZeroDivisor |= enabled->vertexAttributeInstanceRateZeroDivisor == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES: {
-                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(pNext);
+                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(pNext);
                 features->dynamicRenderingLocalRead |= enabled->dynamicRenderingLocalRead == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR: {
-                const VkPhysicalDevicePerformanceQueryFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePerformanceQueryFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(pNext);
                 features->performanceCounterQueryPools |= enabled->performanceCounterQueryPools == VK_TRUE;
                 features->performanceCounterMultipleQueryPools |= enabled->performanceCounterMultipleQueryPools == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_BFLOAT16_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderBfloat16FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderBfloat16FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(pNext);
                 features->shaderBFloat16Type |= enabled->shaderBFloat16Type == VK_TRUE;
                 features->shaderBFloat16DotProduct |= enabled->shaderBFloat16DotProduct == VK_TRUE;
                 features->shaderBFloat16CooperativeMatrix |= enabled->shaderBFloat16CooperativeMatrix == VK_TRUE;
@@ -578,8 +578,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
-                const VkPhysicalDevicePortabilitySubsetFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePortabilitySubsetFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(pNext);
                 features->constantAlphaColorBlendFactors |= enabled->constantAlphaColorBlendFactors == VK_TRUE;
                 features->events |= enabled->events == VK_TRUE;
                 features->imageViewFormatReinterpretation |= enabled->imageViewFormatReinterpretation == VK_TRUE;
@@ -599,65 +599,65 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderClockFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderClockFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(pNext);
                 features->shaderSubgroupClock |= enabled->shaderSubgroupClock == VK_TRUE;
                 features->shaderDeviceClock |= enabled->shaderDeviceClock == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR: {
-                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(pNext);
                 features->pipelineFragmentShadingRate |= enabled->pipelineFragmentShadingRate == VK_TRUE;
                 features->primitiveFragmentShadingRate |= enabled->primitiveFragmentShadingRate == VK_TRUE;
                 features->attachmentFragmentShadingRate |= enabled->attachmentFragmentShadingRate == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderQuadControlFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderQuadControlFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(pNext);
                 features->shaderQuadControl |= enabled->shaderQuadControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR: {
-                const VkPhysicalDevicePresentWaitFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentWaitFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR*>(pNext);
                 features->presentWait |= enabled->presentWait == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR: {
-                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(pNext);
                 features->pipelineExecutableInfo |= enabled->pipelineExecutableInfo == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR: {
-                const VkPhysicalDevicePresentIdFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentIdFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR*>(pNext);
                 features->presentId |= enabled->presentId == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_ADDRESS_COMMANDS_FEATURES_KHR: {
-                const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR*>(pNext);
                 features->deviceAddressCommands |= enabled->deviceAddressCommands == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR: {
-                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(pNext);
                 features->fragmentShaderBarycentric |= enabled->fragmentShaderBarycentric == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(pNext);
                 features->shaderSubgroupUniformControlFlow |= enabled->shaderSubgroupUniformControlFlow == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR: {
-                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(pNext);
                 features->workgroupMemoryExplicitLayout |= enabled->workgroupMemoryExplicitLayout == VK_TRUE;
                 features->workgroupMemoryExplicitLayoutScalarBlockLayout |=
                     enabled->workgroupMemoryExplicitLayoutScalarBlockLayout == VK_TRUE;
@@ -666,379 +666,379 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR: {
-                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(pNext);
                 features->rayTracingMaintenance1 |= enabled->rayTracingMaintenance1 == VK_TRUE;
                 features->rayTracingPipelineTraceRaysIndirect2 |= enabled->rayTracingPipelineTraceRaysIndirect2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(pNext);
                 features->shaderUntypedPointers |= enabled->shaderUntypedPointers == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(pNext);
                 features->shaderMaximalReconvergence |= enabled->shaderMaximalReconvergence == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_2_FEATURES_KHR: {
-                const VkPhysicalDevicePresentId2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentId2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR*>(pNext);
                 features->presentId2 |= enabled->presentId2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_2_FEATURES_KHR: {
-                const VkPhysicalDevicePresentWait2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentWait2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR*>(pNext);
                 features->presentWait2 |= enabled->presentWait2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR: {
-                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(pNext);
                 features->rayTracingPositionFetch |= enabled->rayTracingPositionFetch == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_FEATURES_KHR: {
-                const VkPhysicalDevicePipelineBinaryFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePipelineBinaryFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR*>(pNext);
                 features->pipelineBinaries |= enabled->pipelineBinaries == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_KHR: {
-                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(pNext);
                 features->swapchainMaintenance1 |= enabled->swapchainMaintenance1 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR: {
-                const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR*>(pNext);
                 features->internallySynchronizedQueues |= enabled->internallySynchronizedQueues == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR: {
-                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(pNext);
                 features->cooperativeMatrix |= enabled->cooperativeMatrix == VK_TRUE;
                 features->cooperativeMatrixRobustBufferAccess |= enabled->cooperativeMatrixRobustBufferAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_KHR: {
-                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(pNext);
                 features->computeDerivativeGroupQuads |= enabled->computeDerivativeGroupQuads == VK_TRUE;
                 features->computeDerivativeGroupLinear |= enabled->computeDerivativeGroupLinear == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_AV1_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(pNext);
                 features->videoEncodeAV1 |= enabled->videoEncodeAV1 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_DECODE_VP9_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(pNext);
                 features->videoDecodeVP9 |= enabled->videoDecodeVP9 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(pNext);
                 features->videoMaintenance1 |= enabled->videoMaintenance1 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFIED_IMAGE_LAYOUTS_FEATURES_KHR: {
-                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(pNext);
                 features->unifiedImageLayouts |= enabled->unifiedImageLayouts == VK_TRUE;
                 features->unifiedImageLayoutsVideo |= enabled->unifiedImageLayoutsVideo == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_KHR: {
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(pNext);
                 features->indirectMemoryCopy |= enabled->indirectMemoryCopy == VK_TRUE;
                 features->indirectMemoryToImageCopy |= enabled->indirectMemoryToImageCopy == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_INTRA_REFRESH_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(pNext);
                 features->videoEncodeIntraRefresh |= enabled->videoEncodeIntraRefresh == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUANTIZATION_MAP_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(pNext);
                 features->videoEncodeQuantizationMap |= enabled->videoEncodeQuantizationMap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_RELAXED_EXTENDED_INSTRUCTION_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(pNext);
                 features->shaderRelaxedExtendedInstruction |= enabled->shaderRelaxedExtendedInstruction == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance7FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance7FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR*>(pNext);
                 features->maintenance7 |= enabled->maintenance7 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance8FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance8FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR*>(pNext);
                 features->maintenance8 |= enabled->maintenance8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FMA_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderFmaFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderFmaFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR*>(pNext);
                 features->shaderFmaFloat16 |= enabled->shaderFmaFloat16 == VK_TRUE;
                 features->shaderFmaFloat32 |= enabled->shaderFmaFloat32 == VK_TRUE;
                 features->shaderFmaFloat64 |= enabled->shaderFmaFloat64 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance9FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance9FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR*>(pNext);
                 features->maintenance9 |= enabled->maintenance9 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_2_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(pNext);
                 features->videoMaintenance2 |= enabled->videoMaintenance2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR: {
-                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(pNext);
                 features->depthClampZeroOne |= enabled->depthClampZeroOne == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR: {
-                const VkPhysicalDeviceRobustness2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRobustness2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(pNext);
                 features->robustBufferAccess2 |= enabled->robustBufferAccess2 == VK_TRUE;
                 features->robustImageAccess2 |= enabled->robustImageAccess2 == VK_TRUE;
                 features->nullDescriptor |= enabled->nullDescriptor == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_MODE_FIFO_LATEST_READY_FEATURES_KHR: {
-                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(pNext);
                 features->presentModeFifoLatestReady |= enabled->presentModeFifoLatestReady == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance10FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance10FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR*>(pNext);
                 features->maintenance10 |= enabled->maintenance10 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT: {
-                const VkPhysicalDeviceTransformFeedbackFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceTransformFeedbackFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(pNext);
                 features->transformFeedback |= enabled->transformFeedback == VK_TRUE;
                 features->geometryStreams |= enabled->geometryStreams == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV: {
-                const VkPhysicalDeviceCornerSampledImageFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCornerSampledImageFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(pNext);
                 features->cornerSampledImage |= enabled->cornerSampledImage == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT: {
-                const VkPhysicalDeviceASTCDecodeFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceASTCDecodeFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(pNext);
                 features->decodeModeSharedExponent |= enabled->decodeModeSharedExponent == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT: {
-                const VkPhysicalDeviceConditionalRenderingFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceConditionalRenderingFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(pNext);
                 features->conditionalRendering |= enabled->conditionalRendering == VK_TRUE;
                 features->inheritedConditionalRendering |= enabled->inheritedConditionalRendering == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthClipEnableFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthClipEnableFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(pNext);
                 features->depthClipEnable |= enabled->depthClipEnable == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG: {
-                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(pNext);
+                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(pNext);
                 features->relaxedLineRasterization |= enabled->relaxedLineRasterization == VK_TRUE;
                 break;
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX: {
-                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(pNext);
+                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(pNext);
                 features->shaderEnqueue |= enabled->shaderEnqueue == VK_TRUE;
                 features->shaderMeshEnqueue |= enabled->shaderMeshEnqueue == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT: {
-                const VkPhysicalDeviceDescriptorHeapFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorHeapFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDescriptorHeapFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorHeapFeaturesEXT*>(pNext);
                 features->descriptorHeap |= enabled->descriptorHeap == VK_TRUE;
                 features->descriptorHeapCaptureReplay |= enabled->descriptorHeapCaptureReplay == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT: {
-                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(pNext);
                 features->advancedBlendCoherentOperations |= enabled->advancedBlendCoherentOperations == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV: {
-                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(pNext);
                 features->shaderSMBuiltins |= enabled->shaderSMBuiltins == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV: {
-                const VkPhysicalDeviceShadingRateImageFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShadingRateImageFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(pNext);
                 features->shadingRateImage |= enabled->shadingRateImage == VK_TRUE;
                 features->shadingRateCoarseSampleOrder |= enabled->shadingRateCoarseSampleOrder == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV: {
-                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(pNext);
                 features->representativeFragmentTest |= enabled->representativeFragmentTest == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_CONVERSION_FEATURES_QCOM: {
-                const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM*>(pNext);
                 features->cooperativeMatrixConversion |= enabled->cooperativeMatrixConversion == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV: {
-                const VkPhysicalDeviceMeshShaderFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV *>(pNext);
+                const VkPhysicalDeviceMeshShaderFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(pNext);
                 features->taskShader |= enabled->taskShader == VK_TRUE;
                 features->meshShader |= enabled->meshShader == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV: {
-                const VkPhysicalDeviceShaderImageFootprintFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShaderImageFootprintFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(pNext);
                 features->imageFootprint |= enabled->imageFootprint == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV: {
-                const VkPhysicalDeviceExclusiveScissorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceExclusiveScissorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(pNext);
                 features->exclusiveScissor |= enabled->exclusiveScissor == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_TIMING_FEATURES_EXT: {
-                const VkPhysicalDevicePresentTimingFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePresentTimingFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT*>(pNext);
                 features->presentTiming |= enabled->presentTiming == VK_TRUE;
                 features->presentAtAbsoluteTime |= enabled->presentAtAbsoluteTime == VK_TRUE;
                 features->presentAtRelativeTime |= enabled->presentAtRelativeTime == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL: {
-                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(pNext);
+                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(pNext);
                 features->shaderIntegerFunctions2 |= enabled->shaderIntegerFunctions2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(pNext);
                 features->fragmentDensityMap |= enabled->fragmentDensityMap == VK_TRUE;
                 features->fragmentDensityMapDynamic |= enabled->fragmentDensityMapDynamic == VK_TRUE;
                 features->fragmentDensityMapNonSubsampledImages |= enabled->fragmentDensityMapNonSubsampledImages == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD: {
-                const VkPhysicalDeviceCoherentMemoryFeaturesAMD *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(pNext);
+                const VkPhysicalDeviceCoherentMemoryFeaturesAMD* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(pNext);
                 features->deviceCoherentMemory |= enabled->deviceCoherentMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(pNext);
                 features->shaderImageInt64Atomics |= enabled->shaderImageInt64Atomics == VK_TRUE;
                 features->sparseImageInt64Atomics |= enabled->sparseImageInt64Atomics == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT: {
-                const VkPhysicalDeviceMemoryPriorityFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMemoryPriorityFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(pNext);
                 features->memoryPriority |= enabled->memoryPriority == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV: {
-                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(pNext);
                 features->dedicatedAllocationImageAliasing |= enabled->dedicatedAllocationImageAliasing == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT: {
-                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(pNext);
                 features->bufferDeviceAddressEXT |= enabled->bufferDeviceAddress == VK_TRUE;
                 features->bufferDeviceAddressCaptureReplayEXT |= enabled->bufferDeviceAddressCaptureReplay == VK_TRUE;
                 features->bufferDeviceAddressMultiDeviceEXT |= enabled->bufferDeviceAddressMultiDevice == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV: {
-                const VkPhysicalDeviceCooperativeMatrixFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(pNext);
                 features->cooperativeMatrix |= enabled->cooperativeMatrix == VK_TRUE;
                 features->cooperativeMatrixRobustBufferAccess |= enabled->cooperativeMatrixRobustBufferAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV: {
-                const VkPhysicalDeviceCoverageReductionModeFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCoverageReductionModeFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(pNext);
                 features->coverageReductionMode |= enabled->coverageReductionMode == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(pNext);
                 features->fragmentShaderSampleInterlock |= enabled->fragmentShaderSampleInterlock == VK_TRUE;
                 features->fragmentShaderPixelInterlock |= enabled->fragmentShaderPixelInterlock == VK_TRUE;
                 features->fragmentShaderShadingRateInterlock |= enabled->fragmentShaderShadingRateInterlock == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT: {
-                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(pNext);
                 features->ycbcrImageArrays |= enabled->ycbcrImageArrays == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT: {
-                const VkPhysicalDeviceProvokingVertexFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceProvokingVertexFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT*>(pNext);
                 features->provokingVertexLast |= enabled->provokingVertexLast == VK_TRUE;
                 features->transformFeedbackPreservesProvokingVertex |=
                     enabled->transformFeedbackPreservesProvokingVertex == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(pNext);
                 features->shaderBufferFloat32Atomics |= enabled->shaderBufferFloat32Atomics == VK_TRUE;
                 features->shaderBufferFloat32AtomicAdd |= enabled->shaderBufferFloat32AtomicAdd == VK_TRUE;
                 features->shaderBufferFloat64Atomics |= enabled->shaderBufferFloat64Atomics == VK_TRUE;
@@ -1054,22 +1054,22 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: {
-                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(pNext);
                 features->extendedDynamicState |= enabled->extendedDynamicState == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_FEATURES_EXT: {
-                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(pNext);
                 features->memoryMapPlaced |= enabled->memoryMapPlaced == VK_TRUE;
                 features->memoryMapRangePlaced |= enabled->memoryMapRangePlaced == VK_TRUE;
                 features->memoryUnmapReserve |= enabled->memoryUnmapReserve == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(pNext);
                 features->shaderBufferFloat16Atomics |= enabled->shaderBufferFloat16Atomics == VK_TRUE;
                 features->shaderBufferFloat16AtomicAdd |= enabled->shaderBufferFloat16AtomicAdd == VK_TRUE;
                 features->shaderBufferFloat16AtomicMinMax |= enabled->shaderBufferFloat16AtomicMinMax == VK_TRUE;
@@ -1085,26 +1085,26 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV: {
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(pNext);
                 features->deviceGeneratedCommandsNV |= enabled->deviceGeneratedCommands == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV: {
-                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(pNext);
                 features->inheritedViewportScissor2D |= enabled->inheritedViewportScissor2D == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT: {
-                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(pNext);
                 features->texelBufferAlignment |= enabled->texelBufferAlignment == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthBiasControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthBiasControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(pNext);
                 features->depthBiasControl |= enabled->depthBiasControl == VK_TRUE;
                 features->leastRepresentableValueForceUnormRepresentation |=
                     enabled->leastRepresentableValueForceUnormRepresentation == VK_TRUE;
@@ -1113,47 +1113,47 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT: {
-                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(pNext);
                 features->deviceMemoryReport |= enabled->deviceMemoryReport == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT: {
-                const VkPhysicalDeviceCustomBorderColorFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceCustomBorderColorFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(pNext);
                 features->customBorderColors |= enabled->customBorderColors == VK_TRUE;
                 features->customBorderColorWithoutFormat |= enabled->customBorderColorWithoutFormat == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_3D_FEATURES_EXT: {
-                const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT*>(pNext);
                 features->textureCompressionASTC_3D |= enabled->textureCompressionASTC_3D == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV: {
-                const VkPhysicalDevicePresentBarrierFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV *>(pNext);
+                const VkPhysicalDevicePresentBarrierFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV*>(pNext);
                 features->presentBarrier |= enabled->presentBarrier == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV: {
-                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(pNext);
                 features->diagnosticsConfig |= enabled->diagnosticsConfig == VK_TRUE;
                 break;
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV: {
-                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(pNext);
                 features->cudaKernelLaunchFeatures |= enabled->cudaKernelLaunchFeatures == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_SHADING_FEATURES_QCOM: {
-                const VkPhysicalDeviceTileShadingFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceTileShadingFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM*>(pNext);
                 features->tileShading |= enabled->tileShading == VK_TRUE;
                 features->tileShadingFragmentStage |= enabled->tileShadingFragmentStage == VK_TRUE;
                 features->tileShadingColorAttachments |= enabled->tileShadingColorAttachments == VK_TRUE;
@@ -1171,8 +1171,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT: {
-                const VkPhysicalDeviceDescriptorBufferFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDescriptorBufferFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(pNext);
                 features->descriptorBuffer |= enabled->descriptorBuffer == VK_TRUE;
                 features->descriptorBufferCaptureReplay |= enabled->descriptorBufferCaptureReplay == VK_TRUE;
                 features->descriptorBufferImageLayoutIgnored |= enabled->descriptorBufferImageLayoutIgnored == VK_TRUE;
@@ -1180,73 +1180,73 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT: {
-                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(pNext);
                 features->graphicsPipelineLibrary |= enabled->graphicsPipelineLibrary == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD: {
-                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(pNext);
+                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(pNext);
                 features->shaderEarlyAndLateFragmentTests |= enabled->shaderEarlyAndLateFragmentTests == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV: {
-                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(pNext);
                 features->fragmentShadingRateEnums |= enabled->fragmentShadingRateEnums == VK_TRUE;
                 features->supersampleFragmentShadingRates |= enabled->supersampleFragmentShadingRates == VK_TRUE;
                 features->noInvocationFragmentShadingRates |= enabled->noInvocationFragmentShadingRates == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(pNext);
                 features->rayTracingMotionBlur |= enabled->rayTracingMotionBlur == VK_TRUE;
                 features->rayTracingMotionBlurPipelineTraceRaysIndirect |=
                     enabled->rayTracingMotionBlurPipelineTraceRaysIndirect == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT: {
-                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(pNext);
                 features->ycbcr2plane444Formats |= enabled->ycbcr2plane444Formats == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(pNext);
                 features->fragmentDensityMapDeferred |= enabled->fragmentDensityMapDeferred == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceImageCompressionControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageCompressionControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(pNext);
                 features->imageCompressionControl |= enabled->imageCompressionControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT: {
-                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(pNext);
                 features->attachmentFeedbackLoopLayout |= enabled->attachmentFeedbackLoopLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: {
-                const VkPhysicalDevice4444FormatsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT *>(pNext);
+                const VkPhysicalDevice4444FormatsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(pNext);
                 features->formatA4R4G4B4 |= enabled->formatA4R4G4B4 == VK_TRUE;
                 features->formatA4B4G4R4 |= enabled->formatA4B4G4R4 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT: {
-                const VkPhysicalDeviceFaultFeaturesEXT *enabled = reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFaultFeaturesEXT* enabled = reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT*>(pNext);
                 features->deviceFault |= enabled->deviceFault == VK_TRUE;
                 features->deviceFaultVendorBinary |= enabled->deviceFaultVendorBinary == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT: {
-                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(pNext);
                 features->rasterizationOrderColorAttachmentAccess |= enabled->rasterizationOrderColorAttachmentAccess == VK_TRUE;
                 features->rasterizationOrderDepthAttachmentAccess |= enabled->rasterizationOrderDepthAttachmentAccess == VK_TRUE;
                 features->rasterizationOrderStencilAttachmentAccess |=
@@ -1254,95 +1254,95 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT: {
-                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(pNext);
                 features->formatRgba10x6WithoutYCbCrSampler |= enabled->formatRgba10x6WithoutYCbCrSampler == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT: {
-                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(pNext);
                 features->mutableDescriptorType |= enabled->mutableDescriptorType == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT: {
-                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(pNext);
                 features->vertexInputDynamicState |= enabled->vertexInputDynamicState == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT: {
-                const VkPhysicalDeviceAddressBindingReportFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceAddressBindingReportFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(pNext);
                 features->reportAddressBinding |= enabled->reportAddressBinding == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthClipControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthClipControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT*>(pNext);
                 features->depthClipControl |= enabled->depthClipControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT: {
-                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(pNext);
                 features->primitiveTopologyListRestart |= enabled->primitiveTopologyListRestart == VK_TRUE;
                 features->primitiveTopologyPatchListRestart |= enabled->primitiveTopologyPatchListRestart == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(pNext);
                 features->subpassShading |= enabled->subpassShading == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(pNext);
                 features->invocationMask |= enabled->invocationMask == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV: {
-                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(pNext);
+                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(pNext);
                 features->externalMemoryRDMA |= enabled->externalMemoryRDMA == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROPERTIES_FEATURES_EXT: {
-                const VkPhysicalDevicePipelinePropertiesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePipelinePropertiesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(pNext);
                 features->pipelinePropertiesIdentifier |= enabled->pipelinePropertiesIdentifier == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT: {
-                const VkPhysicalDeviceFrameBoundaryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFrameBoundaryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(pNext);
                 features->frameBoundary |= enabled->frameBoundary == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT: {
-                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(pNext);
                 features->multisampledRenderToSingleSampled |= enabled->multisampledRenderToSingleSampled == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT: {
-                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(pNext);
                 features->extendedDynamicState2 |= enabled->extendedDynamicState2 == VK_TRUE;
                 features->extendedDynamicState2LogicOp |= enabled->extendedDynamicState2LogicOp == VK_TRUE;
                 features->extendedDynamicState2PatchControlPoints |= enabled->extendedDynamicState2PatchControlPoints == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT: {
-                const VkPhysicalDeviceColorWriteEnableFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceColorWriteEnableFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(pNext);
                 features->colorWriteEnable |= enabled->colorWriteEnable == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT: {
-                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(pNext);
                 features->primitivesGeneratedQuery |= enabled->primitivesGeneratedQuery == VK_TRUE;
                 features->primitivesGeneratedQueryWithRasterizerDiscard |=
                     enabled->primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE;
@@ -1351,41 +1351,41 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_RGB_CONVERSION_FEATURES_VALVE: {
-                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(pNext);
+                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(pNext);
                 features->videoEncodeRgbConversion |= enabled->videoEncodeRgbConversion == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT: {
-                const VkPhysicalDeviceImageViewMinLodFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageViewMinLodFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(pNext);
                 features->minLod |= enabled->minLod == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT: {
-                const VkPhysicalDeviceMultiDrawFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMultiDrawFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(pNext);
                 features->multiDraw |= enabled->multiDraw == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT: {
-                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(pNext);
                 features->image2DViewOf3D |= enabled->image2DViewOf3D == VK_TRUE;
                 features->sampler2DViewOf3D |= enabled->sampler2DViewOf3D == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderTileImageFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderTileImageFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT*>(pNext);
                 features->shaderTileImageColorReadAccess |= enabled->shaderTileImageColorReadAccess == VK_TRUE;
                 features->shaderTileImageDepthReadAccess |= enabled->shaderTileImageDepthReadAccess == VK_TRUE;
                 features->shaderTileImageStencilReadAccess |= enabled->shaderTileImageStencilReadAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT: {
-                const VkPhysicalDeviceOpacityMicromapFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceOpacityMicromapFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(pNext);
                 features->micromap |= enabled->micromap == VK_TRUE;
                 features->micromapCaptureReplay |= enabled->micromapCaptureReplay == VK_TRUE;
                 features->micromapHostCommands |= enabled->micromapHostCommands == VK_TRUE;
@@ -1393,132 +1393,132 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV: {
-                const VkPhysicalDeviceDisplacementMicromapFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDisplacementMicromapFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(pNext);
                 features->displacementMicromap |= enabled->displacementMicromap == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(pNext);
                 features->clustercullingShader |= enabled->clustercullingShader == VK_TRUE;
                 features->multiviewClusterCullingShader |= enabled->multiviewClusterCullingShader == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI*>(pNext);
                 features->clusterShadingRate |= enabled->clusterShadingRate == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT: {
-                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(pNext);
                 features->borderColorSwizzle |= enabled->borderColorSwizzle == VK_TRUE;
                 features->borderColorSwizzleFromImage |= enabled->borderColorSwizzleFromImage == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT: {
-                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(pNext);
                 features->pageableDeviceLocalMemory |= enabled->pageableDeviceLocalMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM: {
-                const VkPhysicalDeviceSchedulingControlsFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM *>(pNext);
+                const VkPhysicalDeviceSchedulingControlsFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM*>(pNext);
                 features->schedulingControls |= enabled->schedulingControls == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT: {
-                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(pNext);
                 features->imageSlicedViewOf3D |= enabled->imageSlicedViewOf3D == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE: {
-                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(pNext);
+                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(pNext);
                 features->descriptorSetHostMapping |= enabled->descriptorSetHostMapping == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT: {
-                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(pNext);
                 features->nonSeamlessCubeMap |= enabled->nonSeamlessCubeMap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM: {
-                const VkPhysicalDeviceRenderPassStripedFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM *>(pNext);
+                const VkPhysicalDeviceRenderPassStripedFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM*>(pNext);
                 features->renderPassStriped |= enabled->renderPassStriped == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(pNext);
                 features->fragmentDensityMapOffset |= enabled->fragmentDensityMapOffset == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_NV: {
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(pNext);
                 features->indirectCopy |= enabled->indirectCopy == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_FEATURES_EXT: {
-                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(pNext);
                 features->memoryDecompression |= enabled->memoryDecompression == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV: {
-                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(pNext);
                 features->deviceGeneratedCompute |= enabled->deviceGeneratedCompute == VK_TRUE;
                 features->deviceGeneratedComputePipelines |= enabled->deviceGeneratedComputePipelines == VK_TRUE;
                 features->deviceGeneratedComputeCaptureReplay |= enabled->deviceGeneratedComputeCaptureReplay == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_LINEAR_SWEPT_SPHERES_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(pNext);
                 features->spheres |= enabled->spheres == VK_TRUE;
                 features->linearSweptSpheres |= enabled->linearSweptSpheres == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV: {
-                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(pNext);
+                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(pNext);
                 features->linearColorAttachment |= enabled->linearColorAttachment == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT: {
-                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(pNext);
                 features->imageCompressionControlSwapchain |= enabled->imageCompressionControlSwapchain == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM: {
-                const VkPhysicalDeviceImageProcessingFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceImageProcessingFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM*>(pNext);
                 features->textureSampleWeighted |= enabled->textureSampleWeighted == VK_TRUE;
                 features->textureBoxFilter |= enabled->textureBoxFilter == VK_TRUE;
                 features->textureBlockMatch |= enabled->textureBlockMatch == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT: {
-                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(pNext);
                 features->nestedCommandBuffer |= enabled->nestedCommandBuffer == VK_TRUE;
                 features->nestedCommandBufferRendering |= enabled->nestedCommandBufferRendering == VK_TRUE;
                 features->nestedCommandBufferSimultaneousUse |= enabled->nestedCommandBufferSimultaneousUse == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT: {
-                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(pNext);
                 features->extendedDynamicState3TessellationDomainOrigin |=
                     enabled->extendedDynamicState3TessellationDomainOrigin == VK_TRUE;
                 features->extendedDynamicState3DepthClampEnable |= enabled->extendedDynamicState3DepthClampEnable == VK_TRUE;
@@ -1570,14 +1570,14 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT: {
-                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(pNext);
                 features->subpassMergeFeedback |= enabled->subpassMergeFeedback == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_FEATURES_ARM: {
-                const VkPhysicalDeviceTensorFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM *>(pNext);
+                const VkPhysicalDeviceTensorFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM*>(pNext);
                 features->tensorNonPacked |= enabled->tensorNonPacked == VK_TRUE;
                 features->shaderTensorAccess |= enabled->shaderTensorAccess == VK_TRUE;
                 features->shaderStorageTensorArrayDynamicIndexing |= enabled->shaderStorageTensorArrayDynamicIndexing == VK_TRUE;
@@ -1589,121 +1589,121 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_TENSOR_FEATURES_ARM: {
-                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(pNext);
+                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(pNext);
                 features->descriptorBufferTensorDescriptors |= enabled->descriptorBufferTensorDescriptors == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(pNext);
                 features->shaderModuleIdentifier |= enabled->shaderModuleIdentifier == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV: {
-                const VkPhysicalDeviceOpticalFlowFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV *>(pNext);
+                const VkPhysicalDeviceOpticalFlowFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV*>(pNext);
                 features->opticalFlow |= enabled->opticalFlow == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT: {
-                const VkPhysicalDeviceLegacyDitheringFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceLegacyDitheringFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(pNext);
                 features->legacyDithering |= enabled->legacyDithering == VK_TRUE;
                 break;
             }
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID: {
-                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(pNext);
+                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(pNext);
                 features->externalFormatResolve |= enabled->externalFormatResolve == VK_TRUE;
                 break;
             }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ANTI_LAG_FEATURES_AMD: {
-                const VkPhysicalDeviceAntiLagFeaturesAMD *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD *>(pNext);
+                const VkPhysicalDeviceAntiLagFeaturesAMD* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD*>(pNext);
                 features->antiLag |= enabled->antiLag == VK_TRUE;
                 break;
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DENSE_GEOMETRY_FORMAT_FEATURES_AMDX: {
-                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(pNext);
+                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(pNext);
                 features->denseGeometryFormat |= enabled->denseGeometryFormat == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderObjectFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderObjectFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT*>(pNext);
                 features->shaderObject |= enabled->shaderObject == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM: {
-                const VkPhysicalDeviceTilePropertiesFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceTilePropertiesFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(pNext);
                 features->tileProperties |= enabled->tileProperties == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC: {
-                const VkPhysicalDeviceAmigoProfilingFeaturesSEC *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(pNext);
+                const VkPhysicalDeviceAmigoProfilingFeaturesSEC* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(pNext);
                 features->amigoProfiling |= enabled->amigoProfiling == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM: {
-                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(pNext);
                 features->multiviewPerViewViewports |= enabled->multiviewPerViewViewports == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(pNext);
                 features->rayTracingInvocationReorder |= enabled->rayTracingInvocationReorder == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV: {
-                const VkPhysicalDeviceCooperativeVectorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCooperativeVectorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV*>(pNext);
                 features->cooperativeVector |= enabled->cooperativeVector == VK_TRUE;
                 features->cooperativeVectorTraining |= enabled->cooperativeVectorTraining == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV: {
-                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(pNext);
+                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(pNext);
                 features->extendedSparseAddressSpace |= enabled->extendedSparseAddressSpace == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_FEATURES_EXT: {
-                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(pNext);
                 features->legacyVertexAttributes |= enabled->legacyVertexAttributes == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM: {
-                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(pNext);
+                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(pNext);
                 features->shaderCoreBuiltins |= enabled->shaderCoreBuiltins == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT: {
-                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(pNext);
                 features->pipelineLibraryGroupHandles |= enabled->pipelineLibraryGroupHandles == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT: {
-                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(pNext);
                 features->dynamicRenderingUnusedAttachments |= enabled->dynamicRenderingUnusedAttachments == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM: {
-                const VkPhysicalDeviceDataGraphFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM *>(pNext);
+                const VkPhysicalDeviceDataGraphFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM*>(pNext);
                 features->dataGraph |= enabled->dataGraph == VK_TRUE;
                 features->dataGraphUpdateAfterBind |= enabled->dataGraphUpdateAfterBind == VK_TRUE;
                 features->dataGraphSpecializationConstants |= enabled->dataGraphSpecializationConstants == VK_TRUE;
@@ -1712,157 +1712,157 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM: {
-                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(pNext);
                 features->multiviewPerViewRenderAreas |= enabled->multiviewPerViewRenderAreas == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PER_STAGE_DESCRIPTOR_SET_FEATURES_NV: {
-                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(pNext);
+                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(pNext);
                 features->perStageDescriptorSet |= enabled->perStageDescriptorSet == VK_TRUE;
                 features->dynamicPipelineLayout |= enabled->dynamicPipelineLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM: {
-                const VkPhysicalDeviceImageProcessing2FeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceImageProcessing2FeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(pNext);
                 features->textureBlockMatch2 |= enabled->textureBlockMatch2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM: {
-                const VkPhysicalDeviceCubicWeightsFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceCubicWeightsFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(pNext);
                 features->selectableCubicWeights |= enabled->selectableCubicWeights == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM: {
-                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(pNext);
                 features->ycbcrDegamma |= enabled->ycbcrDegamma == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM: {
-                const VkPhysicalDeviceCubicClampFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceCubicClampFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM*>(pNext);
                 features->cubicRangeClamp |= enabled->cubicRangeClamp == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT: {
-                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(pNext);
                 features->attachmentFeedbackLoopDynamicState |= enabled->attachmentFeedbackLoopDynamicState == VK_TRUE;
                 break;
             }
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX: {
-                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(pNext);
+                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(pNext);
                 features->screenBufferImport |= enabled->screenBufferImport == VK_TRUE;
                 break;
             }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV: {
-                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(pNext);
                 features->descriptorPoolOverallocation |= enabled->descriptorPoolOverallocation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_MEMORY_HEAP_FEATURES_QCOM: {
-                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(pNext);
                 features->tileMemoryHeap |= enabled->tileMemoryHeap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV: {
-                const VkPhysicalDeviceRawAccessChainsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRawAccessChainsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV*>(pNext);
                 features->shaderRawAccessChains |= enabled->shaderRawAccessChains == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMMAND_BUFFER_INHERITANCE_FEATURES_NV: {
-                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(pNext);
                 features->commandBufferInheritance |= enabled->commandBufferInheritance == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV: {
-                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(pNext);
                 features->shaderFloat16VectorAtomics |= enabled->shaderFloat16VectorAtomics == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(pNext);
                 features->shaderReplicatedComposites |= enabled->shaderReplicatedComposites == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT8_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderFloat8FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderFloat8FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT*>(pNext);
                 features->shaderFloat8 |= enabled->shaderFloat8 == VK_TRUE;
                 features->shaderFloat8CooperativeMatrix |= enabled->shaderFloat8CooperativeMatrix == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingValidationFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingValidationFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV*>(pNext);
                 features->rayTracingValidation |= enabled->rayTracingValidation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_FEATURES_NV: {
-                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(pNext);
+                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(pNext);
                 features->clusterAccelerationStructure |= enabled->clusterAccelerationStructure == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_FEATURES_NV: {
-                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(pNext);
+                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(pNext);
                 features->partitionedAccelerationStructure |= enabled->partitionedAccelerationStructure == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_EXT: {
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(pNext);
                 features->deviceGeneratedCommands |= enabled->deviceGeneratedCommands == VK_TRUE;
                 features->dynamicGeneratedPipelineLayout |= enabled->dynamicGeneratedPipelineLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_FEATURES_MESA: {
-                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(pNext);
+                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(pNext);
                 features->imageAlignmentControl |= enabled->imageAlignmentControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_CONSTANT_BANK_FEATURES_NV: {
-                const VkPhysicalDevicePushConstantBankFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePushConstantBankFeaturesNV *>(pNext);
+                const VkPhysicalDevicePushConstantBankFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePushConstantBankFeaturesNV*>(pNext);
                 features->pushConstantBank |= enabled->pushConstantBank == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_EXT: {
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(pNext);
                 features->rayTracingInvocationReorder |= enabled->rayTracingInvocationReorder == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthClampControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthClampControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT*>(pNext);
                 features->depthClampControl |= enabled->depthClampControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HDR_VIVID_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceHdrVividFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceHdrVividFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(pNext);
                 features->hdrVivid |= enabled->hdrVivid == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV: {
-                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(pNext);
+                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(pNext);
                 features->cooperativeMatrixWorkgroupScope |= enabled->cooperativeMatrixWorkgroupScope == VK_TRUE;
                 features->cooperativeMatrixFlexibleDimensions |= enabled->cooperativeMatrixFlexibleDimensions == VK_TRUE;
                 features->cooperativeMatrixReductions |= enabled->cooperativeMatrixReductions == VK_TRUE;
@@ -1873,104 +1873,104 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_OPACITY_MICROMAP_FEATURES_ARM: {
-                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(pNext);
+                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(pNext);
                 features->pipelineOpacityMicromap |= enabled->pipelineOpacityMicromap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_COUNTERS_BY_REGION_FEATURES_ARM: {
-                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(pNext);
+                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(pNext);
                 features->performanceCountersByRegion |= enabled->performanceCountersByRegion == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INSTRUMENTATION_FEATURES_ARM: {
-                const VkPhysicalDeviceShaderInstrumentationFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationFeaturesARM *>(pNext);
+                const VkPhysicalDeviceShaderInstrumentationFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationFeaturesARM*>(pNext);
                 features->shaderInstrumentation |= enabled->shaderInstrumentation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT: {
-                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(pNext);
                 features->vertexAttributeRobustness |= enabled->vertexAttributeRobustness == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FORMAT_PACK_FEATURES_ARM: {
-                const VkPhysicalDeviceFormatPackFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM *>(pNext);
+                const VkPhysicalDeviceFormatPackFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(pNext);
                 features->formatPack |= enabled->formatPack == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_LAYERED_FEATURES_VALVE: {
-                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(pNext);
                 features->fragmentDensityMapLayered |= enabled->fragmentDensityMapLayered == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_METERING_FEATURES_NV: {
-                const VkPhysicalDevicePresentMeteringFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV *>(pNext);
+                const VkPhysicalDevicePresentMeteringFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV*>(pNext);
                 features->presentMetering |= enabled->presentMetering == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_DEVICE_MEMORY_FEATURES_EXT: {
-                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(pNext);
                 features->zeroInitializeDeviceMemory |= enabled->zeroInitializeDeviceMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_64_BIT_INDEXING_FEATURES_EXT: {
-                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(pNext);
                 features->shader64BitIndexing |= enabled->shader64BitIndexing == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_RESOLVE_FEATURES_EXT: {
-                const VkPhysicalDeviceCustomResolveFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceCustomResolveFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT*>(pNext);
                 features->customResolve |= enabled->customResolve == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_MODEL_FEATURES_QCOM: {
-                const VkPhysicalDeviceDataGraphModelFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceDataGraphModelFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(pNext);
                 features->dataGraphModel |= enabled->dataGraphModel == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_LONG_VECTOR_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderLongVectorFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderLongVectorFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderLongVectorFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderLongVectorFeaturesEXT*>(pNext);
                 features->longVector |= enabled->longVector == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CACHE_INCREMENTAL_MODE_FEATURES_SEC: {
-                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(pNext);
+                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(pNext);
                 features->pipelineCacheIncrementalMode |= enabled->pipelineCacheIncrementalMode == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNIFORM_BUFFER_UNSIZED_ARRAY_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(pNext);
                 features->shaderUniformBufferUnsizedArray |= enabled->shaderUniformBufferUnsizedArray == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_OCCUPANCY_PRIORITY_FEATURES_NV: {
-                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(pNext);
+                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(pNext);
                 features->computeOccupancyPriority |= enabled->computeOccupancyPriority == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_PARTITIONED_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT*>(pNext);
                 features->shaderSubgroupPartitioned |= enabled->shaderSubgroupPartitioned == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MIXED_FLOAT_DOT_PRODUCT_FEATURES_VALVE: {
-                const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *>(pNext);
+                const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE*>(pNext);
                 features->shaderMixedFloatDotProductFloat16AccFloat32 |=
                     enabled->shaderMixedFloatDotProductFloat16AccFloat32 == VK_TRUE;
                 features->shaderMixedFloatDotProductFloat16AccFloat16 |=
@@ -1981,8 +1981,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR: {
-                const VkPhysicalDeviceAccelerationStructureFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceAccelerationStructureFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(pNext);
                 features->accelerationStructure |= enabled->accelerationStructure == VK_TRUE;
                 features->accelerationStructureCaptureReplay |= enabled->accelerationStructureCaptureReplay == VK_TRUE;
                 features->accelerationStructureIndirectBuild |= enabled->accelerationStructureIndirectBuild == VK_TRUE;
@@ -1992,8 +1992,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR: {
-                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(pNext);
                 features->rayTracingPipeline |= enabled->rayTracingPipeline == VK_TRUE;
                 features->rayTracingPipelineShaderGroupHandleCaptureReplay |=
                     enabled->rayTracingPipelineShaderGroupHandleCaptureReplay == VK_TRUE;
@@ -2004,14 +2004,14 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR: {
-                const VkPhysicalDeviceRayQueryFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayQueryFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR*>(pNext);
                 features->rayQuery |= enabled->rayQuery == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT: {
-                const VkPhysicalDeviceMeshShaderFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMeshShaderFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT*>(pNext);
                 features->taskShader |= enabled->taskShader == VK_TRUE;
                 features->meshShader |= enabled->meshShader == VK_TRUE;
                 features->multiviewMeshShader |= enabled->multiviewMeshShader == VK_TRUE;

--- a/layers/vulkan/generated/device_features.h
+++ b/layers/vulkan/generated/device_features.h
@@ -1096,6 +1096,6 @@ struct DeviceFeatures {
     bool zeroInitializeDeviceMemory;
 };
 
-void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatures *features, const APIVersion &api_version);
+void GetEnabledDeviceFeatures(const VkDeviceCreateInfo* pCreateInfo, DeviceFeatures* features, const APIVersion& api_version);
 
 // NOLINTEND

--- a/layers/vulkan/generated/dispatch_object.cpp
+++ b/layers/vulkan/generated/dispatch_object.cpp
@@ -799,7 +799,9 @@ void Device::FreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocati
 VkResult Device::MapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, VkMemoryMapFlags flags,
                            void** ppData) {
     if (!wrap_handles) return device_dispatch_table.MapMemory(device, memory, offset, size, flags, ppData);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     VkResult result = device_dispatch_table.MapMemory(device, memory, offset, size, flags, ppData);
 
     return result;
@@ -807,7 +809,9 @@ VkResult Device::MapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize 
 
 void Device::UnmapMemory(VkDevice device, VkDeviceMemory memory) {
     if (!wrap_handles) return device_dispatch_table.UnmapMemory(device, memory);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     device_dispatch_table.UnmapMemory(device, memory);
 }
 
@@ -860,7 +864,9 @@ VkResult Device::InvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRa
 
 void Device::GetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory, VkDeviceSize* pCommittedMemoryInBytes) {
     if (!wrap_handles) return device_dispatch_table.GetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     device_dispatch_table.GetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes);
 }
 
@@ -888,13 +894,17 @@ VkResult Device::BindImageMemory(VkDevice device, VkImage image, VkDeviceMemory 
 
 void Device::GetBufferMemoryRequirements(VkDevice device, VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements) {
     if (!wrap_handles) return device_dispatch_table.GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
 }
 
 void Device::GetImageMemoryRequirements(VkDevice device, VkImage image, VkMemoryRequirements* pMemoryRequirements) {
     if (!wrap_handles) return device_dispatch_table.GetImageMemoryRequirements(device, image, pMemoryRequirements);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageMemoryRequirements(device, image, pMemoryRequirements);
 }
 
@@ -903,7 +913,9 @@ void Device::GetImageSparseMemoryRequirements(VkDevice device, VkImage image, ui
     if (!wrap_handles)
         return device_dispatch_table.GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount,
                                                                       pSparseMemoryRequirements);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 }
 
@@ -1031,7 +1043,9 @@ VkResult Device::ResetFences(VkDevice device, uint32_t fenceCount, const VkFence
 
 VkResult Device::GetFenceStatus(VkDevice device, VkFence fence) {
     if (!wrap_handles) return device_dispatch_table.GetFenceStatus(device, fence);
-    { fence = Unwrap(fence); }
+    {
+        fence = Unwrap(fence);
+    }
     VkResult result = device_dispatch_table.GetFenceStatus(device, fence);
 
     return result;
@@ -1093,7 +1107,9 @@ VkResult Device::GetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uin
                                      size_t dataSize, void* pData, VkDeviceSize stride, VkQueryResultFlags flags) {
     if (!wrap_handles)
         return device_dispatch_table.GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     VkResult result =
         device_dispatch_table.GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
 
@@ -1153,7 +1169,9 @@ void Device::DestroyImage(VkDevice device, VkImage image, const VkAllocationCall
 void Device::GetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource* pSubresource,
                                        VkSubresourceLayout* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout(device, image, pSubresource, pLayout);
 }
 
@@ -1200,7 +1218,9 @@ VkResult Device::CreateCommandPool(VkDevice device, const VkCommandPoolCreateInf
 
 VkResult Device::ResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags) {
     if (!wrap_handles) return device_dispatch_table.ResetCommandPool(device, commandPool, flags);
-    { commandPool = Unwrap(commandPool); }
+    {
+        commandPool = Unwrap(commandPool);
+    }
     VkResult result = device_dispatch_table.ResetCommandPool(device, commandPool, flags);
 
     return result;
@@ -1267,14 +1287,18 @@ void Device::CmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImag
 void Device::CmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize dataSize,
                              const void* pData) {
     if (!wrap_handles) return device_dispatch_table.CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 }
 
 void Device::CmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize size,
                            uint32_t data) {
     if (!wrap_handles) return device_dispatch_table.CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
 }
 
@@ -1323,26 +1347,34 @@ void Device::CmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFl
 
 void Device::CmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, VkQueryControlFlags flags) {
     if (!wrap_handles) return device_dispatch_table.CmdBeginQuery(commandBuffer, queryPool, query, flags);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdBeginQuery(commandBuffer, queryPool, query, flags);
 }
 
 void Device::CmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdEndQuery(commandBuffer, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdEndQuery(commandBuffer, queryPool, query);
 }
 
 void Device::CmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     if (!wrap_handles) return device_dispatch_table.CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
 }
 
 void Device::CmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage, VkQueryPool queryPool,
                                uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
 }
 
@@ -1383,7 +1415,9 @@ void Device::DestroyEvent(VkDevice device, VkEvent event, const VkAllocationCall
 
 VkResult Device::GetEventStatus(VkDevice device, VkEvent event) {
     if (!wrap_handles) return device_dispatch_table.GetEventStatus(device, event);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     VkResult result = device_dispatch_table.GetEventStatus(device, event);
 
     return result;
@@ -1391,7 +1425,9 @@ VkResult Device::GetEventStatus(VkDevice device, VkEvent event) {
 
 VkResult Device::SetEvent(VkDevice device, VkEvent event) {
     if (!wrap_handles) return device_dispatch_table.SetEvent(device, event);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     VkResult result = device_dispatch_table.SetEvent(device, event);
 
     return result;
@@ -1399,7 +1435,9 @@ VkResult Device::SetEvent(VkDevice device, VkEvent event) {
 
 VkResult Device::ResetEvent(VkDevice device, VkEvent event) {
     if (!wrap_handles) return device_dispatch_table.ResetEvent(device, event);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     VkResult result = device_dispatch_table.ResetEvent(device, event);
 
     return result;
@@ -1479,7 +1517,9 @@ void Device::DestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache
 
 VkResult Device::GetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize, void* pData) {
     if (!wrap_handles) return device_dispatch_table.GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
-    { pipelineCache = Unwrap(pipelineCache); }
+    {
+        pipelineCache = Unwrap(pipelineCache);
+    }
     VkResult result = device_dispatch_table.GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
 
     return result;
@@ -1690,7 +1730,9 @@ void Device::UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount
 
 void Device::CmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline) {
     if (!wrap_handles) return device_dispatch_table.CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     device_dispatch_table.CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
 }
 
@@ -1720,7 +1762,9 @@ void Device::CmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, Vk
                                 const VkClearColorValue* pColor, uint32_t rangeCount, const VkImageSubresourceRange* pRanges) {
     if (!wrap_handles)
         return device_dispatch_table.CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 }
 
@@ -1730,19 +1774,25 @@ void Device::CmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, ui
 
 void Device::CmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
     if (!wrap_handles) return device_dispatch_table.CmdDispatchIndirect(commandBuffer, buffer, offset);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDispatchIndirect(commandBuffer, buffer, offset);
 }
 
 void Device::CmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdSetEvent(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdSetEvent(commandBuffer, event, stageMask);
 }
 
 void Device::CmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdResetEvent(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdResetEvent(commandBuffer, event, stageMask);
 }
 
@@ -1801,7 +1851,9 @@ void Device::CmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, c
 void Device::CmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags,
                               uint32_t offset, uint32_t size, const void* pValues) {
     if (!wrap_handles) return device_dispatch_table.CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
 }
 
@@ -1841,7 +1893,9 @@ void Device::DestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, cons
 
 void Device::GetRenderAreaGranularity(VkDevice device, VkRenderPass renderPass, VkExtent2D* pGranularity) {
     if (!wrap_handles) return device_dispatch_table.GetRenderAreaGranularity(device, renderPass, pGranularity);
-    { renderPass = Unwrap(renderPass); }
+    {
+        renderPass = Unwrap(renderPass);
+    }
     device_dispatch_table.GetRenderAreaGranularity(device, renderPass, pGranularity);
 }
 
@@ -1885,7 +1939,9 @@ void Device::CmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFace
 
 void Device::CmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkIndexType indexType) {
     if (!wrap_handles) return device_dispatch_table.CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
 }
 
@@ -1921,14 +1977,18 @@ void Device::CmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, 
 void Device::CmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                              uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
 }
 
 void Device::CmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                                     uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
 }
 
@@ -1951,7 +2011,9 @@ void Device::CmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage im
     if (!wrap_handles)
         return device_dispatch_table.CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount,
                                                                pRanges);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 }
 
@@ -2120,7 +2182,9 @@ void Instance::GetPhysicalDeviceSparseImageFormatProperties2(VkPhysicalDevice ph
 
 void Device::TrimCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags) {
     if (!wrap_handles) return device_dispatch_table.TrimCommandPool(device, commandPool, flags);
-    { commandPool = Unwrap(commandPool); }
+    {
+        commandPool = Unwrap(commandPool);
+    }
     device_dispatch_table.TrimCommandPool(device, commandPool, flags);
 }
 
@@ -2198,13 +2262,17 @@ void Device::DestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConver
 
 void Device::ResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     if (!wrap_handles) return device_dispatch_table.ResetQueryPool(device, queryPool, firstQuery, queryCount);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.ResetQueryPool(device, queryPool, firstQuery, queryCount);
 }
 
 VkResult Device::GetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue) {
     if (!wrap_handles) return device_dispatch_table.GetSemaphoreCounterValue(device, semaphore, pValue);
-    { semaphore = Unwrap(semaphore); }
+    {
+        semaphore = Unwrap(semaphore);
+    }
     VkResult result = device_dispatch_table.GetSemaphoreCounterValue(device, semaphore, pValue);
 
     return result;
@@ -2439,7 +2507,9 @@ void Device::CmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependen
 
 void Device::CmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool, uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
 }
 
@@ -2614,7 +2684,9 @@ void Device::CmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const Vk
 
 void Device::CmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdResetEvent2(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdResetEvent2(commandBuffer, event, stageMask);
 }
 
@@ -2872,7 +2944,9 @@ void Device::GetDeviceImageSubresourceLayout(VkDevice device, const VkDeviceImag
 void Device::GetImageSubresourceLayout2(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
                                         VkSubresourceLayout2* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout2(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout2(device, image, pSubresource, pLayout);
 }
 
@@ -3132,7 +3206,9 @@ void Device::CmdSetLineStipple(VkCommandBuffer commandBuffer, uint32_t lineStipp
 void Device::CmdBindIndexBuffer2(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
                                  VkIndexType indexType) {
     if (!wrap_handles) return device_dispatch_table.CmdBindIndexBuffer2(commandBuffer, buffer, offset, size, indexType);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdBindIndexBuffer2(commandBuffer, buffer, offset, size, indexType);
 }
 
@@ -3160,7 +3236,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalD
                                                       VkSurfaceKHR surface, VkBool32* pSupported) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported);
 
@@ -3171,7 +3249,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice phys
                                                            VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
 
@@ -3183,7 +3263,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalD
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount,
                                                                           pSurfaceFormats);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats);
 
@@ -3195,7 +3277,9 @@ VkResult Instance::GetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice phys
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount,
                                                                                pPresentModes);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes);
 
@@ -3251,7 +3335,9 @@ VkResult Device::GetDeviceGroupPresentCapabilitiesKHR(VkDevice device,
 VkResult Device::GetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface,
                                                       VkDeviceGroupPresentModeFlagsKHR* pModes) {
     if (!wrap_handles) return device_dispatch_table.GetDeviceGroupSurfacePresentModesKHR(device, surface, pModes);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result = device_dispatch_table.GetDeviceGroupSurfacePresentModesKHR(device, surface, pModes);
 
     return result;
@@ -3261,7 +3347,9 @@ VkResult Instance::GetPhysicalDevicePresentRectanglesKHR(VkPhysicalDevice physic
                                                          uint32_t* pRectCount, VkRect2D* pRects) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result = instance_dispatch_table.GetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects);
 
     return result;
@@ -3297,7 +3385,9 @@ VkResult Instance::CreateDisplayModeKHR(VkPhysicalDevice physicalDevice, VkDispl
                                         const VkDisplayModeCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                         VkDisplayModeKHR* pMode) {
     if (!wrap_handles) return instance_dispatch_table.CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
     if (result == VK_SUCCESS) {
         *pMode = WrapNew(*pMode);
@@ -3309,7 +3399,9 @@ VkResult Instance::GetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevic
                                                   VkDisplayPlaneCapabilitiesKHR* pCapabilities) {
     if (!wrap_handles)
         return instance_dispatch_table.GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
-    { mode = Unwrap(mode); }
+    {
+        mode = Unwrap(mode);
+    }
     VkResult result = instance_dispatch_table.GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
 
     return result;
@@ -3506,7 +3598,9 @@ VkResult Device::GetVideoSessionMemoryRequirementsKHR(VkDevice device, VkVideoSe
     if (!wrap_handles)
         return device_dispatch_table.GetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount,
                                                                           pMemoryRequirements);
-    { videoSession = Unwrap(videoSession); }
+    {
+        videoSession = Unwrap(videoSession);
+    }
     VkResult result = device_dispatch_table.GetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount,
                                                                                  pMemoryRequirements);
 
@@ -3571,7 +3665,9 @@ VkResult Device::CreateVideoSessionParametersKHR(VkDevice device, const VkVideoS
 VkResult Device::UpdateVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters,
                                                  const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo) {
     if (!wrap_handles) return device_dispatch_table.UpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo);
-    { videoSessionParameters = Unwrap(videoSessionParameters); }
+    {
+        videoSessionParameters = Unwrap(videoSessionParameters);
+    }
     VkResult result = device_dispatch_table.UpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo);
 
     return result;
@@ -3766,7 +3862,9 @@ void Device::CmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGrou
 
 void Device::TrimCommandPoolKHR(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags) {
     if (!wrap_handles) return device_dispatch_table.TrimCommandPoolKHR(device, commandPool, flags);
-    { commandPool = Unwrap(commandPool); }
+    {
+        commandPool = Unwrap(commandPool);
+    }
     device_dispatch_table.TrimCommandPoolKHR(device, commandPool, flags);
 }
 
@@ -4024,7 +4122,9 @@ void Device::CmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpass
 
 VkResult Device::GetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain) {
     if (!wrap_handles) return device_dispatch_table.GetSwapchainStatusKHR(device, swapchain);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainStatusKHR(device, swapchain);
 
     return result;
@@ -4343,7 +4443,9 @@ void Device::CmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuf
 
 VkResult Device::GetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue) {
     if (!wrap_handles) return device_dispatch_table.GetSemaphoreCounterValueKHR(device, semaphore, pValue);
-    { semaphore = Unwrap(semaphore); }
+    {
+        semaphore = Unwrap(semaphore);
+    }
     VkResult result = device_dispatch_table.GetSemaphoreCounterValueKHR(device, semaphore, pValue);
 
     return result;
@@ -4413,7 +4515,9 @@ void Device::CmdSetRenderingInputAttachmentIndicesKHR(VkCommandBuffer commandBuf
 
 VkResult Device::WaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout) {
     if (!wrap_handles) return device_dispatch_table.WaitForPresentKHR(device, swapchain, presentId, timeout);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.WaitForPresentKHR(device, swapchain, presentId, timeout);
 
     return result;
@@ -4497,7 +4601,9 @@ void Device::DestroyDeferredOperationKHR(VkDevice device, VkDeferredOperationKHR
 
 uint32_t Device::GetDeferredOperationMaxConcurrencyKHR(VkDevice device, VkDeferredOperationKHR operation) {
     if (!wrap_handles) return device_dispatch_table.GetDeferredOperationMaxConcurrencyKHR(device, operation);
-    { operation = Unwrap(operation); }
+    {
+        operation = Unwrap(operation);
+    }
     uint32_t result = device_dispatch_table.GetDeferredOperationMaxConcurrencyKHR(device, operation);
 
     return result;
@@ -4717,7 +4823,9 @@ void Device::CmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const
 
 void Device::CmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdResetEvent2KHR(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdResetEvent2KHR(commandBuffer, event, stageMask);
 }
 
@@ -4798,7 +4906,9 @@ void Device::CmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDepen
 void Device::CmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                    uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
 }
 
@@ -4918,7 +5028,9 @@ void Device::CmdCopyQueryPoolResultsToMemoryKHR(VkCommandBuffer commandBuffer, V
     if (!wrap_handles)
         return device_dispatch_table.CmdCopyQueryPoolResultsToMemoryKHR(commandBuffer, queryPool, firstQuery, queryCount, pDstRange,
                                                                         dstFlags, queryResultFlags);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdCopyQueryPoolResultsToMemoryKHR(commandBuffer, queryPool, firstQuery, queryCount, pDstRange, dstFlags,
                                                              queryResultFlags);
 }
@@ -5128,7 +5240,9 @@ void Device::GetDeviceImageSparseMemoryRequirementsKHR(VkDevice device, const Vk
 void Device::CmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
                                     VkIndexType indexType) {
     if (!wrap_handles) return device_dispatch_table.CmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
 }
 
@@ -5145,13 +5259,17 @@ void Device::GetDeviceImageSubresourceLayoutKHR(VkDevice device, const VkDeviceI
 void Device::GetImageSubresourceLayout2KHR(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
                                            VkSubresourceLayout2* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout2KHR(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout2KHR(device, image, pSubresource, pLayout);
 }
 
 VkResult Device::WaitForPresent2KHR(VkDevice device, VkSwapchainKHR swapchain, const VkPresentWait2InfoKHR* pPresentWait2Info) {
     if (!wrap_handles) return device_dispatch_table.WaitForPresent2KHR(device, swapchain, pPresentWait2Info);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.WaitForPresent2KHR(device, swapchain, pPresentWait2Info);
 
     return result;
@@ -5549,13 +5667,17 @@ void Device::CmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t 
 void Device::CmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                      VkQueryControlFlags flags, uint32_t index) {
     if (!wrap_handles) return device_dispatch_table.CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
 }
 
 void Device::CmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, uint32_t index) {
     if (!wrap_handles) return device_dispatch_table.CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
 }
 
@@ -5565,7 +5687,9 @@ void Device::CmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t
     if (!wrap_handles)
         return device_dispatch_table.CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
                                                                  counterBufferOffset, counterOffset, vertexStride);
-    { counterBuffer = Unwrap(counterBuffer); }
+    {
+        counterBuffer = Unwrap(counterBuffer);
+    }
     device_dispatch_table.CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
                                                       counterBufferOffset, counterOffset, vertexStride);
 }
@@ -5679,7 +5803,9 @@ uint64_t Device::GetImageViewHandle64NVX(VkDevice device, const VkImageViewHandl
 
 VkResult Device::GetImageViewAddressNVX(VkDevice device, VkImageView imageView, VkImageViewAddressPropertiesNVX* pProperties) {
     if (!wrap_handles) return device_dispatch_table.GetImageViewAddressNVX(device, imageView, pProperties);
-    { imageView = Unwrap(imageView); }
+    {
+        imageView = Unwrap(imageView);
+    }
     VkResult result = device_dispatch_table.GetImageViewAddressNVX(device, imageView, pProperties);
 
     return result;
@@ -5721,7 +5847,9 @@ void Device::CmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuf
 VkResult Device::GetShaderInfoAMD(VkDevice device, VkPipeline pipeline, VkShaderStageFlagBits shaderStage,
                                   VkShaderInfoTypeAMD infoType, size_t* pInfoSize, void* pInfo) {
     if (!wrap_handles) return device_dispatch_table.GetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result = device_dispatch_table.GetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
 
     return result;
@@ -5754,7 +5882,9 @@ VkResult Instance::GetPhysicalDeviceExternalImageFormatPropertiesNV(
 VkResult Device::GetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory, VkExternalMemoryHandleTypeFlagsNV handleType,
                                         HANDLE* pHandle) {
     if (!wrap_handles) return device_dispatch_table.GetMemoryWin32HandleNV(device, memory, handleType, pHandle);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     VkResult result = device_dispatch_table.GetMemoryWin32HandleNV(device, memory, handleType, pHandle);
 
     return result;
@@ -5804,7 +5934,9 @@ void Device::CmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t fi
 
 VkResult Instance::ReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.ReleaseDisplayEXT(physicalDevice, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.ReleaseDisplayEXT(physicalDevice, display);
 
     return result;
@@ -5813,7 +5945,9 @@ VkResult Instance::ReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayK
 
 VkResult Instance::AcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.AcquireXlibDisplayEXT(physicalDevice, dpy, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.AcquireXlibDisplayEXT(physicalDevice, dpy, display);
 
     return result;
@@ -5835,7 +5969,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice phy
                                                             VkSurfaceCapabilities2EXT* pSurfaceCapabilities) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities);
 
@@ -5844,7 +5980,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice phy
 
 VkResult Device::DisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, const VkDisplayPowerInfoEXT* pDisplayPowerInfo) {
     if (!wrap_handles) return device_dispatch_table.DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = device_dispatch_table.DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
 
     return result;
@@ -5864,7 +6002,9 @@ VkResult Device::RegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfo
 VkResult Device::RegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, const VkDisplayEventInfoEXT* pDisplayEventInfo,
                                          const VkAllocationCallbacks* pAllocator, VkFence* pFence) {
     if (!wrap_handles) return device_dispatch_table.RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = device_dispatch_table.RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
     if (result == VK_SUCCESS) {
         *pFence = WrapNew(*pFence);
@@ -5875,7 +6015,9 @@ VkResult Device::RegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, 
 VkResult Device::GetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain, VkSurfaceCounterFlagBitsEXT counter,
                                         uint64_t* pCounterValue) {
     if (!wrap_handles) return device_dispatch_table.GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
 
     return result;
@@ -5884,7 +6026,9 @@ VkResult Device::GetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchai
 VkResult Device::GetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
                                                VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties) {
     if (!wrap_handles) return device_dispatch_table.GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
 
     return result;
@@ -5895,7 +6039,9 @@ VkResult Device::GetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR
     if (!wrap_handles)
         return device_dispatch_table.GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount,
                                                                      pPresentationTimings);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result =
         device_dispatch_table.GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings);
 
@@ -6092,7 +6238,9 @@ VkResult Device::CreateExecutionGraphPipelinesAMDX(VkDevice device, VkPipelineCa
 VkResult Device::GetExecutionGraphPipelineScratchSizeAMDX(VkDevice device, VkPipeline executionGraph,
                                                           VkExecutionGraphPipelineScratchSizeAMDX* pSizeInfo) {
     if (!wrap_handles) return device_dispatch_table.GetExecutionGraphPipelineScratchSizeAMDX(device, executionGraph, pSizeInfo);
-    { executionGraph = Unwrap(executionGraph); }
+    {
+        executionGraph = Unwrap(executionGraph);
+    }
     VkResult result = device_dispatch_table.GetExecutionGraphPipelineScratchSizeAMDX(device, executionGraph, pSizeInfo);
 
     return result;
@@ -6103,7 +6251,9 @@ VkResult Device::GetExecutionGraphPipelineNodeIndexAMDX(VkDevice device, VkPipel
                                                         uint32_t* pNodeIndex) {
     if (!wrap_handles)
         return device_dispatch_table.GetExecutionGraphPipelineNodeIndexAMDX(device, executionGraph, pNodeInfo, pNodeIndex);
-    { executionGraph = Unwrap(executionGraph); }
+    {
+        executionGraph = Unwrap(executionGraph);
+    }
     VkResult result = device_dispatch_table.GetExecutionGraphPipelineNodeIndexAMDX(device, executionGraph, pNodeInfo, pNodeIndex);
 
     return result;
@@ -6113,7 +6263,9 @@ void Device::CmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer, 
                                                  VkDeviceSize scratchSize) {
     if (!wrap_handles)
         return device_dispatch_table.CmdInitializeGraphScratchMemoryAMDX(commandBuffer, executionGraph, scratch, scratchSize);
-    { executionGraph = Unwrap(executionGraph); }
+    {
+        executionGraph = Unwrap(executionGraph);
+    }
     device_dispatch_table.CmdInitializeGraphScratchMemoryAMDX(commandBuffer, executionGraph, scratch, scratchSize);
 }
 
@@ -6234,7 +6386,9 @@ void Instance::GetPhysicalDeviceMultisamplePropertiesEXT(VkPhysicalDevice physic
 VkResult Device::GetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image,
                                                         VkImageDrmFormatModifierPropertiesEXT* pProperties) {
     if (!wrap_handles) return device_dispatch_table.GetImageDrmFormatModifierPropertiesEXT(device, image, pProperties);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     VkResult result = device_dispatch_table.GetImageDrmFormatModifierPropertiesEXT(device, image, pProperties);
 
     return result;
@@ -6281,7 +6435,9 @@ VkResult Device::MergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT 
 
 VkResult Device::GetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize, void* pData) {
     if (!wrap_handles) return device_dispatch_table.GetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
-    { validationCache = Unwrap(validationCache); }
+    {
+        validationCache = Unwrap(validationCache);
+    }
     VkResult result = device_dispatch_table.GetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
 
     return result;
@@ -6289,7 +6445,9 @@ VkResult Device::GetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT
 
 void Device::CmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {
     if (!wrap_handles) return device_dispatch_table.CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
-    { imageView = Unwrap(imageView); }
+    {
+        imageView = Unwrap(imageView);
+    }
     device_dispatch_table.CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
 }
 
@@ -6482,7 +6640,9 @@ VkResult Device::GetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline 
                                                     size_t dataSize, void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result =
         device_dispatch_table.GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
 
@@ -6493,7 +6653,9 @@ VkResult Device::GetRayTracingShaderGroupHandlesNV(VkDevice device, VkPipeline p
                                                    size_t dataSize, void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.GetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result =
         device_dispatch_table.GetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
 
@@ -6504,7 +6666,9 @@ VkResult Device::GetAccelerationStructureHandleNV(VkDevice device, VkAcceleratio
                                                   void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.GetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData);
-    { accelerationStructure = Unwrap(accelerationStructure); }
+    {
+        accelerationStructure = Unwrap(accelerationStructure);
+    }
     VkResult result = device_dispatch_table.GetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData);
 
     return result;
@@ -6535,7 +6699,9 @@ void Device::CmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandB
 
 VkResult Device::CompileDeferredNV(VkDevice device, VkPipeline pipeline, uint32_t shader) {
     if (!wrap_handles) return device_dispatch_table.CompileDeferredNV(device, pipeline, shader);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result = device_dispatch_table.CompileDeferredNV(device, pipeline, shader);
 
     return result;
@@ -6554,14 +6720,18 @@ void Device::CmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineSt
                                      VkDeviceSize dstOffset, uint32_t marker) {
     if (!wrap_handles)
         return device_dispatch_table.CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
 }
 
 void Device::CmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkBuffer dstBuffer,
                                       VkDeviceSize dstOffset, uint32_t marker) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
 }
 
@@ -6604,7 +6774,9 @@ void Device::CmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCoun
 void Device::CmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                                         uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
 }
 
@@ -6647,7 +6819,9 @@ void Device::GetQueueCheckpointData2NV(VkQueue queue, uint32_t* pCheckpointDataC
 
 VkResult Device::SetSwapchainPresentTimingQueueSizeEXT(VkDevice device, VkSwapchainKHR swapchain, uint32_t size) {
     if (!wrap_handles) return device_dispatch_table.SetSwapchainPresentTimingQueueSizeEXT(device, swapchain, size);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.SetSwapchainPresentTimingQueueSizeEXT(device, swapchain, size);
 
     return result;
@@ -6659,7 +6833,9 @@ VkResult Device::GetSwapchainTimingPropertiesEXT(VkDevice device, VkSwapchainKHR
     if (!wrap_handles)
         return device_dispatch_table.GetSwapchainTimingPropertiesEXT(device, swapchain, pSwapchainTimingProperties,
                                                                      pSwapchainTimingPropertiesCounter);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainTimingPropertiesEXT(device, swapchain, pSwapchainTimingProperties,
                                                                             pSwapchainTimingPropertiesCounter);
 
@@ -6672,7 +6848,9 @@ VkResult Device::GetSwapchainTimeDomainPropertiesEXT(VkDevice device, VkSwapchai
     if (!wrap_handles)
         return device_dispatch_table.GetSwapchainTimeDomainPropertiesEXT(device, swapchain, pSwapchainTimeDomainProperties,
                                                                          pTimeDomainsCounter);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainTimeDomainPropertiesEXT(device, swapchain, pSwapchainTimeDomainProperties,
                                                                                 pTimeDomainsCounter);
 
@@ -6744,7 +6922,9 @@ VkResult Device::AcquirePerformanceConfigurationINTEL(VkDevice device,
 
 VkResult Device::QueueSetPerformanceConfigurationINTEL(VkQueue queue, VkPerformanceConfigurationINTEL configuration) {
     if (!wrap_handles) return device_dispatch_table.QueueSetPerformanceConfigurationINTEL(queue, configuration);
-    { configuration = Unwrap(configuration); }
+    {
+        configuration = Unwrap(configuration);
+    }
     VkResult result = device_dispatch_table.QueueSetPerformanceConfigurationINTEL(queue, configuration);
 
     return result;
@@ -6759,7 +6939,9 @@ VkResult Device::GetPerformanceParameterINTEL(VkDevice device, VkPerformancePara
 
 void Device::SetLocalDimmingAMD(VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable) {
     if (!wrap_handles) return device_dispatch_table.SetLocalDimmingAMD(device, swapChain, localDimmingEnable);
-    { swapChain = Unwrap(swapChain); }
+    {
+        swapChain = Unwrap(swapChain);
+    }
     device_dispatch_table.SetLocalDimmingAMD(device, swapChain, localDimmingEnable);
 }
 #ifdef VK_USE_PLATFORM_FUCHSIA
@@ -6851,7 +7033,9 @@ VkResult Instance::GetPhysicalDeviceSurfacePresentModes2EXT(VkPhysicalDevice phy
 
 VkResult Device::AcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) {
     if (!wrap_handles) return device_dispatch_table.AcquireFullScreenExclusiveModeEXT(device, swapchain);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.AcquireFullScreenExclusiveModeEXT(device, swapchain);
 
     return result;
@@ -6859,7 +7043,9 @@ VkResult Device::AcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainK
 
 VkResult Device::ReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) {
     if (!wrap_handles) return device_dispatch_table.ReleaseFullScreenExclusiveModeEXT(device, swapchain);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.ReleaseFullScreenExclusiveModeEXT(device, swapchain);
 
     return result;
@@ -6904,7 +7090,9 @@ void Device::CmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineSt
 
 void Device::ResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     if (!wrap_handles) return device_dispatch_table.ResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.ResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
 }
 
@@ -7063,7 +7251,9 @@ VkResult Device::TransitionImageLayoutEXT(VkDevice device, uint32_t transitionCo
 void Device::GetImageSubresourceLayout2EXT(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
                                            VkSubresourceLayout2* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout2EXT(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout2EXT(device, image, pSubresource, pLayout);
 }
 
@@ -7194,7 +7384,9 @@ void Device::CmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipel
                                           uint32_t groupIndex) {
     if (!wrap_handles)
         return device_dispatch_table.CmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     device_dispatch_table.CmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
 }
 
@@ -7240,7 +7432,9 @@ void Device::CmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBia
 
 VkResult Instance::AcquireDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.AcquireDrmDisplayEXT(physicalDevice, drmFd, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.AcquireDrmDisplayEXT(physicalDevice, drmFd, display);
 
     return result;
@@ -7314,7 +7508,9 @@ VkResult Device::CreateCudaModuleNV(VkDevice device, const VkCudaModuleCreateInf
 
 VkResult Device::GetCudaModuleCacheNV(VkDevice device, VkCudaModuleNV module, size_t* pCacheSize, void* pCacheData) {
     if (!wrap_handles) return device_dispatch_table.GetCudaModuleCacheNV(device, module, pCacheSize, pCacheData);
-    { module = Unwrap(module); }
+    {
+        module = Unwrap(module);
+    }
     VkResult result = device_dispatch_table.GetCudaModuleCacheNV(device, module, pCacheSize, pCacheData);
 
     return result;
@@ -7387,14 +7583,18 @@ void Device::CmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkP
 
 void Device::GetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout, VkDeviceSize* pLayoutSizeInBytes) {
     if (!wrap_handles) return device_dispatch_table.GetDescriptorSetLayoutSizeEXT(device, layout, pLayoutSizeInBytes);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.GetDescriptorSetLayoutSizeEXT(device, layout, pLayoutSizeInBytes);
 }
 
 void Device::GetDescriptorSetLayoutBindingOffsetEXT(VkDevice device, VkDescriptorSetLayout layout, uint32_t binding,
                                                     VkDeviceSize* pOffset) {
     if (!wrap_handles) return device_dispatch_table.GetDescriptorSetLayoutBindingOffsetEXT(device, layout, binding, pOffset);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.GetDescriptorSetLayoutBindingOffsetEXT(device, layout, binding, pOffset);
 }
 
@@ -7423,7 +7623,9 @@ void Device::CmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer, VkP
     if (!wrap_handles)
         return device_dispatch_table.CmdSetDescriptorBufferOffsetsEXT(commandBuffer, pipelineBindPoint, layout, firstSet, setCount,
                                                                       pBufferIndices, pOffsets);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.CmdSetDescriptorBufferOffsetsEXT(commandBuffer, pipelineBindPoint, layout, firstSet, setCount,
                                                            pBufferIndices, pOffsets);
 }
@@ -7432,7 +7634,9 @@ void Device::CmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandB
                                                         VkPipelineLayout layout, uint32_t set) {
     if (!wrap_handles)
         return device_dispatch_table.CmdBindDescriptorBufferEmbeddedSamplersEXT(commandBuffer, pipelineBindPoint, layout, set);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.CmdBindDescriptorBufferEmbeddedSamplersEXT(commandBuffer, pipelineBindPoint, layout, set);
 }
 
@@ -7558,7 +7762,9 @@ VkResult Device::GetDeviceFaultInfoEXT(VkDevice device, VkDeviceFaultCountsEXT* 
 
 VkResult Instance::AcquireWinrtDisplayNV(VkPhysicalDevice physicalDevice, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.AcquireWinrtDisplayNV(physicalDevice, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.AcquireWinrtDisplayNV(physicalDevice, display);
 
     return result;
@@ -7692,7 +7898,9 @@ VkResult Device::SetBufferCollectionImageConstraintsFUCHSIA(VkDevice device, VkB
                                                             const VkImageConstraintsInfoFUCHSIA* pImageConstraintsInfo) {
     if (!wrap_handles)
         return device_dispatch_table.SetBufferCollectionImageConstraintsFUCHSIA(device, collection, pImageConstraintsInfo);
-    { collection = Unwrap(collection); }
+    {
+        collection = Unwrap(collection);
+    }
     VkResult result = device_dispatch_table.SetBufferCollectionImageConstraintsFUCHSIA(device, collection, pImageConstraintsInfo);
 
     return result;
@@ -7702,7 +7910,9 @@ VkResult Device::SetBufferCollectionBufferConstraintsFUCHSIA(VkDevice device, Vk
                                                              const VkBufferConstraintsInfoFUCHSIA* pBufferConstraintsInfo) {
     if (!wrap_handles)
         return device_dispatch_table.SetBufferCollectionBufferConstraintsFUCHSIA(device, collection, pBufferConstraintsInfo);
-    { collection = Unwrap(collection); }
+    {
+        collection = Unwrap(collection);
+    }
     VkResult result = device_dispatch_table.SetBufferCollectionBufferConstraintsFUCHSIA(device, collection, pBufferConstraintsInfo);
 
     return result;
@@ -7718,7 +7928,9 @@ void Device::DestroyBufferCollectionFUCHSIA(VkDevice device, VkBufferCollectionF
 VkResult Device::GetBufferCollectionPropertiesFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection,
                                                       VkBufferCollectionPropertiesFUCHSIA* pProperties) {
     if (!wrap_handles) return device_dispatch_table.GetBufferCollectionPropertiesFUCHSIA(device, collection, pProperties);
-    { collection = Unwrap(collection); }
+    {
+        collection = Unwrap(collection);
+    }
     VkResult result = device_dispatch_table.GetBufferCollectionPropertiesFUCHSIA(device, collection, pProperties);
 
     return result;
@@ -7729,7 +7941,9 @@ VkResult Device::GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(VkDevice device, 
                                                                VkExtent2D* pMaxWorkgroupSize) {
     if (!wrap_handles)
         return device_dispatch_table.GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(device, renderpass, pMaxWorkgroupSize);
-    { renderpass = Unwrap(renderpass); }
+    {
+        renderpass = Unwrap(renderpass);
+    }
     VkResult result = device_dispatch_table.GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(device, renderpass, pMaxWorkgroupSize);
 
     return result;
@@ -7741,7 +7955,9 @@ void Device::CmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {
 
 void Device::CmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {
     if (!wrap_handles) return device_dispatch_table.CmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
-    { imageView = Unwrap(imageView); }
+    {
+        imageView = Unwrap(imageView);
+    }
     device_dispatch_table.CmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
 }
 
@@ -8146,13 +8362,17 @@ void Device::CmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupC
 
 void Device::CmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
 }
 
 void Device::SetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority) {
     if (!wrap_handles) return device_dispatch_table.SetDeviceMemoryPriorityEXT(device, memory, priority);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     device_dispatch_table.SetDeviceMemoryPriorityEXT(device, memory, priority);
 }
 
@@ -8179,7 +8399,9 @@ void Device::GetDescriptorSetLayoutHostMappingInfoVALVE(VkDevice device,
 
 void Device::GetDescriptorSetHostMappingVALVE(VkDevice device, VkDescriptorSet descriptorSet, void** ppData) {
     if (!wrap_handles) return device_dispatch_table.GetDescriptorSetHostMappingVALVE(device, descriptorSet, ppData);
-    { descriptorSet = Unwrap(descriptorSet); }
+    {
+        descriptorSet = Unwrap(descriptorSet);
+    }
     device_dispatch_table.GetDescriptorSetHostMappingVALVE(device, descriptorSet, ppData);
 }
 
@@ -8194,7 +8416,9 @@ void Device::CmdCopyMemoryToImageIndirectNV(VkCommandBuffer commandBuffer, VkDev
     if (!wrap_handles)
         return device_dispatch_table.CmdCopyMemoryToImageIndirectNV(commandBuffer, copyBufferAddress, copyCount, stride, dstImage,
                                                                     dstImageLayout, pImageSubresources);
-    { dstImage = Unwrap(dstImage); }
+    {
+        dstImage = Unwrap(dstImage);
+    }
     device_dispatch_table.CmdCopyMemoryToImageIndirectNV(commandBuffer, copyBufferAddress, copyCount, stride, dstImage,
                                                          dstImageLayout, pImageSubresources);
 }
@@ -8242,7 +8466,9 @@ void Device::GetPipelineIndirectMemoryRequirementsNV(VkDevice device, const VkCo
 void Device::CmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                VkPipeline pipeline) {
     if (!wrap_handles) return device_dispatch_table.CmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     device_dispatch_table.CmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
 }
 
@@ -8594,7 +8820,9 @@ VkResult Device::GetTensorViewOpaqueCaptureDescriptorDataARM(VkDevice device, co
 
 void Device::GetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule, VkShaderModuleIdentifierEXT* pIdentifier) {
     if (!wrap_handles) return device_dispatch_table.GetShaderModuleIdentifierEXT(device, shaderModule, pIdentifier);
-    { shaderModule = Unwrap(shaderModule); }
+    {
+        shaderModule = Unwrap(shaderModule);
+    }
     device_dispatch_table.GetShaderModuleIdentifierEXT(device, shaderModule, pIdentifier);
 }
 
@@ -8657,7 +8885,9 @@ VkResult Device::BindOpticalFlowSessionImageNV(VkDevice device, VkOpticalFlowSes
 void Device::CmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
                                      const VkOpticalFlowExecuteInfoNV* pExecuteInfo) {
     if (!wrap_handles) return device_dispatch_table.CmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
-    { session = Unwrap(session); }
+    {
+        session = Unwrap(session);
+    }
     device_dispatch_table.CmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
 }
 
@@ -8673,7 +8903,9 @@ void Device::DestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAlloc
 
 VkResult Device::GetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData) {
     if (!wrap_handles) return device_dispatch_table.GetShaderBinaryDataEXT(device, shader, pDataSize, pData);
-    { shader = Unwrap(shader); }
+    {
+        shader = Unwrap(shader);
+    }
     VkResult result = device_dispatch_table.GetShaderBinaryDataEXT(device, shader, pDataSize, pData);
 
     return result;
@@ -8705,7 +8937,9 @@ VkResult Device::GetFramebufferTilePropertiesQCOM(VkDevice device, VkFramebuffer
                                                   VkTilePropertiesQCOM* pProperties) {
     if (!wrap_handles)
         return device_dispatch_table.GetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties);
-    { framebuffer = Unwrap(framebuffer); }
+    {
+        framebuffer = Unwrap(framebuffer);
+    }
     VkResult result = device_dispatch_table.GetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties);
 
     return result;
@@ -8780,7 +9014,9 @@ void Device::CmdConvertCooperativeVectorMatrixNV(VkCommandBuffer commandBuffer, 
 
 VkResult Device::SetLatencySleepModeNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepModeInfoNV* pSleepModeInfo) {
     if (!wrap_handles) return device_dispatch_table.SetLatencySleepModeNV(device, swapchain, pSleepModeInfo);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.SetLatencySleepModeNV(device, swapchain, pSleepModeInfo);
 
     return result;
@@ -8808,13 +9044,17 @@ VkResult Device::LatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const
 
 void Device::SetLatencyMarkerNV(VkDevice device, VkSwapchainKHR swapchain, const VkSetLatencyMarkerInfoNV* pLatencyMarkerInfo) {
     if (!wrap_handles) return device_dispatch_table.SetLatencyMarkerNV(device, swapchain, pLatencyMarkerInfo);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     device_dispatch_table.SetLatencyMarkerNV(device, swapchain, pLatencyMarkerInfo);
 }
 
 void Device::GetLatencyTimingsNV(VkDevice device, VkSwapchainKHR swapchain, VkGetLatencyMarkerInfoNV* pLatencyMarkerInfo) {
     if (!wrap_handles) return device_dispatch_table.GetLatencyTimingsNV(device, swapchain, pLatencyMarkerInfo);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     device_dispatch_table.GetLatencyTimingsNV(device, swapchain, pLatencyMarkerInfo);
 }
 
@@ -8929,7 +9169,9 @@ void Device::DestroyDataGraphPipelineSessionARM(VkDevice device, VkDataGraphPipe
 void Device::CmdDispatchDataGraphARM(VkCommandBuffer commandBuffer, VkDataGraphPipelineSessionARM session,
                                      const VkDataGraphPipelineDispatchInfoARM* pInfo) {
     if (!wrap_handles) return device_dispatch_table.CmdDispatchDataGraphARM(commandBuffer, session, pInfo);
-    { session = Unwrap(session); }
+    {
+        session = Unwrap(session);
+    }
     device_dispatch_table.CmdDispatchDataGraphARM(commandBuffer, session, pInfo);
 }
 
@@ -9336,7 +9578,9 @@ void Device::DestroyShaderInstrumentationARM(VkDevice device, VkShaderInstrument
 
 void Device::CmdBeginShaderInstrumentationARM(VkCommandBuffer commandBuffer, VkShaderInstrumentationARM instrumentation) {
     if (!wrap_handles) return device_dispatch_table.CmdBeginShaderInstrumentationARM(commandBuffer, instrumentation);
-    { instrumentation = Unwrap(instrumentation); }
+    {
+        instrumentation = Unwrap(instrumentation);
+    }
     device_dispatch_table.CmdBeginShaderInstrumentationARM(commandBuffer, instrumentation);
 }
 
@@ -9350,7 +9594,9 @@ VkResult Device::GetShaderInstrumentationValuesARM(VkDevice device, VkShaderInst
     if (!wrap_handles)
         return device_dispatch_table.GetShaderInstrumentationValuesARM(device, instrumentation, pMetricBlockCount, pMetricValues,
                                                                        flags);
-    { instrumentation = Unwrap(instrumentation); }
+    {
+        instrumentation = Unwrap(instrumentation);
+    }
     VkResult result =
         device_dispatch_table.GetShaderInstrumentationValuesARM(device, instrumentation, pMetricBlockCount, pMetricValues, flags);
 
@@ -9359,7 +9605,9 @@ VkResult Device::GetShaderInstrumentationValuesARM(VkDevice device, VkShaderInst
 
 void Device::ClearShaderInstrumentationMetricsARM(VkDevice device, VkShaderInstrumentationARM instrumentation) {
     if (!wrap_handles) return device_dispatch_table.ClearShaderInstrumentationMetricsARM(device, instrumentation);
-    { instrumentation = Unwrap(instrumentation); }
+    {
+        instrumentation = Unwrap(instrumentation);
+    }
     device_dispatch_table.ClearShaderInstrumentationMetricsARM(device, instrumentation);
 }
 
@@ -9701,7 +9949,9 @@ VkResult Device::GetRayTracingCaptureReplayShaderGroupHandlesKHR(VkDevice device
     if (!wrap_handles)
         return device_dispatch_table.GetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount,
                                                                                      dataSize, pData);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result = device_dispatch_table.GetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup,
                                                                                             groupCount, dataSize, pData);
 
@@ -9721,7 +9971,9 @@ void Device::CmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
 VkDeviceSize Device::GetRayTracingShaderGroupStackSizeKHR(VkDevice device, VkPipeline pipeline, uint32_t group,
                                                           VkShaderGroupShaderKHR groupShader) {
     if (!wrap_handles) return device_dispatch_table.GetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkDeviceSize result = device_dispatch_table.GetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader);
 
     return result;
@@ -9738,7 +9990,9 @@ void Device::CmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCo
 void Device::CmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                                          uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
 }
 

--- a/layers/vulkan/generated/feature_not_present.cpp
+++ b/layers/vulkan/generated/feature_not_present.cpp
@@ -26,14 +26,14 @@
 namespace vvl {
 namespace dispatch {
 
-void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDeviceCreateInfo &create_info) {
+void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDeviceCreateInfo& create_info) {
     std::ostringstream ss;
     ss << "returned VK_ERROR_FEATURE_NOT_PRESENT because the following features were not supported on this physical device:\n";
 
     // First do 1.0 VkPhysicalDeviceFeatures
-    const auto *features2_in = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(create_info.pNext);
+    const auto* features2_in = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(create_info.pNext);
     if (create_info.pEnabledFeatures || features2_in) {
-        const VkPhysicalDeviceFeatures &enabling =
+        const VkPhysicalDeviceFeatures& enabling =
             create_info.pEnabledFeatures ? *create_info.pEnabledFeatures : features2_in->features;
 
         VkPhysicalDeviceFeatures supported = {};
@@ -205,15 +205,15 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
         }
     }
     VkPhysicalDeviceFeatures2 features_2 = vku::InitStructHelper();
-    for (const VkBaseInStructure *current = static_cast<const VkBaseInStructure *>(create_info.pNext); current != nullptr;
+    for (const VkBaseInStructure* current = static_cast<const VkBaseInStructure*>(create_info.pNext); current != nullptr;
          current = current->pNext) {
         switch (current->sType) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES: {
                 VkPhysicalDevice16BitStorageFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevice16BitStorageFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures *>(current);
+                const VkPhysicalDevice16BitStorageFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(current);
                 if (enabling->storageBuffer16BitAccess && !supported.storageBuffer16BitAccess) {
                     ss << "VkPhysicalDevice16BitStorageFeatures::storageBuffer16BitAccess is not supported\n";
                 }
@@ -232,8 +232,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevice4444FormatsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevice4444FormatsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT *>(current);
+                const VkPhysicalDevice4444FormatsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(current);
                 if (enabling->formatA4R4G4B4 && !supported.formatA4R4G4B4) {
                     ss << "VkPhysicalDevice4444FormatsFeaturesEXT::formatA4R4G4B4 is not supported\n";
                 }
@@ -246,8 +246,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevice8BitStorageFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevice8BitStorageFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures *>(current);
+                const VkPhysicalDevice8BitStorageFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(current);
                 if (enabling->storageBuffer8BitAccess && !supported.storageBuffer8BitAccess) {
                     ss << "VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess is not supported\n";
                 }
@@ -263,8 +263,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceASTCDecodeFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceASTCDecodeFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT *>(current);
+                const VkPhysicalDeviceASTCDecodeFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(current);
                 if (enabling->decodeModeSharedExponent && !supported.decodeModeSharedExponent) {
                     ss << "VkPhysicalDeviceASTCDecodeFeaturesEXT::decodeModeSharedExponent is not supported\n";
                 }
@@ -274,8 +274,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAccelerationStructureFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAccelerationStructureFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(current);
+                const VkPhysicalDeviceAccelerationStructureFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(current);
                 if (enabling->accelerationStructure && !supported.accelerationStructure) {
                     ss << "VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructure is not supported\n";
                 }
@@ -299,8 +299,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAddressBindingReportFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAddressBindingReportFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(current);
+                const VkPhysicalDeviceAddressBindingReportFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(current);
                 if (enabling->reportAddressBinding && !supported.reportAddressBinding) {
                     ss << "VkPhysicalDeviceAddressBindingReportFeaturesEXT::reportAddressBinding is not supported\n";
                 }
@@ -310,8 +310,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAmigoProfilingFeaturesSEC supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAmigoProfilingFeaturesSEC *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(current);
+                const VkPhysicalDeviceAmigoProfilingFeaturesSEC* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(current);
                 if (enabling->amigoProfiling && !supported.amigoProfiling) {
                     ss << "VkPhysicalDeviceAmigoProfilingFeaturesSEC::amigoProfiling is not supported\n";
                 }
@@ -321,8 +321,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAntiLagFeaturesAMD supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAntiLagFeaturesAMD *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD *>(current);
+                const VkPhysicalDeviceAntiLagFeaturesAMD* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD*>(current);
                 if (enabling->antiLag && !supported.antiLag) {
                     ss << "VkPhysicalDeviceAntiLagFeaturesAMD::antiLag is not supported\n";
                 }
@@ -332,8 +332,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(current);
+                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(current);
                 if (enabling->attachmentFeedbackLoopDynamicState && !supported.attachmentFeedbackLoopDynamicState) {
                     ss << "VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT::attachmentFeedbackLoopDynamicState is "
                           "not supported\n";
@@ -344,8 +344,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(current);
+                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(current);
                 if (enabling->attachmentFeedbackLoopLayout && !supported.attachmentFeedbackLoopLayout) {
                     ss << "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT::attachmentFeedbackLoopLayout is not "
                           "supported\n";
@@ -356,8 +356,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(current);
+                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(current);
                 if (enabling->advancedBlendCoherentOperations && !supported.advancedBlendCoherentOperations) {
                     ss << "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT::advancedBlendCoherentOperations is not supported\n";
                 }
@@ -367,8 +367,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBorderColorSwizzleFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(current);
+                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(current);
                 if (enabling->borderColorSwizzle && !supported.borderColorSwizzle) {
                     ss << "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT::borderColorSwizzle is not supported\n";
                 }
@@ -381,8 +381,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBufferDeviceAddressFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBufferDeviceAddressFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures *>(current);
+                const VkPhysicalDeviceBufferDeviceAddressFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(current);
                 if (enabling->bufferDeviceAddress && !supported.bufferDeviceAddress) {
                     ss << "VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress is not supported\n";
                 }
@@ -398,8 +398,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBufferDeviceAddressFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *>(current);
+                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(current);
                 if (enabling->bufferDeviceAddress && !supported.bufferDeviceAddress) {
                     ss << "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT::bufferDeviceAddress is not supported\n";
                 }
@@ -415,8 +415,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceClusterAccelerationStructureFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(current);
+                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(current);
                 if (enabling->clusterAccelerationStructure && !supported.clusterAccelerationStructure) {
                     ss << "VkPhysicalDeviceClusterAccelerationStructureFeaturesNV::clusterAccelerationStructure is not supported\n";
                 }
@@ -426,8 +426,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(current);
                 if (enabling->clustercullingShader && !supported.clustercullingShader) {
                     ss << "VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI::clustercullingShader is not supported\n";
                 }
@@ -440,8 +440,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCoherentMemoryFeaturesAMD supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCoherentMemoryFeaturesAMD *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(current);
+                const VkPhysicalDeviceCoherentMemoryFeaturesAMD* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(current);
                 if (enabling->deviceCoherentMemory && !supported.deviceCoherentMemory) {
                     ss << "VkPhysicalDeviceCoherentMemoryFeaturesAMD::deviceCoherentMemory is not supported\n";
                 }
@@ -451,8 +451,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceColorWriteEnableFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceColorWriteEnableFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(current);
+                const VkPhysicalDeviceColorWriteEnableFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(current);
                 if (enabling->colorWriteEnable && !supported.colorWriteEnable) {
                     ss << "VkPhysicalDeviceColorWriteEnableFeaturesEXT::colorWriteEnable is not supported\n";
                 }
@@ -462,8 +462,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCommandBufferInheritanceFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(current);
+                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(current);
                 if (enabling->commandBufferInheritance && !supported.commandBufferInheritance) {
                     ss << "VkPhysicalDeviceCommandBufferInheritanceFeaturesNV::commandBufferInheritance is not supported\n";
                 }
@@ -473,8 +473,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(current);
+                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(current);
                 if (enabling->computeOccupancyPriority && !supported.computeOccupancyPriority) {
                     ss << "VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV::computeOccupancyPriority is not supported\n";
                 }
@@ -484,8 +484,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(current);
+                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(current);
                 if (enabling->computeDerivativeGroupQuads && !supported.computeDerivativeGroupQuads) {
                     ss << "VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR::computeDerivativeGroupQuads is not supported\n";
                 }
@@ -498,8 +498,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceConditionalRenderingFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceConditionalRenderingFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(current);
+                const VkPhysicalDeviceConditionalRenderingFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(current);
                 if (enabling->conditionalRendering && !supported.conditionalRendering) {
                     ss << "VkPhysicalDeviceConditionalRenderingFeaturesEXT::conditionalRendering is not supported\n";
                 }
@@ -512,8 +512,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeMatrix2FeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(current);
+                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(current);
                 if (enabling->cooperativeMatrixWorkgroupScope && !supported.cooperativeMatrixWorkgroupScope) {
                     ss << "VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixWorkgroupScope is not supported\n";
                 }
@@ -541,8 +541,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM *>(current);
+                const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM*>(current);
                 if (enabling->cooperativeMatrixConversion && !supported.cooperativeMatrixConversion) {
                     ss << "VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM::cooperativeMatrixConversion is not supported\n";
                 }
@@ -552,8 +552,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeMatrixFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(current);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(current);
                 if (enabling->cooperativeMatrix && !supported.cooperativeMatrix) {
                     ss << "VkPhysicalDeviceCooperativeMatrixFeaturesKHR::cooperativeMatrix is not supported\n";
                 }
@@ -566,8 +566,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeMatrixFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeMatrixFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV *>(current);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(current);
                 if (enabling->cooperativeMatrix && !supported.cooperativeMatrix) {
                     ss << "VkPhysicalDeviceCooperativeMatrixFeaturesNV::cooperativeMatrix is not supported\n";
                 }
@@ -580,8 +580,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeVectorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeVectorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV *>(current);
+                const VkPhysicalDeviceCooperativeVectorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV*>(current);
                 if (enabling->cooperativeVector && !supported.cooperativeVector) {
                     ss << "VkPhysicalDeviceCooperativeVectorFeaturesNV::cooperativeVector is not supported\n";
                 }
@@ -594,8 +594,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(current);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(current);
                 if (enabling->indirectMemoryCopy && !supported.indirectMemoryCopy) {
                     ss << "VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR::indirectMemoryCopy is not supported\n";
                 }
@@ -608,8 +608,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCopyMemoryIndirectFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(current);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(current);
                 if (enabling->indirectCopy && !supported.indirectCopy) {
                     ss << "VkPhysicalDeviceCopyMemoryIndirectFeaturesNV::indirectCopy is not supported\n";
                 }
@@ -619,8 +619,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCornerSampledImageFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCornerSampledImageFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV *>(current);
+                const VkPhysicalDeviceCornerSampledImageFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(current);
                 if (enabling->cornerSampledImage && !supported.cornerSampledImage) {
                     ss << "VkPhysicalDeviceCornerSampledImageFeaturesNV::cornerSampledImage is not supported\n";
                 }
@@ -630,8 +630,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCoverageReductionModeFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCoverageReductionModeFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(current);
+                const VkPhysicalDeviceCoverageReductionModeFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(current);
                 if (enabling->coverageReductionMode && !supported.coverageReductionMode) {
                     ss << "VkPhysicalDeviceCoverageReductionModeFeaturesNV::coverageReductionMode is not supported\n";
                 }
@@ -641,8 +641,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCubicClampFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCubicClampFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM *>(current);
+                const VkPhysicalDeviceCubicClampFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM*>(current);
                 if (enabling->cubicRangeClamp && !supported.cubicRangeClamp) {
                     ss << "VkPhysicalDeviceCubicClampFeaturesQCOM::cubicRangeClamp is not supported\n";
                 }
@@ -652,8 +652,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCubicWeightsFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCubicWeightsFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(current);
+                const VkPhysicalDeviceCubicWeightsFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(current);
                 if (enabling->selectableCubicWeights && !supported.selectableCubicWeights) {
                     ss << "VkPhysicalDeviceCubicWeightsFeaturesQCOM::selectableCubicWeights is not supported\n";
                 }
@@ -664,8 +664,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCudaKernelLaunchFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(current);
+                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(current);
                 if (enabling->cudaKernelLaunchFeatures && !supported.cudaKernelLaunchFeatures) {
                     ss << "VkPhysicalDeviceCudaKernelLaunchFeaturesNV::cudaKernelLaunchFeatures is not supported\n";
                 }
@@ -676,8 +676,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCustomBorderColorFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCustomBorderColorFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(current);
+                const VkPhysicalDeviceCustomBorderColorFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(current);
                 if (enabling->customBorderColors && !supported.customBorderColors) {
                     ss << "VkPhysicalDeviceCustomBorderColorFeaturesEXT::customBorderColors is not supported\n";
                 }
@@ -690,8 +690,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCustomResolveFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCustomResolveFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT *>(current);
+                const VkPhysicalDeviceCustomResolveFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT*>(current);
                 if (enabling->customResolve && !supported.customResolve) {
                     ss << "VkPhysicalDeviceCustomResolveFeaturesEXT::customResolve is not supported\n";
                 }
@@ -701,8 +701,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDataGraphFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDataGraphFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM *>(current);
+                const VkPhysicalDeviceDataGraphFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM*>(current);
                 if (enabling->dataGraph && !supported.dataGraph) {
                     ss << "VkPhysicalDeviceDataGraphFeaturesARM::dataGraph is not supported\n";
                 }
@@ -724,8 +724,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDataGraphModelFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDataGraphModelFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(current);
+                const VkPhysicalDeviceDataGraphModelFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(current);
                 if (enabling->dataGraphModel && !supported.dataGraphModel) {
                     ss << "VkPhysicalDeviceDataGraphModelFeaturesQCOM::dataGraphModel is not supported\n";
                 }
@@ -735,8 +735,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(current);
+                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(current);
                 if (enabling->dedicatedAllocationImageAliasing && !supported.dedicatedAllocationImageAliasing) {
                     ss << "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV::dedicatedAllocationImageAliasing is not "
                           "supported\n";
@@ -748,8 +748,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(current);
+                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(current);
                 if (enabling->denseGeometryFormat && !supported.denseGeometryFormat) {
                     ss << "VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX::denseGeometryFormat is not supported\n";
                 }
@@ -760,8 +760,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthBiasControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthBiasControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthBiasControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(current);
                 if (enabling->depthBiasControl && !supported.depthBiasControl) {
                     ss << "VkPhysicalDeviceDepthBiasControlFeaturesEXT::depthBiasControl is not supported\n";
                 }
@@ -782,8 +782,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClampControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClampControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthClampControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT*>(current);
                 if (enabling->depthClampControl && !supported.depthClampControl) {
                     ss << "VkPhysicalDeviceDepthClampControlFeaturesEXT::depthClampControl is not supported\n";
                 }
@@ -793,8 +793,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClampZeroOneFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(current);
+                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(current);
                 if (enabling->depthClampZeroOne && !supported.depthClampZeroOne) {
                     ss << "VkPhysicalDeviceDepthClampZeroOneFeaturesKHR::depthClampZeroOne is not supported\n";
                 }
@@ -804,8 +804,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClipControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClipControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthClipControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT*>(current);
                 if (enabling->depthClipControl && !supported.depthClipControl) {
                     ss << "VkPhysicalDeviceDepthClipControlFeaturesEXT::depthClipControl is not supported\n";
                 }
@@ -815,8 +815,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClipEnableFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClipEnableFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthClipEnableFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(current);
                 if (enabling->depthClipEnable && !supported.depthClipEnable) {
                     ss << "VkPhysicalDeviceDepthClipEnableFeaturesEXT::depthClipEnable is not supported\n";
                 }
@@ -826,8 +826,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorBufferFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorBufferFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(current);
+                const VkPhysicalDeviceDescriptorBufferFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(current);
                 if (enabling->descriptorBuffer && !supported.descriptorBuffer) {
                     ss << "VkPhysicalDeviceDescriptorBufferFeaturesEXT::descriptorBuffer is not supported\n";
                 }
@@ -846,8 +846,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorBufferTensorFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(current);
+                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(current);
                 if (enabling->descriptorBufferTensorDescriptors && !supported.descriptorBufferTensorDescriptors) {
                     ss << "VkPhysicalDeviceDescriptorBufferTensorFeaturesARM::descriptorBufferTensorDescriptors is not supported\n";
                 }
@@ -857,8 +857,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorHeapFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorHeapFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorHeapFeaturesEXT *>(current);
+                const VkPhysicalDeviceDescriptorHeapFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorHeapFeaturesEXT*>(current);
                 if (enabling->descriptorHeap && !supported.descriptorHeap) {
                     ss << "VkPhysicalDeviceDescriptorHeapFeaturesEXT::descriptorHeap is not supported\n";
                 }
@@ -871,8 +871,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorIndexingFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorIndexingFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures *>(current);
+                const VkPhysicalDeviceDescriptorIndexingFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(current);
                 if (enabling->shaderInputAttachmentArrayDynamicIndexing && !supported.shaderInputAttachmentArrayDynamicIndexing) {
                     ss << "VkPhysicalDeviceDescriptorIndexingFeatures::shaderInputAttachmentArrayDynamicIndexing is not "
                           "supported\n";
@@ -967,8 +967,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(current);
+                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(current);
                 if (enabling->descriptorPoolOverallocation && !supported.descriptorPoolOverallocation) {
                     ss << "VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV::descriptorPoolOverallocation is not supported\n";
                 }
@@ -978,8 +978,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(current);
+                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(current);
                 if (enabling->descriptorSetHostMapping && !supported.descriptorSetHostMapping) {
                     ss << "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE::descriptorSetHostMapping is not supported\n";
                 }
@@ -989,8 +989,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR *>(current);
+                const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR*>(current);
                 if (enabling->deviceAddressCommands && !supported.deviceAddressCommands) {
                     ss << "VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR::deviceAddressCommands is not supported\n";
                 }
@@ -1000,8 +1000,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(current);
+                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(current);
                 if (enabling->deviceGeneratedCompute && !supported.deviceGeneratedCompute) {
                     ss << "VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV::deviceGeneratedCompute is not supported\n";
                 }
@@ -1019,8 +1019,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(current);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(current);
                 if (enabling->deviceGeneratedCommands && !supported.deviceGeneratedCommands) {
                     ss << "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT::deviceGeneratedCommands is not supported\n";
                 }
@@ -1033,8 +1033,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(current);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(current);
                 if (enabling->deviceGeneratedCommands && !supported.deviceGeneratedCommands) {
                     ss << "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV::deviceGeneratedCommands is not supported\n";
                 }
@@ -1044,8 +1044,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceMemoryReportFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(current);
+                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(current);
                 if (enabling->deviceMemoryReport && !supported.deviceMemoryReport) {
                     ss << "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT::deviceMemoryReport is not supported\n";
                 }
@@ -1055,8 +1055,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDiagnosticsConfigFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(current);
+                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(current);
                 if (enabling->diagnosticsConfig && !supported.diagnosticsConfig) {
                     ss << "VkPhysicalDeviceDiagnosticsConfigFeaturesNV::diagnosticsConfig is not supported\n";
                 }
@@ -1067,8 +1067,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDisplacementMicromapFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDisplacementMicromapFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(current);
+                const VkPhysicalDeviceDisplacementMicromapFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(current);
                 if (enabling->displacementMicromap && !supported.displacementMicromap) {
                     ss << "VkPhysicalDeviceDisplacementMicromapFeaturesNV::displacementMicromap is not supported\n";
                 }
@@ -1079,8 +1079,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDynamicRenderingFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDynamicRenderingFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures *>(current);
+                const VkPhysicalDeviceDynamicRenderingFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures*>(current);
                 if (enabling->dynamicRendering && !supported.dynamicRendering) {
                     ss << "VkPhysicalDeviceDynamicRenderingFeatures::dynamicRendering is not supported\n";
                 }
@@ -1090,8 +1090,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDynamicRenderingLocalReadFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(current);
+                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(current);
                 if (enabling->dynamicRenderingLocalRead && !supported.dynamicRenderingLocalRead) {
                     ss << "VkPhysicalDeviceDynamicRenderingLocalReadFeatures::dynamicRenderingLocalRead is not supported\n";
                 }
@@ -1101,8 +1101,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(current);
+                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(current);
                 if (enabling->dynamicRenderingUnusedAttachments && !supported.dynamicRenderingUnusedAttachments) {
                     ss << "VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT::dynamicRenderingUnusedAttachments is not "
                           "supported\n";
@@ -1113,8 +1113,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExclusiveScissorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExclusiveScissorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV *>(current);
+                const VkPhysicalDeviceExclusiveScissorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(current);
                 if (enabling->exclusiveScissor && !supported.exclusiveScissor) {
                     ss << "VkPhysicalDeviceExclusiveScissorFeaturesNV::exclusiveScissor is not supported\n";
                 }
@@ -1124,8 +1124,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedDynamicState2FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(current);
+                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(current);
                 if (enabling->extendedDynamicState2 && !supported.extendedDynamicState2) {
                     ss << "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT::extendedDynamicState2 is not supported\n";
                 }
@@ -1142,8 +1142,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedDynamicState3FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(current);
+                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(current);
                 if (enabling->extendedDynamicState3TessellationDomainOrigin &&
                     !supported.extendedDynamicState3TessellationDomainOrigin) {
                     ss << "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3TessellationDomainOrigin is not "
@@ -1282,8 +1282,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedDynamicStateFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(current);
+                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(current);
                 if (enabling->extendedDynamicState && !supported.extendedDynamicState) {
                     ss << "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT::extendedDynamicState is not supported\n";
                 }
@@ -1293,8 +1293,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(current);
+                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(current);
                 if (enabling->extendedSparseAddressSpace && !supported.extendedSparseAddressSpace) {
                     ss << "VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV::extendedSparseAddressSpace is not supported\n";
                 }
@@ -1305,8 +1305,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExternalFormatResolveFeaturesANDROID supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(current);
+                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(current);
                 if (enabling->externalFormatResolve && !supported.externalFormatResolve) {
                     ss << "VkPhysicalDeviceExternalFormatResolveFeaturesANDROID::externalFormatResolve is not supported\n";
                 }
@@ -1317,8 +1317,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExternalMemoryRDMAFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(current);
+                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(current);
                 if (enabling->externalMemoryRDMA && !supported.externalMemoryRDMA) {
                     ss << "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV::externalMemoryRDMA is not supported\n";
                 }
@@ -1329,8 +1329,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(current);
+                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(current);
                 if (enabling->screenBufferImport && !supported.screenBufferImport) {
                     ss << "VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX::screenBufferImport is not supported\n";
                 }
@@ -1341,8 +1341,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFaultFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFaultFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT *>(current);
+                const VkPhysicalDeviceFaultFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT*>(current);
                 if (enabling->deviceFault && !supported.deviceFault) {
                     ss << "VkPhysicalDeviceFaultFeaturesEXT::deviceFault is not supported\n";
                 }
@@ -1355,8 +1355,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFormatPackFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFormatPackFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM *>(current);
+                const VkPhysicalDeviceFormatPackFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(current);
                 if (enabling->formatPack && !supported.formatPack) {
                     ss << "VkPhysicalDeviceFormatPackFeaturesARM::formatPack is not supported\n";
                 }
@@ -1366,8 +1366,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMap2FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(current);
                 if (enabling->fragmentDensityMapDeferred && !supported.fragmentDensityMapDeferred) {
                     ss << "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT::fragmentDensityMapDeferred is not supported\n";
                 }
@@ -1377,8 +1377,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMapFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(current);
                 if (enabling->fragmentDensityMap && !supported.fragmentDensityMap) {
                     ss << "VkPhysicalDeviceFragmentDensityMapFeaturesEXT::fragmentDensityMap is not supported\n";
                 }
@@ -1394,8 +1394,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(current);
+                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(current);
                 if (enabling->fragmentDensityMapLayered && !supported.fragmentDensityMapLayered) {
                     ss << "VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE::fragmentDensityMapLayered is not supported\n";
                 }
@@ -1405,8 +1405,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(current);
                 if (enabling->fragmentDensityMapOffset && !supported.fragmentDensityMapOffset) {
                     ss << "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT::fragmentDensityMapOffset is not supported\n";
                 }
@@ -1416,8 +1416,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(current);
+                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(current);
                 if (enabling->fragmentShaderBarycentric && !supported.fragmentShaderBarycentric) {
                     ss << "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR::fragmentShaderBarycentric is not supported\n";
                 }
@@ -1427,8 +1427,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(current);
                 if (enabling->fragmentShaderSampleInterlock && !supported.fragmentShaderSampleInterlock) {
                     ss << "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderSampleInterlock is not supported\n";
                 }
@@ -1445,8 +1445,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(current);
+                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(current);
                 if (enabling->fragmentShadingRateEnums && !supported.fragmentShadingRateEnums) {
                     ss << "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV::fragmentShadingRateEnums is not supported\n";
                 }
@@ -1462,8 +1462,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShadingRateFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(current);
+                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(current);
                 if (enabling->pipelineFragmentShadingRate && !supported.pipelineFragmentShadingRate) {
                     ss << "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::pipelineFragmentShadingRate is not supported\n";
                 }
@@ -1479,8 +1479,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFrameBoundaryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFrameBoundaryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(current);
+                const VkPhysicalDeviceFrameBoundaryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(current);
                 if (enabling->frameBoundary && !supported.frameBoundary) {
                     ss << "VkPhysicalDeviceFrameBoundaryFeaturesEXT::frameBoundary is not supported\n";
                 }
@@ -1490,8 +1490,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceGlobalPriorityQueryFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceGlobalPriorityQueryFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures *>(current);
+                const VkPhysicalDeviceGlobalPriorityQueryFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures*>(current);
                 if (enabling->globalPriorityQuery && !supported.globalPriorityQuery) {
                     ss << "VkPhysicalDeviceGlobalPriorityQueryFeatures::globalPriorityQuery is not supported\n";
                 }
@@ -1501,8 +1501,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(current);
+                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(current);
                 if (enabling->graphicsPipelineLibrary && !supported.graphicsPipelineLibrary) {
                     ss << "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary is not supported\n";
                 }
@@ -1512,8 +1512,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceHdrVividFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceHdrVividFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceHdrVividFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(current);
                 if (enabling->hdrVivid && !supported.hdrVivid) {
                     ss << "VkPhysicalDeviceHdrVividFeaturesHUAWEI::hdrVivid is not supported\n";
                 }
@@ -1523,8 +1523,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceHostImageCopyFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceHostImageCopyFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures *>(current);
+                const VkPhysicalDeviceHostImageCopyFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures*>(current);
                 if (enabling->hostImageCopy && !supported.hostImageCopy) {
                     ss << "VkPhysicalDeviceHostImageCopyFeatures::hostImageCopy is not supported\n";
                 }
@@ -1534,8 +1534,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceHostQueryResetFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceHostQueryResetFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures *>(current);
+                const VkPhysicalDeviceHostQueryResetFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(current);
                 if (enabling->hostQueryReset && !supported.hostQueryReset) {
                     ss << "VkPhysicalDeviceHostQueryResetFeatures::hostQueryReset is not supported\n";
                 }
@@ -1545,8 +1545,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImage2DViewOf3DFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(current);
+                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(current);
                 if (enabling->image2DViewOf3D && !supported.image2DViewOf3D) {
                     ss << "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT::image2DViewOf3D is not supported\n";
                 }
@@ -1559,8 +1559,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageAlignmentControlFeaturesMESA supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(current);
+                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(current);
                 if (enabling->imageAlignmentControl && !supported.imageAlignmentControl) {
                     ss << "VkPhysicalDeviceImageAlignmentControlFeaturesMESA::imageAlignmentControl is not supported\n";
                 }
@@ -1570,8 +1570,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageCompressionControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageCompressionControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageCompressionControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(current);
                 if (enabling->imageCompressionControl && !supported.imageCompressionControl) {
                     ss << "VkPhysicalDeviceImageCompressionControlFeaturesEXT::imageCompressionControl is not supported\n";
                 }
@@ -1581,8 +1581,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(current);
                 if (enabling->imageCompressionControlSwapchain && !supported.imageCompressionControlSwapchain) {
                     ss << "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT::imageCompressionControlSwapchain is not "
                           "supported\n";
@@ -1593,8 +1593,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageProcessing2FeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageProcessing2FeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(current);
+                const VkPhysicalDeviceImageProcessing2FeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(current);
                 if (enabling->textureBlockMatch2 && !supported.textureBlockMatch2) {
                     ss << "VkPhysicalDeviceImageProcessing2FeaturesQCOM::textureBlockMatch2 is not supported\n";
                 }
@@ -1604,8 +1604,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageProcessingFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageProcessingFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM *>(current);
+                const VkPhysicalDeviceImageProcessingFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM*>(current);
                 if (enabling->textureSampleWeighted && !supported.textureSampleWeighted) {
                     ss << "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureSampleWeighted is not supported\n";
                 }
@@ -1621,8 +1621,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageRobustnessFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageRobustnessFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures *>(current);
+                const VkPhysicalDeviceImageRobustnessFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(current);
                 if (enabling->robustImageAccess && !supported.robustImageAccess) {
                     ss << "VkPhysicalDeviceImageRobustnessFeatures::robustImageAccess is not supported\n";
                 }
@@ -1632,8 +1632,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(current);
                 if (enabling->imageSlicedViewOf3D && !supported.imageSlicedViewOf3D) {
                     ss << "VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT::imageSlicedViewOf3D is not supported\n";
                 }
@@ -1643,8 +1643,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageViewMinLodFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageViewMinLodFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageViewMinLodFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(current);
                 if (enabling->minLod && !supported.minLod) {
                     ss << "VkPhysicalDeviceImageViewMinLodFeaturesEXT::minLod is not supported\n";
                 }
@@ -1654,8 +1654,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImagelessFramebufferFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImagelessFramebufferFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures *>(current);
+                const VkPhysicalDeviceImagelessFramebufferFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(current);
                 if (enabling->imagelessFramebuffer && !supported.imagelessFramebuffer) {
                     ss << "VkPhysicalDeviceImagelessFramebufferFeatures::imagelessFramebuffer is not supported\n";
                 }
@@ -1665,8 +1665,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceIndexTypeUint8Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceIndexTypeUint8Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features *>(current);
+                const VkPhysicalDeviceIndexTypeUint8Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features*>(current);
                 if (enabling->indexTypeUint8 && !supported.indexTypeUint8) {
                     ss << "VkPhysicalDeviceIndexTypeUint8Features::indexTypeUint8 is not supported\n";
                 }
@@ -1676,8 +1676,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceInheritedViewportScissorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(current);
+                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(current);
                 if (enabling->inheritedViewportScissor2D && !supported.inheritedViewportScissor2D) {
                     ss << "VkPhysicalDeviceInheritedViewportScissorFeaturesNV::inheritedViewportScissor2D is not supported\n";
                 }
@@ -1687,8 +1687,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceInlineUniformBlockFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceInlineUniformBlockFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures *>(current);
+                const VkPhysicalDeviceInlineUniformBlockFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures*>(current);
                 if (enabling->inlineUniformBlock && !supported.inlineUniformBlock) {
                     ss << "VkPhysicalDeviceInlineUniformBlockFeatures::inlineUniformBlock is not supported\n";
                 }
@@ -1703,8 +1703,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR *>(current);
+                const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR*>(current);
                 if (enabling->internallySynchronizedQueues && !supported.internallySynchronizedQueues) {
                     ss << "VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR::internallySynchronizedQueues is not "
                           "supported\n";
@@ -1715,8 +1715,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceInvocationMaskFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(current);
                 if (enabling->invocationMask && !supported.invocationMask) {
                     ss << "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI::invocationMask is not supported\n";
                 }
@@ -1726,8 +1726,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLegacyDitheringFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLegacyDitheringFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(current);
+                const VkPhysicalDeviceLegacyDitheringFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(current);
                 if (enabling->legacyDithering && !supported.legacyDithering) {
                     ss << "VkPhysicalDeviceLegacyDitheringFeaturesEXT::legacyDithering is not supported\n";
                 }
@@ -1737,8 +1737,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(current);
+                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(current);
                 if (enabling->legacyVertexAttributes && !supported.legacyVertexAttributes) {
                     ss << "VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT::legacyVertexAttributes is not supported\n";
                 }
@@ -1748,8 +1748,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLineRasterizationFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLineRasterizationFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures *>(current);
+                const VkPhysicalDeviceLineRasterizationFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures*>(current);
                 if (enabling->rectangularLines && !supported.rectangularLines) {
                     ss << "VkPhysicalDeviceLineRasterizationFeatures::rectangularLines is not supported\n";
                 }
@@ -1774,8 +1774,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLinearColorAttachmentFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(current);
+                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(current);
                 if (enabling->linearColorAttachment && !supported.linearColorAttachment) {
                     ss << "VkPhysicalDeviceLinearColorAttachmentFeaturesNV::linearColorAttachment is not supported\n";
                 }
@@ -1785,8 +1785,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance10FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance10FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance10FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR*>(current);
                 if (enabling->maintenance10 && !supported.maintenance10) {
                     ss << "VkPhysicalDeviceMaintenance10FeaturesKHR::maintenance10 is not supported\n";
                 }
@@ -1796,8 +1796,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance4Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance4Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features *>(current);
+                const VkPhysicalDeviceMaintenance4Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features*>(current);
                 if (enabling->maintenance4 && !supported.maintenance4) {
                     ss << "VkPhysicalDeviceMaintenance4Features::maintenance4 is not supported\n";
                 }
@@ -1807,8 +1807,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance5Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance5Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features *>(current);
+                const VkPhysicalDeviceMaintenance5Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features*>(current);
                 if (enabling->maintenance5 && !supported.maintenance5) {
                     ss << "VkPhysicalDeviceMaintenance5Features::maintenance5 is not supported\n";
                 }
@@ -1818,8 +1818,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance6Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance6Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features *>(current);
+                const VkPhysicalDeviceMaintenance6Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features*>(current);
                 if (enabling->maintenance6 && !supported.maintenance6) {
                     ss << "VkPhysicalDeviceMaintenance6Features::maintenance6 is not supported\n";
                 }
@@ -1829,8 +1829,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance7FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance7FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance7FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR*>(current);
                 if (enabling->maintenance7 && !supported.maintenance7) {
                     ss << "VkPhysicalDeviceMaintenance7FeaturesKHR::maintenance7 is not supported\n";
                 }
@@ -1840,8 +1840,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance8FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance8FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance8FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR*>(current);
                 if (enabling->maintenance8 && !supported.maintenance8) {
                     ss << "VkPhysicalDeviceMaintenance8FeaturesKHR::maintenance8 is not supported\n";
                 }
@@ -1851,8 +1851,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance9FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance9FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance9FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR*>(current);
                 if (enabling->maintenance9 && !supported.maintenance9) {
                     ss << "VkPhysicalDeviceMaintenance9FeaturesKHR::maintenance9 is not supported\n";
                 }
@@ -1862,8 +1862,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMapMemoryPlacedFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(current);
+                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(current);
                 if (enabling->memoryMapPlaced && !supported.memoryMapPlaced) {
                     ss << "VkPhysicalDeviceMapMemoryPlacedFeaturesEXT::memoryMapPlaced is not supported\n";
                 }
@@ -1879,8 +1879,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMemoryDecompressionFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(current);
+                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(current);
                 if (enabling->memoryDecompression && !supported.memoryDecompression) {
                     ss << "VkPhysicalDeviceMemoryDecompressionFeaturesEXT::memoryDecompression is not supported\n";
                 }
@@ -1890,8 +1890,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMemoryPriorityFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMemoryPriorityFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(current);
+                const VkPhysicalDeviceMemoryPriorityFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(current);
                 if (enabling->memoryPriority && !supported.memoryPriority) {
                     ss << "VkPhysicalDeviceMemoryPriorityFeaturesEXT::memoryPriority is not supported\n";
                 }
@@ -1901,8 +1901,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMeshShaderFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMeshShaderFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT *>(current);
+                const VkPhysicalDeviceMeshShaderFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT*>(current);
                 if (enabling->taskShader && !supported.taskShader) {
                     ss << "VkPhysicalDeviceMeshShaderFeaturesEXT::taskShader is not supported\n";
                 }
@@ -1924,8 +1924,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMeshShaderFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMeshShaderFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV *>(current);
+                const VkPhysicalDeviceMeshShaderFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(current);
                 if (enabling->taskShader && !supported.taskShader) {
                     ss << "VkPhysicalDeviceMeshShaderFeaturesNV::taskShader is not supported\n";
                 }
@@ -1938,8 +1938,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiDrawFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiDrawFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT *>(current);
+                const VkPhysicalDeviceMultiDrawFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(current);
                 if (enabling->multiDraw && !supported.multiDraw) {
                     ss << "VkPhysicalDeviceMultiDrawFeaturesEXT::multiDraw is not supported\n";
                 }
@@ -1949,8 +1949,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(current);
+                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(current);
                 if (enabling->multisampledRenderToSingleSampled && !supported.multisampledRenderToSingleSampled) {
                     ss << "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT::multisampledRenderToSingleSampled is not "
                           "supported\n";
@@ -1961,8 +1961,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiviewFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiviewFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures *>(current);
+                const VkPhysicalDeviceMultiviewFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(current);
                 if (enabling->multiview && !supported.multiview) {
                     ss << "VkPhysicalDeviceMultiviewFeatures::multiview is not supported\n";
                 }
@@ -1978,8 +1978,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(current);
+                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(current);
                 if (enabling->multiviewPerViewRenderAreas && !supported.multiviewPerViewRenderAreas) {
                     ss << "VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM::multiviewPerViewRenderAreas is not supported\n";
                 }
@@ -1989,8 +1989,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(current);
+                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(current);
                 if (enabling->multiviewPerViewViewports && !supported.multiviewPerViewViewports) {
                     ss << "VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM::multiviewPerViewViewports is not supported\n";
                 }
@@ -2000,8 +2000,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(current);
+                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(current);
                 if (enabling->mutableDescriptorType && !supported.mutableDescriptorType) {
                     ss << "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT::mutableDescriptorType is not supported\n";
                 }
@@ -2011,8 +2011,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceNestedCommandBufferFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(current);
+                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(current);
                 if (enabling->nestedCommandBuffer && !supported.nestedCommandBuffer) {
                     ss << "VkPhysicalDeviceNestedCommandBufferFeaturesEXT::nestedCommandBuffer is not supported\n";
                 }
@@ -2028,8 +2028,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(current);
+                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(current);
                 if (enabling->nonSeamlessCubeMap && !supported.nonSeamlessCubeMap) {
                     ss << "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT::nonSeamlessCubeMap is not supported\n";
                 }
@@ -2039,8 +2039,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceOpacityMicromapFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceOpacityMicromapFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(current);
+                const VkPhysicalDeviceOpacityMicromapFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(current);
                 if (enabling->micromap && !supported.micromap) {
                     ss << "VkPhysicalDeviceOpacityMicromapFeaturesEXT::micromap is not supported\n";
                 }
@@ -2056,8 +2056,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceOpticalFlowFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceOpticalFlowFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV *>(current);
+                const VkPhysicalDeviceOpticalFlowFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV*>(current);
                 if (enabling->opticalFlow && !supported.opticalFlow) {
                     ss << "VkPhysicalDeviceOpticalFlowFeaturesNV::opticalFlow is not supported\n";
                 }
@@ -2067,8 +2067,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(current);
+                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(current);
                 if (enabling->pageableDeviceLocalMemory && !supported.pageableDeviceLocalMemory) {
                     ss << "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT::pageableDeviceLocalMemory is not supported\n";
                 }
@@ -2078,8 +2078,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(current);
+                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(current);
                 if (enabling->partitionedAccelerationStructure && !supported.partitionedAccelerationStructure) {
                     ss << "VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV::partitionedAccelerationStructure is not "
                           "supported\n";
@@ -2090,8 +2090,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePerStageDescriptorSetFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(current);
+                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(current);
                 if (enabling->perStageDescriptorSet && !supported.perStageDescriptorSet) {
                     ss << "VkPhysicalDevicePerStageDescriptorSetFeaturesNV::perStageDescriptorSet is not supported\n";
                 }
@@ -2104,8 +2104,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePerformanceCountersByRegionFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(current);
+                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(current);
                 if (enabling->performanceCountersByRegion && !supported.performanceCountersByRegion) {
                     ss << "VkPhysicalDevicePerformanceCountersByRegionFeaturesARM::performanceCountersByRegion is not supported\n";
                 }
@@ -2115,8 +2115,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePerformanceQueryFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePerformanceQueryFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR *>(current);
+                const VkPhysicalDevicePerformanceQueryFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(current);
                 if (enabling->performanceCounterQueryPools && !supported.performanceCounterQueryPools) {
                     ss << "VkPhysicalDevicePerformanceQueryFeaturesKHR::performanceCounterQueryPools is not supported\n";
                 }
@@ -2129,8 +2129,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineBinaryFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineBinaryFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR *>(current);
+                const VkPhysicalDevicePipelineBinaryFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR*>(current);
                 if (enabling->pipelineBinaries && !supported.pipelineBinaries) {
                     ss << "VkPhysicalDevicePipelineBinaryFeaturesKHR::pipelineBinaries is not supported\n";
                 }
@@ -2140,8 +2140,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(current);
+                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(current);
                 if (enabling->pipelineCacheIncrementalMode && !supported.pipelineCacheIncrementalMode) {
                     ss << "VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC::pipelineCacheIncrementalMode is not "
                           "supported\n";
@@ -2152,8 +2152,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineCreationCacheControlFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineCreationCacheControlFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures *>(current);
+                const VkPhysicalDevicePipelineCreationCacheControlFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures*>(current);
                 if (enabling->pipelineCreationCacheControl && !supported.pipelineCreationCacheControl) {
                     ss << "VkPhysicalDevicePipelineCreationCacheControlFeatures::pipelineCreationCacheControl is not supported\n";
                 }
@@ -2163,8 +2163,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(current);
+                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(current);
                 if (enabling->pipelineExecutableInfo && !supported.pipelineExecutableInfo) {
                     ss << "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR::pipelineExecutableInfo is not supported\n";
                 }
@@ -2174,8 +2174,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(current);
+                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(current);
                 if (enabling->pipelineLibraryGroupHandles && !supported.pipelineLibraryGroupHandles) {
                     ss << "VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT::pipelineLibraryGroupHandles is not supported\n";
                 }
@@ -2185,8 +2185,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineOpacityMicromapFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(current);
+                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(current);
                 if (enabling->pipelineOpacityMicromap && !supported.pipelineOpacityMicromap) {
                     ss << "VkPhysicalDevicePipelineOpacityMicromapFeaturesARM::pipelineOpacityMicromap is not supported\n";
                 }
@@ -2196,8 +2196,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelinePropertiesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelinePropertiesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(current);
+                const VkPhysicalDevicePipelinePropertiesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(current);
                 if (enabling->pipelinePropertiesIdentifier && !supported.pipelinePropertiesIdentifier) {
                     ss << "VkPhysicalDevicePipelinePropertiesFeaturesEXT::pipelinePropertiesIdentifier is not supported\n";
                 }
@@ -2207,8 +2207,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineProtectedAccessFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineProtectedAccessFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures *>(current);
+                const VkPhysicalDevicePipelineProtectedAccessFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures*>(current);
                 if (enabling->pipelineProtectedAccess && !supported.pipelineProtectedAccess) {
                     ss << "VkPhysicalDevicePipelineProtectedAccessFeatures::pipelineProtectedAccess is not supported\n";
                 }
@@ -2218,8 +2218,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineRobustnessFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineRobustnessFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures *>(current);
+                const VkPhysicalDevicePipelineRobustnessFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures*>(current);
                 if (enabling->pipelineRobustness && !supported.pipelineRobustness) {
                     ss << "VkPhysicalDevicePipelineRobustnessFeatures::pipelineRobustness is not supported\n";
                 }
@@ -2230,8 +2230,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePortabilitySubsetFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePortabilitySubsetFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(current);
+                const VkPhysicalDevicePortabilitySubsetFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(current);
                 if (enabling->constantAlphaColorBlendFactors && !supported.constantAlphaColorBlendFactors) {
                     ss << "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors is not supported\n";
                 }
@@ -2284,8 +2284,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentBarrierFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentBarrierFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV *>(current);
+                const VkPhysicalDevicePresentBarrierFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV*>(current);
                 if (enabling->presentBarrier && !supported.presentBarrier) {
                     ss << "VkPhysicalDevicePresentBarrierFeaturesNV::presentBarrier is not supported\n";
                 }
@@ -2295,8 +2295,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentId2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentId2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR *>(current);
+                const VkPhysicalDevicePresentId2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR*>(current);
                 if (enabling->presentId2 && !supported.presentId2) {
                     ss << "VkPhysicalDevicePresentId2FeaturesKHR::presentId2 is not supported\n";
                 }
@@ -2306,8 +2306,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentIdFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentIdFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR *>(current);
+                const VkPhysicalDevicePresentIdFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR*>(current);
                 if (enabling->presentId && !supported.presentId) {
                     ss << "VkPhysicalDevicePresentIdFeaturesKHR::presentId is not supported\n";
                 }
@@ -2317,8 +2317,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentMeteringFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentMeteringFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV *>(current);
+                const VkPhysicalDevicePresentMeteringFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV*>(current);
                 if (enabling->presentMetering && !supported.presentMetering) {
                     ss << "VkPhysicalDevicePresentMeteringFeaturesNV::presentMetering is not supported\n";
                 }
@@ -2328,8 +2328,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(current);
+                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(current);
                 if (enabling->presentModeFifoLatestReady && !supported.presentModeFifoLatestReady) {
                     ss << "VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR::presentModeFifoLatestReady is not supported\n";
                 }
@@ -2339,8 +2339,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentTimingFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentTimingFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT *>(current);
+                const VkPhysicalDevicePresentTimingFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT*>(current);
                 if (enabling->presentTiming && !supported.presentTiming) {
                     ss << "VkPhysicalDevicePresentTimingFeaturesEXT::presentTiming is not supported\n";
                 }
@@ -2356,8 +2356,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentWait2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentWait2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR *>(current);
+                const VkPhysicalDevicePresentWait2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR*>(current);
                 if (enabling->presentWait2 && !supported.presentWait2) {
                     ss << "VkPhysicalDevicePresentWait2FeaturesKHR::presentWait2 is not supported\n";
                 }
@@ -2367,8 +2367,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentWaitFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentWaitFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR *>(current);
+                const VkPhysicalDevicePresentWaitFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR*>(current);
                 if (enabling->presentWait && !supported.presentWait) {
                     ss << "VkPhysicalDevicePresentWaitFeaturesKHR::presentWait is not supported\n";
                 }
@@ -2378,8 +2378,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(current);
+                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(current);
                 if (enabling->primitiveTopologyListRestart && !supported.primitiveTopologyListRestart) {
                     ss << "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT::primitiveTopologyListRestart is not "
                           "supported\n";
@@ -2394,8 +2394,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(current);
+                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(current);
                 if (enabling->primitivesGeneratedQuery && !supported.primitivesGeneratedQuery) {
                     ss << "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT::primitivesGeneratedQuery is not supported\n";
                 }
@@ -2414,8 +2414,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePrivateDataFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePrivateDataFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures *>(current);
+                const VkPhysicalDevicePrivateDataFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures*>(current);
                 if (enabling->privateData && !supported.privateData) {
                     ss << "VkPhysicalDevicePrivateDataFeatures::privateData is not supported\n";
                 }
@@ -2425,8 +2425,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceProtectedMemoryFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceProtectedMemoryFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures *>(current);
+                const VkPhysicalDeviceProtectedMemoryFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(current);
                 if (enabling->protectedMemory && !supported.protectedMemory) {
                     ss << "VkPhysicalDeviceProtectedMemoryFeatures::protectedMemory is not supported\n";
                 }
@@ -2436,8 +2436,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceProvokingVertexFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceProvokingVertexFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT *>(current);
+                const VkPhysicalDeviceProvokingVertexFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT*>(current);
                 if (enabling->provokingVertexLast && !supported.provokingVertexLast) {
                     ss << "VkPhysicalDeviceProvokingVertexFeaturesEXT::provokingVertexLast is not supported\n";
                 }
@@ -2451,8 +2451,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePushConstantBankFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePushConstantBankFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePushConstantBankFeaturesNV *>(current);
+                const VkPhysicalDevicePushConstantBankFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePushConstantBankFeaturesNV*>(current);
                 if (enabling->pushConstantBank && !supported.pushConstantBank) {
                     ss << "VkPhysicalDevicePushConstantBankFeaturesNV::pushConstantBank is not supported\n";
                 }
@@ -2462,8 +2462,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(current);
+                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(current);
                 if (enabling->formatRgba10x6WithoutYCbCrSampler && !supported.formatRgba10x6WithoutYCbCrSampler) {
                     ss << "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT::formatRgba10x6WithoutYCbCrSampler is not supported\n";
                 }
@@ -2473,8 +2473,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(current);
+                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(current);
                 if (enabling->rasterizationOrderColorAttachmentAccess && !supported.rasterizationOrderColorAttachmentAccess) {
                     ss << "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT::rasterizationOrderColorAttachmentAccess "
                           "is not supported\n";
@@ -2493,8 +2493,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRawAccessChainsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRawAccessChainsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV *>(current);
+                const VkPhysicalDeviceRawAccessChainsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV*>(current);
                 if (enabling->shaderRawAccessChains && !supported.shaderRawAccessChains) {
                     ss << "VkPhysicalDeviceRawAccessChainsFeaturesNV::shaderRawAccessChains is not supported\n";
                 }
@@ -2504,8 +2504,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayQueryFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayQueryFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR *>(current);
+                const VkPhysicalDeviceRayQueryFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR*>(current);
                 if (enabling->rayQuery && !supported.rayQuery) {
                     ss << "VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery is not supported\n";
                 }
@@ -2515,8 +2515,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(current);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(current);
                 if (enabling->rayTracingInvocationReorder && !supported.rayTracingInvocationReorder) {
                     ss << "VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT::rayTracingInvocationReorder is not supported\n";
                 }
@@ -2526,8 +2526,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(current);
                 if (enabling->rayTracingInvocationReorder && !supported.rayTracingInvocationReorder) {
                     ss << "VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV::rayTracingInvocationReorder is not supported\n";
                 }
@@ -2537,8 +2537,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(current);
                 if (enabling->spheres && !supported.spheres) {
                     ss << "VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV::spheres is not supported\n";
                 }
@@ -2551,8 +2551,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(current);
+                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(current);
                 if (enabling->rayTracingMaintenance1 && !supported.rayTracingMaintenance1) {
                     ss << "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR::rayTracingMaintenance1 is not supported\n";
                 }
@@ -2566,8 +2566,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingMotionBlurFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(current);
                 if (enabling->rayTracingMotionBlur && !supported.rayTracingMotionBlur) {
                     ss << "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV::rayTracingMotionBlur is not supported\n";
                 }
@@ -2582,8 +2582,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingPipelineFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(current);
+                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(current);
                 if (enabling->rayTracingPipeline && !supported.rayTracingPipeline) {
                     ss << "VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipeline is not supported\n";
                 }
@@ -2609,8 +2609,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(current);
+                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(current);
                 if (enabling->rayTracingPositionFetch && !supported.rayTracingPositionFetch) {
                     ss << "VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR::rayTracingPositionFetch is not supported\n";
                 }
@@ -2620,8 +2620,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingValidationFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingValidationFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingValidationFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV*>(current);
                 if (enabling->rayTracingValidation && !supported.rayTracingValidation) {
                     ss << "VkPhysicalDeviceRayTracingValidationFeaturesNV::rayTracingValidation is not supported\n";
                 }
@@ -2631,8 +2631,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(current);
+                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(current);
                 if (enabling->relaxedLineRasterization && !supported.relaxedLineRasterization) {
                     ss << "VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG::relaxedLineRasterization is not supported\n";
                 }
@@ -2642,8 +2642,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRenderPassStripedFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRenderPassStripedFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM *>(current);
+                const VkPhysicalDeviceRenderPassStripedFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM*>(current);
                 if (enabling->renderPassStriped && !supported.renderPassStriped) {
                     ss << "VkPhysicalDeviceRenderPassStripedFeaturesARM::renderPassStriped is not supported\n";
                 }
@@ -2653,8 +2653,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(current);
+                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(current);
                 if (enabling->representativeFragmentTest && !supported.representativeFragmentTest) {
                     ss << "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV::representativeFragmentTest is not supported\n";
                 }
@@ -2664,8 +2664,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRobustness2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRobustness2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR *>(current);
+                const VkPhysicalDeviceRobustness2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(current);
                 if (enabling->robustBufferAccess2 && !supported.robustBufferAccess2) {
                     ss << "VkPhysicalDeviceRobustness2FeaturesKHR::robustBufferAccess2 is not supported\n";
                 }
@@ -2681,8 +2681,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSamplerYcbcrConversionFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSamplerYcbcrConversionFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(current);
+                const VkPhysicalDeviceSamplerYcbcrConversionFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(current);
                 if (enabling->samplerYcbcrConversion && !supported.samplerYcbcrConversion) {
                     ss << "VkPhysicalDeviceSamplerYcbcrConversionFeatures::samplerYcbcrConversion is not supported\n";
                 }
@@ -2692,8 +2692,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceScalarBlockLayoutFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceScalarBlockLayoutFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures *>(current);
+                const VkPhysicalDeviceScalarBlockLayoutFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(current);
                 if (enabling->scalarBlockLayout && !supported.scalarBlockLayout) {
                     ss << "VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout is not supported\n";
                 }
@@ -2703,8 +2703,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSchedulingControlsFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSchedulingControlsFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM *>(current);
+                const VkPhysicalDeviceSchedulingControlsFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM*>(current);
                 if (enabling->schedulingControls && !supported.schedulingControls) {
                     ss << "VkPhysicalDeviceSchedulingControlsFeaturesARM::schedulingControls is not supported\n";
                 }
@@ -2714,8 +2714,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(current);
+                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(current);
                 if (enabling->separateDepthStencilLayouts && !supported.separateDepthStencilLayouts) {
                     ss << "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures::separateDepthStencilLayouts is not supported\n";
                 }
@@ -2725,8 +2725,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShader64BitIndexingFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(current);
+                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(current);
                 if (enabling->shader64BitIndexing && !supported.shader64BitIndexing) {
                     ss << "VkPhysicalDeviceShader64BitIndexingFeaturesEXT::shader64BitIndexing is not supported\n";
                 }
@@ -2736,8 +2736,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(current);
+                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(current);
                 if (enabling->shaderFloat16VectorAtomics && !supported.shaderFloat16VectorAtomics) {
                     ss << "VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV::shaderFloat16VectorAtomics is not supported\n";
                 }
@@ -2747,8 +2747,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(current);
                 if (enabling->shaderBufferFloat16Atomics && !supported.shaderBufferFloat16Atomics) {
                     ss << "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderBufferFloat16Atomics is not supported\n";
                 }
@@ -2791,8 +2791,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicFloatFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(current);
                 if (enabling->shaderBufferFloat32Atomics && !supported.shaderBufferFloat32Atomics) {
                     ss << "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat32Atomics is not supported\n";
                 }
@@ -2835,8 +2835,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicInt64Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicInt64Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features *>(current);
+                const VkPhysicalDeviceShaderAtomicInt64Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(current);
                 if (enabling->shaderBufferInt64Atomics && !supported.shaderBufferInt64Atomics) {
                     ss << "VkPhysicalDeviceShaderAtomicInt64Features::shaderBufferInt64Atomics is not supported\n";
                 }
@@ -2849,8 +2849,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderBfloat16FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderBfloat16FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderBfloat16FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(current);
                 if (enabling->shaderBFloat16Type && !supported.shaderBFloat16Type) {
                     ss << "VkPhysicalDeviceShaderBfloat16FeaturesKHR::shaderBFloat16Type is not supported\n";
                 }
@@ -2866,8 +2866,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderClockFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderClockFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderClockFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(current);
                 if (enabling->shaderSubgroupClock && !supported.shaderSubgroupClock) {
                     ss << "VkPhysicalDeviceShaderClockFeaturesKHR::shaderSubgroupClock is not supported\n";
                 }
@@ -2880,8 +2880,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(current);
+                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(current);
                 if (enabling->shaderCoreBuiltins && !supported.shaderCoreBuiltins) {
                     ss << "VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM::shaderCoreBuiltins is not supported\n";
                 }
@@ -2891,8 +2891,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(current);
+                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(current);
                 if (enabling->shaderDemoteToHelperInvocation && !supported.shaderDemoteToHelperInvocation) {
                     ss << "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures::shaderDemoteToHelperInvocation is not "
                           "supported\n";
@@ -2903,8 +2903,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderDrawParametersFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderDrawParametersFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures *>(current);
+                const VkPhysicalDeviceShaderDrawParametersFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(current);
                 if (enabling->shaderDrawParameters && !supported.shaderDrawParameters) {
                     ss << "VkPhysicalDeviceShaderDrawParametersFeatures::shaderDrawParameters is not supported\n";
                 }
@@ -2914,8 +2914,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(current);
+                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(current);
                 if (enabling->shaderEarlyAndLateFragmentTests && !supported.shaderEarlyAndLateFragmentTests) {
                     ss << "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD::shaderEarlyAndLateFragmentTests is not "
                           "supported\n";
@@ -2927,8 +2927,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderEnqueueFeaturesAMDX supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(current);
+                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(current);
                 if (enabling->shaderEnqueue && !supported.shaderEnqueue) {
                     ss << "VkPhysicalDeviceShaderEnqueueFeaturesAMDX::shaderEnqueue is not supported\n";
                 }
@@ -2942,8 +2942,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderExpectAssumeFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderExpectAssumeFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures *>(current);
+                const VkPhysicalDeviceShaderExpectAssumeFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures*>(current);
                 if (enabling->shaderExpectAssume && !supported.shaderExpectAssume) {
                     ss << "VkPhysicalDeviceShaderExpectAssumeFeatures::shaderExpectAssume is not supported\n";
                 }
@@ -2953,8 +2953,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFloat16Int8Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFloat16Int8Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features *>(current);
+                const VkPhysicalDeviceShaderFloat16Int8Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(current);
                 if (enabling->shaderFloat16 && !supported.shaderFloat16) {
                     ss << "VkPhysicalDeviceShaderFloat16Int8Features::shaderFloat16 is not supported\n";
                 }
@@ -2967,8 +2967,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFloat8FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFloat8FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderFloat8FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT*>(current);
                 if (enabling->shaderFloat8 && !supported.shaderFloat8) {
                     ss << "VkPhysicalDeviceShaderFloat8FeaturesEXT::shaderFloat8 is not supported\n";
                 }
@@ -2981,8 +2981,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFloatControls2Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFloatControls2Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features *>(current);
+                const VkPhysicalDeviceShaderFloatControls2Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features*>(current);
                 if (enabling->shaderFloatControls2 && !supported.shaderFloatControls2) {
                     ss << "VkPhysicalDeviceShaderFloatControls2Features::shaderFloatControls2 is not supported\n";
                 }
@@ -2992,8 +2992,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFmaFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFmaFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderFmaFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR*>(current);
                 if (enabling->shaderFmaFloat16 && !supported.shaderFmaFloat16) {
                     ss << "VkPhysicalDeviceShaderFmaFeaturesKHR::shaderFmaFloat16 is not supported\n";
                 }
@@ -3009,8 +3009,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(current);
                 if (enabling->shaderImageInt64Atomics && !supported.shaderImageInt64Atomics) {
                     ss << "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::shaderImageInt64Atomics is not supported\n";
                 }
@@ -3023,8 +3023,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderImageFootprintFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderImageFootprintFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(current);
+                const VkPhysicalDeviceShaderImageFootprintFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(current);
                 if (enabling->imageFootprint && !supported.imageFootprint) {
                     ss << "VkPhysicalDeviceShaderImageFootprintFeaturesNV::imageFootprint is not supported\n";
                 }
@@ -3034,8 +3034,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderInstrumentationFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderInstrumentationFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationFeaturesARM *>(current);
+                const VkPhysicalDeviceShaderInstrumentationFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationFeaturesARM*>(current);
                 if (enabling->shaderInstrumentation && !supported.shaderInstrumentation) {
                     ss << "VkPhysicalDeviceShaderInstrumentationFeaturesARM::shaderInstrumentation is not supported\n";
                 }
@@ -3045,8 +3045,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderIntegerDotProductFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderIntegerDotProductFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures *>(current);
+                const VkPhysicalDeviceShaderIntegerDotProductFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures*>(current);
                 if (enabling->shaderIntegerDotProduct && !supported.shaderIntegerDotProduct) {
                     ss << "VkPhysicalDeviceShaderIntegerDotProductFeatures::shaderIntegerDotProduct is not supported\n";
                 }
@@ -3056,8 +3056,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(current);
+                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(current);
                 if (enabling->shaderIntegerFunctions2 && !supported.shaderIntegerFunctions2) {
                     ss << "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::shaderIntegerFunctions2 is not supported\n";
                 }
@@ -3067,8 +3067,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderLongVectorFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderLongVectorFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderLongVectorFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderLongVectorFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderLongVectorFeaturesEXT*>(current);
                 if (enabling->longVector && !supported.longVector) {
                     ss << "VkPhysicalDeviceShaderLongVectorFeaturesEXT::longVector is not supported\n";
                 }
@@ -3078,8 +3078,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(current);
                 if (enabling->shaderMaximalReconvergence && !supported.shaderMaximalReconvergence) {
                     ss << "VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR::shaderMaximalReconvergence is not supported\n";
                 }
@@ -3089,8 +3089,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *>(current);
+                const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE*>(current);
                 if (enabling->shaderMixedFloatDotProductFloat16AccFloat32 &&
                     !supported.shaderMixedFloatDotProductFloat16AccFloat32) {
                     ss << "VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE::shaderMixedFloatDotProductFloat16AccFloat32 is "
@@ -3115,8 +3115,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(current);
                 if (enabling->shaderModuleIdentifier && !supported.shaderModuleIdentifier) {
                     ss << "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT::shaderModuleIdentifier is not supported\n";
                 }
@@ -3126,8 +3126,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderObjectFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderObjectFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderObjectFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT*>(current);
                 if (enabling->shaderObject && !supported.shaderObject) {
                     ss << "VkPhysicalDeviceShaderObjectFeaturesEXT::shaderObject is not supported\n";
                 }
@@ -3137,8 +3137,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderQuadControlFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderQuadControlFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderQuadControlFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(current);
                 if (enabling->shaderQuadControl && !supported.shaderQuadControl) {
                     ss << "VkPhysicalDeviceShaderQuadControlFeaturesKHR::shaderQuadControl is not supported\n";
                 }
@@ -3148,8 +3148,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(current);
                 if (enabling->shaderRelaxedExtendedInstruction && !supported.shaderRelaxedExtendedInstruction) {
                     ss << "VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR::shaderRelaxedExtendedInstruction is not "
                           "supported\n";
@@ -3160,8 +3160,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(current);
                 if (enabling->shaderReplicatedComposites && !supported.shaderReplicatedComposites) {
                     ss << "VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT::shaderReplicatedComposites is not supported\n";
                 }
@@ -3171,8 +3171,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSMBuiltinsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(current);
+                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(current);
                 if (enabling->shaderSMBuiltins && !supported.shaderSMBuiltins) {
                     ss << "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV::shaderSMBuiltins is not supported\n";
                 }
@@ -3182,8 +3182,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(current);
+                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(current);
                 if (enabling->shaderSubgroupExtendedTypes && !supported.shaderSubgroupExtendedTypes) {
                     ss << "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures::shaderSubgroupExtendedTypes is not supported\n";
                 }
@@ -3193,8 +3193,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT*>(current);
                 if (enabling->shaderSubgroupPartitioned && !supported.shaderSubgroupPartitioned) {
                     ss << "VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT::shaderSubgroupPartitioned is not supported\n";
                 }
@@ -3204,8 +3204,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSubgroupRotateFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSubgroupRotateFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures *>(current);
+                const VkPhysicalDeviceShaderSubgroupRotateFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures*>(current);
                 if (enabling->shaderSubgroupRotate && !supported.shaderSubgroupRotate) {
                     ss << "VkPhysicalDeviceShaderSubgroupRotateFeatures::shaderSubgroupRotate is not supported\n";
                 }
@@ -3218,8 +3218,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(current);
                 if (enabling->shaderSubgroupUniformControlFlow && !supported.shaderSubgroupUniformControlFlow) {
                     ss << "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR::shaderSubgroupUniformControlFlow is not "
                           "supported\n";
@@ -3230,8 +3230,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderTerminateInvocationFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderTerminateInvocationFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures *>(current);
+                const VkPhysicalDeviceShaderTerminateInvocationFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures*>(current);
                 if (enabling->shaderTerminateInvocation && !supported.shaderTerminateInvocation) {
                     ss << "VkPhysicalDeviceShaderTerminateInvocationFeatures::shaderTerminateInvocation is not supported\n";
                 }
@@ -3241,8 +3241,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderTileImageFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderTileImageFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderTileImageFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT*>(current);
                 if (enabling->shaderTileImageColorReadAccess && !supported.shaderTileImageColorReadAccess) {
                     ss << "VkPhysicalDeviceShaderTileImageFeaturesEXT::shaderTileImageColorReadAccess is not supported\n";
                 }
@@ -3258,8 +3258,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(current);
                 if (enabling->shaderUniformBufferUnsizedArray && !supported.shaderUniformBufferUnsizedArray) {
                     ss << "VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT::shaderUniformBufferUnsizedArray is not "
                           "supported\n";
@@ -3270,8 +3270,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderUntypedPointersFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(current);
                 if (enabling->shaderUntypedPointers && !supported.shaderUntypedPointers) {
                     ss << "VkPhysicalDeviceShaderUntypedPointersFeaturesKHR::shaderUntypedPointers is not supported\n";
                 }
@@ -3281,8 +3281,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShadingRateImageFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShadingRateImageFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV *>(current);
+                const VkPhysicalDeviceShadingRateImageFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(current);
                 if (enabling->shadingRateImage && !supported.shadingRateImage) {
                     ss << "VkPhysicalDeviceShadingRateImageFeaturesNV::shadingRateImage is not supported\n";
                 }
@@ -3295,8 +3295,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSubgroupSizeControlFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSubgroupSizeControlFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures *>(current);
+                const VkPhysicalDeviceSubgroupSizeControlFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(current);
                 if (enabling->subgroupSizeControl && !supported.subgroupSizeControl) {
                     ss << "VkPhysicalDeviceSubgroupSizeControlFeatures::subgroupSizeControl is not supported\n";
                 }
@@ -3309,8 +3309,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(current);
+                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(current);
                 if (enabling->subpassMergeFeedback && !supported.subpassMergeFeedback) {
                     ss << "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT::subpassMergeFeedback is not supported\n";
                 }
@@ -3320,8 +3320,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSubpassShadingFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(current);
                 if (enabling->subpassShading && !supported.subpassShading) {
                     ss << "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI::subpassShading is not supported\n";
                 }
@@ -3331,8 +3331,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(current);
+                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(current);
                 if (enabling->swapchainMaintenance1 && !supported.swapchainMaintenance1) {
                     ss << "VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR::swapchainMaintenance1 is not supported\n";
                 }
@@ -3342,8 +3342,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSynchronization2Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSynchronization2Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features *>(current);
+                const VkPhysicalDeviceSynchronization2Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(current);
                 if (enabling->synchronization2 && !supported.synchronization2) {
                     ss << "VkPhysicalDeviceSynchronization2Features::synchronization2 is not supported\n";
                 }
@@ -3353,8 +3353,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTensorFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTensorFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM *>(current);
+                const VkPhysicalDeviceTensorFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM*>(current);
                 if (enabling->tensorNonPacked && !supported.tensorNonPacked) {
                     ss << "VkPhysicalDeviceTensorFeaturesARM::tensorNonPacked is not supported\n";
                 }
@@ -3380,8 +3380,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(current);
+                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(current);
                 if (enabling->texelBufferAlignment && !supported.texelBufferAlignment) {
                     ss << "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT::texelBufferAlignment is not supported\n";
                 }
@@ -3391,8 +3391,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT *>(current);
+                const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT*>(current);
                 if (enabling->textureCompressionASTC_3D && !supported.textureCompressionASTC_3D) {
                     ss << "VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT::textureCompressionASTC_3D is not supported\n";
                 }
@@ -3402,8 +3402,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTextureCompressionASTCHDRFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(current);
+                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(current);
                 if (enabling->textureCompressionASTC_HDR && !supported.textureCompressionASTC_HDR) {
                     ss << "VkPhysicalDeviceTextureCompressionASTCHDRFeatures::textureCompressionASTC_HDR is not supported\n";
                 }
@@ -3413,8 +3413,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTileMemoryHeapFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(current);
+                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(current);
                 if (enabling->tileMemoryHeap && !supported.tileMemoryHeap) {
                     ss << "VkPhysicalDeviceTileMemoryHeapFeaturesQCOM::tileMemoryHeap is not supported\n";
                 }
@@ -3424,8 +3424,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTilePropertiesFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTilePropertiesFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(current);
+                const VkPhysicalDeviceTilePropertiesFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(current);
                 if (enabling->tileProperties && !supported.tileProperties) {
                     ss << "VkPhysicalDeviceTilePropertiesFeaturesQCOM::tileProperties is not supported\n";
                 }
@@ -3435,8 +3435,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTileShadingFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTileShadingFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM *>(current);
+                const VkPhysicalDeviceTileShadingFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM*>(current);
                 if (enabling->tileShading && !supported.tileShading) {
                     ss << "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShading is not supported\n";
                 }
@@ -3485,8 +3485,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTimelineSemaphoreFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTimelineSemaphoreFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures *>(current);
+                const VkPhysicalDeviceTimelineSemaphoreFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(current);
                 if (enabling->timelineSemaphore && !supported.timelineSemaphore) {
                     ss << "VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore is not supported\n";
                 }
@@ -3496,8 +3496,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTransformFeedbackFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTransformFeedbackFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(current);
+                const VkPhysicalDeviceTransformFeedbackFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(current);
                 if (enabling->transformFeedback && !supported.transformFeedback) {
                     ss << "VkPhysicalDeviceTransformFeedbackFeaturesEXT::transformFeedback is not supported\n";
                 }
@@ -3510,8 +3510,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(current);
+                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(current);
                 if (enabling->unifiedImageLayouts && !supported.unifiedImageLayouts) {
                     ss << "VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR::unifiedImageLayouts is not supported\n";
                 }
@@ -3524,8 +3524,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceUniformBufferStandardLayoutFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(current);
+                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(current);
                 if (enabling->uniformBufferStandardLayout && !supported.uniformBufferStandardLayout) {
                     ss << "VkPhysicalDeviceUniformBufferStandardLayoutFeatures::uniformBufferStandardLayout is not supported\n";
                 }
@@ -3535,8 +3535,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVariablePointersFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVariablePointersFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures *>(current);
+                const VkPhysicalDeviceVariablePointersFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(current);
                 if (enabling->variablePointersStorageBuffer && !supported.variablePointersStorageBuffer) {
                     ss << "VkPhysicalDeviceVariablePointersFeatures::variablePointersStorageBuffer is not supported\n";
                 }
@@ -3549,8 +3549,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVertexAttributeDivisorFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVertexAttributeDivisorFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures *>(current);
+                const VkPhysicalDeviceVertexAttributeDivisorFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures*>(current);
                 if (enabling->vertexAttributeInstanceRateDivisor && !supported.vertexAttributeInstanceRateDivisor) {
                     ss << "VkPhysicalDeviceVertexAttributeDivisorFeatures::vertexAttributeInstanceRateDivisor is not supported\n";
                 }
@@ -3564,8 +3564,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(current);
+                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(current);
                 if (enabling->vertexAttributeRobustness && !supported.vertexAttributeRobustness) {
                     ss << "VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT::vertexAttributeRobustness is not supported\n";
                 }
@@ -3575,8 +3575,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(current);
+                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(current);
                 if (enabling->vertexInputDynamicState && !supported.vertexInputDynamicState) {
                     ss << "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT::vertexInputDynamicState is not supported\n";
                 }
@@ -3586,8 +3586,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoDecodeVP9FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(current);
                 if (enabling->videoDecodeVP9 && !supported.videoDecodeVP9) {
                     ss << "VkPhysicalDeviceVideoDecodeVP9FeaturesKHR::videoDecodeVP9 is not supported\n";
                 }
@@ -3597,8 +3597,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeAV1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(current);
                 if (enabling->videoEncodeAV1 && !supported.videoEncodeAV1) {
                     ss << "VkPhysicalDeviceVideoEncodeAV1FeaturesKHR::videoEncodeAV1 is not supported\n";
                 }
@@ -3608,8 +3608,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(current);
                 if (enabling->videoEncodeIntraRefresh && !supported.videoEncodeIntraRefresh) {
                     ss << "VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR::videoEncodeIntraRefresh is not supported\n";
                 }
@@ -3619,8 +3619,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(current);
                 if (enabling->videoEncodeQuantizationMap && !supported.videoEncodeQuantizationMap) {
                     ss << "VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR::videoEncodeQuantizationMap is not supported\n";
                 }
@@ -3630,8 +3630,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(current);
+                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(current);
                 if (enabling->videoEncodeRgbConversion && !supported.videoEncodeRgbConversion) {
                     ss << "VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE::videoEncodeRgbConversion is not supported\n";
                 }
@@ -3641,8 +3641,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoMaintenance1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(current);
                 if (enabling->videoMaintenance1 && !supported.videoMaintenance1) {
                     ss << "VkPhysicalDeviceVideoMaintenance1FeaturesKHR::videoMaintenance1 is not supported\n";
                 }
@@ -3652,8 +3652,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoMaintenance2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(current);
                 if (enabling->videoMaintenance2 && !supported.videoMaintenance2) {
                     ss << "VkPhysicalDeviceVideoMaintenance2FeaturesKHR::videoMaintenance2 is not supported\n";
                 }
@@ -3663,8 +3663,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan11Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan11Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan11Features *>(current);
+                const VkPhysicalDeviceVulkan11Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(current);
                 if (enabling->storageBuffer16BitAccess && !supported.storageBuffer16BitAccess) {
                     ss << "VkPhysicalDeviceVulkan11Features::storageBuffer16BitAccess is not supported\n";
                 }
@@ -3707,8 +3707,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan12Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan12Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan12Features *>(current);
+                const VkPhysicalDeviceVulkan12Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(current);
                 if (enabling->samplerMirrorClampToEdge && !supported.samplerMirrorClampToEdge) {
                     ss << "VkPhysicalDeviceVulkan12Features::samplerMirrorClampToEdge is not supported\n";
                 }
@@ -3868,8 +3868,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan13Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan13Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan13Features *>(current);
+                const VkPhysicalDeviceVulkan13Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan13Features*>(current);
                 if (enabling->robustImageAccess && !supported.robustImageAccess) {
                     ss << "VkPhysicalDeviceVulkan13Features::robustImageAccess is not supported\n";
                 }
@@ -3922,8 +3922,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan14Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan14Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan14Features *>(current);
+                const VkPhysicalDeviceVulkan14Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan14Features*>(current);
                 if (enabling->globalPriorityQuery && !supported.globalPriorityQuery) {
                     ss << "VkPhysicalDeviceVulkan14Features::globalPriorityQuery is not supported\n";
                 }
@@ -3993,8 +3993,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkanMemoryModelFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkanMemoryModelFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures *>(current);
+                const VkPhysicalDeviceVulkanMemoryModelFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(current);
                 if (enabling->vulkanMemoryModel && !supported.vulkanMemoryModel) {
                     ss << "VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModel is not supported\n";
                 }
@@ -4012,8 +4012,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(current);
+                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(current);
                 if (enabling->workgroupMemoryExplicitLayout && !supported.workgroupMemoryExplicitLayout) {
                     ss << "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::workgroupMemoryExplicitLayout is not "
                           "supported\n";
@@ -4037,8 +4037,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(current);
+                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(current);
                 if (enabling->ycbcr2plane444Formats && !supported.ycbcr2plane444Formats) {
                     ss << "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT::ycbcr2plane444Formats is not supported\n";
                 }
@@ -4048,8 +4048,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceYcbcrDegammaFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(current);
+                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(current);
                 if (enabling->ycbcrDegamma && !supported.ycbcrDegamma) {
                     ss << "VkPhysicalDeviceYcbcrDegammaFeaturesQCOM::ycbcrDegamma is not supported\n";
                 }
@@ -4059,8 +4059,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceYcbcrImageArraysFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(current);
+                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(current);
                 if (enabling->ycbcrImageArrays && !supported.ycbcrImageArrays) {
                     ss << "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT::ycbcrImageArrays is not supported\n";
                 }
@@ -4070,8 +4070,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(current);
+                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(current);
                 if (enabling->zeroInitializeDeviceMemory && !supported.zeroInitializeDeviceMemory) {
                     ss << "VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT::zeroInitializeDeviceMemory is not supported\n";
                 }
@@ -4081,8 +4081,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(current);
+                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(current);
                 if (enabling->shaderZeroInitializeWorkgroupMemory && !supported.shaderZeroInitializeWorkgroupMemory) {
                     ss << "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures::shaderZeroInitializeWorkgroupMemory is not "
                           "supported\n";

--- a/layers/vulkan/generated/feature_requirements_helper.cpp
+++ b/layers/vulkan/generated/feature_requirements_helper.cpp
@@ -29,11 +29,11 @@
 #include <vulkan/utility/vk_struct_helper.hpp>
 
 namespace vkt {
-FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain) {
+FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void** inout_pnext_chain) {
     switch (feature) {
         case Feature::storageBuffer16BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -46,7 +46,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storageBuffer16BitAccess, "VkPhysicalDeviceVulkan11Features::storageBuffer16BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -61,7 +61,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::storageInputOutput16:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -74,7 +74,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storageInputOutput16, "VkPhysicalDeviceVulkan11Features::storageInputOutput16"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -89,7 +89,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::storagePushConstant16:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -102,7 +102,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storagePushConstant16, "VkPhysicalDeviceVulkan11Features::storagePushConstant16"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -117,7 +117,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::uniformAndStorageBuffer16BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -131,7 +131,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->uniformAndStorageBuffer16BitAccess,
                         "VkPhysicalDeviceVulkan11Features::uniformAndStorageBuffer16BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -146,7 +146,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDevice16BitStorageFeatures::uniformAndStorageBuffer16BitAccess"};
             }
         case Feature::formatA4B4G4R4: {
-            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevice4444FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevice4444FormatsFeaturesEXT;
@@ -161,7 +161,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::formatA4R4G4B4: {
-            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevice4444FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevice4444FormatsFeaturesEXT;
@@ -177,7 +177,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::storageBuffer8BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -190,7 +190,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storageBuffer8BitAccess, "VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice8BitStorageFeatures;
@@ -205,7 +205,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::storagePushConstant8:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -218,7 +218,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storagePushConstant8, "VkPhysicalDeviceVulkan12Features::storagePushConstant8"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice8BitStorageFeatures;
@@ -233,7 +233,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::uniformAndStorageBuffer8BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -247,7 +247,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->uniformAndStorageBuffer8BitAccess,
                         "VkPhysicalDeviceVulkan12Features::uniformAndStorageBuffer8BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice8BitStorageFeatures;
@@ -262,7 +262,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDevice8BitStorageFeatures::uniformAndStorageBuffer8BitAccess"};
             }
         case Feature::decodeModeSharedExponent: {
-            auto vk_struct = const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceASTCDecodeFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceASTCDecodeFeaturesEXT;
@@ -277,7 +277,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructure: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -292,7 +292,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructureCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -308,7 +308,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructureHostCommands: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -324,7 +324,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructureIndirectBuild: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -340,7 +340,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBindingAccelerationStructureUpdateAfterBind: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -356,7 +356,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::reportAddressBinding: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAddressBindingReportFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAddressBindingReportFeaturesEXT;
@@ -371,7 +371,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::amigoProfiling: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAmigoProfilingFeaturesSEC>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAmigoProfilingFeaturesSEC;
@@ -386,7 +386,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::antiLag: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAntiLagFeaturesAMD *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAntiLagFeaturesAMD*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAntiLagFeaturesAMD>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAntiLagFeaturesAMD;
@@ -401,7 +401,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::attachmentFeedbackLoopDynamicState: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT;
@@ -417,7 +417,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::attachmentFeedbackLoopLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT;
@@ -433,7 +433,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::advancedBlendCoherentOperations: {
-            auto vk_struct = const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT;
@@ -449,7 +449,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::borderColorSwizzle: {
-            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceBorderColorSwizzleFeaturesEXT;
@@ -464,7 +464,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::borderColorSwizzleFromImage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceBorderColorSwizzleFeaturesEXT;
@@ -481,7 +481,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::bufferDeviceAddress:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -494,7 +494,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->bufferDeviceAddress, "VkPhysicalDeviceVulkan12Features::bufferDeviceAddress"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
@@ -509,7 +509,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::bufferDeviceAddressCaptureReplay:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -523,7 +523,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->bufferDeviceAddressCaptureReplay,
                         "VkPhysicalDeviceVulkan12Features::bufferDeviceAddressCaptureReplay"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
@@ -539,7 +539,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::bufferDeviceAddressMultiDevice:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -553,7 +553,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->bufferDeviceAddressMultiDevice,
                         "VkPhysicalDeviceVulkan12Features::bufferDeviceAddressMultiDevice"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
@@ -568,7 +568,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressMultiDevice"};
             }
         case Feature::clusterAccelerationStructure: {
-            auto vk_struct = const_cast<VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceClusterAccelerationStructureFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceClusterAccelerationStructureFeaturesNV;
@@ -584,7 +584,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::clustercullingShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI;
@@ -599,7 +599,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiviewClusterCullingShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI;
@@ -615,7 +615,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceCoherentMemory: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCoherentMemoryFeaturesAMD>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCoherentMemoryFeaturesAMD;
@@ -630,7 +630,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::colorWriteEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceColorWriteEnableFeaturesEXT;
@@ -645,7 +645,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::commandBufferInheritance: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCommandBufferInheritanceFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCommandBufferInheritanceFeaturesNV;
@@ -661,7 +661,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::computeOccupancyPriority: {
-            auto vk_struct = const_cast<VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV;
@@ -677,7 +677,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::computeDerivativeGroupLinear: {
-            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR;
@@ -693,7 +693,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::computeDerivativeGroupQuads: {
-            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR;
@@ -709,7 +709,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::conditionalRendering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceConditionalRenderingFeaturesEXT;
@@ -724,7 +724,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::inheritedConditionalRendering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceConditionalRenderingFeaturesEXT;
@@ -740,7 +740,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixBlockLoads: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -756,7 +756,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixConversions: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -772,7 +772,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixFlexibleDimensions: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -788,7 +788,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixPerElementOperations: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -804,7 +804,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixReductions: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -820,7 +820,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixTensorAddressing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -836,7 +836,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixWorkgroupScope: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -852,7 +852,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixConversion: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM;
@@ -868,7 +868,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrix: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrixFeaturesKHR;
@@ -883,7 +883,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixRobustBufferAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrixFeaturesKHR;
@@ -899,7 +899,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeVector: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeVectorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeVectorFeaturesNV;
@@ -914,7 +914,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeVectorTraining: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeVectorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeVectorFeaturesNV;
@@ -930,7 +930,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::indirectMemoryCopy: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR;
@@ -945,7 +945,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::indirectMemoryToImageCopy: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR;
@@ -961,7 +961,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::indirectCopy: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCopyMemoryIndirectFeaturesNV;
@@ -976,7 +976,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cornerSampledImage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCornerSampledImageFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCornerSampledImageFeaturesNV;
@@ -991,7 +991,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::coverageReductionMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCoverageReductionModeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCoverageReductionModeFeaturesNV;
@@ -1006,7 +1006,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cubicRangeClamp: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCubicClampFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCubicClampFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCubicClampFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCubicClampFeaturesQCOM;
@@ -1021,7 +1021,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::selectableCubicWeights: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCubicWeightsFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCubicWeightsFeaturesQCOM;
@@ -1037,7 +1037,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::cudaKernelLaunchFeatures: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCudaKernelLaunchFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCudaKernelLaunchFeaturesNV;
@@ -1053,7 +1053,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::customBorderColorWithoutFormat: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCustomBorderColorFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCustomBorderColorFeaturesEXT;
@@ -1069,7 +1069,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::customBorderColors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCustomBorderColorFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCustomBorderColorFeaturesEXT;
@@ -1084,7 +1084,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::customResolve: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCustomResolveFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomResolveFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCustomResolveFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCustomResolveFeaturesEXT;
@@ -1099,7 +1099,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraph: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1114,7 +1114,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphDescriptorBuffer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1129,7 +1129,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphShaderModule: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1144,7 +1144,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphSpecializationConstants: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1160,7 +1160,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphUpdateAfterBind: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1175,7 +1175,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphModel: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphModelFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphModelFeaturesQCOM;
@@ -1190,7 +1190,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dedicatedAllocationImageAliasing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV;
@@ -1207,7 +1207,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::denseGeometryFormat: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX;
@@ -1223,7 +1223,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::depthBiasControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1238,7 +1238,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthBiasExact: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1253,7 +1253,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::floatRepresentation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1268,7 +1268,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::leastRepresentableValueForceUnormRepresentation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1284,7 +1284,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClampControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClampControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClampControlFeaturesEXT;
@@ -1299,7 +1299,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClampZeroOne: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClampZeroOneFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClampZeroOneFeaturesKHR;
@@ -1314,7 +1314,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClipControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClipControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClipControlFeaturesEXT;
@@ -1329,7 +1329,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClipEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClipEnableFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClipEnableFeaturesEXT;
@@ -1344,7 +1344,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBuffer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1359,7 +1359,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1375,7 +1375,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferImageLayoutIgnored: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1391,7 +1391,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferPushDescriptors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1407,7 +1407,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferTensorDescriptors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferTensorFeaturesARM;
@@ -1423,7 +1423,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorHeap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorHeapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorHeapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorHeapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorHeapFeaturesEXT;
@@ -1438,7 +1438,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorHeapCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorHeapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorHeapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorHeapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorHeapFeaturesEXT;
@@ -1455,7 +1455,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::descriptorBindingPartiallyBound:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1469,7 +1469,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingPartiallyBound,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingPartiallyBound"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1485,7 +1485,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingSampledImageUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1499,7 +1499,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingSampledImageUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingSampledImageUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1515,7 +1515,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingStorageBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1529,7 +1529,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingStorageBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1545,7 +1545,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingStorageImageUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1559,7 +1559,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingStorageImageUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageImageUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1575,7 +1575,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingStorageTexelBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1589,7 +1589,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingStorageTexelBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageTexelBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1605,7 +1605,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingUniformBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1619,7 +1619,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingUniformBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingUniformBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1635,7 +1635,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingUniformTexelBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1649,7 +1649,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingUniformTexelBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingUniformTexelBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1665,7 +1665,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingUpdateUnusedWhilePending:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1679,7 +1679,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingUpdateUnusedWhilePending,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingUpdateUnusedWhilePending"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1695,7 +1695,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingVariableDescriptorCount:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1709,7 +1709,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingVariableDescriptorCount,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingVariableDescriptorCount"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1725,7 +1725,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::runtimeDescriptorArray:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1738,7 +1738,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->runtimeDescriptorArray, "VkPhysicalDeviceVulkan12Features::runtimeDescriptorArray"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1753,7 +1753,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderInputAttachmentArrayDynamicIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1767,7 +1767,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderInputAttachmentArrayDynamicIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayDynamicIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1783,7 +1783,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderInputAttachmentArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1797,7 +1797,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderInputAttachmentArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1813,7 +1813,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderSampledImageArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1827,7 +1827,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderSampledImageArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderSampledImageArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1843,7 +1843,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1857,7 +1857,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1873,7 +1873,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageImageArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1887,7 +1887,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageImageArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageImageArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1903,7 +1903,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageTexelBufferArrayDynamicIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1917,7 +1917,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageTexelBufferArrayDynamicIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayDynamicIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1933,7 +1933,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageTexelBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1947,7 +1947,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageTexelBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1963,7 +1963,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderUniformBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1977,7 +1977,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderUniformBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderUniformBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1993,7 +1993,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderUniformTexelBufferArrayDynamicIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -2007,7 +2007,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderUniformTexelBufferArrayDynamicIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayDynamicIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -2023,7 +2023,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderUniformTexelBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -2037,7 +2037,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderUniformTexelBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -2052,7 +2052,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceDescriptorIndexingFeatures::shaderUniformTexelBufferArrayNonUniformIndexing"};
             }
         case Feature::descriptorPoolOverallocation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV;
@@ -2068,7 +2068,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorSetHostMapping: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE;
@@ -2084,7 +2084,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceAddressCommands: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR;
@@ -2099,7 +2099,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedCompute: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
@@ -2115,7 +2115,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedComputeCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
@@ -2131,7 +2131,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedComputePipelines: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
@@ -2147,7 +2147,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedCommands: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT;
@@ -2163,7 +2163,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dynamicGeneratedPipelineLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT;
@@ -2179,7 +2179,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceMemoryReport: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceMemoryReportFeaturesEXT;
@@ -2194,7 +2194,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::diagnosticsConfig: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDiagnosticsConfigFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDiagnosticsConfigFeaturesNV;
@@ -2210,7 +2210,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::displacementMicromap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDisplacementMicromapFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDisplacementMicromapFeaturesNV;
@@ -2227,7 +2227,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::dynamicRendering:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -2240,7 +2240,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->dynamicRendering, "VkPhysicalDeviceVulkan13Features::dynamicRendering"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDynamicRenderingFeatures;
@@ -2255,7 +2255,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::dynamicRenderingLocalRead:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -2268,7 +2268,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->dynamicRenderingLocalRead, "VkPhysicalDeviceVulkan14Features::dynamicRenderingLocalRead"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingLocalReadFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDynamicRenderingLocalReadFeatures;
@@ -2283,7 +2283,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceDynamicRenderingLocalReadFeatures::dynamicRenderingLocalRead"};
             }
         case Feature::dynamicRenderingUnusedAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT;
@@ -2299,7 +2299,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::exclusiveScissor: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExclusiveScissorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExclusiveScissorFeaturesNV;
@@ -2314,7 +2314,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
@@ -2329,7 +2329,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState2LogicOp: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
@@ -2345,7 +2345,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState2PatchControlPoints: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
@@ -2361,7 +2361,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3AlphaToCoverageEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2377,7 +2377,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3AlphaToOneEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2393,7 +2393,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorBlendAdvanced: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2409,7 +2409,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorBlendEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2425,7 +2425,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorBlendEquation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2441,7 +2441,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorWriteMask: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2457,7 +2457,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ConservativeRasterizationMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2473,7 +2473,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageModulationMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2489,7 +2489,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageModulationTable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2505,7 +2505,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageModulationTableEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2521,7 +2521,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageReductionMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2537,7 +2537,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageToColorEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2553,7 +2553,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageToColorLocation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2569,7 +2569,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3DepthClampEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2585,7 +2585,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3DepthClipEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2601,7 +2601,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3DepthClipNegativeOneToOne: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2617,7 +2617,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ExtraPrimitiveOverestimationSize: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2633,7 +2633,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3LineRasterizationMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2649,7 +2649,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3LineStippleEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2665,7 +2665,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3LogicOpEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2681,7 +2681,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3PolygonMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2697,7 +2697,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ProvokingVertexMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2713,7 +2713,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3RasterizationSamples: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2729,7 +2729,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3RasterizationStream: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2745,7 +2745,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3RepresentativeFragmentTestEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2761,7 +2761,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3SampleLocationsEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2777,7 +2777,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3SampleMask: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2793,7 +2793,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ShadingRateImageEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2809,7 +2809,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3TessellationDomainOrigin: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2825,7 +2825,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ViewportSwizzle: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2841,7 +2841,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ViewportWScalingEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2857,7 +2857,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicStateFeaturesEXT;
@@ -2872,7 +2872,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedSparseAddressSpace: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV;
@@ -2889,7 +2889,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 
         case Feature::externalFormatResolve: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExternalFormatResolveFeaturesANDROID;
@@ -2906,7 +2906,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
         case Feature::externalMemoryRDMA: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExternalMemoryRDMAFeaturesNV;
@@ -2922,7 +2922,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
 
         case Feature::screenBufferImport: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX;
@@ -2938,7 +2938,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
         case Feature::deviceFault: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFaultFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFaultFeaturesEXT;
@@ -2953,7 +2953,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceFaultVendorBinary: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFaultFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFaultFeaturesEXT;
@@ -2968,7 +2968,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::formatPack: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFormatPackFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFormatPackFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFormatPackFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFormatPackFeaturesARM;
@@ -2983,7 +2983,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapDeferred: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMap2FeaturesEXT;
@@ -2999,7 +2999,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
@@ -3014,7 +3014,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapDynamic: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
@@ -3030,7 +3030,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapNonSubsampledImages: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
@@ -3046,7 +3046,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapLayered: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE;
@@ -3062,7 +3062,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapOffset: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT;
@@ -3078,7 +3078,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderBarycentric: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR;
@@ -3094,7 +3094,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderPixelInterlock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
@@ -3110,7 +3110,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderSampleInterlock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
@@ -3126,7 +3126,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderShadingRateInterlock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
@@ -3142,7 +3142,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShadingRateEnums: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
@@ -3158,7 +3158,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::noInvocationFragmentShadingRates: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
@@ -3174,7 +3174,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::supersampleFragmentShadingRates: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
@@ -3190,7 +3190,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::attachmentFragmentShadingRate: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
@@ -3206,7 +3206,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineFragmentShadingRate: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
@@ -3222,7 +3222,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveFragmentShadingRate: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
@@ -3238,7 +3238,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::frameBoundary: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFrameBoundaryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFrameBoundaryFeaturesEXT;
@@ -3254,7 +3254,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::globalPriorityQuery:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3267,7 +3267,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->globalPriorityQuery, "VkPhysicalDeviceVulkan14Features::globalPriorityQuery"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceGlobalPriorityQueryFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceGlobalPriorityQueryFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceGlobalPriorityQueryFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceGlobalPriorityQueryFeatures;
@@ -3281,7 +3281,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->globalPriorityQuery, "VkPhysicalDeviceGlobalPriorityQueryFeatures::globalPriorityQuery"};
             }
         case Feature::graphicsPipelineLibrary: {
-            auto vk_struct = const_cast<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT;
@@ -3297,7 +3297,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::hdrVivid: {
-            auto vk_struct = const_cast<VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceHdrVividFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceHdrVividFeaturesHUAWEI;
@@ -3313,7 +3313,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::hostImageCopy:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3326,7 +3326,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->hostImageCopy, "VkPhysicalDeviceVulkan14Features::hostImageCopy"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceHostImageCopyFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceHostImageCopyFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceHostImageCopyFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceHostImageCopyFeatures;
@@ -3341,7 +3341,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::hostQueryReset:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -3354,7 +3354,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->hostQueryReset, "VkPhysicalDeviceVulkan12Features::hostQueryReset"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceHostQueryResetFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceHostQueryResetFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceHostQueryResetFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceHostQueryResetFeatures;
@@ -3368,7 +3368,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->hostQueryReset, "VkPhysicalDeviceHostQueryResetFeatures::hostQueryReset"};
             }
         case Feature::image2DViewOf3D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImage2DViewOf3DFeaturesEXT;
@@ -3383,7 +3383,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sampler2DViewOf3D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImage2DViewOf3DFeaturesEXT;
@@ -3398,7 +3398,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageAlignmentControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageAlignmentControlFeaturesMESA>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageAlignmentControlFeaturesMESA;
@@ -3413,7 +3413,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageCompressionControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageCompressionControlFeaturesEXT;
@@ -3429,7 +3429,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageCompressionControlSwapchain: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT;
@@ -3445,7 +3445,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureBlockMatch2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessing2FeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessing2FeaturesQCOM;
@@ -3460,7 +3460,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureBlockMatch: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
@@ -3475,7 +3475,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureBoxFilter: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
@@ -3490,7 +3490,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureSampleWeighted: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
@@ -3506,7 +3506,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::robustImageAccess:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3519,7 +3519,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->robustImageAccess, "VkPhysicalDeviceVulkan13Features::robustImageAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceImageRobustnessFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceImageRobustnessFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceImageRobustnessFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceImageRobustnessFeatures;
@@ -3533,7 +3533,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->robustImageAccess, "VkPhysicalDeviceImageRobustnessFeatures::robustImageAccess"};
             }
         case Feature::imageSlicedViewOf3D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT;
@@ -3548,7 +3548,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::minLod: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageViewMinLodFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageViewMinLodFeaturesEXT;
@@ -3564,7 +3564,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::imagelessFramebuffer:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -3577,7 +3577,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->imagelessFramebuffer, "VkPhysicalDeviceVulkan12Features::imagelessFramebuffer"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceImagelessFramebufferFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceImagelessFramebufferFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceImagelessFramebufferFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceImagelessFramebufferFeatures;
@@ -3592,7 +3592,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::indexTypeUint8:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3605,7 +3605,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->indexTypeUint8, "VkPhysicalDeviceVulkan14Features::indexTypeUint8"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceIndexTypeUint8Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceIndexTypeUint8Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceIndexTypeUint8Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceIndexTypeUint8Features;
@@ -3619,7 +3619,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->indexTypeUint8, "VkPhysicalDeviceIndexTypeUint8Features::indexTypeUint8"};
             }
         case Feature::inheritedViewportScissor2D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceInheritedViewportScissorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceInheritedViewportScissorFeaturesNV;
@@ -3636,7 +3636,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::descriptorBindingInlineUniformBlockUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3650,7 +3650,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingInlineUniformBlockUpdateAfterBind,
                         "VkPhysicalDeviceVulkan13Features::descriptorBindingInlineUniformBlockUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceInlineUniformBlockFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceInlineUniformBlockFeatures;
@@ -3666,7 +3666,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::inlineUniformBlock:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3679,7 +3679,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->inlineUniformBlock, "VkPhysicalDeviceVulkan13Features::inlineUniformBlock"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceInlineUniformBlockFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceInlineUniformBlockFeatures;
@@ -3693,7 +3693,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->inlineUniformBlock, "VkPhysicalDeviceInlineUniformBlockFeatures::inlineUniformBlock"};
             }
         case Feature::internallySynchronizedQueues: {
-            auto vk_struct = const_cast<VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR;
@@ -3709,7 +3709,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::invocationMask: {
-            auto vk_struct = const_cast<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceInvocationMaskFeaturesHUAWEI;
@@ -3724,7 +3724,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::legacyDithering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceLegacyDitheringFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceLegacyDitheringFeaturesEXT;
@@ -3739,7 +3739,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::legacyVertexAttributes: {
-            auto vk_struct = const_cast<VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT;
@@ -3756,7 +3756,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::bresenhamLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3769,7 +3769,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->bresenhamLines, "VkPhysicalDeviceVulkan14Features::bresenhamLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3784,7 +3784,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::rectangularLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3797,7 +3797,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->rectangularLines, "VkPhysicalDeviceVulkan14Features::rectangularLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3812,7 +3812,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::smoothLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3825,7 +3825,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->smoothLines, "VkPhysicalDeviceVulkan14Features::smoothLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3840,7 +3840,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::stippledBresenhamLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3853,7 +3853,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->stippledBresenhamLines, "VkPhysicalDeviceVulkan14Features::stippledBresenhamLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3868,7 +3868,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::stippledRectangularLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3881,7 +3881,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->stippledRectangularLines, "VkPhysicalDeviceVulkan14Features::stippledRectangularLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3897,7 +3897,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::stippledSmoothLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3910,7 +3910,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->stippledSmoothLines, "VkPhysicalDeviceVulkan14Features::stippledSmoothLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3924,7 +3924,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->stippledSmoothLines, "VkPhysicalDeviceLineRasterizationFeatures::stippledSmoothLines"};
             }
         case Feature::linearColorAttachment: {
-            auto vk_struct = const_cast<VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceLinearColorAttachmentFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceLinearColorAttachmentFeaturesNV;
@@ -3939,7 +3939,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::maintenance10: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance10FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance10FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance10FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance10FeaturesKHR;
@@ -3955,7 +3955,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::maintenance4:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3968,7 +3968,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->maintenance4, "VkPhysicalDeviceVulkan13Features::maintenance4"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance4Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance4Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance4Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMaintenance4Features;
@@ -3983,7 +3983,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::maintenance5:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3996,7 +3996,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->maintenance5, "VkPhysicalDeviceVulkan14Features::maintenance5"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance5Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance5Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance5Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMaintenance5Features;
@@ -4011,7 +4011,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::maintenance6:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -4024,7 +4024,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->maintenance6, "VkPhysicalDeviceVulkan14Features::maintenance6"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance6Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance6Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance6Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMaintenance6Features;
@@ -4038,7 +4038,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->maintenance6, "VkPhysicalDeviceMaintenance6Features::maintenance6"};
             }
         case Feature::maintenance7: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance7FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance7FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance7FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance7FeaturesKHR;
@@ -4053,7 +4053,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::maintenance8: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance8FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance8FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance8FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance8FeaturesKHR;
@@ -4068,7 +4068,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::maintenance9: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance9FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance9FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance9FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance9FeaturesKHR;
@@ -4083,7 +4083,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryMapPlaced: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMapMemoryPlacedFeaturesEXT;
@@ -4098,7 +4098,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryMapRangePlaced: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMapMemoryPlacedFeaturesEXT;
@@ -4113,7 +4113,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryUnmapReserve: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMapMemoryPlacedFeaturesEXT;
@@ -4128,7 +4128,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryDecompression: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMemoryDecompressionFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMemoryDecompressionFeaturesEXT;
@@ -4143,7 +4143,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryPriority: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMemoryPriorityFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMemoryPriorityFeaturesEXT;
@@ -4158,7 +4158,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::meshShaderQueries: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4173,7 +4173,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiviewMeshShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4188,7 +4188,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveFragmentShadingRateMeshShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4204,7 +4204,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::meshShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4219,7 +4219,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::taskShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4234,7 +4234,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiDraw: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultiDrawFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiDrawFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultiDrawFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultiDrawFeaturesEXT;
@@ -4249,7 +4249,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multisampledRenderToSingleSampled: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT;
@@ -4266,7 +4266,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::multiview:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -4279,7 +4279,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->multiview, "VkPhysicalDeviceVulkan11Features::multiview"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMultiviewFeatures;
@@ -4294,7 +4294,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::multiviewGeometryShader:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -4307,7 +4307,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->multiviewGeometryShader, "VkPhysicalDeviceVulkan11Features::multiviewGeometryShader"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMultiviewFeatures;
@@ -4322,7 +4322,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::multiviewTessellationShader:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -4335,7 +4335,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->multiviewTessellationShader, "VkPhysicalDeviceVulkan11Features::multiviewTessellationShader"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMultiviewFeatures;
@@ -4349,7 +4349,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->multiviewTessellationShader, "VkPhysicalDeviceMultiviewFeatures::multiviewTessellationShader"};
             }
         case Feature::multiviewPerViewRenderAreas: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM;
@@ -4365,7 +4365,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiviewPerViewViewports: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM;
@@ -4381,7 +4381,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::mutableDescriptorType: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT;
@@ -4396,7 +4396,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nestedCommandBuffer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
@@ -4411,7 +4411,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nestedCommandBufferRendering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
@@ -4427,7 +4427,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nestedCommandBufferSimultaneousUse: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
@@ -4443,7 +4443,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nonSeamlessCubeMap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT;
@@ -4458,7 +4458,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::micromap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
@@ -4473,7 +4473,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::micromapCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
@@ -4488,7 +4488,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::micromapHostCommands: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
@@ -4503,7 +4503,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::opticalFlow: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpticalFlowFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpticalFlowFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpticalFlowFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpticalFlowFeaturesNV;
@@ -4518,7 +4518,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pageableDeviceLocalMemory: {
-            auto vk_struct = const_cast<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT;
@@ -4534,7 +4534,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::partitionedAccelerationStructure: {
-            auto vk_struct = const_cast<VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV;
@@ -4550,7 +4550,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dynamicPipelineLayout: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerStageDescriptorSetFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerStageDescriptorSetFeaturesNV;
@@ -4565,7 +4565,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::perStageDescriptorSet: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerStageDescriptorSetFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerStageDescriptorSetFeaturesNV;
@@ -4580,7 +4580,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::performanceCountersByRegion: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerformanceCountersByRegionFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerformanceCountersByRegionFeaturesARM;
@@ -4596,7 +4596,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::performanceCounterMultipleQueryPools: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerformanceQueryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerformanceQueryFeaturesKHR;
@@ -4612,7 +4612,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::performanceCounterQueryPools: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerformanceQueryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerformanceQueryFeaturesKHR;
@@ -4628,7 +4628,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineBinaries: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineBinaryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineBinaryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineBinaryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineBinaryFeaturesKHR;
@@ -4643,7 +4643,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineCacheIncrementalMode: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC;
@@ -4660,7 +4660,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::pipelineCreationCacheControl:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -4673,7 +4673,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->pipelineCreationCacheControl, "VkPhysicalDeviceVulkan13Features::pipelineCreationCacheControl"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePipelineCreationCacheControlFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePipelineCreationCacheControlFeatures;
@@ -4688,7 +4688,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDevicePipelineCreationCacheControlFeatures::pipelineCreationCacheControl"};
             }
         case Feature::pipelineExecutableInfo: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR;
@@ -4704,7 +4704,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineLibraryGroupHandles: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT;
@@ -4720,7 +4720,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineOpacityMicromap: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineOpacityMicromapFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineOpacityMicromapFeaturesARM;
@@ -4736,7 +4736,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelinePropertiesIdentifier: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelinePropertiesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelinePropertiesFeaturesEXT;
@@ -4753,7 +4753,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::pipelineProtectedAccess:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -4766,7 +4766,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->pipelineProtectedAccess, "VkPhysicalDeviceVulkan14Features::pipelineProtectedAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePipelineProtectedAccessFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePipelineProtectedAccessFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePipelineProtectedAccessFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePipelineProtectedAccessFeatures;
@@ -4782,7 +4782,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::pipelineRobustness:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -4795,7 +4795,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->pipelineRobustness, "VkPhysicalDeviceVulkan14Features::pipelineRobustness"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePipelineRobustnessFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePipelineRobustnessFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePipelineRobustnessFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePipelineRobustnessFeatures;
@@ -4810,8 +4810,8 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
-            case Feature::constantAlphaColorBlendFactors : {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+        case Feature::constantAlphaColorBlendFactors: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4829,7 +4829,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::events: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4846,7 +4846,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::imageView2DOn3DImage: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4863,7 +4863,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::imageViewFormatReinterpretation: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4881,7 +4881,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::imageViewFormatSwizzle: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4898,7 +4898,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::multisampleArrayImage: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4915,7 +4915,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::mutableComparisonSamplers: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4933,7 +4933,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::pointPolygons: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4950,7 +4950,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::samplerMipLodBias: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4967,7 +4967,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::separateStencilMaskRef: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4984,7 +4984,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::shaderSampleRateInterpolationFunctions: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -5002,7 +5002,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::tessellationIsolines: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -5019,7 +5019,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::tessellationPointMode: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -5036,7 +5036,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::triangleFans: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -5053,7 +5053,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::vertexAttributeAccessBeyondStride: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -5070,7 +5070,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::presentBarrier: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentBarrierFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentBarrierFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentBarrierFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentBarrierFeaturesNV;
@@ -5085,7 +5085,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentId2: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentId2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentId2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentId2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentId2FeaturesKHR;
@@ -5100,7 +5100,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentId: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentIdFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentIdFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentIdFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentIdFeaturesKHR;
@@ -5115,7 +5115,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentMetering: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentMeteringFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentMeteringFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentMeteringFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentMeteringFeaturesNV;
@@ -5130,7 +5130,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentModeFifoLatestReady: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR;
@@ -5146,7 +5146,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentAtAbsoluteTime: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentTimingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentTimingFeaturesEXT;
@@ -5161,7 +5161,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentAtRelativeTime: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentTimingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentTimingFeaturesEXT;
@@ -5176,7 +5176,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentTiming: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentTimingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentTimingFeaturesEXT;
@@ -5191,7 +5191,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentWait2: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentWait2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentWait2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentWait2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentWait2FeaturesKHR;
@@ -5206,7 +5206,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentWait: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentWaitFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentWaitFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentWaitFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentWaitFeaturesKHR;
@@ -5221,7 +5221,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveTopologyListRestart: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT;
@@ -5237,7 +5237,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveTopologyPatchListRestart: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT;
@@ -5253,7 +5253,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitivesGeneratedQuery: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
@@ -5269,7 +5269,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitivesGeneratedQueryWithNonZeroStreams: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
@@ -5285,7 +5285,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitivesGeneratedQueryWithRasterizerDiscard: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
@@ -5302,7 +5302,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::privateData:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -5315,7 +5315,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->privateData, "VkPhysicalDeviceVulkan13Features::privateData"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePrivateDataFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePrivateDataFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePrivateDataFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePrivateDataFeatures;
@@ -5330,7 +5330,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::protectedMemory:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -5343,7 +5343,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->protectedMemory, "VkPhysicalDeviceVulkan11Features::protectedMemory"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceProtectedMemoryFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceProtectedMemoryFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceProtectedMemoryFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceProtectedMemoryFeatures;
@@ -5357,7 +5357,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->protectedMemory, "VkPhysicalDeviceProtectedMemoryFeatures::protectedMemory"};
             }
         case Feature::provokingVertexLast: {
-            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceProvokingVertexFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceProvokingVertexFeaturesEXT;
@@ -5372,7 +5372,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::transformFeedbackPreservesProvokingVertex: {
-            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceProvokingVertexFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceProvokingVertexFeaturesEXT;
@@ -5388,7 +5388,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pushConstantBank: {
-            auto vk_struct = const_cast<VkPhysicalDevicePushConstantBankFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePushConstantBankFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePushConstantBankFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePushConstantBankFeaturesNV;
@@ -5403,7 +5403,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::formatRgba10x6WithoutYCbCrSampler: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT;
@@ -5419,7 +5419,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rasterizationOrderColorAttachmentAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
@@ -5435,7 +5435,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rasterizationOrderDepthAttachmentAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
@@ -5451,7 +5451,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rasterizationOrderStencilAttachmentAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
@@ -5467,7 +5467,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderRawAccessChains: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRawAccessChainsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRawAccessChainsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRawAccessChainsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRawAccessChainsFeaturesNV;
@@ -5482,7 +5482,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayQuery: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayQueryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayQueryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayQueryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayQueryFeaturesKHR;
@@ -5497,7 +5497,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingInvocationReorder: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT;
@@ -5513,7 +5513,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::linearSweptSpheres: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV;
@@ -5528,7 +5528,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::spheres: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV;
@@ -5543,7 +5543,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingMaintenance1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR;
@@ -5559,7 +5559,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineTraceRaysIndirect2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR;
@@ -5575,7 +5575,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingMotionBlur: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMotionBlurFeaturesNV;
@@ -5590,7 +5590,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingMotionBlurPipelineTraceRaysIndirect: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMotionBlurFeaturesNV;
@@ -5606,7 +5606,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipeline: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5621,7 +5621,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineShaderGroupHandleCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5637,7 +5637,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineShaderGroupHandleCaptureReplayMixed: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5653,7 +5653,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineTraceRaysIndirect: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5669,7 +5669,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTraversalPrimitiveCulling: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5685,7 +5685,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPositionFetch: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR;
@@ -5701,7 +5701,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingValidation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingValidationFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingValidationFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingValidationFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingValidationFeaturesNV;
@@ -5716,7 +5716,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::relaxedLineRasterization: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG;
@@ -5732,7 +5732,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::renderPassStriped: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRenderPassStripedFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRenderPassStripedFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRenderPassStripedFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRenderPassStripedFeaturesARM;
@@ -5747,7 +5747,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::representativeFragmentTest: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV;
@@ -5763,7 +5763,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nullDescriptor: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRobustness2FeaturesKHR;
@@ -5778,7 +5778,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::robustBufferAccess2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRobustness2FeaturesKHR;
@@ -5793,7 +5793,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::robustImageAccess2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRobustness2FeaturesKHR;
@@ -5809,7 +5809,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::samplerYcbcrConversion:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -5822,7 +5822,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->samplerYcbcrConversion, "VkPhysicalDeviceVulkan11Features::samplerYcbcrConversion"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSamplerYcbcrConversionFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSamplerYcbcrConversionFeatures;
@@ -5838,7 +5838,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::scalarBlockLayout:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -5851,7 +5851,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->scalarBlockLayout, "VkPhysicalDeviceVulkan12Features::scalarBlockLayout"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceScalarBlockLayoutFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceScalarBlockLayoutFeatures;
@@ -5865,7 +5865,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->scalarBlockLayout, "VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout"};
             }
         case Feature::schedulingControls: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSchedulingControlsFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSchedulingControlsFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSchedulingControlsFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSchedulingControlsFeaturesARM;
@@ -5881,7 +5881,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::separateDepthStencilLayouts:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -5894,7 +5894,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->separateDepthStencilLayouts, "VkPhysicalDeviceVulkan12Features::separateDepthStencilLayouts"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures;
@@ -5909,7 +5909,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures::separateDepthStencilLayouts"};
             }
         case Feature::shader64BitIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShader64BitIndexingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShader64BitIndexingFeaturesEXT;
@@ -5924,7 +5924,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFloat16VectorAtomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV;
@@ -5940,7 +5940,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat16AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5956,7 +5956,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat16AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5972,7 +5972,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat16Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5988,7 +5988,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6004,7 +6004,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat64AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6020,7 +6020,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6036,7 +6036,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat16AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6052,7 +6052,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat16AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6068,7 +6068,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat16Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6084,7 +6084,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6100,7 +6100,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat64AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6116,7 +6116,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6132,7 +6132,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6148,7 +6148,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6164,7 +6164,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat64AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6180,7 +6180,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6196,7 +6196,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6212,7 +6212,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6228,7 +6228,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6244,7 +6244,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6260,7 +6260,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat64AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6276,7 +6276,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6292,7 +6292,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6308,7 +6308,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6325,7 +6325,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderBufferInt64Atomics:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6338,7 +6338,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderBufferInt64Atomics, "VkPhysicalDeviceVulkan12Features::shaderBufferInt64Atomics"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicInt64Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderAtomicInt64Features;
@@ -6354,7 +6354,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderSharedInt64Atomics:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6367,7 +6367,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderSharedInt64Atomics, "VkPhysicalDeviceVulkan12Features::shaderSharedInt64Atomics"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicInt64Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderAtomicInt64Features;
@@ -6382,7 +6382,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderAtomicInt64Features::shaderSharedInt64Atomics"};
             }
         case Feature::shaderBFloat16CooperativeMatrix: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderBfloat16FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderBfloat16FeaturesKHR;
@@ -6398,7 +6398,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBFloat16DotProduct: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderBfloat16FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderBfloat16FeaturesKHR;
@@ -6413,7 +6413,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBFloat16Type: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderBfloat16FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderBfloat16FeaturesKHR;
@@ -6428,7 +6428,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderDeviceClock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderClockFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderClockFeaturesKHR;
@@ -6443,7 +6443,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSubgroupClock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderClockFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderClockFeaturesKHR;
@@ -6458,7 +6458,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderCoreBuiltins: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM;
@@ -6474,7 +6474,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderDemoteToHelperInvocation:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -6488,7 +6488,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderDemoteToHelperInvocation,
                         "VkPhysicalDeviceVulkan13Features::shaderDemoteToHelperInvocation"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures;
@@ -6504,7 +6504,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderDrawParameters:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -6517,7 +6517,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderDrawParameters, "VkPhysicalDeviceVulkan11Features::shaderDrawParameters"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderDrawParametersFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderDrawParametersFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderDrawParametersFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderDrawParametersFeatures;
@@ -6531,7 +6531,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderDrawParameters, "VkPhysicalDeviceShaderDrawParametersFeatures::shaderDrawParameters"};
             }
         case Feature::shaderEarlyAndLateFragmentTests: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD;
@@ -6548,7 +6548,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::shaderEnqueue: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderEnqueueFeaturesAMDX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderEnqueueFeaturesAMDX;
@@ -6565,7 +6565,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::shaderMeshEnqueue: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderEnqueueFeaturesAMDX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderEnqueueFeaturesAMDX;
@@ -6582,7 +6582,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderExpectAssume:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -6595,7 +6595,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderExpectAssume, "VkPhysicalDeviceVulkan14Features::shaderExpectAssume"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderExpectAssumeFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderExpectAssumeFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderExpectAssumeFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderExpectAssumeFeatures;
@@ -6610,7 +6610,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderFloat16:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6623,7 +6623,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderFloat16, "VkPhysicalDeviceVulkan12Features::shaderFloat16"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat16Int8Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderFloat16Int8Features;
@@ -6638,7 +6638,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderInt8:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6651,7 +6651,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderInt8, "VkPhysicalDeviceVulkan12Features::shaderInt8"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat16Int8Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderFloat16Int8Features;
@@ -6665,7 +6665,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderInt8, "VkPhysicalDeviceShaderFloat16Int8Features::shaderInt8"};
             }
         case Feature::shaderFloat8: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat8FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFloat8FeaturesEXT;
@@ -6680,7 +6680,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFloat8CooperativeMatrix: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat8FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFloat8FeaturesEXT;
@@ -6697,7 +6697,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderFloatControls2:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -6710,7 +6710,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderFloatControls2, "VkPhysicalDeviceVulkan14Features::shaderFloatControls2"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloatControls2Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloatControls2Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloatControls2Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderFloatControls2Features;
@@ -6724,7 +6724,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderFloatControls2, "VkPhysicalDeviceShaderFloatControls2Features::shaderFloatControls2"};
             }
         case Feature::shaderFmaFloat16: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFmaFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFmaFeaturesKHR;
@@ -6739,7 +6739,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFmaFloat32: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFmaFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFmaFeaturesKHR;
@@ -6754,7 +6754,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFmaFloat64: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFmaFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFmaFeaturesKHR;
@@ -6769,7 +6769,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageInt64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT;
@@ -6785,7 +6785,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageInt64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT;
@@ -6801,7 +6801,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageFootprint: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageFootprintFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderImageFootprintFeaturesNV;
@@ -6816,7 +6816,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderInstrumentation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderInstrumentationFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderInstrumentationFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderInstrumentationFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderInstrumentationFeaturesARM;
@@ -6832,7 +6832,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderIntegerDotProduct:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -6845,7 +6845,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderIntegerDotProduct, "VkPhysicalDeviceVulkan13Features::shaderIntegerDotProduct"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerDotProductFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerDotProductFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderIntegerDotProductFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderIntegerDotProductFeatures;
@@ -6860,7 +6860,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderIntegerDotProductFeatures::shaderIntegerDotProduct"};
             }
         case Feature::shaderIntegerFunctions2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL;
@@ -6876,7 +6876,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::longVector: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderLongVectorFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderLongVectorFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderLongVectorFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderLongVectorFeaturesEXT;
@@ -6891,7 +6891,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderMaximalReconvergence: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR;
@@ -6907,7 +6907,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderMixedFloatDotProductBFloat16Acc: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE;
@@ -6923,7 +6923,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderMixedFloatDotProductFloat16AccFloat16: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE;
@@ -6939,7 +6939,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderMixedFloatDotProductFloat16AccFloat32: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE;
@@ -6955,7 +6955,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderMixedFloatDotProductFloat8AccFloat32: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE;
@@ -6971,7 +6971,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderModuleIdentifier: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT;
@@ -6987,7 +6987,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderObject: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderObjectFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderObjectFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderObjectFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderObjectFeaturesEXT;
@@ -7002,7 +7002,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderQuadControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderQuadControlFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderQuadControlFeaturesKHR;
@@ -7017,7 +7017,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderRelaxedExtendedInstruction: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR;
@@ -7033,7 +7033,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderReplicatedComposites: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT;
@@ -7049,7 +7049,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSMBuiltins: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderSMBuiltinsFeaturesNV;
@@ -7065,7 +7065,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderSubgroupExtendedTypes:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -7078,7 +7078,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderSubgroupExtendedTypes, "VkPhysicalDeviceVulkan12Features::shaderSubgroupExtendedTypes"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures;
@@ -7093,7 +7093,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures::shaderSubgroupExtendedTypes"};
             }
         case Feature::shaderSubgroupPartitioned: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT;
@@ -7110,7 +7110,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderSubgroupRotate:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -7123,7 +7123,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderSubgroupRotate, "VkPhysicalDeviceVulkan14Features::shaderSubgroupRotate"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupRotateFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderSubgroupRotateFeatures;
@@ -7138,7 +7138,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderSubgroupRotateClustered:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -7152,7 +7152,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderSubgroupRotateClustered,
                         "VkPhysicalDeviceVulkan14Features::shaderSubgroupRotateClustered"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupRotateFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderSubgroupRotateFeatures;
@@ -7167,7 +7167,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderSubgroupRotateFeatures::shaderSubgroupRotateClustered"};
             }
         case Feature::shaderSubgroupUniformControlFlow: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR;
@@ -7184,7 +7184,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderTerminateInvocation:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7197,7 +7197,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderTerminateInvocation, "VkPhysicalDeviceVulkan13Features::shaderTerminateInvocation"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderTerminateInvocationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderTerminateInvocationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderTerminateInvocationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderTerminateInvocationFeatures;
@@ -7212,7 +7212,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderTerminateInvocationFeatures::shaderTerminateInvocation"};
             }
         case Feature::shaderTileImageColorReadAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
@@ -7228,7 +7228,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderTileImageDepthReadAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
@@ -7244,7 +7244,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderTileImageStencilReadAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
@@ -7260,7 +7260,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderUniformBufferUnsizedArray: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT;
@@ -7276,7 +7276,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderUntypedPointers: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderUntypedPointersFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderUntypedPointersFeaturesKHR;
@@ -7291,7 +7291,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shadingRateCoarseSampleOrder: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShadingRateImageFeaturesNV;
@@ -7307,7 +7307,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shadingRateImage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShadingRateImageFeaturesNV;
@@ -7323,7 +7323,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::computeFullSubgroups:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7336,7 +7336,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->computeFullSubgroups, "VkPhysicalDeviceVulkan13Features::computeFullSubgroups"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSubgroupSizeControlFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSubgroupSizeControlFeatures;
@@ -7351,7 +7351,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::subgroupSizeControl:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7364,7 +7364,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->subgroupSizeControl, "VkPhysicalDeviceVulkan13Features::subgroupSizeControl"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSubgroupSizeControlFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSubgroupSizeControlFeatures;
@@ -7378,7 +7378,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->subgroupSizeControl, "VkPhysicalDeviceSubgroupSizeControlFeatures::subgroupSizeControl"};
             }
         case Feature::subpassMergeFeedback: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT;
@@ -7393,7 +7393,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::subpassShading: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSubpassShadingFeaturesHUAWEI;
@@ -7408,7 +7408,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::swapchainMaintenance1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR;
@@ -7424,7 +7424,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::synchronization2:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7437,7 +7437,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->synchronization2, "VkPhysicalDeviceVulkan13Features::synchronization2"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSynchronization2Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSynchronization2Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSynchronization2Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSynchronization2Features;
@@ -7451,7 +7451,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->synchronization2, "VkPhysicalDeviceSynchronization2Features::synchronization2"};
             }
         case Feature::descriptorBindingStorageTensorUpdateAfterBind: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7467,7 +7467,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderStorageTensorArrayDynamicIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7483,7 +7483,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderStorageTensorArrayNonUniformIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7499,7 +7499,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderTensorAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7514,7 +7514,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tensorNonPacked: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7529,7 +7529,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tensors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7544,7 +7544,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::texelBufferAlignment: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT;
@@ -7559,7 +7559,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureCompressionASTC_3D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT;
@@ -7576,7 +7576,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::textureCompressionASTC_HDR:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7589,7 +7589,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->textureCompressionASTC_HDR, "VkPhysicalDeviceVulkan13Features::textureCompressionASTC_HDR"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceTextureCompressionASTCHDRFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceTextureCompressionASTCHDRFeatures;
@@ -7604,7 +7604,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceTextureCompressionASTCHDRFeatures::textureCompressionASTC_HDR"};
             }
         case Feature::tileMemoryHeap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileMemoryHeapFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileMemoryHeapFeaturesQCOM;
@@ -7619,7 +7619,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileProperties: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTilePropertiesFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTilePropertiesFeaturesQCOM;
@@ -7634,7 +7634,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShading: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7649,7 +7649,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingAnisotropicApron: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7665,7 +7665,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingApron: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7680,7 +7680,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingAtomicOps: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7695,7 +7695,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingColorAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7711,7 +7711,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingDepthAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7727,7 +7727,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingDispatchTile: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7742,7 +7742,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingFragmentStage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7757,7 +7757,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingImageProcessing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7772,7 +7772,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingInputAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7788,7 +7788,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingPerTileDispatch: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7803,7 +7803,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingPerTileDraw: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7818,7 +7818,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingSampledAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7834,7 +7834,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingStencilAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7851,7 +7851,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::timelineSemaphore:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -7864,7 +7864,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->timelineSemaphore, "VkPhysicalDeviceVulkan12Features::timelineSemaphore"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceTimelineSemaphoreFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceTimelineSemaphoreFeatures;
@@ -7878,7 +7878,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->timelineSemaphore, "VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore"};
             }
         case Feature::geometryStreams: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTransformFeedbackFeaturesEXT;
@@ -7893,7 +7893,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::transformFeedback: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTransformFeedbackFeaturesEXT;
@@ -7908,7 +7908,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::unifiedImageLayouts: {
-            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR;
@@ -7923,7 +7923,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::unifiedImageLayoutsVideo: {
-            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR;
@@ -7940,7 +7940,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::uniformBufferStandardLayout:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -7953,7 +7953,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->uniformBufferStandardLayout, "VkPhysicalDeviceVulkan12Features::uniformBufferStandardLayout"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceUniformBufferStandardLayoutFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceUniformBufferStandardLayoutFeatures;
@@ -7969,7 +7969,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::variablePointers:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -7982,7 +7982,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->variablePointers, "VkPhysicalDeviceVulkan11Features::variablePointers"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVariablePointersFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVariablePointersFeatures;
@@ -7997,7 +7997,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::variablePointersStorageBuffer:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -8011,7 +8011,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->variablePointersStorageBuffer,
                         "VkPhysicalDeviceVulkan11Features::variablePointersStorageBuffer"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVariablePointersFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVariablePointersFeatures;
@@ -8027,7 +8027,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vertexAttributeInstanceRateDivisor:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -8041,7 +8041,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->vertexAttributeInstanceRateDivisor,
                         "VkPhysicalDeviceVulkan14Features::vertexAttributeInstanceRateDivisor"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVertexAttributeDivisorFeatures;
@@ -8057,7 +8057,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vertexAttributeInstanceRateZeroDivisor:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -8071,7 +8071,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->vertexAttributeInstanceRateZeroDivisor,
                         "VkPhysicalDeviceVulkan14Features::vertexAttributeInstanceRateZeroDivisor"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVertexAttributeDivisorFeatures;
@@ -8086,7 +8086,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceVertexAttributeDivisorFeatures::vertexAttributeInstanceRateZeroDivisor"};
             }
         case Feature::vertexAttributeRobustness: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT;
@@ -8102,7 +8102,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::vertexInputDynamicState: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT;
@@ -8118,7 +8118,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoDecodeVP9: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoDecodeVP9FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoDecodeVP9FeaturesKHR;
@@ -8133,7 +8133,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeAV1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeAV1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeAV1FeaturesKHR;
@@ -8148,7 +8148,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeIntraRefresh: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR;
@@ -8164,7 +8164,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeQuantizationMap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR;
@@ -8180,7 +8180,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeRgbConversion: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE;
@@ -8196,7 +8196,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoMaintenance1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoMaintenance1FeaturesKHR;
@@ -8211,7 +8211,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoMaintenance2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoMaintenance2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoMaintenance2FeaturesKHR;
@@ -8226,7 +8226,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8241,7 +8241,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::drawIndirectCount: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8256,7 +8256,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::samplerFilterMinmax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8271,7 +8271,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::samplerMirrorClampToEdge: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8286,7 +8286,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderOutputLayer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8301,7 +8301,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderOutputViewportIndex: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8316,7 +8316,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::subgroupBroadcastDynamicId: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8332,7 +8332,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::vulkanMemoryModel:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8345,7 +8345,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->vulkanMemoryModel, "VkPhysicalDeviceVulkan12Features::vulkanMemoryModel"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
@@ -8360,7 +8360,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vulkanMemoryModelAvailabilityVisibilityChains:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8374,7 +8374,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->vulkanMemoryModelAvailabilityVisibilityChains,
                         "VkPhysicalDeviceVulkan12Features::vulkanMemoryModelAvailabilityVisibilityChains"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
@@ -8390,7 +8390,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vulkanMemoryModelDeviceScope:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8403,7 +8403,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->vulkanMemoryModelDeviceScope, "VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
@@ -8419,7 +8419,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderZeroInitializeWorkgroupMemory:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -8433,7 +8433,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderZeroInitializeWorkgroupMemory,
                         "VkPhysicalDeviceVulkan13Features::shaderZeroInitializeWorkgroupMemory"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures;
@@ -8448,7 +8448,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures::shaderZeroInitializeWorkgroupMemory"};
             }
         case Feature::pushDescriptor: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -8463,7 +8463,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8479,7 +8479,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayout16BitAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8495,7 +8495,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayout8BitAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8511,7 +8511,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayoutScalarBlockLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8527,7 +8527,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::ycbcr2plane444Formats: {
-            auto vk_struct = const_cast<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT;
@@ -8542,7 +8542,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::ycbcrDegamma: {
-            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceYcbcrDegammaFeaturesQCOM;
@@ -8557,7 +8557,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::ycbcrImageArrays: {
-            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceYcbcrImageArraysFeaturesEXT;
@@ -8572,7 +8572,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::zeroInitializeDeviceMemory: {
-            auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT;

--- a/layers/vulkan/generated/feature_requirements_helper.h
+++ b/layers/vulkan/generated/feature_requirements_helper.h
@@ -1087,13 +1087,13 @@ enum class Feature {
 };
 
 struct FeatureAndName {
-    VkBool32 *feature;
-    const char *name;
+    VkBool32* feature;
+    const char* name;
 };
 
 // Find or add the correct VkPhysicalDeviceFeature struct in `pnext_chain` based on `feature`,
 // a vkt::Feature enum value, and set feature to VK_TRUE
-FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain);
+FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void** inout_pnext_chain);
 
 }  // namespace vkt
 

--- a/layers/vulkan/generated/pnext_chain_extraction.cpp
+++ b/layers/vulkan/generated/pnext_chain_extraction.cpp
@@ -28,3893 +28,3893 @@
 
 namespace vvl {
 
-void *PnextChainAdd(void *chain, void *new_struct) {
+void* PnextChainAdd(void* chain, void* new_struct) {
     assert(chain);
     assert(new_struct);
-    void *chain_end = vku::FindLastStructInPNextChain(chain);
-    auto *vk_base_struct = static_cast<VkBaseOutStructure *>(chain_end);
+    void* chain_end = vku::FindLastStructInPNextChain(chain);
+    auto* vk_base_struct = static_cast<VkBaseOutStructure*>(chain_end);
     assert(!vk_base_struct->pNext);
-    vk_base_struct->pNext = static_cast<VkBaseOutStructure *>(new_struct);
+    vk_base_struct->pNext = static_cast<VkBaseOutStructure*>(new_struct);
     return new_struct;
 }
 
-void PnextChainRemoveLast(void *chain) {
+void PnextChainRemoveLast(void* chain) {
     if (!chain) {
         return;
     }
-    auto *current = static_cast<VkBaseOutStructure *>(chain);
-    auto *prev = current;
+    auto* current = static_cast<VkBaseOutStructure*>(chain);
+    auto* prev = current;
     while (current->pNext) {
         prev = current;
-        current = static_cast<VkBaseOutStructure *>(current->pNext);
+        current = static_cast<VkBaseOutStructure*>(current->pNext);
     }
     prev->pNext = nullptr;
 }
 
-void PnextChainFree(void *chain) {
+void PnextChainFree(void* chain) {
     if (!chain) return;
-    auto header = reinterpret_cast<VkBaseOutStructure *>(chain);
+    auto header = reinterpret_cast<VkBaseOutStructure*>(chain);
     switch (header->sType) {
         case VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkShaderModuleCreateInfo *>(header);
+            delete reinterpret_cast<const VkShaderModuleCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineLayoutCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineLayoutCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryDedicatedRequirements *>(header);
+            delete reinterpret_cast<const VkMemoryDedicatedRequirements*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfo *>(header);
+            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryAllocateFlagsInfo *>(header);
+            delete reinterpret_cast<const VkMemoryAllocateFlagsInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupCommandBufferBeginInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupCommandBufferBeginInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupSubmitInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupSubmitInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupBindSparseInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupBindSparseInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindBufferMemoryDeviceGroupInfo *>(header);
+            delete reinterpret_cast<const VkBindBufferMemoryDeviceGroupInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindImageMemoryDeviceGroupInfo *>(header);
+            delete reinterpret_cast<const VkBindImageMemoryDeviceGroupInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupDeviceCreateInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupDeviceCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFeatures2 *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFeatures2*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewUsageCreateInfo *>(header);
+            delete reinterpret_cast<const VkImageViewUsageCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkProtectedSubmitInfo *>(header);
+            delete reinterpret_cast<const VkProtectedSubmitInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindImagePlaneMemoryInfo *>(header);
+            delete reinterpret_cast<const VkBindImagePlaneMemoryInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImagePlaneMemoryRequirementsInfo *>(header);
+            delete reinterpret_cast<const VkImagePlaneMemoryRequirementsInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalImageFormatInfo *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalImageFormatInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalImageFormatProperties *>(header);
+            delete reinterpret_cast<const VkExternalImageFormatProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceIDProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceIDProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryImageCreateInfo *>(header);
+            delete reinterpret_cast<const VkExternalMemoryImageCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryBufferCreateInfo *>(header);
+            delete reinterpret_cast<const VkExternalMemoryBufferCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryAllocateInfo *>(header);
+            delete reinterpret_cast<const VkExportMemoryAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportFenceCreateInfo *>(header);
+            delete reinterpret_cast<const VkExportFenceCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportSemaphoreCreateInfo *>(header);
+            delete reinterpret_cast<const VkExportSemaphoreCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubgroupProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance3Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance3Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerYcbcrConversionInfo *>(header);
+            delete reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerYcbcrConversionImageFormatProperties *>(header);
+            delete reinterpret_cast<const VkSamplerYcbcrConversionImageFormatProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupRenderPassBeginInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupRenderPassBeginInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePointClippingProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePointClippingProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo *>(header);
+            delete reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineTessellationDomainOriginStateCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineTessellationDomainOriginStateCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassMultiviewCreateInfo *>(header);
+            delete reinterpret_cast<const VkRenderPassMultiviewCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDriverProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDriverProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageFormatListCreateInfo *>(header);
+            delete reinterpret_cast<const VkImageFormatListCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSemaphoreTypeCreateInfo *>(header);
+            delete reinterpret_cast<const VkSemaphoreTypeCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTimelineSemaphoreSubmitInfo *>(header);
+            delete reinterpret_cast<const VkTimelineSemaphoreSubmitInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferOpaqueCaptureAddressCreateInfo *>(header);
+            delete reinterpret_cast<const VkBufferOpaqueCaptureAddressCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryOpaqueCaptureAddressAllocateInfo *>(header);
+            delete reinterpret_cast<const VkMemoryOpaqueCaptureAddressAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFloatControlsProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFloatControlsProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo *>(header);
+            delete reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfo *>(header);
+            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountLayoutSupport *>(header);
+            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountLayoutSupport*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerReductionModeCreateInfo *>(header);
+            delete reinterpret_cast<const VkSamplerReductionModeCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSamplerFilterMinmaxProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSamplerFilterMinmaxProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubpassDescriptionDepthStencilResolve *>(header);
+            delete reinterpret_cast<const VkSubpassDescriptionDepthStencilResolve*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthStencilResolveProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthStencilResolveProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageStencilUsageCreateInfo *>(header);
+            delete reinterpret_cast<const VkImageStencilUsageCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassAttachmentBeginInfo *>(header);
+            delete reinterpret_cast<const VkRenderPassAttachmentBeginInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFramebufferAttachmentsCreateInfo *>(header);
+            delete reinterpret_cast<const VkFramebufferAttachmentsCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentReferenceStencilLayout *>(header);
+            delete reinterpret_cast<const VkAttachmentReferenceStencilLayout*>(header);
             break;
         case VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentDescriptionStencilLayout *>(header);
+            delete reinterpret_cast<const VkAttachmentDescriptionStencilLayout*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDevicePrivateDataCreateInfo *>(header);
+            delete reinterpret_cast<const VkDevicePrivateDataCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_BARRIER_2:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryBarrier2 *>(header);
+            delete reinterpret_cast<const VkMemoryBarrier2*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSynchronization2Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFormatProperties3 *>(header);
+            delete reinterpret_cast<const VkFormatProperties3*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCreationFeedbackCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineCreationFeedbackCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlock *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlock*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfo *>(header);
+            delete reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRenderingCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineRenderingCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDERING_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceRenderingInfo *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceRenderingInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfo *>(header);
+            delete reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyGlobalPriorityProperties *>(header);
+            delete reinterpret_cast<const VkQueueFamilyGlobalPriorityProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferUsageFlags2CreateInfo *>(header);
+            delete reinterpret_cast<const VkBufferUsageFlags2CreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_MEMORY_STATUS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindMemoryStatus *>(header);
+            delete reinterpret_cast<const VkBindMemoryStatus*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubresourceHostMemcpySize *>(header);
+            delete reinterpret_cast<const VkSubresourceHostMemcpySize*>(header);
             break;
         case VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkHostImageCopyDevicePerformanceQuery *>(header);
+            delete reinterpret_cast<const VkHostImageCopyDevicePerformanceQuery*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT_CONTROLS_2_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCreateFlags2CreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineCreateFlags2CreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePushDescriptorProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePushDescriptorProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_ROBUSTNESS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRobustnessCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineRobustnessCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationLineStateCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationLineStateCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingAttachmentLocationInfo *>(header);
+            delete reinterpret_cast<const VkRenderingAttachmentLocationInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingInputAttachmentIndexInfo *>(header);
+            delete reinterpret_cast<const VkRenderingInputAttachmentIndexInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageSwapchainCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkImageSwapchainCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindImageMemorySwapchainInfoKHR *>(header);
+            delete reinterpret_cast<const VkBindImageMemorySwapchainInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupPresentInfoKHR *>(header);
+            delete reinterpret_cast<const VkDeviceGroupPresentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupSwapchainCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkDeviceGroupSwapchainCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplayPresentInfoKHR *>(header);
+            delete reinterpret_cast<const VkDisplayPresentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_QUERY_RESULT_STATUS_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyQueryResultStatusPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkQueueFamilyQueryResultStatusPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_VIDEO_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyVideoPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkQueueFamilyVideoPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoProfileListInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoProfileListInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_USAGE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeUsageInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeUsageInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264QualityLevelPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264QualityLevelPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersGetInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersGetInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_FEEDBACK_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersFeedbackInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersFeedbackInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264RateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264RateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264RateControlLayerInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264RateControlLayerInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264GopRemainingFrameInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264GopRemainingFrameInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265QualityLevelPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265QualityLevelPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_GET_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersGetInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersGetInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_FEEDBACK_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersFeedbackInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersFeedbackInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265RateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265RateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265RateControlLayerInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265RateControlLayerInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_GOP_REMAINING_FRAME_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265GopRemainingFrameInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265GopRemainingFrameInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264DpbSlotInfoKHR*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryFdInfoKHR *>(header);
+            delete reinterpret_cast<const VkImportMemoryFdInfoKHR*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR *>(header);
+            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkD3D12FenceSubmitInfoKHR *>(header);
+            delete reinterpret_cast<const VkD3D12FenceSubmitInfoKHR*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentRegionsKHR *>(header);
+            delete reinterpret_cast<const VkPresentRegionsKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportFenceWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkExportFenceWin32HandleInfoKHR*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryPoolPerformanceCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkQueryPoolPerformanceCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_SUBMIT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPerformanceQuerySubmitInfoKHR *>(header);
+            delete reinterpret_cast<const VkPerformanceQuerySubmitInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_BFLOAT16_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetPropertiesKHR*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFragmentShadingRateAttachmentInfoKHR *>(header);
+            delete reinterpret_cast<const VkFragmentShadingRateAttachmentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineFragmentShadingRateStateCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkPipelineFragmentShadingRateStateCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRatePropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRatePropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR *>(header);
+            delete reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceProtectedCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkSurfaceProtectedCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineLibraryCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkPipelineLibraryCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_ID_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentIdKHR *>(header);
+            delete reinterpret_cast<const VkPresentIdKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryPoolVideoEncodeFeedbackCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkQueryPoolVideoEncodeFeedbackCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeUsageInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeUsageInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeRateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeRateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQualityLevelInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQualityLevelInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_RANGE_BARRIERS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryRangeBarriersInfoKHR *>(header);
+            delete reinterpret_cast<const VkMemoryRangeBarriersInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_ADDRESS_COMMANDS_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_ID_2_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentId2KHR *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentId2KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_ID_2_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentId2KHR *>(header);
+            delete reinterpret_cast<const VkPresentId2KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_WAIT_2_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentWait2KHR *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentWait2KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_PIPELINE_BINARY_INTERNAL_CACHE_CONTROL_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDevicePipelineBinaryInternalCacheControlKHR *>(header);
+            delete reinterpret_cast<const VkDevicePipelineBinaryInternalCacheControlKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_BINARY_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineBinaryInfoKHR *>(header);
+            delete reinterpret_cast<const VkPipelineBinaryInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfacePresentModeKHR *>(header);
+            delete reinterpret_cast<const VkSurfacePresentModeKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfacePresentScalingCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkSurfacePresentScalingCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfacePresentModeCompatibilityKHR *>(header);
+            delete reinterpret_cast<const VkSurfacePresentModeCompatibilityKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentFenceInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentFenceInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentModesCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentModesCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentModeInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentModeInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_SCALING_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentScalingCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentScalingCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INTERNALLY_SYNCHRONIZED_QUEUES_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInternallySynchronizedQueuesFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_AV1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUALITY_LEVEL_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1QualityLevelPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1QualityLevelPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_SESSION_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1SessionCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1SessionCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_GOP_REMAINING_FRAME_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1GopRemainingFrameInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1GopRemainingFrameInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1RateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1RateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_LAYER_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1RateControlLayerInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1RateControlLayerInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_DECODE_VP9_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_VP9_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeVP9ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeVP9ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_VP9_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeVP9CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeVP9CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_VP9_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeVP9PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeVP9PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoInlineQueryInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoInlineQueryInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFIED_IMAGE_LAYOUTS_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_ATTACHMENT_FEEDBACK_LOOP_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentFeedbackLoopInfoEXT *>(header);
+            delete reinterpret_cast<const VkAttachmentFeedbackLoopInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeIntraRefreshCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeIntraRefreshCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_INTRA_REFRESH_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeSessionIntraRefreshCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeSessionIntraRefreshCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeIntraRefreshInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeIntraRefreshInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_REFERENCE_INTRA_REFRESH_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoReferenceIntraRefreshInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoReferenceIntraRefreshInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_INTRA_REFRESH_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_FORMAT_QUANTIZATION_MAP_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoFormatQuantizationMapPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoFormatQuantizationMapPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQuantizationMapInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQuantizationMapInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUANTIZATION_MAP_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264QuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264QuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265QuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265QuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_FORMAT_H265_QUANTIZATION_MAP_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoFormatH265QuantizationMapPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoFormatH265QuantizationMapPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1QuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1QuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_FORMAT_AV1_QUANTIZATION_MAP_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoFormatAV1QuantizationMapPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoFormatAV1QuantizationMapPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_RELAXED_EXTENDED_INSTRUCTION_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_API_PROPERTIES_LIST_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiPropertiesListKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiPropertiesListKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_API_VULKAN_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiVulkanPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiVulkanPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_BARRIER_ACCESS_FLAGS_3_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryBarrierAccessFlags3KHR *>(header);
+            delete reinterpret_cast<const VkMemoryBarrierAccessFlags3KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FMA_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_OWNERSHIP_TRANSFER_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyOwnershipTransferPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkQueueFamilyOwnershipTransferPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_INLINE_SESSION_PARAMETERS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264InlineSessionParametersInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264InlineSessionParametersInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_INLINE_SESSION_PARAMETERS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265InlineSessionParametersInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265InlineSessionParametersInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_INLINE_SESSION_PARAMETERS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1InlineSessionParametersInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1InlineSessionParametersInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRobustness2PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRobustness2PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_MODE_FIFO_LATEST_READY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_FLAGS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingAttachmentFlagsInfoKHR *>(header);
+            delete reinterpret_cast<const VkRenderingAttachmentFlagsInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_RESOLVE_IMAGE_MODE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkResolveImageModeInfoKHR *>(header);
+            delete reinterpret_cast<const VkResolveImageModeInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationStateRasterizationOrderAMD *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationStateRasterizationOrderAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDedicatedAllocationImageCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDedicatedAllocationImageCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDedicatedAllocationBufferCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDedicatedAllocationBufferCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDedicatedAllocationMemoryAllocateInfoNV *>(header);
+            delete reinterpret_cast<const VkDedicatedAllocationMemoryAllocateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_CU_MODULE_TEXTURING_MODE_CREATE_INFO_NVX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCuModuleTexturingModeCreateInfoNVX *>(header);
+            delete reinterpret_cast<const VkCuModuleTexturingModeCreateInfoNVX*>(header);
             break;
         case VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTextureLODGatherFormatPropertiesAMD *>(header);
+            delete reinterpret_cast<const VkTextureLODGatherFormatPropertiesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryImageCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkExternalMemoryImageCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryAllocateInfoNV *>(header);
+            delete reinterpret_cast<const VkExportMemoryAllocateInfoNV*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoNV *>(header);
+            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoNV *>(header);
+            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV *>(header);
+            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkValidationFlagsEXT *>(header);
+            delete reinterpret_cast<const VkValidationFlagsEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewASTCDecodeModeEXT *>(header);
+            delete reinterpret_cast<const VkImageViewASTCDecodeModeEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceConditionalRenderingInfoEXT *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceConditionalRenderingInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportWScalingStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportWScalingStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainCounterCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkSwapchainCounterCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentTimesInfoGOOGLE *>(header);
+            delete reinterpret_cast<const VkPresentTimesInfoGOOGLE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX*>(header);
             break;
         case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_ATTRIBUTES_INFO_NVX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMultiviewPerViewAttributesInfoNVX *>(header);
+            delete reinterpret_cast<const VkMultiviewPerViewAttributesInfoNVX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportSwizzleStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportSwizzleStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDiscardRectanglePropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDiscardRectanglePropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceConservativeRasterizationPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceConservativeRasterizationPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationDepthClipStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationDepthClipStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT *>(header);
+            delete reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferFormatPropertiesANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatPropertiesANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID *>(header);
+            delete reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalFormatANDROID *>(header);
+            delete reinterpret_cast<const VkExternalFormatANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferFormatProperties2ANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatProperties2ANDROID*>(header);
             break;
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueuePropertiesAMDX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueuePropertiesAMDX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineShaderStageNodeCreateInfoAMDX *>(header);
+            delete reinterpret_cast<const VkPipelineShaderStageNodeCreateInfoAMDX*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_SHADER_DESCRIPTOR_SET_AND_BINDING_MAPPING_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkShaderDescriptorSetAndBindingMappingInfoEXT *>(header);
+            delete reinterpret_cast<const VkShaderDescriptorSetAndBindingMappingInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_OPAQUE_CAPTURE_DATA_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkOpaqueCaptureDataCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkOpaqueCaptureDataCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorHeapFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorHeapFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorHeapPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorHeapPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_DESCRIPTOR_HEAP_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceDescriptorHeapInfoEXT *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceDescriptorHeapInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_INDEX_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerCustomBorderColorIndexCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkSamplerCustomBorderColorIndexCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerCustomBorderColorCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkSamplerCustomBorderColorCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_PUSH_DATA_TOKEN_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkIndirectCommandsLayoutPushDataTokenNV *>(header);
+            delete reinterpret_cast<const VkIndirectCommandsLayoutPushDataTokenNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SUBSAMPLED_IMAGE_FORMAT_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubsampledImageFormatPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkSubsampledImageFormatPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_HEAP_TENSOR_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorHeapTensorPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorHeapTensorPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_ATTACHMENT_SAMPLE_COUNT_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentSampleCountInfoAMD *>(header);
+            delete reinterpret_cast<const VkAttachmentSampleCountInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSampleLocationsInfoEXT *>(header);
+            delete reinterpret_cast<const VkSampleLocationsInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassSampleLocationsBeginInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassSampleLocationsBeginInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineSampleLocationsStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineSampleLocationsStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSampleLocationsPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSampleLocationsPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineColorBlendAdvancedStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineColorBlendAdvancedStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCoverageToColorStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineCoverageToColorStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCoverageModulationStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineCoverageModulationStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDrmFormatModifierPropertiesListEXT *>(header);
+            delete reinterpret_cast<const VkDrmFormatModifierPropertiesListEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageDrmFormatModifierInfoEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageDrmFormatModifierInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageDrmFormatModifierListCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageDrmFormatModifierListCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageDrmFormatModifierExplicitCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageDrmFormatModifierExplicitCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDrmFormatModifierPropertiesList2EXT *>(header);
+            delete reinterpret_cast<const VkDrmFormatModifierPropertiesList2EXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkShaderModuleValidationCacheCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkShaderModuleValidationCacheCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportShadingRateImageStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportShadingRateImageStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImagePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImagePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureNV *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageViewImageFormatInfoEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageViewImageFormatInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFilterCubicImageViewImageFormatPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkFilterCubicImageViewImageFormatPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_CONVERSION_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixConversionFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryHostPointerInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMemoryHostPointerInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryHostPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryHostPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCompilerControlCreateInfoAMD *>(header);
+            delete reinterpret_cast<const VkPipelineCompilerControlCreateInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceMemoryOverallocationCreateInfoAMD *>(header);
+            delete reinterpret_cast<const VkDeviceMemoryOverallocationCreateInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_GGP
         case VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentFrameTokenGGP *>(header);
+            delete reinterpret_cast<const VkPresentFrameTokenGGP*>(header);
             break;
 #endif  // VK_USE_PLATFORM_GGP
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportExclusiveScissorStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportExclusiveScissorStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyCheckpointPropertiesNV *>(header);
+            delete reinterpret_cast<const VkQueueFamilyCheckpointPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyCheckpointProperties2NV *>(header);
+            delete reinterpret_cast<const VkQueueFamilyCheckpointProperties2NV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_TIMING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_TIMING_SURFACE_CAPABILITIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentTimingSurfaceCapabilitiesEXT *>(header);
+            delete reinterpret_cast<const VkPresentTimingSurfaceCapabilitiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_CALIBRATED_TIMESTAMP_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainCalibratedTimestampInfoEXT *>(header);
+            delete reinterpret_cast<const VkSwapchainCalibratedTimestampInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_TIMINGS_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentTimingsInfoEXT *>(header);
+            delete reinterpret_cast<const VkPresentTimingsInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryPoolPerformanceQueryCreateInfoINTEL *>(header);
+            delete reinterpret_cast<const VkQueryPoolPerformanceQueryCreateInfoINTEL*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePCIBusInfoPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePCIBusInfoPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplayNativeHdrSurfaceCapabilitiesAMD *>(header);
+            delete reinterpret_cast<const VkDisplayNativeHdrSurfaceCapabilitiesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainDisplayNativeHdrCreateInfoAMD *>(header);
+            delete reinterpret_cast<const VkSwapchainDisplayNativeHdrCreateInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassFragmentDensityMapCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassFragmentDensityMapCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreProperties2AMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreProperties2AMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryBudgetPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryBudgetPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT *>(header);
+            delete reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferDeviceAddressCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkBufferDeviceAddressCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkValidationFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkValidationFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCoverageReductionStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineCoverageReductionStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveInfoEXT *>(header);
+            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesFullScreenExclusiveEXT *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesFullScreenExclusiveEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveWin32InfoEXT *>(header);
+            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveWin32InfoEXT*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_MAP_PLACED_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryMapPlacedInfoEXT *>(header);
+            delete reinterpret_cast<const VkMemoryMapPlacedInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_SHADER_GROUPS_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGraphicsPipelineShaderGroupsCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkGraphicsPipelineShaderGroupsCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceViewportScissorInfoNV *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceViewportScissorInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassTransformBeginInfoQCOM *>(header);
+            delete reinterpret_cast<const VkRenderPassTransformBeginInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceRenderPassTransformInfoQCOM *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceRenderPassTransformInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDepthBiasRepresentationInfoEXT *>(header);
+            delete reinterpret_cast<const VkDepthBiasRepresentationInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_3D_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTC3DFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_BARRIER_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentBarrierNV *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentBarrierNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_BARRIER_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentBarrierCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentBarrierCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceDiagnosticsConfigCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDeviceDiagnosticsConfigCreateInfoNV*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchPropertiesNV*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_SHADING_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_SHADING_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileShadingPropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileShadingPropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_TILE_SHADING_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassTileShadingCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkRenderPassTileShadingCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_LOW_LATENCY_SUPPORT_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryLowLatencySupportNV *>(header);
+            delete reinterpret_cast<const VkQueryLowLatencySupportNV*>(header);
             break;
 #ifdef VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalObjectCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalObjectCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalDeviceInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalDeviceInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalCommandQueueInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalCommandQueueInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalBufferInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalBufferInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_BUFFER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalBufferInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalBufferInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalTextureInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalTextureInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalTextureInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalTextureInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalIOSurfaceInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalIOSurfaceInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalSharedEventInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalSharedEventInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_SHARED_EVENT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalSharedEventInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalSharedEventInfoEXT*>(header);
             break;
 #endif  // VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_DENSITY_MAP_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferDensityMapPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferDensityMapPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_PUSH_DESCRIPTOR_BUFFER_HANDLE_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorBufferBindingPushDescriptorBufferHandleEXT *>(header);
+            delete reinterpret_cast<const VkDescriptorBufferBindingPushDescriptorBufferHandleEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_OPAQUE_CAPTURE_DESCRIPTOR_DATA_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkOpaqueCaptureDescriptorDataCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkOpaqueCaptureDescriptorDataCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGraphicsPipelineLibraryCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkGraphicsPipelineLibraryCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineFragmentShadingRateEnumStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineFragmentShadingRateEnumStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MOTION_TRIANGLES_DATA_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureGeometryMotionTrianglesDataNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureGeometryMotionTrianglesDataNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MOTION_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureMotionInfoNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureMotionInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2PropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2PropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_COPY_COMMAND_TRANSFORM_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCopyCommandTransformInfoQCOM *>(header);
+            delete reinterpret_cast<const VkCopyCommandTransformInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageCompressionControlEXT *>(header);
+            delete reinterpret_cast<const VkImageCompressionControlEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageCompressionPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkImageCompressionPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MUTABLE_DESCRIPTOR_TYPE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMutableDescriptorTypeCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkMutableDescriptorTypeCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDrmPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDrmPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_ADDRESS_BINDING_CALLBACK_DATA_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceAddressBindingCallbackDataEXT *>(header);
+            delete reinterpret_cast<const VkDeviceAddressBindingCallbackDataEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportDepthClipControlCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineViewportDepthClipControlCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_FUCHSIA
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryZirconHandleInfoFUCHSIA *>(header);
+            delete reinterpret_cast<const VkImportMemoryZirconHandleInfoFUCHSIA*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_BUFFER_COLLECTION_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryBufferCollectionFUCHSIA *>(header);
+            delete reinterpret_cast<const VkImportMemoryBufferCollectionFUCHSIA*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_COLLECTION_IMAGE_CREATE_INFO_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferCollectionImageCreateInfoFUCHSIA *>(header);
+            delete reinterpret_cast<const VkBufferCollectionImageCreateInfoFUCHSIA*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_COLLECTION_BUFFER_CREATE_INFO_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferCollectionBufferCreateInfoFUCHSIA *>(header);
+            delete reinterpret_cast<const VkBufferCollectionBufferCreateInfoFUCHSIA*>(header);
             break;
 #endif  // VK_USE_PLATFORM_FUCHSIA
         case VK_STRUCTURE_TYPE_SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubpassShadingPipelineCreateInfoHUAWEI *>(header);
+            delete reinterpret_cast<const VkSubpassShadingPipelineCreateInfoHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingPropertiesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingPropertiesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROPERTIES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFrameBoundaryEXT *>(header);
+            delete reinterpret_cast<const VkFrameBoundaryEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SUBPASS_RESOLVE_PERFORMANCE_QUERY_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubpassResolvePerformanceQueryEXT *>(header);
+            delete reinterpret_cast<const VkSubpassResolvePerformanceQueryEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMultisampledRenderToSingleSampledInfoEXT *>(header);
+            delete reinterpret_cast<const VkMultisampledRenderToSingleSampledInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COLOR_WRITE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineColorWriteCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineColorWriteCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_RGB_CONVERSION_FEATURES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_RGB_CONVERSION_CAPABILITIES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeRgbConversionCapabilitiesVALVE *>(header);
+            delete reinterpret_cast<const VkVideoEncodeRgbConversionCapabilitiesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_PROFILE_RGB_CONVERSION_INFO_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeProfileRgbConversionInfoVALVE *>(header);
+            delete reinterpret_cast<const VkVideoEncodeProfileRgbConversionInfoVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_RGB_CONVERSION_CREATE_INFO_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeSessionRgbConversionCreateInfoVALVE *>(header);
+            delete reinterpret_cast<const VkVideoEncodeSessionRgbConversionCreateInfoVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewMinLodCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageViewMinLodCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImagePropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImagePropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureTrianglesOpacityMicromapEXT *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureTrianglesOpacityMicromapEXT*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureTrianglesDisplacementMicromapNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureTrianglesDisplacementMicromapNV*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerBorderColorComponentMappingCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkSamplerBorderColorComponentMappingCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_QUEUE_SHADER_CORE_CONTROL_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceQueueShaderCoreControlCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDeviceQueueShaderCoreControlCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewSlicedCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageViewSlicedCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_BEGIN_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassStripeBeginInfoARM *>(header);
+            delete reinterpret_cast<const VkRenderPassStripeBeginInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_SUBMIT_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassStripeSubmitInfoARM *>(header);
+            delete reinterpret_cast<const VkRenderPassStripeSubmitInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_OFFSET_END_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassFragmentDensityMapOffsetEndInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassFragmentDensityMapOffsetEndInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_INDIRECT_BUFFER_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkComputePipelineIndirectBufferInfoNV *>(header);
+            delete reinterpret_cast<const VkComputePipelineIndirectBufferInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_LINEAR_SWEPT_SPHERES_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_LINEAR_SWEPT_SPHERES_DATA_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureGeometryLinearSweptSpheresDataNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureGeometryLinearSweptSpheresDataNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_SPHERES_DATA_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureGeometrySpheresDataNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureGeometrySpheresDataNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_SAMPLE_WEIGHT_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewSampleWeightCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkImageViewSampleWeightCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingPropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingPropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferPropertiesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_OHOS
         case VK_STRUCTURE_TYPE_NATIVE_BUFFER_USAGE_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkNativeBufferUsageOHOS *>(header);
+            delete reinterpret_cast<const VkNativeBufferUsageOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_NATIVE_BUFFER_FORMAT_PROPERTIES_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkNativeBufferFormatPropertiesOHOS *>(header);
+            delete reinterpret_cast<const VkNativeBufferFormatPropertiesOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_NATIVE_BUFFER_INFO_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportNativeBufferInfoOHOS *>(header);
+            delete reinterpret_cast<const VkImportNativeBufferInfoOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalFormatOHOS *>(header);
+            delete reinterpret_cast<const VkExternalFormatOHOS*>(header);
             break;
 #endif  // VK_USE_PLATFORM_OHOS
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryAcquireUnmodifiedEXT *>(header);
+            delete reinterpret_cast<const VkExternalMemoryAcquireUnmodifiedEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3PropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3PropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_CONTROL_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassCreationControlEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassCreationControlEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_FEEDBACK_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassCreationFeedbackCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassCreationFeedbackCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_SUBPASS_FEEDBACK_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassSubpassFeedbackCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassSubpassFeedbackCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDirectDriverLoadingListLUNARG *>(header);
+            delete reinterpret_cast<const VkDirectDriverLoadingListLUNARG*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorDescriptionARM *>(header);
+            delete reinterpret_cast<const VkTensorDescriptionARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_TENSOR_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetTensorARM *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetTensorARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorFormatPropertiesARM *>(header);
+            delete reinterpret_cast<const VkTensorFormatPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTensorPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTensorPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_MEMORY_BARRIER_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorMemoryBarrierARM *>(header);
+            delete reinterpret_cast<const VkTensorMemoryBarrierARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_DEPENDENCY_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorDependencyInfoARM *>(header);
+            delete reinterpret_cast<const VkTensorDependencyInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_TENSOR_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfoTensorARM *>(header);
+            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfoTensorARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_TENSOR_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryTensorCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkExternalMemoryTensorCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_TENSOR_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_TENSOR_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_GET_TENSOR_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorGetTensorInfoARM *>(header);
+            delete reinterpret_cast<const VkDescriptorGetTensorInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_TENSORS_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFrameBoundaryTensorsARM *>(header);
+            delete reinterpret_cast<const VkFrameBoundaryTensorsARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineShaderStageModuleIdentifierCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineShaderStageModuleIdentifierCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkOpticalFlowImageFormatInfoNV *>(header);
+            delete reinterpret_cast<const VkOpticalFlowImageFormatInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_OPTICAL_FLOW_SESSION_CREATE_PRIVATE_DATA_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkOpticalFlowSessionCreatePrivateDataInfoNV *>(header);
+            delete reinterpret_cast<const VkOpticalFlowSessionCreatePrivateDataInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_PROPERTIES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolvePropertiesANDROID *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolvePropertiesANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_RESOLVE_PROPERTIES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferFormatResolvePropertiesANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatResolvePropertiesANDROID*>(header);
             break;
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ANTI_LAG_FEATURES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DENSE_GEOMETRY_FORMAT_FEATURES_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DENSE_GEOMETRY_FORMAT_TRIANGLES_DATA_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureDenseGeometryFormatTrianglesDataAMDX *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureDenseGeometryFormatTrianglesDataAMDX*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(header);
             break;
         case VK_STRUCTURE_TYPE_AMIGO_PROFILING_SUBMIT_INFO_SEC:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAmigoProfilingSubmitInfoSEC *>(header);
+            delete reinterpret_cast<const VkAmigoProfilingSubmitInfoSEC*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkLayerSettingsCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkLayerSettingsCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkLatencySubmissionPresentIdNV *>(header);
+            delete reinterpret_cast<const VkLatencySubmissionPresentIdNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_LATENCY_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainLatencyCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkSwapchainLatencyCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_LATENCY_SURFACE_CAPABILITIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkLatencySurfaceCapabilitiesNV *>(header);
+            delete reinterpret_cast<const VkLatencySurfaceCapabilitiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_COMPILER_CONTROL_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineCompilerControlCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineCompilerControlCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SHADER_MODULE_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineShaderModuleCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineShaderModuleCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_IDENTIFIER_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineIdentifierCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineIdentifierCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PROCESSING_ENGINE_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphProcessingEngineCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphProcessingEngineCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CONSTANT_TENSOR_SEMI_STRUCTURED_SPARSITY_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_RENDER_AREAS_RENDER_PASS_BEGIN_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM *>(header);
+            delete reinterpret_cast<const VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PER_STAGE_DESCRIPTOR_SET_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2PropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2PropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerBlockMatchWindowCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkSamplerBlockMatchWindowCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerCubicWeightsCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkSamplerCubicWeightsCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBlitImageCubicWeightsInfoQCOM *>(header);
+            delete reinterpret_cast<const VkBlitImageCubicWeightsInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_YCBCR_DEGAMMA_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
         case VK_STRUCTURE_TYPE_SCREEN_BUFFER_FORMAT_PROPERTIES_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkScreenBufferFormatPropertiesQNX *>(header);
+            delete reinterpret_cast<const VkScreenBufferFormatPropertiesQNX*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_SCREEN_BUFFER_INFO_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportScreenBufferInfoQNX *>(header);
+            delete reinterpret_cast<const VkImportScreenBufferInfoQNX*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalFormatQNX *>(header);
+            delete reinterpret_cast<const VkExternalFormatQNX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(header);
             break;
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_DRIVER_PROPERTIES_MSFT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLayeredDriverPropertiesMSFT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLayeredDriverPropertiesMSFT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_MEMORY_HEAP_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_MEMORY_HEAP_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapPropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapPropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TILE_MEMORY_REQUIREMENTS_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTileMemoryRequirementsQCOM *>(header);
+            delete reinterpret_cast<const VkTileMemoryRequirementsQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TILE_MEMORY_BIND_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTileMemoryBindInfoQCOM *>(header);
+            delete reinterpret_cast<const VkTileMemoryBindInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TILE_MEMORY_SIZE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTileMemorySizeInfoQCOM *>(header);
+            delete reinterpret_cast<const VkTileMemorySizeInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_SURFACE_STEREO_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplaySurfaceStereoCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDisplaySurfaceStereoCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_MODE_STEREO_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplayModeStereoPropertiesNV *>(header);
+            delete reinterpret_cast<const VkDisplayModeStereoPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_COMPUTE_QUEUE_DEVICE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalComputeQueueDeviceCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkExternalComputeQueueDeviceCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_COMPUTE_QUEUE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalComputeQueuePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalComputeQueuePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMMAND_BUFFER_INHERITANCE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT8_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructurePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructurePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CLUSTER_ACCELERATION_STRUCTURE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructurePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructurePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_FLAGS_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPartitionedAccelerationStructureFlagsNV *>(header);
+            delete reinterpret_cast<const VkPartitionedAccelerationStructureFlagsNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_PARTITIONED_ACCELERATION_STRUCTURE_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetPartitionedAccelerationStructureNV *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetPartitionedAccelerationStructureNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_GENERATED_COMMANDS_PIPELINE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGeneratedCommandsPipelineInfoEXT *>(header);
+            delete reinterpret_cast<const VkGeneratedCommandsPipelineInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_GENERATED_COMMANDS_SHADER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGeneratedCommandsShaderInfoEXT *>(header);
+            delete reinterpret_cast<const VkGeneratedCommandsShaderInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_FEATURES_MESA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_PROPERTIES_MESA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlPropertiesMESA *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlPropertiesMESA*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_ALIGNMENT_CONTROL_CREATE_INFO_MESA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageAlignmentControlCreateInfoMESA *>(header);
+            delete reinterpret_cast<const VkImageAlignmentControlCreateInfoMESA*>(header);
             break;
         case VK_STRUCTURE_TYPE_PUSH_CONSTANT_BANK_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPushConstantBankInfoNV *>(header);
+            delete reinterpret_cast<const VkPushConstantBankInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_CONSTANT_BANK_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePushConstantBankFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePushConstantBankFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_CONSTANT_BANK_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePushConstantBankPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePushConstantBankPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLAMP_CONTROL_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportDepthClampControlCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineViewportDepthClampControlCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HDR_VIVID_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_HDR_VIVID_DYNAMIC_METADATA_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkHdrVividDynamicMetadataHUAWEI *>(header);
+            delete reinterpret_cast<const VkHdrVividDynamicMetadataHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2PropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2PropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_OPACITY_MICROMAP_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(header);
             break;
 #ifdef VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_METAL_HANDLE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryMetalHandleInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMemoryMetalHandleInfoEXT*>(header);
             break;
 #endif  // VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_COUNTERS_BY_REGION_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_COUNTERS_BY_REGION_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_PERFORMANCE_COUNTERS_BY_REGION_BEGIN_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassPerformanceCountersByRegionBeginInfoARM *>(header);
+            delete reinterpret_cast<const VkRenderPassPerformanceCountersByRegionBeginInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INSTRUMENTATION_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INSTRUMENTATION_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderInstrumentationPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FORMAT_PACK_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_LAYERED_FEATURES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_LAYERED_PROPERTIES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredPropertiesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredPropertiesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_DENSITY_MAP_LAYERED_CREATE_INFO_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineFragmentDensityMapLayeredCreateInfoVALVE *>(header);
+            delete reinterpret_cast<const VkPipelineFragmentDensityMapLayeredCreateInfoVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_SET_PRESENT_CONFIG_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSetPresentConfigNV *>(header);
+            delete reinterpret_cast<const VkSetPresentConfigNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_METERING_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_DEVICE_MEMORY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_64_BIT_INDEXING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_RESOLVE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_CUSTOM_RESOLVE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCustomResolveCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkCustomResolveCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_BUILTIN_MODEL_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineBuiltinModelCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineBuiltinModelCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_MODEL_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_LONG_VECTOR_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderLongVectorFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderLongVectorFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_LONG_VECTOR_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderLongVectorPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderLongVectorPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CACHE_INCREMENTAL_MODE_FEATURES_SEC:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNIFORM_BUFFER_UNSIZED_ARRAY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_OCCUPANCY_PRIORITY_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_PARTITIONED_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupPartitionedFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MIXED_FLOAT_DOT_PRODUCT_FEATURES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureKHR *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructurePropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructurePropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelinePropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelinePropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesEXT*>(header);
             break;
         default:
             assert(false);
@@ -3923,12 +3923,12 @@ void PnextChainFree(void *chain) {
 }
 
 template <>
-void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceImageFormatInfo2 &out) {
-    void *chain_begin = nullptr;
-    void *chain_end = nullptr;
+void* PnextChainExtract(const void* in_pnext_chain, PnextChainVkPhysicalDeviceImageFormatInfo2& out) {
+    void* chain_begin = nullptr;
+    void* chain_end = nullptr;
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkImageCompressionControlEXT>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkImageCompressionControlEXT>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkImageCompressionControlEXT>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkImageCompressionControlEXT>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3939,8 +3939,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkImageFormatListCreateInfo>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkImageFormatListCreateInfo>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3951,8 +3951,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkImageStencilUsageCreateInfo>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkImageStencilUsageCreateInfo>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3963,8 +3963,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkOpticalFlowImageFormatInfoNV>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkOpticalFlowImageFormatInfoNV>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkOpticalFlowImageFormatInfoNV>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkOpticalFlowImageFormatInfoNV>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3975,8 +3975,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceExternalImageFormatInfo>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkPhysicalDeviceExternalImageFormatInfo>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceExternalImageFormatInfo>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkPhysicalDeviceExternalImageFormatInfo>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3987,8 +3987,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3999,8 +3999,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkPhysicalDeviceImageViewImageFormatInfoEXT>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkPhysicalDeviceImageViewImageFormatInfoEXT>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -4011,8 +4011,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkVideoProfileListInfoKHR>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkVideoProfileListInfoKHR>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {

--- a/layers/vulkan/generated/pnext_chain_extraction.h
+++ b/layers/vulkan/generated/pnext_chain_extraction.h
@@ -32,22 +32,22 @@
 namespace vvl {
 
 // Add element to the end of a pNext chain
-void *PnextChainAdd(void *chain, void *new_struct);
+void* PnextChainAdd(void* chain, void* new_struct);
 
 // Remove last element from a pNext chain
-void PnextChainRemoveLast(void *chain);
+void PnextChainRemoveLast(void* chain);
 
 // Free dynamically allocated pnext chain structs
-void PnextChainFree(void *chain);
+void PnextChainFree(void* chain);
 
 // Helper class relying on RAII to help with adding and removing an element from a pNext chain
 class PnextChainScopedAdd {
   public:
-    PnextChainScopedAdd(void *chain, void *new_struct) : chain(chain) { PnextChainAdd(chain, new_struct); }
+    PnextChainScopedAdd(void* chain, void* new_struct) : chain(chain) { PnextChainAdd(chain, new_struct); }
     ~PnextChainScopedAdd() { PnextChainRemoveLast(chain); }
 
   private:
-    void *chain = nullptr;
+    void* chain = nullptr;
 };
 
 // clang-format off

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -45,14 +45,14 @@ struct FeaturePointer {
     // Default and nullptr constructor to create an empty FeaturePointer
     FeaturePointer() : IsEnabled(nullptr) {}
     FeaturePointer(std::nullptr_t ptr) : IsEnabled(nullptr) {}
-    FeaturePointer(bool DeviceFeatures::*ptr) : IsEnabled([=](const DeviceFeatures& features) { return features.*ptr; }) {}
+    FeaturePointer(bool DeviceFeatures::* ptr) : IsEnabled([=](const DeviceFeatures& features) { return features.*ptr; }) {}
 };
 
 // Each instance of the struct will only have a singel field non-null
 struct RequiredSpirvInfo {
     uint32_t version;
     FeaturePointer feature;
-    ExtEnabled DeviceExtensions::*extension;
+    ExtEnabled DeviceExtensions::* extension;
     const char* property;  // For human readability and make some capabilities unique
 };
 

--- a/layers/vulkan/generated/vk_extension_helper.h
+++ b/layers/vulkan/generated/vk_extension_helper.h
@@ -51,9 +51,9 @@ enum ExtEnabled : unsigned char {
 // Map of promoted extension information per version (a separate map exists for instance and device extensions).
 // The map is keyed by the version number (e.g. VK_API_VERSION_1_1) and each value is a pair consisting of the
 // version string (e.g. "VK_VERSION_1_1") and the set of name of the promoted extensions.
-typedef vvl::unordered_map<uint32_t, std::pair<const char *, vvl::unordered_set<vvl::Extension>>> PromotedExtensionInfoMap;
-const PromotedExtensionInfoMap &GetInstancePromotionInfoMap();
-const PromotedExtensionInfoMap &GetDevicePromotionInfoMap();
+typedef vvl::unordered_map<uint32_t, std::pair<const char*, vvl::unordered_set<vvl::Extension>>> PromotedExtensionInfoMap;
+const PromotedExtensionInfoMap& GetInstancePromotionInfoMap();
+const PromotedExtensionInfoMap& GetDevicePromotionInfoMap();
 
 /*
 This function is a helper to know if the extension is enabled.
@@ -135,21 +135,21 @@ struct InstanceExtensions {
     ExtEnabled vk_sec_ubm_surface{kNotSupported};
 
     struct Requirement {
-        const ExtEnabled InstanceExtensions::*enabled;
-        const char *name;
+        const ExtEnabled InstanceExtensions::* enabled;
+        const char* name;
     };
     typedef std::vector<Requirement> RequirementVec;
     struct Info {
-        Info(ExtEnabled InstanceExtensions::*state_, const RequirementVec requirements_)
+        Info(ExtEnabled InstanceExtensions::* state_, const RequirementVec requirements_)
             : state(state_), requirements(requirements_) {}
-        ExtEnabled InstanceExtensions::*state;
+        ExtEnabled InstanceExtensions::* state;
         RequirementVec requirements;
     };
 
-    const Info &GetInfo(vvl::Extension extension_name) const;
+    const Info& GetInfo(vvl::Extension extension_name) const;
 
     InstanceExtensions() = default;
-    InstanceExtensions(APIVersion requested_api_version, const VkInstanceCreateInfo *pCreateInfo);
+    InstanceExtensions(APIVersion requested_api_version, const VkInstanceCreateInfo* pCreateInfo);
 };
 
 struct DeviceExtensions : public InstanceExtensions {
@@ -564,30 +564,30 @@ struct DeviceExtensions : public InstanceExtensions {
     ExtEnabled vk_ext_mesh_shader{kNotSupported};
 
     struct Requirement {
-        const ExtEnabled DeviceExtensions::*enabled;
-        const char *name;
+        const ExtEnabled DeviceExtensions::* enabled;
+        const char* name;
     };
     typedef std::vector<Requirement> RequirementVec;
     struct Info {
-        Info(ExtEnabled DeviceExtensions::*state_, const RequirementVec requirements_)
+        Info(ExtEnabled DeviceExtensions::* state_, const RequirementVec requirements_)
             : state(state_), requirements(requirements_) {}
-        ExtEnabled DeviceExtensions::*state;
+        ExtEnabled DeviceExtensions::* state;
         RequirementVec requirements;
     };
 
-    const Info &GetInfo(vvl::Extension extension_name) const;
+    const Info& GetInfo(vvl::Extension extension_name) const;
 
     DeviceExtensions() = default;
-    DeviceExtensions(const InstanceExtensions &instance_ext) : InstanceExtensions(instance_ext) {}
+    DeviceExtensions(const InstanceExtensions& instance_ext) : InstanceExtensions(instance_ext) {}
 
-    DeviceExtensions(const InstanceExtensions &instance_extensions, APIVersion requested_api_version,
-                     const VkDeviceCreateInfo *pCreateInfo = nullptr);
-    DeviceExtensions(const InstanceExtensions &instance_ext, APIVersion requested_api_version,
-                     const std::vector<VkExtensionProperties> &props);
+    DeviceExtensions(const InstanceExtensions& instance_extensions, APIVersion requested_api_version,
+                     const VkDeviceCreateInfo* pCreateInfo = nullptr);
+    DeviceExtensions(const InstanceExtensions& instance_ext, APIVersion requested_api_version,
+                     const std::vector<VkExtensionProperties>& props);
 };
 
-const InstanceExtensions::Info &GetInstanceVersionMap(const char *version);
-const DeviceExtensions::Info &GetDeviceVersionMap(const char *version);
+const InstanceExtensions::Info& GetInstanceVersionMap(const char* version);
+const DeviceExtensions::Info& GetDeviceVersionMap(const char* version);
 
 constexpr bool IsInstanceExtension(vvl::Extension extension) {
     switch (extension) {

--- a/scripts/check_code_format.py
+++ b/scripts/check_code_format.py
@@ -53,17 +53,26 @@ def CPrint(msg_type, msg_string):
 # Check clang-formatting of source code diff
 def VerifyClangFormatSource(commit, target_files):
     target_refspec = f'{commit}^...{commit}'
-    retval = 0
-    good_file_pattern = re.compile(r'.*\\.(cpp|cc|c\+\+|cxx|c|h|hpp)$')
+    good_file_pattern = re.compile(r'.*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$')
     diff_files_list = [item for item in target_files if good_file_pattern.search(item)]
     diff_files = ' '.join([str(elem) for elem in diff_files_list])
     retval = 0
     if diff_files != '':
         git_diff = subprocess.Popen(('git', 'diff', '-U0', target_refspec, '--', diff_files), stdout=subprocess.PIPE)
         diff_files_data = subprocess.check_output(('python3', repo_relative('scripts/clang-format-diff.py'), '-p1', '-style=file'), stdin=git_diff.stdout)
+
         diff_files_data = diff_files_data.decode('utf-8')
         if diff_files_data != '':
             CPrint('ERR_MSG', "\nFound formatting errors!")
+            CPrint('HELP_MSG', "\nClang Format 22.1.x is required (version 23 seems to works as well) ... clang-format broke since version 18 unfortunately")
+            CPrint('HELP_MSG', "\nFor Windows:")
+            CPrint('CONTENT', "  https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.1 provides a binary to grab")
+            CPrint('HELP_MSG', "\nFor Visual Studio:")
+            CPrint('CONTENT', "  Navigate to \"Text Editor\" > \"C/C++\" > \"Formatting\" > \"General\" and find \"Use custom clang-format.exe file\"")
+            CPrint('HELP_MSG', "\nFor Linux:")
+            CPrint('CONTENT', "  You should be able to find it in your package manager (sudo apt search clang-format)\n  Or run\n     wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 22")
+            CPrint('HELP_MSG', "\nTo set for the project:")
+            CPrint('CONTENT', "  git config clang-format.binary clang-format-22")
             CPrint('CONTENT', "\n" + diff_files_data)
             retval = 1
     return retval

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# Copyright (c) 2021-2025 The Khronos Group Inc.
-# Copyright (c) 2021-2025 Valve Corporation
-# Copyright (c) 2021-2025 LunarG, Inc.
-# Copyright (c) 2021-2024 Google Inc.
-# Copyright (c) 2023-2024 RasterGrid Kft.
+# Copyright (c) 2021-2026 The Khronos Group Inc.
+# Copyright (c) 2021-2026 Valve Corporation
+# Copyright (c) 2021-2026 LunarG, Inc.
+# Copyright (c) 2021-2026 Google Inc.
+# Copyright (c) 2023-2026 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,9 +32,10 @@ from xml.etree import ElementTree
 from generate_spec_error_message import GenerateSpecErrorMessage
 
 def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFile: str, targetFilter: str, caching: bool):
+    clang_binary = 'clang-format'
 
     try:
-        code = common_ci.RunShellCmd(f'clang-format --version')
+        code = common_ci.RunShellCmd(f'{clang_binary} --version')
         has_clang_format = True
     except:
         has_clang_format = False
@@ -412,7 +413,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
 
         # Run clang-format on the file
         if has_clang_format:
-            common_ci.RunShellCmd(f'clang-format -i --style=file:{styleFile} {os.path.join(directory, target)}')
+            common_ci.RunShellCmd(f'{clang_binary} -i --style=file:{styleFile} {os.path.join(directory, target)}')
 
     if os.path.isfile(cachePath):
         os.remove(cachePath)

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -57,7 +57,7 @@
 
 namespace vkt {
 
-void Instance::Init(const VkInstanceCreateInfo &info) { ASSERT_EQ(VK_SUCCESS, vk::CreateInstance(&info, NULL, &handle_)); }
+void Instance::Init(const VkInstanceCreateInfo& info) { ASSERT_EQ(VK_SUCCESS, vk::CreateInstance(&info, NULL, &handle_)); }
 
 void Instance::Destroy() noexcept {
     if (handle_ != VK_NULL_HANDLE) {
@@ -123,7 +123,7 @@ std::vector<VkExtensionProperties> GetGlobalExtensions() { return GetGlobalExten
  * If pLayerName is NULL, will return extensions implemented by the loader /
  * ICDs
  */
-std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
+std::vector<VkExtensionProperties> GetGlobalExtensions(const char* pLayerName) {
     VkResult err;
     uint32_t extension_count = 32;
     std::vector<VkExtensionProperties> extensions(extension_count);
@@ -145,7 +145,7 @@ std::vector<VkExtensionProperties> GetGlobalExtensions(const char *pLayerName) {
  * Return list of PhysicalDevice extensions provided by the specified layer
  * If pLayerName is NULL, will return extensions for ICD / loader.
  */
-std::vector<VkExtensionProperties> PhysicalDevice::Extensions(const char *pLayerName) const {
+std::vector<VkExtensionProperties> PhysicalDevice::Extensions(const char* pLayerName) const {
     VkResult err;
     uint32_t extension_count = 512;
     std::vector<VkExtensionProperties> extensions(extension_count);
@@ -163,7 +163,7 @@ std::vector<VkExtensionProperties> PhysicalDevice::Extensions(const char *pLayer
     }
 }
 
-bool PhysicalDevice::SetMemoryType(const uint32_t type_bits, VkMemoryAllocateInfo *info, const VkFlags properties,
+bool PhysicalDevice::SetMemoryType(const uint32_t type_bits, VkMemoryAllocateInfo* info, const VkFlags properties,
                                    const VkFlags forbid, const VkMemoryHeapFlags heapFlags) const {
     uint32_t type_mask = type_bits;
     // Search memtypes to find first index with those properties
@@ -209,7 +209,7 @@ std::vector<VkLayerProperties> PhysicalDevice::Layers() const {
     }
 }
 
-QueueCreateInfoArray::QueueCreateInfoArray(const std::vector<VkQueueFamilyProperties> &queue_props, bool all_queue_count)
+QueueCreateInfoArray::QueueCreateInfoArray(const std::vector<VkQueueFamilyProperties>& queue_props, bool all_queue_count)
     : queue_info_(), queue_priorities_() {
     queue_info_.reserve(queue_props.size());
 
@@ -236,7 +236,7 @@ void Device::Destroy() noexcept {
 
 Device::~Device() noexcept { Destroy(); }
 
-void Device::Init(std::vector<const char *> &extensions, VkPhysicalDeviceFeatures *features, void *create_device_pnext,
+void Device::Init(std::vector<const char*>& extensions, VkPhysicalDeviceFeatures* features, void* create_device_pnext,
                   bool all_queue_count) {
     // request all queues
     QueueCreateInfoArray queue_info(physical_device_.queue_properties_, all_queue_count);
@@ -285,7 +285,7 @@ void Device::Init(std::vector<const char *> &extensions, VkPhysicalDeviceFeature
     Init(dev_info);
 }
 
-void Device::Init(const VkDeviceCreateInfo &info) {
+void Device::Init(const VkDeviceCreateInfo& info) {
     VkDevice dev;
 
     ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(physical_device_, &info, nullptr, &dev));
@@ -294,16 +294,16 @@ void Device::Init(const VkDeviceCreateInfo &info) {
     InitQueues(info);
 }
 
-void Device::InitQueues(const VkDeviceCreateInfo &info) {
+void Device::InitQueues(const VkDeviceCreateInfo& info) {
     uint32_t queue_node_count = physical_device_.queue_properties_.size();
 
     queue_families_.resize(queue_node_count);
     for (uint32_t i = 0; i < info.queueCreateInfoCount; i++) {
-        const auto &queue_create_info = info.pQueueCreateInfos[i];
+        const auto& queue_create_info = info.pQueueCreateInfos[i];
         auto queue_family_i = queue_create_info.queueFamilyIndex;
-        const auto &queue_family_prop = physical_device_.queue_properties_[queue_family_i];
+        const auto& queue_family_prop = physical_device_.queue_properties_[queue_family_i];
 
-        QueueFamilyQueues &queue_storage = queue_families_[queue_family_i];
+        QueueFamilyQueues& queue_storage = queue_families_[queue_family_i];
         queue_storage.reserve(queue_create_info.queueCount);
         for (uint32_t queue_i = 0; queue_i < queue_create_info.queueCount; ++queue_i) {
             VkQueue queue = VK_NULL_HANDLE;
@@ -351,7 +351,7 @@ void Device::InitQueues(const VkDeviceCreateInfo &info) {
     }
 }
 
-const Device::QueueFamilyQueues &Device::QueuesFromFamily(uint32_t queue_family) const {
+const Device::QueueFamilyQueues& Device::QueuesFromFamily(uint32_t queue_family) const {
     assert(queue_family < queue_families_.size());
     return queue_families_[queue_family];
 }
@@ -381,14 +381,14 @@ std::optional<uint32_t> Device::QueueFamilyWithoutCapabilities(VkQueueFlags with
     return {};
 }
 
-Queue *Device::QueueWithoutCapabilities(VkQueueFlags without) const {
+Queue* Device::QueueWithoutCapabilities(VkQueueFlags without) const {
     auto family_index = QueueFamilyWithoutCapabilities(without);
     return family_index.has_value() ? QueuesFromFamily(*family_index)[0].get() : nullptr;
 }
 
 std::optional<uint32_t> Device::ComputeOnlyQueueFamily() const { return QueueFamily(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT); }
 
-Queue *Device::ComputeOnlyQueue() const {
+Queue* Device::ComputeOnlyQueue() const {
     auto family_index = ComputeOnlyQueueFamily();
     return family_index.has_value() ? QueuesFromFamily(*family_index)[0].get() : nullptr;
 }
@@ -397,7 +397,7 @@ std::optional<uint32_t> Device::TransferOnlyQueueFamily() const {
     return QueueFamily(VK_QUEUE_TRANSFER_BIT, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
 }
 
-Queue *Device::TransferOnlyQueue() const {
+Queue* Device::TransferOnlyQueue() const {
     auto family_index = TransferOnlyQueueFamily();
     return family_index.has_value() ? QueuesFromFamily(*family_index)[0].get() : nullptr;
 }
@@ -409,13 +409,13 @@ std::optional<uint32_t> Device::NonGraphicsQueueFamily() const {
     return TransferOnlyQueueFamily();
 }
 
-Queue *Device::NonGraphicsQueue() const {
+Queue* Device::NonGraphicsQueue() const {
     auto family_index = NonGraphicsQueueFamily();
     return family_index.has_value() ? QueuesFromFamily(*family_index)[0].get() : nullptr;
 }
 
-bool Device::IsEnabledExtension(const char *extension) const {
-    const auto is_x = [&extension](const char *enabled_extension) { return strcmp(extension, enabled_extension) == 0; };
+bool Device::IsEnabledExtension(const char* extension) const {
+    const auto is_x = [&extension](const char* enabled_extension) { return strcmp(extension, enabled_extension) == 0; };
     return std::any_of(enabled_extensions_.begin(), enabled_extensions_.end(), is_x);
 }
 
@@ -460,11 +460,11 @@ VkFormatFeatureFlags2 Device::FormatFeaturesBuffer(VkFormat format) const {
 
 void Device::Wait() const { ASSERT_EQ(VK_SUCCESS, vk::DeviceWaitIdle(handle())); }
 
-VkResult Device::Wait(const std::vector<const Fence *> &fences, bool wait_all, uint64_t timeout) {
+VkResult Device::Wait(const std::vector<const Fence*>& fences, bool wait_all, uint64_t timeout) {
     std::vector<VkFence> fence_handles;
     fence_handles.reserve(fences.size());
     std::transform(fences.begin(), fences.end(), std::back_inserter(fence_handles),
-                   [](const Fence *o) { return (o) ? o->handle() : VK_NULL_HANDLE; });
+                   [](const Fence* o) { return (o) ? o->handle() : VK_NULL_HANDLE; });
 
     VkResult err =
         vk::WaitForFences(handle(), static_cast<uint32_t>(fence_handles.size()), fence_handles.data(), wait_all, timeout);
@@ -473,7 +473,7 @@ VkResult Device::Wait(const std::vector<const Fence *> &fences, bool wait_all, u
     return err;
 }
 
-VkResult Queue::Submit(const CommandBuffer &cmd, const Fence &fence) {
+VkResult Queue::Submit(const CommandBuffer& cmd, const Fence& fence) {
     VkSubmitInfo submit = vku::InitStructHelper();
     submit.commandBufferCount = cmd.initialized() ? 1 : 0;
     submit.pCommandBuffers = &cmd.handle();
@@ -481,7 +481,7 @@ VkResult Queue::Submit(const CommandBuffer &cmd, const Fence &fence) {
     return result;
 }
 
-VkResult Queue::Submit(const std::vector<VkCommandBuffer> &cmds, const Fence &fence) {
+VkResult Queue::Submit(const std::vector<VkCommandBuffer>& cmds, const Fence& fence) {
     VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = static_cast<uint32_t>(cmds.size());
     submit_info.pCommandBuffers = cmds.data();
@@ -489,7 +489,7 @@ VkResult Queue::Submit(const std::vector<VkCommandBuffer> &cmds, const Fence &fe
     return result;
 }
 
-VkResult Queue::Submit(const CommandBuffer &cmd, const vkt::Wait &wait, const Fence &fence) {
+VkResult Queue::Submit(const CommandBuffer& cmd, const vkt::Wait& wait, const Fence& fence) {
     assert(wait.stage_mask < VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM);
     const auto wait_stage_mask = static_cast<VkPipelineStageFlags>(wait.stage_mask);
 
@@ -503,7 +503,7 @@ VkResult Queue::Submit(const CommandBuffer &cmd, const vkt::Wait &wait, const Fe
     return result;
 }
 
-VkResult Queue::Submit(const CommandBuffer &cmd, const Signal &signal, const Fence &fence) {
+VkResult Queue::Submit(const CommandBuffer& cmd, const Signal& signal, const Fence& fence) {
     assert(signal.stage_mask == VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
     VkSubmitInfo submit = vku::InitStructHelper();
@@ -515,7 +515,7 @@ VkResult Queue::Submit(const CommandBuffer &cmd, const Signal &signal, const Fen
     return result;
 }
 
-VkResult Queue::Submit(const CommandBuffer &cmd, const vkt::Wait &wait, const Signal &signal, const Fence &fence) {
+VkResult Queue::Submit(const CommandBuffer& cmd, const vkt::Wait& wait, const Signal& signal, const Fence& fence) {
     assert(wait.stage_mask < VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM);
     assert(signal.stage_mask == VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     const auto wait_stage_mask = static_cast<VkPipelineStageFlags>(wait.stage_mask);
@@ -532,7 +532,7 @@ VkResult Queue::Submit(const CommandBuffer &cmd, const vkt::Wait &wait, const Si
     return result;
 }
 
-VkResult Queue::Submit(const CommandBuffer &cmd, const TimelineWait &wait, const Fence &fence) {
+VkResult Queue::Submit(const CommandBuffer& cmd, const TimelineWait& wait, const Fence& fence) {
     assert(wait.stage_mask < VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM);
     const auto wait_stage_mask = static_cast<VkPipelineStageFlags>(wait.stage_mask);
 
@@ -550,7 +550,7 @@ VkResult Queue::Submit(const CommandBuffer &cmd, const TimelineWait &wait, const
     return result;
 }
 
-VkResult Queue::Submit(const CommandBuffer &cmd, const TimelineSignal &signal, const Fence &fence) {
+VkResult Queue::Submit(const CommandBuffer& cmd, const TimelineSignal& signal, const Fence& fence) {
     assert(signal.stage_mask == VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
     VkTimelineSemaphoreSubmitInfo timeline_info = vku::InitStructHelper();
@@ -566,7 +566,7 @@ VkResult Queue::Submit(const CommandBuffer &cmd, const TimelineSignal &signal, c
     return result;
 }
 
-VkResult Queue::Submit(const CommandBuffer &cmd, const TimelineWait &wait, const TimelineSignal &signal, const Fence &fence) {
+VkResult Queue::Submit(const CommandBuffer& cmd, const TimelineWait& wait, const TimelineSignal& signal, const Fence& fence) {
     assert(wait.stage_mask < VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM);
     assert(signal.stage_mask == VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     const auto wait_stage_mask = static_cast<VkPipelineStageFlags>(wait.stage_mask);
@@ -589,7 +589,7 @@ VkResult Queue::Submit(const CommandBuffer &cmd, const TimelineWait &wait, const
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const Fence &fence, bool use_khr) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const Fence& fence, bool use_khr) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -606,7 +606,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const Fence &fence, bool use_k
     return result;
 }
 
-VkResult Queue::Submit2(const std::vector<VkCommandBuffer> &cmds, const Fence &fence, bool use_khr) {
+VkResult Queue::Submit2(const std::vector<VkCommandBuffer>& cmds, const Fence& fence, bool use_khr) {
     std::vector<VkCommandBufferSubmitInfo> cmd_submit_infos;
     cmd_submit_infos.reserve(cmds.size());
     for (size_t i = 0; i < cmds.size(); i++) {
@@ -627,7 +627,7 @@ VkResult Queue::Submit2(const std::vector<VkCommandBuffer> &cmds, const Fence &f
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const vkt::Wait &wait, const Fence &fence, bool use_khr) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const vkt::Wait& wait, const Fence& fence, bool use_khr) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -650,7 +650,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const vkt::Wait &wait, const F
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const Signal &signal, const Fence &fence, bool use_khr) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const Signal& signal, const Fence& fence, bool use_khr) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -673,7 +673,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const Signal &signal, const Fe
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const vkt::Wait &wait, const Signal &signal, const Fence &fence, bool use_khr) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const vkt::Wait& wait, const Signal& signal, const Fence& fence, bool use_khr) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -702,7 +702,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const vkt::Wait &wait, const S
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, const Fence &fence, bool use_khr) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const TimelineWait& wait, const Fence& fence, bool use_khr) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -726,7 +726,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, cons
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineSignal &signal, const Fence &fence, bool use_khr) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const TimelineSignal& signal, const Fence& fence, bool use_khr) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -750,7 +750,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineSignal &signal, 
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, const TimelineSignal &signal, const Fence &fence,
+VkResult Queue::Submit2(const CommandBuffer& cmd, const TimelineWait& wait, const TimelineSignal& signal, const Fence& fence,
                         bool use_khr) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
@@ -782,7 +782,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, cons
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const vkt::Wait &wait, const TimelineSignal &signal, const Fence &fence) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const vkt::Wait& wait, const TimelineSignal& signal, const Fence& fence) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -807,7 +807,7 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const vkt::Wait &wait, const T
     return result;
 }
 
-VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, const Signal &signal, const Fence &fence) {
+VkResult Queue::Submit2(const CommandBuffer& cmd, const TimelineWait& wait, const Signal& signal, const Fence& fence) {
     VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = cmd;
 
@@ -832,8 +832,8 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, cons
     return result;
 }
 
-VkResult Queue::Present(const Swapchain &swapchain, uint32_t image_index, const Semaphore &wait_semaphore,
-                        void *present_info_pnext) {
+VkResult Queue::Present(const Swapchain& swapchain, uint32_t image_index, const Semaphore& wait_semaphore,
+                        void* present_info_pnext) {
     VkPresentInfoKHR present = vku::InitStructHelper(present_info_pnext);
     if (wait_semaphore.initialized()) {
         present.waitSemaphoreCount = 1;
@@ -863,12 +863,12 @@ void DeviceMemory::Destroy() noexcept {
 
 DeviceMemory::~DeviceMemory() noexcept { Destroy(); }
 
-void DeviceMemory::Init(const Device &dev, const VkMemoryAllocateInfo &info) {
+void DeviceMemory::Init(const Device& dev, const VkMemoryAllocateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::AllocateMemory, dev, &info);
     memory_allocate_info_ = info;
 }
 
-VkResult DeviceMemory::TryInit(const Device &dev, const VkMemoryAllocateInfo &info) {
+VkResult DeviceMemory::TryInit(const Device& dev, const VkMemoryAllocateInfo& info) {
     assert(!initialized());
     VkDeviceMemory handle = VK_NULL_HANDLE;
     auto result = vk::AllocateMemory(dev, &info, nullptr, &handle);
@@ -878,16 +878,16 @@ VkResult DeviceMemory::TryInit(const Device &dev, const VkMemoryAllocateInfo &in
     return result;
 }
 
-const void *DeviceMemory::Map(VkFlags flags) const {
-    void *data;
+const void* DeviceMemory::Map(VkFlags flags) const {
+    void* data;
     VkResult result = vk::MapMemory(device(), handle(), 0, VK_WHOLE_SIZE, flags, &data);
     EXPECT_EQ(VK_SUCCESS, result);
     if (result != VK_SUCCESS) data = NULL;
     return data;
 }
 
-void *DeviceMemory::Map(VkFlags flags) {
-    void *data;
+void* DeviceMemory::Map(VkFlags flags) {
+    void* data;
     VkResult result = vk::MapMemory(device(), handle(), 0, VK_WHOLE_SIZE, flags, &data);
     EXPECT_EQ(VK_SUCCESS, result);
     if (result != VK_SUCCESS) data = NULL;
@@ -897,8 +897,8 @@ void *DeviceMemory::Map(VkFlags flags) {
 
 void DeviceMemory::Unmap() const { vk::UnmapMemory(device(), handle()); }
 
-VkMemoryAllocateInfo DeviceMemory::GetResourceAllocInfo(const Device &dev, const VkMemoryRequirements &reqs,
-                                                        VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
+VkMemoryAllocateInfo DeviceMemory::GetResourceAllocInfo(const Device& dev, const VkMemoryRequirements& reqs,
+                                                        VkMemoryPropertyFlags mem_props, void* alloc_info_pnext) {
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(alloc_info_pnext);
     alloc_info.allocationSize = reqs.size;
     EXPECT_TRUE(dev.Physical().SetMemoryType(reqs.memoryTypeBits, &alloc_info, mem_props));
@@ -907,15 +907,15 @@ VkMemoryAllocateInfo DeviceMemory::GetResourceAllocInfo(const Device &dev, const
 
 NON_DISPATCHABLE_HANDLE_DTOR(Fence, vk::DestroyFence)
 
-Fence &Fence::operator=(Fence &&rhs) noexcept {
+Fence& Fence::operator=(Fence&& rhs) noexcept {
     Destroy();
     NonDispHandle<VkFence>::operator=(std::move(rhs));
     return *this;
 }
 
-void Fence::Init(const Device &dev, const VkFenceCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateFence, dev, &info); }
+void Fence::Init(const Device& dev, const VkFenceCreateInfo& info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateFence, dev, &info); }
 
-void Fence::Init(const Device &dev, const VkFenceCreateFlags flags) {
+void Fence::Init(const Device& dev, const VkFenceCreateFlags flags) {
     VkFenceCreateInfo fence_ci = vku::InitStructHelper();
     fence_ci.flags = flags;
     Init(dev, fence_ci);
@@ -926,7 +926,7 @@ VkResult Fence::Wait(uint64_t timeout) const { return vk::WaitForFences(device()
 VkResult Fence::Reset() const { return vk::ResetFences(device(), 1, &handle()); }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-VkResult Fence::ExportHandle(HANDLE &win32_handle, VkExternalFenceHandleTypeFlagBits handle_type) {
+VkResult Fence::ExportHandle(HANDLE& win32_handle, VkExternalFenceHandleTypeFlagBits handle_type) {
     VkFenceGetWin32HandleInfoKHR ghi = vku::InitStructHelper();
     ghi.fence = handle();
     ghi.handleType = handle_type;
@@ -943,7 +943,7 @@ VkResult Fence::ImportHandle(HANDLE win32_handle, VkExternalFenceHandleTypeFlagB
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-VkResult Fence::ExportHandle(int &fd_handle, VkExternalFenceHandleTypeFlagBits handle_type) {
+VkResult Fence::ExportHandle(int& fd_handle, VkExternalFenceHandleTypeFlagBits handle_type) {
     VkFenceGetFdInfoKHR gfi = vku::InitStructHelper();
     gfi.fence = handle();
     gfi.handleType = handle_type;
@@ -961,7 +961,7 @@ VkResult Fence::ImportHandle(int fd_handle, VkExternalFenceHandleTypeFlagBits ha
 
 NON_DISPATCHABLE_HANDLE_DTOR(Semaphore, vk::DestroySemaphore)
 
-Semaphore::Semaphore(const Device &dev, VkSemaphoreType type, uint64_t initial_value) {
+Semaphore::Semaphore(const Device& dev, VkSemaphoreType type, uint64_t initial_value) {
     if (type == VK_SEMAPHORE_TYPE_BINARY) {
         Init(dev, vku::InitStruct<VkSemaphoreCreateInfo>());
     } else {
@@ -973,13 +973,13 @@ Semaphore::Semaphore(const Device &dev, VkSemaphoreType type, uint64_t initial_v
     }
 }
 
-Semaphore &Semaphore::operator=(Semaphore &&rhs) noexcept {
+Semaphore& Semaphore::operator=(Semaphore&& rhs) noexcept {
     Destroy();
     NonDispHandle<VkSemaphore>::operator=(std::move(rhs));
     return *this;
 }
 
-void Semaphore::Init(const Device &dev, const VkSemaphoreCreateInfo &info) {
+void Semaphore::Init(const Device& dev, const VkSemaphoreCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSemaphore, dev, &info);
 }
 
@@ -1028,7 +1028,7 @@ uint64_t Semaphore::GetCounterValue(bool use_khr) const {
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-VkResult Semaphore::ExportHandle(HANDLE &win32_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
+VkResult Semaphore::ExportHandle(HANDLE& win32_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
     win32_handle = nullptr;
     VkSemaphoreGetWin32HandleInfoKHR ghi = vku::InitStructHelper();
     ghi.semaphore = handle();
@@ -1047,7 +1047,7 @@ VkResult Semaphore::ImportHandle(HANDLE win32_handle, VkExternalSemaphoreHandleT
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-VkResult Semaphore::ExportHandle(int &fd_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
+VkResult Semaphore::ExportHandle(int& fd_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
     fd_handle = -1;
     VkSemaphoreGetFdInfoKHR ghi = vku::InitStructHelper();
     ghi.semaphore = handle();
@@ -1067,17 +1067,17 @@ VkResult Semaphore::ImportHandle(int fd_handle, VkExternalSemaphoreHandleTypeFla
 
 NON_DISPATCHABLE_HANDLE_DTOR(Event, vk::DestroyEvent)
 
-void Event::Init(const Device &dev, const VkEventCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateEvent, dev, &info); }
+void Event::Init(const Device& dev, const VkEventCreateInfo& info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateEvent, dev, &info); }
 
 void Event::Set() { ASSERT_EQ(VK_SUCCESS, vk::SetEvent(device(), handle())); }
 
-void Event::CmdSet(const CommandBuffer &cmd, VkPipelineStageFlags stage_mask) { vk::CmdSetEvent(cmd, handle(), stage_mask); }
+void Event::CmdSet(const CommandBuffer& cmd, VkPipelineStageFlags stage_mask) { vk::CmdSetEvent(cmd, handle(), stage_mask); }
 
-void Event::CmdReset(const CommandBuffer &cmd, VkPipelineStageFlags stage_mask) { vk::CmdResetEvent(cmd, handle(), stage_mask); }
+void Event::CmdReset(const CommandBuffer& cmd, VkPipelineStageFlags stage_mask) { vk::CmdResetEvent(cmd, handle(), stage_mask); }
 
-void Event::CmdWait(const CommandBuffer &cmd, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
-                    const std::vector<VkMemoryBarrier> &memory_barriers, const std::vector<VkBufferMemoryBarrier> &buffer_barriers,
-                    const std::vector<VkImageMemoryBarrier> &image_barriers) {
+void Event::CmdWait(const CommandBuffer& cmd, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
+                    const std::vector<VkMemoryBarrier>& memory_barriers, const std::vector<VkBufferMemoryBarrier>& buffer_barriers,
+                    const std::vector<VkImageMemoryBarrier>& image_barriers) {
     VkEvent event_handle = handle();
     vk::CmdWaitEvents(cmd, 1, &event_handle, src_stage_mask, dst_stage_mask, static_cast<uint32_t>(memory_barriers.size()),
                       memory_barriers.data(), static_cast<uint32_t>(buffer_barriers.size()), buffer_barriers.data(),
@@ -1088,11 +1088,11 @@ void Event::Reset() { ASSERT_EQ(VK_SUCCESS, vk::ResetEvent(device(), handle()));
 
 NON_DISPATCHABLE_HANDLE_DTOR(QueryPool, vk::DestroyQueryPool)
 
-void QueryPool::Init(const Device &dev, const VkQueryPoolCreateInfo &info) {
+void QueryPool::Init(const Device& dev, const VkQueryPoolCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateQueryPool, dev, &info);
 }
 
-VkResult QueryPool::Results(uint32_t first, uint32_t count, size_t size, void *data, size_t stride) {
+VkResult QueryPool::Results(uint32_t first, uint32_t count, size_t size, void* data, size_t stride) {
     VkResult err = vk::GetQueryPoolResults(device(), handle(), first, count, size, data, stride, 0);
     EXPECT_TRUE(err == VK_SUCCESS || err == VK_NOT_READY);
 
@@ -1101,12 +1101,12 @@ VkResult QueryPool::Results(uint32_t first, uint32_t count, size_t size, void *d
 
 NON_DISPATCHABLE_HANDLE_DTOR(Buffer, vk::DestroyBuffer)
 
-Buffer::Buffer(Buffer &&rhs) noexcept : NonDispHandle(std::move(rhs)) {
+Buffer::Buffer(Buffer&& rhs) noexcept : NonDispHandle(std::move(rhs)) {
     create_info_ = std::move(rhs.create_info_);
     internal_mem_ = std::move(rhs.internal_mem_);
 }
 
-Buffer &Buffer::operator=(Buffer &&rhs) noexcept {
+Buffer& Buffer::operator=(Buffer&& rhs) noexcept {
     if (&rhs == this) {
         return *this;
     }
@@ -1118,7 +1118,7 @@ Buffer &Buffer::operator=(Buffer &&rhs) noexcept {
     return *this;
 }
 
-void Buffer::Init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
+void Buffer::Init(const Device& dev, const VkBufferCreateInfo& info, VkMemoryPropertyFlags mem_props, void* alloc_info_pnext) {
     InitNoMemory(dev, info);
 
     auto alloc_info = DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext);
@@ -1127,8 +1127,8 @@ void Buffer::Init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPro
     BindMemory(internal_mem_, 0);
 }
 
-void Buffer::InitHostVisibleWithData(const Device &dev, VkBufferUsageFlags usage, const void *data, size_t data_size,
-                                     const vvl::span<uint32_t> &queue_families) {
+void Buffer::InitHostVisibleWithData(const Device& dev, VkBufferUsageFlags usage, const void* data, size_t data_size,
+                                     const vvl::span<uint32_t>& queue_families) {
     const auto create_info = CreateInfo(static_cast<VkDeviceSize>(data_size), usage, queue_families);
     InitNoMemory(dev, create_info);
 
@@ -1142,12 +1142,12 @@ void Buffer::InitHostVisibleWithData(const Device &dev, VkBufferUsageFlags usage
     internal_mem_.Init(dev, alloc_info);
     BindMemory(internal_mem_, 0);
 
-    void *ptr = internal_mem_.Map();
+    void* ptr = internal_mem_.Map();
     std::memcpy(ptr, data, data_size);
     internal_mem_.Unmap();
 }
 
-void Buffer::InitNoMemory(const Device &dev, const VkBufferCreateInfo &info) {
+void Buffer::InitNoMemory(const Device& dev, const VkBufferCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateBuffer, dev, &info);
     create_info_ = info;
 }
@@ -1160,13 +1160,13 @@ VkMemoryRequirements Buffer::MemoryRequirements() const {
     return reqs;
 }
 
-void Buffer::AllocateAndBindMemory(const Device &dev, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
+void Buffer::AllocateAndBindMemory(const Device& dev, VkMemoryPropertyFlags mem_props, void* alloc_info_pnext) {
     assert(!internal_mem_.initialized());
     internal_mem_.Init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext));
     BindMemory(internal_mem_, 0);
 }
 
-void Buffer::BindMemory(const DeviceMemory &mem, VkDeviceSize mem_offset) {
+void Buffer::BindMemory(const DeviceMemory& mem, VkDeviceSize mem_offset) {
     const auto result = vk::BindBufferMemory(device(), handle(), mem, mem_offset);
     // Allow successful calls and the calls that cause validation errors (but not actual Vulkan errors).
     // In the case of a validation error, it's part of the test logic how to handle it.
@@ -1200,7 +1200,7 @@ VkStridedDeviceAddressRangeKHR Buffer::StridedAddressRange(VkDeviceSize stride) 
 
 NON_DISPATCHABLE_HANDLE_DTOR(BufferView, vk::DestroyBufferView)
 
-void BufferView::Init(const Device &dev, const VkBufferViewCreateInfo &info) {
+void BufferView::Init(const Device& dev, const VkBufferViewCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateBufferView, dev, &info);
 }
 
@@ -1224,7 +1224,7 @@ Tensor::Tensor() {
     create_info_.pQueueFamilyIndices = nullptr;
 }
 
-Tensor::Tensor(const Device &dev, const bool is_copy_tensor) {
+Tensor::Tensor(const Device& dev, const bool is_copy_tensor) {
     dimensions_ = std::vector<int64_t>{1, 8, 8, 8};
     description_ = vku::InitStructHelper();
     description_.tiling = VK_TENSOR_TILING_LINEAR_ARM;
@@ -1248,13 +1248,13 @@ Tensor::Tensor(const Device &dev, const bool is_copy_tensor) {
     InitNoMem(dev, create_info_);
 }
 
-Tensor::Tensor(const Device &dev, const VkTensorDescriptionARM &desc) : Tensor() {
+Tensor::Tensor(const Device& dev, const VkTensorDescriptionARM& desc) : Tensor() {
     description_ = desc;
     create_info_.pDescription = &description_;
     InitNoMem(dev, create_info_);
 }
 
-Tensor::Tensor(const Device &dev, const VkTensorCreateInfoARM &info) {
+Tensor::Tensor(const Device& dev, const VkTensorCreateInfoARM& info) {
     description_ = *info.pDescription;
     InitNoMem(dev, info);
 }
@@ -1264,7 +1264,8 @@ void Tensor::BindToMem(VkFlags required_flags, VkFlags forbidden_flags) {
 
     VkMemoryAllocateInfo tensor_alloc_info = vku::InitStructHelper();
     tensor_alloc_info.allocationSize = mem_reqs.memoryRequirements.size;
-    device_->Physical().SetMemoryType(mem_reqs.memoryRequirements.memoryTypeBits, &tensor_alloc_info, required_flags, forbidden_flags);
+    device_->Physical().SetMemoryType(mem_reqs.memoryRequirements.memoryTypeBits, &tensor_alloc_info, required_flags,
+                                      forbidden_flags);
     memory_ = vkt::DeviceMemory(*device_, tensor_alloc_info);
     VkBindTensorMemoryInfoARM bind_info = vku::InitStructHelper();
     bind_info.tensor = *this;
@@ -1272,14 +1273,14 @@ void Tensor::BindToMem(VkFlags required_flags, VkFlags forbidden_flags) {
     vk::BindTensorMemoryARM(*device_, 1, &bind_info);
 }
 
-void Tensor::InitNoMem(const Device &dev, const VkTensorCreateInfoARM &info) {
+void Tensor::InitNoMem(const Device& dev, const VkTensorCreateInfoARM& info) {
     device_ = &dev;
     create_info_ = info;
     description_ = *info.pDescription;
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateTensorARM, dev, &create_info_);
 }
 
-const VkMemoryRequirements2 &Tensor::GetMemoryReqs() {
+const VkMemoryRequirements2& Tensor::GetMemoryReqs() {
     mem_req_info_ = vku::InitStructHelper();
     mem_req_info_.tensor = *this;
     mem_reqs_ = vku::InitStructHelper();
@@ -1288,20 +1289,20 @@ const VkMemoryRequirements2 &Tensor::GetMemoryReqs() {
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(TensorView, vk::DestroyTensorViewARM)
-TensorView::TensorView(const Device &dev, const VkTensorViewCreateInfoARM &info) { Init(dev, info); }
+TensorView::TensorView(const Device& dev, const VkTensorViewCreateInfoARM& info) { Init(dev, info); }
 
-void TensorView::Init(const Device &dev, const VkTensorViewCreateInfoARM &info) {
+void TensorView::Init(const Device& dev, const VkTensorViewCreateInfoARM& info) {
     device_ = &dev;
     create_info_ = info;
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateTensorViewARM, dev, &create_info_);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(DataGraphPipelineSession, vk::DestroyDataGraphPipelineSessionARM)
-DataGraphPipelineSession::DataGraphPipelineSession(const Device &dev, const VkDataGraphPipelineSessionCreateInfoARM &info) {
+DataGraphPipelineSession::DataGraphPipelineSession(const Device& dev, const VkDataGraphPipelineSessionCreateInfoARM& info) {
     create_info_ = info;
     Init(dev);
 }
-void DataGraphPipelineSession::Init(const Device &dev) {
+void DataGraphPipelineSession::Init(const Device& dev) {
     device_ = &dev;
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDataGraphPipelineSessionARM, dev, &create_info_);
 }
@@ -1327,11 +1328,11 @@ void DataGraphPipelineSession::GetMemoryReqs() {
     }
 }
 
-void DataGraphPipelineSession::AllocSessionMem(std::vector<vkt::DeviceMemory> &device_mem, bool is_protected, size_t scale_factor,
+void DataGraphPipelineSession::AllocSessionMem(std::vector<vkt::DeviceMemory>& device_mem, bool is_protected, size_t scale_factor,
                                                int32_t size_modifier) {
     assert(mem_reqs_.size() == device_mem.size());
     for (size_t i = 0; i < device_mem.size(); i++) {
-        auto &mem_req = mem_reqs_[i].memoryRequirements;
+        auto& mem_req = mem_reqs_[i].memoryRequirements;
         VkMemoryAllocateInfo session_alloc_info = vku::InitStructHelper();
         session_alloc_info.allocationSize = mem_req.size * scale_factor + size_modifier;
         auto flags = is_protected ? VK_MEMORY_PROPERTY_PROTECTED_BIT : 0;
@@ -1342,18 +1343,18 @@ void DataGraphPipelineSession::AllocSessionMem(std::vector<vkt::DeviceMemory> &d
 
 NON_DISPATCHABLE_HANDLE_DTOR(Image, vk::DestroyImage)
 
-Image::Image(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext)
+Image::Image(const Device& dev, const VkImageCreateInfo& info, VkMemoryPropertyFlags mem_props, void* alloc_info_pnext)
     : device_(&dev) {
     Init(dev, info, mem_props, alloc_info_pnext);
 }
 
-Image::Image(const Device &dev, uint32_t width, uint32_t height, VkFormat format, VkImageUsageFlags usage) : device_(&dev) {
+Image::Image(const Device& dev, uint32_t width, uint32_t height, VkFormat format, VkImageUsageFlags usage) : device_(&dev) {
     Init(dev, width, height, 1, format, usage);
 }
 
-Image::Image(const Device &dev, const VkImageCreateInfo &info, NoMemT) : device_(&dev) { InitNoMemory(dev, info); }
+Image::Image(const Device& dev, const VkImageCreateInfo& info, NoMemT) : device_(&dev) { InitNoMemory(dev, info); }
 
-Image::Image(const Device &dev, const VkImageCreateInfo &info, SetLayoutT) : device_(&dev) {
+Image::Image(const Device& dev, const VkImageCreateInfo& info, SetLayoutT) : device_(&dev) {
     Init(*device_, info);
 
     VkImageLayout newLayout;
@@ -1369,7 +1370,7 @@ Image::Image(const Device &dev, const VkImageCreateInfo &info, SetLayoutT) : dev
     SetLayout(newLayout);
 }
 
-Image::Image(Image &&rhs) noexcept : NonDispHandle(std::move(rhs)) {
+Image::Image(Image&& rhs) noexcept : NonDispHandle(std::move(rhs)) {
     device_ = std::move(rhs.device_);
     rhs.device_ = nullptr;
 
@@ -1379,7 +1380,7 @@ Image::Image(Image &&rhs) noexcept : NonDispHandle(std::move(rhs)) {
     internal_mem_ = std::move(rhs.internal_mem_);
 }
 
-Image &Image::operator=(Image &&rhs) noexcept {
+Image& Image::operator=(Image&& rhs) noexcept {
     if (&rhs == this) {
         return *this;
     }
@@ -1397,7 +1398,7 @@ Image &Image::operator=(Image &&rhs) noexcept {
     return *this;
 }
 
-void Image::Init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
+void Image::Init(const Device& dev, const VkImageCreateInfo& info, VkMemoryPropertyFlags mem_props, void* alloc_info_pnext) {
     InitNoMemory(dev, info);
 
     if (initialized()) {
@@ -1407,14 +1408,14 @@ void Image::Init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPrope
     }
 }
 
-void Image::Init(const Device &dev, uint32_t width, uint32_t height, uint32_t mip_levels, VkFormat format,
+void Image::Init(const Device& dev, uint32_t width, uint32_t height, uint32_t mip_levels, VkFormat format,
                  VkImageUsageFlags usage) {
     const VkImageCreateInfo info = ImageCreateInfo2D(width, height, mip_levels, 1, format, usage, VK_IMAGE_TILING_OPTIMAL);
     Init(dev, info);
 }
 
 // Currently all init call here, so can set things for all path
-void Image::InitNoMemory(const Device &dev, const VkImageCreateInfo &info) {
+void Image::InitNoMemory(const Device& dev, const VkImageCreateInfo& info) {
     if (!device_) {
         device_ = &dev;
     }
@@ -1422,7 +1423,7 @@ void Image::InitNoMemory(const Device &dev, const VkImageCreateInfo &info) {
     create_info_ = info;
 }
 
-bool Image::IsCompatible(const Device &dev, const VkImageUsageFlags usages, const VkFormatFeatureFlags2 features) {
+bool Image::IsCompatible(const Device& dev, const VkImageUsageFlags usages, const VkFormatFeatureFlags2 features) {
     VkFormatFeatureFlags2 all_feature_flags =
         VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT |
         VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT | VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT |
@@ -1470,7 +1471,7 @@ bool Image::IsCompatible(const Device &dev, const VkImageUsageFlags usages, cons
 
 VkImageCreateInfo Image::ImageCreateInfo2D(uint32_t width, uint32_t height, uint32_t mip_levels, uint32_t layers, VkFormat format,
                                            VkImageUsageFlags usage, VkImageTiling requested_tiling,
-                                           const vvl::span<uint32_t> &queue_families) {
+                                           const vvl::span<uint32_t>& queue_families) {
     VkImageCreateInfo create_info = vku::InitStructHelper();
     create_info.imageType = VK_IMAGE_TYPE_2D;
     create_info.format = format;
@@ -1499,13 +1500,13 @@ VkMemoryRequirements Image::MemoryRequirements() const {
     return reqs;
 }
 
-void Image::AllocateAndBindMemory(const Device &dev, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
+void Image::AllocateAndBindMemory(const Device& dev, VkMemoryPropertyFlags mem_props, void* alloc_info_pnext) {
     assert(!internal_mem_.initialized());
     internal_mem_.Init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext));
     BindMemory(internal_mem_, 0);
 }
 
-void Image::BindMemory(const DeviceMemory &mem, VkDeviceSize mem_offset) {
+void Image::BindMemory(const DeviceMemory& mem, VkDeviceSize mem_offset) {
     const auto result = vk::BindImageMemory(device(), handle(), mem, mem_offset);
     // Allow successful calls and the calls that cause validation errors (but not actual Vulkan errors).
     // In the case of a validation error, it's part of the test logic how to handle it.
@@ -1526,20 +1527,20 @@ VkImageAspectFlags Image::AspectMask(VkFormat format) {
     return image_aspect;
 }
 
-void Image::ImageMemoryBarrier(CommandBuffer &cmd_buf, VkAccessFlags src_access, VkAccessFlags dst_access, VkImageLayout old_layout,
+void Image::ImageMemoryBarrier(CommandBuffer& cmd_buf, VkAccessFlags src_access, VkAccessFlags dst_access, VkImageLayout old_layout,
                                VkImageLayout new_layout, VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages) {
     VkImageSubresourceRange subresource_range = SubresourceRange(AspectMask(Format()));
     VkImageMemoryBarrier barrier = ImageMemoryBarrier(src_access, dst_access, old_layout, new_layout, subresource_range);
     vk::CmdPipelineBarrier(cmd_buf, src_stages, dst_stages, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
 }
 
-void Image::SetLayout(CommandBuffer &cmd_buf, VkImageLayout image_layout) {
+void Image::SetLayout(CommandBuffer& cmd_buf, VkImageLayout image_layout) {
     TransitionLayout(cmd_buf, create_info_.initialLayout, image_layout);
 }
 
 void Image::SetLayout(VkImageLayout image_layout) { TransitionLayout(create_info_.initialLayout, image_layout); }
 
-void Image::TransitionLayout(CommandBuffer &cmd_buf, VkImageLayout old_layout, VkImageLayout new_layout) {
+void Image::TransitionLayout(CommandBuffer& cmd_buf, VkImageLayout old_layout, VkImageLayout new_layout) {
     VkFlags src_mask, dst_mask;
     const VkFlags all_cache_outputs = VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
                                       VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -1629,7 +1630,7 @@ VkImageViewCreateInfo Image::BasicViewCreatInfo(VkImageAspectFlags aspect_mask) 
     return ci;
 }
 
-ImageView Image::CreateView(VkImageAspectFlags aspect, void *pNext) const {
+ImageView Image::CreateView(VkImageAspectFlags aspect, void* pNext) const {
     VkImageViewCreateInfo ci = BasicViewCreatInfo(aspect);
     ci.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
     ci.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
@@ -1647,7 +1648,7 @@ ImageView Image::CreateView(VkImageViewType type, uint32_t baseMipLevel, uint32_
 
 NON_DISPATCHABLE_HANDLE_DTOR(ImageView, vk::DestroyImageView)
 
-void ImageView::Init(const Device &dev, const VkImageViewCreateInfo &info) {
+void ImageView::Init(const Device& dev, const VkImageViewCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateImageView, dev, &info);
 }
 
@@ -1692,7 +1693,7 @@ VkMemoryRequirements2 AccelerationStructureNV::BuildScratchMemoryRequirements() 
     return memory_requirements;
 }
 
-void AccelerationStructureNV::Init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory) {
+void AccelerationStructureNV::Init(const Device& dev, const VkAccelerationStructureCreateInfoNV& info, bool init_memory) {
     PFN_vkCreateAccelerationStructureNV vkCreateAccelerationStructureNV =
         (PFN_vkCreateAccelerationStructureNV)vk::GetDeviceProcAddr(dev, "vkCreateAccelerationStructureNV");
     assert(vkCreateAccelerationStructureNV != nullptr);
@@ -1721,7 +1722,7 @@ void AccelerationStructureNV::Init(const Device &dev, const VkAccelerationStruct
     }
 }
 
-Buffer AccelerationStructureNV::CreateScratchBuffer(const Device &device, VkBufferCreateInfo *pCreateInfo /*= nullptr*/,
+Buffer AccelerationStructureNV::CreateScratchBuffer(const Device& device, VkBufferCreateInfo* pCreateInfo /*= nullptr*/,
                                                     bool buffer_device_address /*= false*/) const {
     VkMemoryRequirements scratch_buffer_memory_requirements = BuildScratchMemoryRequirements().memoryRequirements;
     VkBufferCreateInfo create_info = vku::InitStructHelper();
@@ -1734,7 +1735,7 @@ Buffer AccelerationStructureNV::CreateScratchBuffer(const Device &device, VkBuff
     }
 
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
-    void *pNext = nullptr;
+    void* pNext = nullptr;
     if (buffer_device_address) {
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
         pNext = &alloc_flags;
@@ -1745,17 +1746,17 @@ Buffer AccelerationStructureNV::CreateScratchBuffer(const Device &device, VkBuff
 
 NON_DISPATCHABLE_HANDLE_DTOR(ShaderModule, vk::DestroyShaderModule)
 
-ShaderModule &ShaderModule::operator=(ShaderModule &&rhs) noexcept {
+ShaderModule& ShaderModule::operator=(ShaderModule&& rhs) noexcept {
     Destroy();
     NonDispHandle<VkShaderModule>::operator=(std::move(rhs));
     return *this;
 }
 
-void ShaderModule::Init(const Device &dev, const VkShaderModuleCreateInfo &info) {
+void ShaderModule::Init(const Device& dev, const VkShaderModuleCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateShaderModule, dev, &info);
 }
 
-VkResult ShaderModule::InitTry(const Device &dev, const VkShaderModuleCreateInfo &info) {
+VkResult ShaderModule::InitTry(const Device& dev, const VkShaderModuleCreateInfo& info) {
     VkShaderModule mod;
 
     VkResult err = vk::CreateShaderModule(dev, &info, NULL, &mod);
@@ -1766,11 +1767,11 @@ VkResult ShaderModule::InitTry(const Device &dev, const VkShaderModuleCreateInfo
 
 NON_DISPATCHABLE_HANDLE_DTOR(Shader, vk::DestroyShaderEXT)
 
-void Shader::Init(const Device &dev, const VkShaderCreateInfoEXT &info) {
+void Shader::Init(const Device& dev, const VkShaderCreateInfoEXT& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateShadersEXT, dev, 1u, &info);
 }
 
-VkResult Shader::InitTry(const Device &dev, const VkShaderCreateInfoEXT &info) {
+VkResult Shader::InitTry(const Device& dev, const VkShaderCreateInfoEXT& info) {
     VkShaderEXT mod;
 
     VkResult err = vk::CreateShadersEXT(dev, 1u, &info, NULL, &mod);
@@ -1779,8 +1780,8 @@ VkResult Shader::InitTry(const Device &dev, const VkShaderCreateInfoEXT &info) {
     return err;
 }
 
-Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::vector<uint32_t> &spv,
-               const VkDescriptorSetLayout *descriptorSetLayout, const VkPushConstantRange *pushConstRange) {
+Shader::Shader(const Device& dev, const VkShaderStageFlagBits stage, const std::vector<uint32_t>& spv,
+               const VkDescriptorSetLayout* descriptorSetLayout, const VkPushConstantRange* pushConstRange) {
     VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = stage;
     SetNextStage(createInfo, dev.GetFeatures().tessellationShader, dev.GetFeatures().geometryShader);
@@ -1799,8 +1800,8 @@ Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::
     Init(dev, createInfo);
 }
 
-Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const char *code,
-               const VkDescriptorSetLayout *descriptorSetLayout, const VkPushConstantRange *pushConstRange) {
+Shader::Shader(const Device& dev, const VkShaderStageFlagBits stage, const char* code,
+               const VkDescriptorSetLayout* descriptorSetLayout, const VkPushConstantRange* pushConstRange) {
     spv_target_env spv_env = SPV_ENV_VULKAN_1_0;
     if (stage == VK_SHADER_STAGE_TASK_BIT_EXT || stage == VK_SHADER_STAGE_MESH_BIT_EXT || stage == VK_SHADER_STAGE_TASK_BIT_NV ||
         stage == VK_SHADER_STAGE_MESH_BIT_NV) {
@@ -1827,8 +1828,8 @@ Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const char 
     Init(dev, createInfo);
 }
 
-Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::vector<uint8_t> &binary,
-               const VkDescriptorSetLayout *descriptorSetLayout, const VkPushConstantRange *pushConstRange) {
+Shader::Shader(const Device& dev, const VkShaderStageFlagBits stage, const std::vector<uint8_t>& binary,
+               const VkDescriptorSetLayout* descriptorSetLayout, const VkPushConstantRange* pushConstRange) {
     VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = stage;
     SetNextStage(createInfo, dev.GetFeatures().tessellationShader, dev.GetFeatures().geometryShader);
@@ -1849,13 +1850,13 @@ Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::
 
 NON_DISPATCHABLE_HANDLE_DTOR(PipelineCache, vk::DestroyPipelineCache)
 
-void PipelineCache::Init(const Device &dev, const VkPipelineCacheCreateInfo &info) {
+void PipelineCache::Init(const Device& dev, const VkPipelineCacheCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreatePipelineCache, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Pipeline, vk::DestroyPipeline)
 
-void Pipeline::Init(const Device &dev, const VkGraphicsPipelineCreateInfo &info) {
+void Pipeline::Init(const Device& dev, const VkGraphicsPipelineCreateInfo& info) {
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = vku::InitStructHelper();
     VkResult err = vk::CreatePipelineCache(dev, &ci, NULL, &cache);
@@ -1865,7 +1866,7 @@ void Pipeline::Init(const Device &dev, const VkGraphicsPipelineCreateInfo &info)
     }
 }
 
-VkResult Pipeline::InitTry(const Device &dev, const VkGraphicsPipelineCreateInfo &info) {
+VkResult Pipeline::InitTry(const Device& dev, const VkGraphicsPipelineCreateInfo& info) {
     VkPipeline pipe;
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = vku::InitStructHelper();
@@ -1882,7 +1883,7 @@ VkResult Pipeline::InitTry(const Device &dev, const VkGraphicsPipelineCreateInfo
     return err;
 }
 
-void Pipeline::Init(const Device &dev, const VkComputePipelineCreateInfo &info) {
+void Pipeline::Init(const Device& dev, const VkComputePipelineCreateInfo& info) {
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = vku::InitStructHelper();
     VkResult err = vk::CreatePipelineCache(dev, &ci, NULL, &cache);
@@ -1892,11 +1893,11 @@ void Pipeline::Init(const Device &dev, const VkComputePipelineCreateInfo &info) 
     }
 }
 
-void Pipeline::Init(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info) {
+void Pipeline::Init(const Device& dev, const VkRayTracingPipelineCreateInfoKHR& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRayTracingPipelinesKHR, dev, VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &info);
 }
 
-void Pipeline::InitDeferred(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info, VkDeferredOperationKHR deferred_op) {
+void Pipeline::InitDeferred(const Device& dev, const VkRayTracingPipelineCreateInfoKHR& info, VkDeferredOperationKHR deferred_op) {
     // ALL parameters need to survive until deferred operation is completed
     // In our case, it means both info and handle need to be kept alive
     // => cannot use NON_DISPATCHABLE_HANDLE_INIT because used handle is a temporary
@@ -1905,18 +1906,18 @@ void Pipeline::InitDeferred(const Device &dev, const VkRayTracingPipelineCreateI
     NonDispHandle::SetDevice(dev);
 }
 
-void Pipeline::Init(const Device &dev, const VkDataGraphPipelineCreateInfoARM &info) {
+void Pipeline::Init(const Device& dev, const VkDataGraphPipelineCreateInfoARM& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDataGraphPipelinesARM, dev, VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(PipelineLayout, vk::DestroyPipelineLayout)
 
-void PipelineLayout::Init(const Device &dev, VkPipelineLayoutCreateInfo &info,
-                          const std::vector<const DescriptorSetLayout *> &layouts) {
+void PipelineLayout::Init(const Device& dev, VkPipelineLayoutCreateInfo& info,
+                          const std::vector<const DescriptorSetLayout*>& layouts) {
     std::vector<VkDescriptorSetLayout> layout_handles;
     layout_handles.reserve(layouts.size());
     std::transform(layouts.begin(), layouts.end(), std::back_inserter(layout_handles),
-                   [](const DescriptorSetLayout *o) { return (o) ? o->handle() : VK_NULL_HANDLE; });
+                   [](const DescriptorSetLayout* o) { return (o) ? o->handle() : VK_NULL_HANDLE; });
 
     info.setLayoutCount = static_cast<uint32_t>(layout_handles.size());
     info.pSetLayouts = layout_handles.data();
@@ -1924,19 +1925,19 @@ void PipelineLayout::Init(const Device &dev, VkPipelineLayoutCreateInfo &info,
     Init(dev, info);
 }
 
-void PipelineLayout::Init(const Device &dev, VkPipelineLayoutCreateInfo &info) {
+void PipelineLayout::Init(const Device& dev, VkPipelineLayoutCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreatePipelineLayout, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Sampler, vk::DestroySampler)
 
-void Sampler::Init(const Device &dev, const VkSamplerCreateInfo &info) {
+void Sampler::Init(const Device& dev, const VkSamplerCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSampler, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(DescriptorSetLayout, vk::DestroyDescriptorSetLayout)
 
-void DescriptorSetLayout::Init(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info) {
+void DescriptorSetLayout::Init(const Device& dev, const VkDescriptorSetLayoutCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDescriptorSetLayout, dev, &info);
 }
 
@@ -1954,7 +1955,7 @@ VkDeviceSize DescriptorSetLayout::GetDescriptorBufferBindingOffset(uint32_t bind
 
 NON_DISPATCHABLE_HANDLE_DTOR(DescriptorPool, vk::DestroyDescriptorPool)
 
-void DescriptorPool::Init(const Device &dev, const VkDescriptorPoolCreateInfo &info) {
+void DescriptorPool::Init(const Device& dev, const VkDescriptorPoolCreateInfo& info) {
     dynamic_usage_ = (info.flags & VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT) != 0;
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDescriptorPool, dev, &info);
 }
@@ -1974,7 +1975,7 @@ void DescriptorSet::Destroy() noexcept {
 }
 DescriptorSet::~DescriptorSet() noexcept { Destroy(); }
 
-void DescriptorUpdateTemplate::Init(const Device &dev, const VkDescriptorUpdateTemplateCreateInfo &info) {
+void DescriptorUpdateTemplate::Init(const Device& dev, const VkDescriptorUpdateTemplateCreateInfo& info) {
     if (vk::CreateDescriptorUpdateTemplateKHR) {
         NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDescriptorUpdateTemplateKHR, dev, &info);
     } else {
@@ -1999,18 +2000,18 @@ DescriptorUpdateTemplate::~DescriptorUpdateTemplate() noexcept { Destroy(); }
 
 NON_DISPATCHABLE_HANDLE_DTOR(CommandPool, vk::DestroyCommandPool)
 
-void CommandPool::Init(const Device &dev, const VkCommandPoolCreateInfo &info) {
+void CommandPool::Init(const Device& dev, const VkCommandPoolCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateCommandPool, dev, &info);
 }
 
-void CommandPool::Init(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags) {
+void CommandPool::Init(const Device& dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags) {
     VkCommandPoolCreateInfo pool_ci = vku::InitStructHelper();
     pool_ci.flags = flags;
     pool_ci.queueFamilyIndex = queue_family_index;
     Init(dev, pool_ci);
 }
 
-CommandPool::CommandPool(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags) {
+CommandPool::CommandPool(const Device& dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags) {
     Init(dev, queue_family_index, flags);
 }
 
@@ -2024,7 +2025,7 @@ void CommandBuffer::Destroy() noexcept {
 }
 CommandBuffer::~CommandBuffer() noexcept { Destroy(); }
 
-void CommandBuffer::Init(const Device &dev, const VkCommandBufferAllocateInfo &info) {
+void CommandBuffer::Init(const Device& dev, const VkCommandBufferAllocateInfo& info) {
     VkCommandBuffer cmd;
 
     // Make sure commandPool is set
@@ -2036,13 +2037,13 @@ void CommandBuffer::Init(const Device &dev, const VkCommandBufferAllocateInfo &i
     cmd_pool_ = info.commandPool;
 }
 
-void CommandBuffer::Init(const Device &dev, const CommandPool &pool, VkCommandBufferLevel level) {
+void CommandBuffer::Init(const Device& dev, const CommandPool& pool, VkCommandBufferLevel level) {
     auto create_info = CommandBuffer::CreateInfo(pool);
     create_info.level = level;
     Init(dev, create_info);
 }
 
-void CommandBuffer::Begin(const VkCommandBufferBeginInfo *info) { ASSERT_EQ(VK_SUCCESS, vk::BeginCommandBuffer(handle(), info)); }
+void CommandBuffer::Begin(const VkCommandBufferBeginInfo* info) { ASSERT_EQ(VK_SUCCESS, vk::BeginCommandBuffer(handle(), info)); }
 
 void CommandBuffer::Begin(VkCommandBufferUsageFlags flags) {
     VkCommandBufferBeginInfo info = vku::InitStructHelper();
@@ -2073,19 +2074,19 @@ void CommandBuffer::End() {
 
 void CommandBuffer::Reset(VkCommandBufferResetFlags flags) { ASSERT_EQ(VK_SUCCESS, vk::ResetCommandBuffer(handle(), flags)); }
 
-VkCommandBufferAllocateInfo CommandBuffer::CreateInfo(VkCommandPool const &pool) {
+VkCommandBufferAllocateInfo CommandBuffer::CreateInfo(VkCommandPool const& pool) {
     VkCommandBufferAllocateInfo info = vku::InitStructHelper();
     info.commandPool = pool;
     info.commandBufferCount = 1;
     return info;
 }
 
-void CommandBuffer::BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpassContents contents) {
+void CommandBuffer::BeginRenderPass(const VkRenderPassBeginInfo& info, VkSubpassContents contents) {
     vk::CmdBeginRenderPass(handle(), &info, contents);
 }
 
 void CommandBuffer::BeginRenderPass(VkRenderPass rp, VkFramebuffer fb, uint32_t render_area_width, uint32_t render_area_height,
-                                    uint32_t clear_count, const VkClearValue *clear_values) {
+                                    uint32_t clear_count, const VkClearValue* clear_values) {
     VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
     render_pass_begin_info.renderPass = rp;
     render_pass_begin_info.framebuffer = fb;
@@ -2100,7 +2101,7 @@ void CommandBuffer::NextSubpass(VkSubpassContents contents) { vk::CmdNextSubpass
 
 void CommandBuffer::EndRenderPass() { vk::CmdEndRenderPass(handle()); }
 
-void CommandBuffer::BeginRendering(const VkRenderingInfo &renderingInfo) {
+void CommandBuffer::BeginRendering(const VkRenderingInfo& renderingInfo) {
     if (vk::CmdBeginRenderingKHR) {
         vk::CmdBeginRenderingKHR(handle(), &renderingInfo);
     } else {
@@ -2130,21 +2131,21 @@ void CommandBuffer::EndRendering() {
     }
 }
 
-void CommandBuffer::BindShaders(const vkt::Shader &vert_shader, const vkt::Shader &frag_shader) {
+void CommandBuffer::BindShaders(const vkt::Shader& vert_shader, const vkt::Shader& frag_shader) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
     vk::CmdBindShadersEXT(handle(), 1u, &stages[0], &vert_shader.handle());
     vk::CmdBindShadersEXT(handle(), 1u, &stages[1], &frag_shader.handle());
 }
 
-void CommandBuffer::BindShaders(const vkt::Shader &vert_shader, const vkt::Shader &geom_shader, const vkt::Shader &frag_shader) {
+void CommandBuffer::BindShaders(const vkt::Shader& vert_shader, const vkt::Shader& geom_shader, const vkt::Shader& frag_shader) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_GEOMETRY_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
     vk::CmdBindShadersEXT(handle(), 1u, &stages[0], &vert_shader.handle());
     vk::CmdBindShadersEXT(handle(), 1u, &stages[1], &geom_shader.handle());
     vk::CmdBindShadersEXT(handle(), 1u, &stages[2], &frag_shader.handle());
 }
 
-void CommandBuffer::BindShaders(const vkt::Shader &vert_shader, const vkt::Shader &tesc_shader, const vkt::Shader &tese_shader,
-                                const vkt::Shader &frag_shader) {
+void CommandBuffer::BindShaders(const vkt::Shader& vert_shader, const vkt::Shader& tesc_shader, const vkt::Shader& tese_shader,
+                                const vkt::Shader& frag_shader) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
     vk::CmdBindShadersEXT(handle(), 1u, &stages[0], &vert_shader.handle());
@@ -2153,8 +2154,8 @@ void CommandBuffer::BindShaders(const vkt::Shader &vert_shader, const vkt::Shade
     vk::CmdBindShadersEXT(handle(), 1u, &stages[3], &frag_shader.handle());
 }
 
-void CommandBuffer::BindShaders(const vkt::Shader &vert_shader, const vkt::Shader &tesc_shader, const vkt::Shader &tese_shader,
-                                const vkt::Shader &geom_shader, const vkt::Shader &frag_shader) {
+void CommandBuffer::BindShaders(const vkt::Shader& vert_shader, const vkt::Shader& tesc_shader, const vkt::Shader& tese_shader,
+                                const vkt::Shader& geom_shader, const vkt::Shader& frag_shader) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_GEOMETRY_BIT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT};
@@ -2165,83 +2166,83 @@ void CommandBuffer::BindShaders(const vkt::Shader &vert_shader, const vkt::Shade
     vk::CmdBindShadersEXT(handle(), 1u, &stages[4], &frag_shader.handle());
 }
 
-void CommandBuffer::BindCompShader(const vkt::Shader &comp_shader) {
+void CommandBuffer::BindCompShader(const vkt::Shader& comp_shader) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_COMPUTE_BIT};
     const VkShaderEXT shaders[] = {comp_shader};
     vk::CmdBindShadersEXT(handle(), 1u, stages, shaders);
 }
 
-void CommandBuffer::BindMeshShaders(const vkt::Shader &mesh_shader, const vkt::Shader &frag_shader) {
+void CommandBuffer::BindMeshShaders(const vkt::Shader& mesh_shader, const vkt::Shader& frag_shader) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_TASK_BIT_EXT, VK_SHADER_STAGE_MESH_BIT_EXT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT, VK_SHADER_STAGE_VERTEX_BIT};
     const VkShaderEXT shaders[] = {VK_NULL_HANDLE, mesh_shader, frag_shader, VK_NULL_HANDLE};
     vk::CmdBindShadersEXT(handle(), 4u, stages, shaders);
 }
 
-void CommandBuffer::BindMeshShaders(const vkt::Shader &task_shader, const vkt::Shader &mesh_shader,
-                                    const vkt::Shader &frag_shader) {
+void CommandBuffer::BindMeshShaders(const vkt::Shader& task_shader, const vkt::Shader& mesh_shader,
+                                    const vkt::Shader& frag_shader) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_TASK_BIT_EXT, VK_SHADER_STAGE_MESH_BIT_EXT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT, VK_SHADER_STAGE_VERTEX_BIT};
     const VkShaderEXT shaders[] = {task_shader, mesh_shader, frag_shader, VK_NULL_HANDLE};
     vk::CmdBindShadersEXT(handle(), 4u, stages, shaders);
 }
 
-void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR &beginInfo) {
+void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR& beginInfo) {
     vk::CmdBeginVideoCodingKHR(handle(), &beginInfo);
 }
 
-void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR &controlInfo) {
+void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR& controlInfo) {
     vk::CmdControlVideoCodingKHR(handle(), &controlInfo);
 }
 
-void CommandBuffer::DecodeVideo(const VkVideoDecodeInfoKHR &decodeInfo) { vk::CmdDecodeVideoKHR(handle(), &decodeInfo); }
+void CommandBuffer::DecodeVideo(const VkVideoDecodeInfoKHR& decodeInfo) { vk::CmdDecodeVideoKHR(handle(), &decodeInfo); }
 
-void CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR &encodeInfo) { vk::CmdEncodeVideoKHR(handle(), &encodeInfo); }
+void CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR& encodeInfo) { vk::CmdEncodeVideoKHR(handle(), &encodeInfo); }
 
-void CommandBuffer::EndVideoCoding(const VkVideoEndCodingInfoKHR &endInfo) { vk::CmdEndVideoCodingKHR(handle(), &endInfo); }
+void CommandBuffer::EndVideoCoding(const VkVideoEndCodingInfoKHR& endInfo) { vk::CmdEndVideoCodingKHR(handle(), &endInfo); }
 
-void CommandBuffer::Copy(const Buffer &src, const Buffer &dst) {
+void CommandBuffer::Copy(const Buffer& src, const Buffer& dst) {
     assert(src.CreateInfo().size == dst.CreateInfo().size);
     const VkBufferCopy region = {0, 0, src.CreateInfo().size};
     vk::CmdCopyBuffer(handle(), src, dst, 1, &region);
 }
 
-void CommandBuffer::ExecuteCommands(const CommandBuffer &secondary) { vk::CmdExecuteCommands(handle(), 1, &secondary.handle()); }
+void CommandBuffer::ExecuteCommands(const CommandBuffer& secondary) { vk::CmdExecuteCommands(handle(), 1, &secondary.handle()); }
 
-void CommandBuffer::Barrier(const VkMemoryBarrier2 &barrier, VkDependencyFlags dependency_flags) {
+void CommandBuffer::Barrier(const VkMemoryBarrier2& barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = DependencyInfo(barrier, dependency_flags);
     vk::CmdPipelineBarrier2(handle(), &dep_info);
 }
 
-void CommandBuffer::Barrier(const VkBufferMemoryBarrier2 &buffer_barrier, VkDependencyFlags dependency_flags) {
+void CommandBuffer::Barrier(const VkBufferMemoryBarrier2& buffer_barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = DependencyInfo(buffer_barrier, dependency_flags);
     dep_info.dependencyFlags = dependency_flags;
     vk::CmdPipelineBarrier2(handle(), &dep_info);
 }
 
-void CommandBuffer::Barrier(const VkImageMemoryBarrier2 &image_barrier, VkDependencyFlags dependency_flags) {
+void CommandBuffer::Barrier(const VkImageMemoryBarrier2& image_barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = DependencyInfo(image_barrier, dependency_flags);
     vk::CmdPipelineBarrier2(handle(), &dep_info);
 }
 
-void CommandBuffer::Barrier(const VkDependencyInfo &dep_info) { vk::CmdPipelineBarrier2(handle(), &dep_info); }
+void CommandBuffer::Barrier(const VkDependencyInfo& dep_info) { vk::CmdPipelineBarrier2(handle(), &dep_info); }
 
-void CommandBuffer::BarrierKHR(const VkMemoryBarrier2 &barrier, VkDependencyFlags dependency_flags) {
+void CommandBuffer::BarrierKHR(const VkMemoryBarrier2& barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = DependencyInfo(barrier, dependency_flags);
     vk::CmdPipelineBarrier2KHR(handle(), &dep_info);
 }
 
-void CommandBuffer::BarrierKHR(const VkBufferMemoryBarrier2 &buffer_barrier, VkDependencyFlags dependency_flags) {
+void CommandBuffer::BarrierKHR(const VkBufferMemoryBarrier2& buffer_barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = DependencyInfo(buffer_barrier, dependency_flags);
     vk::CmdPipelineBarrier2KHR(handle(), &dep_info);
 }
 
-void CommandBuffer::BarrierKHR(const VkImageMemoryBarrier2 &image_barrier, VkDependencyFlags dependency_flags) {
+void CommandBuffer::BarrierKHR(const VkImageMemoryBarrier2& image_barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = DependencyInfo(image_barrier, dependency_flags);
     vk::CmdPipelineBarrier2KHR(handle(), &dep_info);
 }
 
-void CommandBuffer::BarrierKHR(const VkDependencyInfo &dep_info) { vk::CmdPipelineBarrier2KHR(handle(), &dep_info); }
+void CommandBuffer::BarrierKHR(const VkDependencyInfo& dep_info) { vk::CmdPipelineBarrier2KHR(handle(), &dep_info); }
 
 // For positive tests, if you run with sync val, ideally want no errors.
 // Many tests need a simple quick way to sync multiple commands
@@ -2253,11 +2254,11 @@ void CommandBuffer::FullMemoryBarrier() {
                            nullptr, 0, nullptr);
 }
 
-void RenderPass::Init(const Device &dev, const VkRenderPassCreateInfo &info) {
+void RenderPass::Init(const Device& dev, const VkRenderPassCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass, dev, &info);
 }
 
-void RenderPass::Init(const Device &dev, const VkRenderPassCreateInfo2 &info) {
+void RenderPass::Init(const Device& dev, const VkRenderPassCreateInfo2& info) {
     if (vk::CreateRenderPass2KHR) {
         NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass2KHR, dev, &info);
     } else {
@@ -2267,13 +2268,13 @@ void RenderPass::Init(const Device &dev, const VkRenderPassCreateInfo2 &info) {
 
 NON_DISPATCHABLE_HANDLE_DTOR(RenderPass, vk::DestroyRenderPass)
 
-void Framebuffer::Init(const Device &dev, const VkFramebufferCreateInfo &info) {
+void Framebuffer::Init(const Device& dev, const VkFramebufferCreateInfo& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateFramebuffer, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Framebuffer, vk::DestroyFramebuffer)
 
-void SamplerYcbcrConversion::Init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info) {
+void SamplerYcbcrConversion::Init(const Device& dev, const VkSamplerYcbcrConversionCreateInfo& info) {
     if (vk::CreateSamplerYcbcrConversionKHR) {
         NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSamplerYcbcrConversionKHR, dev, &info);
     } else {
@@ -2319,7 +2320,7 @@ SamplerYcbcrConversion::~SamplerYcbcrConversion() noexcept { Destroy(); }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Swapchain, vk::DestroySwapchainKHR)
 
-void Swapchain::Init(const Device &dev, const VkSwapchainCreateInfoKHR &info) {
+void Swapchain::Init(const Device& dev, const VkSwapchainCreateInfoKHR& info) {
     assert(!initialized());
     VkSwapchainKHR handle = VK_NULL_HANDLE;
     auto result = vk::CreateSwapchainKHR(dev, &info, nullptr, &handle);
@@ -2346,7 +2347,7 @@ std::vector<VkImage> Swapchain::GetImages() const {
     return images;
 }
 
-uint32_t Swapchain::AcquireNextImage(const Semaphore &image_acquired, uint64_t timeout, VkResult *result) {
+uint32_t Swapchain::AcquireNextImage(const Semaphore& image_acquired, uint64_t timeout, VkResult* result) {
     uint32_t image_index = 0;
     VkResult acquire_result = vk::AcquireNextImageKHR(device(), handle(), timeout, image_acquired, VK_NULL_HANDLE, &image_index);
     if (result) {
@@ -2355,7 +2356,7 @@ uint32_t Swapchain::AcquireNextImage(const Semaphore &image_acquired, uint64_t t
     return image_index;
 }
 
-uint32_t Swapchain::AcquireNextImage(const Fence &image_acquired, uint64_t timeout, VkResult *result) {
+uint32_t Swapchain::AcquireNextImage(const Fence& image_acquired, uint64_t timeout, VkResult* result) {
     uint32_t image_index = 0;
     VkResult acquire_result = vk::AcquireNextImageKHR(device(), handle(), timeout, VK_NULL_HANDLE, image_acquired, &image_index);
     if (result) {
@@ -2365,16 +2366,16 @@ uint32_t Swapchain::AcquireNextImage(const Fence &image_acquired, uint64_t timeo
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(IndirectCommandsLayout, vk::DestroyIndirectCommandsLayoutEXT)
-void IndirectCommandsLayout::Init(const Device &dev, const VkIndirectCommandsLayoutCreateInfoEXT &info) {
+void IndirectCommandsLayout::Init(const Device& dev, const VkIndirectCommandsLayoutCreateInfoEXT& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateIndirectCommandsLayoutEXT, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(IndirectExecutionSet, vk::DestroyIndirectExecutionSetEXT)
-void IndirectExecutionSet::Init(const Device &dev, const VkIndirectExecutionSetCreateInfoEXT &info) {
+void IndirectExecutionSet::Init(const Device& dev, const VkIndirectExecutionSetCreateInfoEXT& info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateIndirectExecutionSetEXT, dev, &info);
 }
 
-IndirectExecutionSet::IndirectExecutionSet(const Device &dev, VkPipeline init_pipeline, uint32_t max_pipelines) {
+IndirectExecutionSet::IndirectExecutionSet(const Device& dev, VkPipeline init_pipeline, uint32_t max_pipelines) {
     VkIndirectExecutionSetPipelineInfoEXT exe_set_pipeline_info = vku::InitStructHelper();
     exe_set_pipeline_info.initialPipeline = init_pipeline;
     exe_set_pipeline_info.maxPipelineCount = max_pipelines;
@@ -2384,7 +2385,7 @@ IndirectExecutionSet::IndirectExecutionSet(const Device &dev, VkPipeline init_pi
     exe_set_ci.info.pPipelineInfo = &exe_set_pipeline_info;
     Init(dev, exe_set_ci);
 }
-IndirectExecutionSet::IndirectExecutionSet(const Device &dev, const VkIndirectExecutionSetShaderInfoEXT &shader_info) {
+IndirectExecutionSet::IndirectExecutionSet(const Device& dev, const VkIndirectExecutionSetShaderInfoEXT& shader_info) {
     VkIndirectExecutionSetCreateInfoEXT exe_set_ci = vku::InitStructHelper();
     exe_set_ci.type = VK_INDIRECT_EXECUTION_SET_INFO_TYPE_SHADER_OBJECTS_EXT;
     exe_set_ci.info.pShaderInfo = &shader_info;
@@ -2392,42 +2393,42 @@ IndirectExecutionSet::IndirectExecutionSet(const Device &dev, const VkIndirectEx
 }
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-VkResult Surface::Init(VkInstance instance, const VkWin32SurfaceCreateInfoKHR &info) {
+VkResult Surface::Init(VkInstance instance, const VkWin32SurfaceCreateInfoKHR& info) {
     VkResult result = vk::CreateWin32SurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
 }
 #endif
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-VkResult Surface::Init(VkInstance instance, const VkMetalSurfaceCreateInfoEXT &info) {
+VkResult Surface::Init(VkInstance instance, const VkMetalSurfaceCreateInfoEXT& info) {
     VkResult result = vk::CreateMetalSurfaceEXT(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
 }
 #endif
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-VkResult Surface::Init(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR &info) {
+VkResult Surface::Init(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR& info) {
     VkResult result = vk::CreateAndroidSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
 }
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-VkResult Surface::Init(VkInstance instance, const VkXlibSurfaceCreateInfoKHR &info) {
+VkResult Surface::Init(VkInstance instance, const VkXlibSurfaceCreateInfoKHR& info) {
     VkResult result = vk::CreateXlibSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
 }
 #endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-VkResult Surface::Init(VkInstance instance, const VkXcbSurfaceCreateInfoKHR &info) {
+VkResult Surface::Init(VkInstance instance, const VkXcbSurfaceCreateInfoKHR& info) {
     VkResult result = vk::CreateXcbSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
 }
 #endif
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-VkResult Surface::Init(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR &info) {
+VkResult Surface::Init(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR& info) {
     VkResult result = vk::CreateWaylandSurfaceKHR(instance, &info, nullptr, &handle_);
     instance_ = instance;
     return result;
@@ -2457,14 +2458,14 @@ VkSurfacePresentScalingCapabilitiesKHR Surface::GetScalingCapabilities(VkPhysica
 }
 
 struct DummyAlloc {
-    static VKAPI_ATTR void *VKAPI_CALL allocFunction(void *, size_t size, size_t, VkSystemAllocationScope) { return malloc(size); };
-    static VKAPI_ATTR void *VKAPI_CALL realloc(void *, void *, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
-    static VKAPI_ATTR void VKAPI_CALL freeFunction(void *, void *pMemory) { free(pMemory); };
-    static VKAPI_ATTR void VKAPI_CALL internalAlloc(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
-    static VKAPI_ATTR void VKAPI_CALL internalFree(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
+    static VKAPI_ATTR void* VKAPI_CALL allocFunction(void*, size_t size, size_t, VkSystemAllocationScope) { return malloc(size); };
+    static VKAPI_ATTR void* VKAPI_CALL realloc(void*, void*, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
+    static VKAPI_ATTR void VKAPI_CALL freeFunction(void*, void* pMemory) { free(pMemory); };
+    static VKAPI_ATTR void VKAPI_CALL internalAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
+    static VKAPI_ATTR void VKAPI_CALL internalFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
 };
 
-const VkAllocationCallbacks *DefaultAllocator() {
+const VkAllocationCallbacks* DefaultAllocator() {
     static const VkAllocationCallbacks alloc = {nullptr,
                                                 DummyAlloc::allocFunction,
                                                 DummyAlloc::realloc,

--- a/tests/framework/cooperative_matrix_helper.cpp
+++ b/tests/framework/cooperative_matrix_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  * Copyright (C) 2025 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 #include "containers/container_utils.h"
 #include "layer_validation_tests.h"
 
-CooperativeMatrixHelper::CooperativeMatrixHelper(VkLayerTest &layer_test) : layer_test(layer_test) {
+CooperativeMatrixHelper::CooperativeMatrixHelper(VkLayerTest& layer_test) : layer_test(layer_test) {
     const VkPhysicalDevice gpu = layer_test.Gpu();
     uint32_t props_count = 0;
     vk::GetPhysicalDeviceCooperativeMatrixPropertiesKHR(gpu, &props_count, nullptr);
@@ -45,7 +45,7 @@ bool CooperativeMatrixHelper::SupportsStage(VkShaderStageFlags required_stage) {
     return ((props.cooperativeMatrixSupportedStages & required_stage) != 0);
 }
 
-bool CooperativeMatrixHelper::Has8BitComponentType(const VkCooperativeMatrixPropertiesKHR &prop) const {
+bool CooperativeMatrixHelper::Has8BitComponentType(const VkCooperativeMatrixPropertiesKHR& prop) const {
     const VkComponentTypeKHR type_8bit[6] = {
         VK_COMPONENT_TYPE_SINT8_KHR,       VK_COMPONENT_TYPE_UINT8_KHR,       VK_COMPONENT_TYPE_SINT8_PACKED_NV,
         VK_COMPONENT_TYPE_UINT8_PACKED_NV, VK_COMPONENT_TYPE_FLOAT8_E4M3_EXT, VK_COMPONENT_TYPE_FLOAT8_E5M2_EXT,
@@ -54,7 +54,7 @@ bool CooperativeMatrixHelper::Has8BitComponentType(const VkCooperativeMatrixProp
            IsValueIn(prop.ResultType, type_8bit);
 }
 
-bool CooperativeMatrixHelper::Has64BitComponentType(const VkCooperativeMatrixPropertiesKHR &prop) const {
+bool CooperativeMatrixHelper::Has64BitComponentType(const VkCooperativeMatrixPropertiesKHR& prop) const {
     const VkComponentTypeKHR type_64bit[3] = {VK_COMPONENT_TYPE_FLOAT64_KHR, VK_COMPONENT_TYPE_SINT64_KHR,
                                               VK_COMPONENT_TYPE_UINT64_KHR};
     return IsValueIn(prop.AType, type_64bit) || IsValueIn(prop.BType, type_64bit) || IsValueIn(prop.CType, type_64bit) ||
@@ -62,7 +62,7 @@ bool CooperativeMatrixHelper::Has64BitComponentType(const VkCooperativeMatrixPro
 }
 
 bool CooperativeMatrixHelper::Has16x16UintProperty() const {
-    for (const auto &prop : coop_matrix_props) {
+    for (const auto& prop : coop_matrix_props) {
         if (prop.scope == VK_SCOPE_SUBGROUP_KHR && prop.KSize == 16 && prop.MSize == 16 && prop.NSize == 16 &&
             prop.AType == VK_COMPONENT_TYPE_UINT8_KHR && prop.BType == VK_COMPONENT_TYPE_UINT8_KHR &&
             prop.CType == VK_COMPONENT_TYPE_UINT32_KHR && prop.ResultType == VK_COMPONENT_TYPE_UINT32_KHR) {
@@ -78,7 +78,7 @@ bool CooperativeMatrixHelper::HasValidProperty(VkScopeKHR scope, uint32_t m, uin
     bool found_b = false;
     bool found_c = false;
     bool found_r = false;
-    for (const auto &prop : coop_matrix_props) {
+    for (const auto& prop : coop_matrix_props) {
         if (prop.scope == scope && prop.AType == type && prop.MSize == m && prop.KSize == k) {
             found_a = true;
         }
@@ -100,7 +100,7 @@ bool CooperativeMatrixHelper::HasValidProperty(VkScopeKHR scope, uint32_t m, uin
     found_b = false;
     found_c = false;
     found_r = false;
-    for (const auto &prop : coop_matrix_flex_props) {
+    for (const auto& prop : coop_matrix_flex_props) {
         if (prop.scope == scope && prop.AType == type && (m % prop.MGranularity) == 0 && (k % prop.KGranularity) == 0) {
             found_a = true;
         }
@@ -121,7 +121,7 @@ bool CooperativeMatrixHelper::HasValidProperty(VkScopeKHR scope, uint32_t m, uin
     return false;
 }
 
-const char *CooperativeMatrixHelper::VkComponentTypeToGLSL(VkComponentTypeKHR type) const {
+const char* CooperativeMatrixHelper::VkComponentTypeToGLSL(VkComponentTypeKHR type) const {
     switch (type) {
         case VK_COMPONENT_TYPE_FLOAT16_KHR:
             return "float16_t";

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -30,8 +30,10 @@ void DataGraphPipelineHelper::CreateShaderModule(const char* spirv_source, const
     // TODO - Replace with ASMtoSPV
     std::vector<uint32_t> spirv_binary;
     if (!tools.Assemble(spirv_source, &spirv_binary)) {
-        GTEST_FAIL() << "Failed to compile SPIRV shader module. Error:\n" << error_msg << std::endl
-        << "SpirV:\n" << spirv_source << std::endl;
+        GTEST_FAIL() << "Failed to compile SPIRV shader module. Error:\n"
+                     << error_msg << std::endl
+                     << "SpirV:\n"
+                     << spirv_source << std::endl;
     }
 
     VkShaderModuleCreateInfo shader_module_create_info = vku::InitStructHelper();
@@ -127,7 +129,8 @@ std::string DataGraphPipelineHelper::GetSpirvModifyableDataGraph(const Modifiabl
     ss << R"(
                                   OpCapability GraphARM
                                   OpCapability TensorsARM
-)" << params.capabilities << R"(
+)" << params.capabilities
+       << R"(
                                   OpCapability Int8
                                   OpCapability Shader
                                   OpCapability VulkanMemoryModel
@@ -163,7 +166,8 @@ std::string DataGraphPipelineHelper::GetSpirvModifyableDataGraph(const Modifiabl
           %uchar_1_4_8_4_tensor = OpTypeTensorARM %uchar %uint_4 %uint_arr_4_1_4_8_4
                  %uint_2_tensor = OpTypeTensorARM %uint %uint_1 %uint_arr_1_2
                  %uint_4_tensor = OpTypeTensorARM %uint %uint_1 %uint_arr_1_4
-)" << params.types << R"(
+)" << params.types
+       << R"(
              %uint_2_tensor_2_2 = OpConstantComposite %uint_2_tensor %uint_2 %uint_2
          %uint_4_tensor_0_0_0_0 = OpConstantComposite %uint_4_tensor %uint_0 %uint_0 %uint_0 %uint_0
      %uchar_1_8_16_4_tensor_ptr = OpTypePointer UniformConstant %uchar_1_8_16_4_tensor
@@ -176,7 +180,8 @@ std::string DataGraphPipelineHelper::GetSpirvModifyableDataGraph(const Modifiabl
                           %in_0 = OpGraphInputARM %uchar_1_8_16_4_tensor %uint_0
                           %op_0 = OpExtInst %uchar_1_4_8_4_tensor %tosa MAX_POOL2D  %uint_2_tensor_2_2 %uint_2_tensor_2_2 %uint_4_tensor_0_0_0_0 %uint_0 %in_0
                           %op_1 = OpExtInst %uchar_1_2_4_4_tensor %tosa MAX_POOL2D  %uint_2_tensor_2_2 %uint_2_tensor_2_2 %uint_4_tensor_0_0_0_0 %uint_0 %op_0
-)" << params.instructions << R"(
+)" << params.instructions
+       << R"(
                                   OpGraphSetOutputARM %op_1 %uint_0
                                   OpGraphEndARM
 )";
@@ -195,7 +200,8 @@ std::string DataGraphPipelineHelper::GetSpirvModifiableShader(const ModifiableSh
 ; Bound: 19
 ; Schema: 0
                OpCapability Shader
-)" << params.capabilities << R"(
+)" << params.capabilities
+       << R"(
                OpCapability TensorsARM
                OpExtension "SPV_ARM_tensors"
           %1 = OpExtInstImport "GLSL.std.450"
@@ -219,7 +225,8 @@ std::string DataGraphPipelineHelper::GetSpirvModifiableShader(const ModifiableSh
      %uint_1 = OpConstant %uint 1
      %uint_2 = OpConstant %uint 2
          %11 = OpTypeTensorARM %int %uint_1
-)" << params.types << R"(
+)" << params.types
+       << R"(
 %_ptr_UniformConstant_11 = OpTypePointer UniformConstant %11
        %tens = OpVariable %_ptr_UniformConstant_11 UniformConstant
      %v3uint = OpTypeVector %uint 3
@@ -230,7 +237,8 @@ std::string DataGraphPipelineHelper::GetSpirvModifiableShader(const ModifiableSh
 %loaded_tens = OpLoad %11 %tens
          %16 = OpTensorQuerySizeARM %uint %loaded_tens %uint_0
                OpStore %size_x %16
-)" << params.instructions << R"(
+)" << params.instructions
+       << R"(
                OpReturn
                OpFunctionEnd
 )";
@@ -243,7 +251,8 @@ std::string DataGraphPipelineHelper::GetSpirvTensorArrayDataGraph(bool is_runtim
     ss << R"(
                             OpCapability GraphARM
                             OpCapability TensorsARM
-)" << (is_runtime ? "OpCapability RuntimeDescriptorArray" : "") << R"(
+)" << (is_runtime ? "OpCapability RuntimeDescriptorArray" : "")
+       << R"(
                             OpCapability Int8
                             OpCapability Shader
                             OpCapability VulkanMemoryModel
@@ -268,7 +277,8 @@ std::string DataGraphPipelineHelper::GetSpirvTensorArrayDataGraph(bool is_runtim
                %i32_arr_4 = OpTypeArray %i32 %i32_4
             %tensor_shape = OpConstantComposite %i32_arr_4 %i32_1 %i32_4 %i32_4 %i32_2
                   %tensor = OpTypeTensorARM %i32 %i32_4 %tensor_shape
-)" << (is_runtime ? "%tensor_array = OpTypeRuntimeArray %tensor" : "%tensor_array = OpTypeArray %tensor %i32_2") << R"(
+)" << (is_runtime ? "%tensor_array = OpTypeRuntimeArray %tensor" : "%tensor_array = OpTypeArray %tensor %i32_2")
+       << R"(
         %ptr_tensor_array = OpTypePointer UniformConstant %tensor_array
               %ptr_tensor = OpTypePointer UniformConstant %tensor
               %main_arg_0 = OpVariable %ptr_tensor_array UniformConstant
@@ -302,7 +312,7 @@ const std::vector<int64_t> add_tensor_dims{1, 4, 4, 2};
 // Tensor description for the various spirvs
 VkTensorDescriptionARM DataGraphPipelineHelper::GetTensorDesc(TensorType type) {
     VkFormat format = VK_FORMAT_UNDEFINED;
-    const std::vector<int64_t> *dims = nullptr;
+    const std::vector<int64_t>* dims = nullptr;
     switch (type) {
         case BASIC_SPIRV_IN:
             format = VK_FORMAT_R8_SINT;

--- a/tests/framework/descriptor_helper.cpp
+++ b/tests/framework/descriptor_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  * Copyright (C) 2025 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +15,12 @@
 #include <vulkan/utility/vk_struct_helper.hpp>
 #include "binding.h"
 
-OneOffDescriptorSet::OneOffDescriptorSet(vkt::Device *device, const std::vector<VkDescriptorSetLayoutBinding> &bindings,
-                                         VkDescriptorSetLayoutCreateFlags layout_flags, void *layout_pnext,
-                                         VkDescriptorPoolCreateFlags pool_flags, void *allocate_pnext, void *create_pool_pnext)
+OneOffDescriptorSet::OneOffDescriptorSet(vkt::Device* device, const std::vector<VkDescriptorSetLayoutBinding>& bindings,
+                                         VkDescriptorSetLayoutCreateFlags layout_flags, void* layout_pnext,
+                                         VkDescriptorPoolCreateFlags pool_flags, void* allocate_pnext, void* create_pool_pnext)
     : device_{device}, layout_(*device, bindings, layout_flags, layout_pnext) {
     std::vector<VkDescriptorPoolSize> pool_sizes;
-    for (const auto &b : bindings) {
+    for (const auto& b : bindings) {
         pool_sizes.emplace_back(VkDescriptorPoolSize{b.descriptorType, std::max(1u, b.descriptorCount)});
     }
 
@@ -41,8 +41,8 @@ OneOffDescriptorSet::OneOffDescriptorSet(vkt::Device *device, const std::vector<
     }
 }
 
-OneOffDescriptorIndexingSet::OneOffDescriptorIndexingSet(vkt::Device *device, const OneOffDescriptorIndexingSet::Bindings &bindings,
-                                                         void *allocate_pnext, void *create_pool_pnext) {
+OneOffDescriptorIndexingSet::OneOffDescriptorIndexingSet(vkt::Device* device, const OneOffDescriptorIndexingSet::Bindings& bindings,
+                                                         void* allocate_pnext, void* create_pool_pnext) {
     device_ = device;
     std::vector<VkDescriptorPoolSize> pool_sizes;
     VkDescriptorSetLayoutCreateFlags layout_flags = 0;
@@ -50,7 +50,7 @@ OneOffDescriptorIndexingSet::OneOffDescriptorIndexingSet(vkt::Device *device, co
     std::vector<VkDescriptorSetLayoutBinding> ds_layout_bindings;
     std::vector<VkDescriptorBindingFlags> ds_binding_flags;
 
-    for (const auto &b : bindings) {
+    for (const auto& b : bindings) {
         pool_sizes.emplace_back(VkDescriptorPoolSize{b.descriptorType, std::max(1u, b.descriptorCount)});
         ds_layout_bindings.emplace_back(
             VkDescriptorSetLayoutBinding{b.binding, b.descriptorType, b.descriptorCount, b.stageFlags, b.pImmutableSamplers});
@@ -90,9 +90,9 @@ OneOffDescriptorIndexingSet::OneOffDescriptorIndexingSet(vkt::Device *device, co
     }
 }
 
-OneOffDescriptorSet::OneOffDescriptorSet(OneOffDescriptorSet &&rhs) noexcept { *this = std::move(rhs); }
+OneOffDescriptorSet::OneOffDescriptorSet(OneOffDescriptorSet&& rhs) noexcept { *this = std::move(rhs); }
 
-OneOffDescriptorSet &OneOffDescriptorSet::operator=(OneOffDescriptorSet &&rhs) noexcept {
+OneOffDescriptorSet& OneOffDescriptorSet::operator=(OneOffDescriptorSet&& rhs) noexcept {
     device_ = rhs.device_;
     rhs.device_ = nullptr;
 
@@ -170,7 +170,7 @@ void OneOffDescriptorSet::WriteDescriptorImageInfo(int binding, VkImageView imag
 }
 
 void OneOffDescriptorSet::WriteDescriptorAccelStruct(int binding, uint32_t accelerationStructureCount,
-                                                     const VkAccelerationStructureKHR *pAccelerationStructures,
+                                                     const VkAccelerationStructureKHR* pAccelerationStructures,
                                                      uint32_t arrayElement /*= 0*/) {
     VkWriteDescriptorSetAccelerationStructureKHR write_desc_set_accel_struct = vku::InitStructHelper();
     write_desc_set_accel_struct.accelerationStructureCount = accelerationStructureCount;
@@ -182,7 +182,7 @@ void OneOffDescriptorSet::WriteDescriptorAccelStruct(int binding, uint32_t accel
     AddDescriptorWrite(binding, arrayElement, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, accelerationStructureCount);
 }
 
-void OneOffDescriptorSet::WriteDescriptorTensorInfo(int binding, const VkTensorViewARM *view, uint32_t arrayElement) {
+void OneOffDescriptorSet::WriteDescriptorTensorInfo(int binding, const VkTensorViewARM* view, uint32_t arrayElement) {
     VkWriteDescriptorSetTensorARM tensor_desc_write_info = vku::InitStructHelper();
     tensor_desc_write_info.tensorViewCount = 1;
     tensor_desc_write_info.pTensorViews = view;
@@ -196,7 +196,7 @@ void OneOffDescriptorSet::WriteDescriptorTensorInfo(int binding, const VkTensorV
 void OneOffDescriptorSet::UpdateDescriptorSets() {
     assert(resource_infos.size() == descriptor_writes.size());
     for (size_t i = 0; i < resource_infos.size(); i++) {
-        const auto &info = resource_infos[i];
+        const auto& info = resource_infos[i];
         if (info.image_info.has_value()) {
             descriptor_writes[i].pImageInfo = &info.image_info.value();
         } else if (info.buffer_info.has_value()) {
@@ -214,7 +214,7 @@ void OneOffDescriptorSet::UpdateDescriptorSets() {
 }
 
 namespace vkt {
-DescriptorGetInfo::DescriptorGetInfo(VkSampler *sampler) {
+DescriptorGetInfo::DescriptorGetInfo(VkSampler* sampler) {
     get_info.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     get_info.data.pSampler = sampler;
 }
@@ -259,6 +259,6 @@ DescriptorGetInfo::DescriptorGetInfo(VkDescriptorType type, VkDeviceAddress addr
     }
 }
 
-DescriptorGetInfo::DescriptorGetInfo(VkDescriptorType type, const vkt::Buffer &buffer, VkDeviceSize range, VkFormat format)
+DescriptorGetInfo::DescriptorGetInfo(VkDescriptorType type, const vkt::Buffer& buffer, VkDeviceSize range, VkFormat format)
     : DescriptorGetInfo(type, buffer.Address(), range, format) {}
 }  // namespace vkt

--- a/tests/framework/error_monitor.cpp
+++ b/tests/framework/error_monitor.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,10 +56,10 @@ static inline LogMessageTypeFlags DebugAnnotFlagsToMsgTypeFlags(VkDebugUtilsMess
 
 static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                     VkDebugUtilsMessageTypeFlagsEXT message_type,
-                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data) {
+                                                    const VkDebugUtilsMessengerCallbackDataEXT* callback_data, void* user_data) {
     const auto message_flags = DebugAnnotFlagsToMsgTypeFlags(message_severity, message_type);
-    const char *vuid = callback_data->pMessageIdName;
-    auto *error_monitor = reinterpret_cast<ErrorMonitor *>(user_data);
+    const char* vuid = callback_data->pMessageIdName;
+    auto* error_monitor = reinterpret_cast<ErrorMonitor*>(user_data);
 
     // mimic CreateDefaultCallbackMessage we do for default callback so
     // (while this is a bad 'copy-and-paste' the format of the default callback *should* not be changing often)
@@ -88,7 +88,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugUtilsMessageSeverityF
         if (callback_data->objectCount > 0) {
             oss << "Objects: " << callback_data->objectCount << '\n';
             for (uint32_t i = 0; i < callback_data->objectCount; i++) {
-                const auto &debug_object = callback_data->pObjects[i];
+                const auto& debug_object = callback_data->pObjects[i];
                 oss << "    [" << i << "] " << string_VkObjectTypeHandleName(debug_object.objectType);
                 if (debug_object.objectHandle) {
                     oss << " 0x" << std::hex << debug_object.objectHandle;
@@ -161,11 +161,11 @@ void ErrorMonitor::Reset() {
     MonitorReset();
 }
 
-void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msg_flags, const std::string &msg) {
+void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msg_flags, const std::string& msg) {
     SetDesiredFailureMsg(msg_flags, msg.c_str());
 }
 
-void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msg_flags, const char *const msg_string) {
+void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msg_flags, const char* const msg_string) {
     if (NeedCheckSuccess()) {
         VerifyNotFound();
     }
@@ -177,7 +177,7 @@ void ErrorMonitor::SetDesiredFailureMsg(const VkFlags msg_flags, const char *con
     message_flags_ |= msg_flags;
 }
 
-void ErrorMonitor::SetDesiredFailureMsgRegex(const VkFlags msg_flags, const char *vuid, std::string regex_str) {
+void ErrorMonitor::SetDesiredFailureMsgRegex(const VkFlags msg_flags, const char* vuid, std::string regex_str) {
     if (NeedCheckSuccess()) {
         VerifyNotFound();
     }
@@ -190,7 +190,7 @@ void ErrorMonitor::SetDesiredFailureMsgRegex(const VkFlags msg_flags, const char
     message_flags_ |= msg_flags;
 }
 
-void ErrorMonitor::SetDesiredFailureMsgRegex(const VkFlags msg_flags, const char *vuid, std::string regex_str,
+void ErrorMonitor::SetDesiredFailureMsgRegex(const VkFlags msg_flags, const char* vuid, std::string regex_str,
                                              std::string undesired_regex_str) {
     if (NeedCheckSuccess()) {
         VerifyNotFound();
@@ -205,43 +205,43 @@ void ErrorMonitor::SetDesiredFailureMsgRegex(const VkFlags msg_flags, const char
     message_flags_ |= msg_flags;
 }
 
-void ErrorMonitor::SetDesiredError(const char *msg, uint32_t count) {
+void ErrorMonitor::SetDesiredError(const char* msg, uint32_t count) {
     for (uint32_t i = 0; i < count; i++) {
         SetDesiredFailureMsg(kErrorBit, msg);
     }
 }
 
-void ErrorMonitor::SetDesiredErrorRegex(const char *vuid, std::string regex_str, uint32_t count /*= 1*/) {
+void ErrorMonitor::SetDesiredErrorRegex(const char* vuid, std::string regex_str, uint32_t count /*= 1*/) {
     for (uint32_t i = 0; i < count; i++) {
         SetDesiredFailureMsgRegex(kErrorBit, vuid, regex_str);
     }
 }
 
-void ErrorMonitor::SetDesiredWarningRegex(const char *vuid, std::string regex_str, uint32_t count /*= 1*/) {
+void ErrorMonitor::SetDesiredWarningRegex(const char* vuid, std::string regex_str, uint32_t count /*= 1*/) {
     for (uint32_t i = 0; i < count; i++) {
         SetDesiredFailureMsgRegex(kWarningBit, vuid, regex_str);
     }
 }
 
-void ErrorMonitor::SetDesiredWarning(const char *msg, uint32_t count) {
+void ErrorMonitor::SetDesiredWarning(const char* msg, uint32_t count) {
     for (uint32_t i = 0; i < count; ++i) {
         SetDesiredFailureMsg(kWarningBit, msg);
     }
 }
 
-void ErrorMonitor::SetDesiredInfo(const char *msg, uint32_t count /*= 1*/) {
+void ErrorMonitor::SetDesiredInfo(const char* msg, uint32_t count /*= 1*/) {
     for (uint32_t i = 0; i < count; ++i) {
         SetDesiredFailureMsg(kInformationBit, msg);
     }
 }
 
 // If you are using this, please leave a comment why, otherwise its hard to remove these once added
-void ErrorMonitor::SetAllowedFailureMsg(const char *const msg) {
+void ErrorMonitor::SetAllowedFailureMsg(const char* const msg) {
     auto guard = Lock();
     allowed_message_strings_.emplace_back(msg);
 }
 
-void ErrorMonitor::SetUnexpectedError(const char *const msg) {
+void ErrorMonitor::SetUnexpectedError(const char* const msg) {
     if (NeedCheckSuccess()) {
         VerifyNotFound();
     }
@@ -249,7 +249,7 @@ void ErrorMonitor::SetUnexpectedError(const char *const msg) {
     ignore_message_strings_.emplace_back(msg);
 }
 
-VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *vuid, const char *const msg_string) {
+VkBool32 ErrorMonitor::CheckForDesiredMsg(const char* vuid, const char* const msg_string) {
     VkBool32 result = VK_FALSE;
     auto guard = Lock();
     if (bailout_ != nullptr) {
@@ -270,13 +270,13 @@ VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *vuid, const char *const ms
         return result;
     }
 
-    for (const VuidAndMessage &undesired_message : undesired_messages_) {
+    for (const VuidAndMessage& undesired_message : undesired_messages_) {
         if (undesired_message.Search(vuid, msg_string)) {
         }
     }
 
     for (size_t desired_message_i = 0; desired_message_i < desired_messages_.size(); ++desired_message_i) {
-        VuidAndMessage &desired_message = desired_messages_[desired_message_i];
+        VuidAndMessage& desired_message = desired_messages_[desired_message_i];
         if (desired_message.SearchUndesiredRegex(msg_string)) {
             ADD_FAILURE() << "Received undesired error message " << '"' << desired_message.undesired_msg_regex_string << '"'
                           << " in:\n"
@@ -296,7 +296,7 @@ VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *vuid, const char *const ms
     }
 
     if (!found_expected) {
-        for (const auto &allowed_msg : allowed_message_strings_) {
+        for (const auto& allowed_msg : allowed_message_strings_) {
             if (error_string.find(allowed_msg) != std::string::npos) {
                 found_expected = true;
                 break;
@@ -316,13 +316,13 @@ VkDebugReportFlagsEXT ErrorMonitor::GetMessageFlags() { return message_flags_; }
 
 bool ErrorMonitor::AnyDesiredMsgFound() const { return message_found_; }
 
-void ErrorMonitor::SetError(const char *const errorString) {
+void ErrorMonitor::SetError(const char* const errorString) {
     auto guard = Lock();
     message_found_ = true;
     failure_message_strings_.emplace_back(errorString);
 }
 
-void ErrorMonitor::SetBailout(std::atomic<bool> *bailout) {
+void ErrorMonitor::SetBailout(std::atomic<bool>* bailout) {
     auto guard = Lock();
     bailout_ = bailout;
 }
@@ -345,7 +345,7 @@ void ErrorMonitor::VerifyFound() {
         // The lock must be released before the ExpectSuccess call at the end
         auto guard = Lock();
         // Not receiving expected message(s) is a failure.
-        for (const auto &desired_msg : desired_messages_) {
+        for (const auto& desired_msg : desired_messages_) {
             ADD_FAILURE() << "Did not receive expected error '" << desired_msg.Print() << "'";
         }
 
@@ -364,24 +364,24 @@ void ErrorMonitor::VerifyNotFound() {
     auto guard = Lock();
     // ExpectSuccess() configured us to match anything. Any error is a failure.
     if (AnyDesiredMsgFound()) {
-        for (const auto &msg : failure_message_strings_) {
+        for (const auto& msg : failure_message_strings_) {
             ADD_FAILURE() << "Expected to succeed but got error: " << msg;
         }
     }
     MonitorReset();
 }
 
-bool ErrorMonitor::IgnoreMessage(std::string const &msg) const {
+bool ErrorMonitor::IgnoreMessage(std::string const& msg) const {
     if (ignore_message_strings_.empty()) {
         return false;
     }
 
-    return std::find_if(ignore_message_strings_.begin(), ignore_message_strings_.end(), [&msg](std::string const &str) {
+    return std::find_if(ignore_message_strings_.begin(), ignore_message_strings_.end(), [&msg](std::string const& str) {
                return msg.find(str) != std::string::npos;
            }) != ignore_message_strings_.end();
 }
 
-bool ErrorMonitor::VuidAndMessage::Search(const char *vuid_, std::string_view msg) const {
+bool ErrorMonitor::VuidAndMessage::Search(const char* vuid_, std::string_view msg) const {
     assert(msg_type != VuidAndMessage::Undefined);
     const bool vuid_compare = !vuid.empty() ? (vuid == vuid_) : true;
     switch (msg_type) {

--- a/tests/framework/external_memory_sync.cpp
+++ b/tests/framework/external_memory_sync.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 #include "containers/container_utils.h"
 
 // We are trying to query unsupported handle types, which means we will likley trigger *-handleType-parameter VUs
-void IgnoreHandleTypeError(ErrorMonitor *monitor) {
+void IgnoreHandleTypeError(ErrorMonitor* monitor) {
     monitor->SetAllowedFailureMsg("VUID-VkPhysicalDeviceExternalFenceInfo-handleType-parameter");
 
     monitor->SetAllowedFailureMsg("VUID-VkFenceGetFdInfoKHR-handleType-parameter");
@@ -42,7 +42,7 @@ void IgnoreHandleTypeError(ErrorMonitor *monitor) {
     monitor->SetAllowedFailureMsg("VUID-VkExternalMemoryImageCreateInfo-handleTypes-parameter");
 }
 
-VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkBufferCreateInfo &buffer_create_info,
+VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkBufferCreateInfo& buffer_create_info,
                                                          VkExternalMemoryHandleTypeFlagBits handle_type) {
     VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
     external_info.flags = buffer_create_info.flags;
@@ -53,7 +53,7 @@ VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, c
     return external_buffer_properties.externalMemoryProperties.compatibleHandleTypes;
 }
 
-VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkImageCreateInfo &image_create_info,
+VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkImageCreateInfo& image_create_info,
                                                          VkExternalMemoryHandleTypeFlagBits handle_type) {
     VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;
@@ -119,7 +119,7 @@ VkExternalSemaphoreHandleTypeFlags FindSupportedExternalSemaphoreHandleTypes(VkP
 }
 
 VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(VkPhysicalDevice gpu,
-                                                                       const VkBufferCreateInfo &buffer_create_info,
+                                                                       const VkBufferCreateInfo& buffer_create_info,
                                                                        VkExternalMemoryFeatureFlags requested_features) {
     VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
     external_info.flags = buffer_create_info.flags;
@@ -140,7 +140,7 @@ VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(VkPhysica
 }
 
 VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(VkPhysicalDevice gpu,
-                                                                       const VkImageCreateInfo &image_create_info,
+                                                                       const VkImageCreateInfo& image_create_info,
                                                                        VkExternalMemoryFeatureFlags requested_features) {
     VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
     VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_info);
@@ -166,7 +166,7 @@ VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(VkPhysica
 }
 
 VkExternalMemoryHandleTypeFlagsNV FindSupportedExternalMemoryHandleTypesNV(VkPhysicalDevice gpu,
-                                                                           const VkImageCreateInfo &image_create_info,
+                                                                           const VkImageCreateInfo& image_create_info,
                                                                            VkExternalMemoryFeatureFlagsNV requested_features) {
     VkExternalMemoryHandleTypeFlagsNV supported_types = 0;
     IterateFlags<VkExternalMemoryHandleTypeFlagBitsNV>(
@@ -183,7 +183,7 @@ VkExternalMemoryHandleTypeFlagsNV FindSupportedExternalMemoryHandleTypesNV(VkPhy
     return supported_types;
 }
 
-bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkBufferCreateInfo &buffer_create_info,
+bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkBufferCreateInfo& buffer_create_info,
                                         VkExternalMemoryHandleTypeFlagBits handle_type) {
     VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
     external_info.flags = buffer_create_info.flags;
@@ -197,7 +197,7 @@ bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkBufferCrea
     return (external_features & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0;
 }
 
-bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkImageCreateInfo &image_create_info,
+bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkImageCreateInfo& image_create_info,
                                         VkExternalMemoryHandleTypeFlagBits handle_type) {
     VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,11 +88,11 @@ bool FormatFeatures2AreSupported(VkPhysicalDevice phy, VkFormat format, VkImageT
     return (features == (phy_features & features));
 }
 
-VkResult GetImageFormatProps(VkPhysicalDevice gpu, const VkImageCreateInfo &ci, VkImageFormatProperties &out_limits) {
+VkResult GetImageFormatProps(VkPhysicalDevice gpu, const VkImageCreateInfo& ci, VkImageFormatProperties& out_limits) {
     return vk::GetPhysicalDeviceImageFormatProperties(gpu, ci.format, ci.imageType, ci.tiling, ci.usage, ci.flags, &out_limits);
 }
 
-bool IsImageFormatSupported(const VkPhysicalDevice gpu, const VkImageCreateInfo &ci, const VkFormatFeatureFlags features) {
+bool IsImageFormatSupported(const VkPhysicalDevice gpu, const VkImageCreateInfo& ci, const VkFormatFeatureFlags features) {
     // Verify physical device support of format features
     if (!FormatFeaturesAreSupported(gpu, ci.format, ci.tiling, features)) {
         return false;
@@ -121,7 +121,7 @@ bool BufferFormatAndFeaturesSupported(VkPhysicalDevice gpu, VkFormat format, VkF
     return (features == (gpu_features & features));
 }
 
-bool operator==(const VkDebugUtilsLabelEXT &rhs, const VkDebugUtilsLabelEXT &lhs) {
+bool operator==(const VkDebugUtilsLabelEXT& rhs, const VkDebugUtilsLabelEXT& lhs) {
     bool is_equal = (rhs.color[0] == lhs.color[0]) && (rhs.color[1] == lhs.color[1]) && (rhs.color[2] == lhs.color[2]) &&
                     (rhs.color[3] == lhs.color[3]);
     if (is_equal) {
@@ -135,8 +135,8 @@ bool operator==(const VkDebugUtilsLabelEXT &rhs, const VkDebugUtilsLabelEXT &lhs
 }
 
 VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT,
-                                                  const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData) {
-    auto *data = reinterpret_cast<DebugUtilsLabelCheckData *>(pUserData);
+                                                  const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData) {
+    auto* data = reinterpret_cast<DebugUtilsLabelCheckData*>(pUserData);
     data->callback(pCallbackData, data);
     return VK_FALSE;
 }
@@ -178,31 +178,31 @@ VkFormat FindFormatWithoutFeatures2(VkPhysicalDevice gpu, VkImageTiling tiling, 
     return return_format;
 }
 
-void VkLayerTest::CreateSamplerTest(const VkSamplerCreateInfo &create_info, const char *vuid) {
+void VkLayerTest::CreateSamplerTest(const VkSamplerCreateInfo& create_info, const char* vuid) {
     Monitor().SetDesiredError(vuid);
     vkt::Sampler sampler(*m_device, create_info);
     Monitor().VerifyFound();
 }
 
-void VkLayerTest::CreateBufferTest(const VkBufferCreateInfo &create_info, const char *vuid) {
+void VkLayerTest::CreateBufferTest(const VkBufferCreateInfo& create_info, const char* vuid) {
     Monitor().SetDesiredError(vuid);
     vkt::Buffer buffer(*m_device, create_info, vkt::no_mem);
     Monitor().VerifyFound();
 }
 
-void VkLayerTest::CreateImageTest(const VkImageCreateInfo &create_info, const char *vuid) {
+void VkLayerTest::CreateImageTest(const VkImageCreateInfo& create_info, const char* vuid) {
     Monitor().SetDesiredError(vuid);
     vkt::Image image(*m_device, create_info, vkt::no_mem);
     Monitor().VerifyFound();
 }
 
-void VkLayerTest::CreateBufferViewTest(const VkBufferViewCreateInfo &create_info, const char *vuid) {
+void VkLayerTest::CreateBufferViewTest(const VkBufferViewCreateInfo& create_info, const char* vuid) {
     Monitor().SetDesiredError(vuid);
     vkt::BufferView view(*m_device, create_info);
     Monitor().VerifyFound();
 }
 
-void VkLayerTest::CreateImageViewTest(const VkImageViewCreateInfo &create_info, const char *vuid) {
+void VkLayerTest::CreateImageViewTest(const VkImageViewCreateInfo& create_info, const char* vuid) {
     Monitor().SetDesiredError(vuid);
     vkt::ImageView view(*m_device, create_info);
     Monitor().VerifyFound();
@@ -240,8 +240,8 @@ VkResolveModeFlagBits VkLayerTest::FindSupportedStencilResolveMode() {
     return stencil_resolve_mode;
 }
 
-void VkLayerTest::CreateRenderPassTest(const VkRenderPassCreateInfo &create_info, bool rp2_supported, const char *rp1_vuid,
-                                       const char *rp2_vuid) {
+void VkLayerTest::CreateRenderPassTest(const VkRenderPassCreateInfo& create_info, bool rp2_supported, const char* rp1_vuid,
+                                       const char* rp2_vuid) {
     if (rp1_vuid) {
         // If the second VUID is not provided, set it equal to the first VUID.  In this way,
         // we can check both vkCreateRenderPass and vkCreateRenderPass2 with the same VUID
@@ -263,8 +263,8 @@ void VkLayerTest::CreateRenderPassTest(const VkRenderPassCreateInfo &create_info
     }
 }
 
-void VkLayerTest::CreateRenderPassBeginTest(const VkCommandBuffer command_buffer, const VkRenderPassBeginInfo *begin_info,
-                                            bool rp2_supported, const char *rp1_vuid, const char *rp2_vuid) {
+void VkLayerTest::CreateRenderPassBeginTest(const VkCommandBuffer command_buffer, const VkRenderPassBeginInfo* begin_info,
+                                            bool rp2_supported, const char* rp1_vuid, const char* rp2_vuid) {
     VkCommandBufferBeginInfo cmd_begin_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
                                                VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, nullptr};
 
@@ -296,7 +296,7 @@ void VkLayerTest::CreateRenderPassBeginTest(const VkCommandBuffer command_buffer
     }
 }
 
-VkSamplerCreateInfo SafeSaneSamplerCreateInfo(void *p_next) {
+VkSamplerCreateInfo SafeSaneSamplerCreateInfo(void* p_next) {
     VkSamplerCreateInfo sampler_create_info = vku::InitStructHelper(p_next);
     sampler_create_info.magFilter = VK_FILTER_NEAREST;
     sampler_create_info.minFilter = VK_FILTER_NEAREST;
@@ -329,7 +329,7 @@ float NearestSmaller(const float from) {
     return std::nextafter(from, negative_direction);
 }
 
-void VkLayerTest::Init(VkPhysicalDeviceFeatures *features, VkPhysicalDeviceFeatures2 *features2, void *instance_pnext) {
+void VkLayerTest::Init(VkPhysicalDeviceFeatures* features, VkPhysicalDeviceFeatures2* features2, void* instance_pnext) {
     RETURN_IF_SKIP(InitFramework(instance_pnext));
     RETURN_IF_SKIP(InitState(features, features2));
 }
@@ -414,7 +414,7 @@ APIVersion VkLayerTest::DeviceValidationVersion() const {
 }
 
 template <>
-VkPhysicalDeviceFeatures2 VkLayerTest::GetPhysicalDeviceFeatures2(VkPhysicalDeviceFeatures2 &features2) {
+VkPhysicalDeviceFeatures2 VkLayerTest::GetPhysicalDeviceFeatures2(VkPhysicalDeviceFeatures2& features2) {
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         vk::GetPhysicalDeviceFeatures2(Gpu(), &features2);
     } else {
@@ -427,7 +427,7 @@ VkPhysicalDeviceFeatures2 VkLayerTest::GetPhysicalDeviceFeatures2(VkPhysicalDevi
 }
 
 template <>
-VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysicalDeviceProperties2 &props2) {
+VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysicalDeviceProperties2& props2) {
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
     } else {
@@ -440,8 +440,8 @@ VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysical
 }
 
 bool VkLayerTest::LoadDeviceProfileLayer(
-    PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
-    PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT) {
+    PFN_vkSetPhysicalDeviceFormatPropertiesEXT& fpvkSetPhysicalDeviceFormatPropertiesEXT,
+    PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT& fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT) {
     if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
@@ -464,8 +464,8 @@ bool VkLayerTest::LoadDeviceProfileLayer(
 }
 
 bool VkLayerTest::LoadDeviceProfileLayer(
-    PFN_vkSetPhysicalDeviceFormatProperties2EXT &fpvkSetPhysicalDeviceFormatProperties2EXT,
-    PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT &fpvkGetOriginalPhysicalDeviceFormatProperties2EXT) {
+    PFN_vkSetPhysicalDeviceFormatProperties2EXT& fpvkSetPhysicalDeviceFormatProperties2EXT,
+    PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT& fpvkGetOriginalPhysicalDeviceFormatProperties2EXT) {
     if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
@@ -488,8 +488,8 @@ bool VkLayerTest::LoadDeviceProfileLayer(
     return true;
 }
 
-bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceLimitsEXT &fpvkSetPhysicalDeviceLimitsEXT,
-                                         PFN_vkGetOriginalPhysicalDeviceLimitsEXT &fpvkGetOriginalPhysicalDeviceLimitsEXT) {
+bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceLimitsEXT& fpvkSetPhysicalDeviceLimitsEXT,
+                                         PFN_vkGetOriginalPhysicalDeviceLimitsEXT& fpvkGetOriginalPhysicalDeviceLimitsEXT) {
     if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
@@ -511,8 +511,8 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceLimitsEXT &fpvkS
     return true;
 }
 
-bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpvkSetPhysicalDeviceFeaturesEXT,
-                                         PFN_vkGetOriginalPhysicalDeviceFeaturesEXT &fpvkGetOriginalPhysicalDeviceFeaturesEXT) {
+bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT& fpvkSetPhysicalDeviceFeaturesEXT,
+                                         PFN_vkGetOriginalPhysicalDeviceFeaturesEXT& fpvkGetOriginalPhysicalDeviceFeaturesEXT) {
     if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
@@ -534,7 +534,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpv
     return true;
 }
 
-bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &fpvkSetPhysicalDeviceProperties2EXT) {
+bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT& fpvkSetPhysicalDeviceProperties2EXT) {
     if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
@@ -554,7 +554,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &
     return true;
 }
 
-void PrintAndroid(const char *c) {
+void PrintAndroid(const char* c) {
     (void)c;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     __android_log_print(ANDROID_LOG_INFO, "VulkanLayerValidationTests", "%s", c);
@@ -562,19 +562,19 @@ void PrintAndroid(const char *c) {
 }
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR) && !defined(VVL_MOCK_ANDROID)
-const char *appTag = "VulkanLayerValidationTests";
+const char* appTag = "VulkanLayerValidationTests";
 static bool initialized = false;
 static bool active = false;
 
 // Convert Intents to argv
 // Ported from Hologram sample, only difference is flexible key
-std::vector<std::string> get_args(android_app &app, const char *intent_extra_data_key) {
+std::vector<std::string> get_args(android_app& app, const char* intent_extra_data_key) {
     std::vector<std::string> args;
-    JavaVM &vm = *app.activity->vm;
-    JNIEnv *p_env;
+    JavaVM& vm = *app.activity->vm;
+    JNIEnv* p_env;
     if (vm.AttachCurrentThread(&p_env, nullptr) != JNI_OK) return args;
 
-    JNIEnv &env = *p_env;
+    JNIEnv& env = *p_env;
     jobject activity = app.activity->clazz;
     jmethodID get_intent_method = env.GetMethodID(env.GetObjectClass(activity), "getIntent", "()Landroid/content/Intent;");
     jobject intent = env.CallObjectMethod(activity, get_intent_method);
@@ -586,7 +586,7 @@ std::vector<std::string> get_args(android_app &app, const char *intent_extra_dat
 
     std::string args_str;
     if (extra_str) {
-        const char *extra_utf = env.GetStringUTFChars(extra_str, nullptr);
+        const char* extra_utf = env.GetStringUTFChars(extra_str, nullptr);
         args_str = extra_utf;
         env.ReleaseStringUTFChars(extra_str, extra_utf);
         env.DeleteLocalRef(extra_str);
@@ -606,9 +606,9 @@ std::vector<std::string> get_args(android_app &app, const char *intent_extra_dat
     return args;
 }
 
-void addFullTestCommentIfPresent(const ::testing::TestInfo &test_info, std::string &error_message) {
-    const char *const type_param = test_info.type_param();
-    const char *const value_param = test_info.value_param();
+void addFullTestCommentIfPresent(const ::testing::TestInfo& test_info, std::string& error_message) {
+    const char* const type_param = test_info.type_param();
+    const char* const value_param = test_info.value_param();
 
     if (type_param != NULL || value_param != NULL) {
         error_message.append(", where ");
@@ -624,12 +624,12 @@ void addFullTestCommentIfPresent(const ::testing::TestInfo &test_info, std::stri
 
 class LogcatPrinter : public ::testing::EmptyTestEventListener {
     // Called before a test starts.
-    virtual void OnTestStart(const ::testing::TestInfo &test_info) {
+    virtual void OnTestStart(const ::testing::TestInfo& test_info) {
         __android_log_print(ANDROID_LOG_INFO, appTag, "[ RUN      ] %s.%s", test_info.test_case_name(), test_info.name());
     }
 
     // Called after a failed assertion or a SUCCEED() invocation.
-    virtual void OnTestPartResult(const ::testing::TestPartResult &result) {
+    virtual void OnTestPartResult(const ::testing::TestPartResult& result) {
         // If the test part succeeded, we don't need to do anything.
         if (result.type() == ::testing::TestPartResult::kSuccess) return;
 
@@ -638,7 +638,7 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
     }
 
     // Called after a test ends.
-    virtual void OnTestEnd(const ::testing::TestInfo &info) {
+    virtual void OnTestEnd(const ::testing::TestInfo& info) {
         std::string result;
         if (info.result()->Passed()) {
             result.append("[       OK ]");
@@ -660,9 +660,9 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
     };
 };
 
-static int32_t processInput(struct android_app *, AInputEvent *) { return 0; }
+static int32_t processInput(struct android_app*, AInputEvent*) { return 0; }
 
-static void processCommand(struct android_app *app, int32_t cmd) {
+static void processCommand(struct android_app* app, int32_t cmd) {
     switch (cmd) {
         case APP_CMD_INIT_WINDOW: {
             if (app->window) {
@@ -682,13 +682,13 @@ static void processCommand(struct android_app *app, int32_t cmd) {
     }
 }
 
-static void destroyActivity(struct android_app *app) {
+static void destroyActivity(struct android_app* app) {
     ANativeActivity_finish(app->activity);
 
     // Wait for APP_CMD_DESTROY
     while (app->destroyRequested == 0) {
-        struct android_poll_source *source = nullptr;
-        int result = ALooper_pollOnce(-1, nullptr, nullptr, reinterpret_cast<void **>(&source));
+        struct android_poll_source* source = nullptr;
+        int result = ALooper_pollOnce(-1, nullptr, nullptr, reinterpret_cast<void**>(&source));
         if (result == ALOOPER_POLL_ERROR) {
             __android_log_print(ANDROID_LOG_ERROR, appTag, "ALooper_pollOnce returned an error");
         }
@@ -701,14 +701,14 @@ static void destroyActivity(struct android_app *app) {
     }
 }
 
-void android_main(struct android_app *app) {
+void android_main(struct android_app* app) {
     app->onAppCmd = processCommand;
     app->onInputEvent = processInput;
 
     while (1) {
-        struct android_poll_source *source;
+        struct android_poll_source* source;
 
-        int result = ALooper_pollOnce(-1, nullptr, nullptr, reinterpret_cast<void **>(&source));
+        int result = ALooper_pollOnce(-1, nullptr, nullptr, reinterpret_cast<void**>(&source));
         if (result == ALOOPER_POLL_ERROR) {
             __android_log_print(ANDROID_LOG_ERROR, appTag, "ALooper_pollOnce returned an error");
             VkTestFramework::Finish();
@@ -741,7 +741,7 @@ void android_main(struct android_app *app) {
             }
 
             int argc = 2;
-            char *argv[] = {(char *)"foo", (char *)filter.c_str()};
+            char* argv[] = {(char*)"foo", (char*)filter.c_str()};
             __android_log_print(ANDROID_LOG_DEBUG, appTag, "filter = %s", argv[1]);
 
             // Route output to files until we can override the gtest output
@@ -750,7 +750,7 @@ void android_main(struct android_app *app) {
 
             ::testing::InitGoogleTest(&argc, argv);
 
-            ::testing::TestEventListeners &listeners = ::testing::UnitTest::GetInstance()->listeners();
+            ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
             listeners.Append(new LogcatPrinter);
 
             VkTestFramework::InitArgs(&argc, argv);
@@ -783,7 +783,7 @@ void android_main(struct android_app *app) {
 
 // Makes any failed assertion throw, allowing for graceful cleanup of resources instead of hard aborts
 class ThrowListener : public testing::EmptyTestEventListener {
-    void OnTestPartResult(const testing::TestPartResult &result) override {
+    void OnTestPartResult(const testing::TestPartResult& result) override {
         if (result.type() == testing::TestPartResult::kFatalFailure) {
             // We need to make sure an exception wasn't already thrown so we dont throw another exception at the same time
             std::exception_ptr ex = std::current_exception();
@@ -802,7 +802,7 @@ class ThrowListener : public testing::EmptyTestEventListener {
 // class. This #ifndef thus makes sure that when the definition is
 // present we do not include the default main entry point.
 #ifndef VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
     int result;
 
 #if defined(_WIN32)

--- a/tests/framework/pipeline_helper.cpp
+++ b/tests/framework/pipeline_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 
 #include "pipeline_helper.h"
 
-CreatePipelineHelper::CreatePipelineHelper(VkLayerTest &test, void *pNext) : layer_test_(test) {
+CreatePipelineHelper::CreatePipelineHelper(VkLayerTest& test, void* pNext) : layer_test_(test) {
     // default VkDevice, can be overwritten if multi-device tests
     device_ = layer_test_.DeviceObj();
 
@@ -121,7 +121,7 @@ CreatePipelineHelper::~CreatePipelineHelper() { Destroy(); }
 
 void CreatePipelineHelper::InitShaderInfo() { ResetShaderInfo(kVertexMinimalGlsl, kFragmentMinimalGlsl); }
 
-void CreatePipelineHelper::ResetShaderInfo(const char *vertex_shader_text, const char *fragment_shader_text) {
+void CreatePipelineHelper::ResetShaderInfo(const char* vertex_shader_text, const char* fragment_shader_text) {
     vs_ = std::make_unique<VkShaderObj>(*device_, vertex_shader_text, VK_SHADER_STAGE_VERTEX_BIT);
     fs_ = std::make_unique<VkShaderObj>(*device_, fragment_shader_text, VK_SHADER_STAGE_FRAGMENT_BIT);
     // We shouldn't need a fragment shader but add it to be able to run on more devices
@@ -154,7 +154,7 @@ void CreatePipelineHelper::AddDynamicState(VkDynamicState dynamic_state) {
     gp_ci_.pDynamicState = &dyn_state_ci_;
 }
 
-void CreatePipelineHelper::InitVertexInputLibInfo(void *p_next) {
+void CreatePipelineHelper::InitVertexInputLibInfo(void* p_next) {
     gpl_info.emplace(vku::InitStruct<VkGraphicsPipelineLibraryCreateInfoEXT>(p_next));
     gpl_info->flags = VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT;
 
@@ -167,7 +167,7 @@ void CreatePipelineHelper::InitVertexInputLibInfo(void *p_next) {
     shader_stages_.clear();
 }
 
-void CreatePipelineHelper::InitPreRasterLibInfo(const VkPipelineShaderStageCreateInfo *info, void *p_next) {
+void CreatePipelineHelper::InitPreRasterLibInfo(const VkPipelineShaderStageCreateInfo* info, void* p_next) {
     gpl_info.emplace(vku::InitStruct<VkGraphicsPipelineLibraryCreateInfoEXT>(p_next));
     gpl_info->flags = VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT;
 
@@ -185,7 +185,7 @@ void CreatePipelineHelper::InitPreRasterLibInfo(const VkPipelineShaderStageCreat
     gp_ci_.pStages = info;
 }
 
-void CreatePipelineHelper::InitFragmentLibInfo(const VkPipelineShaderStageCreateInfo *info, void *p_next) {
+void CreatePipelineHelper::InitFragmentLibInfo(const VkPipelineShaderStageCreateInfo* info, void* p_next) {
     gpl_info.emplace(vku::InitStruct<VkGraphicsPipelineLibraryCreateInfoEXT>(p_next));
     gpl_info->flags = VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT;
 
@@ -206,7 +206,7 @@ void CreatePipelineHelper::InitFragmentLibInfo(const VkPipelineShaderStageCreate
     gp_ci_.pStages = info;
 }
 
-void CreatePipelineHelper::InitFragmentOutputLibInfo(void *p_next) {
+void CreatePipelineHelper::InitFragmentOutputLibInfo(void* p_next) {
     gpl_info.emplace(vku::InitStruct<VkGraphicsPipelineLibraryCreateInfoEXT>(p_next));
     gpl_info->flags = VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT;
 
@@ -225,7 +225,7 @@ void CreatePipelineHelper::InitFragmentOutputLibInfo(void *p_next) {
     shader_stages_.clear();
 }
 
-void CreatePipelineHelper::InitShaderLibInfo(std::vector<VkPipelineShaderStageCreateInfo> &info, void *p_next) {
+void CreatePipelineHelper::InitShaderLibInfo(std::vector<VkPipelineShaderStageCreateInfo>& info, void* p_next) {
     gpl_info.emplace(vku::InitStruct<VkGraphicsPipelineLibraryCreateInfoEXT>(p_next));
     gpl_info->flags =
         VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT | VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT;
@@ -297,7 +297,7 @@ VkResult CreatePipelineHelper::CreateGraphicsPipeline(bool do_late_bind, bool no
                                        &pipeline_);
 }
 
-CreateComputePipelineHelper::CreateComputePipelineHelper(vkt::Device& device, void *pNext) {
+CreateComputePipelineHelper::CreateComputePipelineHelper(vkt::Device& device, void* pNext) {
     // default VkDevice, can be overwritten if multi-device tests
     device_ = &device;
 
@@ -324,12 +324,12 @@ CreateComputePipelineHelper::CreateComputePipelineHelper(vkt::Device& device, vo
     cp_ci_.layout = VK_NULL_HANDLE;
 }
 
-CreateComputePipelineHelper::CreateComputePipelineHelper(VkLayerTest &test, void *pNext)
+CreateComputePipelineHelper::CreateComputePipelineHelper(VkLayerTest& test, void* pNext)
     : CreateComputePipelineHelper(*test.DeviceObj(), pNext) {}
 
-CreateComputePipelineHelper::CreateComputePipelineHelper(CreateComputePipelineHelper &&rhs) noexcept { *this = std::move(rhs); }
+CreateComputePipelineHelper::CreateComputePipelineHelper(CreateComputePipelineHelper&& rhs) noexcept { *this = std::move(rhs); }
 
-CreateComputePipelineHelper &CreateComputePipelineHelper::operator=(CreateComputePipelineHelper &&rhs) noexcept {
+CreateComputePipelineHelper& CreateComputePipelineHelper::operator=(CreateComputePipelineHelper&& rhs) noexcept {
     dsl_bindings_ = std::move(rhs.dsl_bindings_);
     descriptor_set_ = std::move(rhs.descriptor_set_);
 
@@ -424,7 +424,7 @@ GraphicsPipelineLibraryStage::GraphicsPipelineLibraryStage(vvl::span<const uint3
     stage_ci.pName = "main";
 }
 
-SimpleGPL::SimpleGPL(VkLayerTest &test, VkPipelineLayout layout, const char *vertex_shader, const char *fragment_shader)
+SimpleGPL::SimpleGPL(VkLayerTest& test, VkPipelineLayout layout, const char* vertex_shader, const char* fragment_shader)
     : vertex_input_lib_(test), pre_raster_lib_(test), frag_shader_lib_(test), frag_out_lib_(test) {
     auto device = test.DeviceObj();
 

--- a/tests/framework/ray_tracing_helper_nv.cpp
+++ b/tests/framework/ray_tracing_helper_nv.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 namespace nv {
 namespace rt {
 
-RayTracingPipelineHelper::RayTracingPipelineHelper(VkLayerTest &test) : layer_test_(test) { InitInfo(); }
+RayTracingPipelineHelper::RayTracingPipelineHelper(VkLayerTest& test) : layer_test_(test) { InitInfo(); }
 RayTracingPipelineHelper::~RayTracingPipelineHelper() {
     VkDevice device = layer_test_.device();
     if (pipeline_cache_ != VK_NULL_HANDLE) {
@@ -138,7 +138,7 @@ void RayTracingPipelineHelper::InitNVRayTracingPipelineInfo() {
     rp_ci_.pGroups = groups_.data();
 }
 
-void RayTracingPipelineHelper::AddLibrary(const RayTracingPipelineHelper &library) {
+void RayTracingPipelineHelper::AddLibrary(const RayTracingPipelineHelper& library) {
     libraries_.emplace_back(library);
     rp_library_ci_ = vku::InitStructHelper();
     rp_library_ci_.libraryCount = size32(libraries_);
@@ -198,11 +198,11 @@ VkResult RayTracingPipelineHelper::CreateNVRayTracingPipeline(bool do_late_bind)
     return vkCreateRayTracingPipelinesNV(layer_test_.device(), pipeline_cache_, 1, &rp_ci_, nullptr, &pipeline_);
 }
 
-void GetSimpleGeometryForAccelerationStructureTests(const vkt::Device &device, vkt::Buffer *vbo, vkt::Buffer *ibo,
-                                                    VkGeometryNV *geometry, VkDeviceSize offset, bool buffer_device_address) {
+void GetSimpleGeometryForAccelerationStructureTests(const vkt::Device& device, vkt::Buffer* vbo, vkt::Buffer* ibo,
+                                                    VkGeometryNV* geometry, VkDeviceSize offset, bool buffer_device_address) {
     VkBufferUsageFlags usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
-    void *alloc_pnext = nullptr;
+    void* alloc_pnext = nullptr;
     if (buffer_device_address) {
         usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
@@ -214,12 +214,12 @@ void GetSimpleGeometryForAccelerationStructureTests(const vkt::Device &device, v
     constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
     constexpr std::array<uint32_t, 3> indicies = {{0, 1, 2}};
 
-    uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo->Memory().Map();
-    std::memcpy(mapped_vbo_buffer_data + offset, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
+    uint8_t* mapped_vbo_buffer_data = (uint8_t*)vbo->Memory().Map();
+    std::memcpy(mapped_vbo_buffer_data + offset, (uint8_t*)vertices.data(), sizeof(float) * vertices.size());
     vbo->Memory().Unmap();
 
-    uint8_t *mapped_ibo_buffer_data = (uint8_t *)ibo->Memory().Map();
-    std::memcpy(mapped_ibo_buffer_data + offset, (uint8_t *)indicies.data(), sizeof(uint32_t) * indicies.size());
+    uint8_t* mapped_ibo_buffer_data = (uint8_t*)ibo->Memory().Map();
+    std::memcpy(mapped_ibo_buffer_data + offset, (uint8_t*)indicies.data(), sizeof(uint32_t) * indicies.size());
     ibo->Memory().Unmap();
 
     *geometry = vku::InitStructHelper();

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -24,12 +24,12 @@ namespace as {
 
 GeometryKHR::GeometryKHR() : vk_obj_(vku::InitStructHelper()) {}
 
-GeometryKHR &GeometryKHR::SetFlags(VkGeometryFlagsKHR flags) {
+GeometryKHR& GeometryKHR::SetFlags(VkGeometryFlagsKHR flags) {
     vk_obj_.flags = flags;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetType(Type type) {
+GeometryKHR& GeometryKHR::SetType(Type type) {
     type_ = type;
     vk_obj_.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
     vk_obj_.pNext = nullptr;
@@ -55,14 +55,14 @@ GeometryKHR &GeometryKHR::SetType(Type type) {
             spheres_.sphere_geometry_ptr->pNext = nullptr;
             spheres_.sphere_geometry_ptr->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_SPHERES_DATA_NV;
             vk_obj_.geometryType = VK_GEOMETRY_TYPE_SPHERES_NV;
-            vk_obj_.pNext = static_cast<const void *>(spheres_.sphere_geometry_ptr.get());
+            vk_obj_.pNext = static_cast<const void*>(spheres_.sphere_geometry_ptr.get());
             break;
         case Type::LSSpheres:
             lsspheres_.sphere_geometry_ptr = std::make_shared<VkAccelerationStructureGeometryLinearSweptSpheresDataNV>();
             lsspheres_.sphere_geometry_ptr->pNext = nullptr;
             lsspheres_.sphere_geometry_ptr->sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_LINEAR_SWEPT_SPHERES_DATA_NV;
             vk_obj_.geometryType = VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV;
-            vk_obj_.pNext = static_cast<const void *>(lsspheres_.sphere_geometry_ptr.get());
+            vk_obj_.pNext = static_cast<const void*>(lsspheres_.sphere_geometry_ptr.get());
             break;
         case Type::_INTERNAL_UNSPECIFIED:
             [[fallthrough]];
@@ -73,12 +73,12 @@ GeometryKHR &GeometryKHR::SetType(Type type) {
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetPrimitiveCount(uint32_t primitiveCount) {
+GeometryKHR& GeometryKHR::SetPrimitiveCount(uint32_t primitiveCount) {
     primitive_count_ = primitiveCount;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetStride(VkDeviceSize stride) {
+GeometryKHR& GeometryKHR::SetStride(VkDeviceSize stride) {
     switch (type_) {
         case Type::Triangle:
             vk_obj_.geometry.triangles.vertexStride = stride;
@@ -97,7 +97,7 @@ GeometryKHR &GeometryKHR::SetStride(VkDeviceSize stride) {
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesDeviceVertexBuffer(vkt::Buffer &&vertex_buffer, uint32_t max_vertex,
+GeometryKHR& GeometryKHR::SetTrianglesDeviceVertexBuffer(vkt::Buffer&& vertex_buffer, uint32_t max_vertex,
                                                          VkFormat vertex_format /*= VK_FORMAT_R32G32B32_SFLOAT*/,
                                                          VkDeviceSize stride /*= 3 * sizeof(float)*/,
                                                          VkDeviceSize vertex_buffer_offset /* = 0*/) {
@@ -109,7 +109,7 @@ GeometryKHR &GeometryKHR::SetTrianglesDeviceVertexBuffer(vkt::Buffer &&vertex_bu
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesHostVertexBuffer(std::unique_ptr<float[]> &&vertex_buffer, uint32_t max_vertex,
+GeometryKHR& GeometryKHR::SetTrianglesHostVertexBuffer(std::unique_ptr<float[]>&& vertex_buffer, uint32_t max_vertex,
                                                        VkDeviceSize stride /*= 3 * sizeof(float)*/) {
     triangles_.host_vertex_buffer = std::move(vertex_buffer);
     vk_obj_.geometry.triangles.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
@@ -119,7 +119,7 @@ GeometryKHR &GeometryKHR::SetTrianglesHostVertexBuffer(std::unique_ptr<float[]> 
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesDeviceIndexBuffer(vkt::Buffer &&index_buffer,
+GeometryKHR& GeometryKHR::SetTrianglesDeviceIndexBuffer(vkt::Buffer&& index_buffer,
                                                         VkIndexType index_type /*= VK_INDEX_TYPE_UINT32*/) {
     triangles_.device_index_buffer = std::move(index_buffer);
     vk_obj_.geometry.triangles.indexType = index_type;
@@ -127,64 +127,64 @@ GeometryKHR &GeometryKHR::SetTrianglesDeviceIndexBuffer(vkt::Buffer &&index_buff
     return *this;
 }
 
-vkt::Buffer &GeometryKHR::GetTrianglesDeviceIndexBuffer() { return triangles_.device_index_buffer; }
+vkt::Buffer& GeometryKHR::GetTrianglesDeviceIndexBuffer() { return triangles_.device_index_buffer; }
 
-GeometryKHR &GeometryKHR::SetTrianglesHostIndexBuffer(std::unique_ptr<uint32_t[]> index_buffer) {
+GeometryKHR& GeometryKHR::SetTrianglesHostIndexBuffer(std::unique_ptr<uint32_t[]> index_buffer) {
     triangles_.host_index_buffer = std::move(index_buffer);
     vk_obj_.geometry.triangles.indexType = VK_INDEX_TYPE_UINT32;
     vk_obj_.geometry.triangles.indexData.hostAddress = triangles_.host_index_buffer.get();
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesIndexType(VkIndexType index_type) {
+GeometryKHR& GeometryKHR::SetTrianglesIndexType(VkIndexType index_type) {
     vk_obj_.geometry.triangles.indexType = index_type;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesVertexFormat(VkFormat vertex_format) {
+GeometryKHR& GeometryKHR::SetTrianglesVertexFormat(VkFormat vertex_format) {
     vk_obj_.geometry.triangles.vertexFormat = vertex_format;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesVertexStride(uint32_t vertex_stride) {
+GeometryKHR& GeometryKHR::SetTrianglesVertexStride(uint32_t vertex_stride) {
     vk_obj_.geometry.triangles.vertexStride = vertex_stride;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesMaxVertex(uint32_t max_vertex) {
+GeometryKHR& GeometryKHR::SetTrianglesMaxVertex(uint32_t max_vertex) {
     vk_obj_.geometry.triangles.maxVertex = max_vertex;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesTransformBuffer(vkt::Buffer &&transform_buffer) {
+GeometryKHR& GeometryKHR::SetTrianglesTransformBuffer(vkt::Buffer&& transform_buffer) {
     triangles_.device_transform_buffer = std::move(transform_buffer);
     vk_obj_.geometry.triangles.transformData.deviceAddress = triangles_.device_transform_buffer.Address();
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesTransformatData(VkDeviceAddress address) {
+GeometryKHR& GeometryKHR::SetTrianglesTransformatData(VkDeviceAddress address) {
     vk_obj_.geometry.triangles.transformData.deviceAddress = address;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesVertexBufferDeviceAddress(VkDeviceAddress address) {
+GeometryKHR& GeometryKHR::SetTrianglesVertexBufferDeviceAddress(VkDeviceAddress address) {
     vk_obj_.geometry.triangles.vertexData.deviceAddress = address;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetTrianglesIndexBufferDeviceAddress(VkDeviceAddress address) {
+GeometryKHR& GeometryKHR::SetTrianglesIndexBufferDeviceAddress(VkDeviceAddress address) {
     vk_obj_.geometry.triangles.indexData.deviceAddress = address;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetAABBsDeviceBuffer(vkt::Buffer &&buffer, VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
+GeometryKHR& GeometryKHR::SetAABBsDeviceBuffer(vkt::Buffer&& buffer, VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
     aabbs_.device_buffer = std::move(buffer);
     vk_obj_.geometry.aabbs.data.deviceAddress = aabbs_.device_buffer.Address();
     vk_obj_.geometry.aabbs.stride = stride;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetAABBsHostBuffer(std::unique_ptr<VkAabbPositionsKHR[]> buffer,
+GeometryKHR& GeometryKHR::SetAABBsHostBuffer(std::unique_ptr<VkAabbPositionsKHR[]> buffer,
                                              VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
     aabbs_.host_buffer = std::move(buffer);
     vk_obj_.geometry.aabbs.data.hostAddress = aabbs_.host_buffer.get();
@@ -192,18 +192,18 @@ GeometryKHR &GeometryKHR::SetAABBsHostBuffer(std::unique_ptr<VkAabbPositionsKHR[
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetAABBsStride(VkDeviceSize stride) {
+GeometryKHR& GeometryKHR::SetAABBsStride(VkDeviceSize stride) {
     vk_obj_.geometry.aabbs.stride = stride;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetAABBsDeviceAddress(VkDeviceAddress address) {
+GeometryKHR& GeometryKHR::SetAABBsDeviceAddress(VkDeviceAddress address) {
     vk_obj_.geometry.aabbs.data.deviceAddress = address;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device &device, VkAccelerationStructureKHR blas,
-                                                          const VkAccelerationStructureInstanceKHR &instance) {
+GeometryKHR& GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device& device, VkAccelerationStructureKHR blas,
+                                                          const VkAccelerationStructureInstanceKHR& instance) {
     auto vkGetAccelerationStructureDeviceAddressKHR = reinterpret_cast<PFN_vkGetAccelerationStructureDeviceAddressKHR>(
         vk::GetDeviceProcAddr(device, "vkGetAccelerationStructureDeviceAddressKHR"));
     assert(vkGetAccelerationStructureDeviceAddressKHR);
@@ -230,7 +230,7 @@ GeometryKHR &GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device &dev
                                      VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                                  kHostVisibleMemProps, &alloc_flags);
 
-    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR *>(instances_buffer.Memory().Map());
+    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR*>(instances_buffer.Memory().Map());
     for (size_t vk_instance_i = 0; vk_instance_i < instances_.vk_instances.size(); ++vk_instance_i) {
         instance_buffer_ptr[vk_instance_i] = instances_.vk_instances[vk_instance_i];
     }
@@ -243,14 +243,14 @@ GeometryKHR &GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device &dev
     return *this;
 }
 
-void GeometryKHR::UpdateAccelerationStructureInstance(size_t i, std::function<void(VkAccelerationStructureInstanceKHR &)> f) {
+void GeometryKHR::UpdateAccelerationStructureInstance(size_t i, std::function<void(VkAccelerationStructureInstanceKHR&)> f) {
     assert(i < instances_.vk_instances.size());
     f(instances_.vk_instances[i]);
-    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR *>(instances_.buffer.Memory().Map());
+    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR*>(instances_.buffer.Memory().Map());
     f(instance_buffer_ptr[i]);
 }
 
-GeometryKHR &GeometryKHR::AddInstanceHostAccelStructRef(VkAccelerationStructureKHR blas) {
+GeometryKHR& GeometryKHR::AddInstanceHostAccelStructRef(VkAccelerationStructureKHR blas) {
     instances_.vk_instances.emplace_back(VkAccelerationStructureInstanceKHR{});
     ++primitive_count_;
     instances_.vk_instances.back().accelerationStructureReference = (uint64_t)(blas);
@@ -261,27 +261,27 @@ GeometryKHR &GeometryKHR::AddInstanceHostAccelStructRef(VkAccelerationStructureK
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetInstancesDeviceAddress(VkDeviceAddress address) {
+GeometryKHR& GeometryKHR::SetInstancesDeviceAddress(VkDeviceAddress address) {
     vk_obj_.geometry.instances.data.deviceAddress = address;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetInstanceHostAccelStructRef(VkAccelerationStructureKHR blas, uint32_t instance_i) {
+GeometryKHR& GeometryKHR::SetInstanceHostAccelStructRef(VkAccelerationStructureKHR blas, uint32_t instance_i) {
     instances_.vk_instances[instance_i].accelerationStructureReference = (uint64_t)(blas);
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetInstanceHostAddress(void *address) {
+GeometryKHR& GeometryKHR::SetInstanceHostAddress(void* address) {
     vk_obj_.geometry.instances.data.hostAddress = address;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetInstanceShaderBindingTableRecordOffset(uint32_t instance_i, uint32_t instance_sbt_record_offset) {
+GeometryKHR& GeometryKHR::SetInstanceShaderBindingTableRecordOffset(uint32_t instance_i, uint32_t instance_sbt_record_offset) {
     instances_.vk_instances[instance_i].instanceShaderBindingTableRecordOffset = instance_sbt_record_offset;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresDeviceVertexBuffer(vkt::Buffer &&vertex_buffer,
+GeometryKHR& GeometryKHR::SetSpheresDeviceVertexBuffer(vkt::Buffer&& vertex_buffer,
                                                        VkFormat vertex_format /*= VK_FORMAT_R32G32B32_SFLOAT*/,
                                                        VkDeviceSize stride /*= 3 * sizeof(float)*/) {
     spheres_.device_vertex_buffer = std::move(vertex_buffer);
@@ -291,7 +291,7 @@ GeometryKHR &GeometryKHR::SetSpheresDeviceVertexBuffer(vkt::Buffer &&vertex_buff
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresDeviceIndexBuffer(vkt::Buffer &&index_buffer,
+GeometryKHR& GeometryKHR::SetSpheresDeviceIndexBuffer(vkt::Buffer&& index_buffer,
                                                       VkIndexType index_type /*= VK_INDEX_TYPE_UINT32*/) {
     spheres_.device_index_buffer = std::move(index_buffer);
     spheres_.sphere_geometry_ptr->indexType = index_type;
@@ -300,7 +300,7 @@ GeometryKHR &GeometryKHR::SetSpheresDeviceIndexBuffer(vkt::Buffer &&index_buffer
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresDeviceRadiusBuffer(vkt::Buffer &&radius_buffer, VkDeviceSize stride /*=sizeof(float)*/) {
+GeometryKHR& GeometryKHR::SetSpheresDeviceRadiusBuffer(vkt::Buffer&& radius_buffer, VkDeviceSize stride /*=sizeof(float)*/) {
     spheres_.device_radius_buffer = std::move(radius_buffer);
     spheres_.sphere_geometry_ptr->radiusFormat = VK_FORMAT_R32_SFLOAT;
     spheres_.sphere_geometry_ptr->radiusData.deviceAddress = spheres_.device_radius_buffer.Address();
@@ -308,7 +308,7 @@ GeometryKHR &GeometryKHR::SetSpheresDeviceRadiusBuffer(vkt::Buffer &&radius_buff
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresHostVertexBuffer(std::unique_ptr<float[]> &&vertex_buffer,
+GeometryKHR& GeometryKHR::SetSpheresHostVertexBuffer(std::unique_ptr<float[]>&& vertex_buffer,
                                                      VkDeviceSize stride /*= 3 * sizeof(float)*/) {
     spheres_.host_vertex_buffer = std::move(vertex_buffer);
     spheres_.sphere_geometry_ptr->vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
@@ -317,7 +317,7 @@ GeometryKHR &GeometryKHR::SetSpheresHostVertexBuffer(std::unique_ptr<float[]> &&
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresHostIndexBuffer(std::unique_ptr<uint32_t[]> index_buffer) {
+GeometryKHR& GeometryKHR::SetSpheresHostIndexBuffer(std::unique_ptr<uint32_t[]> index_buffer) {
     spheres_.host_index_buffer = std::move(index_buffer);
     spheres_.sphere_geometry_ptr->indexType = VK_INDEX_TYPE_UINT32;
     spheres_.sphere_geometry_ptr->indexData.hostAddress = spheres_.host_index_buffer.get();
@@ -325,7 +325,7 @@ GeometryKHR &GeometryKHR::SetSpheresHostIndexBuffer(std::unique_ptr<uint32_t[]> 
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresHostRadiusBuffer(std::unique_ptr<float[]> radius_buffer,
+GeometryKHR& GeometryKHR::SetSpheresHostRadiusBuffer(std::unique_ptr<float[]> radius_buffer,
                                                      VkDeviceSize stride /*=sizeof(float)*/) {
     spheres_.host_radius_buffer = std::move(radius_buffer);
     spheres_.sphere_geometry_ptr->radiusFormat = VK_FORMAT_R32_SFLOAT;
@@ -334,47 +334,47 @@ GeometryKHR &GeometryKHR::SetSpheresHostRadiusBuffer(std::unique_ptr<float[]> ra
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresVertexStride(VkDeviceSize stride) {
+GeometryKHR& GeometryKHR::SetSpheresVertexStride(VkDeviceSize stride) {
     spheres_.sphere_geometry_ptr->vertexStride = stride;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresRadiusStride(VkDeviceSize stride) {
+GeometryKHR& GeometryKHR::SetSpheresRadiusStride(VkDeviceSize stride) {
     spheres_.sphere_geometry_ptr->radiusStride = stride;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresVertexFormat(VkFormat vertex_format) {
+GeometryKHR& GeometryKHR::SetSpheresVertexFormat(VkFormat vertex_format) {
     spheres_.sphere_geometry_ptr->vertexFormat = vertex_format;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresRadiusFormat(VkFormat radius_format) {
+GeometryKHR& GeometryKHR::SetSpheresRadiusFormat(VkFormat radius_format) {
     spheres_.sphere_geometry_ptr->radiusFormat = radius_format;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresIndexType(VkIndexType index_type) {
+GeometryKHR& GeometryKHR::SetSpheresIndexType(VkIndexType index_type) {
     spheres_.sphere_geometry_ptr->indexType = index_type;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresIndexAddressZero() {
+GeometryKHR& GeometryKHR::SetSpheresIndexAddressZero() {
     spheres_.sphere_geometry_ptr->indexData.deviceAddress = 0;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresVertexAddressZero() {
+GeometryKHR& GeometryKHR::SetSpheresVertexAddressZero() {
     spheres_.sphere_geometry_ptr->vertexData.deviceAddress = 0;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetSpheresRadiusAddressZero() {
+GeometryKHR& GeometryKHR::SetSpheresRadiusAddressZero() {
     spheres_.sphere_geometry_ptr->radiusData.deviceAddress = 0;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresDeviceVertexBuffer(vkt::Buffer &&vertex_buffer,
+GeometryKHR& GeometryKHR::SetLSSpheresDeviceVertexBuffer(vkt::Buffer&& vertex_buffer,
                                                          VkFormat vertex_format /*= VK_FORMAT_R32G32B32_SFLOAT*/,
                                                          VkDeviceSize stride /*= 3 * sizeof(float)*/) {
     lsspheres_.device_vertex_buffer = std::move(vertex_buffer);
@@ -384,7 +384,7 @@ GeometryKHR &GeometryKHR::SetLSSpheresDeviceVertexBuffer(vkt::Buffer &&vertex_bu
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresDeviceIndexBuffer(vkt::Buffer &&index_buffer,
+GeometryKHR& GeometryKHR::SetLSSpheresDeviceIndexBuffer(vkt::Buffer&& index_buffer,
                                                         VkIndexType index_type /*= VK_INDEX_TYPE_UINT32*/) {
     lsspheres_.device_index_buffer = std::move(index_buffer);
     lsspheres_.sphere_geometry_ptr->indexType = index_type;
@@ -394,7 +394,7 @@ GeometryKHR &GeometryKHR::SetLSSpheresDeviceIndexBuffer(vkt::Buffer &&index_buff
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresDeviceRadiusBuffer(vkt::Buffer &&radius_buffer, VkDeviceSize stride /*=sizeof(float)*/) {
+GeometryKHR& GeometryKHR::SetLSSpheresDeviceRadiusBuffer(vkt::Buffer&& radius_buffer, VkDeviceSize stride /*=sizeof(float)*/) {
     lsspheres_.device_radius_buffer = std::move(radius_buffer);
     lsspheres_.sphere_geometry_ptr->radiusFormat = VK_FORMAT_R32_SFLOAT;
     lsspheres_.sphere_geometry_ptr->radiusData.deviceAddress = lsspheres_.device_radius_buffer.Address();
@@ -402,7 +402,7 @@ GeometryKHR &GeometryKHR::SetLSSpheresDeviceRadiusBuffer(vkt::Buffer &&radius_bu
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresHostVertexBuffer(std::unique_ptr<float[]> &&vertex_buffer,
+GeometryKHR& GeometryKHR::SetLSSpheresHostVertexBuffer(std::unique_ptr<float[]>&& vertex_buffer,
                                                        VkDeviceSize stride /*= 3 * sizeof(float)*/) {
     lsspheres_.host_vertex_buffer = std::move(vertex_buffer);
     lsspheres_.sphere_geometry_ptr->vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
@@ -411,7 +411,7 @@ GeometryKHR &GeometryKHR::SetLSSpheresHostVertexBuffer(std::unique_ptr<float[]> 
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresHostIndexBuffer(std::unique_ptr<uint32_t[]> index_buffer) {
+GeometryKHR& GeometryKHR::SetLSSpheresHostIndexBuffer(std::unique_ptr<uint32_t[]> index_buffer) {
     lsspheres_.host_index_buffer = std::move(index_buffer);
     lsspheres_.sphere_geometry_ptr->indexType = VK_INDEX_TYPE_UINT32;
     lsspheres_.sphere_geometry_ptr->indexData.hostAddress = lsspheres_.host_index_buffer.get();
@@ -419,7 +419,7 @@ GeometryKHR &GeometryKHR::SetLSSpheresHostIndexBuffer(std::unique_ptr<uint32_t[]
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresHostRadiusBuffer(std::unique_ptr<float[]> radius_buffer,
+GeometryKHR& GeometryKHR::SetLSSpheresHostRadiusBuffer(std::unique_ptr<float[]> radius_buffer,
                                                        VkDeviceSize stride /*=sizeof(float)*/) {
     lsspheres_.host_radius_buffer = std::move(radius_buffer);
     lsspheres_.sphere_geometry_ptr->radiusFormat = VK_FORMAT_R32_SFLOAT;
@@ -428,52 +428,52 @@ GeometryKHR &GeometryKHR::SetLSSpheresHostRadiusBuffer(std::unique_ptr<float[]> 
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresVertexStride(VkDeviceSize stride) {
+GeometryKHR& GeometryKHR::SetLSSpheresVertexStride(VkDeviceSize stride) {
     lsspheres_.sphere_geometry_ptr->vertexStride = stride;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresRadiusStride(VkDeviceSize stride) {
+GeometryKHR& GeometryKHR::SetLSSpheresRadiusStride(VkDeviceSize stride) {
     lsspheres_.sphere_geometry_ptr->radiusStride = stride;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresVertexFormat(VkFormat vertex_format) {
+GeometryKHR& GeometryKHR::SetLSSpheresVertexFormat(VkFormat vertex_format) {
     lsspheres_.sphere_geometry_ptr->vertexFormat = vertex_format;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresRadiusFormat(VkFormat radius_format) {
+GeometryKHR& GeometryKHR::SetLSSpheresRadiusFormat(VkFormat radius_format) {
     lsspheres_.sphere_geometry_ptr->radiusFormat = radius_format;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresIndexType(VkIndexType index_type) {
+GeometryKHR& GeometryKHR::SetLSSpheresIndexType(VkIndexType index_type) {
     lsspheres_.sphere_geometry_ptr->indexType = index_type;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresIndexingMode(VkRayTracingLssIndexingModeNV index_mode) {
+GeometryKHR& GeometryKHR::SetLSSpheresIndexingMode(VkRayTracingLssIndexingModeNV index_mode) {
     lsspheres_.sphere_geometry_ptr->indexingMode = index_mode;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresIndexDataNull() {
+GeometryKHR& GeometryKHR::SetLSSpheresIndexDataNull() {
     lsspheres_.sphere_geometry_ptr->indexData = {};
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresIndexAddressZero() {
+GeometryKHR& GeometryKHR::SetLSSpheresIndexAddressZero() {
     lsspheres_.sphere_geometry_ptr->indexData.deviceAddress = 0;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresVertexAddressZero() {
+GeometryKHR& GeometryKHR::SetLSSpheresVertexAddressZero() {
     lsspheres_.sphere_geometry_ptr->vertexData.deviceAddress = 0;
     return *this;
 }
 
-GeometryKHR &GeometryKHR::SetLSSpheresRadiusAddressZero() {
+GeometryKHR& GeometryKHR::SetLSSpheresRadiusAddressZero() {
     lsspheres_.sphere_geometry_ptr->radiusData.deviceAddress = 0;
     return *this;
 }
@@ -488,69 +488,69 @@ VkAccelerationStructureBuildRangeInfoKHR GeometryKHR::GetFullBuildRange() const 
     return range_info;
 }
 
-AccelerationStructureKHR::AccelerationStructureKHR(const vkt::Device *device)
+AccelerationStructureKHR::AccelerationStructureKHR(const vkt::Device* device)
     : device_(device), vk_info_(vku::InitStructHelper()), device_buffer_() {}
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetCreateWithVersion2(bool create_with_version_2) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetCreateWithVersion2(bool create_with_version_2) {
     create_with_version_2_ = create_with_version_2;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetAddressRange(std::optional<VkDeviceAddressRangeKHR> address_range) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetAddressRange(std::optional<VkDeviceAddressRangeKHR> address_range) {
     address_range_ = address_range;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetAddressFlags(VkAddressCommandFlagsKHR address_flags) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetAddressFlags(VkAddressCommandFlagsKHR address_flags) {
     vk_info_2_.addressFlags = address_flags;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetSize(VkDeviceSize size) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetSize(VkDeviceSize size) {
     vk_info_.size = size;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetOffset(VkDeviceSize offset) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetOffset(VkDeviceSize offset) {
     vk_info_.offset = offset;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetType(VkAccelerationStructureTypeKHR type) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetType(VkAccelerationStructureTypeKHR type) {
     vk_info_.type = type;
     vk_info_2_.type = type;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetFlags(VkAccelerationStructureCreateFlagsKHR flags) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetFlags(VkAccelerationStructureCreateFlagsKHR flags) {
     vk_info_.createFlags = flags;
     vk_info_2_.createFlags = flags;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetDeviceBuffer(vkt::Buffer &&buffer) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetDeviceBuffer(vkt::Buffer&& buffer) {
     device_buffer_ = std::move(buffer);
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetDeviceBufferMemoryAllocateFlags(
+AccelerationStructureKHR& AccelerationStructureKHR::SetDeviceBufferMemoryAllocateFlags(
     VkMemoryAllocateFlags memory_allocate_flags) {
     buffer_memory_allocate_flags_ = memory_allocate_flags;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetDeviceBufferMemoryPropertyFlags(
+AccelerationStructureKHR& AccelerationStructureKHR::SetDeviceBufferMemoryPropertyFlags(
     VkMemoryPropertyFlags memory_property_flags) {
     buffer_memory_property_flags_ = memory_property_flags;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetDeviceBufferInitNoMem(bool buffer_init_no_me) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetDeviceBufferInitNoMem(bool buffer_init_no_me) {
     buffer_init_no_mem_ = buffer_init_no_me;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetBufferUsageFlags(VkBufferUsageFlags usage_flags) {
+AccelerationStructureKHR& AccelerationStructureKHR::SetBufferUsageFlags(VkBufferUsageFlags usage_flags) {
     buffer_usage_flags_ = usage_flags;
     return *this;
 }
@@ -625,7 +625,7 @@ void AccelerationStructureKHR::Destroy() {
     device_buffer_.Destroy();
 }
 
-BuildGeometryInfoKHR::BuildGeometryInfoKHR(const vkt::Device *device)
+BuildGeometryInfoKHR::BuildGeometryInfoKHR(const vkt::Device* device)
     : device_(device),
       vk_info_(vku::InitStructHelper()),
       geometries_(),
@@ -633,62 +633,62 @@ BuildGeometryInfoKHR::BuildGeometryInfoKHR(const vkt::Device *device)
       dst_as_(std::make_shared<AccelerationStructureKHR>(device)),
       device_scratch_(std::make_shared<vkt::Buffer>()) {}
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetGeometries(std::vector<GeometryKHR> &&geometries) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetGeometries(std::vector<GeometryKHR>&& geometries) {
     geometries_ = std::move(geometries);
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetBuildRanges(
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetBuildRanges(
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos) {
     build_range_infos_ = std::move(build_range_infos);
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetType(VkAccelerationStructureTypeKHR type) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetType(VkAccelerationStructureTypeKHR type) {
     src_as_->SetType(type);
     dst_as_->SetType(type);
     vk_info_.type = type;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetBuildType(VkAccelerationStructureBuildTypeKHR build_type) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetBuildType(VkAccelerationStructureBuildTypeKHR build_type) {
     build_type_ = build_type;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetMode(VkBuildAccelerationStructureModeKHR mode) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetMode(VkBuildAccelerationStructureModeKHR mode) {
     vk_info_.mode = mode;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetFlags(VkBuildAccelerationStructureFlagsKHR flags) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetFlags(VkBuildAccelerationStructureFlagsKHR flags) {
     vk_info_.flags = flags;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::AddFlags(VkBuildAccelerationStructureFlagsKHR flags) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::AddFlags(VkBuildAccelerationStructureFlagsKHR flags) {
     vk_info_.flags |= flags;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetSrcAS(std::shared_ptr<AccelerationStructureKHR> src_as) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetSrcAS(std::shared_ptr<AccelerationStructureKHR> src_as) {
     assert(src_as);  // nullptr not supported
     src_as_ = std::move(src_as);
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetDstAS(std::shared_ptr<AccelerationStructureKHR> dst_as) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetDstAS(std::shared_ptr<AccelerationStructureKHR> dst_as) {
     assert(dst_as);  // nullptr not supported
     dst_as_ = std::move(dst_as);
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetScratchBuffer(std::shared_ptr<vkt::Buffer> scratch_buffer) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetScratchBuffer(std::shared_ptr<vkt::Buffer> scratch_buffer) {
     device_scratch_ = std::move(scratch_buffer);
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetHostScratchBuffer(std::shared_ptr<std::vector<uint8_t>> host_scratch) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetHostScratchBuffer(std::shared_ptr<std::vector<uint8_t>> host_scratch) {
     host_scratch_ = std::move(host_scratch);
     if (host_scratch_) {
         vk_info_.scratchData.hostAddress = host_scratch_->data();
@@ -696,58 +696,58 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetHostScratchBuffer(std::shared_ptr
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetDeviceScratchOffset(VkDeviceAddress offset) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetDeviceScratchOffset(VkDeviceAddress offset) {
     device_scratch_offset_ = offset;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetDeviceScratchAdditionalFlags(VkBufferUsageFlags additional_flags) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetDeviceScratchAdditionalFlags(VkBufferUsageFlags additional_flags) {
     device_scratch_additional_flags_ = additional_flags;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetEnableScratchBuild(bool build_scratch) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetEnableScratchBuild(bool build_scratch) {
     build_scratch_ = build_scratch;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetInfoCount(uint32_t info_count) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetInfoCount(uint32_t info_count) {
     assert(info_count <= 1);
     vk_info_count_ = info_count;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetNullInfos(bool use_null_infos) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetNullInfos(bool use_null_infos) {
     use_null_infos_ = use_null_infos;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetNullGeometries(bool use_null_geometries) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetNullGeometries(bool use_null_geometries) {
     use_null_geometries_ = use_null_geometries;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetNullBuildRangeInfos(bool use_null_build_range_infos) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetNullBuildRangeInfos(bool use_null_build_range_infos) {
     use_null_build_range_infos_ = use_null_build_range_infos;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetDeferredOp(VkDeferredOperationKHR deferred_op) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetDeferredOp(VkDeferredOperationKHR deferred_op) {
     deferred_op_ = deferred_op;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetUpdateDstAccelStructSizeBeforeBuild(bool update_before_build) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetUpdateDstAccelStructSizeBeforeBuild(bool update_before_build) {
     update_dst_as_size_before_build_ = update_before_build;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetIndirectStride(uint32_t indirect_stride) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetIndirectStride(uint32_t indirect_stride) {
     indirect_stride_ = indirect_stride;
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetIndirectDeviceAddress(std::optional<VkDeviceAddress> indirect_buffer_address) {
+BuildGeometryInfoKHR& BuildGeometryInfoKHR::SetIndirectDeviceAddress(std::optional<VkDeviceAddress> indirect_buffer_address) {
     indirect_buffer_address_ = indirect_buffer_address;
     return *this;
 }
@@ -840,7 +840,7 @@ void BuildGeometryInfoKHR::SetupBuild(bool is_on_device_build, bool use_ppGeomet
 
 void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, bool use_ppGeometries /*= true*/) {
     // fill vk_info_ with geometry data, and get build ranges
-    std::vector<const VkAccelerationStructureGeometryKHR *> pGeometries;
+    std::vector<const VkAccelerationStructureGeometryKHR*> pGeometries;
     std::vector<VkAccelerationStructureGeometryKHR> geometries;
     if (use_ppGeometries) {
         pGeometries.resize(geometries_.size());
@@ -849,9 +849,9 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresKHR(VkCommandBuffer c
     }
 
     assert(build_range_infos_.size() >= geometries_.size());
-    std::vector<const VkAccelerationStructureBuildRangeInfoKHR *> pRange_infos(geometries_.size());
+    std::vector<const VkAccelerationStructureBuildRangeInfoKHR*> pRange_infos(geometries_.size());
     for (size_t i = 0; i < geometries_.size(); ++i) {
-        const auto &geometry = geometries_[i];
+        const auto& geometry = geometries_[i];
         if (use_ppGeometries) {
             pGeometries[i] = &geometry.GetVkObj();
         } else {
@@ -870,8 +870,8 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresKHR(VkCommandBuffer c
     }
 
     // Build acceleration structure
-    const VkAccelerationStructureBuildGeometryInfoKHR *pInfos = use_null_infos_ ? nullptr : &vk_info_;
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos =
+    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos = use_null_infos_ ? nullptr : &vk_info_;
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos =
         use_null_build_range_infos_ ? nullptr : pRange_infos.data();
     vk::CmdBuildAccelerationStructuresKHR(cmd_buffer, vk_info_count_, pInfos, ppBuildRangeInfos);
 
@@ -895,10 +895,10 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresIndirectKHR(VkCommand
                            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps,
                            &alloc_flags);
 
-    auto *ranges_info = static_cast<VkAccelerationStructureBuildRangeInfoKHR *>(indirect_buffer_->Memory().Map());
+    auto* ranges_info = static_cast<VkAccelerationStructureBuildRangeInfoKHR*>(indirect_buffer_->Memory().Map());
 
     // fill vk_info_ with geometry data, and get build ranges
-    std::vector<const VkAccelerationStructureGeometryKHR *> pGeometries(geometries_.size());
+    std::vector<const VkAccelerationStructureGeometryKHR*> pGeometries(geometries_.size());
 
     pGeometries.reserve(geometries_.size());
     for (const auto [i, geometry] : vvl::enumerate(geometries_)) {
@@ -914,7 +914,7 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresIndirectKHR(VkCommand
     indirect_buffer_->Memory().Unmap();
 
     std::vector<uint32_t> p_max_primitive_counts(vk_info_.geometryCount, 1);
-    const uint32_t *pp_max_primitive_counts = p_max_primitive_counts.data();
+    const uint32_t* pp_max_primitive_counts = p_max_primitive_counts.data();
 
     const VkDeviceAddress indirect_address = indirect_buffer_address_ ? *indirect_buffer_address_ : indirect_buffer_->Address();
 
@@ -929,12 +929,12 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresIndirectKHR(VkCommand
 
 void BuildGeometryInfoKHR::VkBuildAccelerationStructuresKHR() {
     // fill vk_info_ with geometry data, and get build ranges
-    std::vector<const VkAccelerationStructureGeometryKHR *> pGeometries(geometries_.size());
+    std::vector<const VkAccelerationStructureGeometryKHR*> pGeometries(geometries_.size());
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> range_infos(geometries_.size());
-    std::vector<const VkAccelerationStructureBuildRangeInfoKHR *> pRange_infos(geometries_.size());
+    std::vector<const VkAccelerationStructureBuildRangeInfoKHR*> pRange_infos(geometries_.size());
     pGeometries.reserve(geometries_.size());
     for (size_t i = 0; i < geometries_.size(); ++i) {
-        const auto &geometry = geometries_[i];
+        const auto& geometry = geometries_[i];
         pGeometries[i] = &geometry.GetVkObj();
         range_infos[i] = geometry.GetFullBuildRange();
         pRange_infos[i] = &range_infos[i];
@@ -947,8 +947,8 @@ void BuildGeometryInfoKHR::VkBuildAccelerationStructuresKHR() {
         vk_info_.ppGeometries = pGeometries.data();
     }
     // Build acceleration structure
-    const VkAccelerationStructureBuildGeometryInfoKHR *pInfos = use_null_infos_ ? nullptr : &vk_info_;
-    const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos =
+    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos = use_null_infos_ ? nullptr : &vk_info_;
+    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos =
         use_null_build_range_infos_ ? nullptr : pRange_infos.data();
     vk::BuildAccelerationStructuresKHR(device_->handle(), deferred_op_, vk_info_count_, pInfos, ppBuildRangeInfos);
 
@@ -960,7 +960,7 @@ void BuildGeometryInfoKHR::VkBuildAccelerationStructuresKHR() {
 VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(bool use_ppGeometries /*= true*/) {
     // Computer total primitives count, and get pointers to geometries
     std::vector<uint32_t> primitives_count(geometries_.size());
-    std::vector<const VkAccelerationStructureGeometryKHR *> pGeometries;
+    std::vector<const VkAccelerationStructureGeometryKHR*> pGeometries;
     std::vector<VkAccelerationStructureGeometryKHR> geometries;
 
     if (use_ppGeometries) {
@@ -969,7 +969,7 @@ VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(bool 
         geometries.reserve(geometries_.size());
     }
 
-    for (const auto &[geometry_i, geometry] : vvl::enumerate(geometries_)) {
+    for (const auto& [geometry_i, geometry] : vvl::enumerate(geometries_)) {
         primitives_count[geometry_i] = geometry.GetFullBuildRange().primitiveCount;
         if (use_ppGeometries) {
             pGeometries.emplace_back(&geometry.GetVkObj());
@@ -1008,18 +1008,18 @@ std::vector<VkAccelerationStructureBuildRangeInfoKHR> BuildGeometryInfoKHR::GetB
     return range_infos;
 }
 
-void BuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, std::vector<BuildGeometryInfoKHR> &infos) {
+void BuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, std::vector<BuildGeometryInfoKHR>& infos) {
     size_t total_geomertry_count = 0;
 
-    for (auto &build_info : infos) {
+    for (auto& build_info : infos) {
         total_geomertry_count += build_info.geometries_.size();
     }
 
     // Those vectors will be used to contiguously store the "raw vulkan data" for each element of `infos`
     // To do that, total memory needed needs to be know upfront
-    std::vector<const VkAccelerationStructureGeometryKHR *> pGeometries(total_geomertry_count);
+    std::vector<const VkAccelerationStructureGeometryKHR*> pGeometries(total_geomertry_count);
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> range_infos(total_geomertry_count);
-    std::vector<const VkAccelerationStructureBuildRangeInfoKHR *> pRange_infos(total_geomertry_count);
+    std::vector<const VkAccelerationStructureBuildRangeInfoKHR*> pRange_infos(total_geomertry_count);
 
     std::vector<VkAccelerationStructureBuildGeometryInfoKHR> vk_infos;
     vk_infos.reserve(infos.size());
@@ -1028,12 +1028,12 @@ void BuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, std::vector<Buil
     size_t range_infos_offset = 0;
     size_t pRange_infos_offset = 0;
 
-    for (BuildGeometryInfoKHR &build_info : infos) {
+    for (BuildGeometryInfoKHR& build_info : infos) {
         build_info.SetupBuild(true);
 
         // Fill current vk_info_ with geometry data in ppGeometries, and get build ranges
         for (size_t i = 0; i < build_info.geometries_.size(); ++i) {
-            const auto &geometry = build_info.geometries_[i];
+            const auto& geometry = build_info.geometries_[i];
             pGeometries[pGeometries_offset + i] = &geometry.GetVkObj();
             range_infos[range_infos_offset + i] = geometry.GetFullBuildRange();
             pRange_infos[pRange_infos_offset + i] = &range_infos[range_infos_offset + i];
@@ -1053,25 +1053,25 @@ void BuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, std::vector<Buil
     vk::CmdBuildAccelerationStructuresKHR(cmd_buffer, static_cast<uint32_t>(vk_infos.size()), vk_infos.data(), pRange_infos.data());
 
     // Clean
-    for (BuildGeometryInfoKHR &build_info : infos) {
+    for (BuildGeometryInfoKHR& build_info : infos) {
         // pGeometries is going to be destroyed
         build_info.vk_info_.geometryCount = 0;
         build_info.vk_info_.ppGeometries = nullptr;
     }
 }
 
-void BuildHostAccelerationStructuresKHR(VkDevice device, std::vector<BuildGeometryInfoKHR> &infos) {
+void BuildHostAccelerationStructuresKHR(VkDevice device, std::vector<BuildGeometryInfoKHR>& infos) {
     size_t total_geomertry_count = 0;
 
-    for (auto &build_info : infos) {
+    for (auto& build_info : infos) {
         total_geomertry_count += build_info.geometries_.size();
     }
 
     // Those vectors will be used to contiguously store the "raw vulkan data" for each element of `infos`
     // To do that, total memory needed needs to be know upfront
-    std::vector<const VkAccelerationStructureGeometryKHR *> pGeometries(total_geomertry_count);
+    std::vector<const VkAccelerationStructureGeometryKHR*> pGeometries(total_geomertry_count);
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> range_infos(total_geomertry_count);
-    std::vector<const VkAccelerationStructureBuildRangeInfoKHR *> pRange_infos(total_geomertry_count);
+    std::vector<const VkAccelerationStructureBuildRangeInfoKHR*> pRange_infos(total_geomertry_count);
 
     std::vector<VkAccelerationStructureBuildGeometryInfoKHR> vk_infos;
     vk_infos.reserve(infos.size());
@@ -1080,12 +1080,12 @@ void BuildHostAccelerationStructuresKHR(VkDevice device, std::vector<BuildGeomet
     size_t range_infos_offset = 0;
     size_t pRange_infos_offset = 0;
 
-    for (auto &build_info : infos) {
+    for (auto& build_info : infos) {
         build_info.SetupBuild(false);
 
         // Fill current vk_info_ with geometry data in ppGeometries, and get build ranges
         for (size_t i = 0; i < build_info.geometries_.size(); ++i) {
-            const auto &geometry = build_info.geometries_[i];
+            const auto& geometry = build_info.geometries_[i];
             pGeometries[pGeometries_offset + i] = &geometry.GetVkObj();
             range_infos[range_infos_offset + i] = geometry.GetFullBuildRange();
             pRange_infos[pRange_infos_offset + i] = &range_infos[range_infos_offset + i];
@@ -1106,7 +1106,7 @@ void BuildHostAccelerationStructuresKHR(VkDevice device, std::vector<BuildGeomet
                                        pRange_infos.data());
 
     // Clean
-    for (auto &build_info : infos) {
+    for (auto& build_info : infos) {
         // pGeometries is going to be destroyed
         build_info.vk_info_.geometryCount = 0;
         build_info.vk_info_.ppGeometries = nullptr;
@@ -1114,7 +1114,7 @@ void BuildHostAccelerationStructuresKHR(VkDevice device, std::vector<BuildGeomet
 }
 
 namespace blueprint {
-GeometryKHR GeometrySimpleOnDeviceIndexedTriangleInfo(const vkt::Device &device, size_t triangles_count,
+GeometryKHR GeometrySimpleOnDeviceIndexedTriangleInfo(const vkt::Device& device, size_t triangles_count,
                                                       VkBufferUsageFlags additional_geometry_buffer_flags) {
     assert(triangles_count > 0);
     GeometryKHR triangle_geometry;
@@ -1148,11 +1148,11 @@ GeometryKHR GeometrySimpleOnDeviceIndexedTriangleInfo(const vkt::Device &device,
         indices[3 * triangle_i + 2] = 2;
     }
 
-    auto vertex_buffer_ptr = static_cast<float *>(vertex_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<float*>(vertex_buffer.Memory().Map());
     std::copy(vertices.begin(), vertices.end(), vertex_buffer_ptr);
     vertex_buffer.Memory().Unmap();
 
-    auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.Memory().Map());
+    auto index_buffer_ptr = static_cast<uint32_t*>(index_buffer.Memory().Map());
     std::copy(indices.begin(), indices.end(), index_buffer_ptr);
     index_buffer.Memory().Unmap();
 
@@ -1164,7 +1164,7 @@ GeometryKHR GeometrySimpleOnDeviceIndexedTriangleInfo(const vkt::Device &device,
     }};
     // clang-format on
 
-    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.Memory().Map());
+    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR*>(transform_buffer.Memory().Map());
     std::memcpy(transform_buffer_ptr, &transform_matrix, sizeof(transform_matrix));
     transform_buffer.Memory().Unmap();
 
@@ -1178,7 +1178,7 @@ GeometryKHR GeometrySimpleOnDeviceIndexedTriangleInfo(const vkt::Device &device,
     return triangle_geometry;
 }
 
-GeometryKHR GeometrySimpleOnDeviceSpheresInfo(const vkt::Device &device) {
+GeometryKHR GeometrySimpleOnDeviceSpheresInfo(const vkt::Device& device) {
     GeometryKHR sphere_geometry;
     sphere_geometry.SetType(GeometryKHR::Type::Spheres);
 
@@ -1209,13 +1209,13 @@ GeometryKHR GeometrySimpleOnDeviceSpheresInfo(const vkt::Device &device) {
         0.5f, 0.6f, 0.7f, 0.8f, 0.6f, 0.5f, 0.9f, 0.4f, 0.7f, 0.6f, 0.9f, 0.5f, 0.9f, 0.6f, 0.8f, 0.5f,
     };
 
-    auto mapped_vbo_buffer_data = static_cast<float *>(vertex_buffer.Memory().Map());
+    auto mapped_vbo_buffer_data = static_cast<float*>(vertex_buffer.Memory().Map());
     std::copy(vertices.begin(), vertices.end(), mapped_vbo_buffer_data);
     vertex_buffer.Memory().Unmap();
-    auto mapped_ibo_buffer_data = static_cast<uint32_t *>(index_buffer.Memory().Map());
+    auto mapped_ibo_buffer_data = static_cast<uint32_t*>(index_buffer.Memory().Map());
     std::copy(indices.begin(), indices.end(), mapped_ibo_buffer_data);
     index_buffer.Memory().Unmap();
-    auto mapped_rbo_buffer_data = static_cast<float *>(radius_buffer.Memory().Map());
+    auto mapped_rbo_buffer_data = static_cast<float*>(radius_buffer.Memory().Map());
     std::copy(radius.begin(), radius.end(), mapped_rbo_buffer_data);
     radius_buffer.Memory().Unmap();
 
@@ -1256,7 +1256,7 @@ GeometryKHR GeometrySimpleOnHostSpheresInfo() {
     return sphere_geometry;
 }
 
-GeometryKHR GeometrySimpleOnDeviceLSSpheresInfo(const vkt::Device &device) {
+GeometryKHR GeometrySimpleOnDeviceLSSpheresInfo(const vkt::Device& device) {
     GeometryKHR sphere_geometry;
     sphere_geometry.SetType(GeometryKHR::Type::LSSpheres);
 
@@ -1289,13 +1289,13 @@ GeometryKHR GeometrySimpleOnDeviceLSSpheresInfo(const vkt::Device &device) {
         0.5f, 0.6f, 0.7f, 0.8f, 0.6f, 0.5f, 0.9f, 0.4f, 0.7f, 0.6f, 0.9f, 0.5f, 0.9f, 0.6f, 0.8f, 0.5f,
     };
 
-    auto mapped_vbo_buffer_data = static_cast<float *>(vertex_buffer.Memory().Map());
+    auto mapped_vbo_buffer_data = static_cast<float*>(vertex_buffer.Memory().Map());
     std::copy(vertices.begin(), vertices.end(), mapped_vbo_buffer_data);
     vertex_buffer.Memory().Unmap();
-    auto mapped_ibo_buffer_data = static_cast<uint32_t *>(index_buffer.Memory().Map());
+    auto mapped_ibo_buffer_data = static_cast<uint32_t*>(index_buffer.Memory().Map());
     std::copy(indices.begin(), indices.end(), mapped_ibo_buffer_data);
     index_buffer.Memory().Unmap();
-    auto mapped_rbo_buffer_data = static_cast<float *>(radius_buffer.Memory().Map());
+    auto mapped_rbo_buffer_data = static_cast<float*>(radius_buffer.Memory().Map());
     std::copy(radius.begin(), radius.end(), mapped_rbo_buffer_data);
     radius_buffer.Memory().Unmap();
 
@@ -1338,7 +1338,7 @@ GeometryKHR GeometrySimpleOnHostLSSpheresInfo() {
     return sphere_geometry;
 }
 
-GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device, VkBufferUsageFlags additional_geometry_buffer_flags) {
+GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device& device, VkBufferUsageFlags additional_geometry_buffer_flags) {
     GeometryKHR triangle_geometry;
 
     triangle_geometry.SetType(GeometryKHR::Type::Triangle);
@@ -1362,7 +1362,7 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device, VkBuff
                                      // Vertex 2
                                      0.0f, -10.0f, 0.0f};
 
-    auto vertex_buffer_ptr = static_cast<float *>(vertex_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<float*>(vertex_buffer.Memory().Map());
     std::copy(vertices.begin(), vertices.end(), vertex_buffer_ptr);
     vertex_buffer.Memory().Unmap();
 
@@ -1374,7 +1374,7 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device, VkBuff
     }};
     // clang-format on
 
-    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.Memory().Map());
+    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR*>(transform_buffer.Memory().Map());
     std::memcpy(transform_buffer_ptr, &transform_matrix, sizeof(transform_matrix));
     transform_buffer.Memory().Unmap();
 
@@ -1409,7 +1409,7 @@ GeometryKHR GeometrySimpleOnHostIndexedTriangleInfo() {
     return triangle_geometry;
 }
 
-GeometryKHR GeometryCubeOnDeviceInfo(const vkt::Device &device) {
+GeometryKHR GeometryCubeOnDeviceInfo(const vkt::Device& device) {
     GeometryKHR cube_geometry;
 
     cube_geometry.SetType(GeometryKHR::Type::Triangle);
@@ -1489,15 +1489,15 @@ GeometryKHR GeometryCubeOnDeviceInfo(const vkt::Device &device) {
     vkt::Buffer index_buffer(device, sizeof(indices[0]) * indices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
     vkt::Buffer transform_buffer(device, sizeof(VkTransformMatrixKHR), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-    auto vertex_buffer_ptr = static_cast<Vertex *>(vertex_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<Vertex*>(vertex_buffer.Memory().Map());
     std::copy(vertices.begin(), vertices.end(), vertex_buffer_ptr);
     vertex_buffer.Memory().Unmap();
 
-    auto index_buffer_ptr = static_cast<TriangleIndices *>(index_buffer.Memory().Map());
+    auto index_buffer_ptr = static_cast<TriangleIndices*>(index_buffer.Memory().Map());
     std::copy(indices.begin(), indices.end(), index_buffer_ptr);
     index_buffer.Memory().Unmap();
 
-    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.Memory().Map());
+    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR*>(transform_buffer.Memory().Map());
     std::memcpy(transform_buffer_ptr, &transform_matrix, sizeof(transform_matrix));
     transform_buffer.Memory().Unmap();
 
@@ -1511,7 +1511,7 @@ GeometryKHR GeometryCubeOnDeviceInfo(const vkt::Device &device) {
     return cube_geometry;
 }
 
-GeometryKHR GeometrySimpleOnDeviceAABBInfo(const vkt::Device &device, VkBufferUsageFlags additional_geometry_buffer_flags) {
+GeometryKHR GeometrySimpleOnDeviceAABBInfo(const vkt::Device& device, VkBufferUsageFlags additional_geometry_buffer_flags) {
     GeometryKHR aabb_geometry;
 
     aabb_geometry.SetType(GeometryKHR::Type::AABB);
@@ -1531,7 +1531,7 @@ GeometryKHR GeometrySimpleOnDeviceAABBInfo(const vkt::Device &device, VkBufferUs
 
     // Fill buffer with one AABB
     aabb_geometry.SetPrimitiveCount(static_cast<uint32_t>(aabbs.size()));
-    auto mapped_aabb_buffer_data = static_cast<VkAabbPositionsKHR *>(aabb_buffer.Memory().Map());
+    auto mapped_aabb_buffer_data = static_cast<VkAabbPositionsKHR*>(aabb_buffer.Memory().Map());
     std::copy(aabbs.begin(), aabbs.end(), mapped_aabb_buffer_data);
     aabb_buffer.Memory().Unmap();
 
@@ -1558,7 +1558,7 @@ GeometryKHR GeometrySimpleOnHostAABBInfo() {
     return aabb_geometry;
 }
 
-GeometryKHR GeometrySimpleDeviceInstance(const vkt::Device &device, VkAccelerationStructureKHR device_blas) {
+GeometryKHR GeometrySimpleDeviceInstance(const vkt::Device& device, VkAccelerationStructureKHR device_blas) {
     GeometryKHR instance_geometry;
 
     instance_geometry.SetType(GeometryKHR::Type::Instance);
@@ -1581,13 +1581,13 @@ GeometryKHR GeometrySimpleHostInstance(VkAccelerationStructureKHR host_instance)
     return instance_geometry;
 }
 
-std::shared_ptr<AccelerationStructureKHR> AccelStructNull(const vkt::Device &device) {
+std::shared_ptr<AccelerationStructureKHR> AccelStructNull(const vkt::Device& device) {
     auto as = std::make_shared<AccelerationStructureKHR>(&device);
     as->SetNull(true);
     return as;
 }
 
-std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceBottomLevel(const vkt::Device &device, VkDeviceSize size) {
+std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceBottomLevel(const vkt::Device& device, VkDeviceSize size) {
     auto as = std::make_shared<AccelerationStructureKHR>(&device);
     as->SetSize(size);
     as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR);
@@ -1599,7 +1599,7 @@ std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceBottomLevel(c
     return as;
 }
 
-std::shared_ptr<vkt::as::AccelerationStructureKHR> AccelStructSimpleOnHostBottomLevel(const vkt::Device &device,
+std::shared_ptr<vkt::as::AccelerationStructureKHR> AccelStructSimpleOnHostBottomLevel(const vkt::Device& device,
                                                                                       VkDeviceSize size) {
     auto as = std::make_shared<AccelerationStructureKHR>(&device);
     as->SetSize(size);
@@ -1611,7 +1611,7 @@ std::shared_ptr<vkt::as::AccelerationStructureKHR> AccelStructSimpleOnHostBottom
     return as;
 }
 
-std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceTopLevel(const vkt::Device &device, VkDeviceSize size) {
+std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceTopLevel(const vkt::Device& device, VkDeviceSize size) {
     auto as = std::make_shared<AccelerationStructureKHR>(&device);
     as->SetSize(size);
     as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
@@ -1623,7 +1623,7 @@ std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceTopLevel(cons
     return as;
 }
 
-BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(const vkt::Device &device,
+BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(const vkt::Device& device,
                                                                 GeometryKHR::Type geometry_type /*= GeometryKHR::Type::Triangle*/) {
     // Set geometry
     GeometryKHR geometry;
@@ -1650,7 +1650,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(const vkt::Devic
     return BuildGeometryInfoOnDeviceBottomLevel(device, std::move(geometry));
 }
 
-BuildGeometryInfoKHR BuildGeometryInfoOnDeviceBottomLevel(const vkt::Device &device, GeometryKHR &&geometry) {
+BuildGeometryInfoKHR BuildGeometryInfoOnDeviceBottomLevel(const vkt::Device& device, GeometryKHR&& geometry) {
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR);
@@ -1676,7 +1676,7 @@ BuildGeometryInfoKHR BuildGeometryInfoOnDeviceBottomLevel(const vkt::Device &dev
     return out_build_info;
 }
 
-BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostBottomLevel(const vkt::Device &device,
+BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostBottomLevel(const vkt::Device& device,
                                                               GeometryKHR::Type geometry_type /*= GeometryKHR::Type::Triangle*/) {
     BuildGeometryInfoKHR out_build_info(&device);
 
@@ -1721,8 +1721,8 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostBottomLevel(const vkt::Device 
     return out_build_info;
 }
 
-vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(const vkt::Device &device,
-                                                                      const vkt::as::AccelerationStructureKHR &on_device_blas) {
+vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(const vkt::Device& device,
+                                                                      const vkt::as::AccelerationStructureKHR& on_device_blas) {
     assert(on_device_blas.IsBuilt());
 
     BuildGeometryInfoKHR out_build_info(&device);
@@ -1752,7 +1752,7 @@ vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(const vkt:
     return out_build_info;
 }
 
-vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device &device,
+vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device& device,
                                                                     std::shared_ptr<BuildGeometryInfoKHR> on_host_blas) {
     assert(on_host_blas->GetDstAS()->IsBuilt());
 
@@ -1783,7 +1783,7 @@ vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::D
     return out_build_info;
 }
 
-BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::Queue &queue, vkt::CommandBuffer &cmd_buffer) {
+BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device& device, vkt::Queue& queue, vkt::CommandBuffer& cmd_buffer) {
     // Create acceleration structure
     cmd_buffer.Begin();
     // Build Bottom Level Acceleration Structure
@@ -1807,8 +1807,8 @@ BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::Queue
     return top_level_accel_struct;
 }
 
-vkt::as::BuildGeometryInfoKHR GetCubesTLAS(vkt::Device &device, vkt::CommandBuffer &cb, vkt::Queue &queue,
-                                           std::shared_ptr<vkt::as::BuildGeometryInfoKHR> &out_cube_blas) {
+vkt::as::BuildGeometryInfoKHR GetCubesTLAS(vkt::Device& device, vkt::CommandBuffer& cb, vkt::Queue& queue,
+                                           std::shared_ptr<vkt::as::BuildGeometryInfoKHR>& out_cube_blas) {
     vkt::as::GeometryKHR cube(vkt::as::blueprint::GeometryCubeOnDeviceInfo(device));
     out_cube_blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
         vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(device, std::move(cube)));
@@ -1863,7 +1863,7 @@ vkt::as::BuildGeometryInfoKHR GetCubesTLAS(vkt::Device &device, vkt::CommandBuff
     return tlas;
 }
 
-vkt::as::BuildGeometryInfoKHR CreateTLAS(vkt::Device &device, std::vector<vkt::as::GeometryKHR> &&blas_vec) {
+vkt::as::BuildGeometryInfoKHR CreateTLAS(vkt::Device& device, std::vector<vkt::as::GeometryKHR>&& blas_vec) {
     vkt::as::BuildGeometryInfoKHR tlas(&device);
 
     tlas.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
@@ -1893,7 +1893,7 @@ vkt::as::BuildGeometryInfoKHR CreateTLAS(vkt::Device &device, std::vector<vkt::a
 
 namespace rt {
 
-Pipeline::Pipeline(VkLayerTest &test, vkt::Device *device)
+Pipeline::Pipeline(VkLayerTest& test, vkt::Device* device)
     : test_(test), device_(device), pipeline_layout_ci_(vku::InitStructHelper()) {}
 
 Pipeline::~Pipeline() {
@@ -1951,7 +1951,7 @@ void Pipeline::CreateDescriptorIndexingSet() {
     desc_indexing_set_ = std::make_unique<OneOffDescriptorIndexingSet>(device_, desc_indexing_bindings_);
 }
 
-void Pipeline::SetPipelineSetLayouts(uint32_t set_layout_count, const VkDescriptorSetLayout *set_layouts) {
+void Pipeline::SetPipelineSetLayouts(uint32_t set_layout_count, const VkDescriptorSetLayout* set_layouts) {
     pipeline_layout_ci_.setLayoutCount = set_layout_count;
     pipeline_layout_ci_.pSetLayouts = set_layouts;
 }
@@ -1965,46 +1965,46 @@ void Pipeline::SetGlslRayGenShader(const char* glsl, const void* shader_module_c
                                                                 pipeline_shader_stage_create_info_pNext));
 }
 
-void Pipeline::AddSpirvRayGenShader(const char *spirv, const char *entry_point) {
+void Pipeline::AddSpirvRayGenShader(const char* spirv, const char* entry_point) {
     ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, spirv, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2,
                                                                 SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
-void Pipeline::AddSlangRayGenShader(const char *slang, const char *entry_point) {
+void Pipeline::AddSlangRayGenShader(const char* slang, const char* entry_point) {
     ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2,
                                                                 SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
-void Pipeline::AddGlslMissShader(const char *glsl) {
+void Pipeline::AddGlslMissShader(const char* glsl) {
     miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, glsl, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2));
 }
 
-void Pipeline::AddSpirvMissShader(const char *spirv, const char *entry_point) {
+void Pipeline::AddSpirvMissShader(const char* spirv, const char* entry_point) {
     miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, spirv, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
                                                              SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
-void Pipeline::AddSlangMissShader(const char *slang, const char *entry_point) {
+void Pipeline::AddSlangMissShader(const char* slang, const char* entry_point) {
     miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
                                                              SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
-void Pipeline::AddGlslClosestHitShader(const char *glsl) {
+void Pipeline::AddGlslClosestHitShader(const char* glsl) {
     closest_hit_shaders_.emplace_back(
         std::make_unique<VkShaderObj>(*device_, glsl, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, SPV_ENV_VULKAN_1_2));
 }
 
-void Pipeline::AddSpirvClosestHitShader(const char *spirv, const char *entry_point) {
+void Pipeline::AddSpirvClosestHitShader(const char* spirv, const char* entry_point) {
     closest_hit_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, spirv, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR,
                                                                     SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
-void Pipeline::AddSlangClosestHitShader(const char *slang, const char *entry_point) {
+void Pipeline::AddSlangClosestHitShader(const char* slang, const char* entry_point) {
     closest_hit_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, slang, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR,
                                                                     SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
-void Pipeline::AddLibrary(const Pipeline &library) {
+void Pipeline::AddLibrary(const Pipeline& library) {
     libraries_.emplace_back(&library);
     library_handles_.emplace_back(library.rt_pipeline_);
     pipeline_lib_info_ = vku::InitStructHelper();
@@ -2034,7 +2034,7 @@ void Pipeline::BuildPipeline() {
             pipeline_layout_ci_.pPushConstantRanges = &push_constant_range;
         }
         assert(!(desc_set_ && desc_indexing_set_));
-        VkDescriptorSetLayout *desc_set = desc_set_            ? &desc_set_->layout_.handle()
+        VkDescriptorSetLayout* desc_set = desc_set_            ? &desc_set_->layout_.handle()
                                           : desc_indexing_set_ ? &desc_indexing_set_->layout_.handle()
                                                                : nullptr;
 
@@ -2054,7 +2054,7 @@ void Pipeline::BuildPipeline() {
     // ----
     std::vector<VkPipelineShaderStageCreateInfo> pipeline_stage_cis;
     assert(shader_group_cis_.empty());  // For now this list is expected to be empty at this point
-    for (const auto &ray_gen_shader : ray_gen_shaders_) {
+    for (const auto& ray_gen_shader : ray_gen_shaders_) {
         VkPipelineShaderStageCreateInfo raygen_stage_ci = vku::InitStructHelper();
         raygen_stage_ci.stage = VK_SHADER_STAGE_RAYGEN_BIT_KHR;
         raygen_stage_ci.module = ray_gen_shader->handle();
@@ -2070,7 +2070,7 @@ void Pipeline::BuildPipeline() {
         raygen_group_ci.intersectionShader = VK_SHADER_UNUSED_KHR;
         shader_group_cis_.emplace_back(raygen_group_ci);
     }
-    for (const auto &miss_shader : miss_shaders_) {
+    for (const auto& miss_shader : miss_shaders_) {
         VkPipelineShaderStageCreateInfo miss_stage_ci = vku::InitStructHelper();
         miss_stage_ci.stage = VK_SHADER_STAGE_MISS_BIT_KHR;
         miss_stage_ci.module = miss_shader->handle();
@@ -2086,7 +2086,7 @@ void Pipeline::BuildPipeline() {
         miss_group_ci.intersectionShader = VK_SHADER_UNUSED_KHR;
         shader_group_cis_.emplace_back(miss_group_ci);
     }
-    for (const auto &closest_hit : closest_hit_shaders_) {
+    for (const auto& closest_hit : closest_hit_shaders_) {
         VkPipelineShaderStageCreateInfo closest_hit_stage_ci = vku::InitStructHelper();
         closest_hit_stage_ci.stage = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
         closest_hit_stage_ci.module = closest_hit->handle();
@@ -2159,7 +2159,7 @@ void Pipeline::BuildSbt() {
         closest_hit_handle_indices.emplace_back(shader_i++);
     }
 
-    for (const Pipeline *lib : libraries_) {
+    for (const Pipeline* lib : libraries_) {
         for (uint32_t ray_gen_i = 0; ray_gen_i < size32(lib->ray_gen_shaders_); ++ray_gen_i) {
             ray_gen_handle_indices.emplace_back(shader_i++);
         }
@@ -2201,12 +2201,12 @@ void Pipeline::BuildSbt() {
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     sbt_buffer_.Init(*device_, sbt_buffer_info, kHostVisibleMemProps, &alloc_flags);
 
-    void *const sbt_buffer_base_ptr = sbt_buffer_.Memory().Map();
-    void *sbt_buffer_ptr = sbt_buffer_base_ptr;
+    void* const sbt_buffer_base_ptr = sbt_buffer_.Memory().Map();
+    void* sbt_buffer_ptr = sbt_buffer_base_ptr;
     (void)sbt_buffer_base_ptr;
     size_t sbt_buffer_space_left = static_cast<size_t>(sbt_buffer_info.size);
     std::vector<uint8_t> sbt_host_storage = GetRayTracingShaderGroupHandles();
-    uint8_t *const sbt_host_storage_ptr = sbt_host_storage.data();
+    uint8_t* const sbt_host_storage_ptr = sbt_host_storage.data();
 
 #ifdef VVL_DEBUG_LOG_SBT
     std::cout << __FUNCTION__ << "\n===\n\n";
@@ -2230,7 +2230,7 @@ void Pipeline::BuildSbt() {
     // Fill Ray Generation shaders headers
     // ---
     {
-        void *ray_gen_sbt = nullptr;
+        void* ray_gen_sbt = nullptr;
         for (size_t ray_gen_i = 0; ray_gen_i < ray_gen_handle_indices.size(); ++ray_gen_i) {
             if (!std::align(rt_pipeline_props.shaderGroupBaseAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
                             sbt_buffer_space_left)) {
@@ -2240,10 +2240,10 @@ void Pipeline::BuildSbt() {
             if (!ray_gen_sbt) {
                 ray_gen_sbt = sbt_buffer_ptr;
             }
-            uint8_t *ray_gen_handle =
+            uint8_t* ray_gen_handle =
                 sbt_host_storage_ptr + rt_pipeline_props.shaderGroupHandleSize * ray_gen_handle_indices[ray_gen_i];
             std::memcpy(sbt_buffer_ptr, ray_gen_handle, rt_pipeline_props.shaderGroupHandleSize);
-            sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
+            sbt_buffer_ptr = (uint8_t*)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
             sbt_buffer_space_left -= rt_pipeline_props.shaderGroupHandleSize;
         }
         (void)ray_gen_sbt;
@@ -2268,7 +2268,7 @@ void Pipeline::BuildSbt() {
                     ++line_i;
                 }
 
-                uint32_t byte = ((uint8_t *)ray_gen_sbt)[byte_i];
+                uint32_t byte = ((uint8_t*)ray_gen_sbt)[byte_i];
                 std::cout << std::hex;
                 if (byte == 0)
                     std::cout << "-- ";
@@ -2294,7 +2294,7 @@ void Pipeline::BuildSbt() {
             return;
         }
 
-        void *miss_sbt = nullptr;
+        void* miss_sbt = nullptr;
         for (size_t miss_i = 0; miss_i < miss_handle_indices.size(); ++miss_i) {
             if (!std::align(rt_pipeline_props.shaderGroupHandleAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
                             sbt_buffer_space_left)) {
@@ -2305,9 +2305,9 @@ void Pipeline::BuildSbt() {
                 miss_sbt = sbt_buffer_ptr;
             }
 
-            uint8_t *miss_handle = sbt_host_storage_ptr + rt_pipeline_props.shaderGroupHandleSize * miss_handle_indices[miss_i];
+            uint8_t* miss_handle = sbt_host_storage_ptr + rt_pipeline_props.shaderGroupHandleSize * miss_handle_indices[miss_i];
             std::memcpy(sbt_buffer_ptr, miss_handle, rt_pipeline_props.shaderGroupHandleSize);
-            sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
+            sbt_buffer_ptr = (uint8_t*)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
             sbt_buffer_space_left -= rt_pipeline_props.shaderGroupHandleSize;
         }
         (void)miss_sbt;
@@ -2330,7 +2330,7 @@ void Pipeline::BuildSbt() {
                     ++line_i;
                 }
 
-                uint32_t byte = ((uint8_t *)miss_sbt)[byte_i];
+                uint32_t byte = ((uint8_t*)miss_sbt)[byte_i];
                 std::cout << std::hex;
                 if (byte == 0)
                     std::cout << "-- ";
@@ -2356,7 +2356,7 @@ void Pipeline::BuildSbt() {
             return;
         }
 
-        void *closest_hit_sbt = nullptr;
+        void* closest_hit_sbt = nullptr;
         for (size_t closest_hit_i = 0; closest_hit_i < closest_hit_handle_indices.size(); ++closest_hit_i) {
             if (!std::align(rt_pipeline_props.shaderGroupHandleAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
                             sbt_buffer_space_left)) {
@@ -2367,10 +2367,10 @@ void Pipeline::BuildSbt() {
                 closest_hit_sbt = sbt_buffer_ptr;
             }
 
-            uint8_t *closest_hit_handle =
+            uint8_t* closest_hit_handle =
                 sbt_host_storage_ptr + rt_pipeline_props.shaderGroupHandleSize * closest_hit_handle_indices[closest_hit_i];
             std::memcpy(sbt_buffer_ptr, closest_hit_handle, rt_pipeline_props.shaderGroupHandleSize);
-            sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
+            sbt_buffer_ptr = (uint8_t*)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
             sbt_buffer_space_left -= rt_pipeline_props.shaderGroupHandleSize;
         }
         (void)closest_hit_sbt;
@@ -2393,7 +2393,7 @@ void Pipeline::BuildSbt() {
                     ++line_i;
                 }
 
-                uint32_t byte = ((uint8_t *)closest_hit_sbt)[byte_i];
+                uint32_t byte = ((uint8_t*)closest_hit_sbt)[byte_i];
                 std::cout << std::hex;
                 if (byte == 0)
                     std::cout << "-- ";
@@ -2421,7 +2421,7 @@ void Pipeline::DeferBuild() {
     }
 }
 
-VkShaderObj &Pipeline::GetRayGenShader(uint32_t ray_gen_i) { return *ray_gen_shaders_[ray_gen_i]; }
+VkShaderObj& Pipeline::GetRayGenShader(uint32_t ray_gen_i) { return *ray_gen_shaders_[ray_gen_i]; }
 
 vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt(uint32_t ray_gen_shader_i /*= 0*/) {
     // As of now, no function support if not using any ray generation shader
@@ -2495,7 +2495,7 @@ vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt(uint32_t ray_gen_shader_i /*= 0*
     return out;
 }
 
-const vkt::Buffer &Pipeline::GetTraceRaysSbtBuffer() { return sbt_buffer_; }
+const vkt::Buffer& Pipeline::GetTraceRaysSbtBuffer() { return sbt_buffer_; }
 
 void Pipeline::DestroySbtBuffer() { sbt_buffer_.Destroy(); }
 
@@ -2504,7 +2504,7 @@ vkt::Buffer Pipeline::GetTraceRaysSbtIndirectBuffer(uint32_t ray_gen_shader_i, u
 
     vkt::Buffer indirect_rt_buffer(*device_, sizeof(VkTraceRaysIndirectCommand2KHR), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                    vkt::device_address);
-    auto indirect_rt_ptr = (VkTraceRaysIndirectCommand2KHR *)indirect_rt_buffer.Memory().Map();
+    auto indirect_rt_ptr = (VkTraceRaysIndirectCommand2KHR*)indirect_rt_buffer.Memory().Map();
     *indirect_rt_ptr = {};
     indirect_rt_ptr->raygenShaderRecordAddress = sbt.ray_gen_sbt.deviceAddress;
     indirect_rt_ptr->raygenShaderRecordSize = sbt.ray_gen_sbt.size;
@@ -2568,7 +2568,7 @@ std::vector<uint8_t> Pipeline::GetRayTracingShaderGroupHandles() {
             closest_hit_handle_indices.emplace_back(shader_i++);
         }
 
-        for (const Pipeline *lib : libraries_) {
+        for (const Pipeline* lib : libraries_) {
             for (uint32_t ray_gen_i = 0; ray_gen_i < size32(lib->ray_gen_shaders_); ++ray_gen_i) {
                 ray_gen_handle_indices.emplace_back(shader_i++);
             }
@@ -2594,14 +2594,14 @@ std::vector<uint8_t> Pipeline::GetRayTracingShaderGroupHandles() {
         std::cout << i << ' ';
     }
 
-    std::array<std::pair<const std::vector<uint32_t> &, const char *>, 3> shader_groups = {
+    std::array<std::pair<const std::vector<uint32_t>&, const char*>, 3> shader_groups = {
         {{ray_gen_handle_indices, "Ray Gen shader handles"},
          {miss_handle_indices, "Miss shader handles"},
          {closest_hit_handle_indices, "Closest hit shader handles"}}};
 
     std::cout << "\nSBT entries obtained from driver:\n";
     const auto original_fmt_flags = std::cout.flags();
-    for (const auto &shader_group : shader_groups) {
+    for (const auto& shader_group : shader_groups) {
         std::cout << shader_group.second << ":\n";
         for (uint32_t shader_i : shader_group.first) {
             const size_t start_offset = rt_pipeline_props.shaderGroupHandleSize * shader_i;
@@ -2652,7 +2652,7 @@ std::vector<VkRayTracingShaderGroupCreateInfoKHR> Pipeline::GetRayTracingShaderG
 uint32_t Pipeline::GetRayGenShadersCount() const {
     uint32_t count = 0;
     count += size32(ray_gen_shaders_);
-    for (const Pipeline *lib : libraries_) {
+    for (const Pipeline* lib : libraries_) {
         count += lib->GetRayGenShadersCount();
     }
     return count;
@@ -2661,7 +2661,7 @@ uint32_t Pipeline::GetRayGenShadersCount() const {
 uint32_t Pipeline::GetMissShadersCount() const {
     uint32_t count = 0;
     count += size32(miss_shaders_);
-    for (const Pipeline *lib : libraries_) {
+    for (const Pipeline* lib : libraries_) {
         count += lib->GetMissShadersCount();
     }
     return count;
@@ -2670,7 +2670,7 @@ uint32_t Pipeline::GetMissShadersCount() const {
 uint32_t Pipeline::GetClosestHitShadersCount() const {
     uint32_t count = 0;
     count += size32(closest_hit_shaders_);
-    for (const Pipeline *lib : libraries_) {
+    for (const Pipeline* lib : libraries_) {
         count += lib->GetClosestHitShadersCount();
     }
     return count;

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -35,7 +35,7 @@
 #endif
 
 template <typename C, typename F>
-typename C::iterator RemoveIf(C &container, F &&fn) {
+typename C::iterator RemoveIf(C& container, F&& fn) {
     return container.erase(std::remove_if(container.begin(), container.end(), std::forward<F>(fn)), container.end());
 }
 
@@ -84,19 +84,19 @@ VkPhysicalDevice VkRenderFramework::Gpu() const {
     return gpu_;
 }
 
-const VkPhysicalDeviceProperties &VkRenderFramework::PhysicalDeviceProps() const {
+const VkPhysicalDeviceProperties& VkRenderFramework::PhysicalDeviceProps() const {
     EXPECT_NE((VkPhysicalDevice)0, gpu_);  // Invalid to request physical device properties before gpu
     return physDevProps_;
 }
 
 // Return true if layer name is found and spec+implementation values are >= requested values
-bool VkRenderFramework::InstanceLayerSupported(const char *const layer_name, const uint32_t spec_version,
+bool VkRenderFramework::InstanceLayerSupported(const char* const layer_name, const uint32_t spec_version,
                                                const uint32_t impl_version) {
     if (available_layers_.empty()) {
         available_layers_ = vkt::GetGlobalLayers();
     }
 
-    for (const auto &layer : available_layers_) {
+    for (const auto& layer : available_layers_) {
         if (0 == strncmp(layer_name, layer.layerName, VK_MAX_EXTENSION_NAME_SIZE)) {
             return layer.specVersion >= spec_version && layer.implementationVersion >= impl_version;
         }
@@ -116,7 +116,7 @@ bool VkRenderFramework::InstanceExtensionSupported(const char* const extension_n
         available_extensions_ = vkt::GetGlobalExtensions();
     }
 
-    const auto IsTheQueriedExtension = [extension_name, spec_version](const VkExtensionProperties &extension) {
+    const auto IsTheQueriedExtension = [extension_name, spec_version](const VkExtensionProperties& extension) {
         return strncmp(extension_name, extension.extensionName, VK_MAX_EXTENSION_NAME_SIZE) == 0 &&
                extension.specVersion >= spec_version;
     };
@@ -125,7 +125,7 @@ bool VkRenderFramework::InstanceExtensionSupported(const char* const extension_n
 }
 
 // Return true if extension name is found and spec value is >= requested spec value
-bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, const uint32_t spec_version) const {
+bool VkRenderFramework::DeviceExtensionSupported(const char* extension_name, const uint32_t spec_version) const {
     if (!instance_ || !gpu_) {
         EXPECT_NE((VkInstance)0, instance_);  // Complain, not cool without an instance
         EXPECT_NE((VkPhysicalDevice)0, gpu_);
@@ -137,12 +137,12 @@ bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, con
     const auto enabled_layers = instance_layers_;  // assumes instance_layers_ contains enabled layers
 
     auto extensions = device_obj.Extensions();
-    for (const auto &layer : enabled_layers) {
+    for (const auto& layer : enabled_layers) {
         const auto layer_extensions = device_obj.Extensions(layer);
         extensions.insert(extensions.end(), layer_extensions.begin(), layer_extensions.end());
     }
 
-    const auto IsTheQueriedExtension = [extension_name, spec_version](const VkExtensionProperties &extension) {
+    const auto IsTheQueriedExtension = [extension_name, spec_version](const VkExtensionProperties& extension) {
         return strncmp(extension_name, extension.extensionName, VK_MAX_EXTENSION_NAME_SIZE) == 0 &&
                extension.specVersion >= spec_version;
     };
@@ -168,10 +168,10 @@ VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
     return info;
 }
 
-void VkRenderFramework::InitFramework(void *instance_pnext) {
+void VkRenderFramework::InitFramework(void* instance_pnext) {
     ASSERT_EQ((VkInstance)0, instance_);
 
-    const auto ExtensionIncludedInTargetVersion = [this](const char *extension) {
+    const auto ExtensionIncludedInTargetVersion = [this](const char* extension) {
         if (IsPromotedInstanceExtension(extension)) {
             // Replicate the core entry points into the extension entry points
             vk::InitExtensionFromCore(extension);
@@ -179,7 +179,7 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
         }
         return false;
     };
-    const auto LayerNotSupportedWithReporting = [this](const char *layer) {
+    const auto LayerNotSupportedWithReporting = [this](const char* layer) {
         if (InstanceLayerSupported(layer))
             return false;
         else {
@@ -187,7 +187,7 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
             return true;
         }
     };
-    const auto ExtensionNotSupportedWithReporting = [this](const char *extension) {
+    const auto ExtensionNotSupportedWithReporting = [this](const char* extension) {
         if (InstanceExtensionSupported(extension))
             return false;
         else {
@@ -226,21 +226,21 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
     auto ici = GetInstanceCreateInfo();
 
     // concatenate pNexts
-    void *last_pnext = nullptr;
+    void* last_pnext = nullptr;
     if (instance_pnext) {
         last_pnext = instance_pnext;
-        while (reinterpret_cast<const VkBaseOutStructure *>(last_pnext)->pNext)
-            last_pnext = reinterpret_cast<VkBaseOutStructure *>(last_pnext)->pNext;
+        while (reinterpret_cast<const VkBaseOutStructure*>(last_pnext)->pNext)
+            last_pnext = reinterpret_cast<VkBaseOutStructure*>(last_pnext)->pNext;
 
-        void *&link = reinterpret_cast<void *&>(reinterpret_cast<VkBaseOutStructure *>(last_pnext)->pNext);
-        link = const_cast<void *>(ici.pNext);
+        void*& link = reinterpret_cast<void*&>(reinterpret_cast<VkBaseOutStructure*>(last_pnext)->pNext);
+        link = const_cast<void*>(ici.pNext);
         ici.pNext = instance_pnext;
     }
 
     ASSERT_EQ(VK_SUCCESS, vk::CreateInstance(&ici, nullptr, &instance_));
-    if (instance_pnext) reinterpret_cast<VkBaseOutStructure *>(last_pnext)->pNext = nullptr;  // reset back borrowed pNext chain
+    if (instance_pnext) reinterpret_cast<VkBaseOutStructure*>(last_pnext)->pNext = nullptr;  // reset back borrowed pNext chain
 
-    for (const char *instance_ext_name : m_instance_extension_names) {
+    for (const char* instance_ext_name : m_instance_extension_names) {
         vk::InitInstanceExtension(instance_, instance_ext_name);
     }
 
@@ -292,7 +292,7 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
     if (print_driver_info && !driver_printed) {
         bool phys_dev_props_2_enabled = m_target_api_version.Minor() >= 1;
         if (!phys_dev_props_2_enabled) {
-            for (const char *ext : vvl::make_span(ici.ppEnabledExtensionNames, ici.enabledExtensionCount)) {
+            for (const char* ext : vvl::make_span(ici.ppEnabledExtensionNames, ici.enabledExtensionCount)) {
                 if (strcmp(ext, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) == 0) {
                     phys_dev_props_2_enabled = true;
                     break;
@@ -324,51 +324,51 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
         AddRequestedDeviceExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 #endif
 
-    for (const auto &ext : m_required_extensions) {
+    for (const auto& ext : m_required_extensions) {
         AddRequestedDeviceExtensions(ext);
     }
 
     if (!std::all_of(m_required_extensions.begin(), m_required_extensions.end(),
-                     [&](const char *ext) -> bool { return IsExtensionsEnabled(ext); })) {
+                     [&](const char* ext) -> bool { return IsExtensionsEnabled(ext); })) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
     // If the user requested wsi extension(s), only 1 needs to be enabled.
     if (!m_wsi_extensions.empty()) {
         if (!std::any_of(m_wsi_extensions.begin(), m_wsi_extensions.end(),
-                         [&](const char *ext) -> bool { return CanEnableInstanceExtension(ext); })) {
+                         [&](const char* ext) -> bool { return CanEnableInstanceExtension(ext); })) {
             GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
         }
     }
 
-    for (const auto &ext : m_optional_extensions) {
+    for (const auto& ext : m_optional_extensions) {
         AddRequestedDeviceExtensions(ext);
     }
 }
 
-void VkRenderFramework::AddRequiredExtensions(const char *ext_name) {
+void VkRenderFramework::AddRequiredExtensions(const char* ext_name) {
     m_required_extensions.push_back(ext_name);
     AddRequestedInstanceExtensions(ext_name);
 }
 
-void VkRenderFramework::AddOptionalExtensions(const char *ext_name) {
+void VkRenderFramework::AddOptionalExtensions(const char* ext_name) {
     m_optional_extensions.push_back(ext_name);
     AddRequestedInstanceExtensions(ext_name);
 }
 
-void VkRenderFramework::AddWsiExtensions(const char *ext_name) {
+void VkRenderFramework::AddWsiExtensions(const char* ext_name) {
     m_wsi_extensions.push_back(ext_name);
     AddRequestedInstanceExtensions(ext_name);
 }
 
-bool VkRenderFramework::IsExtensionsEnabled(const char *ext_name) const {
+bool VkRenderFramework::IsExtensionsEnabled(const char* ext_name) const {
     return (CanEnableDeviceExtension(ext_name) || CanEnableInstanceExtension(ext_name));
 }
 
 std::string VkRenderFramework::RequiredExtensionsNotSupported() const {
     std::ostringstream ss;
     bool first = true;
-    for (const auto &ext : m_required_extensions) {
+    for (const auto& ext : m_required_extensions) {
         if (!CanEnableDeviceExtension(ext) && !CanEnableInstanceExtension(ext)) {
             if (first) {
                 first = false;
@@ -392,14 +392,14 @@ void VkRenderFramework::AddOptionalFeature(vkt::Feature feature) {
     requested_features_.AddOptionalFeature(m_target_api_version, feature);
 }
 
-bool VkRenderFramework::AddRequestedInstanceExtensions(const char *ext_name) {
+bool VkRenderFramework::AddRequestedInstanceExtensions(const char* ext_name) {
     if (CanEnableInstanceExtension(ext_name)) {
         return true;
     }
 
     bool is_instance_ext = false;
     vvl::Extension extension = GetExtension(ext_name);
-    const auto &instance_info = m_instance_extensions->GetInfo(extension);
+    const auto& instance_info = m_instance_extensions->GetInfo(extension);
     if (instance_info.state) {
         if (!InstanceExtensionSupported(ext_name)) {
             return false;
@@ -411,7 +411,7 @@ bool VkRenderFramework::AddRequestedInstanceExtensions(const char *ext_name) {
     // Different tables need to be used for extension dependency lookup depending on whether `ext_name` refers to a device or
     // instance extension
     if (is_instance_ext) {
-        for (const auto &req : instance_info.requirements) {
+        for (const auto& req : instance_info.requirements) {
             if (0 == strncmp(req.name, "VK_VERSION", 10)) {
                 continue;
             }
@@ -421,8 +421,8 @@ bool VkRenderFramework::AddRequestedInstanceExtensions(const char *ext_name) {
         }
         m_instance_extension_names.push_back(ext_name);
     } else {
-        const auto &info = m_device_extensions->GetInfo(extension);
-        for (const auto &req : info.requirements) {
+        const auto& info = m_device_extensions->GetInfo(extension);
+        for (const auto& req : info.requirements) {
             if (!AddRequestedInstanceExtensions(req.name)) {
                 return false;
             }
@@ -432,11 +432,11 @@ bool VkRenderFramework::AddRequestedInstanceExtensions(const char *ext_name) {
     return true;
 }
 
-bool VkRenderFramework::IsPromotedInstanceExtension(const char *inst_ext_name) const {
+bool VkRenderFramework::IsPromotedInstanceExtension(const char* inst_ext_name) const {
     if (!m_target_api_version.Valid()) return false;
 
     const auto promotion_info_map = GetInstancePromotionInfoMap();
-    for (const auto &version_it : promotion_info_map) {
+    for (const auto& version_it : promotion_info_map) {
         if (m_target_api_version >= version_it.first) {
             const auto promoted_exts = version_it.second.second;
             vvl::Extension extension = GetExtension(inst_ext_name);
@@ -449,13 +449,13 @@ bool VkRenderFramework::IsPromotedInstanceExtension(const char *inst_ext_name) c
     return false;
 }
 
-bool VkRenderFramework::CanEnableInstanceExtension(const std::string &inst_ext_name) const {
+bool VkRenderFramework::CanEnableInstanceExtension(const std::string& inst_ext_name) const {
     return (!allow_promoted_extensions_ && IsPromotedInstanceExtension(inst_ext_name.c_str())) ||
            std::any_of(m_instance_extension_names.cbegin(), m_instance_extension_names.cend(),
-                       [&inst_ext_name](const char *ext) { return inst_ext_name == ext; });
+                       [&inst_ext_name](const char* ext) { return inst_ext_name == ext; });
 }
 
-bool VkRenderFramework::AddRequestedDeviceExtensions(const char *dev_ext_name) {
+bool VkRenderFramework::AddRequestedDeviceExtensions(const char* dev_ext_name) {
     // Check if the extension has already been added
     if (CanEnableDeviceExtension(dev_ext_name)) {
         return true;
@@ -468,7 +468,7 @@ bool VkRenderFramework::AddRequestedDeviceExtensions(const char *dev_ext_name) {
     // If this is an instance extension, just return true under the assumption instance extensions do not depend on any device
     // extensions.
     vvl::Extension extension = GetExtension(dev_ext_name);
-    const auto &instance_info = m_instance_extensions->GetInfo(extension);
+    const auto& instance_info = m_instance_extensions->GetInfo(extension);
     if (instance_info.state) {
         return true;
     }
@@ -478,8 +478,8 @@ bool VkRenderFramework::AddRequestedDeviceExtensions(const char *dev_ext_name) {
     }
     m_device_extension_names.push_back(dev_ext_name);
 
-    const auto &info = m_device_extensions->GetInfo(extension);
-    for (const auto &req : info.requirements) {
+    const auto& info = m_device_extensions->GetInfo(extension);
+    for (const auto& req : info.requirements) {
         if (!AddRequestedDeviceExtensions(req.name)) {
             return false;
         }
@@ -487,12 +487,12 @@ bool VkRenderFramework::AddRequestedDeviceExtensions(const char *dev_ext_name) {
     return true;
 }
 
-bool VkRenderFramework::IsPromotedDeviceExtension(const char *dev_ext_name) const {
+bool VkRenderFramework::IsPromotedDeviceExtension(const char* dev_ext_name) const {
     auto device_version = std::min(m_target_api_version, APIVersion(PhysicalDeviceProps().apiVersion));
     if (!device_version.Valid()) return false;
 
     const auto promotion_info_map = GetDevicePromotionInfoMap();
-    for (const auto &version_it : promotion_info_map) {
+    for (const auto& version_it : promotion_info_map) {
         if (device_version >= version_it.first) {
             const auto promoted_exts = version_it.second.second;
             vvl::Extension extension = GetExtension(dev_ext_name);
@@ -505,10 +505,10 @@ bool VkRenderFramework::IsPromotedDeviceExtension(const char *dev_ext_name) cons
     return false;
 }
 
-bool VkRenderFramework::CanEnableDeviceExtension(const std::string &dev_ext_name) const {
+bool VkRenderFramework::CanEnableDeviceExtension(const std::string& dev_ext_name) const {
     return (!allow_promoted_extensions_ && IsPromotedDeviceExtension(dev_ext_name.c_str())) ||
            std::any_of(m_device_extension_names.cbegin(), m_device_extension_names.cend(),
-                       [&dev_ext_name](const char *ext) { return dev_ext_name == ext; });
+                       [&dev_ext_name](const char* ext) { return dev_ext_name == ext; });
 }
 
 void VkRenderFramework::ShutdownFramework() {
@@ -557,9 +557,9 @@ void VkRenderFramework::ShutdownFramework() {
     vk::ResetAllExtensions();
 }
 
-ErrorMonitor &VkRenderFramework::Monitor() { return monitor_; }
+ErrorMonitor& VkRenderFramework::Monitor() { return monitor_; }
 
-void VkRenderFramework::GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features) {
+void VkRenderFramework::GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures* features) {
     vk::GetPhysicalDeviceFeatures(Gpu(), features);
 }
 
@@ -580,7 +580,7 @@ bool VkRenderFramework::IsPlatformMockICD() {
     }
 }
 
-void VkRenderFramework::GetPhysicalDeviceProperties(VkPhysicalDeviceProperties *props) { *props = physDevProps_; }
+void VkRenderFramework::GetPhysicalDeviceProperties(VkPhysicalDeviceProperties* props) { *props = physDevProps_; }
 
 VkFormat VkRenderFramework::GetRenderTargetFormat() {
     VkFormatProperties format_props = {};
@@ -599,9 +599,9 @@ VkFormat VkRenderFramework::GetRenderTargetFormat() {
     return VK_FORMAT_UNDEFINED;
 }
 
-void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *create_device_pnext,
+void VkRenderFramework::InitState(VkPhysicalDeviceFeatures* features, void* create_device_pnext,
                                   const VkCommandPoolCreateFlags flags) {
-    const auto ExtensionIncludedInDeviceApiVersion = [&](const char *extension) {
+    const auto ExtensionIncludedInDeviceApiVersion = [&](const char* extension) {
         if (IsPromotedDeviceExtension(extension)) {
             // Replicate the core entry points into the extension entry points
             vk::InitExtensionFromCore(extension);
@@ -626,7 +626,7 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
         }
         return false;
     };
-    const auto ExtensionNotSupportedWithReporting = [this](const char *extension) {
+    const auto ExtensionNotSupportedWithReporting = [this](const char* extension) {
         if (DeviceExtensionSupported(extension))
             return false;
         else {
@@ -657,18 +657,18 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
             GetPhysicalDeviceFeatures(requested_features_.GetQueriedFeatures());
         }
 
-        if (const char *f = requested_features_.AnyRequiredFeatureDisabled()) {
+        if (const char* f = requested_features_.AnyRequiredFeatureDisabled()) {
             GTEST_SKIP() << "Required feature " << f << " is not available on device, skipping test";
         }
 
         if (requested_features_.HasFeatures2()) {
             if (create_device_pnext) {
                 // Chain to the end of the list
-                VkBaseOutStructure *p = reinterpret_cast<VkBaseOutStructure *>(create_device_pnext);
+                VkBaseOutStructure* p = reinterpret_cast<VkBaseOutStructure*>(create_device_pnext);
                 while (p->pNext != nullptr) {
                     p = p->pNext;
                 }
-                p->pNext = reinterpret_cast<VkBaseOutStructure *>(requested_features_.GetEnabledFeatures2());
+                p->pNext = reinterpret_cast<VkBaseOutStructure*>(requested_features_.GetEnabledFeatures2());
             } else {
                 create_device_pnext = requested_features_.GetEnabledFeatures2();
             }
@@ -679,23 +679,23 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
 
     m_device = new vkt::Device(gpu_, m_device_extension_names, features, create_device_pnext, all_queue_count_);
 
-    for (const char *device_ext_name : m_device_extension_names) {
+    for (const char* device_ext_name : m_device_extension_names) {
         vk::InitDeviceExtension(instance_, *m_device, device_ext_name);
     }
 
-    std::vector<vkt::Queue *> queues;
+    std::vector<vkt::Queue*> queues;
     vvl::Append(queues, m_device->QueuesWithGraphicsCapability());
-    for (vkt::Queue *queue_with_compute_caps : m_device->QueuesWithComputeCapability()) {
+    for (vkt::Queue* queue_with_compute_caps : m_device->QueuesWithComputeCapability()) {
         if (!vvl::Contains(queues, queue_with_compute_caps)) {
             queues.emplace_back(queue_with_compute_caps);
         }
     }
-    for (vkt::Queue *queue_with_transfer_caps : m_device->QueuesWithTransferCapability()) {
+    for (vkt::Queue* queue_with_transfer_caps : m_device->QueuesWithTransferCapability()) {
         if (!vvl::Contains(queues, queue_with_transfer_caps)) {
             queues.emplace_back(queue_with_transfer_caps);
         }
     }
-    for (vkt::Queue *queue_with_data_graph_caps : m_device->QueuesWithDataGraphCapability()) {
+    for (vkt::Queue* queue_with_data_graph_caps : m_device->QueuesWithDataGraphCapability()) {
         if (!vvl::Contains(queues, queue_with_data_graph_caps)) {
             queues.emplace_back(queue_with_data_graph_caps);
         }
@@ -749,7 +749,7 @@ void SurfaceContext::Resize(uint32_t width, uint32_t height) {
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-VkResult VkRenderFramework::CreateSurface(SurfaceContext &surface_context, vkt::Surface &surface, VkInstance custom_instance) {
+VkResult VkRenderFramework::CreateSurface(SurfaceContext& surface_context, vkt::Surface& surface, VkInstance custom_instance) {
     const VkInstance surface_instance = (custom_instance != VK_NULL_HANDLE) ? custom_instance : instance();
     (void)surface_instance;
     (void)surface_context;
@@ -763,7 +763,8 @@ VkResult VkRenderFramework::CreateSurface(SurfaceContext &surface_context, vkt::
         wc.hInstance = window_instance;
         wc.lpszClassName = class_name;
         RegisterClass(&wc);
-        HWND window = CreateWindowEx(0, class_name, nullptr, 0, 0, 0, (int)m_width, (int)m_height, NULL, NULL, window_instance, NULL);
+        HWND window =
+            CreateWindowEx(0, class_name, nullptr, 0, 0, 0, (int)m_width, (int)m_height, NULL, NULL, window_instance, NULL);
         surface_context.m_win32Window = window;
         ShowWindow(window, SW_HIDE);
 
@@ -836,7 +837,7 @@ VkResult VkRenderFramework::CreateSurface(SurfaceContext &surface_context, vkt::
 }
 
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-int IgnoreXErrors(Display *, XErrorEvent *) { return 0; }
+int IgnoreXErrors(Display*, XErrorEvent*) { return 0; }
 #endif
 
 void SurfaceContext::Destroy() {
@@ -929,7 +930,7 @@ SurfaceInformation VkRenderFramework::GetSwapchainInfo(const VkSurfaceKHR surfac
 }
 
 VkSwapchainCreateInfoKHR VkRenderFramework::GetDefaultSwapchainCreateInfo(VkSurfaceKHR surface,
-                                                                          const SurfaceInformation &surface_info,
+                                                                          const SurfaceInformation& surface_info,
                                                                           VkImageUsageFlags image_usage) {
     VkSwapchainCreateInfoKHR swapchain_ci = vku::InitStructHelper();
     swapchain_ci.surface = surface;
@@ -1014,9 +1015,9 @@ void VkRenderFramework::InitRenderTarget() { InitRenderTarget(1); }
 
 void VkRenderFramework::InitRenderTarget(uint32_t targets) { InitRenderTarget(targets, NULL); }
 
-void VkRenderFramework::InitRenderTarget(const VkImageView *dsBinding) { InitRenderTarget(1, dsBinding); }
+void VkRenderFramework::InitRenderTarget(const VkImageView* dsBinding) { InitRenderTarget(1, dsBinding); }
 
-void VkRenderFramework::InitRenderTarget(uint32_t targets, const VkImageView *dsBinding) {
+void VkRenderFramework::InitRenderTarget(uint32_t targets, const VkImageView* dsBinding) {
     std::vector<VkAttachmentReference> color_references;
     std::vector<VkAttachmentDescription> attachment_descriptions;
 
@@ -1166,10 +1167,10 @@ void VkRenderFramework::DestroyRenderTarget() {
     m_framebuffer = nullptr;
 }
 
-void VkRenderFramework::SetDefaultDynamicStatesExclude(const std::vector<VkDynamicState> &exclude, bool tessellation,
+void VkRenderFramework::SetDefaultDynamicStatesExclude(const std::vector<VkDynamicState>& exclude, bool tessellation,
                                                        VkCommandBuffer commandBuffer) {
     const auto excluded = [&exclude](VkDynamicState state) {
-        for (const auto &check_state : exclude) {
+        for (const auto& check_state : exclude) {
             if (check_state == state) {
                 return true;
             }
@@ -1294,7 +1295,7 @@ void VkRenderFramework::SetDefaultDynamicStatesAll(VkCommandBuffer cmdBuffer) {
 
 // Used by the test as a "default"
 // TODO these are poorly similar names and easy to get confused
-std::vector<uint32_t> VkRenderFramework::GLSLToSPV(VkShaderStageFlagBits stage, const char *code, const spv_target_env env) {
+std::vector<uint32_t> VkRenderFramework::GLSLToSPV(VkShaderStageFlagBits stage, const char* code, const spv_target_env env) {
     std::vector<uint32_t> spv;
     GLSLtoSPV(m_device->Physical().limits_, stage, code, spv, env);
     return spv;

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -35,7 +35,7 @@
 #pragma pop_macro("Bool")
 #endif
 
-static void ProcessConfigFile(const VkPhysicalDeviceLimits &device_limits, TBuiltInResource &out_resources) {
+static void ProcessConfigFile(const VkPhysicalDeviceLimits& device_limits, TBuiltInResource& out_resources) {
     // These are the default resources for TBuiltInResources.
     out_resources.maxLights = 32;
     out_resources.maxClipPlanes = 6;
@@ -261,8 +261,8 @@ struct GlslangTargetEnv {
 // Compile a given string containing GLSL into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type, const char *p_shader,
-               std::vector<uint32_t> &spirv, const spv_target_env spv_env) {
+bool GLSLtoSPV(const VkPhysicalDeviceLimits& device_limits, const VkShaderStageFlagBits shader_type, const char* p_shader,
+               std::vector<uint32_t>& spirv, const spv_target_env spv_env) {
     TBuiltInResource resources;
     ProcessConfigFile(device_limits, resources);
 
@@ -273,7 +273,7 @@ bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageF
     shader.setEnvTarget(glslang::EshTargetSpv, glslang_env);
     shader.setEnvClient(glslang::EShClientVulkan, glslang_env);
 
-    const char *shader_strings[1];
+    const char* shader_strings[1];
     shader_strings[0] = p_shader;
     shader.setStrings(shader_strings, 1);
 
@@ -302,7 +302,7 @@ bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageF
 // Compile a given string containing SPIR-V assembly into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &spv) {
+bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char* p_asm, std::vector<uint32_t>& spv) {
     spv_binary binary;
     spv_diagnostic diagnostic = nullptr;
     spv_context context = spvContextCreate(target_env);
@@ -390,7 +390,7 @@ bool SlangToSPV(const spv_target_env target_env, const char* slang_shader, const
     Slang::ComPtr<slang::IModule> slang_module;
     slang_module = session->loadModuleFromSourceString("my_shader", "my_shader.slang", slang_shader, diagnostics.writeRef());
     if (slang_module == NULL) {
-        ADD_FAILURE() << "Slang failure: loadModuleFromSourceString()\n" << ((const char *)diagnostics->getBufferPointer());
+        ADD_FAILURE() << "Slang failure: loadModuleFromSourceString()\n" << ((const char*)diagnostics->getBufferPointer());
         return false;
     }
 
@@ -424,7 +424,7 @@ bool SlangToSPV(const spv_target_env target_env, const char* slang_shader, const
     // other pieces, and that is what we are going to do with our module
     // and entry points.
     //
-    std::vector<slang::IComponentType *> componentTypes;
+    std::vector<slang::IComponentType*> componentTypes;
     componentTypes.emplace_back(slang_module);
     componentTypes.emplace_back(entry_point);
 
@@ -439,7 +439,7 @@ bool SlangToSPV(const spv_target_env target_env, const char* slang_shader, const
         result = session->createCompositeComponentType(componentTypes.data(), (SlangInt)componentTypes.size(),
                                                        composedProgram.writeRef(), diagnostics.writeRef());
         if (result != 0) {
-            ADD_FAILURE() << "Slang failure: createCompositeComponentType()\n" << ((const char *)diagnostics->getBufferPointer());
+            ADD_FAILURE() << "Slang failure: createCompositeComponentType()\n" << ((const char*)diagnostics->getBufferPointer());
             return false;
         }
     }
@@ -451,7 +451,7 @@ bool SlangToSPV(const spv_target_env target_env, const char* slang_shader, const
     {
         result = composedProgram->getEntryPointCode(0, 0, spirvCode.writeRef(), diagnostics.writeRef());
         if (result != 0) {
-            ADD_FAILURE() << "Slang failure: createCompositeComponentType()\n" << ((const char *)diagnostics->getBufferPointer());
+            ADD_FAILURE() << "Slang failure: createCompositeComponentType()\n" << ((const char*)diagnostics->getBufferPointer());
             return false;
         }
     }
@@ -463,7 +463,7 @@ bool SlangToSPV(const spv_target_env target_env, const char* slang_shader, const
 #endif
 }
 
-VkPipelineShaderStageCreateInfo const &VkShaderObj::GetStageCreateInfo() const { return m_stage_info; }
+VkPipelineShaderStageCreateInfo const& VkShaderObj::GetStageCreateInfo() const { return m_stage_info; }
 
 VkShaderObj::VkShaderObj(vkt::Device& device, const char* source, VkShaderStageFlagBits stage, const spv_target_env env,
                          SpvSourceType source_type, const VkSpecializationInfo* spec_info, const char* entry_point,
@@ -502,7 +502,7 @@ bool VkShaderObj::InitFromGLSL(const void* shader_module_ci_pNext) {
 // Because shaders are currently validated at pipeline creation time, there are test cases that might fail shader module
 // creation due to supplying an invalid/unknown SPIR-V capability/operation. This is called after VkShaderObj creation when
 // tests are found to crash on a CI device
-VkResult VkShaderObj::InitFromGLSLTry(const vkt::Device *custom_device) {
+VkResult VkShaderObj::InitFromGLSLTry(const vkt::Device* custom_device) {
     std::vector<uint32_t> spv;
     // 99% of tests just use the framework's VkDevice, but this allows for tests to use custom device object
     // Can't set at contructor time since all reference members need to be initialized then.
@@ -554,7 +554,7 @@ bool VkShaderObj::InitFromSlang() {
     }
     VkShaderModuleCreateInfo module_ci = vku::InitStructHelper();
     module_ci.codeSize = bytes.size();
-    module_ci.pCode = (uint32_t *)bytes.data();
+    module_ci.pCode = (uint32_t*)bytes.data();
 
     const auto result = InitTry(*m_device, module_ci);
     m_stage_info.module = handle();
@@ -563,9 +563,9 @@ bool VkShaderObj::InitFromSlang() {
 }
 
 // static
-VkShaderObj VkShaderObj::CreateFromGLSL(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage,
-                                        const spv_target_env spv_env, const VkSpecializationInfo *spec_info,
-                                        const char *entry_point) {
+VkShaderObj VkShaderObj::CreateFromGLSL(VkRenderFramework* framework, const char* source, VkShaderStageFlagBits stage,
+                                        const spv_target_env spv_env, const VkSpecializationInfo* spec_info,
+                                        const char* entry_point) {
     auto shader = VkShaderObj(*framework->DeviceObj(), source, stage, spv_env, SPV_SOURCE_GLSL_TRY, spec_info, entry_point);
     if (VK_SUCCESS == shader.InitFromGLSLTry()) {
         return shader;
@@ -574,9 +574,9 @@ VkShaderObj VkShaderObj::CreateFromGLSL(VkRenderFramework *framework, const char
 }
 
 // static
-VkShaderObj VkShaderObj::CreateFromASM(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage,
-                                       const spv_target_env spv_env, const VkSpecializationInfo *spec_info,
-                                       const char *entry_point) {
+VkShaderObj VkShaderObj::CreateFromASM(VkRenderFramework* framework, const char* source, VkShaderStageFlagBits stage,
+                                       const spv_target_env spv_env, const VkSpecializationInfo* spec_info,
+                                       const char* entry_point) {
     auto shader = VkShaderObj(*framework->DeviceObj(), source, stage, spv_env, SPV_SOURCE_ASM_TRY, spec_info, entry_point);
     if (VK_SUCCESS == shader.InitFromASMTry()) {
         return shader;

--- a/tests/framework/sync_helper.cpp
+++ b/tests/framework/sync_helper.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 
 #include "sync_helper.h"
 
-VkDependencyInfo DependencyInfo(const VkMemoryBarrier2 &barrier, VkDependencyFlags dependency_flags) {
+VkDependencyInfo DependencyInfo(const VkMemoryBarrier2& barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = vku::InitStructHelper();
     dep_info.dependencyFlags = dependency_flags;
     dep_info.memoryBarrierCount = 1;
@@ -19,7 +19,7 @@ VkDependencyInfo DependencyInfo(const VkMemoryBarrier2 &barrier, VkDependencyFla
     return dep_info;
 }
 
-VkDependencyInfo DependencyInfo(const VkBufferMemoryBarrier2 &buffer_barrier, VkDependencyFlags dependency_flags) {
+VkDependencyInfo DependencyInfo(const VkBufferMemoryBarrier2& buffer_barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = vku::InitStructHelper();
     dep_info.dependencyFlags = dependency_flags;
     dep_info.bufferMemoryBarrierCount = 1;
@@ -27,7 +27,7 @@ VkDependencyInfo DependencyInfo(const VkBufferMemoryBarrier2 &buffer_barrier, Vk
     return dep_info;
 }
 
-VkDependencyInfo DependencyInfo(const VkImageMemoryBarrier2 &image_barrier, VkDependencyFlags dependency_flags) {
+VkDependencyInfo DependencyInfo(const VkImageMemoryBarrier2& image_barrier, VkDependencyFlags dependency_flags) {
     VkDependencyInfo dep_info = vku::InitStructHelper();
     dep_info.dependencyFlags = dependency_flags;
     dep_info.imageMemoryBarrierCount = 1;
@@ -42,7 +42,7 @@ BarrierQueueFamilyBase::QueueFamilyObjs::~QueueFamilyObjs() {
     delete queue;
 }
 
-void BarrierQueueFamilyBase::QueueFamilyObjs::Init(vkt::Device *device, uint32_t qf_index, VkQueue qf_queue,
+void BarrierQueueFamilyBase::QueueFamilyObjs::Init(vkt::Device* device, uint32_t qf_index, VkQueue qf_queue,
                                                    VkCommandPoolCreateFlags cp_flags) {
     index = qf_index;
     queue = new vkt::Queue(qf_queue, qf_index);
@@ -51,11 +51,11 @@ void BarrierQueueFamilyBase::QueueFamilyObjs::Init(vkt::Device *device, uint32_t
     command_buffer2 = new vkt::CommandBuffer(*device, *command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 }
 
-BarrierQueueFamilyBase::Context::Context(VkLayerTest *test, const std::vector<uint32_t> &queue_family_indices) : layer_test(test) {
+BarrierQueueFamilyBase::Context::Context(VkLayerTest* test, const std::vector<uint32_t>& queue_family_indices) : layer_test(test) {
     if (0 == queue_family_indices.size()) {
         return;  // This is invalid
     }
-    vkt::Device *device_obj = layer_test->DeviceObj();
+    vkt::Device* device_obj = layer_test->DeviceObj();
     queue_families.reserve(queue_family_indices.size());
     default_index = queue_family_indices[0];
     for (auto qfi : queue_family_indices) {
@@ -68,13 +68,13 @@ BarrierQueueFamilyBase::Context::Context(VkLayerTest *test, const std::vector<ui
 
 void BarrierQueueFamilyBase::Context::Reset() {
     layer_test->DeviceObj()->Wait();
-    for (auto &qf : queue_families) {
+    for (auto& qf : queue_families) {
         vk::ResetCommandPool(layer_test->device(), qf.second.command_pool->handle(), 0);
     }
 }
 
-void BarrierQueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool image_memory, bool buffer_memory) {
-    vkt::Device *device_obj = context_->layer_test->DeviceObj();
+void BarrierQueueFamilyTestHelper::Init(std::vector<uint32_t>* families, bool image_memory, bool buffer_memory) {
+    vkt::Device* device_obj = context_->layer_test->DeviceObj();
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(
         32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL,
@@ -105,7 +105,7 @@ void BarrierQueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool im
 }
 
 void Barrier2QueueFamilyTestHelper::Init(bool image_memory, bool buffer_memory) {
-    vkt::Device *device_obj = context_->layer_test->DeviceObj();
+    vkt::Device* device_obj = context_->layer_test->DeviceObj();
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     VkImageLayout image_layout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -141,8 +141,8 @@ void Barrier2QueueFamilyTestHelper::Init(bool image_memory, bool buffer_memory) 
                                                   VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_TRANSFER_READ_BIT, 0, VK_WHOLE_SIZE);
 }
 
-BarrierQueueFamilyBase::QueueFamilyObjs *BarrierQueueFamilyBase::GetQueueFamilyInfo(Context *context, uint32_t qfi) {
-    QueueFamilyObjs *qf;
+BarrierQueueFamilyBase::QueueFamilyObjs* BarrierQueueFamilyBase::GetQueueFamilyInfo(Context* context, uint32_t qfi) {
+    QueueFamilyObjs* qf;
 
     auto qf_it = context->queue_families.find(qfi);
     if (qf_it != context->queue_families.end()) {
@@ -153,9 +153,9 @@ BarrierQueueFamilyBase::QueueFamilyObjs *BarrierQueueFamilyBase::GetQueueFamilyI
     return qf;
 }
 
-void BarrierQueueFamilyTestHelper::operator()(const std::string &img_err, const std::string &buf_err, uint32_t src, uint32_t dst,
+void BarrierQueueFamilyTestHelper::operator()(const std::string& img_err, const std::string& buf_err, uint32_t src, uint32_t dst,
                                               uint32_t queue_family_index, Modifier mod) {
-    auto &monitor = context_->layer_test->Monitor();
+    auto& monitor = context_->layer_test->Monitor();
     const bool has_img_err = img_err.size() > 0;
     const bool has_buf_err = buf_err.size() > 0;
     bool positive = !has_img_err && !has_buf_err;
@@ -167,9 +167,9 @@ void BarrierQueueFamilyTestHelper::operator()(const std::string &img_err, const 
     buffer_barrier_.srcQueueFamilyIndex = src;
     buffer_barrier_.dstQueueFamilyIndex = dst;
 
-    QueueFamilyObjs *qf = GetQueueFamilyInfo(context_, queue_family_index);
+    QueueFamilyObjs* qf = GetQueueFamilyInfo(context_, queue_family_index);
 
-    vkt::CommandBuffer *command_buffer = qf->command_buffer;
+    vkt::CommandBuffer* command_buffer = qf->command_buffer;
     for (int cb_repeat = 0; cb_repeat < (mod == Modifier::DOUBLE_COMMAND_BUFFER ? 2 : 1); cb_repeat++) {
         command_buffer->Begin();
         for (int repeat = 0; repeat < (mod == Modifier::DOUBLE_RECORD ? 2 : 1); repeat++) {
@@ -196,9 +196,9 @@ void BarrierQueueFamilyTestHelper::operator()(const std::string &img_err, const 
     context_->Reset();
 }
 
-void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const std::string &buf_err, uint32_t src, uint32_t dst,
+void Barrier2QueueFamilyTestHelper::operator()(const std::string& img_err, const std::string& buf_err, uint32_t src, uint32_t dst,
                                                uint32_t queue_family_index, Modifier mod) {
-    auto &monitor = context_->layer_test->Monitor();
+    auto& monitor = context_->layer_test->Monitor();
     bool positive = true;
     if (img_err.length()) {
         monitor.SetDesiredFailureMsg(kErrorBit | kWarningBit, img_err);
@@ -220,9 +220,9 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &image_barrier_;
 
-    QueueFamilyObjs *qf = GetQueueFamilyInfo(context_, queue_family_index);
+    QueueFamilyObjs* qf = GetQueueFamilyInfo(context_, queue_family_index);
 
-    vkt::CommandBuffer *command_buffer = qf->command_buffer;
+    vkt::CommandBuffer* command_buffer = qf->command_buffer;
     for (int cb_repeat = 0; cb_repeat < (mod == Modifier::DOUBLE_COMMAND_BUFFER ? 2 : 1); cb_repeat++) {
         command_buffer->Begin();
         for (int repeat = 0; repeat < (mod == Modifier::DOUBLE_RECORD ? 2 : 1); repeat++) {
@@ -248,9 +248,9 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
     context_->Reset();
 }
 
-void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, VkPipelineStageFlags src_stages,
-                              VkPipelineStageFlags dst_stages, const VkBufferMemoryBarrier *buf_barrier,
-                              const VkImageMemoryBarrier *img_barrier) {
+void ValidOwnershipTransferOp(vkt::Queue* queue, vkt::CommandBuffer& cb, VkPipelineStageFlags src_stages,
+                              VkPipelineStageFlags dst_stages, const VkBufferMemoryBarrier* buf_barrier,
+                              const VkImageMemoryBarrier* img_barrier) {
     cb.Begin();
     uint32_t num_buf_barrier = (buf_barrier) ? 1 : 0;
     uint32_t num_img_barrier = (img_barrier) ? 1 : 0;
@@ -260,15 +260,15 @@ void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, VkPipel
     queue->Wait();
 }
 
-void ValidOwnershipTransfer(vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to, vkt::CommandBuffer &cb_to,
+void ValidOwnershipTransfer(vkt::Queue* queue_from, vkt::CommandBuffer& cb_from, vkt::Queue* queue_to, vkt::CommandBuffer& cb_to,
                             VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages,
-                            const VkBufferMemoryBarrier *buf_barrier, const VkImageMemoryBarrier *img_barrier) {
+                            const VkBufferMemoryBarrier* buf_barrier, const VkImageMemoryBarrier* img_barrier) {
     ValidOwnershipTransferOp(queue_from, cb_from, src_stages, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, buf_barrier, img_barrier);
     ValidOwnershipTransferOp(queue_to, cb_to, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, dst_stages, buf_barrier, img_barrier);
 }
 
-void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, const VkBufferMemoryBarrier2 *buf_barrier,
-                              const VkImageMemoryBarrier2 *img_barrier) {
+void ValidOwnershipTransferOp(vkt::Queue* queue, vkt::CommandBuffer& cb, const VkBufferMemoryBarrier2* buf_barrier,
+                              const VkImageMemoryBarrier2* img_barrier) {
     cb.Begin();
     VkDependencyInfo dep_info = vku::InitStructHelper();
     dep_info.bufferMemoryBarrierCount = (buf_barrier) ? 1 : 0;
@@ -281,8 +281,8 @@ void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, const V
     queue->Wait();
 }
 
-void ValidOwnershipTransfer(vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to, vkt::CommandBuffer &cb_to,
-                            const VkBufferMemoryBarrier2 *buf_barrier, const VkImageMemoryBarrier2 *img_barrier) {
+void ValidOwnershipTransfer(vkt::Queue* queue_from, vkt::CommandBuffer& cb_from, vkt::Queue* queue_to, vkt::CommandBuffer& cb_to,
+                            const VkBufferMemoryBarrier2* buf_barrier, const VkImageMemoryBarrier2* img_barrier) {
     VkBufferMemoryBarrier2 fixup_buf_barrier;
     VkImageMemoryBarrier2 fixup_img_barrier;
     if (buf_barrier) {

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -1,7 +1,7 @@
 ﻿/*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ struct SwapchainBuffers {
 // EX input:
 //  export VK_DRIVER_FILES=/intel.json:/amd.json
 //  set VK_DRIVER_FILES=\nvidia.json;\mesa.json
-static std::vector<std::string> GetVkEnvironmentVariable(const char *env_var) {
+static std::vector<std::string> GetVkEnvironmentVariable(const char* env_var) {
     const std::string str = GetEnvironment(env_var);
     if (str.empty()) {
         return {};
@@ -73,9 +73,9 @@ static std::vector<std::string> GetVkEnvironmentVariable(const char *env_var) {
 }
 
 static void CheckAndSetEnvironmentVariables() {
-    for (const char *env_var : {"VK_DRIVER_FILES", "VK_ICD_FILENAMES"}) {
+    for (const char* env_var : {"VK_DRIVER_FILES", "VK_ICD_FILENAMES"}) {
         const std::vector<std::string> driver_files = GetVkEnvironmentVariable(env_var);
-        for (const std::string &driver_file : driver_files) {
+        for (const std::string& driver_file : driver_files) {
             const std::filesystem::path icd_file(driver_file);
             // TODO: Error check relative paths (platform dependent)
             if (icd_file.is_relative()) {
@@ -92,7 +92,7 @@ static void CheckAndSetEnvironmentVariables() {
                     std::exit(EXIT_FAILURE);
                 }
                 bool contains_json = false;
-                for (auto const &dir_entry : std::filesystem::directory_iterator{icd_file}) {
+                for (auto const& dir_entry : std::filesystem::directory_iterator{icd_file}) {
                     if (dir_entry.path().extension() == ".json") {
                         contains_json = true;
                     }
@@ -120,12 +120,12 @@ static void CheckAndSetEnvironmentVariables() {
     bool found_json = false;
     bool vk_layer_env_vars_present = false;
     std::ostringstream error_log;  // Build up error log in case the validation json cannot be found
-    for (const char *env_var : {"VK_LAYER_PATH", "VK_ADD_LAYER_PATH"}) {
+    for (const char* env_var : {"VK_LAYER_PATH", "VK_ADD_LAYER_PATH"}) {
         const std::vector<std::string> vk_layer_paths = GetVkEnvironmentVariable(env_var);
         if (!vk_layer_paths.empty()) {
             vk_layer_env_vars_present = true;
         }
-        for (const std::string &vk_layer_path : vk_layer_paths) {
+        for (const std::string& vk_layer_path : vk_layer_paths) {
             const std::filesystem::path layer_path(vk_layer_path);
 
             if (!std::filesystem::exists(layer_path)) {
@@ -134,7 +134,7 @@ static void CheckAndSetEnvironmentVariables() {
             }
 
             if (std::filesystem::is_directory(layer_path)) {
-                for (auto const &dir_entry : std::filesystem::directory_iterator{layer_path}) {
+                for (auto const& dir_entry : std::filesystem::directory_iterator{layer_path}) {
                     if (dir_entry.path().filename() == "VkLayer_khronos_validation.json") {
                         if (std::filesystem::exists(dir_entry)) {
                             found_json = true;
@@ -180,16 +180,16 @@ bool WaylandContext::Init() {
         return false;
     }
 
-    auto global = [](void *data, struct wl_registry *registry, uint32_t id, const char *interface, uint32_t version) {
+    auto global = [](void* data, struct wl_registry* registry, uint32_t id, const char* interface, uint32_t version) {
         (void)version;
         const std::string_view interface_str = interface;
         if (interface_str == "wl_compositor") {
-            auto compositor = reinterpret_cast<wl_compositor **>(data);
-            *compositor = reinterpret_cast<wl_compositor *>(wl_registry_bind(registry, id, &wl_compositor_interface, 1));
+            auto compositor = reinterpret_cast<wl_compositor**>(data);
+            *compositor = reinterpret_cast<wl_compositor*>(wl_registry_bind(registry, id, &wl_compositor_interface, 1));
         }
     };
 
-    auto global_remove = [](void *data, struct wl_registry *registry, uint32_t id) {
+    auto global_remove = [](void* data, struct wl_registry* registry, uint32_t id) {
         (void)data;
         (void)registry;
         (void)id;
@@ -250,7 +250,7 @@ void TestEnvironment::SetUp() {
 
 void TestEnvironment::TearDown() { glslang::FinalizeProcess(); }
 
-void VkTestFramework::InitArgs(int *argc, char *argv[]) {
+void VkTestFramework::InitArgs(int* argc, char* argv[]) {
     for (int i = 1; i < *argc; ++i) {
         const std::string_view current_argument = argv[i];
         if (current_argument == "--print-vu") {

--- a/tests/framework/thread_helper.cpp
+++ b/tests/framework/thread_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ void ThreadTimeoutHelper::OnThreadDone() {
 }
 
 #if GTEST_IS_THREADSAFE
-void AddToCommandBuffer(ThreadTestData *data) {
+void AddToCommandBuffer(ThreadTestData* data) {
     for (int i = 0; i < 80000; i++) {
         vk::CmdSetEvent(data->commandBuffer, data->event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
         if (*data->bailout) {
@@ -45,7 +45,7 @@ void AddToCommandBuffer(ThreadTestData *data) {
     }
 }
 
-void UpdateDescriptor(ThreadTestData *data) {
+void UpdateDescriptor(ThreadTestData* data) {
     VkDescriptorBufferInfo buffer_info = {};
     buffer_info.buffer = data->buffer;
     buffer_info.offset = 0;
@@ -68,7 +68,7 @@ void UpdateDescriptor(ThreadTestData *data) {
 
 #endif  // GTEST_IS_THREADSAFE
 
-void ReleaseNullFence(ThreadTestData *data) {
+void ReleaseNullFence(ThreadTestData* data) {
     for (int i = 0; i < 40000; i++) {
         vk::DestroyFence(data->device, VK_NULL_HANDLE, NULL);
         if (*data->bailout) {

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -752,7 +752,8 @@ static VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBuff
     unique_lock_t lock(global_lock);
     *pBuffer = (VkBuffer)global_unique_handle++;
     // Some address for RTX need to be aligned to 256
-    if (pCreateInfo->usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT || pCreateInfo->usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) {
+    if (pCreateInfo->usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT ||
+        pCreateInfo->usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) {
         const uint64_t rtx_alignment = current_available_address % 256;
         if (rtx_alignment != 0) {
             current_available_address += (256 - rtx_alignment);
@@ -865,8 +866,7 @@ static VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2(VkDevice device, c
 }
 
 static VKAPI_ATTR void VKAPI_CALL GetTensorMemoryRequirementsARM(VkDevice device, const VkTensorMemoryRequirementsInfoARM* pInfo,
-                                                                 VkMemoryRequirements2* pMemoryRequirements)
-{
+                                                                 VkMemoryRequirements2* pMemoryRequirements) {
     VkMemoryRequirements& memReq = pMemoryRequirements->memoryRequirements;
     memReq.size = 1024;
     memReq.alignment = 32;
@@ -1421,12 +1421,9 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(VkPhysicalD
 
     if (auto* tensor_props = vku::FindStructInPNextChain<VkTensorFormatPropertiesARM>(pFormatProperties->pNext)) {
         constexpr VkFormatFeatureFlagBits2 tensor_flags =
-            VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT |
-            VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
-            VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM |
-            VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM |
-            VK_FORMAT_FEATURE_2_TENSOR_IMAGE_ALIASING_BIT_ARM |
-            VK_FORMAT_FEATURE_2_TENSOR_DATA_GRAPH_BIT_ARM;
+            VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT |
+            VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM | VK_FORMAT_FEATURE_2_TENSOR_SHADER_BIT_ARM |
+            VK_FORMAT_FEATURE_2_TENSOR_IMAGE_ALIASING_BIT_ARM | VK_FORMAT_FEATURE_2_TENSOR_DATA_GRAPH_BIT_ARM;
         tensor_props->linearTilingTensorFeatures = tensor_flags;
         tensor_props->optimalTilingTensorFeatures = tensor_flags;
     }
@@ -1435,7 +1432,6 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(VkPhysicalD
 static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalTensorPropertiesARM(
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalTensorInfoARM* pExternalTensorInfo,
     VkExternalTensorPropertiesARM* pExternalTensorProperties) {
-
     constexpr VkExternalMemoryHandleTypeFlags supported_flags = VK_EXTERNAL_MEMORY_HANDLE_TYPE_FLAG_BITS_MAX_ENUM;
     if (pExternalTensorInfo->handleType & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) {
         // Can't have dedicated memory with AHB
@@ -1454,16 +1450,18 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalTensorPropertiesARM(
     }
 }
 
-static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, uint32_t *pQueueFamilyDataGraphPropertyCount, VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties) {
-
+static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+    VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, uint32_t* pQueueFamilyDataGraphPropertyCount,
+    VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties) {
     // TODO: Need a way for test to decide to support or not support various engines
 
     if (pQueueFamilyDataGraphProperties == nullptr) {
         *pQueueFamilyDataGraphPropertyCount = 1;
     } else {
         pQueueFamilyDataGraphProperties[0].sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM;
-        pQueueFamilyDataGraphProperties[0].engine = { VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM, false };
-        pQueueFamilyDataGraphProperties[0].operation = { VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM, "TOSA.001000.1", 0 };
+        pQueueFamilyDataGraphProperties[0].engine = {VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM, false};
+        pQueueFamilyDataGraphProperties[0].operation = {
+            VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM, "TOSA.001000.1", 0};
     }
     return VK_SUCCESS;
 }
@@ -1967,16 +1965,17 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPipelineBinaryDataKHR(VkDevice device, 
     return VK_SUCCESS;
 }
 
-static VKAPI_ATTR void VKAPI_CALL GetPartitionedAccelerationStructuresBuildSizesNV(VkDevice device,
-                                                                                    const VkPartitionedAccelerationStructureInstancesInputNV* pInfo,
-                                                                                    VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo) {
+static VKAPI_ATTR void VKAPI_CALL
+GetPartitionedAccelerationStructuresBuildSizesNV(VkDevice device, const VkPartitionedAccelerationStructureInstancesInputNV* pInfo,
+                                                 VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo) {
     // value from real running test
     pSizeInfo->accelerationStructureSize = 1062400;
     pSizeInfo->updateScratchSize = 4;
     pSizeInfo->buildScratchSize = 388480;
 }
 
-static VKAPI_ATTR void VKAPI_CALL GetClusterAccelerationStructureBuildSizesNV(VkDevice device, const VkClusterAccelerationStructureInputInfoNV* pInfo, VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo){
+static VKAPI_ATTR void VKAPI_CALL GetClusterAccelerationStructureBuildSizesNV(
+    VkDevice device, const VkClusterAccelerationStructureInputInfoNV* pInfo, VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo) {
     pSizeInfo->accelerationStructureSize = 256;
     pSizeInfo->buildScratchSize = 256;
     pSizeInfo->updateScratchSize = 4;

--- a/tests/layers/device_profile_api.cpp
+++ b/tests/layers/device_profile_api.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,18 +47,18 @@ struct layer_data {
     VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props;
 };
 
-static std::unordered_map<void *, layer_data *> device_profile_api_dev_data_map;
+static std::unordered_map<void*, layer_data*> device_profile_api_dev_data_map;
 
 // For the given data key, look up the layer_data instance from given layer_data_map
 template <typename DATA_T>
-DATA_T *GetLayerDataPtr(void *data_key, std::unordered_map<void *, DATA_T *> &layer_data_map) {
-    DATA_T *debug_data;
+DATA_T* GetLayerDataPtr(void* data_key, std::unordered_map<void*, DATA_T*>& layer_data_map) {
+    DATA_T* debug_data;
     /* TODO: We probably should lock here, or have caller lock */
     auto got = layer_data_map.find(data_key);
 
     if (got == layer_data_map.end()) {
         debug_data = new DATA_T;
-        layer_data_map[(void *)data_key] = debug_data;
+        layer_data_map[(void*)data_key] = debug_data;
     } else {
         debug_data = got->second;
     }
@@ -67,7 +67,7 @@ DATA_T *GetLayerDataPtr(void *data_key, std::unordered_map<void *, DATA_T *> &la
 }
 
 template <typename DATA_T>
-void FreeLayerDataPtr(void *data_key, std::unordered_map<void *, DATA_T *> &layer_data_map) {
+void FreeLayerDataPtr(void* data_key, std::unordered_map<void*, DATA_T*>& layer_data_map) {
     auto got = layer_data_map.find(data_key);
     assert(got != layer_data_map.end());
 
@@ -76,50 +76,50 @@ void FreeLayerDataPtr(void *data_key, std::unordered_map<void *, DATA_T *> &laye
 }
 
 // device_profile_api Layer EXT APIs
-typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceLimitsEXT)(VkPhysicalDevice physicalDevice,
-                                                                  const VkPhysicalDeviceLimits *limits);
-typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceLimitsEXT)(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceLimits *newLimits);
-typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT)(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                                            const VkFormatProperties *properties);
-typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFormatPropertiesEXT)(VkPhysicalDevice physicalDevice, VkFormat format,
+typedef void(VKAPI_PTR* PFN_vkGetOriginalPhysicalDeviceLimitsEXT)(VkPhysicalDevice physicalDevice,
+                                                                  const VkPhysicalDeviceLimits* limits);
+typedef void(VKAPI_PTR* PFN_vkSetPhysicalDeviceLimitsEXT)(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceLimits* newLimits);
+typedef void(VKAPI_PTR* PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT)(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                                            const VkFormatProperties* properties);
+typedef void(VKAPI_PTR* PFN_vkSetPhysicalDeviceFormatPropertiesEXT)(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                     const VkFormatProperties newProperties);
-typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT)(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                                             const VkFormatProperties2 *properties);
-typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFormatProperties2EXT)(VkPhysicalDevice physicalDevice, VkFormat format,
+typedef void(VKAPI_PTR* PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT)(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                                             const VkFormatProperties2* properties);
+typedef void(VKAPI_PTR* PFN_vkSetPhysicalDeviceFormatProperties2EXT)(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                      const VkFormatProperties2 newProperties);
-typedef void(VKAPI_PTR *PFN_vkGetOriginalPhysicalDeviceFeaturesEXT)(VkPhysicalDevice physicalDevice,
-                                                                    const VkPhysicalDeviceFeatures *features);
-typedef void(VKAPI_PTR *PFN_vkSetPhysicalDeviceFeaturesEXT)(VkPhysicalDevice physicalDevice, const VkFormatProperties2 newFeatures);
-typedef void(VKAPI_PTR *PFN_VkSetPhysicalDeviceProperties2EXT)(VkPhysicalDevice physicalDevice,
+typedef void(VKAPI_PTR* PFN_vkGetOriginalPhysicalDeviceFeaturesEXT)(VkPhysicalDevice physicalDevice,
+                                                                    const VkPhysicalDeviceFeatures* features);
+typedef void(VKAPI_PTR* PFN_vkSetPhysicalDeviceFeaturesEXT)(VkPhysicalDevice physicalDevice, const VkFormatProperties2 newFeatures);
+typedef void(VKAPI_PTR* PFN_VkSetPhysicalDeviceProperties2EXT)(VkPhysicalDevice physicalDevice,
                                                                const VkPhysicalDeviceProperties2 newProperties);
 
-VKAPI_ATTR void VKAPI_CALL GetOriginalPhysicalDeviceLimitsEXT(VkPhysicalDevice physicalDevice, VkPhysicalDeviceLimits *orgLimits) {
+VKAPI_ATTR void VKAPI_CALL GetOriginalPhysicalDeviceLimitsEXT(VkPhysicalDevice physicalDevice, VkPhysicalDeviceLimits* orgLimits) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
-    layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
     VkPhysicalDeviceProperties props;
     instance_data->dispatch_table.GetPhysicalDeviceProperties(physicalDevice, &props);
     memcpy(orgLimits, &props.limits, sizeof(VkPhysicalDeviceLimits));
 }
 
-VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceLimitsEXT(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceLimits *newLimits) {
+VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceLimitsEXT(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceLimits* newLimits) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
     memcpy(&(phy_dev_data->phy_device_props.limits), newLimits, sizeof(VkPhysicalDeviceLimits));
 }
 
 VKAPI_ATTR void VKAPI_CALL GetOriginalPhysicalDeviceFormatPropertiesEXT(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                                        VkFormatProperties *properties) {
+                                                                        VkFormatProperties* properties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
-    layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
     instance_data->dispatch_table.GetPhysicalDeviceFormatProperties(physicalDevice, format, properties);
 }
 
 VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceFormatPropertiesEXT(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                 const VkFormatProperties newProperties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
 
     memcpy(&(phy_dev_data->format_properties_map[format]), &newProperties, sizeof(VkFormatProperties));
 
@@ -133,37 +133,37 @@ VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceFormatPropertiesEXT(VkPhysicalDevice
 }
 
 VKAPI_ATTR void VKAPI_CALL GetOriginalPhysicalDeviceFormatProperties2EXT(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                                         VkFormatProperties2 *properties) {
+                                                                         VkFormatProperties2* properties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
-    layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
     instance_data->dispatch_table.GetPhysicalDeviceFormatProperties2(physicalDevice, format, properties);
 }
 
 VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceFormatProperties2EXT(VkPhysicalDevice physicalDevice, VkFormat format,
                                                                  const VkFormatProperties2 newProperties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
 
     memcpy(&(phy_dev_data->format_properties_map[format]), &(newProperties.formatProperties), sizeof(VkFormatProperties));
-    VkFormatProperties3 *fmt_props_3 = vku::FindStructInPNextChain<VkFormatProperties3>(newProperties.pNext);
+    VkFormatProperties3* fmt_props_3 = vku::FindStructInPNextChain<VkFormatProperties3>(newProperties.pNext);
     if (fmt_props_3) {
         memcpy(&(phy_dev_data->format_properties3_map[format]), fmt_props_3, sizeof(VkFormatProperties3));
     }
 }
 
 VKAPI_ATTR void VKAPI_CALL GetOriginalPhysicalDeviceFeaturesEXT(VkPhysicalDevice physicalDevice,
-                                                                VkPhysicalDeviceFeatures *features) {
+                                                                VkPhysicalDeviceFeatures* features) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
-    layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
     instance_data->dispatch_table.GetPhysicalDeviceFeatures(physicalDevice, features);
 }
 
 VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceFeaturesEXT(VkPhysicalDevice physicalDevice,
                                                         const VkPhysicalDeviceFeatures newFeatures) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
 
     memcpy(&phy_dev_data->phy_device_features, &newFeatures, sizeof(VkPhysicalDeviceFeatures));
 }
@@ -171,29 +171,29 @@ VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceFeaturesEXT(VkPhysicalDevice physica
 VKAPI_ATTR void VKAPI_CALL SetPhysicalDeviceProperties2EXT(VkPhysicalDevice physicalDevice,
                                                            const VkPhysicalDeviceProperties2 newProperties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
 
     // Will let GetPhysicalDeviceProperties2 know changes were added
     phy_dev_data->modify_properties2 = true;
 
-    VkBaseOutStructure *next = reinterpret_cast<VkBaseOutStructure *>(newProperties.pNext);
+    VkBaseOutStructure* next = reinterpret_cast<VkBaseOutStructure*>(newProperties.pNext);
     while (next != nullptr) {
         switch (next->sType) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT: {
-                auto *props = reinterpret_cast<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *>(next);
+                auto* props = reinterpret_cast<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(next);
                 phy_dev_data->blend_operation_advanced_props = *props;
                 break;
             }
             default:
                 break;
         }
-        next = reinterpret_cast<VkBaseOutStructure *>(next->pNext);
+        next = reinterpret_cast<VkBaseOutStructure*>(next->pNext);
     }
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                              VkInstance *pInstance) {
-    VkLayerInstanceCreateInfo *chain_info = GetChainInfo(pCreateInfo, VK_LAYER_LINK_INFO);
+VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                              VkInstance* pInstance) {
+    VkLayerInstanceCreateInfo* chain_info = GetChainInfo(pCreateInfo, VK_LAYER_LINK_INFO);
     std::lock_guard<std::mutex> lock(global_lock);
 
     assert(chain_info->u.pLayerInfo);
@@ -207,7 +207,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     VkResult result = fp_create_instance(pCreateInfo, pAllocator, pInstance);
     if (result != VK_SUCCESS) return result;
 
-    layer_data *instance_data = GetLayerDataPtr(*pInstance, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(*pInstance, device_profile_api_dev_data_map);
     instance_data->instance = *pInstance;
     layer_init_instance_dispatch_table(*pInstance, &instance_data->dispatch_table, fp_get_instance_proc_addr);
     instance_data->dispatch_table.GetPhysicalDeviceProcAddr =
@@ -221,7 +221,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     if (result != VK_SUCCESS) return result;
 
     for (VkPhysicalDevice physical_device : physical_devices) {
-        layer_data *phy_dev_data = GetLayerDataPtr(physical_device, device_profile_api_dev_data_map);
+        layer_data* phy_dev_data = GetLayerDataPtr(physical_device, device_profile_api_dev_data_map);
         instance_data->dispatch_table.GetPhysicalDeviceProperties(physical_device, &phy_dev_data->phy_device_props);
         instance_data->dispatch_table.GetPhysicalDeviceFeatures(physical_device, &phy_dev_data->phy_device_features);
         phy_dev_data->instance = *pInstance;
@@ -229,8 +229,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     return result;
 }
 
-VKAPI_ATTR void VKAPI_CALL DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
-    layer_data *instance_data = GetLayerDataPtr(instance, device_profile_api_dev_data_map);
+VKAPI_ATTR void VKAPI_CALL DestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator) {
+    layer_data* instance_data = GetLayerDataPtr(instance, device_profile_api_dev_data_map);
     if (!instance_data) {
         return;
     }
@@ -250,16 +250,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(VkInstance instance, const VkAllocati
     FreeLayerDataPtr(instance, device_profile_api_dev_data_map);
 }
 
-VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties *pProperties) {
+VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties* pProperties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
     memcpy(pProperties, &phy_dev_data->phy_device_props, sizeof(VkPhysicalDeviceProperties));
 }
 
-VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2 *pProperties) {
+VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2* pProperties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
-    layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
     // Get original value and then update each pNext needed
     instance_data->dispatch_table.GetPhysicalDeviceProperties2(physicalDevice, pProperties);
     if (!phy_dev_data->modify_properties2) {
@@ -267,12 +267,12 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(VkPhysicalDevice physica
     }
 
     // Always save the original pNext and just update the values
-    VkBaseOutStructure *next = reinterpret_cast<VkBaseOutStructure *>(pProperties->pNext);
+    VkBaseOutStructure* next = reinterpret_cast<VkBaseOutStructure*>(pProperties->pNext);
     while (next != nullptr) {
         switch (next->sType) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT: {
-                auto *props = reinterpret_cast<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *>(next);
-                void *original_next = next->pNext;
+                auto* props = reinterpret_cast<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(next);
+                void* original_next = next->pNext;
                 *props = phy_dev_data->blend_operation_advanced_props;
                 props->pNext = original_next;
                 break;
@@ -280,15 +280,15 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(VkPhysicalDevice physica
             default:
                 break;
         }
-        next = reinterpret_cast<VkBaseOutStructure *>(next->pNext);
+        next = reinterpret_cast<VkBaseOutStructure*>(next->pNext);
     }
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                             VkFormatProperties *pProperties) {
+                                                             VkFormatProperties* pProperties) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
-    layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
     auto device_format_map_it = phy_dev_data->format_properties_map.find(format);
     if (device_format_map_it != phy_dev_data->format_properties_map.end()) {
         memcpy(pProperties, &phy_dev_data->format_properties_map[format], sizeof(VkFormatProperties));
@@ -298,14 +298,14 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(VkPhysicalDevice ph
 }
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(VkPhysicalDevice physicalDevice, VkFormat format,
-                                                              VkFormatProperties2 *pProperties) {
-    VkFormatProperties3 *fmt_props_3 = vku::FindStructInPNextChain<VkFormatProperties3>(pProperties->pNext);
+                                                              VkFormatProperties2* pProperties) {
+    VkFormatProperties3* fmt_props_3 = vku::FindStructInPNextChain<VkFormatProperties3>(pProperties->pNext);
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
-    layer_data *instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* instance_data = GetLayerDataPtr(phy_dev_data->instance, device_profile_api_dev_data_map);
     auto device_format_map_it = phy_dev_data->format_properties_map.find(format);
     if (device_format_map_it != phy_dev_data->format_properties_map.end()) {
-        memcpy((void *)&(pProperties->formatProperties), &phy_dev_data->format_properties_map[format], sizeof(VkFormatProperties));
+        memcpy((void*)&(pProperties->formatProperties), &phy_dev_data->format_properties_map[format], sizeof(VkFormatProperties));
         if (fmt_props_3) {
             memcpy(fmt_props_3, &phy_dev_data->format_properties3_map[format], sizeof(VkFormatProperties3));
         }
@@ -314,21 +314,21 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(VkPhysicalDevice p
     }
 }
 
-VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures *pFeatures) {
+VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures* pFeatures) {
     std::lock_guard<std::mutex> lock(global_lock);
-    layer_data *phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
+    layer_data* phy_dev_data = GetLayerDataPtr(physicalDevice, device_profile_api_dev_data_map);
     memcpy(pFeatures, &phy_dev_data->phy_device_features, sizeof(VkPhysicalDeviceFeatures));
 }
 
 static const VkLayerProperties device_profile_api_LayerProps = {
     "VK_LAYER_LUNARG_device_profile_api",
-    VK_HEADER_VERSION_COMPLETE,             // specVersion
-    1,                                      // implementationVersion
+    VK_HEADER_VERSION_COMPLETE,  // specVersion
+    1,                           // implementationVersion
     "LunarG device profile api Layer",
 };
 
 template <typename T>
-VkResult EnumerateProperties(uint32_t src_count, const T *src_props, uint32_t *dst_count, T *dst_props) {
+VkResult EnumerateProperties(uint32_t src_count, const T* src_props, uint32_t* dst_count, T* dst_props) {
     if (!dst_props || !src_props) {
         *dst_count = src_count;
         return VK_SUCCESS;
@@ -341,19 +341,19 @@ VkResult EnumerateProperties(uint32_t src_count, const T *src_props, uint32_t *d
     return (copy_count == src_count) ? VK_SUCCESS : VK_INCOMPLETE;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceLayerProperties(uint32_t* pCount, VkLayerProperties* pProperties) {
     return EnumerateProperties(1, &device_profile_api_LayerProps, pCount, pProperties);
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
-                                                                    VkExtensionProperties *pProperties) {
+VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pCount,
+                                                                    VkExtensionProperties* pProperties) {
     if (pLayerName && !strcmp(pLayerName, device_profile_api_LayerProps.layerName)) {
         return EnumerateProperties<VkExtensionProperties>(0, NULL, pCount, pProperties);
     }
     return VK_ERROR_LAYER_NOT_PRESENT;
 }
 
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance instance, const char *name) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance instance, const char* name) {
     if (!strcmp(name, "vkSetPhysicalDeviceLimitsEXT")) return (PFN_vkVoidFunction)SetPhysicalDeviceLimitsEXT;
     if (!strcmp(name, "vkGetOriginalPhysicalDeviceLimitsEXT")) return (PFN_vkVoidFunction)GetOriginalPhysicalDeviceLimitsEXT;
     if (!strcmp(name, "vkSetPhysicalDeviceFormatPropertiesEXT")) return (PFN_vkVoidFunction)SetPhysicalDeviceFormatPropertiesEXT;
@@ -365,13 +365,13 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance in
     if (!strcmp(name, "vkGetOriginalPhysicalDeviceFeaturesEXT")) return (PFN_vkVoidFunction)GetOriginalPhysicalDeviceFeaturesEXT;
     if (!strcmp(name, "vkSetPhysicalDeviceFeaturesEXT")) return (PFN_vkVoidFunction)SetPhysicalDeviceFeaturesEXT;
     if (!strcmp(name, "vkSetPhysicalDeviceProperties2EXT")) return (PFN_vkVoidFunction)SetPhysicalDeviceProperties2EXT;
-    layer_data *instance_data = GetLayerDataPtr(instance, device_profile_api_dev_data_map);
-    auto &table = instance_data->dispatch_table;
+    layer_data* instance_data = GetLayerDataPtr(instance, device_profile_api_dev_data_map);
+    auto& table = instance_data->dispatch_table;
     if (!table.GetPhysicalDeviceProcAddr) return nullptr;
     return table.GetPhysicalDeviceProcAddr(instance, name);
 }
 
-VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char *name) {
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char* name) {
     if (!strcmp(name, "vkCreateInstance")) return (PFN_vkVoidFunction)CreateInstance;
     if (!strcmp(name, "vkDestroyInstance")) return (PFN_vkVoidFunction)DestroyInstance;
     if (!strcmp(name, "vkGetPhysicalDeviceProperties")) return (PFN_vkVoidFunction)GetPhysicalDeviceProperties;
@@ -397,8 +397,8 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
     if (!strcmp(name, "vkSetPhysicalDeviceProperties2EXT")) return (PFN_vkVoidFunction)SetPhysicalDeviceProperties2EXT;
     if (!strcmp(name, "vk_layerGetPhysicalDeviceProcAddr")) return (PFN_vkVoidFunction)GetPhysicalDeviceProcAddr;
     assert(instance);
-    layer_data *instance_data = GetLayerDataPtr(instance, device_profile_api_dev_data_map);
-    auto &table = instance_data->dispatch_table;
+    layer_data* instance_data = GetLayerDataPtr(instance, device_profile_api_dev_data_map);
+    auto& table = instance_data->dispatch_table;
     if (!table.GetInstanceProcAddr) return nullptr;
     return table.GetInstanceProcAddr(instance, name);
 }
@@ -415,24 +415,24 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance
 // for consistency across platforms that don't accept those linker options.
 extern "C" {
 
-VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t *pCount, VkLayerProperties *pProperties) {
+VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pCount, VkLayerProperties* pProperties) {
     return device_profile_api::EnumerateInstanceLayerProperties(pCount, pProperties);
 }
 
-VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
-                                                                                 VkExtensionProperties *pProperties) {
+VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pCount,
+                                                                                 VkExtensionProperties* pProperties) {
     return device_profile_api::EnumerateInstanceExtensionProperties(pLayerName, pCount, pProperties);
 }
 
-VVL_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char *funcName) {
+VVL_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* funcName) {
     return device_profile_api::GetInstanceProcAddr(instance, funcName);
 }
 
-VVL_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance, const char *funcName) {
+VVL_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance instance, const char* funcName) {
     return device_profile_api::GetPhysicalDeviceProcAddr(instance, funcName);
 }
 
-VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface *pVersionStruct) {
+VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVersion(VkNegotiateLayerInterface* pVersionStruct) {
     assert(pVersionStruct != NULL);
     assert(pVersionStruct->sType == LAYER_NEGOTIATE_INTERFACE_STRUCT);
 

--- a/tests/stress/gpu_av_stress.cpp
+++ b/tests/stress/gpu_av_stress.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+/* Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ TEST_F(StressGpuAV, DescriptorIndexing) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     // send index to select in image array
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;  // index
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -109,7 +109,7 @@ TEST_F(StressGpuAV, DescriptorIndexing) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 2);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -306,7 +306,7 @@ TEST_F(StressGpuAV, DescriptorIndexingLoop) {
     TEST_DESCRIPTION("Show the GPU overhead of doing redundant checks inside a loop");
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (local_size_x = 256) in;
         layout(set = 0, binding = 0) buffer Data {

--- a/tests/stress/sync_val_stress.cpp
+++ b/tests/stress/sync_val_stress.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,8 +81,8 @@ TEST_F(StressSyncVal, CopyPagesInSmallChunks) {
     VkBufferCopy region = {0 /*src offset*/, 16 /*dst offset*/, 16 /*size*/};
 
     for (uint32_t page = 0; page < page_count; page++) {
-        vkt::CommandBuffer &command_buffer = command_buffers[page % 2];
-        vkt::Fence &fence = fences[page % 2];
+        vkt::CommandBuffer& command_buffer = command_buffers[page % 2];
+        vkt::Fence& fence = fences[page % 2];
         fence.Wait(kWaitTimeout);
         fence.Reset();
         command_buffer.Begin();
@@ -131,7 +131,7 @@ TEST_F(StressSyncVal, CopyPagesInSmallChunksNoQueueSync) {
     VkBufferCopy region = {0 /*src offset*/, 16 /*dst offset*/, 16 /*size*/};
 
     for (uint32_t page = 0; page < page_count; page++) {
-        vkt::CommandBuffer &command_buffer = command_buffers[page];
+        vkt::CommandBuffer& command_buffer = command_buffers[page];
         command_buffer.Begin();
         for (uint32_t copy = (page == 0) ? 1 : 0; copy < copies_per_page; copy++) {
             command_buffer.Barrier(barrier);

--- a/tests/undefined/core_undefined.cpp
+++ b/tests/undefined/core_undefined.cpp
@@ -29,7 +29,7 @@ TEST_F(UndefinedCore, BindInvalidPipelineLayout) {
     descriptor_set.UpdateDescriptorSets();
 
     // Create PSO to be used for draw-time errors below
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0, binding=1) uniform foo1 { vec4 y; };

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 #include "../framework/pipeline_helper.h"
 
 // Tests for AMD-specific best practices
-const char *kEnableAMDValidation = "validate_best_practices_amd";
+const char* kEnableAMDValidation = "validate_best_practices_amd";
 
 class VkAmdBestPracticesLayerTest : public VkBestPracticesLayerTest {};
 
@@ -556,7 +556,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSizeMaintenance5) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
         void main(){}

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -852,7 +852,7 @@ TEST_F(NegativeAndroidExternalResolve, MissingImageUsage) {
     image_ci.pNext = &external_format;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.format = VK_FORMAT_UNDEFINED;
-    image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT; // missing VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+    image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;  // missing VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
     vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -18,7 +18,7 @@
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 
 void AndroidExternalResolveTest::InitBasicAndroidExternalResolve() {
-    SetTargetApiVersion(VK_API_VERSION_1_2); // for RenderPass2
+    SetTargetApiVersion(VK_API_VERSION_1_2);  // for RenderPass2
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_FORMAT_RESOLVE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::externalFormatResolve);
     AddRequiredFeature(vkt::Feature::samplerYcbcrConversion);

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -263,8 +263,7 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageColor) {
     dedicated_allocation_info.image = image;
     dedicated_allocation_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&dedicated_allocation_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&dedicated_allocation_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -319,8 +318,7 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageDS) {
     dedicated_allocation_info.image = image;
     dedicated_allocation_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&dedicated_allocation_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&dedicated_allocation_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -374,8 +372,7 @@ TEST_F(NegativeAndroidHardwareBuffer, MipmapChainComplete) {
     dedicated_allocation_info.image = image;
     dedicated_allocation_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&dedicated_allocation_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&dedicated_allocation_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -476,8 +473,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ImageDimensions) {
     dedicated_allocation_info.image = image;
     dedicated_allocation_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&dedicated_allocation_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&dedicated_allocation_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -519,8 +515,7 @@ TEST_F(NegativeAndroidHardwareBuffer, UnknownFormat) {
     dedicated_allocation_info.image = image;
     dedicated_allocation_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&dedicated_allocation_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&dedicated_allocation_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -581,8 +576,7 @@ TEST_F(NegativeAndroidHardwareBuffer, GpuUsage) {
     dedicated_allocation_info.image = image;
     dedicated_allocation_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&dedicated_allocation_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&dedicated_allocation_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -764,7 +758,7 @@ TEST_F(NegativeAndroidHardwareBuffer, CreateImageView) {
     RETURN_IF_SKIP(Init());
 
     // Allocate an AHB and fetch its properties
-    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer* ahb = nullptr;
     AHardwareBuffer_Desc ahb_desc = {};
     ahb_desc.format = AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM;
     ahb_desc.usage = AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE;
@@ -794,10 +788,8 @@ TEST_F(NegativeAndroidHardwareBuffer, CreateImageView) {
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
     // Create another VkExternalFormatANDROID for test VUID-VkImageViewCreateInfo-image-02400
-    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props_Ycbcr =
-        vku::InitStructHelper();
-    VkAndroidHardwareBufferPropertiesANDROID ahb_props_Ycbcr =
-        vku::InitStructHelper(&ahb_fmt_props_Ycbcr);
+    VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props_Ycbcr = vku::InitStructHelper();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props_Ycbcr = vku::InitStructHelper(&ahb_fmt_props_Ycbcr);
     vk::GetAndroidHardwareBufferPropertiesANDROID(device(), ahb, &ahb_props_Ycbcr);
     AHardwareBuffer_release(ahb);
 
@@ -960,7 +952,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportBufferHandleType) {
 
     VkMemoryGetAndroidHardwareBufferInfoANDROID mgahbi = vku::InitStructHelper();
     mgahbi.memory = memory;
-    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer* ahb = nullptr;
     m_errorMonitor->SetDesiredError("VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-handleTypes-01882");
     vk::GetMemoryAndroidHardwareBufferANDROID(device(), &mgahbi, &ahb);
     m_errorMonitor->VerifyFound();
@@ -1049,7 +1041,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportImageNonBound) {
     mgahbi.memory = memory;
 
     m_errorMonitor->SetDesiredError("VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-pNext-01883");
-    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer* ahb = nullptr;
     vk::GetMemoryAndroidHardwareBufferANDROID(device(), &mgahbi, &ahb);
     m_errorMonitor->VerifyFound();
 }
@@ -1244,8 +1236,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ImportImageHandleType) {
     memory_dedicated_info.image = image;
     memory_dedicated_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&memory_dedicated_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&memory_dedicated_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = vku::InitStructHelper();

--- a/tests/unit/android_hardware_buffer_positive.cpp
+++ b/tests/unit/android_hardware_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,8 +101,7 @@ TEST_F(PositiveAndroidHardwareBuffer, DepthStencil) {
     memory_dedicated_info.image = ds_image;
     memory_dedicated_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&memory_dedicated_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&memory_dedicated_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -201,7 +200,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExportBuffer) {
     vk::BindBufferMemory(device(), buffer, memory, 0);
 
     // Export memory to AHB
-    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer* ahb = nullptr;
 
     VkMemoryGetAndroidHardwareBufferInfoANDROID get_ahb_info = vku::InitStructHelper();
     get_ahb_info.memory = memory;
@@ -259,7 +258,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExportImage) {
     vk::BindImageMemory(device(), image, memory, 0);
 
     // Export memory to AHB
-    AHardwareBuffer *ahb = nullptr;
+    AHardwareBuffer* ahb = nullptr;
 
     VkMemoryGetAndroidHardwareBufferInfoANDROID get_ahb_info = vku::InitStructHelper();
     get_ahb_info.memory = memory;
@@ -318,8 +317,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalImage) {
     memory_dedicated_info.image = image;
     memory_dedicated_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&memory_dedicated_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&memory_dedicated_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);
@@ -387,8 +385,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalCameraFormat) {
     memory_dedicated_info.image = image;
     memory_dedicated_info.buffer = VK_NULL_HANDLE;
 
-    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info =
-        vku::InitStructHelper(&memory_dedicated_info);
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper(&memory_dedicated_info);
     import_ahb_Info.buffer = ahb.handle();
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
 
     // Test StoreOp
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, rgba8) uniform image2D si0;
             void main() {
@@ -38,7 +38,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
 
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        auto info_override = [&](CreatePipelineHelper &info) {
+        auto info_override = [&](CreatePipelineHelper& info) {
             info.shader_stages_ = {vs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
             info.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
         };
@@ -48,7 +48,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
 
     // Test AtomicOp
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, r32f) uniform image2D si0;
             void main() {
@@ -58,7 +58,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
 
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL_TRY);
         if (VK_SUCCESS == vs.InitFromGLSLTry()) {
-            auto info_override = [&](CreatePipelineHelper &info) {
+            auto info_override = [&](CreatePipelineHelper& info) {
                 info.shader_stages_ = {vs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
                 info.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
             };
@@ -79,7 +79,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureDisable) {
 
     // Test StoreOp
     {
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, rgba8) uniform image2D si0;
             void main() {
@@ -89,7 +89,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureDisable) {
 
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto info_override = [&](CreatePipelineHelper &info) {
+        auto info_override = [&](CreatePipelineHelper& info) {
             info.shader_stages_ = {info.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             info.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
         };
@@ -99,7 +99,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureDisable) {
 
     // Test AtomicOp
     {
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, r32f) uniform image2D si0;
             void main() {
@@ -109,7 +109,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureDisable) {
 
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL_TRY);
         if (VK_SUCCESS == fs.InitFromGLSLTry()) {
-            auto info_override = [&](CreatePipelineHelper &info) {
+            auto info_override = [&](CreatePipelineHelper& info) {
                 info.shader_stages_ = {info.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
                 info.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
             };
@@ -126,7 +126,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureBuffer) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { int y; };
         void main() {
@@ -136,7 +136,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureBuffer) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    auto info_override = [&](CreatePipelineHelper &info) {
+    auto info_override = [&](CreatePipelineHelper& info) {
         info.shader_stages_ = {info.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         info.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     };
@@ -154,7 +154,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisableShaderObject) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D si0;
         void main() {
@@ -386,7 +386,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime64) {
     vkt::ImageView view = image.CreateView();
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -427,7 +427,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
     vkt::ImageView view = image.CreateView();
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -451,7 +451,7 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
     AddRequiredFeature(vkt::Feature::shaderImageInt64Atomics);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
         #extension GL_EXT_shader_image_int64 : enable
@@ -483,7 +483,7 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
     vkt::ImageView image_view = image.CreateView();
     pipe.descriptor_set_.WriteDescriptorImageInfo(1, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -507,7 +507,7 @@ TEST_F(NegativeAtomic, ImageInt64Mesh32) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -752,7 +752,9 @@ TEST_F(NegativeAtomic, Float) {
     }
 
     // shaderBufferFloat64Atomics (requires shaderFloat64)
-    {{m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
+    {
+        {
+            m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
             VkShaderObj cs(*m_device, cs_buffer_float_64_load.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
             m_errorMonitor->VerifyFound();
         }
@@ -1017,13 +1019,13 @@ TEST_F(NegativeAtomic, Float2With16bit) {
         }
     )glsl";
 
-     // clang-format on
+    // clang-format on
 
-     // shaderBufferFloat16Atomics
-     {
-         m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
-         VkShaderObj cs(*m_device, cs_buffer_float_16_load.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
-         m_errorMonitor->VerifyFound();
+    // shaderBufferFloat16Atomics
+    {
+        m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
+        VkShaderObj cs(*m_device, cs_buffer_float_16_load.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
+        m_errorMonitor->VerifyFound();
     }
     {
         m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
@@ -1213,7 +1215,7 @@ TEST_F(NegativeAtomic, Float2WidthMismatch) {
     )glsl";
     // clang-format on
 
-    const char *current_shader = nullptr;
+    const char* current_shader = nullptr;
     const auto set_info = [this, &current_shader](CreateComputePipelineHelper& helper) {
         helper.cs_ = VkShaderObj(*m_device, current_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3);
         helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
@@ -1337,7 +1339,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
     vkt::BufferView buffer_view(*m_device, buffer, buffer_view_format);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set = 0, binding = 3, r32f) uniform image2D si0;
         layout(set = 0, binding = 2, r32f) uniform image2D si1[2];
@@ -1474,7 +1476,7 @@ TEST_F(NegativeAtomic, VertexPipelineStoresAndAtomics) {
     //     float a;
     //     float b;
     // } data;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %o

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +57,8 @@ TEST_F(PositiveAtomic, ImageInt64) {
     )glsl";
     // clang-format on
 
-    const char *current_shader = nullptr;
-    const auto set_info = [&](CreateComputePipelineHelper &helper) {
+    const char* current_shader = nullptr;
+    const auto set_info = [&](CreateComputePipelineHelper& helper) {
         // Requires SPIR-V 1.3 for SPV_KHR_storage_buffer_storage_class
         helper.cs_ = VkShaderObj(*m_device, current_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -91,7 +91,7 @@ TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
     AddRequiredFeature(vkt::Feature::sparseResidencyImage2D);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
         #extension GL_EXT_shader_image_int64 : enable
@@ -119,7 +119,7 @@ TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
     vkt::ImageView image_view = image.CreateView();
     pipe.descriptor_set_.WriteDescriptorImageInfo(1, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -277,12 +277,12 @@ TEST_F(PositiveAtomic, Float) {
     )glsl";
     // clang-format on
 
-    const char *current_shader = nullptr;
+    const char* current_shader = nullptr;
     // set binding for buffer tests
     std::vector<VkDescriptorSetLayoutBinding> current_bindings = {
         {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
 
-    const auto set_info = [&](CreateComputePipelineHelper &helper) {
+    const auto set_info = [&](CreateComputePipelineHelper& helper) {
         // Requires SPIR-V 1.3 for SPV_KHR_storage_buffer_storage_class
         helper.cs_ = VkShaderObj(*m_device, current_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
         helper.dsl_bindings_ = current_bindings;
@@ -540,71 +540,71 @@ TEST_F(PositiveAtomic, Float2) {
            y = imageAtomicMax(z, ivec2(1, 1), y);
         }
     )glsl";
-     // clang-format on
+    // clang-format on
 
-     const char *current_shader = nullptr;
-     // set binding for buffer tests
-     std::vector<VkDescriptorSetLayoutBinding> current_bindings = {
-         {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    const char* current_shader = nullptr;
+    // set binding for buffer tests
+    std::vector<VkDescriptorSetLayoutBinding> current_bindings = {
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
 
-     const auto set_info = [&](CreateComputePipelineHelper &helper) {
-         // This could get triggered in the event that the shader fails to compile
-         m_errorMonitor->SetUnexpectedError("VUID-VkShaderModuleCreateInfo-pCode-08740");
-         // Requires SPIR-V 1.3 for SPV_KHR_storage_buffer_storage_class
-         helper.cs_ = VkShaderObj::CreateFromGLSL(this, current_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
-         // Skip the test if shader failed to compile
-         helper.override_skip_ = !static_cast<bool>(helper.cs_);
-         helper.dsl_bindings_ = current_bindings;
-     };
+    const auto set_info = [&](CreateComputePipelineHelper& helper) {
+        // This could get triggered in the event that the shader fails to compile
+        m_errorMonitor->SetUnexpectedError("VUID-VkShaderModuleCreateInfo-pCode-08740");
+        // Requires SPIR-V 1.3 for SPV_KHR_storage_buffer_storage_class
+        helper.cs_ = VkShaderObj::CreateFromGLSL(this, current_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
+        // Skip the test if shader failed to compile
+        helper.override_skip_ = !static_cast<bool>(helper.cs_);
+        helper.dsl_bindings_ = current_bindings;
+    };
 
-     if (float16int8_features.shaderFloat16 == VK_TRUE && storage_16_bit_features.storageBuffer16BitAccess == VK_TRUE) {
-         if (atomic_float2_features.shaderBufferFloat16Atomics == VK_TRUE) {
-             current_shader = cs_buffer_float_16_load.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+    if (float16int8_features.shaderFloat16 == VK_TRUE && storage_16_bit_features.storageBuffer16BitAccess == VK_TRUE) {
+        if (atomic_float2_features.shaderBufferFloat16Atomics == VK_TRUE) {
+            current_shader = cs_buffer_float_16_load.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
-             current_shader = cs_buffer_float_16_store.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+            current_shader = cs_buffer_float_16_store.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
-             current_shader = cs_buffer_float_16_exchange.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
-         }
+            current_shader = cs_buffer_float_16_exchange.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        }
 
-         if (atomic_float2_features.shaderBufferFloat16AtomicAdd == VK_TRUE) {
-             current_shader = cs_buffer_float_16_add.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
-         }
+        if (atomic_float2_features.shaderBufferFloat16AtomicAdd == VK_TRUE) {
+            current_shader = cs_buffer_float_16_add.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        }
 
-         if (atomic_float2_features.shaderBufferFloat16AtomicMinMax == VK_TRUE) {
-             current_shader = cs_buffer_float_16_min.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        if (atomic_float2_features.shaderBufferFloat16AtomicMinMax == VK_TRUE) {
+            current_shader = cs_buffer_float_16_min.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
-             current_shader = cs_buffer_float_16_max.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
-         }
+            current_shader = cs_buffer_float_16_max.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        }
 
-         if (atomic_float2_features.shaderSharedFloat16Atomics == VK_TRUE) {
-             current_shader = cs_shared_float_16_load.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        if (atomic_float2_features.shaderSharedFloat16Atomics == VK_TRUE) {
+            current_shader = cs_shared_float_16_load.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
-             current_shader = cs_shared_float_16_store.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+            current_shader = cs_shared_float_16_store.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
-             current_shader = cs_shared_float_16_exchange.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
-         }
+            current_shader = cs_shared_float_16_exchange.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        }
 
-         if (atomic_float2_features.shaderSharedFloat16AtomicAdd == VK_TRUE) {
-             current_shader = cs_shared_float_16_add.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
-         }
+        if (atomic_float2_features.shaderSharedFloat16AtomicAdd == VK_TRUE) {
+            current_shader = cs_shared_float_16_add.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        }
 
-         if (atomic_float2_features.shaderSharedFloat16AtomicMinMax == VK_TRUE) {
-             current_shader = cs_shared_float_16_min.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        if (atomic_float2_features.shaderSharedFloat16AtomicMinMax == VK_TRUE) {
+            current_shader = cs_shared_float_16_min.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
-             current_shader = cs_shared_float_16_max.c_str();
-             CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
-         }
+            current_shader = cs_shared_float_16_max.c_str();
+            CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+        }
     }
 
     if (atomic_float2_features.shaderBufferFloat32AtomicMinMax == VK_TRUE) {
@@ -661,7 +661,7 @@ TEST_F(PositiveAtomic, PhysicalPointer) {
     AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Int64
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Shader
@@ -763,8 +763,8 @@ TEST_F(PositiveAtomic, Int64) {
     )glsl";
     // clang-format on
 
-    const char *current_shader = nullptr;
-    const auto set_info = [&](CreateComputePipelineHelper &helper) {
+    const char* current_shader = nullptr;
+    const auto set_info = [&](CreateComputePipelineHelper& helper) {
         // Requires SPIR-V 1.3 for SPV_KHR_storage_buffer_storage_class
         helper.cs_ = VkShaderObj(*m_device, current_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
         helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
@@ -785,7 +785,7 @@ TEST_F(PositiveAtomic, Int64Shared) {
     AddRequiredExtensions(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_workgroup = R"glsl(
+    const char* cs_workgroup = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
         #extension GL_EXT_shader_atomic_int64 : enable
@@ -799,7 +799,7 @@ TEST_F(PositiveAtomic, Int64Shared) {
         }
     )glsl";
 
-    const auto set_info = [&](CreateComputePipelineHelper &helper) {
+    const auto set_info = [&](CreateComputePipelineHelper& helper) {
         // Requires SPIR-V 1.3 for SPV_KHR_storage_buffer_storage_class
         helper.cs_ = VkShaderObj(*m_device, cs_workgroup, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
         helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
@@ -832,7 +832,7 @@ TEST_F(PositiveAtomic, OpImageTexelPointerWithNoAtomic) {
     vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
              OpCapability Shader
              OpMemoryModel Logical GLSL450
              OpEntryPoint GLCompute %main "main"
@@ -864,7 +864,7 @@ TEST_F(PositiveAtomic, OpImageTexelPointerWithNoAtomic) {
     pipe.CreateComputePipeline();
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -919,8 +919,8 @@ TEST_F(PositiveAtomic, ImageFloat16Vector) {
     )glsl";
     // clang-format on
 
-    const char *current_shader = nullptr;
-    const auto set_info = [&](CreateComputePipelineHelper &helper) {
+    const char* current_shader = nullptr;
+    const auto set_info = [&](CreateComputePipelineHelper& helper) {
         // Requires SPIR-V 1.3 for SPV_KHR_storage_buffer_storage_class
         helper.cs_ = VkShaderObj(*m_device, current_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -946,7 +946,7 @@ TEST_F(PositiveAtomic, VertexPipelineStoresAndAtomics) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(set=0, binding=0, std430) readonly buffer SSBO {
             float a;

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -20,7 +20,7 @@
 #include "../framework/sync_helper.h"
 #include "../framework/thread_helper.h"
 
-void VkBestPracticesLayerTest::InitBestPracticesFramework(const char *vendor_checks_to_enable) {
+void VkBestPracticesLayerTest::InitBestPracticesFramework(const char* vendor_checks_to_enable) {
     const VkLayerSettingEXT settings = {OBJECT_LAYER_NAME, vendor_checks_to_enable, VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
     const VkLayerSettingsCreateInfoEXT layer_settings_create_info{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
                                                                   &settings};
@@ -619,7 +619,7 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     }
 
     bool fifo_present = false;
-    for (const auto &present_mode : m_surface_present_modes) {
+    for (const auto& present_mode : m_surface_present_modes) {
         if (present_mode == VK_PRESENT_MODE_FIFO_KHR) {
             fifo_present = true;
             break;
@@ -816,7 +816,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float x[2];
         void main(){
@@ -824,7 +824,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float x[1];
         layout(location=0) out vec4 color;
@@ -836,7 +836,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "WARNING-Shader-OutputNotConsumed");
@@ -850,7 +850,7 @@ TEST_F(VkBestPracticesLayerTest, WorkgroupSizeDeprecated) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -1252,9 +1252,9 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    vkt::Queue *graphics_queue = m_device->QueuesWithGraphicsCapability()[0];
+    vkt::Queue* graphics_queue = m_device->QueuesWithGraphicsCapability()[0];
 
-    vkt::Queue *compute_queue = nullptr;
+    vkt::Queue* compute_queue = nullptr;
     for (uint32_t i = 0; i < m_device->QueuesWithComputeCapability().size(); ++i) {
         auto cqi = m_device->QueuesWithComputeCapability()[i];
         if (cqi->family_index != graphics_queue->family_index) {
@@ -1320,7 +1320,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     // Prepare compute
 
-    const char *cs = R"glsl(#version 450
+    const char* cs = R"glsl(#version 450
     layout(local_size_x=1, local_size_y=1) in;
     layout(set=0, binding=0, rgba32f) uniform image2D img;
     void main(){
@@ -1337,7 +1337,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     vkt::CommandPool compute_pool(*m_device, compute_queue->family_index);
@@ -1665,7 +1665,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEnd) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { uint x[2]; } constants;
         void main(){
@@ -1707,7 +1707,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo {
             uint a; // set
@@ -1961,7 +1961,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEndCompute) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *const csSource = R"glsl(
+    const char* const csSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { uint x[2]; } constants;
         layout(set = 0, binding = 0) buffer bar { vec4 r; } res;

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, PushConstantSet) {
 
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { uint x[4]; } constants;
         void main(){
@@ -378,7 +378,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, CreateFifoRelaxedSwapchain) {
     }
 
     bool fifo_relaxed = false;
-    for (const auto &present_mode : m_surface_present_modes) {
+    for (const auto& present_mode : m_surface_present_modes) {
         if (present_mode == VK_PRESENT_MODE_FIFO_RELAXED_KHR) {
             fifo_relaxed = true;
             break;
@@ -497,7 +497,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, CreateDeviceWithFeatures) {
     VkPhysicalDeviceFeatures features;
     vk::GetPhysicalDeviceFeatures(gpu_, &features);
 
-    const char *portability_extension = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
+    const char* portability_extension = VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME;
 
     VkDeviceCreateInfo device_ci = vku::InitStructHelper();
     device_ci.queueCreateInfoCount = create_queue_infos.size();

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -146,7 +146,7 @@ TEST_F(NegativeBuffer, CreateBufferViewNoMemoryBoundToBuffer) {
 TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     TEST_DESCRIPTION("Attempt to create a buffer view with invalid create info.");
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     const VkDeviceSize min_alignment = dev_limits.minTexelBufferOffsetAlignment;
     if (min_alignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
@@ -220,7 +220,7 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoFeatures) {
     TEST_DESCRIPTION("Attempt to create a buffer view with invalid create info.");
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     const VkDeviceSize min_alignment = dev_limits.minTexelBufferOffsetAlignment;
     if (min_alignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
@@ -251,7 +251,7 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoFeatures) {
 
 TEST_F(NegativeBuffer, BufferViewMaxTexelBufferElements) {
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     // Create a new test buffer that is larger than VkPhysicalDeviceLimits::maxTexelBufferElements
     // The spec min max is just 64K, but some implementations support a much larger value than that.
     // Skip the test if the limit is very large to not allocate excessive amounts of memory.

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ TEST_F(PositiveBuffer, OwnershipTranfers) {
     TEST_DESCRIPTION("Valid buffer ownership transfers that shouldn't create errors");
     RETURN_IF_SKIP(Init());
 
-    vkt::Queue *no_gfx_queue = m_device->QueueWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
+    vkt::Queue* no_gfx_queue = m_device->QueueWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
     if (!no_gfx_queue) {
         GTEST_SKIP() << "Required queue not present (non-graphics capable required)";
     } else if ((m_device->Physical().queue_properties_[no_gfx_queue->family_index].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0) {
@@ -113,7 +113,7 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressWorstCase) {
     VkDeviceAddress ref_address = 0;
 
     for (size_t i = 0; i < N; ++i) {
-        vkt::Buffer &buffer = buffers[i];
+        vkt::Buffer& buffer = buffers[i];
         buffer_ci.size = (i + 1) * 4096;
         buffer.InitNoMemory(*m_device, buffer_ci);
         vk::BindBufferMemory(device(), buffer, buffer_memory, 0);
@@ -153,7 +153,7 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressGoodCase) {
     buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
     for (size_t i = 0; i < N; ++i) {
-        vkt::Buffer &buffer = buffers[i];
+        vkt::Buffer& buffer = buffers[i];
         buffer.InitNoMemory(*m_device, buffer_ci);
         // Consecutive offsets
         vk::BindBufferMemory(device(), buffer, buffer_memory, i * buffer_ci.size);

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -295,7 +295,7 @@ TEST_F(NegativeCommand, PushConstants) {
     // Check for invalid push constant ranges in pipeline layouts.
     struct PipelineLayoutTestCase {
         VkPushConstantRange const range;
-        const char *msg;
+        const char* msg;
     };
 
     const uint32_t too_big = m_device->Physical().limits_.maxPushConstantsSize + 0x4;
@@ -313,7 +313,7 @@ TEST_F(NegativeCommand, PushConstants) {
     }};
 
     // Check for invalid offset and size
-    for (const auto &iter : range_tests) {
+    for (const auto& iter : range_tests) {
         pc_range = iter.range;
         m_errorMonitor->SetDesiredError(iter.msg);
         vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
@@ -336,7 +336,7 @@ TEST_F(NegativeCommand, PushConstants) {
     const uint32_t ranges_per_test = 5;
     struct DuplicateStageFlagsTestCase {
         VkPushConstantRange const ranges[ranges_per_test];
-        std::vector<const char *> const msg;
+        std::vector<const char*> const msg;
     };
     // Overlapping ranges are OK, but a stage flag can appear only once.
     const std::array<DuplicateStageFlagsTestCase, 3> duplicate_stage_flags_tests = {
@@ -372,10 +372,10 @@ TEST_F(NegativeCommand, PushConstants) {
         },
     };
 
-    for (const auto &iter : duplicate_stage_flags_tests) {
+    for (const auto& iter : duplicate_stage_flags_tests) {
         pipeline_layout_ci.pPushConstantRanges = iter.ranges;
         pipeline_layout_ci.pushConstantRangeCount = ranges_per_test;
-        for (const auto &vuid : iter.msg) {
+        for (const auto& vuid : iter.msg) {
             m_errorMonitor->SetDesiredError(vuid);
         }
         vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
@@ -842,7 +842,7 @@ TEST_F(NegativeCommand, ExecuteCommandsPrimaryCB) {
 
 TEST_F(NegativeCommand, SimultaneousUseOneShot) {
     TEST_DESCRIPTION("Submit the same command buffer twice in one submit looking for simultaneous use and one time submit errors");
-    const char *simultaneous_use_message = "is already in use and is not marked for simultaneous use";
+    const char* simultaneous_use_message = "is already in use and is not marked for simultaneous use";
     RETURN_IF_SKIP(Init());
 
     VkCommandBuffer cmd_bufs[2];
@@ -889,7 +889,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -937,7 +937,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineFunction) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -993,7 +993,7 @@ TEST_F(NegativeCommand, DrawTimeImageComponentTypeMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform isampler2D s;
         layout(location=0) out vec4 color;
@@ -1383,7 +1383,7 @@ TEST_F(NegativeCommand, ResolveImageImageType) {
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.extent = {32, 1, 1};
     image_create_info.mipLevels = 1;
-    image_create_info.arrayLayers = 4;  // more than 1 to not trip other validation
+    image_create_info.arrayLayers = 4;                  // more than 1 to not trip other validation
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;  // guarantee support from sampledImageColorSampleCounts
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage =
@@ -2199,11 +2199,11 @@ TEST_F(NegativeCommand, ExclusiveScissorNV) {
 
         struct TestCase {
             uint32_t viewport_count;
-            VkViewport *viewports;
+            VkViewport* viewports;
             uint32_t scissor_count;
-            VkRect2D *scissors;
+            VkRect2D* scissors;
             uint32_t exclusive_scissor_count;
-            VkRect2D *exclusive_scissors;
+            VkRect2D* exclusive_scissors;
 
             std::vector<std::string> vuids;
         };
@@ -2229,11 +2229,10 @@ TEST_F(NegativeCommand, ExclusiveScissorNV) {
             {1, viewports, 1, scissors, 1, nullptr, {"VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04056"}},
         };
 
-        for (const auto &test_case : test_cases) {
-            VkPipelineViewportExclusiveScissorStateCreateInfoNV exc =
-                vku::InitStructHelper();
+        for (const auto& test_case : test_cases) {
+            VkPipelineViewportExclusiveScissorStateCreateInfoNV exc = vku::InitStructHelper();
 
-            const auto break_vp = [&test_case, &exc](CreatePipelineHelper &helper) {
+            const auto break_vp = [&test_case, &exc](CreatePipelineHelper& helper) {
                 helper.vp_state_ci_.viewportCount = test_case.viewport_count;
                 helper.vp_state_ci_.pViewports = test_case.viewports;
                 helper.vp_state_ci_.scissorCount = test_case.scissor_count;
@@ -2295,7 +2294,7 @@ TEST_F(NegativeCommand, ExclusiveScissorNV) {
             {{{0, vvl::kI32Max}, {16, 1}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"},
             {{{0, 0}, {16, uint32_t{vvl::kI32Max} + 1}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"}};
 
-        for (const auto &test_case : test_cases) {
+        for (const auto& test_case : test_cases) {
             m_errorMonitor->SetDesiredError(test_case.vuid.c_str());
             vk::CmdSetExclusiveScissorNV(m_command_buffer, 0, 1, &test_case.scissor);
             m_errorMonitor->VerifyFound();
@@ -2356,7 +2355,7 @@ TEST_F(NegativeCommand, ViewportWScalingNV) {
     vpci.scissorCount = vp_count;
     vpci.pScissors = sc.data();
 
-    const auto set_vpci = [&vpci](CreatePipelineHelper &helper) { helper.vp_state_ci_ = vpci; };
+    const auto set_vpci = [&vpci](CreatePipelineHelper& helper) { helper.vp_state_ci_ = vpci; };
 
     // Make sure no errors show up when creating the pipeline with w-scaling enabled
     CreatePipelineHelper::OneshotTest(*this, set_vpci, kErrorBit);
@@ -2569,7 +2568,7 @@ TEST_F(NegativeCommand, CmdUpdateBufferSize) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdUpdateBuffer-dataSize-00033");
     m_command_buffer.Begin();
-    vk::CmdUpdateBuffer(m_command_buffer, buffer, sizeof(uint32_t), data_size, (void *)update_data);
+    vk::CmdUpdateBuffer(m_command_buffer, buffer, sizeof(uint32_t), data_size, (void*)update_data);
     m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
@@ -2584,7 +2583,7 @@ TEST_F(NegativeCommand, CmdUpdateBufferDstOffset) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdUpdateBuffer-dstOffset-00032");
     m_command_buffer.Begin();
-    vk::CmdUpdateBuffer(m_command_buffer, buffer, sizeof(uint32_t) * 8, data_size, (void *)update_data);
+    vk::CmdUpdateBuffer(m_command_buffer, buffer, sizeof(uint32_t) * 8, data_size, (void*)update_data);
     m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
@@ -2842,7 +2841,7 @@ TEST_F(NegativeCommand, ResolveUsage) {
     TEST_DESCRIPTION("Resolve image with missing usage flags.");
 
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required VkSampleCountFlagBits are not supported; skipping";
     }
@@ -4103,7 +4102,7 @@ TEST_F(NegativeCommand, CommandBufferRecording) {
 TEST_F(NegativeCommand, ManyInvalidatedObjects) {
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO_0 {
             vec4 a;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -320,7 +320,7 @@ TEST_F(PositiveCommand, ThreadedCommandBuffersWithLabels) {
     constexpr int wait_time = 60;
     if (!timeout_helper.WaitForThreads(wait_time))
         ADD_FAILURE() << "The waiting time for the worker threads exceeded the maximum limit: " << wait_time << " seconds.";
-    for (auto &worker : workers) worker.join();
+    for (auto& worker : workers) worker.join();
 }
 
 TEST_F(PositiveCommand, ClearAttachmentsDepthStencil) {
@@ -531,7 +531,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchWithZeroExtend) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    const char *csSource = R"(
+    const char* csSource = R"(
                      OpCapability Shader
                      OpCapability StorageImageExtendedFormats
                      OpMemoryModel Logical GLSL450
@@ -574,7 +574,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchWithZeroExtend) {
     vkt::ImageView view = image.CreateView();
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -597,7 +597,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchRedundantExtend) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    const char *csSource = R"(
+    const char* csSource = R"(
                      OpCapability Shader
                      OpCapability StorageImageExtendedFormats
                      OpMemoryModel Logical GLSL450
@@ -642,7 +642,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchRedundantExtend) {
     vkt::ImageView view = image.CreateView();
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL);
+                                                  VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -738,11 +738,11 @@ TEST_F(PositiveCommand, CommandBufferInheritanceInfoIgnoredPointer) {
 
     const uint64_t fake_address_64 = 0xCDCDCDCDCDCDCDCD;
     const uint64_t fake_address_32 = 0xCDCDCDCD;
-    const void *undereferencable_pointer =
-        sizeof(void *) == 8 ? reinterpret_cast<void *>(fake_address_64) : reinterpret_cast<void *>(fake_address_32);
+    const void* undereferencable_pointer =
+        sizeof(void*) == 8 ? reinterpret_cast<void*>(fake_address_64) : reinterpret_cast<void*>(fake_address_32);
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    begin_info.pInheritanceInfo = reinterpret_cast<const VkCommandBufferInheritanceInfo *>(undereferencable_pointer);
+    begin_info.pInheritanceInfo = reinterpret_cast<const VkCommandBufferInheritanceInfo*>(undereferencable_pointer);
     m_command_buffer.Begin(&begin_info);
     m_command_buffer.End();
 }

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -581,7 +581,7 @@ TEST_F(NegativeCopyBufferImage, ImageLayerCountMismatch) {
     copy_region.dstOffset = {0, 0, 0};
     copy_region.extent = {1, 1, 1};
 
-    const char *vuid = (maintenance1 == true) ? "VUID-vkCmdCopyImage-srcImage-08793" : "VUID-VkImageCopy-apiVersion-07941";
+    const char* vuid = (maintenance1 == true) ? "VUID-vkCmdCopyImage-srcImage-08793" : "VUID-VkImageCopy-apiVersion-07941";
     m_errorMonitor->SetDesiredError(vuid);
     vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyFound();
@@ -4514,8 +4514,8 @@ TEST_F(NegativeCopyBufferImage, MemoryIndirect) {
     vk::CmdCopyMemoryIndirectKHR(m_command_buffer, &indirect_info);
     m_errorMonitor->VerifyFound();
 
-    copy_address_range.address = indirect_buffer.Address();                  // Fix address alignment
-    copy_address_range.stride = copy_size + 1;                               // Not aligned
+    copy_address_range.address = indirect_buffer.Address();  // Fix address alignment
+    copy_address_range.stride = copy_size + 1;               // Not aligned
     indirect_info.copyAddressRange = copy_address_range;
     m_errorMonitor->SetDesiredError("VUID-VkStridedDeviceAddressRangeKHR-stride-10957");
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryIndirectInfoKHR-copyAddressRange-10943");
@@ -4674,8 +4674,8 @@ TEST_F(NegativeCopyBufferImage, MemoryToImageIndirect) {
     vk::CmdCopyMemoryToImageIndirectKHR(m_command_buffer, &indirect_info);
     m_errorMonitor->VerifyFound();
 
-    copy_address_range.address = indirect_buffer.Address();                         // Fix address alignment
-    copy_address_range.stride = copy_size + 1;                                      // Not aligned
+    copy_address_range.address = indirect_buffer.Address();  // Fix address alignment
+    copy_address_range.stride = copy_size + 1;               // Not aligned
     indirect_info.copyAddressRange = copy_address_range;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageIndirectInfoKHR-copyAddressRange-10953");
     vk::CmdCopyMemoryToImageIndirectKHR(m_command_buffer, &indirect_info);
@@ -4687,9 +4687,9 @@ TEST_F(NegativeCopyBufferImage, MemoryToImageIndirect) {
     vk::CmdCopyMemoryToImageIndirectKHR(m_command_buffer, &indirect_info);
     m_errorMonitor->VerifyFound();
 
-    copy_address_range.stride = copy_size;                                      // Fix stride
-    copy_address_range.size = copy_size;                                        // Only enough for one command
-    indirect_info.copyCount = 2;                                                // But trying to use two commands
+    copy_address_range.stride = copy_size;  // Fix stride
+    copy_address_range.size = copy_size;    // Only enough for one command
+    indirect_info.copyCount = 2;            // But trying to use two commands
     indirect_info.copyAddressRange = copy_address_range;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageIndirectInfoKHR-copyCount-10951");
     vk::CmdCopyMemoryToImageIndirectKHR(m_command_buffer, &indirect_info);

--- a/tests/unit/copy_buffer_image_positive.cpp
+++ b/tests/unit/copy_buffer_image_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1744,7 +1744,7 @@ TEST_F(PositiveCopyBufferImage, MemoryIndirect) {
     const VkDeviceSize buffer_size = sizeof(cmds);
 
     vkt::Buffer indirect_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    void *indirect_buffer_data = indirect_buffer.Memory().Map();
+    void* indirect_buffer_data = indirect_buffer.Memory().Map();
     memcpy(indirect_buffer_data, cmds, buffer_size);
 
     VkStridedDeviceAddressRangeKHR address_range = {};
@@ -1788,7 +1788,7 @@ TEST_F(PositiveCopyBufferImage, MemoryToImageIndirect) {
     VkCopyMemoryToImageIndirectCommandKHR cmds[2] = {cmd1, cmd2};
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(cmds), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    void *indirect_buffer_data = indirect_buffer.Memory().Map();
+    void* indirect_buffer_data = indirect_buffer.Memory().Map();
     memcpy(indirect_buffer_data, cmds, sizeof(cmds));
 
     VkImageSubresourceLayers res_layer = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -52,7 +52,8 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesDeferredOperationNotNull) {
     vk::CreateDeferredOperationKHR(*m_device, nullptr, &deferred_operation);
     VkPipeline pipeline;
     m_errorMonitor->SetDesiredError("VUID-vkCreateDataGraphPipelinesARM-deferredOperation-09761");
-    vk::CreateDataGraphPipelinesARM(*m_device, deferred_operation, VK_NULL_HANDLE, 1, &pipeline_helper.pipeline_ci_, nullptr, &pipeline);
+    vk::CreateDataGraphPipelinesARM(*m_device, deferred_operation, VK_NULL_HANDLE, 1, &pipeline_helper.pipeline_ci_, nullptr,
+                                    &pipeline);
     m_errorMonitor->VerifyFound();
     vk::DestroyDeferredOperationKHR(*m_device, deferred_operation, nullptr);
 }
@@ -86,7 +87,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesInvalidFlags) {
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.pipeline_ci_.flags = VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHR;
     };
     vkt::dg::DataGraphPipelineHelper::OneshotTest(*this, set_info, 0, "VUID-VkDataGraphPipelineCreateInfoARM-flags-09764");
@@ -99,7 +100,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesNoProtectedAccessButFeatureNot
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.pipeline_ci_.flags = VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT_EXT;
     };
     vkt::dg::DataGraphPipelineHelper::OneshotTest(*this, set_info, 0,
@@ -113,7 +114,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesProtectedAccessOnlyButFeatureN
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.pipeline_ci_.flags = VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT;
     };
     vkt::dg::DataGraphPipelineHelper::OneshotTest(*this, set_info, 0,
@@ -129,7 +130,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesBothProtectedAccessBits) {
     AddRequiredFeature(vkt::Feature::pipelineProtectedAccess);
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.pipeline_ci_.flags =
             VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT_EXT | VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT;
     };
@@ -148,7 +149,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesStageCreationFeedbackCountNotZ
     creation_feedback_create_info.pPipelineCreationFeedback = &creation_feedback;
     creation_feedback_create_info.pipelineStageCreationFeedbackCount = 1;
     creation_feedback_create_info.pPipelineStageCreationFeedbacks = &creation_feedback;
-    auto set_info = [&](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [&](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.shader_module_ci_.pNext = &creation_feedback_create_info;
     };
     vkt::dg::DataGraphPipelineHelper::OneshotTest(*this, set_info, 0, "VUID-VkDataGraphPipelineCreateInfoARM-pNext-09804");
@@ -162,7 +163,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesPushConstantCountNotZero) {
     RETURN_IF_SKIP(Init());
 
     std::vector<VkPushConstantRange> pcr = {{VK_SHADER_STAGE_ALL, 0, sizeof(uint32_t)}};
-    auto set_info = [&](vkt::dg::DataGraphPipelineHelper &pipeline) { pipeline.CreatePipelineLayout(pcr); };
+    auto set_info = [&](vkt::dg::DataGraphPipelineHelper& pipeline) { pipeline.CreatePipelineLayout(pcr); };
     vkt::dg::DataGraphPipelineHelper::OneshotTest(*this, set_info, 0, "VUID-VkDataGraphPipelineCreateInfoARM-layout-09767");
 }
 
@@ -173,7 +174,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesUpdateAfterBindFeatureNotEnabl
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [&](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [&](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.descriptor_set_.reset(new OneOffDescriptorSet(pipeline.device_, pipeline.descriptor_set_layout_bindings_,
                                                                VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT, nullptr,
                                                                VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT));
@@ -197,7 +198,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesMutableDescriptor) {
     mutable_descriptor_info.mutableDescriptorTypeListCount = 1;
     mutable_descriptor_info.pMutableDescriptorTypeLists = &mutable_descriptor_type_list;
 
-    auto set_info = [&](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [&](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.descriptor_set_layout_bindings_[0].descriptorType =
             VK_DESCRIPTOR_TYPE_MUTABLE_EXT;  // the pipeline sets this to tensor
         pipeline.descriptor_set_.reset(
@@ -214,7 +215,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesEarlyReturnFlagCacheControlNot
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.pipeline_ci_.flags = VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR;
     };
     vkt::dg::DataGraphPipelineHelper::OneshotTest(*this, set_info, 0,
@@ -228,7 +229,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesFailOnPipelineCompileFlagCache
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [](vkt::dg::DataGraphPipelineHelper &pipeline) {
+    auto set_info = [](vkt::dg::DataGraphPipelineHelper& pipeline) {
         pipeline.pipeline_ci_.flags = VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_KHR;
     };
     vkt::dg::DataGraphPipelineHelper::OneshotTest(*this, set_info, 0,
@@ -252,7 +253,7 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesTypeMismatch) {
     m_errorMonitor->VerifyFound();
 }
 
-static void InitDefaultComputePipeline(CreateComputePipelineHelper &pipeline, VkRenderFramework *framework) {
+static void InitDefaultComputePipeline(CreateComputePipelineHelper& pipeline, VkRenderFramework* framework) {
     std::vector<VkDescriptorSetLayoutBinding> bindings = {
         {0, VK_DESCRIPTOR_TYPE_TENSOR_ARM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
@@ -320,7 +321,8 @@ TEST_F(NegativeDataGraph, GetDataGraphPipelinePropertiesDuplicatedProperty) {
 
 TEST_F(NegativeDataGraph, SessionCreateInfoInvalidGraphPipeline) {
     TEST_DESCRIPTION(
-        "Try to create a DataGraphPipelineSession where the dataGraphPipeline member of VkDataGraphPipelineSessionCreateInfoARM was "
+        "Try to create a DataGraphPipelineSession where the dataGraphPipeline member of VkDataGraphPipelineSessionCreateInfoARM "
+        "was "
         "not created by vkCreateDataGraphPipelinesARM");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
@@ -413,7 +415,8 @@ TEST_F(NegativeDataGraph, BindSessionTwice) {
 
 TEST_F(NegativeDataGraph, BindSessionMemoryOffsetLargerThanSize) {
     TEST_DESCRIPTION(
-        "Try to create a bind DataGraphPipelineSession to DeviceMemory at an offset which is larger than the allocated memory size");
+        "Try to create a bind DataGraphPipelineSession to DeviceMemory at an offset which is larger than the allocated memory "
+        "size");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
@@ -432,13 +435,12 @@ TEST_F(NegativeDataGraph, BindSessionMemoryOffsetLargerThanSize) {
     session.AllocSessionMem(device_mem);
 
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
-    auto &mem_req = session.MemReqs()[0];
+    auto& mem_req = session.MemReqs()[0];
     session_bind_infos[0].memoryOffset = mem_req.memoryRequirements.size + 2 * mem_req.memoryRequirements.alignment;
 
     m_errorMonitor->SetDesiredError("VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-memoryOffset-09787");
     vk::BindDataGraphPipelineSessionMemoryARM(*m_device, session_bind_infos.size(), session_bind_infos.data());
     m_errorMonitor->VerifyFound();
-
 }
 
 TEST_F(NegativeDataGraph, BindSessionMemoryInvalidMemoryBits) {
@@ -460,8 +462,8 @@ TEST_F(NegativeDataGraph, BindSessionMemoryInvalidMemoryBits) {
     CheckSessionMemory(session);
 
     std::vector<vkt::DeviceMemory> device_mem(session.BindPointsCount());
-    auto &bind_point_reqs = session.BindPointReqs();
-    auto &mem_reqs = session.MemReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
+    auto& mem_reqs = session.MemReqs();
     for (uint32_t i = 0; i < bind_point_reqs.size(); i++) {
         if (bind_point_reqs[i].bindPointType != VK_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_TYPE_MEMORY_ARM) {
             continue;
@@ -501,7 +503,7 @@ TEST_F(NegativeDataGraph, BindSessionMemoryInvalidOffsetAlignment) {
     session.AllocSessionMem(device_mem, false, 2);
 
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
-    auto &mem_reqs = session.MemReqs();
+    auto& mem_reqs = session.MemReqs();
     session_bind_infos[0].memoryOffset = mem_reqs[0].memoryRequirements.alignment - 1;
 
     m_errorMonitor->SetDesiredError("VUID-VkBindDataGraphPipelineSessionMemoryInfoARM-memoryOffset-09789");
@@ -553,7 +555,7 @@ TEST_F(NegativeDataGraph, BindProtectedSessionToUnprotectedMemory) {
 
     // allocate unprotected memory
     std::vector<vkt::DeviceMemory> device_mem(session.BindPointsCount());
-    auto &mem_reqs = session.MemReqs();
+    auto& mem_reqs = session.MemReqs();
     for (uint32_t i = 0; i < mem_reqs.size(); i++) {
         VkMemoryAllocateInfo session_alloc_info = vku::InitStructHelper();
         session_alloc_info.allocationSize = mem_reqs[i].memoryRequirements.size;
@@ -590,7 +592,7 @@ TEST_F(NegativeDataGraph, BindUnprotectedSessionToProtectedMemory) {
 
     // allocate protected memory
     std::vector<vkt::DeviceMemory> device_mem(session.BindPointsCount());
-    auto &mem_reqs = session.MemReqs();
+    auto& mem_reqs = session.MemReqs();
     for (uint32_t i = 0; i < mem_reqs.size(); i++) {
         VkMemoryAllocateInfo session_alloc_info = vku::InitStructHelper();
         session_alloc_info.allocationSize = mem_reqs[i].memoryRequirements.size;
@@ -927,7 +929,9 @@ TEST_F(NegativeDataGraph, CmdDispatchProtectedNoFaultUnsupportedUnprotectedCmdBu
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline.pipeline_layout_, 0, 1,
                               &pipeline.descriptor_set_.get()->set_, 0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchDataGraphARM-commandBuffer-09800");
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchDataGraphARM-commandBuffer-09800"); // We are using 2 protected resources in this unprotected command buffer and so need to log the error twice
+    m_errorMonitor->SetDesiredError(
+        "VUID-vkCmdDispatchDataGraphARM-commandBuffer-09800");  // We are using 2 protected resources in this unprotected command
+                                                                // buffer and so need to log the error twice
     vk::CmdDispatchDataGraphARM(m_command_buffer, session, nullptr);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -973,7 +977,9 @@ TEST_F(NegativeDataGraph, CmdDispatchProtectedNoFaultUnsupportedProtectedCmdBuff
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline.pipeline_layout_, 0, 1,
                               &pipeline.descriptor_set_.get()->set_, 0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchDataGraphARM-commandBuffer-09801");
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchDataGraphARM-commandBuffer-09801"); // We are using 2 unprotected resources in this protected command buffer and so need to log the error twice
+    m_errorMonitor->SetDesiredError(
+        "VUID-vkCmdDispatchDataGraphARM-commandBuffer-09801");  // We are using 2 unprotected resources in this protected command
+                                                                // buffer and so need to log the error twice
     vk::CmdDispatchDataGraphARM(m_command_buffer, session, nullptr);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -993,7 +999,7 @@ TEST_F(NegativeDataGraph, CmdDispatchInvalidDescriptorNoUpdate) {
     session.GetMemoryReqs();
     CheckSessionMemory(session);
 
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -1029,7 +1035,7 @@ TEST_F(NegativeDataGraph, CmdDispatchInvalidDescriptorDeletedObject) {
         session.GetMemoryReqs();
         CheckSessionMemory(session);
 
-        auto &bind_point_reqs = session.BindPointReqs();
+        auto& bind_point_reqs = session.BindPointReqs();
         std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
         session.AllocSessionMem(device_mem);
         auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -1058,7 +1064,8 @@ TEST_F(NegativeDataGraph, CmdDispatchInvalidDescriptorDeletedObject) {
 }
 
 TEST_F(NegativeDataGraph, CmdDispatchInvalidDescriptorBufferBit) {
-    TEST_DESCRIPTION("Try dispatching a datagraph with VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT set, but using descriptor sets.");
+    TEST_DESCRIPTION(
+        "Try dispatching a datagraph with VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT set, but using descriptor sets.");
     InitBasicDataGraph();
     AddRequiredFeature(vkt::Feature::dataGraphDescriptorBuffer);
     RETURN_IF_SKIP(Init());
@@ -1073,7 +1080,7 @@ TEST_F(NegativeDataGraph, CmdDispatchInvalidDescriptorBufferBit) {
     session.GetMemoryReqs();
     CheckSessionMemory(session);
 
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -1086,7 +1093,7 @@ TEST_F(NegativeDataGraph, CmdDispatchInvalidDescriptorBufferBit) {
     m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline.pipeline_layout_.handle(), 0, 1,
-                                &pipeline.descriptor_set_.get()->set_, 0, nullptr);
+                              &pipeline.descriptor_set_.get()->set_, 0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchDataGraphARM-None-09936");
     vk::CmdDispatchDataGraphARM(m_command_buffer, session.handle(), nullptr);
     m_errorMonitor->VerifyFound();
@@ -1094,7 +1101,8 @@ TEST_F(NegativeDataGraph, CmdDispatchInvalidDescriptorBufferBit) {
 }
 
 TEST_F(NegativeDataGraph, CmdDispatchMissingDescriptorBufferBit) {
-    TEST_DESCRIPTION("Try dispatching a datagraph with descriptor buffers but without the VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT.");
+    TEST_DESCRIPTION(
+        "Try dispatching a datagraph with descriptor buffers but without the VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT.");
     InitBasicDataGraph();
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -1126,7 +1134,7 @@ TEST_F(NegativeDataGraph, CmdDispatchMissingDescriptorBufferBit) {
     session.GetMemoryReqs();
     CheckSessionMemory(session);
 
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -1148,7 +1156,8 @@ TEST_F(NegativeDataGraph, CmdDispatchMissingDescriptorBufferBit) {
 
     uint32_t index = 0;
     VkDeviceSize offset = 0;
-    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline_layout, 0, 1, &index, &offset);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline_layout, 0, 1, &index,
+                                         &offset);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchDataGraphARM-None-09938");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchDataGraphARM-None-09797");
@@ -1177,11 +1186,12 @@ TEST_F(NegativeDataGraph, ShaderModuleCreateInfoInvalidConstantID) {
 }
 
 TEST_F(NegativeDataGraph, TensorSparsitySuppliedMissingDescription) {
-    TEST_DESCRIPTION("Try creating a datagraph pipeline with a tensor sparsity structure but missing a tensor description structure");
+    TEST_DESCRIPTION(
+        "Try creating a datagraph pipeline with a tensor sparsity structure but missing a tensor description structure");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1206,11 +1216,12 @@ TEST_F(NegativeDataGraph, TensorSparsitySuppliedMissingDescription) {
 
 TEST_F(NegativeDataGraph, TensorSparsityDimensionTooLarge) {
     TEST_DESCRIPTION(
-        "Try creating a datagraph pipeline with a tensor sparsity structure but the supplied dimension is larger than the dimensionCount in the tensor description supplied");
+        "Try creating a datagraph pipeline with a tensor sparsity structure but the supplied dimension is larger than the "
+        "dimensionCount in the tensor description supplied");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1234,11 +1245,12 @@ TEST_F(NegativeDataGraph, TensorSparsityDimensionTooLarge) {
 
 TEST_F(NegativeDataGraph, TensorSparsityDescriptionDimensionNotMultipleOfSparsityGroupSize) {
     TEST_DESCRIPTION(
-        "Try creating a datagraph pipeline with a tensor sparsity structure but dimension[sparsity->dimension] is not a multiple of sparsity->groupSize");
+        "Try creating a datagraph pipeline with a tensor sparsity structure but dimension[sparsity->dimension] is not a multiple "
+        "of sparsity->groupSize");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1268,7 +1280,7 @@ TEST_F(NegativeDataGraph, TensorSparsityDoubleDefinition) {
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1304,7 +1316,7 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongID) {
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1331,7 +1343,7 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongRank) {
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1356,11 +1368,12 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongRank) {
 }
 
 TEST_F(NegativeDataGraph, GraphConstantTensorWrongDimensions) {
-    TEST_DESCRIPTION("Try creating a datagraph pipeline with a constant based on a tensor with dimensions different from the spirv definition");
+    TEST_DESCRIPTION(
+        "Try creating a datagraph pipeline with a constant based on a tensor with dimensions different from the spirv definition");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1385,11 +1398,12 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongDimensions) {
 }
 
 TEST_F(NegativeDataGraph, GraphConstantTensorWrongFormat) {
-    TEST_DESCRIPTION("Try creating a datagraph pipeline with a constant based on a tensor with format different from the spirv definition");
+    TEST_DESCRIPTION(
+        "Try creating a datagraph pipeline with a constant based on a tensor with format different from the spirv definition");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1415,7 +1429,7 @@ TEST_F(NegativeDataGraph, GraphConstantTensorMissingDescription) {
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1437,7 +1451,7 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongTiling) {
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1459,7 +1473,7 @@ TEST_F(NegativeDataGraph, GraphConstantTensorMissingUsageFlags) {
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvConstantDataGraph();
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -1538,8 +1552,8 @@ TEST_F(NegativeDataGraph, ResourceTensorWrongRank) {
     vkt::dg::DataGraphPipelineHelper pipeline(*this);
 
     // define a tensor with rank 3, the spirv has rank 4
-    auto *desc =
-        const_cast<VkTensorDescriptionARM *>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
+    auto* desc =
+        const_cast<VkTensorDescriptionARM*>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
     const std::vector<int64_t> dimensions{1, 4, 16};
     desc->dimensionCount = dimensions.size();
     desc->pDimensions = dimensions.data();
@@ -1558,8 +1572,8 @@ TEST_F(NegativeDataGraph, ResourceTensorWrongDimensions) {
     vkt::dg::DataGraphPipelineHelper pipeline(*this);
 
     // dim[3] is different from the spirv (4)
-    auto *desc =
-        const_cast<VkTensorDescriptionARM *>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
+    auto* desc =
+        const_cast<VkTensorDescriptionARM*>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
     const std::vector<int64_t> dimensions{1, 8, 16, 1};  // dim[3] is 4 in the spirv
     desc->dimensionCount = dimensions.size();
     desc->pDimensions = dimensions.data();
@@ -1580,8 +1594,8 @@ TEST_F(NegativeDataGraph, ResourceTensorWrongFormat) {
          {VK_FORMAT_R8_BOOL_ARM, VK_FORMAT_R32_SINT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM}) {
         vkt::dg::DataGraphPipelineHelper pipeline(*this);
 
-        auto *desc =
-            const_cast<VkTensorDescriptionARM *>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
+        auto* desc =
+            const_cast<VkTensorDescriptionARM*>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
         desc->format = format;
 
         m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09923");
@@ -1615,8 +1629,8 @@ TEST_F(NegativeDataGraph, ResourceTensorInvalidUsage) {
     vkt::dg::DataGraphPipelineHelper pipeline(*this);
 
     // set an incorrect usage in the tensor description
-    auto *desc =
-        const_cast<VkTensorDescriptionARM *>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
+    auto* desc =
+        const_cast<VkTensorDescriptionARM*>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
     desc->usage = VK_TENSOR_USAGE_SHADER_BIT_ARM;  // should be VK_TENSOR_USAGE_DATA_GRAPH_BIT_ARM
     m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineResourceInfoARM-descriptorSet-09851");
     pipeline.CreateDataGraphPipeline();
@@ -1644,7 +1658,7 @@ TEST_F(NegativeDataGraph, SessionGetMemoryRequirementsIndexTooLarge) {
         GTEST_FAIL() << "No bind points, " << IncorrectSpirvMessage;
     }
     std::vector<VkDataGraphPipelineSessionBindPointRequirementARM> bind_point_reqs(bind_point_req_count);
-    for (auto &bp_req : bind_point_reqs) {
+    for (auto& bp_req : bind_point_reqs) {
         bp_req = vku::InitStructHelper();
     }
     vk::GetDataGraphPipelineSessionBindPointRequirementsARM(*m_device, &bind_point_req_info, &bind_point_req_count,
@@ -1696,7 +1710,7 @@ TEST_F(NegativeDataGraph, ShaderSpirvUsesOpSpecFeatureNotEnabled) {
     // inject a dummy line in the spirv to trigger the error
     vkt::dg::ModifiableShaderParameters spirv_params;
     spirv_params.types = R"(%dummy_spec_constant = OpSpecConstant %uint 3)";
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
 
     // ShaderModule in VkDataGraphPipelineShaderModuleCreateInfoARM::module
     {
@@ -1748,7 +1762,9 @@ TEST_F(NegativeDataGraph, DataGraphShaderModuleCreateInfoIncorrectName) {
 }
 
 TEST_F(NegativeDataGraph, DataGraphShaderModuleCreateInfoHasModuleAndShaderModuleCreateInfo) {
-    TEST_DESCRIPTION("Create a datagraph pipeline where VkDataGraphPipelineShaderModuleCreateInfoARM::module is not null, but it also includes a VkShaderModuleCreateInfo structure in its pNext chain.");
+    TEST_DESCRIPTION(
+        "Create a datagraph pipeline where VkDataGraphPipelineShaderModuleCreateInfoARM::module is not null, but it also includes "
+        "a VkShaderModuleCreateInfo structure in its pNext chain.");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
@@ -1757,7 +1773,7 @@ TEST_F(NegativeDataGraph, DataGraphShaderModuleCreateInfoHasModuleAndShaderModul
 
     // also add the same ShaderModule in the pNext chain
     spvtools::SpirvTools tools{SPV_ENV_UNIVERSAL_1_6};
-    const std::string &spirv_source = vkt::dg::DataGraphPipelineHelper::GetSpirvBasicDataGraph();
+    const std::string& spirv_source = vkt::dg::DataGraphPipelineHelper::GetSpirvBasicDataGraph();
     std::vector<uint32_t> spirv_binary;
     if (!tools.Assemble(spirv_source, &spirv_binary)) {
         Monitor().SetError("Failed to compile SPIRV shader module");
@@ -1790,7 +1806,9 @@ TEST_F(NegativeDataGraph, DataGraphShaderModuleCreateInfoHasModuleAndShaderModul
 }
 
 TEST_F(NegativeDataGraph, DataGraphShaderModuleCreateInfoInvalidModule) {
-    TEST_DESCRIPTION("Create a datagraph pipeline where VkDataGraphPipelineShaderModuleCreateInfoARM::module is NULL and there is no VkShaderModuleCreateInfo structure in its pNext chain.");
+    TEST_DESCRIPTION(
+        "Create a datagraph pipeline where VkDataGraphPipelineShaderModuleCreateInfoARM::module is NULL and there is no "
+        "VkShaderModuleCreateInfo structure in its pNext chain.");
     InitBasicDataGraph();
     RETURN_IF_SKIP(Init());
 
@@ -1926,7 +1944,7 @@ TEST_F(NegativeDataGraph, DataGraphTensorNoShape) {
     RETURN_IF_SKIP(Init());
 
     // input and output variables are tensors without a shape, rank only (%tensor_r4)
-    static const char *tensorNoShapeDataGraphSpirv = R"spirv(
+    static const char* tensorNoShapeDataGraphSpirv = R"spirv(
                             OpCapability GraphARM
                             OpCapability TensorsARM
                             OpCapability Int8
@@ -2075,7 +2093,7 @@ TEST_F(NegativeDataGraph, DataGraphCreateInfoNullResources) {
     RETURN_IF_SKIP(Init());
 
     vkt::dg::DataGraphPipelineHelper pipeline(*this);
-    pipeline.pipeline_ci_.pResourceInfos = nullptr; // this is to avoid VU 12364
+    pipeline.pipeline_ci_.pResourceInfos = nullptr;  // this is to avoid VU 12364
     pipeline.pipeline_ci_.resourceInfoCount = 0;
 
     m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineCreateInfoARM-None-12365");
@@ -2120,7 +2138,7 @@ TEST_F(NegativeDataGraph, DataGraphOpGraphConstantARMNoShape) {
     spirv_params.types = R"(%tensor_r4 = OpTypeTensorARM %uchar %uint_4
             %constant_no_shape = OpGraphConstantARM %tensor_r4 0)";
     spirv_params.instructions = "%dummy = OpExtInst %uchar_1_2_4_4_tensor %tosa ADD %op_1 %constant_no_shape";
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -2162,8 +2180,9 @@ TEST_F(NegativeDataGraph, DataGraphOpGraphConstantARMNotTensor) {
     vkt::dg::ModifiableShaderParameters spirv_params;
     spirv_params.types = R"(%constant_scalar_min = OpGraphConstantARM %uint 0
                 %constant_scalar_max = OpGraphConstantARM %uint 128)";
-    spirv_params.instructions = "%dummy = OpExtInst %uchar_1_2_4_4_tensor %tosa CLAMP %op_1 %constant_scalar_min %constant_scalar_max %uint_2";
-    const std::string &spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
+    spirv_params.instructions =
+        "%dummy = OpExtInst %uchar_1_2_4_4_tensor %tosa CLAMP %op_1 %constant_scalar_min %constant_scalar_max %uint_2";
+    const std::string& spirv_string = vkt::dg::DataGraphPipelineHelper::GetSpirvModifyableDataGraph(spirv_params);
 
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
@@ -2262,7 +2281,7 @@ TEST_F(NegativeDataGraph, CmdDispatchWrongPipeline) {
     CheckSessionMemory(session);
 
     // setup the command buffer with the _default_ pipeline, as usual.
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -2297,7 +2316,7 @@ TEST_F(NegativeDataGraph, CmdDispatchWrongTensorUsage) {
     session.GetMemoryReqs();
     CheckSessionMemory(session);
 
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -2379,20 +2398,21 @@ TEST_F(NegativeDataGraph, CmdDispatchWrongQueue) {
     RETURN_IF_SKIP(Init());
 
     // find a queue family that does NOT support TOSA
-    const VkQueueFamilyDataGraphPropertiesARM tosa_1_0_property {
+    const VkQueueFamilyDataGraphPropertiesARM tosa_1_0_property{
         VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM,
         nullptr,
         {VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM, false},
-        {VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM, "TOSA.001000.1", 0}
-    };
+        {VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM, "TOSA.001000.1", 0}};
     uint32_t queue_without_tosa_1_0_idx = UINT32_MAX;
     uint32_t n_queue_families;
     vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &n_queue_families, nullptr);
     for (uint32_t qfi = 0; qfi < n_queue_families; qfi++) {
         uint32_t n_properties;
         ASSERT_TRUE(VK_SUCCESS == vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(Gpu(), qfi, &n_properties, nullptr));
-        std::vector<VkQueueFamilyDataGraphPropertiesARM> properties(n_properties, {VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM});
-        ASSERT_TRUE(VK_SUCCESS == vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(Gpu(), qfi, &n_properties, properties.data()));
+        std::vector<VkQueueFamilyDataGraphPropertiesARM> properties(n_properties,
+                                                                    {VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM});
+        ASSERT_TRUE(VK_SUCCESS ==
+                    vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(Gpu(), qfi, &n_properties, properties.data()));
 
         bool queue_supports_tosa_1_0 = false;
         for (const auto& p : properties) {
@@ -2420,7 +2440,7 @@ TEST_F(NegativeDataGraph, CmdDispatchWrongQueue) {
     session.GetMemoryReqs();
     CheckSessionMemory(session);
 
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -26,11 +26,12 @@ void DataGraphTest::InitBasicDataGraph() {
     AddRequiredFeature(vkt::Feature::shaderInt8);
 }
 
-const std::string DataGraphTest::IncorrectSpirvMessage{"test incorrect. Possible causes: incorrect spirv, or inconsistency between spirv and tensor/constant declarations\n"};
+const std::string DataGraphTest::IncorrectSpirvMessage{
+    "test incorrect. Possible causes: incorrect spirv, or inconsistency between spirv and tensor/constant declarations\n"};
 const VkTensorDescriptionARM DataGraphTest::defaultConstantTensorDesc{DefaultConstantTensorDesc()};
 
 void DataGraphTest::CheckSessionMemory(const vkt::DataGraphPipelineSession& session) {
-    const auto &mem_reqs = session.MemReqs();
+    const auto& mem_reqs = session.MemReqs();
     if (mem_reqs.empty()) {
         GTEST_FAIL() << "No bind points, " << IncorrectSpirvMessage;
     }
@@ -41,8 +42,9 @@ void DataGraphTest::CheckSessionMemory(const vkt::DataGraphPipelineSession& sess
     }
 }
 
-std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> DataGraphTest::InitSessionBindInfo(const vkt::DataGraphPipelineSession& session, const std::vector<vkt::DeviceMemory>& device_mem) {
-    const auto &bind_point_reqs = session.BindPointReqs();
+std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> DataGraphTest::InitSessionBindInfo(
+    const vkt::DataGraphPipelineSession& session, const std::vector<vkt::DeviceMemory>& device_mem) {
+    const auto& bind_point_reqs = session.BindPointReqs();
     std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> session_bind_infos(session.MemReqs().size());
     uint32_t req_i = 0;
     for (uint32_t i = 0; i < bind_point_reqs.size(); i++) {
@@ -112,7 +114,7 @@ TEST_F(PositiveDataGraph, ExecuteDataGraph) {
     session.GetMemoryReqs();
     CheckSessionMemory(session);
 
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -286,7 +288,7 @@ TEST_F(PositiveDataGraph, CmdDispatchDescriptorBuffer) {
     session.GetMemoryReqs();
     CheckSessionMemory(session);
 
-    auto &bind_point_reqs = session.BindPointReqs();
+    auto& bind_point_reqs = session.BindPointReqs();
     std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
     session.AllocSessionMem(device_mem);
     auto session_bind_infos = InitSessionBindInfo(session, device_mem);
@@ -307,7 +309,8 @@ TEST_F(PositiveDataGraph, CmdDispatchDescriptorBuffer) {
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &dbbi);
     uint32_t index = 0;
     VkDeviceSize offset = 0;
-    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline_layout, 0, 1, &index, &offset);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline_layout, 0, 1, &index,
+                                         &offset);
     vk::CmdDispatchDataGraphARM(m_command_buffer, session, nullptr);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -139,7 +139,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT*, DebugUtilsLabelCheckData* data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -235,8 +235,8 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     command_label.color[2] = 2.;
     command_label.color[3] = 3.0;
     bool command_label_test = false;
-    auto command_label_callback = [command_label, &command_label_test](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData,
-                                                                       DebugUtilsLabelCheckData *data) {
+    auto command_label_callback = [command_label, &command_label_test](const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
+                                                                       DebugUtilsLabelCheckData* data) {
         data->count++;
         command_label_test = false;
         if (pCallbackData->cmdBufLabelCount == 1) {
@@ -306,7 +306,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsParameterFlags) {
     RETURN_IF_SKIP(Init());
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT*, DebugUtilsLabelCheckData* data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -322,8 +322,8 @@ TEST_F(NegativeDebugExtensions, DebugUtilsParameterFlags) {
 }
 
 struct LayerStatusCheckData {
-    std::function<void(const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, LayerStatusCheckData *)> callback;
-    ErrorMonitor *error_monitor;
+    std::function<void(const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, LayerStatusCheckData*)> callback;
+    ErrorMonitor* error_monitor;
 };
 
 TEST_F(NegativeDebugExtensions, LayerInfoMessages) {
@@ -331,7 +331,7 @@ TEST_F(NegativeDebugExtensions, LayerInfoMessages) {
 
     auto ici = GetInstanceCreateInfo();
     LayerStatusCheckData callback_data;
-    auto local_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, LayerStatusCheckData *data) {
+    auto local_callback = [](const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, LayerStatusCheckData* data) {
         std::string message(pCallbackData->pMessage);
         if ((data->error_monitor->GetMessageFlags() & kInformationBit) &&
             (message.find("UNASSIGNED-khronos-validation-createinstance-status-message") == std::string::npos)) {
@@ -379,7 +379,7 @@ TEST_F(NegativeDebugExtensions, SetDebugUtilsObjectSecondDevice) {
     vkt::Device second_device(gpu_, m_device_extension_names, &features);
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT*, DebugUtilsLabelCheckData* data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -392,7 +392,7 @@ TEST_F(NegativeDebugExtensions, SetDebugUtilsObjectSecondDevice) {
     VkDebugUtilsMessengerEXT my_messenger = VK_NULL_HANDLE;
     vk::CreateDebugUtilsMessengerEXT(instance(), &callback_create_info, nullptr, &my_messenger);
 
-    const char *object_name = "device_object";
+    const char* object_name = "device_object";
 
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_DEVICE;
@@ -415,7 +415,7 @@ TEST_F(NegativeDebugExtensions, SetDebugUtilsObjectDestroyedHandle) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT*, DebugUtilsLabelCheckData* data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -431,7 +431,7 @@ TEST_F(NegativeDebugExtensions, SetDebugUtilsObjectDestroyedHandle) {
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     uint64_t bad_handle = (uint64_t)sampler.handle();
     sampler.Destroy();
-    const char *object_name = "sampler_object";
+    const char* object_name = "sampler_object";
 
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_SAMPLER;
@@ -630,8 +630,8 @@ TEST_F(NegativeDebugExtensions, SetDeviceHandle) {
     VkDevice second_device;
     ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_create_info, nullptr, &second_device));
 
-    const char *device_1_name = "device_1";
-    const char *device_2_name = "device_2";
+    const char* device_1_name = "device_1";
+    const char* device_2_name = "device_2";
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_DEVICE;
     name_info.pObjectName = device_1_name;

--- a/tests/unit/debug_extensions_positive.cpp
+++ b/tests/unit/debug_extensions_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ TEST_F(PositiveDebugExtensions, SetDebugUtilsObjectBuffer) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT*, DebugUtilsLabelCheckData* data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -58,7 +58,7 @@ TEST_F(PositiveDebugExtensions, SetDebugUtilsObjectDevice) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT*, DebugUtilsLabelCheckData* data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -21,7 +21,7 @@
 #include "../framework/gpu_av_helper.h"
 #include "utils/math_utils.h"
 
-void DebugPrintfTests::InitDebugPrintfFramework(void *p_next, bool reserve_slot) {
+void DebugPrintfTests::InitDebugPrintfFramework(void* p_next, bool reserve_slot) {
     VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT,
                                               VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT};
     VkValidationFeaturesEXT features = vku::InitStructHelper(p_next);
@@ -42,12 +42,12 @@ void DebugPrintfTests::InitDebugPrintfFramework(void *p_next, bool reserve_slot)
 
 class NegativeDebugPrintf : public DebugPrintfTests {
   public:
-    void BasicComputeTest(const char *shader, const char *message);
-    void BasicFormattingTest(const char *shader, bool warning = false);
-    void CoopMat2CallbackTest(const char *shader_source, const char *message);
+    void BasicComputeTest(const char* shader, const char* message);
+    void BasicFormattingTest(const char* shader, bool warning = false);
+    void CoopMat2CallbackTest(const char* shader_source, const char* message);
 };
 
-void NegativeDebugPrintf::BasicComputeTest(const char *shader, const char *message) {
+void NegativeDebugPrintf::BasicComputeTest(const char* shader, const char* message) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
@@ -66,7 +66,7 @@ void NegativeDebugPrintf::BasicComputeTest(const char *shader, const char *messa
 }
 
 TEST_F(NegativeDebugPrintf, Float) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -78,7 +78,7 @@ TEST_F(NegativeDebugPrintf, Float) {
 }
 
 TEST_F(NegativeDebugPrintf, IntUnsigned) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -90,7 +90,7 @@ TEST_F(NegativeDebugPrintf, IntUnsigned) {
 }
 
 TEST_F(NegativeDebugPrintf, IntUnsignedUnderflow) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -102,7 +102,7 @@ TEST_F(NegativeDebugPrintf, IntUnsignedUnderflow) {
 }
 
 TEST_F(NegativeDebugPrintf, IntSignedOverflow) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -114,7 +114,7 @@ TEST_F(NegativeDebugPrintf, IntSignedOverflow) {
 }
 
 TEST_F(NegativeDebugPrintf, TwoFloats) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -126,7 +126,7 @@ TEST_F(NegativeDebugPrintf, TwoFloats) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatPrecision) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -138,7 +138,7 @@ TEST_F(NegativeDebugPrintf, FloatPrecision) {
 }
 
 TEST_F(NegativeDebugPrintf, TextBeforeAndAfter) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -150,7 +150,7 @@ TEST_F(NegativeDebugPrintf, TextBeforeAndAfter) {
 }
 
 TEST_F(NegativeDebugPrintf, IntOctal) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -162,7 +162,7 @@ TEST_F(NegativeDebugPrintf, IntOctal) {
 }
 
 TEST_F(NegativeDebugPrintf, IntOctalNegative) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -174,7 +174,7 @@ TEST_F(NegativeDebugPrintf, IntOctalNegative) {
 }
 
 TEST_F(NegativeDebugPrintf, IntNegative) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -186,7 +186,7 @@ TEST_F(NegativeDebugPrintf, IntNegative) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVector2) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -198,7 +198,7 @@ TEST_F(NegativeDebugPrintf, FloatVector2) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVector3) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -210,7 +210,7 @@ TEST_F(NegativeDebugPrintf, FloatVector3) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVector4) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -222,7 +222,7 @@ TEST_F(NegativeDebugPrintf, FloatVector4) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorPrecision) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -234,7 +234,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorPrecision) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorPrecisionZeroPad) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -246,7 +246,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorPrecisionZeroPad) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorZeroPad) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -258,7 +258,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorZeroPad) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorScientificNotation) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -270,7 +270,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorScientificNotation) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVector) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -282,7 +282,7 @@ TEST_F(NegativeDebugPrintf, IntVector) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVectorUnsigned) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -294,7 +294,7 @@ TEST_F(NegativeDebugPrintf, IntVectorUnsigned) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVectorHex) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -306,7 +306,7 @@ TEST_F(NegativeDebugPrintf, IntVectorHex) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVectorZeroPad) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -318,7 +318,7 @@ TEST_F(NegativeDebugPrintf, IntVectorZeroPad) {
 }
 
 TEST_F(NegativeDebugPrintf, ScientificNotation) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -330,7 +330,7 @@ TEST_F(NegativeDebugPrintf, ScientificNotation) {
 }
 
 TEST_F(NegativeDebugPrintf, ScientificNotationPrecision) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -342,7 +342,7 @@ TEST_F(NegativeDebugPrintf, ScientificNotationPrecision) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatShortest) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -355,7 +355,7 @@ TEST_F(NegativeDebugPrintf, FloatShortest) {
 
 // TODO - This prints out  0x1.921cacp+1 vs 0x1.921cac0000000p+1 depending on Windows or not
 TEST_F(NegativeDebugPrintf, DISABLED_FloatHex) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -367,7 +367,7 @@ TEST_F(NegativeDebugPrintf, DISABLED_FloatHex) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatHexPrecision) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -380,7 +380,7 @@ TEST_F(NegativeDebugPrintf, FloatHexPrecision) {
 
 TEST_F(NegativeDebugPrintf, Int64) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -394,7 +394,7 @@ TEST_F(NegativeDebugPrintf, Int64) {
 
 TEST_F(NegativeDebugPrintf, Int64Vector) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -409,7 +409,7 @@ TEST_F(NegativeDebugPrintf, Int64Vector) {
 
 TEST_F(NegativeDebugPrintf, Int64Hex) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -423,7 +423,7 @@ TEST_F(NegativeDebugPrintf, Int64Hex) {
 
 TEST_F(NegativeDebugPrintf, Int64VectorHex) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -439,7 +439,7 @@ TEST_F(NegativeDebugPrintf, Int64VectorHex) {
 // TODO - Windows trims the leading values and will print 0x001 (Linux ignores the Precision)
 TEST_F(NegativeDebugPrintf, DISABLED_Int64VectorHexPrecision) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -454,7 +454,7 @@ TEST_F(NegativeDebugPrintf, DISABLED_Int64VectorHexPrecision) {
 
 TEST_F(NegativeDebugPrintf, Int64VectorDecimal) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -469,7 +469,7 @@ TEST_F(NegativeDebugPrintf, Int64VectorDecimal) {
 
 TEST_F(NegativeDebugPrintf, Float64) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
@@ -484,7 +484,7 @@ TEST_F(NegativeDebugPrintf, Float64) {
 
 TEST_F(NegativeDebugPrintf, Float64Vector) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
@@ -499,7 +499,7 @@ TEST_F(NegativeDebugPrintf, Float64Vector) {
 
 TEST_F(NegativeDebugPrintf, Float64VectorPrecision) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
@@ -516,7 +516,7 @@ TEST_F(NegativeDebugPrintf, FloatMix) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -534,7 +534,7 @@ TEST_F(NegativeDebugPrintf, FloatMix) {
 TEST_F(NegativeDebugPrintf, Float16) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -550,7 +550,7 @@ TEST_F(NegativeDebugPrintf, Float16) {
 TEST_F(NegativeDebugPrintf, Float16Vector) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -566,7 +566,7 @@ TEST_F(NegativeDebugPrintf, Float16Vector) {
 TEST_F(NegativeDebugPrintf, Float16Precision) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -581,7 +581,7 @@ TEST_F(NegativeDebugPrintf, Float16Precision) {
 // TODO casting is wrong
 TEST_F(NegativeDebugPrintf, Int16) {
     AddRequiredFeature(vkt::Feature::shaderInt16);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -596,7 +596,7 @@ TEST_F(NegativeDebugPrintf, Int16) {
 
 TEST_F(NegativeDebugPrintf, Int16Vector) {
     AddRequiredFeature(vkt::Feature::shaderInt16);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -613,7 +613,7 @@ TEST_F(NegativeDebugPrintf, Int16Vector) {
 
 TEST_F(NegativeDebugPrintf, Int16Hex) {
     AddRequiredFeature(vkt::Feature::shaderInt16);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -629,7 +629,7 @@ TEST_F(NegativeDebugPrintf, Int16Hex) {
 TEST_F(NegativeDebugPrintf, Int8) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderInt8);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -645,7 +645,7 @@ TEST_F(NegativeDebugPrintf, Int8) {
 TEST_F(NegativeDebugPrintf, Int8Vector) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderInt8);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -663,7 +663,7 @@ TEST_F(NegativeDebugPrintf, Int8Vector) {
 TEST_F(NegativeDebugPrintf, Int8Hex) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderInt8);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -677,7 +677,7 @@ TEST_F(NegativeDebugPrintf, Int8Hex) {
 }
 
 TEST_F(NegativeDebugPrintf, BoolAsHex) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -690,7 +690,7 @@ TEST_F(NegativeDebugPrintf, BoolAsHex) {
 }
 
 TEST_F(NegativeDebugPrintf, BoolVector) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -709,7 +709,7 @@ TEST_F(NegativeDebugPrintf, BoolVector) {
 }
 
 TEST_F(NegativeDebugPrintf, BoolNonConstant) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -725,7 +725,7 @@ TEST_F(NegativeDebugPrintf, BoolNonConstant) {
 }
 
 TEST_F(NegativeDebugPrintf, Int32Before) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -740,7 +740,7 @@ TEST_F(NegativeDebugPrintf, Int32Before) {
 }
 
 TEST_F(NegativeDebugPrintf, Int32After) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -756,7 +756,7 @@ TEST_F(NegativeDebugPrintf, Int32After) {
 
 TEST_F(NegativeDebugPrintf, Int64Before) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -774,7 +774,7 @@ TEST_F(NegativeDebugPrintf, Int64Before) {
 
 TEST_F(NegativeDebugPrintf, Int64After) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -791,7 +791,7 @@ TEST_F(NegativeDebugPrintf, Int64After) {
 
 TEST_F(NegativeDebugPrintf, Int64Signed) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -808,7 +808,7 @@ TEST_F(NegativeDebugPrintf, Int64Signed) {
 
 TEST_F(NegativeDebugPrintf, Int64SignedMix) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -823,7 +823,7 @@ TEST_F(NegativeDebugPrintf, Int64SignedMix) {
 }
 
 TEST_F(NegativeDebugPrintf, FunctionParam) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         int foo(int x, int y) {
@@ -845,7 +845,7 @@ TEST_F(NegativeDebugPrintf, Pointers) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_buffer_reference : enable
@@ -873,7 +873,7 @@ TEST_F(NegativeDebugPrintf, Pointers) {
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = (VkDeviceAddress *)in_buffer.Memory().Map();
+    auto in_buffer_ptr = (VkDeviceAddress*)in_buffer.Memory().Map();
     in_buffer_ptr[0] = block_buffer.Address();
     in_buffer_ptr[1] = block_buffer.Address();
 
@@ -903,7 +903,7 @@ TEST_F(NegativeDebugPrintf, Empty) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -932,7 +932,7 @@ TEST_F(NegativeDebugPrintf, MultipleFunctions) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         int data = 0;
@@ -980,7 +980,7 @@ TEST_F(NegativeDebugPrintf, Fragment) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -1025,7 +1025,7 @@ TEST_F(NegativeDebugPrintf, HLSL) {
     //         printf("launchIndex %v2d", launchIndex);
     //    }
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
          %29 = OpExtInstImport "NonSemantic.DebugPrintf"
@@ -1106,7 +1106,7 @@ TEST_F(NegativeDebugPrintf, MultiDraw) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform ufoo {
@@ -1151,7 +1151,7 @@ TEST_F(NegativeDebugPrintf, MultiDraw) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
+    VkDeviceAddress* data = (VkDeviceAddress*)buffer_in.Memory().Map();
     data[0] = 0;
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredInfo("Here are two float values 1.000000, 3.141500");
@@ -1160,7 +1160,7 @@ TEST_F(NegativeDebugPrintf, MultiDraw) {
     m_errorMonitor->VerifyFound();
 
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint16_t *ptr = static_cast<uint16_t *>(buffer.Memory().Map());
+    uint16_t* ptr = static_cast<uint16_t*>(buffer.Memory().Map());
     ptr[0] = 0;
     ptr[1] = 1;
     ptr[2] = 2;
@@ -1260,7 +1260,7 @@ TEST_F(NegativeDebugPrintf, MeshShaders) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         #extension GL_EXT_debug_printf : enable
@@ -1305,7 +1305,7 @@ TEST_F(NegativeDebugPrintf, TaskShaders) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         #extension GL_EXT_debug_printf : enable
@@ -1349,12 +1349,12 @@ TEST_F(NegativeDebugPrintf, MeshTaskIndirect) {
 
     vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawMeshTasksIndirectCommandEXT), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    auto *draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT *>(draw_buffer.Memory().Map());
+    auto* draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT*>(draw_buffer.Memory().Map());
     draw_ptr->groupCountX = 1;
     draw_ptr->groupCountY = 1;
     draw_ptr->groupCountZ = 1;
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         #extension GL_EXT_debug_printf : enable
@@ -1366,7 +1366,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskIndirect) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         #extension GL_EXT_debug_printf : enable
@@ -1385,7 +1385,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskIndirect) {
         }
     )glsl";
 
-    const char *frag_source = R"glsl(
+    const char* frag_source = R"glsl(
         #version 460
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 uFragColor;
@@ -1404,7 +1404,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskIndirect) {
     VkShaderObj fs(*m_device, frag_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3);
 
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    ((uint32_t *)buffer.Memory().Map())[0] = 0;
+    ((uint32_t*)buffer.Memory().Map())[0] = 0;
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
@@ -1449,7 +1449,7 @@ TEST_F(NegativeDebugPrintf, GPL) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform ufoo {
@@ -1513,7 +1513,7 @@ TEST_F(NegativeDebugPrintf, GPL) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    std::vector<const char *> messages;
+    std::vector<const char*> messages;
     messages.emplace_back("Here are two float values 1.000000, 3.141500");
     messages.emplace_back("Here's a smaller float value 3.14");
     messages.emplace_back("Here's an integer -135 with text before and after it");
@@ -1528,7 +1528,7 @@ TEST_F(NegativeDebugPrintf, GPL) {
     messages.emplace_back("First printf with a % and no value");
     messages.emplace_back("Second printf with a value -135");
     for (uint32_t i = 0; i < messages.size(); i++) {
-        VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
+        VkDeviceAddress* data = (VkDeviceAddress*)buffer_in.Memory().Map();
         data[0] = i;
         buffer_in.Memory().Unmap();
         m_errorMonitor->SetDesiredInfo(messages[i]);
@@ -1559,7 +1559,7 @@ TEST_F(NegativeDebugPrintf, GPLMultiDraw) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform ufoo {
@@ -1598,7 +1598,7 @@ TEST_F(NegativeDebugPrintf, GPLMultiDraw) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
+    VkDeviceAddress* data = (VkDeviceAddress*)buffer_in.Memory().Map();
     data[0] = 0;
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredInfo("Here are two float values 1.000000, 3.141500");
@@ -1607,7 +1607,7 @@ TEST_F(NegativeDebugPrintf, GPLMultiDraw) {
     m_errorMonitor->VerifyFound();
 
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint16_t *ptr = static_cast<uint16_t *>(buffer.Memory().Map());
+    uint16_t* ptr = static_cast<uint16_t*>(buffer.Memory().Map());
     ptr[0] = 0;
     ptr[1] = 1;
     ptr[2] = 2;
@@ -1643,7 +1643,7 @@ TEST_F(NegativeDebugPrintf, GPLInt64) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    const char *shader_source_int64 = R"glsl(
+    const char* shader_source_int64 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -1681,7 +1681,7 @@ TEST_F(NegativeDebugPrintf, GPLInt64) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
+    VkDeviceAddress* data = (VkDeviceAddress*)buffer_in.Memory().Map();
     data[0] = 0;
     m_errorMonitor->SetDesiredInfo("Here's an unsigned long 0x2000000000000001");
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -1722,16 +1722,16 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.Memory().Map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t*>(vs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
-        for (auto &v : vert_data) {
+        for (auto& v : vert_data) {
             v = 0x01030507;
         }
     }
     {
-        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.Memory().Map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t*>(fs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
-        for (auto &v : frag_data) {
+        for (auto& v : frag_data) {
             v = 0x02040608;
         }
     }
@@ -1813,16 +1813,16 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.Memory().Map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t*>(vs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
-        for (auto &v : vert_data) {
+        for (auto& v : vert_data) {
             v = 0x01030507;
         }
     }
     {
-        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.Memory().Map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t*>(fs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
-        for (auto &v : frag_data) {
+        for (auto& v : frag_data) {
             v = 0x02040608;
         }
     }
@@ -1923,7 +1923,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsGraphics) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -1957,7 +1957,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjects) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2007,7 +2007,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsInt64) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -2047,7 +2047,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsMultiDraw) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2082,7 +2082,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsMultiDraw) {
     m_errorMonitor->VerifyFound();
 
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint16_t *ptr = static_cast<uint16_t *>(buffer.Memory().Map());
+    uint16_t* ptr = static_cast<uint16_t*>(buffer.Memory().Map());
     ptr[0] = 0;
     ptr[1] = 1;
     ptr[2] = 2;
@@ -2121,7 +2121,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *taskShaderText = R"glsl(
+    const char* taskShaderText = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require // Requires SPIR-V 1.5 (Vulkan 1.2)
         #extension GL_EXT_debug_printf : enable
@@ -2132,7 +2132,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
         }
     )glsl";
 
-    const char *meshShaderText = R"glsl(
+    const char* meshShaderText = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require // Requires SPIR-V 1.5 (Vulkan 1.2)
         #extension GL_EXT_debug_printf : enable
@@ -2229,7 +2229,7 @@ TEST_F(NegativeDebugPrintf, VertexFragmentMultiEntrypoint) {
     //     debugPrintfEXT("Fragment value is %i", 8);
     //     c_out = vec4(0.0);
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %9 = OpExtInstImport "NonSemantic.DebugPrintf"
@@ -2337,7 +2337,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectFragment) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2374,7 +2374,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectCompute) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2422,7 +2422,7 @@ TEST_F(NegativeDebugPrintf, SetupErrorVersion) {
 
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2449,7 +2449,7 @@ TEST_F(NegativeDebugPrintf, LocalSizeId) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
          %30 = OpExtInstImport "NonSemantic.DebugPrintf"
@@ -2533,7 +2533,7 @@ TEST_F(NegativeDebugPrintf, Maintenance5) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2575,7 +2575,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2592,7 +2592,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineReserved) {
         m_errorMonitor->SetDesiredWarning(
             "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
             "pipelines created with it");
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit);
         for (uint32_t i = 0; i < set_limit; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2616,7 +2616,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineReserved) {
 
     // Reduce by one (so there is room now) and print something
     {
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit - 1);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit - 1);
         for (uint32_t i = 0; i < set_limit - 1; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2644,7 +2644,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineNotReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2660,7 +2660,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineNotReserved) {
         m_errorMonitor->SetDesiredWarning(
             "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
             "pipelines created with it");
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit);
         for (uint32_t i = 0; i < set_limit; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2683,7 +2683,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineNotReserved) {
 
     // Reduce by one (so there is room now) and print something
     {
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit - 1);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit - 1);
         for (uint32_t i = 0; i < set_limit - 1; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2712,7 +2712,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGraphics) {
     InitRenderTarget();
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2729,7 +2729,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGraphics) {
         m_errorMonitor->SetDesiredWarning(
             "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
             "pipelines created with it");
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit);
         for (uint32_t i = 0; i < set_limit; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2754,7 +2754,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGraphics) {
 
     // Reduce by one (so there is room now) and print something
     {
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit - 1);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit - 1);
         for (uint32_t i = 0; i < set_limit - 1; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2789,7 +2789,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGPL) {
     InitRenderTarget();
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2805,7 +2805,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGPL) {
         m_errorMonitor->SetDesiredWarning(
             "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
             "pipelines created with it");
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit);
         for (uint32_t i = 0; i < set_limit; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2827,7 +2827,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGPL) {
 
     // Reduce by one (so there is room now) and print something
     {
-        std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit - 1);
+        std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit - 1);
         for (uint32_t i = 0; i < set_limit - 1; i++) {
             layouts[i] = &descriptor_set.layout_;
         }
@@ -2857,7 +2857,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsShaderObjectReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2897,7 +2897,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsShaderObjectReserved) {
     // Reduce by one (so there is room now) and print something
     {
         uint32_t under_set_limit = set_limit - 1;
-        std::vector<const vkt::DescriptorSetLayout *> vkt_layouts;
+        std::vector<const vkt::DescriptorSetLayout*> vkt_layouts;
         for (uint32_t i = 0; i < under_set_limit; i++) {
             vkt_layouts.push_back(&descriptor_set.layout_);
         }
@@ -2927,7 +2927,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsShaderObjectNotReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2966,7 +2966,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsShaderObjectNotReserved) {
     // Reduce by one (so there is room now) and print something
     {
         uint32_t under_set_limit = set_limit - 1;
-        std::vector<const vkt::DescriptorSetLayout *> vkt_layouts;
+        std::vector<const vkt::DescriptorSetLayout*> vkt_layouts;
         for (uint32_t i = 0; i < under_set_limit; i++) {
             vkt_layouts.push_back(&descriptor_set.layout_);
         }
@@ -2998,7 +2998,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectMultiCreate) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         vec2 vertices[3];
@@ -3011,7 +3011,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectMultiCreate) {
         }
     )glsl";
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3063,7 +3063,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectBoundDescriptor) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO { uint x; };
@@ -3100,7 +3100,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectUnusedBoundDescriptor) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO { uint x; };
@@ -3142,7 +3142,7 @@ TEST_F(NegativeDebugPrintf, OverflowBuffer) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
@@ -3175,7 +3175,7 @@ TEST_F(NegativeDebugPrintf, OverflowBufferLoop) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
@@ -3201,7 +3201,7 @@ TEST_F(NegativeDebugPrintf, OverflowBufferLoop) {
     m_errorMonitor->VerifyFound();
 }
 
-void NegativeDebugPrintf::BasicFormattingTest(const char *shader, bool warning) {
+void NegativeDebugPrintf::BasicFormattingTest(const char* shader, bool warning) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
@@ -3213,7 +3213,7 @@ void NegativeDebugPrintf::BasicFormattingTest(const char *shader, bool warning) 
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoVectorSize) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3224,7 +3224,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoVectorSize) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedLargeVectorSize) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3236,7 +3236,7 @@ TEST_F(NegativeDebugPrintf, MisformattedLargeVectorSize) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedSmallVectorSize) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3248,7 +3248,7 @@ TEST_F(NegativeDebugPrintf, MisformattedSmallVectorSize) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier1) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3259,7 +3259,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier2) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3270,7 +3270,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier2) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedUnknown1) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3281,7 +3281,7 @@ TEST_F(NegativeDebugPrintf, MisformattedUnknown1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedUnknown2) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3292,7 +3292,7 @@ TEST_F(NegativeDebugPrintf, MisformattedUnknown2) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedUnknown3) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3303,7 +3303,7 @@ TEST_F(NegativeDebugPrintf, MisformattedUnknown3) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedExtraArguments) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3314,7 +3314,7 @@ TEST_F(NegativeDebugPrintf, MisformattedExtraArguments) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoModifiers) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3325,7 +3325,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoModifiers) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedIsloatedPercent) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3336,7 +3336,7 @@ TEST_F(NegativeDebugPrintf, MisformattedIsloatedPercent) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotEnoughArguments) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3347,7 +3347,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNotEnoughArguments) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoArguments) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3358,7 +3358,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoArguments) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotVectorArg) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3370,7 +3370,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNotVectorArg) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotVectorParam) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3382,7 +3382,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNotVectorParam) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedVectorSmall) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3393,7 +3393,7 @@ TEST_F(NegativeDebugPrintf, MisformattedVectorSmall) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedVectorLarge) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3404,7 +3404,7 @@ TEST_F(NegativeDebugPrintf, MisformattedVectorLarge) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloat1) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3416,7 +3416,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloat1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloat2) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3428,7 +3428,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloat2) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloatVector1) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3440,7 +3440,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloatVector1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloatVector2) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3453,7 +3453,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloatVector2) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64Int1) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3467,7 +3467,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64Int1) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64Int2) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3481,7 +3481,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64Int2) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64IntVector1) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3496,7 +3496,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64IntVector1) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64IntVector2) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3510,7 +3510,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64IntVector2) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64Bool) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3523,7 +3523,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64Bool) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedEmptyString) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3534,7 +3534,7 @@ TEST_F(NegativeDebugPrintf, MisformattedEmptyString) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNewLine) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3546,7 +3546,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNewLine) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedVectorNewLine) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3558,7 +3558,7 @@ TEST_F(NegativeDebugPrintf, MisformattedVectorNewLine) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedPointer) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_buffer_reference : enable
@@ -3578,7 +3578,7 @@ TEST_F(NegativeDebugPrintf, MisformattedPointer) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotPointer) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3627,7 +3627,7 @@ TEST_F(NegativeDebugPrintf, DualPipelines) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3670,7 +3670,7 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferHalfPrint) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3714,7 +3714,7 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferBothPrint) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(push_constant) uniform PushConstants { int x; } pc;
@@ -3767,7 +3767,7 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferEmpty) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3814,7 +3814,7 @@ TEST_F(NegativeDebugPrintf, DispatchIndirect) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3825,7 +3825,7 @@ TEST_F(NegativeDebugPrintf, DispatchIndirect) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 kHostVisibleMemProps);
-    auto indirect_command = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    auto indirect_command = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     indirect_command->x = 1;
     indirect_command->y = 1;
     indirect_command->z = 1;
@@ -3848,7 +3848,7 @@ TEST_F(NegativeDebugPrintf, DispatchBase) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3877,7 +3877,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexed) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
     #version 450
         #extension GL_EXT_debug_printf : enable
         vec2 vertices[3];
@@ -3889,7 +3889,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexed) {
             debugPrintfEXT("gl_VertexIndex %u\n", gl_VertexIndex);
         }
     )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -3930,7 +3930,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirect) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -3952,7 +3952,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirect) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 kHostVisibleMemProps);
-    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.Memory().Map());
+    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand*>(indirect_buffer.Memory().Map());
     indirect_command->indexCount = 3;
     indirect_command->instanceCount = 1;
     indirect_command->firstIndex = 1;
@@ -3979,7 +3979,7 @@ TEST_F(NegativeDebugPrintf, DrawIndirectCount) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -3999,7 +3999,7 @@ TEST_F(NegativeDebugPrintf, DrawIndirectCount) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 kHostVisibleMemProps);
-    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.Memory().Map());
+    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand*>(indirect_buffer.Memory().Map());
     indirect_command->indexCount = 3;
     indirect_command->instanceCount = 1;
     indirect_command->firstIndex = 1;
@@ -4007,7 +4007,7 @@ TEST_F(NegativeDebugPrintf, DrawIndirectCount) {
     indirect_command->firstInstance = 1;
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 1;
 
     m_command_buffer.Begin();
@@ -4029,7 +4029,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirectCount) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -4051,7 +4051,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirectCount) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 kHostVisibleMemProps);
-    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.Memory().Map());
+    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand*>(indirect_buffer.Memory().Map());
     indirect_command->indexCount = 3;
     indirect_command->instanceCount = 1;
     indirect_command->firstIndex = 1;
@@ -4059,7 +4059,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirectCount) {
     indirect_command->firstInstance = 1;
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 1;
 
     m_command_buffer.Begin();
@@ -4102,7 +4102,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsCompute) {
     command_layout_ci.pTokens = &token;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4138,7 +4138,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsCompute) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    VkDispatchIndirectCommand *block_buffer_ptr = (VkDispatchIndirectCommand *)block_buffer.Memory().Map();
+    VkDispatchIndirectCommand* block_buffer_ptr = (VkDispatchIndirectCommand*)block_buffer.Memory().Map();
     block_buffer_ptr->x = 2;
     block_buffer_ptr->y = 1;
     block_buffer_ptr->z = 1;
@@ -4193,7 +4193,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsGraphics) {
     command_layout_ci.pTokens = &token;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4231,7 +4231,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsGraphics) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    VkDrawIndirectCommand *block_buffer_ptr = (VkDrawIndirectCommand *)block_buffer.Memory().Map();
+    VkDrawIndirectCommand* block_buffer_ptr = (VkDrawIndirectCommand*)block_buffer.Memory().Map();
     block_buffer_ptr->vertexCount = 3;
     block_buffer_ptr->instanceCount = 1;
     block_buffer_ptr->firstVertex = 0;
@@ -4297,21 +4297,21 @@ TEST_F(NegativeDebugPrintf, DISABLED_DeviceGeneratedCommandsIES) {
     command_layout_ci.pTokens = tokens;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    const char *shader_source_1 = R"glsl(
+    const char* shader_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
             debugPrintfEXT("Init Pipeline\n");
         }
     )glsl";
-    const char *shader_source_2 = R"glsl(
+    const char* shader_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
             debugPrintfEXT("IndirectExecutionSet Pipeline 1\n");
         }
     )glsl";
-    const char *shader_source_3 = R"glsl(
+    const char* shader_source_3 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4364,9 +4364,9 @@ TEST_F(NegativeDebugPrintf, DISABLED_DeviceGeneratedCommandsIES) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    uint32_t *block_buffer_ptr = (uint32_t *)block_buffer.Memory().Map();
+    uint32_t* block_buffer_ptr = (uint32_t*)block_buffer.Memory().Map();
     block_buffer_ptr[0] = 2;  // pick pipeline 2
-    VkDispatchIndirectCommand *indirect_command_ptr = (VkDispatchIndirectCommand *)(block_buffer_ptr + 1);
+    VkDispatchIndirectCommand* indirect_command_ptr = (VkDispatchIndirectCommand*)(block_buffer_ptr + 1);
     indirect_command_ptr->x = 1;
     indirect_command_ptr->y = 1;
     indirect_command_ptr->z = 1;
@@ -4397,7 +4397,7 @@ TEST_F(NegativeDebugPrintf, MultipleComputePasses) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source_1 = R"glsl(
+    const char* shader_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(binding = 0, set = 0) uniform UBO {
@@ -4407,7 +4407,7 @@ TEST_F(NegativeDebugPrintf, MultipleComputePasses) {
             debugPrintfEXT("float x == %f", x);
         }
     )glsl";
-    const char *shader_source_2 = R"glsl(
+    const char* shader_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4450,7 +4450,7 @@ TEST_F(NegativeDebugPrintf, SpecConstant) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(constant_id = 0) const uint value = 22; // default
@@ -4502,7 +4502,7 @@ TEST_F(NegativeDebugPrintf, InlineUniformBlock) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform UBO0 { uint ubo_0; };
@@ -4514,7 +4514,7 @@ TEST_F(NegativeDebugPrintf, InlineUniformBlock) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    VkDeviceAddress *buffer_ptr = (VkDeviceAddress *)buffer.Memory().Map();
+    VkDeviceAddress* buffer_ptr = (VkDeviceAddress*)buffer.Memory().Map();
     buffer_ptr[0] = 3;
 
     VkDescriptorPoolInlineUniformBlockCreateInfo pool_inline_info = vku::InitStructHelper();
@@ -4570,7 +4570,7 @@ TEST_F(NegativeDebugPrintf, StorageBufferLength) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -4638,7 +4638,7 @@ TEST_F(NegativeDebugPrintf, StorageBufferLengthUpdateAfterBind) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -4697,7 +4697,7 @@ TEST_F(NegativeDebugPrintf, PushDescriptor) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform Push {
@@ -4713,10 +4713,10 @@ TEST_F(NegativeDebugPrintf, PushDescriptor) {
     )glsl";
 
     vkt::Buffer buffer_a(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_a_ptr = (uint32_t *)buffer_a.Memory().Map();
+    auto buffer_a_ptr = (uint32_t*)buffer_a.Memory().Map();
     buffer_a_ptr[0] = 5;
     vkt::Buffer buffer_b(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_b_ptr = (uint32_t *)buffer_b.Memory().Map();
+    auto buffer_b_ptr = (uint32_t*)buffer_b.Memory().Map();
     buffer_b_ptr[0] = 7;
 
     VkDescriptorSetLayoutBinding bindning = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
@@ -4758,7 +4758,7 @@ TEST_F(NegativeDebugPrintf, DescriptorTemplates) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform UBO {
@@ -4770,7 +4770,7 @@ TEST_F(NegativeDebugPrintf, DescriptorTemplates) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 8, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    auto buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 42;
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr}});
@@ -4822,7 +4822,7 @@ TEST_F(NegativeDebugPrintf, PushDescriptorTemplates) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform UBO {
@@ -4834,7 +4834,7 @@ TEST_F(NegativeDebugPrintf, PushDescriptorTemplates) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 8, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    auto buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 42;
 
     vkt::DescriptorSetLayout push_dsl(*m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}},
@@ -4887,7 +4887,7 @@ TEST_F(NegativeDebugPrintf, DuplicateMessageLimit) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -4927,7 +4927,7 @@ TEST_F(NegativeDebugPrintf, DuplicateMessageLimitExplicit) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -4968,7 +4968,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBuffer) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -4987,10 +4987,10 @@ TEST_F(NegativeDebugPrintf, DescriptorBuffer) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5062,7 +5062,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferGPL) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -5081,10 +5081,10 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferGPL) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5182,7 +5182,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferShaderObject) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -5201,10 +5201,10 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferShaderObject) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5264,7 +5264,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferPushConstantOnly) {
     pipe_layout_ci.pSetLayouts = &ds_layout.handle();
     vkt::PipelineLayout pipeline_layout(*m_device, pipe_layout_ci);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(push_constant) uniform PushConstants {
@@ -5304,7 +5304,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferMixClassic) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5321,7 +5321,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferMixClassic) {
 
     const VkDeviceSize offset = 256;  // minStorageBufferOffsetAlignment required to be at most 256
     vkt::Buffer buffer_data(*m_device, 1024, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -5342,7 +5342,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferMixClassic) {
     vkt::Buffer descriptor_buffer(*m_device, ds_layout_size, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT,
                                   vkt::device_address);
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
     CreateComputePipelineHelper pipe_db(*this);
@@ -5415,11 +5415,11 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferMultipleCommandBuffers) {
 
     vkt::Buffer buffer1_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
     vkt::Buffer buffer2_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer1_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer1_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
-    data = (uint32_t *)buffer2_data.Memory().Map();
+    data = (uint32_t*)buffer2_data.Memory().Map();
     data[0] = 7;
     data[1] = 3;
     data[2] = 1;
@@ -5437,7 +5437,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferMultipleCommandBuffers) {
     vkt::Buffer descriptor_buffer(*m_device, ds_layout_size * 2, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT,
                                   vkt::device_address);
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     {
         vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer1_data, 16);
         vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
@@ -5448,7 +5448,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBufferMultipleCommandBuffers) {
                              mapped_descriptor_data + ds_layout_size);
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5516,7 +5516,7 @@ TEST_F(NegativeDebugPrintf, DrawMeshTasksIndirectCountEXT) {
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         #extension GL_EXT_debug_printf : enable
@@ -5545,12 +5545,12 @@ TEST_F(NegativeDebugPrintf, DrawMeshTasksIndirectCountEXT) {
                            GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl, SPV_ENV_VULKAN_1_2));
 
     vkt::Buffer count_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 1;
 
     vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawMeshTasksIndirectCommandEXT), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    auto *draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT *>(draw_buffer.Memory().Map());
+    auto* draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT*>(draw_buffer.Memory().Map());
     draw_ptr->groupCountX = 1;
     draw_ptr->groupCountY = 1;
     draw_ptr->groupCountZ = 1;
@@ -5587,7 +5587,7 @@ TEST_F(NegativeDebugPrintf, DisableShaderValidation) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *frag_shader = R"glsl(
+    const char* frag_shader = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO {
@@ -5659,7 +5659,7 @@ TEST_F(NegativeDebugPrintf, DisableShaderValidationShaderObject) {
     ds.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     ds.UpdateDescriptorSets();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO {
@@ -5694,7 +5694,7 @@ TEST_F(NegativeDebugPrintf, MidCommandBuffer) {
     // Make sure doing everything inside the command buffer is still ok
     m_command_buffer.Begin();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -5728,7 +5728,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeap) {
     GetPhysicalDeviceProperties2(heap_props);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -5739,7 +5739,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeap) {
 
     vkt::Buffer descriptor_heap(*m_device, resource_heap_size_driver, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT,
                                 vkt::device_address);
-    const auto descriptor_heap_ptr = static_cast<char *>(descriptor_heap.Memory().Map());
+    const auto descriptor_heap_ptr = static_cast<char*>(descriptor_heap.Memory().Map());
 
     VkHostAddressRangeEXT descriptor_host;
     descriptor_host.address = descriptor_heap_ptr;
@@ -5755,7 +5755,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeap) {
 
     vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5845,7 +5845,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapGraphics) {
     GetPhysicalDeviceProperties2(heap_props);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -5856,7 +5856,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapGraphics) {
 
     vkt::Buffer descriptor_heap(*m_device, resource_heap_size_driver, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT,
                                 vkt::device_address);
-    const auto descriptor_heap_ptr = static_cast<char *>(descriptor_heap.Memory().Map());
+    const auto descriptor_heap_ptr = static_cast<char*>(descriptor_heap.Memory().Map());
 
     VkHostAddressRangeEXT descriptor_host;
     descriptor_host.address = descriptor_heap_ptr;
@@ -5872,7 +5872,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapGraphics) {
 
     vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5954,7 +5954,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapUntypedPointers) {
     const uint32_t size = static_cast<uint32_t>(props2.properties.limits.minStorageBufferOffsetAlignment);
 
     vkt::Buffer buffer_data(*m_device, size * 3, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0 * size / sizeof(uint32_t)] = 8;
     data[1 * size / sizeof(uint32_t)] = 12;
     data[2 * size / sizeof(uint32_t)] = 1;
@@ -5965,7 +5965,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapUntypedPointers) {
 
     vkt::Buffer descriptor_heap(*m_device, resource_heap_size_driver, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT,
                                 vkt::device_address);
-    const auto descriptor_heap_ptr = static_cast<uint8_t *>(descriptor_heap.Memory().Map());
+    const auto descriptor_heap_ptr = static_cast<uint8_t*>(descriptor_heap.Memory().Map());
 
     VkHostAddressRangeEXT descriptor_host;
     descriptor_host.address = descriptor_heap_ptr;
@@ -5985,7 +5985,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapUntypedPointers) {
         vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_descriptor_heap : require
@@ -6042,7 +6042,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapGPL) {
     GetPhysicalDeviceProperties2(heap_props);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -6053,7 +6053,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapGPL) {
 
     vkt::Buffer descriptor_heap(*m_device, resource_heap_size_driver, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT,
                                 vkt::device_address);
-    const auto descriptor_heap_ptr = static_cast<char *>(descriptor_heap.Memory().Map());
+    const auto descriptor_heap_ptr = static_cast<char*>(descriptor_heap.Memory().Map());
 
     VkHostAddressRangeEXT descriptor_host;
     descriptor_host.address = descriptor_heap_ptr;
@@ -6069,7 +6069,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapGPL) {
 
     vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -6181,7 +6181,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapShaderObjects) {
     GetPhysicalDeviceProperties2(heap_props);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -6192,7 +6192,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapShaderObjects) {
 
     vkt::Buffer descriptor_heap(*m_device, resource_heap_size_driver, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT,
                                 vkt::device_address);
-    const auto descriptor_heap_ptr = static_cast<char *>(descriptor_heap.Memory().Map());
+    const auto descriptor_heap_ptr = static_cast<char*>(descriptor_heap.Memory().Map());
 
     VkHostAddressRangeEXT descriptor_host;
     descriptor_host.address = descriptor_heap_ptr;
@@ -6208,7 +6208,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapShaderObjects) {
 
     vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -6271,7 +6271,7 @@ TEST_F(NegativeDebugPrintf, DescriptorHeapPushConstantOnly) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(push_constant) uniform PushConstants {
@@ -6322,7 +6322,7 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeap) {
     GetPhysicalDeviceProperties2(heap_props);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -6339,7 +6339,7 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeap) {
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
     vkt::Buffer copy_src(*m_device, resource_heap_size_app, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, kHostVisibleMemProps);
-    const auto descriptor_heap_ptr = static_cast<char *>(copy_src.Memory().Map());
+    const auto descriptor_heap_ptr = static_cast<char*>(copy_src.Memory().Map());
 
     VkHostAddressRangeEXT descriptor_host;
     descriptor_host.address = descriptor_heap_ptr;
@@ -6355,7 +6355,7 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeap) {
 
     vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -6445,7 +6445,7 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeapGraphics) {
     GetPhysicalDeviceProperties2(heap_props);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -6462,7 +6462,7 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeapGraphics) {
         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
     vkt::Buffer copy_src(*m_device, resource_heap_size_app, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, kHostVisibleMemProps);
-    const auto descriptor_heap_ptr = static_cast<char *>(copy_src.Memory().Map());
+    const auto descriptor_heap_ptr = static_cast<char*>(copy_src.Memory().Map());
 
     VkHostAddressRangeEXT descriptor_host;
     descriptor_host.address = descriptor_heap_ptr;
@@ -6478,7 +6478,7 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeapGraphics) {
 
     vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -6561,7 +6561,7 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeapGraphics) {
     m_errorMonitor->VerifyFound();
 }
 
-void NegativeDebugPrintf::CoopMat2CallbackTest(const char *shader_source, const char *message) {
+void NegativeDebugPrintf::CoopMat2CallbackTest(const char* shader_source, const char* message) {
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
     AddRequiredExtensions(VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -6599,7 +6599,7 @@ TEST_F(NegativeDebugPrintf, CoopMat2PerElementOp) {
     TEST_DESCRIPTION("debugPrintfEXT inside a coopMatPerElementNV callback function");
     AddRequiredFeature(vkt::Feature::cooperativeMatrixPerElementOperations);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -6629,7 +6629,7 @@ TEST_F(NegativeDebugPrintf, CoopMat2Reduce) {
     TEST_DESCRIPTION("debugPrintfEXT inside a coopMatReduceNV combine callback function");
     AddRequiredFeature(vkt::Feature::cooperativeMatrixReductions);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -6663,7 +6663,7 @@ TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecode) {
     AddRequiredFeature(vkt::Feature::cooperativeMatrixTensorAddressing);
     AddRequiredFeature(vkt::Feature::cooperativeMatrixBlockLoads);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -6700,7 +6700,7 @@ TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecodeWithView) {
     AddRequiredFeature(vkt::Feature::cooperativeMatrixTensorAddressing);
     AddRequiredFeature(vkt::Feature::cooperativeMatrixBlockLoads);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_KHR_memory_scope_semantics : enable

--- a/tests/unit/debug_printf_shader_debug_info.cpp
+++ b/tests/unit/debug_printf_shader_debug_info.cpp
@@ -26,7 +26,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, PipelineHandle) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -39,7 +39,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, PipelineHandle) {
     pipe.cs_ = VkShaderObj(*m_device, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    const char *object_name = "bad_pipeline";
+    const char* object_name = "bad_pipeline";
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_PIPELINE;
     name_info.objectHandle = (uint64_t)pipe.Handle();
@@ -64,7 +64,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, ShaderObjectHandle) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -76,7 +76,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, ShaderObjectHandle) {
     VkShaderStageFlagBits shader_stages[] = {VK_SHADER_STAGE_COMPUTE_BIT};
     const vkt::Shader comp_shader(*m_device, shader_stages[0], GLSLToSPV(shader_stages[0], shader_source));
 
-    const char *object_name = "bad_shader_object";
+    const char* object_name = "bad_shader_object";
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_SHADER_EXT;
     name_info.objectHandle = (uint64_t)comp_shader.handle();
@@ -98,7 +98,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, OpLine) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %2 = OpExtInstImport "GLSL.std.450"
@@ -158,7 +158,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, ShaderDebugInfoDebugLine) {
 
     // Manually ran:
     //   glslangValidator -V -gVS in.comp -o out.spv --target-env vulkan1.0
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -243,7 +243,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndex) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -278,7 +278,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndexMulti) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(push_constant) uniform PushConstants { int x; } pc;
@@ -342,7 +342,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, StageInfo) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -374,7 +374,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, Fragment) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -421,7 +421,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, VertexFragmentMultiEntrypoint) {
     //     debugPrintfEXT("Fragment value is %i", 8);
     //     c_out = vec4(0.0);
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %9 = OpExtInstImport "NonSemantic.DebugPrintf"
@@ -523,7 +523,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, DISABLED_DebugLabelRegion1) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -557,7 +557,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, DISABLED_DebugLabelRegion2) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -1048,10 +1048,10 @@ TEST_F(NegativeDescriptorBuffer, LegacyDescriptorInvalidate) {
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
 
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 { uint x; };
         void main() {
@@ -1126,7 +1126,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     dbbi.address = buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform ufoo { uint index; };
         void main() {
@@ -1165,7 +1165,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
                                        });
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform ufoo { uint index; };
         void main() {
@@ -1960,7 +1960,7 @@ TEST_F(NegativeDescriptorBuffer, MaxResourceDescriptorBufferBindings) {
     buffer_descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     buffer_descriptor_info.data.pStorageBuffer = &addr_info;
 
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
 

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -15,7 +15,7 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
-void DescriptorBufferTest::InitBasicDescriptorBuffer(void *instance_pnext) {
+void DescriptorBufferTest::InitBasicDescriptorBuffer(void* instance_pnext) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -186,7 +186,7 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -201,10 +201,10 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
 
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -266,7 +266,7 @@ TEST_F(PositiveDescriptorBuffer, BasicSampler) {
         *m_device, ds_layout_size,
         VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT,
         vkt::device_address);
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
 
     vkt::DescriptorGetInfo get_info_sampler(&sampler.handle());
     vk::GetDescriptorEXT(device(), get_info_sampler, descriptor_buffer_properties.samplerDescriptorSize,
@@ -285,7 +285,7 @@ TEST_F(PositiveDescriptorBuffer, BasicSampler) {
     vk::GetDescriptorEXT(device(), get_info_buffer, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(3));
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform sampler s;
         layout(set = 0, binding = 1) uniform texture2D t; // sampled image
@@ -345,7 +345,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleDescriptors) {
     vkt::Buffer resource_descriptor_buffer(*m_device, ds_layout_size, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT,
                                            vkt::device_address);
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)resource_descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)resource_descriptor_buffer.Memory().Map();
     vkt::DescriptorGetInfo get_info_image(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_NULL_HANDLE, image_view, VK_IMAGE_LAYOUT_GENERAL);
     vk::GetDescriptorEXT(device(), get_info_image, descriptor_buffer_properties.sampledImageDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(0));
@@ -354,11 +354,11 @@ TEST_F(PositiveDescriptorBuffer, MultipleDescriptors) {
     vk::GetDescriptorEXT(device(), get_info_buffer, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(1));
 
-    mapped_descriptor_data = (uint8_t *)sampler_descriptor_buffer.Memory().Map();
+    mapped_descriptor_data = (uint8_t*)sampler_descriptor_buffer.Memory().Map();
     vkt::DescriptorGetInfo get_info_sampler(&sampler.handle());
     vk::GetDescriptorEXT(device(), get_info_sampler, descriptor_buffer_properties.samplerDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 2) uniform sampler s;
         layout(set = 0, binding = 0) uniform texture2D t;
@@ -411,7 +411,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     const uint32_t offset_1 = alignment / sizeof(uint32_t);
     const uint32_t offset_2 = offset_1 * 2;
     vkt::Buffer buffer_data(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[offset_0] = 8;
     data[offset_1] = 12;
     data[offset_2] = 1;
@@ -424,7 +424,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     vkt::Buffer descriptor_buffer(*m_device, ds_layout_size * 3, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT,
                                   vkt::device_address);
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 4);
     // Sets data_buffer[0] to set 0
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
@@ -439,7 +439,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     mapped_descriptor_data += ds_layout_size;
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -493,7 +493,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
     const uint32_t offset_1 = alignment / sizeof(uint32_t);
     const uint32_t offset_2 = offset_1 * 2;
     vkt::Buffer buffer_data(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[offset_0] = 8;
     data[offset_1] = 12;
     data[offset_2] = 1;
@@ -509,7 +509,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 4);
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     // Sets data_buffer[0] to binding 0
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(0));
@@ -524,7 +524,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(2));
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -578,11 +578,11 @@ TEST_F(PositiveDescriptorBuffer, DescriptorIndexing) {
     vkt::Buffer buffer_0(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
     vkt::Buffer buffer_1(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
     vkt::Buffer buffer_2(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_0.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_0.Memory().Map();
     data[0] = 8;
-    data = (uint32_t *)buffer_1.Memory().Map();
+    data = (uint32_t*)buffer_1.Memory().Map();
     data[0] = 12;
-    data = (uint32_t *)buffer_2.Memory().Map();
+    data = (uint32_t*)buffer_2.Memory().Map();
     data[0] = 1;
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3, VK_SHADER_STAGE_ALL, nullptr};
@@ -595,7 +595,7 @@ TEST_F(PositiveDescriptorBuffer, DescriptorIndexing) {
 
     size_t descriptor_size = descriptor_buffer_properties.storageBufferDescriptorSize;
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_0, 16);
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_size, mapped_descriptor_data);
 
     get_info.address_info.address = buffer_1.Address();
@@ -606,7 +606,7 @@ TEST_F(PositiveDescriptorBuffer, DescriptorIndexing) {
     mapped_descriptor_data += descriptor_size;
     vk::GetDescriptorEXT(device(), get_info, descriptor_size, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint data;
@@ -699,7 +699,7 @@ TEST_F(PositiveDescriptorBuffer, TexelBuffer) {
     vkt::Buffer uniform_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, vkt::device_address);
     vkt::BufferView uniform_buffer_view(*m_device, uniform_buffer, VK_FORMAT_R32_UINT);
 
-    uint32_t *data = (uint32_t *)uniform_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)uniform_buffer.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -716,7 +716,7 @@ TEST_F(PositiveDescriptorBuffer, TexelBuffer) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info_s(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, storage_buffer, 32, VK_FORMAT_R32_UINT);
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info_s, descriptor_buffer_properties.storageTexelBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(0));
 
@@ -724,7 +724,7 @@ TEST_F(PositiveDescriptorBuffer, TexelBuffer) {
     vk::GetDescriptorEXT(device(), get_info_u, descriptor_buffer_properties.uniformTexelBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(1));
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, r32ui) uniform uimageBuffer s_buffer;
         layout(set = 0, binding = 1) uniform usamplerBuffer u_buffer;
@@ -760,7 +760,7 @@ TEST_F(PositiveDescriptorBuffer, TexelBuffer) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    data = (uint32_t *)storage_buffer.Memory().Map();
+    data = (uint32_t*)storage_buffer.Memory().Map();
     if (!IsPlatformMockICD()) {
         ASSERT_TRUE(data[0] == 8);
         ASSERT_TRUE(data[1] == 12);
@@ -785,7 +785,7 @@ TEST_F(PositiveDescriptorBuffer, BindingOffsets) {
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
     get_info.address_info.address += 64;
@@ -796,7 +796,7 @@ TEST_F(PositiveDescriptorBuffer, BindingOffsets) {
     mapped_descriptor_data += ds_layout_size;
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint data;
@@ -839,7 +839,7 @@ TEST_F(PositiveDescriptorBuffer, BindingOffsets) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     if (!IsPlatformMockICD()) {
         ASSERT_TRUE(data[0] == 42);   // [0]
         ASSERT_TRUE(data[16] == 42);  // [64]
@@ -853,7 +853,7 @@ TEST_F(PositiveDescriptorBuffer, ShaderObject) {
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -867,10 +867,10 @@ TEST_F(PositiveDescriptorBuffer, ShaderObject) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -931,10 +931,10 @@ TEST_F(PositiveDescriptorBuffer, NotInvalidatedLegacy) {
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
 
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 { uint x; };
         void main() {
@@ -971,7 +971,7 @@ TEST_F(PositiveDescriptorBuffer, MeshShader) {
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 3, max_primitives=1) out;
@@ -1008,12 +1008,12 @@ TEST_F(PositiveDescriptorBuffer, MeshShader) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout});
 
     vkt::Buffer buffer(*m_device, sizeof(uint32_t) * 4u, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     data[0] = 3u;
     data[1] = 1u;
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
     VkDeviceSize buffer_offset = ds_layout.GetDescriptorBufferBindingOffset(0);
 
     vkt::DescriptorGetInfo buffer_get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer, buffer.CreateInfo().size);
@@ -1077,7 +1077,7 @@ TEST_F(PositiveDescriptorBuffer, GraphicsPipelineLibrary) {
 
     vkt::Buffer uniform_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
     VkDeviceSize buffer_offset = ds_layout1.GetDescriptorBufferBindingOffset(0);
 
     vkt::DescriptorGetInfo buffer_get_info(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uniform_buffer, uniform_buffer.CreateInfo().size);
@@ -1177,7 +1177,7 @@ TEST_F(PositiveDescriptorBuffer, GraphicsPipelineLibraryIndependent) {
 
     vkt::Buffer uniform_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
     VkDeviceSize buffer_offset = ds_layout1.GetDescriptorBufferBindingOffset(0);
 
     vkt::DescriptorGetInfo buffer_get_info(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, uniform_buffer, uniform_buffer.CreateInfo().size);
@@ -1272,7 +1272,7 @@ TEST_F(PositiveDescriptorBuffer, EmbeddedSamplers) {
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform sampler samp;
         layout(set = 1, binding = 0) uniform texture2D tex;
@@ -1310,7 +1310,7 @@ TEST_F(PositiveDescriptorBuffer, EmbeddedSamplers) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&sampler_ds_layout, &image_ds_layout});
 
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
     VkDeviceSize buffer_offset = image_ds_layout.GetDescriptorBufferBindingOffset(0);
 
     vkt::DescriptorGetInfo image_get_info(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_NULL_HANDLE, image_view, VK_IMAGE_LAYOUT_GENERAL);
@@ -1368,7 +1368,7 @@ TEST_F(PositiveDescriptorBuffer, EmbeddedSamplers) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float *data = (float *)result_buffer.Memory().Map();
+    float* data = (float*)result_buffer.Memory().Map();
     if (!IsPlatformMockICD()) {
         for (uint32_t i = 0; i < 4; i++) {
             ASSERT_NEAR(data[i], clear_color_value.float32[i], 0.0001f);
@@ -1398,7 +1398,7 @@ TEST_F(PositiveDescriptorBuffer, InputAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
             layout(set = 0, binding = 0, rgba8) readonly uniform image2D image1;
@@ -1430,7 +1430,7 @@ TEST_F(PositiveDescriptorBuffer, InputAttachment) {
     pipe.CreateGraphicsPipeline();
 
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
     VkDeviceSize image_offset = descriptor_set_layout.GetDescriptorBufferBindingOffset(0);
     VkDeviceSize input_attachment_offset =
         descriptor_set_layout2.GetDescriptorBufferBindingOffset(0) + descriptor_buffer_properties.storageImageDescriptorSize;
@@ -1477,7 +1477,7 @@ TEST_F(PositiveDescriptorBuffer, ImageLayoutIgnored) {
         image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 0, 1, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
             layout(set = 0, binding = 0) uniform sampler s;
@@ -1509,7 +1509,7 @@ TEST_F(PositiveDescriptorBuffer, ImageLayoutIgnored) {
     vkt::Buffer descriptor_buffer(
         *m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT,
         vkt::device_address);
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
 
     vkt::DescriptorGetInfo get_info_sampler(&sampler.handle());
     vk::GetDescriptorEXT(device(), get_info_sampler, descriptor_buffer_properties.samplerDescriptorSize,
@@ -1571,11 +1571,13 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics) {
                    (offset2 % descriptor_buffer_properties.descriptorBufferOffsetAlignment);
     }
 
-    uint8_t *mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
-    vk::GetDescriptorEXT(device(), get_info1, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data + offset1);
-    vk::GetDescriptorEXT(device(), get_info2, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data + offset2);
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
+    vk::GetDescriptorEXT(device(), get_info1, descriptor_buffer_properties.storageBufferDescriptorSize,
+                         mapped_descriptor_data + offset1);
+    vk::GetDescriptorEXT(device(), get_info2, descriptor_buffer_properties.storageBufferDescriptorSize,
+                         mapped_descriptor_data + offset2);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
             #version 450
             layout (set = 0, binding = 0) buffer Buf {
                 vec4 data;
@@ -1595,7 +1597,7 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics) {
     pipe.gp_ci_.layout = pipeline_layout;
     pipe.CreateGraphicsPipeline();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer Buf {
             vec4 data;
@@ -1621,7 +1623,8 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &buffer_binding_info);
-    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index, &offset1);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index,
+                                         &offset1);
     vk::CmdDraw(m_command_buffer, 4, 1, 0, 0);
     m_command_buffer.EndRenderPass();
 
@@ -1632,8 +1635,8 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float *data1 = (float *)buffer1.Memory().Map();
-    float *data2 = (float *)buffer2.Memory().Map();
+    float* data1 = (float*)buffer1.Memory().Map();
+    float* data2 = (float*)buffer2.Memory().Map();
     if (!IsPlatformMockICD()) {
         for (uint32_t i = 0; i < 4; i++) {
             ASSERT_EQ(data1[i], 1.0f);
@@ -1662,11 +1665,10 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics2) {
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer, 32u);
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
-    vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize,
-                         mapped_descriptor_data);
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
+    vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
             #version 450
             layout (set = 0, binding = 0) buffer Buf {
                 vec4 data[2];
@@ -1686,7 +1688,7 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics2) {
     pipe.gp_ci_.layout = pipeline_layout;
     pipe.CreateGraphicsPipeline();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 1, binding = 0) buffer Buf {
             vec4 data[2];
@@ -1713,8 +1715,7 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics2) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &buffer_binding_info);
-    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index,
-                                         &offset);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index, &offset);
     vk::CmdDraw(m_command_buffer, 4, 1, 0, 0);
     m_command_buffer.EndRenderPass();
 
@@ -1725,7 +1726,7 @@ TEST_F(PositiveDescriptorBuffer, ComputeAndGraphics2) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float *data = (float *)buffer.Memory().Map();
+    float* data = (float*)buffer.Memory().Map();
     if (!IsPlatformMockICD()) {
         for (uint32_t i = 0; i < 4; i++) {
             ASSERT_EQ(data[i], 1.0f);
@@ -1742,7 +1743,7 @@ TEST_F(PositiveDescriptorBuffer, PushDescriptor) {
 
     vkt::Buffer buffer_data0(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
     vkt::Buffer buffer_data1(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data0.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data0.Memory().Map();
     data[0] = 8;
     data[1] = 12;
 
@@ -1762,10 +1763,10 @@ TEST_F(PositiveDescriptorBuffer, PushDescriptor) {
     vkt::Buffer descriptor_buffer(*m_device, ds_layout_size, descriptor_buffer_usage, vkt::device_address);
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data0, 16);
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -1821,7 +1822,7 @@ TEST_F(PositiveDescriptorBuffer, PushDescriptor) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     if (!IsPlatformMockICD()) {
-        data = (uint32_t *)buffer_data1.Memory().Map();
+        data = (uint32_t*)buffer_data1.Memory().Map();
         ASSERT_TRUE(data[0] == 20);
     }
 }
@@ -1833,7 +1834,7 @@ TEST_F(PositiveDescriptorBuffer, PushDescriptorOnly) {
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -1846,7 +1847,7 @@ TEST_F(PositiveDescriptorBuffer, PushDescriptorOnly) {
         VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT | VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -1915,10 +1916,10 @@ TEST_F(PositiveDescriptorBuffer, DeviceLocal) {
 
     const VkDeviceSize offset = 0;
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)src_descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)src_descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
             #version 450
             layout (set = 0, binding = 0) buffer Buf {
                 vec4 data;
@@ -1977,7 +1978,7 @@ TEST_F(PositiveDescriptorBuffer, DeviceLocal) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float *data = (float *)buffer.Memory().Map();
+    float* data = (float*)buffer.Memory().Map();
     if (!IsPlatformMockICD()) {
         for (uint32_t i = 0; i < 4; i++) {
             ASSERT_EQ(data[i], 1.0f);
@@ -2003,13 +2004,13 @@ TEST_F(PositiveDescriptorBuffer, DestroyDescriptor) {
 
     const VkDeviceSize offset = 0;
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
     buffer.Destroy();
     set_layout.Destroy();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
             #version 450
             layout (set = 0, binding = 0) buffer Buf {
                 vec4 data;
@@ -2046,7 +2047,7 @@ TEST_F(PositiveDescriptorBuffer, DestroyDescriptor) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float *data = (float *)buffer.Memory().Map();
+    float* data = (float*)buffer.Memory().Map();
     if (!IsPlatformMockICD()) {
         for (uint32_t i = 0; i < 4; i++) {
             ASSERT_EQ(data[i], 1.0f);
@@ -2076,17 +2077,17 @@ TEST_F(PositiveDescriptorBuffer, SharedSet) {
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer, buffer.CreateInfo().size);
 
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     data[0] = 5u;
     data[1] = 7u;
 
-    void *mapped_copy_data = copy_buffer.Memory().Map();
+    void* mapped_copy_data = copy_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_copy_data);
 
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     memcpy(mapped_descriptor_data, mapped_copy_data, descriptor_buffer_properties.storageBufferDescriptorSize);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
             #version 450
             layout(set = 0, binding = 0) buffer SSBO_0 {
                 uint a_0;

--- a/tests/unit/descriptor_heap.cpp
+++ b/tests/unit/descriptor_heap.cpp
@@ -482,8 +482,7 @@ TEST_F(NegativeDescriptorHeap, ResourceParameterDataNull) {
          std::vector<VkDescriptorType>{// checked in separate test VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR,
                                        // VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV,
                                        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER}},
-        {"VUID-VkResourceDescriptorInfoEXT-None-11457",
-         std::vector<VkDescriptorType>{VK_DESCRIPTOR_TYPE_TENSOR_ARM}},
+        {"VUID-VkResourceDescriptorInfoEXT-None-11457", std::vector<VkDescriptorType>{VK_DESCRIPTOR_TYPE_TENSOR_ARM}},
     };
     for (const auto& s : subtests) {
         for (auto type : s.types) {

--- a/tests/unit/descriptor_heap_positive.cpp
+++ b/tests/unit/descriptor_heap_positive.cpp
@@ -346,9 +346,12 @@ TEST_F(PositiveDescriptorHeap, ResourceParameterDataNull) {
     AddRequiredFeature(vkt::Feature::tensors);
     RETURN_IF_SKIP(InitBasicDescriptorHeap());
 
-    std::vector<VkDescriptorType> types{VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                        VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
-                                        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,       VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+    std::vector<VkDescriptorType> types{VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                        VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                        VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER,
+                                        VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER,
+                                        VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                                        VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
                                         VK_DESCRIPTOR_TYPE_TENSOR_ARM};
     for (auto type : types) {
         const VkDeviceSize size = vk::GetPhysicalDeviceDescriptorSizeEXT(Gpu(), type);
@@ -1457,8 +1460,7 @@ TEST_F(PositiveDescriptorHeap, MappingSourceHeapData) {
     const int32_t read_push_offset = 8;
     const uint32_t read_push_data_offset = 48u;
     const uint32_t read_offset = read_heap_offset + read_push_offset;
-    const VkDeviceSize write_offset =
-        Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
+    const VkDeviceSize write_offset = Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
 
     CreateResourceHeap(write_offset + resource_stride);
@@ -1561,8 +1563,7 @@ TEST_F(PositiveDescriptorHeap, MappingSourcePushData) {
     vkt::Buffer write_buffer(*m_device, sizeof(uint32_t) * 4, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
 
     const uint32_t read_offset = 48u;
-    const VkDeviceSize write_offset =
-        Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
+    const VkDeviceSize write_offset = Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
 
     CreateResourceHeap(write_offset + resource_stride);
@@ -1669,8 +1670,7 @@ TEST_F(PositiveDescriptorHeap, MappingSourcePushAddress) {
     vkt::Buffer write_buffer(*m_device, sizeof(uint32_t) * 4, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
 
     const uint32_t read_offset = 48u;
-    const VkDeviceSize write_offset =
-        Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
+    const VkDeviceSize write_offset = Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(write_offset + resource_stride);
 
@@ -1779,8 +1779,7 @@ TEST_F(PositiveDescriptorHeap, MappingSourceIndirectAddress) {
     VkDeviceAddress* indirect_data_address = reinterpret_cast<VkDeviceAddress*>(indirect_data + indirect_offset);
     *indirect_data_address = read_buffer.Address();
 
-    const VkDeviceSize write_offset =
-        Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
+    const VkDeviceSize write_offset = Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(write_offset + resource_stride);
 
@@ -3684,7 +3683,7 @@ TEST_F(PositiveDescriptorHeap, ComputeTensor) {
 
     // buffer
     descriptor_ranges[1] = {resource_heap_data_ + buffer_desc_offset, static_cast<size_t>(buffer_desc_size)};
-    VkDeviceAddressRangeEXT buffer_address_range = { buffer.Address(), buffer.CreateInfo().size };
+    VkDeviceAddressRangeEXT buffer_address_range = {buffer.Address(), buffer.CreateInfo().size};
     descriptor_infos[1] = vku::InitStructHelper();
     descriptor_infos[1].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     descriptor_infos[1].data.pAddressRange = &buffer_address_range;

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2021 ARM, Inc. All rights reserved.
  *
@@ -92,7 +92,7 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
     // Create a dummy pipeline, since VL inspects which bindings are actually used at draw time
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         layout(set=0, binding=0) uniform foo0 { float x0; } bar0;
@@ -463,7 +463,7 @@ TEST_F(NegativeDescriptorIndexing, VariableDescriptorCountBuffer) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout(set = 0, binding = 0) buffer SSBO { int x; } bufs[4];
         void main() {

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
-void DescriptorIndexingTest::ComputePipelineShaderTest(const char *shader, std::vector<VkDescriptorSetLayoutBinding> &bindings) {
+void DescriptorIndexingTest::ComputePipelineShaderTest(const char* shader, std::vector<VkDescriptorSetLayoutBinding>& bindings) {
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
@@ -61,7 +61,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform foo_0 { int val; } doit;
         layout(set = 0, binding = 1) uniform foo_1 { int val; } readit;
@@ -235,7 +235,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderBasic) {
         {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer block { int x; };
@@ -256,7 +256,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderSampler2D) {
         {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer block { vec2 x; };
@@ -276,7 +276,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderImageBufferArray) {
         {1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer block { int x; };
@@ -303,7 +303,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderMultiArrayIndexing) {
         {2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 6, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform A { uint value; };
@@ -368,7 +368,7 @@ TEST_F(PositiveDescriptorIndexing, StaticAccessSomeOfTheArray) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_0, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { float x; } bufs[2];
         void main() {
@@ -421,7 +421,7 @@ TEST_F(PositiveDescriptorIndexing, VariableDescriptorCountBuffer) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout(set = 0, binding = 0) buffer SSBO { int x; } bufs[3];
         void main() {

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -833,7 +833,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
         vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
 
         // Create PSO that uses the uniform buffers
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=0) layout(binding=0) uniform foo { int x; int y; } bar;
@@ -878,7 +878,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
         vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
         // Create PSO to be used for draw-time errors below
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=0) layout(binding=0) uniform foo { int x; int y; } bar;
@@ -926,7 +926,7 @@ TEST_F(NegativeDescriptors, DrawDescriptorSetBufferDestroyed) {
         vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
         // Create PSO to be used for draw-time errors below
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=0) layout(binding=0) uniform foo { int x; int y; } bar;
@@ -1014,7 +1014,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
 
     // Create PSO to be used for draw-time errors below
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 x;
@@ -1162,7 +1162,7 @@ TEST_F(NegativeDescriptors, OpArrayLengthStaticallyUsed) {
     RETURN_IF_SKIP(Init());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -1241,7 +1241,7 @@ TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     sampler1.Destroy();
 
     // Create PSO to be used for draw-time errors below
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(set=0, binding=1) uniform sampler2D s1;
@@ -1326,7 +1326,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
     constexpr std::array external_errors = {"VUID-vkCmdDraw-None-09600"};
 
     // Common steps to create the two classes of errors (or two classes of positives)
-    auto do_test = [&](vkt::Image *image, vkt::ImageView *view, VkImageAspectFlags aspect_mask, VkImageLayout image_layout,
+    auto do_test = [&](vkt::Image* image, vkt::ImageView* view, VkImageAspectFlags aspect_mask, VkImageLayout image_layout,
                        VkImageLayout descriptor_layout, const bool positive_test) {
         // Set up the descriptor
         img_info.imageView = view->handle();
@@ -1357,7 +1357,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
             // At draw time the update layout will mis-match the actual layout
             if (positive_test || (test_type == kExternal)) {
             } else {
-                for (const auto &err : internal_errors) {
+                for (const auto& err : internal_errors) {
                     m_errorMonitor->SetDesiredError(err);
                 }
             }
@@ -1373,7 +1373,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
             // Submit cmd buffer
             if (positive_test || (test_type == kInternal)) {
             } else {
-                for (const auto &err : external_errors) {
+                for (const auto& err : external_errors) {
                     m_errorMonitor->SetDesiredError(err);
                 }
             }
@@ -1796,7 +1796,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Create PSO to be used for draw-time errors below
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0) layout(binding=0) uniform foo1 { int x; int y; } bar1;
@@ -1985,7 +1985,7 @@ TEST_F(NegativeDescriptors, DISABLED_MutableBufferUpdate) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer SSBO { uint x; };
         void main() {
@@ -2085,7 +2085,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     ds_layouts.emplace_back(*m_device, std::vector<VkDescriptorSetLayoutBinding>(1, dsl_binding[0]));
 
     std::vector<VkDescriptorSetLayout> ds_vk_layouts;
-    for (const auto &ds_layout : ds_layouts) {
+    for (const auto& ds_layout : ds_layouts) {
         ds_vk_layouts.push_back(ds_layout);
     }
 
@@ -2215,7 +2215,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibilityCompute) {
     const vkt::PipelineLayout pipeline_layout_a(*m_device, {&descriptor_set_storage.layout_, &descriptor_set_storage.layout_});
     const vkt::PipelineLayout pipeline_layout_b(*m_device, {&descriptor_set_storage.layout_, &descriptor_set_uniform.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 1, binding = 0) buffer StorageBuffer_1 {
             uint a;
@@ -2271,7 +2271,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibilityMutableDescriptors) {
     descriptor_set_1.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set_1.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint a;
@@ -2490,7 +2490,7 @@ TEST_F(NegativeDescriptors, DSBufferLimit) {
         std::string min_align_vu;
     };
 
-    for (const auto &test_case : {
+    for (const auto& test_case : {
              TestCase({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                        m_device->Physical().limits_.maxUniformBufferRange, "VUID-VkWriteDescriptorSet-descriptorType-00332",
                        m_device->Physical().limits_.minUniformBufferOffsetAlignment,
@@ -3591,7 +3591,7 @@ TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     sampler_descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     sampler_descriptor_set.UpdateDescriptorSets();
     const vkt::PipelineLayout pipeline_layout(*m_device, {&sampler_descriptor_set.layout_});
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D tex;
         layout(location=0) out vec4 x;
@@ -3648,7 +3648,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
     vkt::Framebuffer fb(*m_device, rp, 2u, attachments, 64, 64);
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput ia0;
         layout(set=0, binding=1) uniform sampler2D ci1;
@@ -4344,7 +4344,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 x;
             layout(set = 0, binding = 0) writeonly uniform image2D image;
@@ -4419,7 +4419,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     //     x = vec4(1.0f);
     //     foo(image_0);
     // }
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color_attach
@@ -4521,7 +4521,7 @@ TEST_F(NegativeDescriptors, DISABLED_DescriptorReadFromWriteAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
             layout(set = 0, binding = 0, rgba8) readonly uniform image2D image1;
@@ -4593,7 +4593,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
             #version 450
             layout(set = 0, binding = 0, rgba8) writeonly uniform image2D image1;
             layout(set = 1, binding = 0, input_attachment_index = 0) uniform subpassInput inputColor;
@@ -5004,7 +5004,7 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
     TEST_DESCRIPTION("Dispatch with unbound descriptor set");
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(local_size_x=1, local_size_y=1, local_size_z=1) in;
         layout(set = 0, binding = 0) uniform sampler2D InputTexture;
@@ -5050,7 +5050,7 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
 TEST_F(NegativeDescriptors, CompatiblePushConstantRanges) {
     RETURN_IF_SKIP(Init());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
 
         layout(push_constant, std430) uniform PC {
@@ -6188,7 +6188,7 @@ TEST_F(NegativeDescriptors, ImmutableSamplerIdenticallyDefined) {
     descriptor_set.WriteDescriptorBufferInfo(0, storage_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -6248,7 +6248,7 @@ TEST_F(NegativeDescriptors, ImmutableSamplerIdenticallyDefinedMaintenance4) {
     descriptor_set.WriteDescriptorBufferInfo(0, storage_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -6315,7 +6315,7 @@ TEST_F(NegativeDescriptors, ImmutableSamplerIdenticallyDefinedFilterMinmax) {
     descriptor_set.WriteDescriptorBufferInfo(0, storage_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -127,8 +127,8 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
         // This will most likely produce a crash if the parameter_validation
         // layer
         // does not correctly ignore pBufferInfo.
-        descriptor_write.pBufferInfo = reinterpret_cast<const VkDescriptorBufferInfo *>(invalid_ptr);
-        descriptor_write.pTexelBufferView = reinterpret_cast<const VkBufferView *>(invalid_ptr);
+        descriptor_write.pBufferInfo = reinterpret_cast<const VkDescriptorBufferInfo*>(invalid_ptr);
+        descriptor_write.pTexelBufferView = reinterpret_cast<const VkBufferView*>(invalid_ptr);
 
         vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
     }
@@ -155,8 +155,8 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
         // This will most likely produce a crash if the parameter_validation
         // layer
         // does not correctly ignore pImageInfo.
-        descriptor_write.pImageInfo = reinterpret_cast<const VkDescriptorImageInfo *>(invalid_ptr);
-        descriptor_write.pTexelBufferView = reinterpret_cast<const VkBufferView *>(invalid_ptr);
+        descriptor_write.pImageInfo = reinterpret_cast<const VkDescriptorImageInfo*>(invalid_ptr);
+        descriptor_write.pTexelBufferView = reinterpret_cast<const VkBufferView*>(invalid_ptr);
 
         vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
     }
@@ -184,8 +184,8 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
         // This will most likely produce a crash if the parameter_validation
         // layer
         // does not correctly ignore pImageInfo and pBufferInfo.
-        descriptor_write.pImageInfo = reinterpret_cast<const VkDescriptorImageInfo *>(invalid_ptr);
-        descriptor_write.pBufferInfo = reinterpret_cast<const VkDescriptorBufferInfo *>(invalid_ptr);
+        descriptor_write.pImageInfo = reinterpret_cast<const VkDescriptorImageInfo*>(invalid_ptr);
+        descriptor_write.pBufferInfo = reinterpret_cast<const VkDescriptorBufferInfo*>(invalid_ptr);
 
         vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
     }
@@ -216,7 +216,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerOnlyDescriptor) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0, binding=0) uniform sampler immutableSampler;
@@ -308,7 +308,7 @@ TEST_F(PositiveDescriptors, DynamicOffsetWithInactiveBinding) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Create PSO to be used for draw-time errors below
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0) layout(binding=0) uniform foo1 { int x; int y; } bar1;
@@ -444,7 +444,7 @@ TEST_F(PositiveDescriptors, DescriptorSetCompatibilityMutableDescriptors) {
     descriptor_set_1.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set_1.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint a;
@@ -643,7 +643,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
             layout(set = 0, binding = 0, rgba8) readonly uniform image2D image1;
@@ -732,7 +732,7 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
                                        VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_EXT, nullptr,
                                        VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT);
 
-    const auto &testing_thread1 = [&]() {
+    const auto& testing_thread1 = [&]() {
         VkDescriptorImageInfo image_info = {VK_NULL_HANDLE, view1, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
         VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
@@ -743,7 +743,7 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
 
         vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
     };
-    const auto &testing_thread2 = [&]() {
+    const auto& testing_thread2 = [&]() {
         VkDescriptorImageInfo image_info = {VK_NULL_HANDLE, view2, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
         VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
@@ -757,7 +757,7 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
     };
 
     std::array<std::thread, 2> threads = {std::thread(testing_thread1), std::thread(testing_thread2)};
-    for (auto &t : threads) t.join();
+    for (auto& t : threads) t.join();
 }
 
 TEST_F(PositiveDescriptors, BindingEmptyDescriptorSets) {
@@ -796,7 +796,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
 
     vkt::Framebuffer fb(*m_device, rp, 1, &view_input.handle(), width, height);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         void main() {
@@ -905,7 +905,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
 
         // Bind set A to a command buffer and submit the command buffer;
         {
-            auto &cb = use_single_command_buffer ? m_command_buffer : cb0;
+            auto& cb = use_single_command_buffer ? m_command_buffer : cb0;
             cb.Begin();
             vk::CmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &set_A, 0, nullptr);
             vk::CmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
@@ -921,7 +921,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
 
         // Bind set B to a command buffer and submit the command buffer;
         {
-            auto &cb = use_single_command_buffer ? m_command_buffer : cb1;
+            auto& cb = use_single_command_buffer ? m_command_buffer : cb1;
             cb.Begin();
             vk::CmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &set_B, 0, nullptr);
             vk::CmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
@@ -1027,7 +1027,7 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
                                             VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *frag_src = R"glsl(
+    const char* frag_src = R"glsl(
         #version 450
         layout(set=0) layout(binding=0) uniform sampler2D tex;
         layout(location=0) out vec4 color;
@@ -1153,7 +1153,7 @@ TEST_F(PositiveDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     //     x = vec4(1.0f);
     //     foo(image_1);
     // }
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color_attach
@@ -1927,7 +1927,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerIdenticallyDefined) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -1985,7 +1985,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerIdenticallyDefinedMaintenance4) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -2046,7 +2046,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerIdenticallyDefinedMaintenance4_2) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -2113,7 +2113,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerIdenticallyDefinedFilterMinmax) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -2226,7 +2226,7 @@ TEST_F(PositiveDescriptors, ReuseSetLayoutDefWithImmutableSamplers2) {
         descriptor_write.pImageInfo = &image_info;
         vk::UpdateDescriptorSets(*m_device, 1u, &descriptor_write, 0u, nullptr);
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 440
 
             layout(set = 0, binding = 0) uniform sampler2DMS u_ms_image_sampler;
@@ -2317,7 +2317,7 @@ TEST_F(PositiveDescriptors, DummySecondDevice) {
     OneOffDescriptorSet ds_0(m_device, {binding_def});
     const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint x; };
         void main() {
@@ -2359,7 +2359,7 @@ TEST_F(PositiveDescriptors, DummySecondInstance) {
     OneOffDescriptorSet ds_0(m_device, {binding_def});
     const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint x; };
         void main() {

--- a/tests/unit/device_feature_property.cpp
+++ b/tests/unit/device_feature_property.cpp
@@ -18,7 +18,7 @@ class NegativeDeviceFeatureProperty : public VkLayerTest {
   public:
     VkDevice m_second_device = VK_NULL_HANDLE;
     VkDeviceCreateInfo m_second_device_ci = vku::InitStructHelper();
-    vkt::QueueCreateInfoArray *m_queue_info = nullptr;
+    vkt::QueueCreateInfoArray* m_queue_info = nullptr;
     void InitDeviceFeatureProperty();
 
     ~NegativeDeviceFeatureProperty() {
@@ -169,7 +169,7 @@ TEST_F(NegativeDeviceFeatureProperty, PromotedFeaturesExtensions11) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitDeviceFeatureProperty());
 
-    std::vector<const char *> extension_list;
+    std::vector<const char*> extension_list;
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME)) {
         extension_list.push_back(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
     }
@@ -191,7 +191,7 @@ TEST_F(NegativeDeviceFeatureProperty, PromotedFeaturesExtensions12) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitDeviceFeatureProperty());
 
-    std::vector<const char *> extension_list;
+    std::vector<const char*> extension_list;
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
         extension_list.push_back(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
         m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-02831");
@@ -242,7 +242,7 @@ TEST_F(NegativeDeviceFeatureProperty, PromotedFeaturesExtensions14) {
     features14.pushDescriptor = VK_FALSE;
     m_second_device_ci.pNext = &features14;
 
-    std::array<const char *, 1> extension_list = {VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME};
+    std::array<const char*, 1> extension_list = {VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME};
     m_second_device_ci.ppEnabledExtensionNames = extension_list.data();
     m_second_device_ci.enabledExtensionCount = extension_list.size();
 
@@ -354,7 +354,7 @@ TEST_F(NegativeDeviceFeatureProperty, NegativeViewportHeight11) {
         GTEST_SKIP() << "AMD_negative viewport height extensions not supported";
     }
 
-    const char *extension_names = VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME;
+    const char* extension_names = VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME;
     m_second_device_ci.enabledExtensionCount = 1;
     m_second_device_ci.ppEnabledExtensionNames = &extension_names;
 
@@ -376,7 +376,7 @@ TEST_F(NegativeDeviceFeatureProperty, BufferDeviceAddress) {
     features12.bufferDeviceAddress = VK_TRUE;
     m_second_device_ci.pNext = &features12;
 
-    const char *extension_names = VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME;
+    const char* extension_names = VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME;
     m_second_device_ci.enabledExtensionCount = 1;
     m_second_device_ci.ppEnabledExtensionNames = &extension_names;
 

--- a/tests/unit/device_feature_property_positive.cpp
+++ b/tests/unit/device_feature_property_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 class PositiveDeviceFeatureProperty : public VkLayerTest {
   public:
     VkDeviceCreateInfo m_second_device_ci = vku::InitStructHelper();
-    vkt::QueueCreateInfoArray *m_queue_info = nullptr;
+    vkt::QueueCreateInfoArray* m_queue_info = nullptr;
     void InitDeviceFeatureProperty();
 
     ~PositiveDeviceFeatureProperty() {

--- a/tests/unit/device_generated_commands.cpp
+++ b/tests/unit/device_generated_commands.cpp
@@ -853,7 +853,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineFragmentOutput) {
     CreatePipelineHelper init_pipe(*this, &pipe_flags2);
     init_pipe.CreateGraphicsPipeline();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout(location = 1) out vec4 uFragColor;
         void main(){
@@ -887,7 +887,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineFragDepth) {
     init_pipe.CreateGraphicsPipeline();
     vkt::IndirectExecutionSet exe_set(*m_device, init_pipe, 1);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -920,7 +920,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineSampleMask) {
     init_pipe.CreateGraphicsPipeline();
     vkt::IndirectExecutionSet exe_set(*m_device, init_pipe, 1);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -954,7 +954,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineStencilExportEXT) {
     init_pipe.CreateGraphicsPipeline();
     vkt::IndirectExecutionSet exe_set(*m_device, init_pipe, 1);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         #extension GL_ARB_shader_stencil_export: enable
         layout(location = 0) out vec4 uFragColor;
@@ -1029,7 +1029,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineCompatible) {
     const vkt::PipelineLayout pipeline_layout_vert(*m_device, {&descriptor_set_vert.layout_});
     const vkt::PipelineLayout pipeline_layout_all(*m_device, {&descriptor_set_all.layout_});
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer {
             uint a;
@@ -1276,7 +1276,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     write_exe_set.index = 1;
 
     {
-        const char *fs_source_location = R"glsl(
+        const char* fs_source_location = R"glsl(
             #version 460
             layout(location = 1) out vec4 uFragColor;
             void main(){
@@ -1295,7 +1295,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     }
 
     {
-        const char *fs_source_depth = R"glsl(
+        const char* fs_source_depth = R"glsl(
             #version 460
             layout(location = 0) out vec4 uFragColor;
             void main(){
@@ -1316,7 +1316,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     }
 
     {
-        const char *fs_source_mask = R"glsl(
+        const char* fs_source_mask = R"glsl(
             #version 460
             layout(location = 0) out vec4 uFragColor;
             void main(){
@@ -1337,7 +1337,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     }
 
     {
-        const char *fs_source_stencil = R"glsl(
+        const char* fs_source_stencil = R"glsl(
             #version 460
             #extension GL_ARB_shader_stencil_export: enable
             layout(location = 0) out vec4 uFragColor;

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -230,8 +230,7 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     inheritance_rendering_info.colorAttachmentCount = 1;
     inheritance_rendering_info.pColorAttachmentFormats = &render_target_ci.format;
     inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-    VkCommandBufferInheritanceInfo secondary_cmd_buffer_inheritance_info =
-        vku::InitStructHelper(&inheritance_rendering_info);
+    VkCommandBufferInheritanceInfo secondary_cmd_buffer_inheritance_info = vku::InitStructHelper(&inheritance_rendering_info);
 
     VkCommandBufferBeginInfo secondary_cmd_buffer_begin_info = vku::InitStructHelper();
     secondary_cmd_buffer_begin_info.flags =
@@ -1504,8 +1503,7 @@ TEST_F(NegativeDynamicRendering, AttachmentInfo) {
     depth_attachment.resolveMode = resolve_mode;
     depth_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
-    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map =
-        vku::InitStructHelper();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
     fragment_density_map.imageView = depth_image_view;
     fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
@@ -1678,8 +1676,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
 
     if (shading_rate) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-imageView-06183");
-        VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate =
-            vku::InitStructHelper();
+        VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
         fragment_shading_rate.imageView = depth_image_view;
         fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
         fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
@@ -1712,8 +1709,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
 
     if (fragment_density) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-imageView-06184");
-        VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map =
-            vku::InitStructHelper();
+        VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
         fragment_density_map.imageView = depth_image_view;
         fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
@@ -2830,7 +2826,9 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
 }
 
 TEST_F(NegativeDynamicRendering, SecondaryCommandBufferContents) {
-    TEST_DESCRIPTION("Execute secondary command buffers within active render pass that was not begun with VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS");
+    TEST_DESCRIPTION(
+        "Execute secondary command buffers within active render pass that was not begun with "
+        "VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
@@ -2864,7 +2862,7 @@ TEST_F(NegativeDynamicRendering, InputAttachmentCapability) {
 
     InitRenderTarget();
 
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                OpCapability Shader
                OpCapability InputAttachment
           %1 = OpExtInstImport "GLSL.std.450"
@@ -3789,7 +3787,7 @@ TEST_F(NegativeDynamicRendering, AttachmentImageViewShadingRateLayout) {
     m_command_buffer.Begin();
 
     // SHADING_RATE_OPTIMAL_NV is aliased FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR so VU depends on which extensions
-    const char *vuid =
+    const char* vuid =
         khr_fragment_shading ? "VUID-VkRenderingAttachmentInfo-imageView-06143" : "VUID-VkRenderingAttachmentInfo-imageView-06138";
     m_errorMonitor->SetDesiredError(vuid);
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -3843,7 +3841,7 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewShadingRateLayout) {
     m_command_buffer.Begin();
 
     // SHADING_RATE_OPTIMAL_NV is aliased FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR so VU depends on which extensions
-    const char *vuid =
+    const char* vuid =
         khr_fragment_shading ? "VUID-VkRenderingAttachmentInfo-imageView-06144" : "VUID-VkRenderingAttachmentInfo-imageView-06139";
     m_errorMonitor->SetDesiredError(vuid);
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -4084,7 +4082,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachment) {
 
     const uint32_t max_color_attachments = m_device->Physical().limits_.maxColorAttachments + 1;
     std::vector<VkRenderingAttachmentInfo> color_attachments(max_color_attachments);
-    for (auto &attachment : color_attachments) {
+    for (auto& attachment : color_attachments) {
         attachment = vku::InitStructHelper();
         attachment.imageView = image_view;
         attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -6455,7 +6453,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipeline) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -6486,7 +6484,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipelineNoInfo) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled but no rendering info struct.");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -8229,8 +8227,8 @@ TEST_F(NegativeDynamicRendering, CountersByRegionARM) {
     auto render_pass_create_info = vku::InitStruct<VkRenderPassCreateInfo2>(nullptr, 0u, 0u, nullptr, 1u, &subpass, 0u, nullptr);
     vkt::RenderPass render_pass(*m_device, render_pass_create_info);
     vkt::Framebuffer framebuffer(*m_device, render_pass, 0, nullptr, ra_extent.width, ra_extent.height);
-    auto rp_begin =
-        vku::InitStruct<VkRenderPassBeginInfo>(&perf_begin_info, render_pass.handle(), framebuffer.handle(), render_area, 0u, nullptr);
+    auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>(&perf_begin_info, render_pass.handle(), framebuffer.handle(),
+                                                           render_area, 0u, nullptr);
 
     VkRenderingInfo rendering_info = vku::InitStructHelper(&perf_begin_info);
     rendering_info.layerCount = 1;
@@ -8240,7 +8238,7 @@ TEST_F(NegativeDynamicRendering, CountersByRegionARM) {
         perf_begin_info.counterAddressCount = 2;
 
         CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false,
-                            "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterAddressCount-11815", nullptr);
+                                  "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterAddressCount-11815", nullptr);
 
         m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterAddressCount-11815");
@@ -8255,7 +8253,7 @@ TEST_F(NegativeDynamicRendering, CountersByRegionARM) {
         counter_buffer.Memory().Destroy();
 
         CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false,
-                            "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11816", nullptr);
+                                  "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11816", nullptr);
 
         m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11816");
@@ -8268,11 +8266,12 @@ TEST_F(NegativeDynamicRendering, CountersByRegionARM) {
     }
 
     {
-        vkt::Buffer counter_buffer_too_small(*m_device, counter_buffer_size - 1, VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
+        vkt::Buffer counter_buffer_too_small(*m_device, counter_buffer_size - 1, VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                             vkt::device_address);
         counter_addresses[0] = counter_buffer_too_small.Address();
 
         CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false,
-                            "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11817", nullptr);
+                                  "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11817", nullptr);
 
         m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11817");
@@ -8298,7 +8297,7 @@ TEST_F(NegativeDynamicRendering, CountersByRegionARM) {
         counter_addresses[0] = extended_counter_buffer.Address();
 
         CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false,
-                            "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterIndexCount-11818", nullptr);
+                                  "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterIndexCount-11818", nullptr);
 
         m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterIndexCount-11818");
@@ -8353,8 +8352,8 @@ TEST_F(NegativeDynamicRendering, MultiviewCountersByRegionARM) {
     auto render_pass_create_info = vku::InitStruct<VkRenderPassCreateInfo2>(nullptr, 0u, 0u, nullptr, 1u, &subpass, 0u, nullptr);
     vkt::RenderPass render_pass(*m_device, render_pass_create_info);
     vkt::Framebuffer framebuffer(*m_device, render_pass, 0, nullptr, ra_extent.width, ra_extent.height);
-    auto rp_begin =
-        vku::InitStruct<VkRenderPassBeginInfo>(&perf_begin_info, render_pass.handle(), framebuffer.handle(), render_area, 0u, nullptr);
+    auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>(&perf_begin_info, render_pass.handle(), framebuffer.handle(),
+                                                           render_area, 0u, nullptr);
 
     VkRenderingInfo rendering_info = vku::InitStructHelper(&perf_begin_info);
     rendering_info.layerCount = 1;
@@ -8364,7 +8363,7 @@ TEST_F(NegativeDynamicRendering, MultiviewCountersByRegionARM) {
         perf_begin_info.counterAddressCount = 2;
 
         CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false,
-                            "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterAddressCount-11815", nullptr);
+                                  "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterAddressCount-11815", nullptr);
 
         m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-counterAddressCount-11815");

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -289,7 +289,8 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrier) {
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierOwnership) {
-    TEST_DESCRIPTION("Test setting image memory barrier transferring ownership without dynamic rendering local read features enabled.");
+    TEST_DESCRIPTION(
+        "Test setting image memory barrier transferring ownership without dynamic rendering local read features enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
@@ -340,7 +341,8 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierOwnership) {
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierNoBufferOrImage) {
-    TEST_DESCRIPTION("Test setting image memory barrier within BeginRenderning without dynamic rendering local read features enabled.");
+    TEST_DESCRIPTION(
+        "Test setting image memory barrier within BeginRenderning without dynamic rendering local read features enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_LOCAL_READ_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_SHADER_TILE_IMAGE_EXTENSION_NAME);
@@ -1076,7 +1078,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexSetToUnused) {
         {VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, nullptr, 1, &locations[0], nullptr, nullptr},
         {VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, nullptr, 1, &unused, &locations[0], nullptr},
         {VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, nullptr, 1, &unused, nullptr, &locations[0]}};
-    const char *vuids[] = {"VUID-VkRenderingInputAttachmentIndexInfo-dynamicRenderingLocalRead-09519",
+    const char* vuids[] = {"VUID-VkRenderingInputAttachmentIndexInfo-dynamicRenderingLocalRead-09519",
                            "VUID-VkRenderingInputAttachmentIndexInfo-dynamicRenderingLocalRead-09520",
                            "VUID-VkRenderingInputAttachmentIndexInfo-dynamicRenderingLocalRead-09521"};
 
@@ -1120,7 +1122,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexUnique) {
         {VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, nullptr, 2, &locations_bad[0], nullptr, nullptr},
         {VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, nullptr, 2, &locations_good[0], &locations_bad[0], nullptr},
         {VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, nullptr, 2, &locations_good[0], nullptr, &locations_bad[0]}};
-    const char *vuids[] = {"VUID-VkRenderingInputAttachmentIndexInfo-pColorAttachmentInputIndices-09522",
+    const char* vuids[] = {"VUID-VkRenderingInputAttachmentIndexInfo-pColorAttachmentInputIndices-09522",
                            "VUID-VkRenderingInputAttachmentIndexInfo-pColorAttachmentInputIndices-09523",
                            "VUID-VkRenderingInputAttachmentIndexInfo-pColorAttachmentInputIndices-09524"};
 
@@ -1592,7 +1594,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingInputAttachmentIndexInfoMisma
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment_info;
 
-    const auto begin_record_and_verify_cmd_buffers = [&](const VkCommandBufferBeginInfo &commandBufferBeginInfo) {
+    const auto begin_record_and_verify_cmd_buffers = [&](const VkCommandBufferBeginInfo& commandBufferBeginInfo) {
         secondary_cmd_buffer.Begin(&commandBufferBeginInfo);
         secondary_cmd_buffer.End();
 

--- a/tests/unit/dynamic_rendering_local_read_positive.cpp
+++ b/tests/unit/dynamic_rendering_local_read_positive.cpp
@@ -41,8 +41,7 @@ TEST_F(PositiveDynamicRenderingLocalRead, BasicUsage) {
 
     CreatePipelineHelper pipe1(*this);
     CreatePipelineHelper pipe2(*this);
-    for (uint32_t i = 0; i < 2; i++)
-    {
+    for (uint32_t i = 0; i < 2; i++) {
         CreatePipelineHelper* pipe = (i == 0) ? &pipe1 : &pipe2;
         VkFormat color_formats[] = {VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED};
 

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -2004,11 +2004,12 @@ TEST_F(PositiveDynamicRendering, CountersByRegionARM) {
 
     {
         VkSubpassDescription2 subpass = vku::InitStructHelper();
-        auto render_pass_create_info = vku::InitStruct<VkRenderPassCreateInfo2>(nullptr, 0u, 0u, nullptr, 1u, &subpass, 0u, nullptr);
+        auto render_pass_create_info =
+            vku::InitStruct<VkRenderPassCreateInfo2>(nullptr, 0u, 0u, nullptr, 1u, &subpass, 0u, nullptr);
         vkt::RenderPass render_pass(*m_device, render_pass_create_info);
         vkt::Framebuffer framebuffer(*m_device, render_pass, 0, nullptr, ra_extent.width, ra_extent.height);
-        auto rp_begin =
-            vku::InitStruct<VkRenderPassBeginInfo>(&perf_begin_info, render_pass.handle(), framebuffer.handle(), render_area, 0u, nullptr);
+        auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>(&perf_begin_info, render_pass.handle(), framebuffer.handle(),
+                                                               render_area, 0u, nullptr);
 
         m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp_begin);

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -24,9 +24,9 @@ class NegativeDynamicState : public DynamicStateTest {
     // helper functions for tests in this file
   public:
     // VK_EXT_extended_dynamic_state - not calling vkCmdSet before draw
-    void ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char *vuid);
+    void ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char* vuid);
     // VK_EXT_extended_dynamic_state3 - Create a pipeline with dynamic state, but the feature disabled
-    void ExtendedDynamicState3PipelineFeatureDisabled(VkDynamicState dynamic_state, const char *vuid);
+    void ExtendedDynamicState3PipelineFeatureDisabled(VkDynamicState dynamic_state, const char* vuid);
     // VK_EXT_line_rasterization - Init with LineRasterization features off
     void InitLineRasterizationFeatureDisabled();
 };
@@ -391,7 +391,7 @@ TEST_F(NegativeDynamicState, SetScissorParam) {
                                         {{{0, vvl::kI32Max}, {16, 1}}, "VUID-vkCmdSetScissor-offset-00597"},
                                         {{{0, 0}, {16, uint32_t{vvl::kI32Max} + 1}}, "VUID-vkCmdSetScissor-offset-00597"}};
 
-    for (const auto &test_case : test_cases) {
+    for (const auto& test_case : test_cases) {
         m_errorMonitor->SetDesiredError(test_case.vuid.c_str());
         vk::CmdSetScissor(m_command_buffer, 0, 1, &test_case.scissor);
         m_errorMonitor->VerifyFound();
@@ -449,7 +449,7 @@ TEST_F(NegativeDynamicState, SetScissorParamMultiviewportLimit) {
 }
 
 template <typename ExtType, typename Parm>
-void ExtendedDynStateCalls(ErrorMonitor *error_monitor, VkCommandBuffer cmd_buf, ExtType ext_call, const char *vuid, Parm parm) {
+void ExtendedDynStateCalls(ErrorMonitor* error_monitor, VkCommandBuffer cmd_buf, ExtType ext_call, const char* vuid, Parm parm) {
     error_monitor->SetDesiredError(vuid);
     ext_call(cmd_buf, parm);
     error_monitor->VerifyFound();
@@ -704,7 +704,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
 
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
-    AddRequiredFeature(vkt::Feature::multiViewport); // needed to have 2 viewport count
+    AddRequiredFeature(vkt::Feature::multiViewport);  // needed to have 2 viewport count
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -777,7 +777,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
     std::vector<VkBuffer> buffers(m_device->Physical().limits_.maxVertexInputBindings + 1ull, buffer);
     std::vector<VkDeviceSize> offsets(buffers.size(), 0);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         void main(){}
@@ -1163,7 +1163,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
     }
 }
 
-void NegativeDynamicState::ExtendedDynamicState3PipelineFeatureDisabled(VkDynamicState dynamic_state, const char *vuid) {
+void NegativeDynamicState::ExtendedDynamicState3PipelineFeatureDisabled(VkDynamicState dynamic_state, const char* vuid) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
@@ -2566,8 +2566,8 @@ TEST_F(NegativeDynamicState, RasterizationLineModeDefault) {
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT);
-    pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR;      // ignored
-    pipe.line_state_ci_.stippledLineEnable = VK_TRUE;                                        // ignored
+    pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR;  // ignored
+    pipe.line_state_ci_.stippledLineEnable = VK_TRUE;                                    // ignored
     pipe.line_state_ci_.lineStippleFactor = 1;
     pipe.CreateGraphicsPipeline();
 
@@ -2720,7 +2720,7 @@ TEST_F(NegativeDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     }
     InitRenderTarget(count);
 
-    const char *fs_src = R"glsl(
+    const char* fs_src = R"glsl(
         #version 460
         layout(location = 0) out vec4 c0;
         layout(location = 1) out vec4 c1;
@@ -3501,7 +3501,7 @@ TEST_F(NegativeDynamicState, SetViewportParam) {
         test_cases.push_back({{0.0, 0.0, 64.0, NAN, 0.0, 1.0}, "VUID-VkViewport-height-01773"});
     }
 
-    for (const auto &test_case : test_cases) {
+    for (const auto& test_case : test_cases) {
         m_errorMonitor->SetDesiredError(test_case.vuid.c_str());
         vk::CmdSetViewport(m_command_buffer, 0, 1, &test_case.vp);
         m_errorMonitor->VerifyFound();
@@ -3513,7 +3513,7 @@ TEST_F(NegativeDynamicState, SetViewportParamMaintenance1) {
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    const auto &limits = m_device->Physical().limits_;
+    const auto& limits = m_device->Physical().limits_;
     m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkViewport-height-01773");
@@ -3841,7 +3841,7 @@ TEST_F(NegativeDynamicState, PipelineColorBlendStateCreateInfoArrayNonDynamic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const auto set_info = [](CreatePipelineHelper &helper) { helper.cb_ci_.pAttachments = nullptr; };
+    const auto set_info = [](CreatePipelineHelper& helper) { helper.cb_ci_.pAttachments = nullptr; };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-07353");
 }
 
@@ -3855,7 +3855,7 @@ TEST_F(NegativeDynamicState, PipelineColorBlendStateCreateInfoArrayDynamic) {
     InitRenderTarget();
 
     {
-        const auto set_info = [](CreatePipelineHelper &helper) { helper.cb_ci_.pAttachments = nullptr; };
+        const auto set_info = [](CreatePipelineHelper& helper) { helper.cb_ci_.pAttachments = nullptr; };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
                                           "VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-07353");
     }
@@ -3899,7 +3899,7 @@ TEST_F(NegativeDynamicState, SettingCommands) {
     m_command_buffer.End();
 }
 
-void NegativeDynamicState::ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char *vuid) {
+void NegativeDynamicState::ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char* vuid) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
     RETURN_IF_SKIP(Init());
@@ -4113,9 +4113,9 @@ TEST_F(NegativeDynamicState, Viewport) {
     // test viewport and scissor arrays
     struct TestCase {
         uint32_t viewport_count;
-        VkViewport *viewports;
+        VkViewport* viewports;
         uint32_t scissor_count;
-        VkRect2D *scissors;
+        VkRect2D* scissors;
 
         std::vector<std::string> vuids;
     };
@@ -4185,8 +4185,8 @@ TEST_F(NegativeDynamicState, Viewport) {
 
     const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
 
-    for (const auto &test_case : dyn_test_cases) {
-        const auto break_vp = [&](CreatePipelineHelper &helper) {
+    for (const auto& test_case : dyn_test_cases) {
+        const auto break_vp = [&](CreatePipelineHelper& helper) {
             VkPipelineDynamicStateCreateInfo dyn_state_ci = vku::InitStructHelper();
             dyn_state_ci.dynamicStateCount = size32(dyn_states);
             dyn_state_ci.pDynamicStates = dyn_states;
@@ -4218,9 +4218,9 @@ TEST_F(NegativeDynamicState, MultiViewport) {
 
     struct TestCase {
         uint32_t viewport_count;
-        VkViewport *viewports;
+        VkViewport* viewports;
         uint32_t scissor_count;
-        VkRect2D *scissors;
+        VkRect2D* scissors;
 
         std::vector<std::string> vuids;
     };
@@ -4290,8 +4290,8 @@ TEST_F(NegativeDynamicState, MultiViewport) {
               "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04131"}});
     }
 
-    for (const auto &test_case : test_cases) {
-        const auto break_vp = [&test_case](CreatePipelineHelper &helper) {
+    for (const auto& test_case : test_cases) {
+        const auto break_vp = [&test_case](CreatePipelineHelper& helper) {
             helper.vp_state_ci_.viewportCount = test_case.viewport_count;
             helper.vp_state_ci_.pViewports = test_case.viewports;
             helper.vp_state_ci_.scissorCount = test_case.scissor_count;
@@ -4352,8 +4352,8 @@ TEST_F(NegativeDynamicState, MultiViewport) {
 
     const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
 
-    for (const auto &test_case : dyn_test_cases) {
-        const auto break_vp = [&](CreatePipelineHelper &helper) {
+    for (const auto& test_case : dyn_test_cases) {
+        const auto break_vp = [&](CreatePipelineHelper& helper) {
             VkPipelineDynamicStateCreateInfo dyn_state_ci = vku::InitStructHelper();
             dyn_state_ci.dynamicStateCount = size32(dyn_states);
             dyn_state_ci.pDynamicStates = dyn_states;
@@ -4488,7 +4488,7 @@ TEST_F(NegativeDynamicState, LineWidth) {
 
     // test VkPipelineRasterizationStateCreateInfo::lineWidth
     for (const auto test_case : test_cases) {
-        const auto set_lineWidth = [&](CreatePipelineHelper &helper) { helper.rs_state_ci_.lineWidth = test_case; };
+        const auto set_lineWidth = [&](CreatePipelineHelper& helper) { helper.rs_state_ci_.lineWidth = test_case; };
         CreatePipelineHelper::OneshotTest(*this, set_lineWidth, kErrorBit,
                                           "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749");
     }
@@ -4687,7 +4687,7 @@ TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 x;
         void main(){
@@ -4922,7 +4922,7 @@ TEST_F(NegativeDynamicState, VertexInputLocationMissing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec4 x;
         layout(location = 1) in vec4 y;
@@ -5386,7 +5386,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3RasterizationSamples);
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required VkSampleCountFlagBits are not supported; skipping";
     }

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -570,7 +570,7 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location = 0) out float x;
         void main(){
@@ -1018,7 +1018,7 @@ TEST_F(PositiveDynamicState, VertexInputMultipleBindings) {
     attributes[3].format = VK_FORMAT_R32_SFLOAT;
     attributes[3].offset = offsetof(PerInstance, d);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in int a;
         layout(location = 1) in float b;
@@ -1098,7 +1098,7 @@ TEST_F(PositiveDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     }
     InitRenderTarget(count);
 
-    const char *fs_src = R"glsl(
+    const char* fs_src = R"glsl(
         #version 460
         layout(location = 0) out vec4 c0;
         layout(location = 1) out vec4 c1;
@@ -1576,7 +1576,7 @@ TEST_F(PositiveDynamicState, VertexInputLocationMissing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec4 x;
         layout(location = 1) in vec4 y;

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -497,11 +497,11 @@ TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto extension_name = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
-    const char *no_tempory_tl_vuid = "VUID-VkImportSemaphoreWin32HandleInfoKHR-flags-03322";
+    const char* no_tempory_tl_vuid = "VUID-VkImportSemaphoreWin32HandleInfoKHR-flags-03322";
 #else
     const auto extension_name = VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
-    const char *no_tempory_tl_vuid = "VUID-VkImportSemaphoreFdInfoKHR-flags-03323";
+    const char* no_tempory_tl_vuid = "VUID-VkImportSemaphoreFdInfoKHR-flags-03323";
 #endif
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -910,17 +910,17 @@ TEST_F(NegativeExternalMemorySync, Fence) {
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     const auto other_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
     const auto bad_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT;
-    const char *bad_export_type_vuid = "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452";
-    const char *other_export_type_vuid = "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448";
-    const char *bad_import_type_vuid = "VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457";
+    const char* bad_export_type_vuid = "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452";
+    const char* other_export_type_vuid = "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448";
+    const char* bad_import_type_vuid = "VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457";
 #else
     const auto extension_name = VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT;
     const auto other_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT;
     const auto bad_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
-    const char *bad_export_type_vuid = "VUID-VkFenceGetFdInfoKHR-handleType-01456";
-    const char *other_export_type_vuid = "VUID-VkFenceGetFdInfoKHR-handleType-01453";
-    const char *bad_import_type_vuid = "VUID-VkImportFenceFdInfoKHR-handleType-01464";
+    const char* bad_export_type_vuid = "VUID-VkFenceGetFdInfoKHR-handleType-01456";
+    const char* other_export_type_vuid = "VUID-VkFenceGetFdInfoKHR-handleType-01453";
+    const char* bad_import_type_vuid = "VUID-VkImportFenceFdInfoKHR-handleType-01464";
 #endif
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1130,17 +1130,17 @@ TEST_F(NegativeExternalMemorySync, Semaphore) {
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
     const auto bad_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
     const auto other_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    const char *bad_export_type_vuid = "VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01131";
-    const char *other_export_type_vuid = "VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01126";
-    const char *bad_import_type_vuid = "VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140";
+    const char* bad_export_type_vuid = "VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01131";
+    const char* other_export_type_vuid = "VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01126";
+    const char* bad_import_type_vuid = "VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140";
 #else
     const auto extension_name = VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
     const auto bad_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
     const auto other_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
-    const char *bad_export_type_vuid = "VUID-VkSemaphoreGetFdInfoKHR-handleType-01136";
-    const char *other_export_type_vuid = "VUID-VkSemaphoreGetFdInfoKHR-handleType-01132";
-    const char *bad_import_type_vuid = "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143";
+    const char* bad_export_type_vuid = "VUID-VkSemaphoreGetFdInfoKHR-handleType-01136";
+    const char* other_export_type_vuid = "VUID-VkSemaphoreGetFdInfoKHR-handleType-01132";
+    const char* bad_import_type_vuid = "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143";
 #endif
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2623,7 +2623,7 @@ TEST_F(NegativeExternalMemorySync, GetMemoryHostAlignment) {
 
     VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
     VkDeviceSize bad_alloc_size = alloc_size / 4;
-    void *host_memory = ::operator new((size_t)bad_alloc_size, std::align_val_t(alloc_size));
+    void* host_memory = ::operator new((size_t)bad_alloc_size, std::align_val_t(alloc_size));
     if (!host_memory) {
         GTEST_SKIP() << "Can't allocate host memory";
     }
@@ -2650,7 +2650,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHostDedicated) {
     GetPhysicalDeviceProperties2(memory_host_props);
 
     VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
-    void *host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alloc_size));
+    void* host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alloc_size));
     if (!host_memory) {
         GTEST_SKIP() << "Can't allocate host memory";
     }
@@ -2695,7 +2695,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHostMemoryIndex) {
     GetPhysicalDeviceProperties2(memory_host_props);
 
     VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
-    void *host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alloc_size));
+    void* host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alloc_size));
     if (!host_memory) {
         GTEST_SKIP() << "Can't allocate host memory";
     }

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -98,7 +98,7 @@ TEST_F(PositiveExternalMemorySync, ImportMemoryHost) {
     GetPhysicalDeviceProperties2(memory_host_props);
 
     VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
-    void *host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alloc_size));
+    void* host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alloc_size));
     if (!host_memory) {
         GTEST_SKIP() << "Can't allocate host memory";
     }

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -229,7 +229,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateWriteMultiViewpo
     }
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_EXT_fragment_shading_rate : enable
         void main() {
@@ -1248,7 +1248,7 @@ TEST_F(NegativeFragmentShadingRate, Pipeline) {
     fsr_ci.fragmentSize.width = 1;
     fsr_ci.fragmentSize.height = 1;
 
-    auto set_fsr_ci = [&](CreatePipelineHelper &helper) { helper.gp_ci_.pNext = &fsr_ci; };
+    auto set_fsr_ci = [&](CreatePipelineHelper& helper) { helper.gp_ci_.pNext = &fsr_ci; };
 
     fsr_ci.fragmentSize.width = 0;
     CreatePipelineHelper::OneshotTest(*this, set_fsr_ci, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04494");
@@ -1287,7 +1287,7 @@ TEST_F(NegativeFragmentShadingRate, PipelineFeatureUsage) {
     fsr_ci.fragmentSize.width = 1;
     fsr_ci.fragmentSize.height = 1;
 
-    auto set_fsr_ci = [&](CreatePipelineHelper &helper) { helper.gp_ci_.pNext = &fsr_ci; };
+    auto set_fsr_ci = [&](CreatePipelineHelper& helper) { helper.gp_ci_.pNext = &fsr_ci; };
 
     fsr_ci.fragmentSize.width = 2;
     CreatePipelineHelper::OneshotTest(*this, set_fsr_ci, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04500");
@@ -1329,7 +1329,7 @@ TEST_F(NegativeFragmentShadingRate, PipelineCombinerOpsLimit) {
     fsr_ci.fragmentSize.width = 1;
     fsr_ci.fragmentSize.height = 1;
 
-    auto set_fsr_ci = [&](CreatePipelineHelper &helper) { helper.gp_ci_.pNext = &fsr_ci; };
+    auto set_fsr_ci = [&](CreatePipelineHelper& helper) { helper.gp_ci_.pNext = &fsr_ci; };
 
     // primitiveFragmentShadingRate
     {
@@ -1376,7 +1376,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
     // Test PrimitiveShadingRate writes with multiple viewports
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_fragment_shading_rate : enable
             void main() {
@@ -1389,7 +1389,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
         VkViewport viewports[2] = {{0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}};
         VkRect2D scissors[2] = {};
 
-        auto info_override = [&](CreatePipelineHelper &info) {
+        auto info_override = [&](CreatePipelineHelper& info) {
             info.shader_stages_ = {vs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
             info.vp_state_ci_.viewportCount = 2;
             info.vp_state_ci_.pViewports = viewports;
@@ -1406,12 +1406,12 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
     // Test PrimitiveShadingRate writes with ViewportIndex writes in a geometry shader
     if (features2.features.geometryShader) {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             void main() {}
         )glsl";
 
-        const char *gsSource = R"glsl(
+        const char* gsSource = R"glsl(
             #version 450
             #extension GL_EXT_fragment_shading_rate : enable
             layout (points) in;
@@ -1429,7 +1429,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
         VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-        auto info_override = [&](CreatePipelineHelper &info) {
+        auto info_override = [&](CreatePipelineHelper& info) {
             info.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
             info.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
         };
@@ -1441,7 +1441,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
     // Test PrimitiveShadingRate writes with ViewportIndex writes in a vertex shader
     if (vil_extension) {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_fragment_shading_rate : enable
             #extension GL_ARB_shader_viewport_layer_array : enable
@@ -1453,7 +1453,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        auto info_override = [&](CreatePipelineHelper &info) {
+        auto info_override = [&](CreatePipelineHelper& info) {
             info.shader_stages_ = {vs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
         };
 
@@ -1465,12 +1465,12 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
     if (va2_extension) {
         // Test PrimitiveShadingRate writes with ViewportIndex writes in a geometry shader
         if (features2.features.geometryShader) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 void main() {}
             )glsl";
 
-            const char *gsSource = R"glsl(
+            const char* gsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_fragment_shading_rate : enable
                 #extension GL_NV_viewport_array2 : enable
@@ -1489,7 +1489,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
             VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-            auto info_override = [&](CreatePipelineHelper &info) {
+            auto info_override = [&](CreatePipelineHelper& info) {
                 info.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
                 info.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
             };
@@ -1501,7 +1501,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
         // Test PrimitiveShadingRate writes with ViewportIndex writes in a vertex shader
         if (vil_extension) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_fragment_shading_rate : enable
                 #extension GL_NV_viewport_array2 : enable
@@ -1513,7 +1513,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-            auto info_override = [&](CreatePipelineHelper &info) {
+            auto info_override = [&](CreatePipelineHelper& info) {
                 info.shader_stages_ = {vs.GetStageCreateInfo(), info.fs_->GetStageCreateInfo()};
             };
 
@@ -1540,7 +1540,7 @@ TEST_F(NegativeFragmentShadingRate, Ops) {
     fsr_ci.combinerOps[0] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
     fsr_ci.combinerOps[1] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
 
-    auto set_fsr_ci = [&](CreatePipelineHelper &helper) { helper.gp_ci_.pNext = &fsr_ci; };
+    auto set_fsr_ci = [&](CreatePipelineHelper& helper) { helper.gp_ci_.pNext = &fsr_ci; };
 
     // Pass an invalid value for op 0
     fsr_ci.combinerOps[0] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_MAX_ENUM_KHR;
@@ -2808,7 +2808,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
 
     // viewportCount must be 0 or 1 when multiViewport is disabled
     {
-        const auto break_vp = [&](CreatePipelineHelper &helper) {
+        const auto break_vp = [&](CreatePipelineHelper& helper) {
             helper.vp_state_ci_.viewportCount = 2;
             helper.vp_state_ci_.pViewports = viewports;
             helper.vp_state_ci_.scissorCount = 2;
@@ -2825,7 +2825,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
         CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit, vuids);
     }
     {
-        const auto break_vp = [&](CreatePipelineHelper &helper) {
+        const auto break_vp = [&](CreatePipelineHelper& helper) {
             helper.vp_state_ci_.viewportCount = 1;
             helper.vp_state_ci_.pViewports = viewports;
             helper.vp_state_ci_.scissorCount = 1;
@@ -2919,7 +2919,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
         csosci.customSampleOrderCount = 1;
 
         struct TestCase {
-            const VkCoarseSampleOrderCustomNV *order;
+            const VkCoarseSampleOrderCustomNV* order;
             std::vector<std::string> vuids;
         };
 
@@ -2938,15 +2938,15 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
             {&sampOrdGood, {}},
         };
 
-        for (const auto &test_case : test_cases) {
-            const auto break_vp = [&](CreatePipelineHelper &helper) {
+        for (const auto& test_case : test_cases) {
+            const auto break_vp = [&](CreatePipelineHelper& helper) {
                 helper.vp_state_ci_.pNext = &csosci;
                 csosci.pCustomSampleOrders = test_case.order;
             };
             CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit, test_case.vuids);
         }
 
-        for (const auto &test_case : test_cases) {
+        for (const auto& test_case : test_cases) {
             for (uint32_t i = 0; i < test_case.vuids.size(); ++i) {
                 m_errorMonitor->SetDesiredError(test_case.vuids[i].c_str());
             }
@@ -2995,7 +2995,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNVViewportCount) {
     VkDynamicState dynPalette = VK_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV;
     VkPipelineDynamicStateCreateInfo dyn = {VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, nullptr, 0, 1, &dynPalette};
 
-    const auto break_vp = [&](CreatePipelineHelper &helper) {
+    const auto break_vp = [&](CreatePipelineHelper& helper) {
         helper.vp_state_ci_.viewportCount = 1;
         helper.vp_state_ci_.pViewports = viewports;
         helper.vp_state_ci_.scissorCount = 1;
@@ -3067,7 +3067,7 @@ TEST_F(NegativeFragmentShadingRate, ImageMaxLimitsEXT) {
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_OFFSET_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags = 0;
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -3343,7 +3343,7 @@ TEST_F(NegativeFragmentShadingRate, ImagelessAttachmentFragmentDensity) {
 
     VkPhysicalDeviceFragmentDensityMapPropertiesEXT fdm_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fdm_properties);
-    const auto &maxFragmentDensityTexelSize = fdm_properties.maxFragmentDensityTexelSize;
+    const auto& maxFragmentDensityTexelSize = fdm_properties.maxFragmentDensityTexelSize;
 
     VkFormat image_format = VK_FORMAT_R8G8_UNORM;
 
@@ -3669,7 +3669,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateMeshShader) {
     AddRequiredFeature(vkt::Feature::meshShader);
     RETURN_IF_SKIP(Init());
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         #extension GL_EXT_fragment_shading_rate : enable

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -85,7 +85,7 @@ TEST_F(NegativeGeometryTessellation, GeometryShaderEnabled) {
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkShaderModuleCreateInfo-pCode-08740");
     VkShaderObj gs(*m_device, kGeometryMinimalGlsl, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -107,7 +107,7 @@ TEST_F(NegativeGeometryTessellation, TessellationShaderEnabled) {
         GTEST_SKIP() << "patchControlPoints not supported";
     }
 
-    const char *tcsSource = R"glsl(
+    const char* tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -117,7 +117,7 @@ TEST_F(NegativeGeometryTessellation, TessellationShaderEnabled) {
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -138,7 +138,7 @@ TEST_F(NegativeGeometryTessellation, TessellationShaderEnabled) {
 
     VkPipelineTessellationStateCreateInfo tsci{VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 3};
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
         helper.gp_ci_.pTessellationState = &tsci;
         helper.gp_ci_.pInputAssemblyState = &iasci;
@@ -160,7 +160,7 @@ TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderDontWrite) {
     InitRenderTarget();
 
     // Create GS declaring PointSize and writing to it
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -174,7 +174,7 @@ TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderDontWrite) {
     VkShaderObj vs(*m_device, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -201,7 +201,7 @@ TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderWrite) {
     //     gl_PointSize = 1.0f;
     //     EmitVertex();
     // }
-    const char *gsSource = R"(
+    const char* gsSource = R"(
                OpCapability Geometry
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -247,7 +247,7 @@ TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderWrite) {
     VkShaderObj vs(*m_device, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -278,7 +278,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockOrderMismatchVsGs) {
     //     EmitVertex();
     // }
 
-    const char *gsSource = R"(
+    const char* gsSource = R"(
                OpCapability Geometry
                OpCapability GeometryPointSize
           %1 = OpExtInstImport "GLSL.std.450"
@@ -336,7 +336,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockOrderMismatchVsGs) {
     VkShaderObj vs(*m_device, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -351,7 +351,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGs) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -373,7 +373,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGs) {
     VkShaderObj vs(*m_device, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -392,7 +392,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGsShaderObject) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -776,7 +776,7 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInstanceVertexCount) {
         )";
         VkShaderObj gs(*m_device, gsSourceStr.c_str(), VK_SHADER_STAGE_GEOMETRY_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
         };
@@ -800,7 +800,7 @@ TEST_F(NegativeGeometryTessellation, DISABLED_TessellationPatchDecorationMismatc
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *tcsSource = R"glsl(
+    const char* tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -810,7 +810,7 @@ TEST_F(NegativeGeometryTessellation, DISABLED_TessellationPatchDecorationMismatc
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -827,7 +827,7 @@ TEST_F(NegativeGeometryTessellation, DISABLED_TessellationPatchDecorationMismatc
 
     VkPipelineTessellationStateCreateInfo tsci{VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 3};
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.pTessellationState = &tsci;
         helper.gp_ci_.pInputAssemblyState = &iasci;
         helper.shader_stages_.emplace_back(tcs.GetStageCreateInfo());
@@ -843,7 +843,7 @@ TEST_F(NegativeGeometryTessellation, Tessellation) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *tcsSource = R"glsl(
+    const char* tcsSource = R"glsl(
         #version 450
         layout(vertices=3) out;
         void main(){
@@ -851,7 +851,7 @@ TEST_F(NegativeGeometryTessellation, Tessellation) {
            gl_TessLevelInner[0] = 1;
         }
     )glsl";
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -869,11 +869,11 @@ TEST_F(NegativeGeometryTessellation, Tessellation) {
 
     std::vector<VkPipelineShaderStageCreateInfo> shader_stages = {};
     VkPipelineInputAssemblyStateCreateInfo iasci_bad = iasci;
-    VkPipelineInputAssemblyStateCreateInfo *p_iasci = nullptr;
+    VkPipelineInputAssemblyStateCreateInfo* p_iasci = nullptr;
     VkPipelineTessellationStateCreateInfo tsci_bad = tsci;
-    VkPipelineTessellationStateCreateInfo *p_tsci = nullptr;
+    VkPipelineTessellationStateCreateInfo* p_tsci = nullptr;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.pTessellationState = p_tsci;
         helper.gp_ci_.pInputAssemblyState = p_iasci;
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
@@ -933,7 +933,7 @@ TEST_F(NegativeGeometryTessellation, PatchListTopology) {
                                                  VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_FALSE};
     VkPipelineTessellationStateCreateInfo tsci{VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 3};
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.pTessellationState = &tsci;
         helper.gp_ci_.pInputAssemblyState = &iasci;
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), helper.fs_->GetStageCreateInfo(), tcs.GetStageCreateInfo(),
@@ -1054,7 +1054,7 @@ TEST_F(NegativeGeometryTessellation, IncompatiblePrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -1075,7 +1075,7 @@ TEST_F(NegativeGeometryTessellation, IncompatiblePrimitiveTopology) {
     VkShaderObj vs(*m_device, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -1091,7 +1091,7 @@ TEST_F(NegativeGeometryTessellation, IncompatibleTessGeomPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *tcsSource = R"glsl(
+    const char* tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -1101,7 +1101,7 @@ TEST_F(NegativeGeometryTessellation, IncompatibleTessGeomPrimitiveTopology) {
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -1110,7 +1110,7 @@ TEST_F(NegativeGeometryTessellation, IncompatibleTessGeomPrimitiveTopology) {
            gl_Position.w = x;
         }
     )glsl";
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -1136,7 +1136,7 @@ TEST_F(NegativeGeometryTessellation, IncompatibleTessGeomPrimitiveTopology) {
 
     VkPipelineTessellationStateCreateInfo tsci{VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 3};
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
         helper.gp_ci_.pTessellationState = &tsci;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), tcs.GetStageCreateInfo(),
@@ -1497,7 +1497,7 @@ TEST_F(NegativeGeometryTessellation, MismatchedTessellationExecutionModesDraw) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *tesc_src = R"(
+    const char* tesc_src = R"(
                OpCapability Tessellation
                OpMemoryModel Logical GLSL450
                OpEntryPoint TessellationControl %main "main" %gl_TessLevelOuter %gl_TessLevelInner
@@ -1534,7 +1534,7 @@ TEST_F(NegativeGeometryTessellation, MismatchedTessellationExecutionModesDraw) {
                OpFunctionEnd
     )";
 
-    const char *tese_src = R"(
+    const char* tese_src = R"(
                OpCapability Tessellation
                OpMemoryModel Logical GLSL450
                OpEntryPoint TessellationEvaluation %main "main" %_
@@ -1646,7 +1646,7 @@ TEST_F(NegativeGeometryTessellation, DrawDynamicPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;

--- a/tests/unit/geometry_tessellation_positive.cpp
+++ b/tests/unit/geometry_tessellation_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,8 @@ class PositiveGeometryTessellation : public VkLayerTest {};
 
 TEST_F(PositiveGeometryTessellation, PointSizeGeomShaderDontWriteMaintenance5) {
     TEST_DESCRIPTION(
-        "Create a pipeline using TOPOLOGY_POINT_LIST, set PointSize vertex shader, but not in the final geometry stage, but have maintenance5.");
+        "Create a pipeline using TOPOLOGY_POINT_LIST, set PointSize vertex shader, but not in the final geometry stage, but have "
+        "maintenance5.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
@@ -30,7 +31,7 @@ TEST_F(PositiveGeometryTessellation, PointSizeGeomShaderDontWriteMaintenance5) {
     InitRenderTarget();
 
     // Create GS declaring PointSize and writing to it
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -44,7 +45,7 @@ TEST_F(PositiveGeometryTessellation, PointSizeGeomShaderDontWriteMaintenance5) {
     VkShaderObj vs(*m_device, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -53,7 +54,8 @@ TEST_F(PositiveGeometryTessellation, PointSizeGeomShaderDontWriteMaintenance5) {
 }
 
 TEST_F(PositiveGeometryTessellation, IncompatibleDynamicPrimitiveTopology) {
-    TEST_DESCRIPTION("Create pipeline with primitive topology incompatible with shaders, but use VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY.");
+    TEST_DESCRIPTION(
+        "Create pipeline with primitive topology incompatible with shaders, but use VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
@@ -63,7 +65,7 @@ TEST_F(PositiveGeometryTessellation, IncompatibleDynamicPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -102,7 +104,7 @@ TEST_F(PositiveGeometryTessellation, DrawDynamicPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -186,7 +188,7 @@ TEST_F(PositiveGeometryTessellation, InterfaceComponents) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location = 0) out ivec4 a;
         void main() {
@@ -194,7 +196,7 @@ TEST_F(PositiveGeometryTessellation, InterfaceComponents) {
         }
     )glsl";
 
-    const char *geom_source = R"glsl(
+    const char* geom_source = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip) out;
@@ -219,7 +221,7 @@ TEST_F(PositiveGeometryTessellation, InterfaceComponents) {
         }
     )glsl";
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location = 0) in vec4 b;
         layout(location = 0) out vec4 c;
@@ -245,7 +247,7 @@ TEST_F(PositiveGeometryTessellation, TessGeomPointPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *tcsSource = R"asm(
+    const char* tcsSource = R"asm(
                OpCapability Tessellation
           %2 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -268,7 +270,7 @@ TEST_F(PositiveGeometryTessellation, TessGeomPointPrimitiveTopology) {
                OpReturn
                OpFunctionEnd
     )asm";
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -277,7 +279,7 @@ TEST_F(PositiveGeometryTessellation, TessGeomPointPrimitiveTopology) {
            gl_Position.w = x;
         }
     )glsl";
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -121,7 +121,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShadersRegex) {
     AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
     std::vector<VkLayerSettingEXT> layer_settings(2);
     layer_settings[0] = {OBJECT_LAYER_NAME, "gpuav_select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    std::array<const char *, 2> shader_regexes = {{"vertex_foo", "fragment_.*"}};
+    std::array<const char*, 2> shader_regexes = {{"vertex_foo", "fragment_.*"}};
     layer_settings[1] = {OBJECT_LAYER_NAME, "gpuav_shaders_to_instrument", VK_LAYER_SETTING_TYPE_STRING_EXT, size32(shader_regexes),
                          shader_regexes.data()};
 
@@ -190,7 +190,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShadersRegexDestroyedShaders) {
     AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
     std::vector<VkLayerSettingEXT> layer_settings(2);
     layer_settings[0] = {OBJECT_LAYER_NAME, "gpuav_select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    std::array<const char *, 2> shader_regexes = {{"vertex_foo", "fragment_.*"}};
+    std::array<const char*, 2> shader_regexes = {{"vertex_foo", "fragment_.*"}};
     layer_settings[1] = {OBJECT_LAYER_NAME, "gpuav_shaders_to_instrument", VK_LAYER_SETTING_TYPE_STRING_EXT, size32(shader_regexes),
                          shader_regexes.data()};
 
@@ -374,7 +374,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShadersShaderObjectDrawIndexedIndirect2K
     vert_descriptor_set.UpdateDescriptorSets();
 
     vkt::Buffer index_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, vkt::device_address);
-    uint32_t *index_data = reinterpret_cast<uint32_t *>(index_buffer.Memory().Map());
+    uint32_t* index_data = reinterpret_cast<uint32_t*>(index_buffer.Memory().Map());
     index_data[0] = 0u;
     index_data[1] = 1u;
     index_data[2] = 2u;
@@ -436,7 +436,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineNotReserved) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -450,7 +450,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineNotReserved) {
         m_errorMonitor->SetDesiredWarning(
             "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
             "pipelines created with it");
-        std::vector<const vkt::DescriptorSetLayout *> empty_layouts(set_limit);
+        std::vector<const vkt::DescriptorSetLayout*> empty_layouts(set_limit);
         for (uint32_t i = 0; i < set_limit; i++) {
             empty_layouts[i] = &descriptor_set.layout_;
         }
@@ -459,13 +459,13 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineNotReserved) {
     }
 
     // Reduce by one (so there is room now) and do something invalid. (To make sure things still work as expected)
-    std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit - 1);
+    std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit - 1);
     for (uint32_t i = 0; i < set_limit - 1; i++) {
         layouts[i] = &descriptor_set.layout_;
     }
     vkt::PipelineLayout pipe_layout(*m_device, layouts);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -509,7 +509,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineReserved) {
 
     vkt::Buffer index_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer storage_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(storage_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(storage_buffer.Memory().Map());
     data[0] = index_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -524,7 +524,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineReserved) {
         m_errorMonitor->SetDesiredWarning(
             "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
             "pipelines created with it");
-        std::vector<const vkt::DescriptorSetLayout *> empty_layouts(set_limit);
+        std::vector<const vkt::DescriptorSetLayout*> empty_layouts(set_limit);
         for (uint32_t i = 0; i < set_limit; i++) {
             empty_layouts[i] = &descriptor_set.layout_;
         }
@@ -533,13 +533,13 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineReserved) {
     }
 
     // Reduce by one (so there is room now) and do something invalid. (To make sure things still work as expected)
-    std::vector<const vkt::DescriptorSetLayout *> layouts(set_limit - 1);
+    std::vector<const vkt::DescriptorSetLayout*> layouts(set_limit - 1);
     for (uint32_t i = 0; i < set_limit - 1; i++) {
         layouts[i] = &descriptor_set.layout_;
     }
     vkt::PipelineLayout pipe_layout(*m_device, layouts);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -623,7 +623,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineLayout) {
     // Add one to use the descriptor slot we tried to reserve
     const uint32_t set_limit = m_device->Physical().limits_.maxBoundDescriptorSets + 1;
 
-    std::vector<const vkt::DescriptorSetLayout *> empty_layouts(set_limit);
+    std::vector<const vkt::DescriptorSetLayout*> empty_layouts(set_limit);
     for (uint32_t i = 0; i < set_limit; i++) {
         empty_layouts[i] = &descriptor_set.layout_;
     }
@@ -631,7 +631,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineLayout) {
     m_errorMonitor->SetAllowedFailureMsg("This Pipeline Layout has too many descriptor sets");
     vkt::PipelineLayout bad_pipe_layout(*m_device, empty_layouts);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             int x;
@@ -741,7 +741,7 @@ TEST_F(NegativeGpuAV, LeakedResource) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) uniform sampler2D samplerColor[2];
         void main() {

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -29,7 +29,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     plci.pPushConstantRanges = &push_constant_ranges;
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
             layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -73,7 +73,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the other 3 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
+    auto* buffer_ptr = static_cast<uint32_t*>(buffer.Memory().Map());
     for (int i = 0; i < 3; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
@@ -91,7 +91,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
     plci.pPushConstantRanges = &push_constant_ranges;
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
             layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -134,7 +134,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the first 4 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
+    auto* buffer_ptr = static_cast<uint32_t*>(buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
@@ -159,11 +159,11 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     VkDeviceAddress invalid_buffer_address = u_info_ptr - 16;
     uint32_t n_writes = 4;
 
-    uint8_t *uniform_buffer_ptr = (uint8_t *)uniform_buffer.Memory().Map();
+    uint8_t* uniform_buffer_ptr = (uint8_t*)uniform_buffer.Memory().Map();
     memcpy(uniform_buffer_ptr, &invalid_buffer_address, sizeof(VkDeviceAddress));
     memcpy(uniform_buffer_ptr + sizeof(VkDeviceAddress), &n_writes, sizeof(uint32_t));
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -202,7 +202,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the other 3 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
+    auto* buffer_ptr = static_cast<uint32_t*>(buffer.Memory().Map());
     for (int i = 0; i < 3; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
@@ -226,11 +226,11 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
     // will go over a[4] by one
     uint32_t n_writes = 5;
 
-    uint8_t *uniform_buffer_ptr = (uint8_t *)uniform_buffer.Memory().Map();
+    uint8_t* uniform_buffer_ptr = (uint8_t*)uniform_buffer.Memory().Map();
     memcpy(uniform_buffer_ptr, &u_info_ptr, sizeof(VkDeviceAddress));
     memcpy(uniform_buffer_ptr + sizeof(VkDeviceAddress), &n_writes, sizeof(uint32_t));
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -268,7 +268,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the first 4 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
+    auto* buffer_ptr = static_cast<uint32_t*>(buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
@@ -280,7 +280,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, UVec3Array) {
     AddRequiredFeature(vkt::Feature::scalarBlockLayout);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -313,7 +313,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, UVec3Array) {
     VkDeviceAddress block_ptr = block_buffer.Address();
     const uint32_t n_reads = 4;  // uvec3[0] to uvec3[3]
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &n_reads, sizeof(uint32_t));
 
@@ -340,7 +340,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, Maintenance5) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -396,7 +396,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, Maintenance5) {
     VkDeviceAddress block_ptr = block_buffer.Address();
     const uint32_t n_reads = 64;  // way too large
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &n_reads, sizeof(uint32_t));
 
@@ -421,7 +421,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ArrayOfStruct) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(std430, buffer_reference) buffer T1 {
@@ -460,7 +460,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ArrayOfStruct) {
 
     vkt::Buffer storage_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    uint8_t *buffer_ptr = (uint8_t *)storage_buffer.Memory().Map();
+    uint8_t* buffer_ptr = (uint8_t*)storage_buffer.Memory().Map();
     const uint32_t index = 8;  // out of bounds
     memcpy(buffer_ptr, &index, sizeof(uint32_t));
     memcpy(buffer_ptr + (1 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
@@ -490,7 +490,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140) {
     const uint32_t uniform_buffer_size = 8 + 4;  // 64 bits pointer + int
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -530,7 +530,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140) {
     const uint32_t storage_buffer_size = 16 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 5;
 
@@ -539,7 +539,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<uint32_t*>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
@@ -555,7 +555,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
     const uint32_t uniform_buffer_size = 8 + 4;  // 64 bits pointer + int
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -613,7 +613,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
         }
     }
 
-    auto uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer_addr;
     uniform_buffer_ptr[1] = 5;  // Will provoke a 4 bytes write past buffer end
 
@@ -622,7 +622,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<uint32_t*>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
@@ -638,7 +638,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
     const uint32_t uniform_buffer_size = 8 + 4;  // 64 bits pointer + int
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -678,7 +678,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
     const uint32_t storage_buffer_size = 4 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 5;
 
@@ -687,7 +687,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<uint32_t*>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], 42);
     }
@@ -711,7 +711,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     //     ssbo.ptr.f = 42.0;
     //     ssbo.ptr.v = uvec3(1.0, 2.0, 3.0);
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpMemoryModel PhysicalStorageBuffer64 GLSL450
@@ -792,7 +792,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     const VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
 
     // Base buffer address is (storage_buffer_addr), so expect writing to `v.z` to cause an OOB access
-    auto uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer_addr;
 
     m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
@@ -800,7 +800,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote to float
-    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<float*>(storage_buffer.Memory().Map());
     ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
 }
 
@@ -821,7 +821,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayoutFront) {
     // void main() {
     //     ssbo.ptr.f = 42.0;
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpMemoryModel PhysicalStorageBuffer64 GLSL450
@@ -883,7 +883,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayoutFront) {
     const VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
 
     // Base buffer address is (storage_buffer_addr - 16), so expect writing to `f` to cause an OOB access
-    auto uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     // The OpStore is aligned to 16 bytes, so need to substract by that
     uniform_buffer_ptr[0] = storage_buffer_addr - 16;
 
@@ -900,7 +900,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -943,7 +943,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
     const VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
 
     // Base buffer address is (storage_buffer_addr), so expect writing to `v.z` to cause an OOB access
-    auto uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer_addr;
 
     m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
@@ -951,7 +951,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote to float
-    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<float*>(storage_buffer.Memory().Map());
     ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
 }
 
@@ -963,7 +963,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayoutFront) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -1005,7 +1005,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayoutFront) {
     const VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
 
     // Base buffer address is (storage_buffer_addr - 16), so expect writing to `f` to cause an OOB access
-    auto uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     // The OpStore is aligned to 16 bytes, so need to substract by that
     uniform_buffer_ptr[0] = storage_buffer_addr - 16;
 
@@ -1022,7 +1022,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     const uint32_t uniform_buffer_size = 3 * sizeof(VkDeviceAddress);
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1069,7 +1069,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     // Make a list of storage buffers, each one holding a Node
     uint32_t storage_buffer_size = (4 * sizeof(float)) + sizeof(VkDeviceAddress);
     std::vector<vkt::Buffer> storage_buffers;
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     for (size_t i = 0; i < nodes_count; ++i) {
         // Last node's memory only holds 2 * sizeof(float), so writing to v.z is illegal
         if (i == nodes_count - 1) {
@@ -1086,7 +1086,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
 
     // Make sure shader wrote values to all nodes but the last
     for (auto [buffer_i, buffer] : vvl::enumerate(storage_buffers.data(), nodes_count - 1)) {
-        auto storage_buffer_ptr = static_cast<float *>(buffer.Memory().Map());
+        auto storage_buffer_ptr = static_cast<float*>(buffer.Memory().Map());
 
         ASSERT_EQ(storage_buffer_ptr[0], float(3 * buffer_i + 1));
         ASSERT_EQ(storage_buffer_ptr[1], float(3 * buffer_i + 2));
@@ -1098,7 +1098,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoad) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1136,7 +1136,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoad) {
     vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress buffer_ptr = bda_buffer.Address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1159,7 +1159,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoad2) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1193,7 +1193,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoad2) {
     vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress buffer_ptr = bda_buffer.Address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1233,7 +1233,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadSlang) {
     //     Foo a = pc.node[0];
     //     result[0] = a.x;
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Shader
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -1325,7 +1325,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadUint64) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1363,7 +1363,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadUint64) {
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress buffer_ptr = bda_buffer.Address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1385,7 +1385,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadBadAddress) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1422,7 +1422,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadBadAddress) {
     vkt::Buffer in_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress buffer_ptr = bda_buffer.Address() + 256;  // wrong
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1443,7 +1443,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadBadAddress) {
 TEST_F(NegativeGpuAVBufferDeviceAddress, StoreAlignment) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1468,7 +1468,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreAlignment) {
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress block_ptr = block_buffer.Address();
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = block_ptr + 4;
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE);
@@ -1489,7 +1489,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreAlignment) {
 TEST_F(NegativeGpuAVBufferDeviceAddress, LoadAlignment) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1516,7 +1516,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, LoadAlignment) {
     vkt::Buffer in_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress block_ptr = block_buffer.Address();
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = block_ptr + 4;
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1541,7 +1541,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, NonStructPointer) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         uniform uint* data_ptr; // only 256 bytes
         [numthreads(1,1,1)]
         void main() {
@@ -1557,7 +1557,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, NonStructPointer) {
     vkt::Buffer block_buffer(*m_device, 256, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = block_buffer.Address();
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE);
@@ -1582,7 +1582,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MultipleAccessChains) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Data {
             uint x;
             uint payload[16]; // last item is OOB
@@ -1598,7 +1598,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MultipleAccessChains) {
     vkt::Buffer bda_buffer(*m_device, 64, 0, vkt::device_address);
     vkt::Buffer ubo_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto ubo_buffer_ptr = static_cast<VkDeviceAddress *>(ubo_buffer.Memory().Map());
+    auto ubo_buffer_ptr = static_cast<VkDeviceAddress*>(ubo_buffer.Memory().Map());
     ubo_buffer_ptr[0] = bda_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -1633,7 +1633,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, OpCopyObject) {
     // void main() {
     //     ptr.a = ptr.b;
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -1680,7 +1680,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, OpCopyObject) {
     vkt::Buffer bda_buffer(*m_device, 4, 0, vkt::device_address);
     vkt::Buffer ubo_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto ubo_buffer_ptr = static_cast<VkDeviceAddress *>(ubo_buffer.Memory().Map());
+    auto ubo_buffer_ptr = static_cast<VkDeviceAddress*>(ubo_buffer.Memory().Map());
     ubo_buffer_ptr[0] = bda_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -1712,7 +1712,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MemoryModelOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1736,7 +1736,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MemoryModelOperand) {
     vkt::Buffer bda_buffer(*m_device, 32, 0, vkt::device_address);  // too small
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
@@ -1765,7 +1765,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MemoryModelOperand2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1798,7 +1798,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MemoryModelOperand2) {
     vkt::Buffer bda_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
     in_buffer_ptr[1] = 0;  // set SSBO.a to be zero
 
@@ -1828,7 +1828,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicLoad) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1848,7 +1848,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicLoad) {
     vkt::Buffer bda_buffer(*m_device, 32, 0, vkt::device_address);  // too small
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -1876,7 +1876,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicStore) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1895,7 +1895,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicStore) {
     vkt::Buffer bda_buffer(*m_device, 32, 0, vkt::device_address);  // too small
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -1922,7 +1922,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicExchange) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1943,7 +1943,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicExchange) {
     vkt::Buffer bda_buffer(*m_device, 32, 0, vkt::device_address);  // too small
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -1972,7 +1972,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicAddValueOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1993,7 +1993,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicAddValueOperand) {
     vkt::Buffer bda_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -2022,7 +2022,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicAddPointerOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2042,7 +2042,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicAddPointerOperand) {
     vkt::Buffer bda_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -2070,7 +2070,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicsMaxMin) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2093,7 +2093,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicsMaxMin) {
     vkt::Buffer bda_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -2123,7 +2123,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PieceOfDataPointer) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         RWStructuredBuffer<uint> result;
         struct Data{
            uint* node;
@@ -2186,7 +2186,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicExchangeSlang) {
     //     InterlockedExchange(*(x->b), 0);
     // }
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Int64
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Shader
@@ -2247,7 +2247,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicExchangeSlang) {
     vkt::Buffer bda_buffer(*m_device, 256, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 8, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -2277,7 +2277,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PieceOfDataPointerInStruct) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         RWStructuredBuffer<uint> result;
 
         struct Bar {
@@ -2338,7 +2338,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainLastInvalid) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain, and the last pointer is bad");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2370,10 +2370,10 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainLastInvalid) {
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
-    auto buffer_ptr = (VkDeviceAddress *)in_buffer.Memory().Map();
+    auto buffer_ptr = (VkDeviceAddress*)in_buffer.Memory().Map();
     buffer_ptr[0] = ssbo_b_buffer.Address();
 
-    buffer_ptr = (VkDeviceAddress *)ssbo_b_buffer.Memory().Map();
+    buffer_ptr = (VkDeviceAddress*)ssbo_b_buffer.Memory().Map();
     buffer_ptr[0] = 0xffffffffffffff00;  // bad pointer
 
     m_command_buffer.Begin();
@@ -2392,7 +2392,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainFirstInvalid) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain, and the first pointer is bad");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2424,10 +2424,10 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainFirstInvalid) {
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
-    auto buffer_ptr = (VkDeviceAddress *)in_buffer.Memory().Map();
+    auto buffer_ptr = (VkDeviceAddress*)in_buffer.Memory().Map();
     buffer_ptr[0] = 0xffffffffffffff00;  // bad pointer
 
-    buffer_ptr = (VkDeviceAddress *)ssbo_b_buffer.Memory().Map();
+    buffer_ptr = (VkDeviceAddress*)ssbo_b_buffer.Memory().Map();
     buffer_ptr[0] = ssbo_a_buffer.Address();
 
     m_command_buffer.Begin();
@@ -2447,7 +2447,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainFirstInvalidAtomic) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain, and the first pointer is bad");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2480,10 +2480,10 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainFirstInvalidAtomic) {
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
-    auto buffer_ptr = (VkDeviceAddress *)in_buffer.Memory().Map();
+    auto buffer_ptr = (VkDeviceAddress*)in_buffer.Memory().Map();
     buffer_ptr[0] = 0xffffffffffffff00;  // bad pointer
 
-    buffer_ptr = (VkDeviceAddress *)ssbo_b_buffer.Memory().Map();
+    buffer_ptr = (VkDeviceAddress*)ssbo_b_buffer.Memory().Map();
     buffer_ptr[0] = ssbo_a_buffer.Address();
 
     m_command_buffer.Begin();
@@ -2500,7 +2500,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainFirstInvalidAtomic) {
 }
 
 // Used by various GPL tests
-static const char *gpl_vs_source = R"glsl(
+static const char* gpl_vs_source = R"glsl(
     #version 450
     #extension GL_EXT_buffer_reference : enable
     layout(buffer_reference) buffer BDA {
@@ -2521,7 +2521,7 @@ static const char *gpl_vs_source = R"glsl(
     }
 )glsl";
 
-static const char *gpl_fs_source = R"glsl(
+static const char* gpl_fs_source = R"glsl(
     #version 450
     #extension GL_EXT_buffer_reference : enable
     layout(buffer_reference) buffer BDA {

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -34,7 +34,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -78,14 +78,14 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140) {
     const uint32_t storage_buffer_size = 16 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 4;
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<uint32_t*>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
@@ -99,7 +99,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140NumerousAddressRanges) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -149,14 +149,14 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140NumerousAddressRanges) {
         (void)dummy_storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).Address();
     }
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 4;
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<uint32_t*>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
@@ -168,7 +168,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -212,14 +212,14 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430) {
     const uint32_t storage_buffer_size = 4 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 4;
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<uint32_t*>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], 42);
     }
@@ -229,7 +229,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreExplicitOffset) {
     TEST_DESCRIPTION("Do a OpStore to a PhysicalStorageBuffer");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -258,7 +258,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreExplicitOffset) {
     vkt::Buffer bda_buffer(*m_device, 64, 0, vkt::device_address);
 
     VkDeviceAddress buffer_ptr = bda_buffer.Address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -273,8 +273,8 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreExplicitOffset) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    uint8_t *bda_buffer_ptr = (uint8_t *)bda_buffer.Memory().Map();
-    uint32_t output = *((uint32_t *)(bda_buffer_ptr + 32));
+    uint8_t* bda_buffer_ptr = (uint8_t*)bda_buffer.Memory().Map();
+    uint32_t output = *((uint32_t*)(bda_buffer_ptr + 32));
     ASSERT_TRUE(output == 0xca7);
 }
 
@@ -282,7 +282,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoad) {
     TEST_DESCRIPTION("Do a OpLoad through a struct PhysicalStorageBuffer");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -317,14 +317,14 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoad) {
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
 
     float expected_output = 0x00EEAADD;
-    uint8_t *block_buffer_ptr = (uint8_t *)block_buffer.Memory().Map();
+    uint8_t* block_buffer_ptr = (uint8_t*)block_buffer.Memory().Map();
     memcpy(block_buffer_ptr, &expected_output, sizeof(float));
 
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress block_ptr = block_buffer.Address();
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -339,7 +339,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoad) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float output = *((float *)(in_buffer_ptr + sizeof(VkDeviceAddress)));
+    float output = *((float*)(in_buffer_ptr + sizeof(VkDeviceAddress)));
     ASSERT_TRUE(output == expected_output);
 }
 
@@ -349,7 +349,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoadPadded) {
     TEST_DESCRIPTION("Do a OpLoad through a padded struct PhysicalStorageBuffer");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -386,14 +386,14 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoadPadded) {
     vkt::Buffer block_buffer(*m_device, 32, 0, vkt::device_address);
 
     float expected_output = 0x00EEAADD;
-    uint8_t *block_buffer_ptr = (uint8_t *)block_buffer.Memory().Map();
+    uint8_t* block_buffer_ptr = (uint8_t*)block_buffer.Memory().Map();
     memcpy(block_buffer_ptr + 24, &expected_output, sizeof(float));
 
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress block_ptr = block_buffer.Address();
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -408,7 +408,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoadPadded) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float output = *((float *)(in_buffer_ptr + sizeof(VkDeviceAddress)));
+    float output = *((float*)(in_buffer_ptr + sizeof(VkDeviceAddress)));
     ASSERT_TRUE(output == expected_output);
 }
 
@@ -417,7 +417,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, UVec3Array) {
     AddRequiredFeature(vkt::Feature::scalarBlockLayout);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -451,7 +451,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, UVec3Array) {
     VkDeviceAddress block_ptr = block_buffer.Address();
     const uint32_t n_reads = 4;  // uvec3[0] to uvec3[3]
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &n_reads, sizeof(uint32_t));
 
@@ -472,7 +472,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ArrayOfStruct) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(std430, buffer_reference) buffer T1 {
@@ -510,7 +510,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ArrayOfStruct) {
 
     vkt::Buffer storage_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    uint8_t *buffer_ptr = (uint8_t *)storage_buffer.Memory().Map();
+    uint8_t* buffer_ptr = (uint8_t*)storage_buffer.Memory().Map();
     const uint32_t index = 0;
     memcpy(buffer_ptr, &index, sizeof(uint32_t));
     memcpy(buffer_ptr + (1 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
@@ -534,7 +534,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, BitCastUvec2) {
     TEST_DESCRIPTION("test loading and storing with GL_EXT_buffer_reference_uvec2");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_EXT_buffer_reference_uvec2 : enable
@@ -566,12 +566,12 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, BitCastUvec2) {
     VkDeviceAddress block_a_ptr = buffer_node_a.Address();
     VkDeviceAddress block_b_ptr = buffer_node_b.Address();
 
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer_node_b.Memory().Map());
+    auto* buffer_ptr = static_cast<uint32_t*>(buffer_node_b.Memory().Map());
     *buffer_ptr = 1234;  // data to pass
 
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_a_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &block_b_ptr, sizeof(VkDeviceAddress));
 
@@ -587,7 +587,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, BitCastUvec2) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    buffer_ptr = static_cast<uint32_t *>(buffer_node_a.Memory().Map());
+    buffer_ptr = static_cast<uint32_t*>(buffer_node_a.Memory().Map());
     ASSERT_TRUE(*buffer_ptr == 1234);
 }
 
@@ -610,7 +610,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     //     ssbo.ptr.f = 42.0;
     //     ssbo.ptr.v = uvec3(1.0, 2.0, 3.0);
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpMemoryModel PhysicalStorageBuffer64 GLSL450
@@ -689,13 +689,13 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     const uint32_t storage_buffer_size = 4 * sizeof(float);  // float + vec3
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer.Address();
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     // Make sure shader wrote to float and vec3
-    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<float*>(storage_buffer.Memory().Map());
     ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
     ASSERT_EQ(storage_buffer_ptr[1], 1.0f);
     ASSERT_EQ(storage_buffer_ptr[2], 2.0f);
@@ -711,7 +711,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -752,12 +752,12 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
     const uint32_t storage_buffer_size = 4 * sizeof(float);  // float + vec3
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = storage_buffer.Address();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     // Make sure shader wrote to float and vec3
-    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
+    auto* storage_buffer_ptr = static_cast<float*>(storage_buffer.Memory().Map());
     ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
     ASSERT_EQ(storage_buffer_ptr[1], 1.0f);
     ASSERT_EQ(storage_buffer_ptr[2], 2.0f);
@@ -772,7 +772,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     const uint32_t uniform_buffer_size = 3 * sizeof(VkDeviceAddress);
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -818,7 +818,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     constexpr size_t nodes_count = 3;
     const uint32_t storage_buffer_size = (4 * sizeof(float)) + sizeof(VkDeviceAddress);
     std::vector<vkt::Buffer> storage_buffers;
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
 
     for (size_t i = 0; i < nodes_count; ++i) {
         const VkDeviceAddress addr = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).Address();
@@ -829,7 +829,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
 
     // Make sure shader wrote values to all nodes
     for (auto [buffer_i, buffer] : vvl::enumerate(storage_buffers)) {
-        auto storage_buffer_ptr = static_cast<float *>(buffer.Memory().Map());
+        auto storage_buffer_ptr = static_cast<float*>(buffer.Memory().Map());
 
         ASSERT_EQ(storage_buffer_ptr[0], float(3 * buffer_i + 1));
         ASSERT_EQ(storage_buffer_ptr[1], float(3 * buffer_i + 2));
@@ -842,7 +842,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleBufferReferenceBlocks) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -894,15 +894,15 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleBufferReferenceBlocks) {
     const uint32_t bar_storage_buffer_size = sizeof(float) + sizeof(int32_t) + 4 * sizeof(float);
     vkt::Buffer bar_storage_buffer(*m_device, bar_storage_buffer_size, 0, vkt::device_address);
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto* uniform_buffer_ptr = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = foo_storage_buffer.Address();
     uniform_buffer_ptr[1] = bar_storage_buffer.Address();
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     // Make sure shader wrote to float and vec3
-    auto *foo_ptr = static_cast<int *>(foo_storage_buffer.Memory().Map());
-    auto *bar_ptr = static_cast<int *>(bar_storage_buffer.Memory().Map());
+    auto* foo_ptr = static_cast<int*>(foo_storage_buffer.Memory().Map());
+    auto* bar_ptr = static_cast<int*>(bar_storage_buffer.Memory().Map());
     ASSERT_EQ(bar_ptr[0], 42);
     ASSERT_EQ(foo_ptr[3], bar_ptr[0]);
 }
@@ -912,7 +912,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -966,7 +966,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
     // Write vertex 0
-    auto vertex_buffer_ptr = static_cast<Vertex *>(storage_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<Vertex*>(storage_buffer.Memory().Map());
     vertex_buffer_ptr[0].x = 1.0f;
     vertex_buffer_ptr[0].y = 2.0f;
     vertex_buffer_ptr[0].z = 3.0f;
@@ -978,7 +978,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
     vertex_buffer_ptr[0].uv[0] = 7.0f;
     vertex_buffer_ptr[0].uv[1] = 8.0f;
 
-    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     data[0] = storage_buffer.Address();
 
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -1019,7 +1019,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ConcurrentAccessesToBdaBuffer) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1051,11 +1051,11 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ConcurrentAccessesToBdaBuffer) {
     std::vector<vkt::CommandBuffer> cmd_buffers;
     std::vector<vkt::Buffer> storage_buffers;
     for (int i = 0; i < 64; ++i) {
-        auto &cb = cmd_buffers.emplace_back(*m_device, m_command_pool);
+        auto& cb = cmd_buffers.emplace_back(*m_device, m_command_pool);
 
         // Create a storage buffer and get its address,
         // effectively adding it to the BDA table
-        auto &storage_buffer = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address);
+        auto& storage_buffer = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address);
 
         auto storage_buffer_addr = storage_buffer.Address();
 
@@ -1079,7 +1079,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructLoad) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1112,7 +1112,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructLoad) {
     vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress buffer_ptr = bda_buffer.Address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1132,7 +1132,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructLoadLinkedList) {
     TEST_DESCRIPTION("Make sure we don't get in an infinite loop searching for BDA length");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -1166,7 +1166,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructUnsafe) {
     TEST_DESCRIPTION("Make sure the range for a struct load is the whole struct.");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference2 : require
 
@@ -1218,7 +1218,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructUnsafe) {
     vkt::Buffer ssbo_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
     VkDeviceAddress bda_buffer_addr = bda_buffer.Address();
-    uint8_t *ssbo_buffer_ptr = (uint8_t *)ssbo_buffer.Memory().Map();
+    uint8_t* ssbo_buffer_ptr = (uint8_t*)ssbo_buffer.Memory().Map();
     memcpy(ssbo_buffer_ptr, &bda_buffer_addr, sizeof(VkDeviceAddress));
 
     descriptor_set.WriteDescriptorBufferInfo(0, ssbo_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1240,7 +1240,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, BasicRangeUnsafe) {
     TEST_DESCRIPTION("Simple test to examine how we do the range check in unsafe mode.");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference2 : require
 
@@ -1300,7 +1300,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, NonStructPointer) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         uniform uint* data_ptr;
         [numthreads(1,1,1)]
         void main() {
@@ -1316,7 +1316,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, NonStructPointer) {
     vkt::Buffer block_buffer(*m_device, 256, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = block_buffer.Address();
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE);
@@ -1331,7 +1331,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, NonStructPointer) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto block_buffer_ptr = static_cast<uint32_t *>(block_buffer.Memory().Map());
+    auto block_buffer_ptr = static_cast<uint32_t*>(block_buffer.Memory().Map());
     ASSERT_TRUE(block_buffer_ptr[2] == 999);
 }
 
@@ -1342,7 +1342,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleAccessChains) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Data {
             uint x;
             uint payload[16]; // last item is OOB
@@ -1357,7 +1357,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleAccessChains) {
     vkt::Buffer bda_buffer(*m_device, 64, 0, vkt::device_address);
     vkt::Buffer ubo_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto ubo_buffer_ptr = static_cast<VkDeviceAddress *>(ubo_buffer.Memory().Map());
+    auto ubo_buffer_ptr = static_cast<VkDeviceAddress*>(ubo_buffer.Memory().Map());
     ubo_buffer_ptr[0] = bda_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -1388,7 +1388,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DescriptorStructPointerSlang) {
     RETURN_IF_SKIP(CheckSlangSupport());
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Data {
             int32_t x;
         }
@@ -1402,7 +1402,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DescriptorStructPointerSlang) {
     vkt::Buffer bda_buffer(*m_device, 4, 0, vkt::device_address);
     vkt::Buffer ubo_buffer(*m_device, 8, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto ubo_buffer_ptr = static_cast<VkDeviceAddress *>(ubo_buffer.Memory().Map());
+    auto ubo_buffer_ptr = static_cast<VkDeviceAddress*>(ubo_buffer.Memory().Map());
     ubo_buffer_ptr[0] = bda_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -1436,7 +1436,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PushConstantStructPointerSlang) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
     InitRenderTarget();
 
-    const char *vert_source = R"(
+    const char* vert_source = R"(
         float4 operator*(float4x4 a, float4 b) { return mul(b, a); }
 
         struct PerFrame {
@@ -1489,7 +1489,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleStructPointerSlang) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
     InitRenderTarget();
 
-    const char *vert_source = R"(
+    const char* vert_source = R"(
         struct Data {
             float4 a;
             float4 b;
@@ -1553,7 +1553,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleAccessChainsDescriptorBuffer) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Data {
             uint x;
             uint payload[16]; // last item is OOB
@@ -1568,7 +1568,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleAccessChainsDescriptorBuffer) {
     vkt::Buffer bda_buffer(*m_device, 64, 0, vkt::device_address);
     vkt::Buffer ubo_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
 
-    auto ubo_buffer_ptr = static_cast<VkDeviceAddress *>(ubo_buffer.Memory().Map());
+    auto ubo_buffer_ptr = static_cast<VkDeviceAddress*>(ubo_buffer.Memory().Map());
     ubo_buffer_ptr[0] = bda_buffer.Address();
 
     const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
@@ -1594,7 +1594,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleAccessChainsDescriptorBuffer) {
     pipe.CreateComputePipeline();
 
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
     VkDeviceSize buffer_offset = ds_layout.GetDescriptorBufferBindingOffset(0);
 
     vkt::DescriptorGetInfo buffer_get_info(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, ubo_buffer, ubo_buffer.CreateInfo().size);
@@ -1638,7 +1638,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, AtomicExchangeSlang) {
     //     InterlockedExchange(*foo.a, 0);
     //     InterlockedExchange(*(x->b), 0);
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Int64
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Shader
@@ -1700,7 +1700,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, AtomicExchangeSlang) {
     vkt::Buffer bda_buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 8, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -1732,7 +1732,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MemoryModelOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1758,7 +1758,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MemoryModelOperand) {
     vkt::Buffer bda_buffer(*m_device, 128, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -1786,7 +1786,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MemoryModelOperand2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1820,7 +1820,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MemoryModelOperand2) {
     vkt::Buffer bda_buffer(*m_device, 128, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
     in_buffer_ptr[1] = 0;  // set SSBO.a to be zero
 
@@ -1848,7 +1848,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Atomics) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1874,7 +1874,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Atomics) {
     vkt::Buffer bda_buffer(*m_device, 128, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -1902,7 +1902,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Atomics2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1937,7 +1937,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Atomics2) {
     vkt::Buffer bda_buffer(*m_device, 64, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto in_buffer_ptr = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     in_buffer_ptr[0] = bda_buffer.Address();
 
     CreateComputePipelineHelper pipe(*this);
@@ -1961,7 +1961,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, AtomicsWorkgroups) {
     TEST_DESCRIPTION("Found case where a potential BDA points to a variable not in the function");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         shared int x;
@@ -1990,7 +1990,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PieceOfDataPointer) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         RWStructuredBuffer<uint> result;
         struct Data{
            uint* node;
@@ -2005,7 +2005,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PieceOfDataPointer) {
     vkt::Buffer bda_buffer(*m_device, 32, 0, vkt::device_address);
     vkt::Buffer out_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto bda_buffer_ptr = static_cast<uint32_t *>(bda_buffer.Memory().Map());
+    auto bda_buffer_ptr = static_cast<uint32_t*>(bda_buffer.Memory().Map());
     bda_buffer_ptr[0] = 33;
     bda_buffer_ptr[1] = 66;
     bda_buffer_ptr[2] = 99;
@@ -2034,7 +2034,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PieceOfDataPointer) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto out_buffer_ptr = static_cast<uint32_t *>(out_buffer.Memory().Map());
+    auto out_buffer_ptr = static_cast<uint32_t*>(out_buffer.Memory().Map());
     ASSERT_TRUE(out_buffer_ptr[0] == 66);
 }
 
@@ -2046,7 +2046,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PieceOfDataPointerInStruct) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         RWStructuredBuffer<uint> result;
         struct Foo {
             uint pad_0;
@@ -2069,7 +2069,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PieceOfDataPointerInStruct) {
     vkt::Buffer bda_buffer(*m_device, 32, 0, vkt::device_address);
     vkt::Buffer out_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    auto bda_buffer_ptr = static_cast<uint32_t *>(bda_buffer.Memory().Map());
+    auto bda_buffer_ptr = static_cast<uint32_t*>(bda_buffer.Memory().Map());
     bda_buffer_ptr[0] = 33;
 
     VkPushConstantRange pc_range = {VK_SHADER_STAGE_COMPUTE_BIT, 0, 64};
@@ -2096,7 +2096,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PieceOfDataPointerInStruct) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto out_buffer_ptr = static_cast<uint32_t *>(out_buffer.Memory().Map());
+    auto out_buffer_ptr = static_cast<uint32_t*>(out_buffer.Memory().Map());
     ASSERT_TRUE(out_buffer_ptr[0] == 33);
 }
 
@@ -2127,7 +2127,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
     pipeline_layout_ci.pushConstantRangeCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2145,7 +2145,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
         }
     )glsl";
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint c; };
         void main() {}
@@ -2223,7 +2223,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
     pipeline_layout_ci.pPushConstantRanges = push_constant_ranges.data();
     const vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2241,7 +2241,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
         }
     )glsl";
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint c; };
         void main() {}
@@ -2313,7 +2313,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PointerChain) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2350,13 +2350,13 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PointerChain) {
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
-    auto buffer_ptr = (VkDeviceAddress *)in_buffer.Memory().Map();
+    auto buffer_ptr = (VkDeviceAddress*)in_buffer.Memory().Map();
     buffer_ptr[0] = ssbo_c_buffer.Address();
 
-    buffer_ptr = (VkDeviceAddress *)ssbo_c_buffer.Memory().Map();
+    buffer_ptr = (VkDeviceAddress*)ssbo_c_buffer.Memory().Map();
     buffer_ptr[0] = ssbo_b_buffer.Address();
 
-    buffer_ptr = (VkDeviceAddress *)ssbo_b_buffer.Memory().Map();
+    buffer_ptr = (VkDeviceAddress*)ssbo_b_buffer.Memory().Map();
     buffer_ptr[0] = ssbo_a_buffer.Address();
 
     m_command_buffer.Begin();
@@ -2368,7 +2368,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PointerChain) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto out_buffer_ptr = (uint32_t *)ssbo_a_buffer.Memory().Map();
+    auto out_buffer_ptr = (uint32_t*)ssbo_a_buffer.Memory().Map();
     ASSERT_TRUE(out_buffer_ptr[0] == 42);
 }
 
@@ -2377,7 +2377,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ManyAccessToSameStruct) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2441,7 +2441,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, GlobalInvocationIdIVec3) {
     // void main() {
     //     ptr.x = int(gl_GlobalInvocationID.x);
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2499,7 +2499,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DualShaderLibrary) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2574,7 +2574,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DualShaderLibraryDestroyModule) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 

--- a/tests/unit/gpu_av_cooperative_vector.cpp
+++ b/tests/unit/gpu_av_cooperative_vector.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
- * Copyright (c) 2023-2025 NVIDIA Corporation
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
+ * Copyright (c) 2023-2026 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 
 class NegativeGpuAVCooperativeVector : public GpuAVTest {
   public:
-    void RunTest(const char *expected_error, const char *shaderBody);
+    void RunTest(const char* expected_error, const char* shaderBody);
 };
 
-void NegativeGpuAVCooperativeVector::RunTest(const char *expected_error, const char *shaderBody) {
+void NegativeGpuAVCooperativeVector::RunTest(const char* expected_error, const char* shaderBody) {
     TEST_DESCRIPTION("GPU AV negative tests for CooperativeVector");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME);

--- a/tests/unit/gpu_av_cooperative_vector_positive.cpp
+++ b/tests/unit/gpu_av_cooperative_vector_positive.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2024 Google, Inc.
- * Copyright (c) 2023-2025 NVIDIA Corporation
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
+ * Copyright (c) 2023-2026 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ TEST_F(PositiveGpuAVCooperativeVector, CooperativeVector) {
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_KHR_shader_subgroup_basic : enable

--- a/tests/unit/gpu_av_copies.cpp
+++ b/tests/unit/gpu_av_copies.cpp
@@ -26,7 +26,7 @@ TEST_F(NegativeGpuAVCopies, BufferToImageD32) {
     vkt::Buffer copy_src_buffer(*m_device, sizeof(float) * 64 * 64,
                                 VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, kHostVisibleMemProps);
 
-    float *ptr = static_cast<float *>(copy_src_buffer.Memory().Map());
+    float* ptr = static_cast<float*>(copy_src_buffer.Memory().Map());
     for (size_t i = 0; i < 64 * 64; ++i) {
         ptr[i] = 0.1f;
     }
@@ -126,7 +126,7 @@ TEST_F(NegativeGpuAVCopies, BufferToImageD32Vk13) {
     vkt::Buffer copy_src_buffer(*m_device, sizeof(float) * 64 * 64,
                                 VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, kHostVisibleMemProps);
 
-    float *ptr = static_cast<float *>(copy_src_buffer.Memory().Map());
+    float* ptr = static_cast<float*>(copy_src_buffer.Memory().Map());
     for (size_t i = 0; i < 64 * 64; ++i) {
         ptr[i] = 0.1f;
     }
@@ -180,10 +180,10 @@ TEST_F(NegativeGpuAVCopies, BufferToImageD32U8) {
     vkt::Buffer copy_src_buffer(*m_device, 5 * 64 * 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                 kHostVisibleMemProps);
 
-    auto ptr = static_cast<uint8_t *>(copy_src_buffer.Memory().Map());
+    auto ptr = static_cast<uint8_t*>(copy_src_buffer.Memory().Map());
     std::memset(ptr, 0, static_cast<size_t>(copy_src_buffer.CreateInfo().size));
     for (size_t i = 0; i < 64 * 64; ++i) {
-        auto ptr_float = reinterpret_cast<float *>(ptr + 5 * i);
+        auto ptr_float = reinterpret_cast<float*>(ptr + 5 * i);
         if (i == 64 * 64 - 1) {
             *ptr_float = 42.0f;
         } else {
@@ -226,10 +226,10 @@ TEST_F(NegativeGpuAVCopies, BufferToImageD32U8Vk13) {
     vkt::Buffer copy_src_buffer(*m_device, 5 * 64 * 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                 kHostVisibleMemProps);
 
-    auto ptr = static_cast<uint8_t *>(copy_src_buffer.Memory().Map());
+    auto ptr = static_cast<uint8_t*>(copy_src_buffer.Memory().Map());
     std::memset(ptr, 0, static_cast<size_t>(copy_src_buffer.CreateInfo().size));
     for (size_t i = 0; i < 64 * 64; ++i) {
-        auto ptr_float = reinterpret_cast<float *>(ptr + 5 * i);
+        auto ptr_float = reinterpret_cast<float*>(ptr + 5 * i);
         if (i == 64 * 64 - 1) {
             *ptr_float = 42.0f;
         } else {

--- a/tests/unit/gpu_av_copies_positive.cpp
+++ b/tests/unit/gpu_av_copies_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
- * Copyright (c) 2023-2025 Google, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
+ * Copyright (c) 2023-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ TEST_F(PositiveGpuAVCopies, CopyBufferToImageD32) {
     vkt::Buffer copy_src_buffer(*m_device, sizeof(float) * 64 * 64,
                                 VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, kHostVisibleMemProps);
 
-    float *ptr = static_cast<float *>(copy_src_buffer.Memory().Map());
+    float* ptr = static_cast<float*>(copy_src_buffer.Memory().Map());
     for (size_t i = 0; i < 64 * 64; ++i) {
         if (i % 2) {
             ptr[i] = 1.0f;
@@ -77,10 +77,10 @@ TEST_F(PositiveGpuAVCopies, CopyBufferToImageD32U8) {
     vkt::Buffer copy_src_buffer(*m_device, 5 * 64 * 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                 kHostVisibleMemProps);
 
-    auto ptr = static_cast<uint8_t *>(copy_src_buffer.Memory().Map());
+    auto ptr = static_cast<uint8_t*>(copy_src_buffer.Memory().Map());
     std::memset(ptr, 0, static_cast<size_t>(copy_src_buffer.CreateInfo().size));
     for (size_t i = 0; i < 64 * 64; ++i) {
-        auto ptr_float = reinterpret_cast<float *>(ptr + 5 * i);
+        auto ptr_float = reinterpret_cast<float*>(ptr + 5 * i);
         if (i % 2) {
             *ptr_float = 1.0f;
         } else {
@@ -152,7 +152,7 @@ TEST_F(PositiveGpuAVCopies, Resubmit) {
 
     vkt::Buffer copy_src_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                 kHostVisibleMemProps);
-    auto buffer_ptr = static_cast<uint8_t *>(copy_src_buffer.Memory().Map());
+    auto buffer_ptr = static_cast<uint8_t*>(copy_src_buffer.Memory().Map());
     memset(buffer_ptr, 0, 16);
 
     VkBufferImageCopy2 region2 = vku::InitStructHelper();
@@ -213,7 +213,7 @@ TEST_F(PositiveGpuAVCopies, BatchSubmit) {
 
     vkt::Buffer copy_src_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                 kHostVisibleMemProps);
-    auto buffer_ptr = static_cast<uint8_t *>(copy_src_buffer.Memory().Map());
+    auto buffer_ptr = static_cast<uint8_t*>(copy_src_buffer.Memory().Map());
     memset(buffer_ptr, 0, 16);
 
     VkBufferImageCopy2 region2 = vku::InitStructHelper();

--- a/tests/unit/gpu_av_copy_memory_indirect.cpp
+++ b/tests/unit/gpu_av_copy_memory_indirect.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, SrcAddressAlignment) {
     vkt::Buffer dst_payload(*m_device, 16, 0, vkt::device_address);
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr->srcAddress = src_payload.Address() + 1;
     indirect_buffer_ptr->dstAddress = dst_payload.Address();
     indirect_buffer_ptr->size = 8;
@@ -58,7 +58,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, DstAddressAlignment) {
     vkt::Buffer dst_payload(*m_device, 32, 0, vkt::device_address);
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr[0].srcAddress = src_payload.Address();
     indirect_buffer_ptr[0].dstAddress = dst_payload.Address();
     indirect_buffer_ptr[0].size = 8;
@@ -94,7 +94,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, SizeAlignment) {
     vkt::Buffer dst_payload(*m_device, 16, 0, vkt::device_address);
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr->srcAddress = src_payload.Address();
     indirect_buffer_ptr->dstAddress = dst_payload.Address();
     indirect_buffer_ptr->size = 5;
@@ -128,7 +128,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, ImageSrcAddress) {
                          VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryToImageIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryToImageIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr->srcAddress = src_payload.Address() + 1;
     indirect_buffer_ptr->bufferRowLength = 8;
     indirect_buffer_ptr->bufferImageHeight = 8;
@@ -168,7 +168,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, ImageExtent) {
                          VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     vkt::Buffer indirect_buffer(*m_device, 128, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryToImageIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryToImageIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr[0].srcAddress = src_payload.Address();
     indirect_buffer_ptr[0].bufferRowLength = 1;  // invalid
     indirect_buffer_ptr[0].bufferImageHeight = 8;
@@ -220,7 +220,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, Combined) {
 
     vkt::Buffer indirect_buffer1(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
     vkt::Buffer indirect_buffer2(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer1_ptr = (VkCopyMemoryToImageIndirectCommandKHR *)indirect_buffer1.Memory().Map();
+    auto* indirect_buffer1_ptr = (VkCopyMemoryToImageIndirectCommandKHR*)indirect_buffer1.Memory().Map();
     indirect_buffer1_ptr->srcAddress = src_payload.Address() + 1;
     indirect_buffer1_ptr->bufferRowLength = 8;
     indirect_buffer1_ptr->bufferImageHeight = 8;
@@ -242,7 +242,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, Combined) {
     VkImageSubresourceLayers res_layer = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     copy_image_info.pImageSubresources = &res_layer;
 
-    auto *indirect_buffer2_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer2.Memory().Map();
+    auto* indirect_buffer2_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer2.Memory().Map();
     indirect_buffer2_ptr->srcAddress = src_payload.Address() + 1;
     indirect_buffer2_ptr->dstAddress = dst_payload.Address();
     indirect_buffer2_ptr->size = 4;
@@ -277,13 +277,13 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, GpuUpdate) {
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                                 vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr->srcAddress = src_payload.Address();
     indirect_buffer_ptr->dstAddress = dst_payload.Address();
     indirect_buffer_ptr->size = 4;  // valid, but will update to be invalid
 
     vkt::Buffer update_buffer(*m_device, 64, VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT, vkt::device_address);
-    auto *update_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)update_buffer.Memory().Map();
+    auto* update_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)update_buffer.Memory().Map();
     update_buffer_ptr->srcAddress = src_payload.Address();
     update_buffer_ptr->dstAddress = dst_payload.Address();
     update_buffer_ptr->size = 5;
@@ -326,7 +326,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, NullAddress) {
     vkt::Buffer dst_payload(*m_device, 16, 0, vkt::device_address);
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr[0].srcAddress = 0;
     indirect_buffer_ptr[0].dstAddress = dst_payload.Address();
     indirect_buffer_ptr[0].size = 8;
@@ -364,7 +364,7 @@ TEST_F(NegativeGpuAVCopyMemoryIndirect, ManyCopies) {
 
     const uint32_t indirect_buffer_size = sizeof(VkCopyMemoryIndirectCommandKHR) * copy_count;
     vkt::Buffer indirect_buffer(*m_device, indirect_buffer_size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     for (uint32_t i = 0; i < copy_count; i++) {
         indirect_buffer_ptr[i].srcAddress = src_payload.Address();
         indirect_buffer_ptr[i].dstAddress = dst_payload.Address();

--- a/tests/unit/gpu_av_copy_memory_indirect_positive.cpp
+++ b/tests/unit/gpu_av_copy_memory_indirect_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,14 +33,14 @@ TEST_F(PositiveGpuAVCopyMemoryIndirect, Basic) {
     vkt::Buffer src_payload(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer dst_payload(*m_device, 16, 0, vkt::device_address);
 
-    auto *src_payload_ptr = (uint32_t *)src_payload.Memory().Map();
+    auto* src_payload_ptr = (uint32_t*)src_payload.Memory().Map();
     src_payload_ptr[0] = 3;
     src_payload_ptr[1] = 6;
     src_payload_ptr[2] = 9;
     src_payload_ptr[3] = 12;
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr->srcAddress = src_payload.Address();
     indirect_buffer_ptr->dstAddress = dst_payload.Address();
     indirect_buffer_ptr->size = 16;
@@ -62,7 +62,7 @@ TEST_F(PositiveGpuAVCopyMemoryIndirect, Basic) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto *dst_payload_ptr = (uint32_t *)dst_payload.Memory().Map();
+    auto* dst_payload_ptr = (uint32_t*)dst_payload.Memory().Map();
     ASSERT_TRUE(dst_payload_ptr[0] == 3);
     ASSERT_TRUE(dst_payload_ptr[1] == 6);
     ASSERT_TRUE(dst_payload_ptr[2] == 9);
@@ -76,20 +76,20 @@ TEST_F(PositiveGpuAVCopyMemoryIndirect, MultiCopy) {
     vkt::Buffer src2_payload(*m_device, 32, 0, vkt::device_address);
     vkt::Buffer dst_payload(*m_device, 32, 0, vkt::device_address);
 
-    auto *src1_payload_ptr = (uint32_t *)src1_payload.Memory().Map();
+    auto* src1_payload_ptr = (uint32_t*)src1_payload.Memory().Map();
     src1_payload_ptr[0] = 3;
     src1_payload_ptr[1] = 5;
     src1_payload_ptr[2] = 7;
     src1_payload_ptr[3] = 9;
 
-    auto *src2_payload_ptr = (uint32_t *)src2_payload.Memory().Map();
+    auto* src2_payload_ptr = (uint32_t*)src2_payload.Memory().Map();
     src2_payload_ptr[0] = 2;
     src2_payload_ptr[1] = 4;
     src2_payload_ptr[2] = 6;
     src2_payload_ptr[3] = 8;
 
     vkt::Buffer indirect_buffer(*m_device, 512, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr[0].srcAddress = src1_payload.Address();
     indirect_buffer_ptr[0].dstAddress = dst_payload.Address();
     indirect_buffer_ptr[0].size = 4;
@@ -120,7 +120,7 @@ TEST_F(PositiveGpuAVCopyMemoryIndirect, MultiCopy) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto *dst_payload_ptr = (uint32_t *)dst_payload.Memory().Map();
+    auto* dst_payload_ptr = (uint32_t*)dst_payload.Memory().Map();
     ASSERT_TRUE(dst_payload_ptr[0] == 3);
     ASSERT_TRUE(dst_payload_ptr[1] == 7);
     ASSERT_TRUE(dst_payload_ptr[2] == 2);
@@ -137,7 +137,7 @@ TEST_F(PositiveGpuAVCopyMemoryIndirect, Image) {
                          VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryToImageIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryToImageIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr->srcAddress = src_payload.Address();
     indirect_buffer_ptr->bufferRowLength = 8;
     indirect_buffer_ptr->bufferImageHeight = 8;
@@ -176,13 +176,13 @@ TEST_F(PositiveGpuAVCopyMemoryIndirect, GpuUpdate) {
 
     vkt::Buffer indirect_buffer(*m_device, 64, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                                 vkt::device_address);
-    auto *indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)indirect_buffer.Memory().Map();
+    auto* indirect_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)indirect_buffer.Memory().Map();
     indirect_buffer_ptr->srcAddress = src_payload.Address();
     indirect_buffer_ptr->dstAddress = dst_payload.Address();
     indirect_buffer_ptr->size = 5;  // invalid, but will update
 
     vkt::Buffer update_buffer(*m_device, 64, VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT, vkt::device_address);
-    auto *update_buffer_ptr = (VkCopyMemoryIndirectCommandKHR *)update_buffer.Memory().Map();
+    auto* update_buffer_ptr = (VkCopyMemoryIndirectCommandKHR*)update_buffer.Memory().Map();
     update_buffer_ptr->srcAddress = src_payload.Address();
     update_buffer_ptr->dstAddress = dst_payload.Address();
     update_buffer_ptr->size = 4;

--- a/tests/unit/gpu_av_debug_printf.cpp
+++ b/tests/unit/gpu_av_debug_printf.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
- * Copyright (c) 2024 Google, Inc.
+ * Copyright (c) 2024-2026 The Khronos Group Inc.
+ * Copyright (c) 2024-2026 Valve Corporation
+ * Copyright (c) 2024-2026 LunarG, Inc.
+ * Copyright (c) 2024-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 class NegativeGpuAVDebugPrintf : public virtual VkLayerTest {
   public:
-    void InitGpuAvDebugPrintfFramework(void *p_next = nullptr);
+    void InitGpuAvDebugPrintfFramework(void* p_next = nullptr);
     void InitWithLayerSettings(bool enable_printf, bool enable_gpuav, bool shader_instrumentation);
 
     VkValidationFeaturesEXT GetGpuAvDebugPrintfValidationFeatures();
@@ -40,7 +40,7 @@ VkValidationFeaturesEXT NegativeGpuAVDebugPrintf::GetGpuAvDebugPrintfValidationF
     return features;
 }
 
-void NegativeGpuAVDebugPrintf::InitGpuAvDebugPrintfFramework(void *p_next) {
+void NegativeGpuAVDebugPrintf::InitGpuAvDebugPrintfFramework(void* p_next) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
@@ -63,7 +63,8 @@ void NegativeGpuAVDebugPrintf::InitWithLayerSettings(bool enable_printf, bool en
     VkLayerSettingEXT gpuav_setting = {OBJECT_LAYER_NAME, "gpuav_enable", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &gpuav_value};
 
     VkBool32 shader_instrumentation_value = shader_instrumentation ? VK_TRUE : VK_FALSE;
-    VkLayerSettingEXT shader_instrumentation_setting = {OBJECT_LAYER_NAME, "gpuav_shader_instrumentation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &shader_instrumentation_value};
+    VkLayerSettingEXT shader_instrumentation_setting = {OBJECT_LAYER_NAME, "gpuav_shader_instrumentation",
+                                                        VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &shader_instrumentation_value};
 
     std::array<VkLayerSettingEXT, 3> layer_settings = {printf_setting, gpuav_setting, shader_instrumentation_setting};
     VkLayerSettingsCreateInfoEXT layer_settings_create_info = vku::InitStructHelper();
@@ -76,7 +77,7 @@ void NegativeGpuAVDebugPrintf::InitWithLayerSettings(bool enable_printf, bool en
 }
 
 void NegativeGpuAVDebugPrintf::BasicComputeTest() {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -138,7 +139,7 @@ TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsNoPrintf) {
 }
 
 TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsNoGpuAV) {
-    AddRequiredFeature(vkt::Feature::robustBufferAccess); // prevent crashing
+    AddRequiredFeature(vkt::Feature::robustBufferAccess);  // prevent crashing
     RETURN_IF_SKIP(InitWithLayerSettings(true, false, true));
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->SetDesiredInfo("b.length == 3");
@@ -146,7 +147,7 @@ TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsNoGpuAV) {
 }
 
 TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsNoShaderInstrumentation) {
-    AddRequiredFeature(vkt::Feature::robustBufferAccess); // prevent crashing
+    AddRequiredFeature(vkt::Feature::robustBufferAccess);  // prevent crashing
     RETURN_IF_SKIP(InitWithLayerSettings(true, true, false));
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->SetDesiredInfo("b.length == 3");
@@ -154,7 +155,7 @@ TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsNoShaderInstrumentation) {
 }
 
 TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsNoPrintfOrGpuAV) {
-    AddRequiredFeature(vkt::Feature::robustBufferAccess); // prevent crashing
+    AddRequiredFeature(vkt::Feature::robustBufferAccess);  // prevent crashing
     RETURN_IF_SKIP(InitWithLayerSettings(false, false, true));
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
@@ -164,7 +165,7 @@ TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsNoPrintfOrGpuAV) {
 TEST_F(NegativeGpuAVDebugPrintf, BasicLayerSettingsPrintfPreset) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::robustBufferAccess); // prevent crashing
+    AddRequiredFeature(vkt::Feature::robustBufferAccess);  // prevent crashing
     VkBool32 value = VK_TRUE;
     VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "printf_only_preset", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &value};
     VkLayerSettingsCreateInfoEXT layer_settings_create_info = vku::InitStructHelper();
@@ -187,7 +188,7 @@ TEST_F(NegativeGpuAVDebugPrintf, Graphics) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -236,7 +237,7 @@ TEST_F(NegativeGpuAVDebugPrintf, GPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -282,7 +283,7 @@ TEST_F(NegativeGpuAVDebugPrintf, ShaderObject) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -329,7 +330,7 @@ TEST_F(NegativeGpuAVDebugPrintf, DynamicRendering) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {

--- a/tests/unit/gpu_av_descriptor_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025 Valve Corporation
- * Copyright (c) 2024-2025 LunarG, Inc.
+ * Copyright (c) 2024-2026 Valve Corporation
+ * Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ TEST_F(PositiveGpuAVDescriptorBuffer, BasicCompute) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
@@ -51,10 +51,10 @@ TEST_F(PositiveGpuAVDescriptorBuffer, BasicCompute) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_data, 16);
-    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
+    void* mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -115,9 +115,9 @@ TEST_F(PositiveGpuAVDescriptorBuffer, BasicGraphics) {
     vkt::Buffer bda(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
     vkt::Buffer ssbo_0(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
     vkt::Buffer ubo_1(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
-    auto ssbo_ptr = (VkDeviceAddress *)ssbo_0.Memory().Map();
+    auto ssbo_ptr = (VkDeviceAddress*)ssbo_0.Memory().Map();
     ssbo_ptr[0] = bda.Address();  // ptr
-    uint32_t *data = (uint32_t *)ubo_1.Memory().Map();
+    uint32_t* data = (uint32_t*)ubo_1.Memory().Map();
     data[0] = 0;  // index
 
     std::vector<VkDescriptorSetLayoutBinding> bindings = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr},
@@ -135,7 +135,7 @@ TEST_F(PositiveGpuAVDescriptorBuffer, BasicGraphics) {
                                   vkt::device_address);
 
     vkt::DescriptorGetInfo get_info_0(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, ssbo_0, 16);
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info_0, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(0));
 
@@ -143,7 +143,7 @@ TEST_F(PositiveGpuAVDescriptorBuffer, BasicGraphics) {
     vk::GetDescriptorEXT(device(), get_info_1, descriptor_buffer_properties.uniformBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(1));
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_EXT_nonuniform_qualifier : enable
@@ -190,7 +190,7 @@ TEST_F(PositiveGpuAVDescriptorBuffer, BasicGraphics) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    data = (uint32_t *)bda.Memory().Map();
+    data = (uint32_t*)bda.Memory().Map();
     ASSERT_TRUE(data[0] == 11);
 }
 
@@ -214,7 +214,7 @@ TEST_F(PositiveGpuAVDescriptorBuffer, NoPipelineLayout) {
 
     vkt::Buffer descriptor_buffer(*m_device, 1024, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout (constant_id = 0) const uint c = 3;
         #extension GL_EXT_debug_printf : enable

--- a/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
@@ -97,7 +97,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ReachMaxActionsCommandValidati
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", std::max(gpuav::glsl::kMaxErrorsPerCmd, 10u));
@@ -168,7 +168,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ReachMaxActionsCommandValidati
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 1;
     m_errorMonitor->SetDesiredError("GPUAV-Overflow-Unknown", 3);  // 3 descriptor accesses
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -194,7 +194,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, RobustBuffer) {
     descriptor_set.WriteDescriptorBufferInfo(1, storage_buffer, 0, 16, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *vertshader = R"glsl(
+    const char* vertshader = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform foo { uint index[]; } u_index;
         layout(set = 0, binding = 1) buffer StorageBuffer { uint data[]; } Data;
@@ -228,7 +228,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, RobustBuffer) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)uniform_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)uniform_buffer.Memory().Map();
     *data = 0;
     // normally VUID-vkCmdDraw-uniformBuffers-06935
     m_errorMonitor->SetDesiredWarning("size is 4 bytes, 4 bytes were bound, and the highest out of bounds access was at [19] bytes",
@@ -286,7 +286,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Basic) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);
@@ -321,7 +321,7 @@ void NegativeGpuAVDescriptorClassGeneralBuffer::ShaderBufferSizeTest(VkDeviceSiz
     } else {
         InitRenderTarget();
     }
-    for (const char *error : expected_errors) {
+    for (const char* error : expected_errors) {
         m_errorMonitor->SetDesiredError(error);
     }
 
@@ -336,8 +336,8 @@ void NegativeGpuAVDescriptorClassGeneralBuffer::ShaderBufferSizeTest(VkDeviceSiz
     ds.WriteDescriptorBufferInfo(0, buffer, binding_offset, binding_range, descriptor_type);
     ds.UpdateDescriptorSets();
 
-    vkt::Shader *vso = nullptr;
-    vkt::Shader *fso = nullptr;
+    vkt::Shader* vso = nullptr;
+    vkt::Shader* fso = nullptr;
     if (shader_objects) {
         vso = new vkt::Shader(*m_device, VK_SHADER_STAGE_VERTEX_BIT,
                               GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexDrawPassthroughGlsl), &ds.layout_.handle());
@@ -425,7 +425,7 @@ void NegativeGpuAVDescriptorClassGeneralBuffer::ShaderBufferSizeTest(VkDeviceSiz
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall) {
     TEST_DESCRIPTION("Test that an error is produced when trying to access uniform buffer outside the bound region.");
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -434,7 +434,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall) {
            x = vec4(bar.x, bar.y, 0, 1);
         }
         )glsl";
-    std::vector<const char *> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
+    std::vector<const char*> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
     ShaderBufferSizeTest(4,  // buffer size
                          0,  // binding offset
                          4,  // binding range
@@ -443,7 +443,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall) {
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall2) {
     TEST_DESCRIPTION("Buffer is correct size, but only updating half of it.");
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -455,7 +455,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall2) {
            x = vec4(bar.x, bar.y, 0, 1);
         }
         )glsl";
-    std::vector<const char *> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
+    std::vector<const char*> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
     ShaderBufferSizeTest(8,  // buffer size
                          0,  // binding offset
                          4,  // binding range
@@ -465,7 +465,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall2) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBufferTooSmall) {
     TEST_DESCRIPTION("Test that an error is produced when trying to access storage buffer outside the bound region.");
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -475,7 +475,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBufferTooSmall) {
         }
         )glsl";
 
-    std::vector<const char *> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-storageBuffers-06936");
+    std::vector<const char*> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-storageBuffers-06936");
     ShaderBufferSizeTest(4,  // buffer size
                          0,  // binding offset
                          4,  // binding range
@@ -487,7 +487,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallArray) {
         "Test that an error is produced when trying to access uniform buffer outside the bound region. Uses array in block "
         "definition.");
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -500,7 +500,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallArray) {
         }
         )glsl";
 
-    std::vector<const char *> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
+    std::vector<const char*> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
     ShaderBufferSizeTest(64,  // buffer size
                          0,   // binding offset
                          64,  // binding range
@@ -512,7 +512,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallNestedStr
         "Test that an error is produced when trying to access uniform buffer outside the bound region. Uses nested struct in block "
         "definition.");
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
 
         struct S {
@@ -526,7 +526,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallNestedStr
         }
         )glsl";
 
-    std::vector<const char *> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
+    std::vector<const char*> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-uniformBuffers-06935");
     ShaderBufferSizeTest(8,  // buffer size
                          0,  // binding offset
                          8,  // binding range
@@ -535,7 +535,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallNestedStr
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ObjectUniformBufferTooSmall) {
     TEST_DESCRIPTION("Test that an error is produced when trying to access uniform buffer outside the bound region.");
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -545,7 +545,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ObjectUniformBufferTooSmall) {
         }
         )glsl";
 
-    std::vector<const char *> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-None-08612");
+    std::vector<const char*> expected_errors(gpuav::glsl::kMaxErrorsPerCmd, "VUID-vkCmdDraw-None-08612");
     ShaderBufferSizeTest(4,  // buffer size
                          0,  // binding offset
                          4,  // binding range
@@ -571,7 +571,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWrite) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     const char vertshader[] = R"glsl(
@@ -609,7 +609,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWriteSelectPipeline) {
 
     std::vector<VkLayerSettingEXT> layer_settings(2);
     layer_settings[0] = {OBJECT_LAYER_NAME, "gpuav_select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    std::array<const char *, 2> shader_regexes = {{"bim_bap_boom", ".*_my_pipeline.*"}};
+    std::array<const char*, 2> shader_regexes = {{"bim_bap_boom", ".*_my_pipeline.*"}};
     layer_settings[1] = {OBJECT_LAYER_NAME, "gpuav_shaders_to_instrument", VK_LAYER_SETTING_TYPE_STRING_EXT, size32(shader_regexes),
                          shader_regexes.data()};
 
@@ -627,7 +627,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWriteSelectPipeline) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     const char vertshader[] = R"glsl(
@@ -719,7 +719,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWriteSelectShaders) {
 
     std::vector<VkLayerSettingEXT> layer_settings(2);
     layer_settings[0] = {OBJECT_LAYER_NAME, "gpuav_select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    std::array<const char *, 2> shader_regexes = {{"verte[xyz]_foo", ".*gment_.*"}};
+    std::array<const char*, 2> shader_regexes = {{"verte[xyz]_foo", ".*gment_.*"}};
     layer_settings[1] = {OBJECT_LAYER_NAME, "gpuav_shaders_to_instrument", VK_LAYER_SETTING_TYPE_STRING_EXT, size32(shader_regexes),
                          shader_regexes.data()};
 
@@ -737,7 +737,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWriteSelectShaders) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     const char vertshader[] = R"glsl(
@@ -906,7 +906,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLReadWriteIndependentSets) {
 
     const std::array<VkDescriptorSet, 3> desc_sets = {vertex_set.set_, common_set.set_, fragment_set.set_};
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     const char vert_shader[] = R"glsl(
@@ -1011,7 +1011,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLNonInlined) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* offset_buffer_ptr = (uint32_t*)offset_buffer.Memory().Map();
     *offset_buffer_ptr = 8;
 
     const char vertshader[] = R"glsl(
@@ -1121,7 +1121,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLIndependentSetsUnusedSets) 
     bad_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
     bad_set.UpdateDescriptorSets();
 
-    const char *vert_shader = R"glsl(
+    const char* vert_shader = R"glsl(
         #version 450
         layout(set = 1, binding = 0) buffer StorageBuffer { uint data[]; };
         const vec2 vertices[3] = vec2[](
@@ -1135,7 +1135,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLIndependentSetsUnusedSets) 
         }
     )glsl";
 
-    const char *frag_shader = R"glsl(
+    const char* frag_shader = R"glsl(
         #version 450
         layout(set = 2, binding = 1) uniform samplerBuffer u_buffer;
         layout(location = 0) out vec4 c_out;
@@ -1210,7 +1210,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBuffer) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -1249,7 +1249,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBuffer) {
 
     VkDeviceAddress block_ptr = block_buffer.Address();
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
+    uint8_t* in_buffer_ptr = (uint8_t*)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1270,7 +1270,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBuffer) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Vector) {
     TEST_DESCRIPTION("index into a vector OOB");
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         // 28 bytes large
@@ -1289,7 +1289,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Vector) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Matrix) {
     TEST_DESCRIPTION("index into a matrix OOB");
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         // 32 bytes large
@@ -1314,7 +1314,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Geometry) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices=3) out;
@@ -1501,7 +1501,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, VertexFragmentMultiEntrypoint)
     // void frag_main() {
     //     data[4] = index[0];
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %frag_main "frag_main" %c_out
@@ -1623,7 +1623,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorCopy) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a;
@@ -1697,7 +1697,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DeviceGeneratedCommandsCompute
     command_layout_ci.pTokens = &token;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -1740,7 +1740,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DeviceGeneratedCommandsCompute
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    VkDispatchIndirectCommand *block_buffer_ptr = (VkDispatchIndirectCommand *)block_buffer.Memory().Map();
+    VkDispatchIndirectCommand* block_buffer_ptr = (VkDispatchIndirectCommand*)block_buffer.Memory().Map();
     block_buffer_ptr->x = 1;
     block_buffer_ptr->y = 1;
     block_buffer_ptr->z = 1;
@@ -1817,7 +1817,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBO) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -1856,7 +1856,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBO) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, VectorArray) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             uvec4 a[8]; // stride 16
@@ -1869,7 +1869,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, VectorArray) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo {
             uvec4 a;
@@ -1891,7 +1891,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopySlang) {
 
     RETURN_IF_SKIP(CheckSlangSupport());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
           uint4 a;
           uint pad;
@@ -1916,7 +1916,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo1 {
             uvec4 a;
@@ -1969,7 +1969,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar1 {
             uint4 a;
             uint b[4];
@@ -2018,7 +2018,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -2043,7 +2043,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -2066,7 +2066,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         struct Bar2 {
@@ -2095,7 +2095,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopySlang) {
     RETURN_IF_SKIP(CheckSlangSupport());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
           uint x;
           uint y;
@@ -2125,7 +2125,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
 
     RETURN_IF_SKIP(CheckSlangSupport());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
             uint a;
             uint d[4]; // this really ends up being a 1 element struct with the array in it
@@ -2144,7 +2144,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicStore) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -2160,7 +2160,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicStore) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicLoad) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -2176,7 +2176,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicLoad) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicExchange) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -2212,7 +2212,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer SSBO {
@@ -2255,7 +2255,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DescriptorIndexSlang) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
           uint4 a;
           uint b[4];
@@ -2297,7 +2297,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DescriptorIndexSlang) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Loops) {
     TEST_DESCRIPTION("Invalid during last iteration of a loop");
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2318,7 +2318,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Loops) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNested) {
     TEST_DESCRIPTION("Invalid during last iteration of a loop");
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2341,7 +2341,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNested) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsHoistable) {
     TEST_DESCRIPTION("Invalid during each iteration of a loop, but not dependent on the loop itself");
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2362,7 +2362,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsHoistable) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNestedHoistable) {
     TEST_DESCRIPTION("Invalid during each iteration of a loop, but not dependent on the loop itself");
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2385,7 +2385,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNestedHoistable) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsWithBranch) {
     TEST_DESCRIPTION("Invalid during last iteration of a loop, but has branch in it");
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2409,7 +2409,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsWithBranch) {
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ComplexCalculate) {
     TEST_DESCRIPTION("from Granite meshopt-sandbox test");
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer SSBO {
@@ -2444,7 +2444,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, TaskShader) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         taskPayloadSharedEXT uint payload;
@@ -2507,12 +2507,12 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
 
     vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawMeshTasksIndirectCommandEXT), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    auto *draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT *>(draw_buffer.Memory().Map());
+    auto* draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT*>(draw_buffer.Memory().Map());
     draw_ptr->groupCountX = 1;
     draw_ptr->groupCountY = 1;
     draw_ptr->groupCountZ = 1;
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         taskPayloadSharedEXT uint payload;
@@ -2530,7 +2530,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -2552,7 +2552,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    const char *frag_source = R"glsl(
+    const char* frag_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         layout(set = 0, binding = 2) readonly uniform UBO {
@@ -2620,7 +2620,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLOneLibraryTwoLinkedPipeline
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     const char vertshader[] = R"glsl(
@@ -2716,7 +2716,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLOneLibraryTwoLinkedPipeline
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     const char vertshader[] = R"glsl(
@@ -2773,7 +2773,9 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLOneLibraryTwoLinkedPipeline
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pipeline_layout;
-    { vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci); }
+    {
+        vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
+    }
     vkt::Pipeline exe_pipe_2(*m_device, exe_pipe_ci);
 
     m_command_buffer.Begin();

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_coop_mat_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_coop_mat_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ void GpuAVDescriptorClassGeneralBufferCoopMat::InitCooperativeMatrixKHR(bool saf
     RETURN_IF_SKIP(InitState());
 }
 
-void GpuAVDescriptorClassGeneralBufferCoopMat::BasicComputeTest(const char *shader, int source_type, VkDeviceSize buffer_size,
-                                                                const char *expected_error, uint32_t error_count) {
+void GpuAVDescriptorClassGeneralBufferCoopMat::BasicComputeTest(const char* shader, int source_type, VkDeviceSize buffer_size,
+                                                                const char* expected_error, uint32_t error_count) {
     const bool safe_mode = expected_error != nullptr;
     RETURN_IF_SKIP(InitCooperativeMatrixKHR(safe_mode));
     CooperativeMatrixHelper helper(*this);
@@ -70,7 +70,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, Basic) {
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -135,7 +135,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, BDA) {
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -172,7 +172,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, BDA) {
     descriptor_set.UpdateDescriptorSets();
 
     vkt::Buffer payload(*m_device, 512, 0, vkt::device_address);
-    auto *ssbo_ptr = static_cast<VkDeviceAddress *>(ssbo.Memory().Map());
+    auto* ssbo_ptr = static_cast<VkDeviceAddress*>(ssbo.Memory().Map());
     ssbo_ptr[0] = payload.Address();
 
     m_command_buffer.Begin();
@@ -191,7 +191,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, UnsafeOptimization) {
     AddRequiredFeature(vkt::Feature::shaderInt8);
     AddRequiredFeature(vkt::Feature::storageBuffer8BitAccess);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -237,7 +237,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, Robustness) {
     AddRequiredFeature(vkt::Feature::storageBuffer8BitAccess);
     AddRequiredFeature(vkt::Feature::cooperativeMatrixRobustBufferAccess);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -281,7 +281,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, RobustnessForced) {
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -326,7 +326,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, DynamicStrideAndElement
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -355,7 +355,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBufferCoopMat, DynamicStrideAndElement
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
-    uint32_t *buffer_ptr = (uint32_t *)in_buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)in_buffer.Memory().Map();
     buffer_ptr[0] = 16;  // stride
     buffer_ptr[1] = 4;   // element
 

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -18,8 +18,8 @@
 
 class PositiveGpuAVDescriptorClassGeneralBuffer : public GpuAVDescriptorClassGeneralBuffer {};
 
-void GpuAVDescriptorClassGeneralBuffer::ComputeStorageBufferTest(const char *shader, int source_type, VkDeviceSize buffer_size,
-                                                                 const char *expected_error, uint32_t error_count) {
+void GpuAVDescriptorClassGeneralBuffer::ComputeStorageBufferTest(const char* shader, int source_type, VkDeviceSize buffer_size,
+                                                                 const char* expected_error, uint32_t error_count) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
@@ -104,7 +104,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Basic) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 1;
     m_default_queue->SubmitAndWait(m_command_buffer);
 
@@ -178,7 +178,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, GPL) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 1;
     m_default_queue->SubmitAndWait(m_command_buffer);
 
@@ -209,7 +209,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, GPLNonInlined) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* offset_buffer_ptr = (uint32_t*)offset_buffer.Memory().Map();
     *offset_buffer_ptr = 8;
 
     const char vertshader[] = R"glsl(
@@ -308,16 +308,16 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, GPLFragmentIndependentSets) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.Memory().Map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t*>(vs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
-        for (auto &v : vert_data) {
+        for (auto& v : vert_data) {
             v = 0x01030507;
         }
     }
     {
-        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.Memory().Map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t*>(fs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
-        for (auto &v : frag_data) {
+        for (auto& v : frag_data) {
             v = 0x02040608;
         }
     }
@@ -431,7 +431,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, VertexFragmentMultiEntrypoint)
     // void frag_main() {
     //     data[4] = index[0];
     // }
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %frag_main "frag_main" %c_out
@@ -549,7 +549,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBO) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -591,7 +591,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBOUpda
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -633,7 +633,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorBuffer) 
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -675,7 +675,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorCopy) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -763,14 +763,14 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, RobustBuffer) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, VectorArray) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             uvec4 a[8]; // stride 16
@@ -784,7 +784,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, VectorArray) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             uvec4 a;
@@ -805,7 +805,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopySlang) {
 
     RETURN_IF_SKIP(CheckSlangSupport());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
             uint4 a;
             uint b[4];
@@ -833,7 +833,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayStrideEnd) {
     // void main() {
     //     x[3] = 0;
     // }
-    const char *cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %_
@@ -872,7 +872,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo1 {
             uvec4 a;
@@ -921,7 +921,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar1 {
             uint4 a;
             uint b[4];
@@ -968,7 +968,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -991,7 +991,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL) {
     ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 32);
 }
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -1013,7 +1013,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         struct Bar2 {
@@ -1043,7 +1043,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopySlang) {
     RETURN_IF_SKIP(CheckSlangSupport());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
           uint x;
           uint y;
@@ -1073,7 +1073,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
 
     RETURN_IF_SKIP(CheckSlangSupport());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
             uint a;
             uint d[4];
@@ -1091,7 +1091,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Atomics) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -1114,7 +1114,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer SSBO {
@@ -1164,7 +1164,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndexDescript
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer SSBO {
@@ -1207,7 +1207,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndexDescript
 
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
     VkDeviceSize buffer_offset = ds_layout.GetDescriptorBufferBindingOffset(0);
 
     vkt::DescriptorGetInfo buffer_get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, in_buffer, in_buffer.CreateInfo().size);
@@ -1240,7 +1240,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, DescriptorIndexSlang) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
           uint4 a;
           uint b[4];
@@ -1282,7 +1282,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, OpArrayLength) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -1328,7 +1328,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, OpArrayLength) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Loops) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -1357,7 +1357,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Loops) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, LoopsEarlyBranch) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -1392,12 +1392,12 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
 
     vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawMeshTasksIndirectCommandEXT), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    auto *draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT *>(draw_buffer.Memory().Map());
+    auto* draw_ptr = static_cast<VkDrawMeshTasksIndirectCommandEXT*>(draw_buffer.Memory().Map());
     draw_ptr->groupCountX = 1;
     draw_ptr->groupCountY = 1;
     draw_ptr->groupCountZ = 1;
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         taskPayloadSharedEXT uint payload;
@@ -1415,7 +1415,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -1437,7 +1437,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    const char *frag_source = R"glsl(
+    const char* frag_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         layout(set = 0, binding = 2) readonly uniform UBO {

--- a/tests/unit/gpu_av_descriptor_class_texel_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_texel_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,7 +184,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLTexelFetchIndependentSets) {
 
     const std::array<VkDescriptorSet, 3> desc_sets = {vertex_set.set_, common_set.set_, fragment_set.set_};
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     const char vert_shader[] = R"glsl(
@@ -310,7 +310,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, TexelFetch) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -360,7 +360,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -416,7 +416,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, ImageLoad) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo {
             vec4 a;
@@ -464,7 +464,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, ImageStore) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, r32f) uniform imageBuffer s_buffer;  // texel_buffer[4]
 

--- a/tests/unit/gpu_av_descriptor_class_texel_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_texel_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, ImageLoadStoreTexelFetch) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0) uniform samplerBuffer u_buffer; // texel_buffer[5]
@@ -77,7 +77,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, AtomicImageLoadStore) {
         GTEST_SKIP() << "No atomic texel buffer support";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         #extension GL_EXT_shader_atomic_float : enable
@@ -132,7 +132,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, AtomicImageLoadStoreDescriptorBu
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         #extension GL_EXT_shader_atomic_float : enable
@@ -171,7 +171,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, AtomicImageLoadStoreDescriptorBu
 
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
 
     VkDeviceSize buffer_offset = ds_layout.GetDescriptorBufferBindingOffset(0);
     vkt::DescriptorGetInfo buffer_get_info(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, storage_texel_buffer,
@@ -189,8 +189,8 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, AtomicImageLoadStoreDescriptorBu
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1u, &buffer_binding_info);
     uint32_t buffer_index = 0u;
     VkDeviceSize offset = 0u;
-    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0u, 1u,
-                                         &buffer_index, &offset);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0u, 1u, &buffer_index,
+                                         &offset);
 
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
@@ -205,7 +205,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -263,7 +263,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, Robustness) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0) uniform samplerBuffer u_buffer; // texel_buffer[5]

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -78,7 +78,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, NoMappings) {
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -139,7 +139,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, NoHeapBound) {
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -210,7 +210,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, HeapBoundBeforePipeline) {
 
     vkt::Buffer heap(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -289,7 +289,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, HeapBoundAfterPipeline) {
 
     vkt::Buffer heap(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -368,7 +368,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, SamplerHeapBound) {
 
     vkt::Buffer heap(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -447,7 +447,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, MappingsUsed) {
     const VkDeviceSize heap_size = descriptor_size + heap_props.minResourceHeapReservedRange;
 
     vkt::Buffer heap(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
-    uint8_t *heap_data = static_cast<uint8_t *>(heap.Memory().Map());
+    uint8_t* heap_data = static_cast<uint8_t*>(heap.Memory().Map());
 
     vkt::Buffer buffer1(*m_device, 256u, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
     vkt::Buffer buffer2(*m_device, 256u, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
@@ -481,7 +481,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, MappingsUsed) {
     host_addresses[2].size = static_cast<size_t>(heap_props.bufferDescriptorSize);
     vk::WriteResourceDescriptorsEXT(*m_device, 3u, resource_infos, host_addresses);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(set=0, binding=0) buffer Buf1 { uint data1[]; } buf1;
@@ -603,7 +603,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, DispatchWorkgroupSize) {
 
     vkt::Buffer indirect_buffer(*m_device, 5 * sizeof(VkDispatchIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 kHostVisibleMemProps);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    VkDispatchIndirectCommand* ptr = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     // VkDispatchIndirectCommand[0]
     ptr->x = 4;  // over
     ptr->y = 2;
@@ -688,7 +688,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, HeapRebound) {
     vkt::Buffer heap1(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
     vkt::Buffer heap2(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -769,7 +769,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, ShaderObjects) {
 
     vkt::Buffer heap(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -68,7 +68,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBuffer) {
     descriptor_writes[1].pBufferInfo = &buffer_info[1];
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -82,7 +82,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBuffer) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -111,7 +111,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBuffer) {
         vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
         m_command_buffer.End();
-        uint32_t *buffer_ptr = (uint32_t *)ubo_buffer.Memory().Map();
+        uint32_t* buffer_ptr = (uint32_t*)ubo_buffer.Memory().Map();
         buffer_ptr[0] = 25;
 
         SCOPED_TRACE("Out of Bounds");
@@ -176,7 +176,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBufferEmptyUnusedDescSet) {
     descriptor_writes[1].pBufferInfo = &buffer_info[1];
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, set = 1, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -190,7 +190,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBufferEmptyUnusedDescSet) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -220,7 +220,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBufferEmptyUnusedDescSet) {
         vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
         m_command_buffer.End();
-        uint32_t *buffer_ptr = (uint32_t *)ubo_buffer.Memory().Map();
+        uint32_t* buffer_ptr = (uint32_t*)ubo_buffer.Memory().Map();
         buffer_ptr[0] = 25;
 
         SCOPED_TRACE("Out of Bounds");
@@ -284,7 +284,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
     descriptor_writes[1].pImageInfo = image_info;
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, set = 0, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -298,7 +298,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
            gl_Position += 1e-30 * texture(tex[uniform_index_buffer.tex_index[0]], vec2(0, 0));
         }
         )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -326,7 +326,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 25;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", 2 * 3);
@@ -525,7 +525,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -539,7 +539,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -567,7 +567,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 25;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", gpuav::glsl::kMaxErrorsPerCmd);
@@ -648,7 +648,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
     descriptor_writes[1].dstSet = descriptor_set_variable.set_;
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -662,7 +662,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -692,7 +692,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 25;
 
     SCOPED_TRACE("Out of Bounds");
@@ -751,7 +751,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform foo { uint tex_index; };
@@ -779,7 +779,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 2;
 
     // VUID-vkCmdDraw-None-10068
@@ -831,7 +831,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocateU
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform foo { uint tex_index; };
@@ -859,7 +859,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocateU
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114", gpuav::glsl::kMaxErrorsPerCmd);
@@ -920,7 +920,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBTess) {
     descriptor_writes[1].pBufferInfo = &buffer_info[1];
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(std140, set = 0, binding = 0) uniform ufoo { uint index; } uniform_index_buffer;
@@ -958,7 +958,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBTess) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 25;
 
     SCOPED_TRACE("Out of Bounds");
@@ -1035,7 +1035,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *gs_source = R"glsl(
+    const char* gs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(triangles) in;
@@ -1065,7 +1065,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 25;
     SCOPED_TRACE("Out of Bounds");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068");
@@ -1133,7 +1133,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBCompute) {
     descriptor_writes[1].pBufferInfo = &buffer_info[1];
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform ufoo { uint index; } u_index;
@@ -1157,7 +1157,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBCompute) {
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     {
         SCOPED_TRACE("Uninitialized");
         buffer_ptr[0] = 5;
@@ -1236,7 +1236,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -1252,7 +1252,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
         )glsl";
     VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1279,7 +1279,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 1;
 
     // NOTE: object in use checking is entirely disabled for bindless descriptor sets so
@@ -1355,7 +1355,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -1371,7 +1371,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
          )glsl";
     VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1399,7 +1399,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 1;
 
     // NOTE: object in use checking is entirely disabled for bindless descriptor sets so
@@ -1492,7 +1492,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBind) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
     // Create a dummy pipeline, since VL inspects which bindings are actually used at draw time
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         layout(set=0, binding=0) uniform foo0 { float x0; } bar0;
@@ -1570,7 +1570,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, VariableDescriptorCountAllocateAfterPipe
 
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform UBO { uint in_buffer; };
@@ -1612,7 +1612,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, VariableDescriptorCountAllocateAfterPipe
     vk::AllocateDescriptorSets(*m_device, &ds_alloc_info, &ds);
 
     vkt::Buffer in_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *in_buffer_ptr = (uint32_t *)in_buffer.Memory().Map();
+    uint32_t* in_buffer_ptr = (uint32_t*)in_buffer.Memory().Map();
     in_buffer_ptr[0] = 7;  // point to index that no longer exsist because the variable count shrunk it
 
     vkt::Buffer storage_buffer(*m_device, 1024, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
@@ -1657,7 +1657,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 5;  // go past textures[4]
 
     OneOffDescriptorIndexingSet descriptor_set(
@@ -1692,7 +1692,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    const char *cs_source = R"asm(
+    const char* cs_source = R"asm(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %data %ss %textures
@@ -1776,7 +1776,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     // send index to select in image array
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 7;
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -1811,7 +1811,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    const char *cs_source = R"asm(
+    const char* cs_source = R"asm(
                OpCapability Shader
                OpCapability RuntimeDescriptorArray
                OpExtension "SPV_EXT_descriptor_indexing"
@@ -1909,7 +1909,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushConstant) {
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1952,7 +1952,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleIndexes) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
     // send index to select in image array
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 3;
     buffer_ptr[1] = 0;  // valid
     buffer_ptr[2] = 5;
@@ -1973,7 +1973,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleIndexes) {
     descriptor_set.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2067,7 +2067,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -2081,7 +2081,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -2110,7 +2110,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
     cb_1.EndRenderPass();
     cb_1.End();
     {
-        uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+        uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
         buffer_ptr[0] = 25;
     }
 
@@ -2163,7 +2163,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
         vk::UpdateDescriptorSets(device(), 2, descriptor_writes_cb_2, 0, nullptr);
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform ufoo { uint index; } u_index;
@@ -2187,7 +2187,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
     vk::CmdDispatch(cb_2, 1, 1, 1);
     cb_2.End();
     {
-        uint32_t *buffer_ptr = (uint32_t *)buffer0_cb_2.Memory().Map();
+        uint32_t* buffer_ptr = (uint32_t*)buffer0_cb_2.Memory().Map();
         buffer_ptr[0] = 25;
     }
 
@@ -2256,7 +2256,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -2270,7 +2270,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -2298,7 +2298,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     {
-        uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+        uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
         buffer_ptr[0] = 25;
     }
 
@@ -2346,7 +2346,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
         vk::UpdateDescriptorSets(device(), 2, descriptor_writes_cb_2, 0, nullptr);
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform ufoo { uint index; } u_index;
@@ -2369,7 +2369,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
     {
-        uint32_t *buffer_ptr = (uint32_t *)buffer0_cb_2.Memory().Map();
+        uint32_t* buffer_ptr = (uint32_t*)buffer0_cb_2.Memory().Map();
         buffer_ptr[0] = 25;
     }
 
@@ -2391,7 +2391,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BindingOOB) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
     // send index to select in image array
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorSet descriptor_set(
@@ -2414,7 +2414,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BindingOOB) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2453,10 +2453,10 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetFirst) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;
 
-    const char *cs_source_1 = R"glsl(
+    const char* cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2480,10 +2480,10 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetFirst) {
     // Don't find index [1] so this is invalid
     pipe_1.descriptor_set_.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     pipe_1.descriptor_set_.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
+                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    const char *cs_source_2 = R"glsl(
+    const char* cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2527,10 +2527,10 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetLast) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;
 
-    const char *cs_source_1 = R"glsl(
+    const char* cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2553,12 +2553,12 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetLast) {
 
     pipe_1.descriptor_set_.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     pipe_1.descriptor_set_.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
+                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     pipe_1.descriptor_set_.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
+                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    const char *cs_source_2 = R"glsl(
+    const char* cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2604,10 +2604,10 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindF
     InitRenderTarget();
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    const char *cs_source_1 = R"glsl(
+    const char* cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2631,7 +2631,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindF
     pipe_1.cp_ci_.layout = pipeline_layout_1;
     pipe_1.CreateComputePipeline();
 
-    const char *cs_source_2 = R"glsl(
+    const char* cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2696,10 +2696,10 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindL
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    const char *cs_source_1 = R"glsl(
+    const char* cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2723,7 +2723,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindL
     pipe_1.cp_ci_.layout = pipeline_layout_1;
     pipe_1.CreateComputePipeline();
 
-    const char *cs_source_2 = R"glsl(
+    const char* cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2786,7 +2786,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleSetSomeUninitialized) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // storage_buffers[1]
 
     OneOffDescriptorSet ds_good(m_device, {
@@ -2807,7 +2807,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleSetSomeUninitialized) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2861,7 +2861,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleSetSomeUninitializedUpdateAfterB
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // storage_buffers[1]
 
     OneOffDescriptorIndexingSet ds_good(
@@ -2878,7 +2878,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleSetSomeUninitializedUpdateAfterB
         });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_good.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2937,7 +2937,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ReSubmitCommandBuffer) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // storage_buffers[1]
 
     OneOffDescriptorSet ds_good(m_device, {
@@ -2958,7 +2958,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ReSubmitCommandBuffer) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -3009,7 +3009,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantUpdateAfterBind) {
     AddRequiredFeature(vkt::Feature::descriptorBindingStorageBufferUpdateAfterBind);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 0;
 
@@ -3070,7 +3070,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantPartiallyBound) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 0;
 
@@ -3130,7 +3130,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantPartiallyBound) {
 TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstant) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 1;
 
@@ -3175,7 +3175,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantNullDescriptorBindless) {
     AddRequiredFeature(vkt::Feature::nullDescriptor);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // will update to zero which is uninitialized
         layout(constant_id = 0) const uint index = 1;
@@ -3224,7 +3224,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantNullDescriptorBindless) {
 TEST_F(NegativeGpuAVDescriptorIndexing, PartiallyBoundNoArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 0;
 
@@ -3264,7 +3264,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetch) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform sampler2D tex[];
@@ -3362,7 +3362,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ConstantArrayOOBBuffer) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)offset_buffer.Memory().Map();
     *data = 8;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", 3);
@@ -3684,7 +3684,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetchNested) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform sampler2D tex[];
@@ -3749,7 +3749,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetchTexelBuffer) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform samplerBuffer u_buffer;
         layout (set = 0, binding = 1) buffer SSBO { vec4 color; };
@@ -3795,7 +3795,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetchConstantArrayOOB) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo {
             int index;
@@ -3824,7 +3824,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetchConstantArrayOOB) {
     pipe.descriptor_set_.WriteDescriptorBufferView(1, buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)storage_buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)storage_buffer.Memory().Map();
     *data = 8;
 
     m_command_buffer.Begin();
@@ -3843,7 +3843,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicImagePartiallyBound) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -3892,7 +3892,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicImageRuntimeArray) {
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -3935,7 +3935,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicBufferPartiallyBound) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { uint z; };
         void main() {
@@ -3968,7 +3968,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicBufferRuntimeArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { uint x; } atomic_buffers[];
         void main() {
@@ -4005,7 +4005,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, StorageImagePartiallyBound) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // VK_FORMAT_R32_UINT
         layout(set = 0, binding = 0, r32ui) uniform uimage2D storageImage;
@@ -4041,7 +4041,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, StorageImageRuntimeArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // VK_FORMAT_R32_UINT
         layout(set = 0, binding = 0, r32ui) uniform uimage2D storageImageArray[];
@@ -4099,7 +4099,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleCommandBuffersSameDescriptorSet)
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source0 = R"glsl(
+    const char* cs_source0 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[]; // only [0] is set
@@ -4117,7 +4117,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleCommandBuffersSameDescriptorSet)
     pipe0.CreateComputePipeline();
 
     // Create different shaders so pipelines are different
-    const char *cs_source1 = R"glsl(
+    const char* cs_source1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[2];
@@ -4147,7 +4147,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleCommandBuffersSameDescriptorSet)
     vk::CmdDispatch(cb_1, 1, 1, 1);
     cb_1.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
 
     m_default_queue->SubmitAndWait(cb_0);
@@ -4175,7 +4175,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CommandBufferRerecordSameDescriptorSet) 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
     buffer_ptr[1] = 1;
 
@@ -4189,7 +4189,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CommandBufferRerecordSameDescriptorSet) 
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source0 = R"glsl(
+    const char* cs_source0 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[]; // only [0] is set
@@ -4208,7 +4208,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CommandBufferRerecordSameDescriptorSet) 
     pipe_good.CreateComputePipeline();
 
     // Create different shaders so pipelines are different
-    const char *cs_source1 = R"glsl(
+    const char* cs_source1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[2];
@@ -4270,7 +4270,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleAccessChains) {
     RETURN_IF_SKIP(CheckSlangSupport());
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         struct Bar {
             uint x;
         };
@@ -4296,7 +4296,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleAccessChains) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 9;
 
     CreateComputePipelineHelper pipe(*this);
@@ -4326,7 +4326,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, OpInBoundsAccessChain) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     // Use OpInBoundsAccessChain instead of normal generated OpAccessChain
-    const char *cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -4377,7 +4377,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MiddleBindingOOB) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 3;
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -4397,7 +4397,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MiddleBindingOOB) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 0);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -4437,7 +4437,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DualShaderLibrary) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform sampler2D tex;
         void main() {
@@ -4516,7 +4516,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptor) {
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer UBO {
@@ -4533,7 +4533,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptor) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    auto buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 4;
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -4573,7 +4573,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptor) {
 TEST_F(NegativeGpuAVDescriptorIndexing, DescriptorTemplates) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer UBO {
@@ -4590,7 +4590,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DescriptorTemplates) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    auto buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 4;
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr},
@@ -4647,7 +4647,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptorTemplates) {
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer UBO {
@@ -4664,7 +4664,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptorTemplates) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    auto buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 4;
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -4735,7 +4735,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CooperativeMatrixUpdateAfterBind) {
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -4801,7 +4801,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CooperativeMatrixRuntimeArray) {
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_EXT_nonuniform_qualifier : enable
@@ -4837,7 +4837,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CooperativeMatrixRuntimeArray) {
     vkt::Buffer ubo_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer ssbo_buffer(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
-    auto ubo_ptr = (uint32_t *)ubo_buffer.Memory().Map();
+    auto ubo_ptr = (uint32_t*)ubo_buffer.Memory().Map();
     ubo_ptr[0] = 0;
 
     descriptor_set.WriteDescriptorBufferInfo(0, ubo_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+/* Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
     // send index to select in image array
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -69,7 +69,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -106,7 +106,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSL) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     // send index to select in image array
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorIndexingSet descriptor_set(
@@ -143,7 +143,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSL) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    const char *cs_source = R"asm(
+    const char* cs_source = R"asm(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %data %ss %textures
@@ -225,7 +225,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     // send index to select in image array
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 7;
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -260,7 +260,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    const char *cs_source = R"asm(
+    const char* cs_source = R"asm(
                OpCapability Shader
                OpCapability RuntimeDescriptorArray
                OpExtension "SPV_EXT_descriptor_indexing"
@@ -436,7 +436,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -452,7 +452,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
     )glsl";
     VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -479,7 +479,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
     vk::CmdEndRenderPass(m_command_buffer);
     m_command_buffer.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 1;
 
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -517,7 +517,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -533,7 +533,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
     )glsl";
     VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
     #version 450
     #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -565,7 +565,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
     vk::CmdEndRenderPass(m_command_buffer);
     m_command_buffer.End();
 
-    uint32_t *buffer_ptr = (uint32_t *)buffer0.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer0.Memory().Map();
     buffer_ptr[0] = 1;
 
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -578,7 +578,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingUnusedPipeline) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source_2d = R"glsl(
+    const char* fs_source_2d = R"glsl(
         #version 450
         layout(location = 0) out vec4 outColor;
         layout(set = 1, binding = 2) uniform sampler2D tex;
@@ -588,7 +588,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingUnusedPipeline) {
         }
     )glsl";
 
-    const char *fs_source_3d = R"glsl(
+    const char* fs_source_3d = R"glsl(
         #version 450
         layout(location = 0) out vec4 outColor;
         layout(set = 1, binding = 2) uniform sampler3D tex;
@@ -649,7 +649,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : require
         layout (set = 0, binding = 0) uniform texture2D kTextures2D[];
@@ -726,7 +726,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingBDA) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference : require
         #extension GL_EXT_nonuniform_qualifier : require
@@ -762,7 +762,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingBDA) {
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     vkt::Buffer storage_buffer(*m_device, 12, 0, vkt::device_address);
-    uint32_t *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
+    uint32_t* storage_buffer_ptr = static_cast<uint32_t*>(storage_buffer.Memory().Map());
     storage_buffer_ptr[0] = 8;  // texture_cube_id
     storage_buffer_ptr[1] = 7;  // texture_2d_id
     storage_buffer_ptr[2] = 0;  // sampler_id
@@ -842,14 +842,14 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetCompute) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    const char *source_1 = R"glsl(
+    const char* source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
             a = b;
         }
     )glsl";
-    const char *source_2 = R"glsl(
+    const char* source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) buffer foo_1 { int b; };
@@ -963,14 +963,14 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphics) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    const char *vs_source_1 = R"glsl(
+    const char* vs_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
             a = b;
         }
     )glsl";
-    const char *vs_source_2 = R"glsl(
+    const char* vs_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) readonly buffer foo_1 { int b; };
@@ -1095,14 +1095,14 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsGPL) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    const char *vs_source_1 = R"glsl(
+    const char* vs_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
             a = b;
         }
         )glsl";
-    const char *vs_source_2 = R"glsl(
+    const char* vs_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) readonly buffer foo_1 { int b; };
@@ -1216,7 +1216,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    const char *vs_source_1 = R"glsl(
+    const char* vs_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
@@ -1224,7 +1224,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
         }
     )glsl";
     const std::vector<uint32_t> vs_spv_1 = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source_1);
-    const char *vs_source_2 = R"glsl(
+    const char* vs_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) readonly buffer foo_1 { int b; };
@@ -1340,17 +1340,17 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
 
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    const char *vs_source_1 = R"glsl(
+    const char* vs_source_1 = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_0 { uint a; uint b; };
         void main() {}
     )glsl";
-    const char *vs_source_2 = R"glsl(
+    const char* vs_source_2 = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint a; uint b; };
         void main() {}
     )glsl";
-    const char *fs_source_2 = R"glsl(
+    const char* fs_source_2 = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint c; };
         void main() {}
@@ -1424,10 +1424,10 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSet) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    const char *cs_source_1 = R"glsl(
+    const char* cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -1450,12 +1450,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSet) {
 
     pipe_1.descriptor_set_.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     pipe_1.descriptor_set_.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
+                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     pipe_1.descriptor_set_.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
+                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    const char *cs_source_2 = R"glsl(
+    const char* cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -1497,10 +1497,10 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsDifferentSet) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    const char *cs_source_1 = R"glsl(
+    const char* cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -1523,12 +1523,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsDifferentSet) {
 
     pipe_1.descriptor_set_.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     pipe_1.descriptor_set_.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
+                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     pipe_1.descriptor_set_.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                                                     VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
+                                                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    const char *cs_source_2 = R"glsl(
+    const char* cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 1, binding = 1) uniform Input { uint index; };
@@ -1578,10 +1578,10 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBind)
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    const char *cs_source_1 = R"glsl(
+    const char* cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -1605,7 +1605,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBind)
     pipe_1.cp_ci_.layout = pipeline_layout_1;
     pipe_1.CreateComputePipeline();
 
-    const char *cs_source_2 = R"glsl(
+    const char* cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -1670,10 +1670,10 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleUnusedBoundDescriptorsUpdateAfte
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -1756,7 +1756,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleSetSomeUninitialized) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // storage_buffers[1]
 
     OneOffDescriptorSet ds_good(m_device, {
@@ -1777,7 +1777,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleSetSomeUninitialized) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1823,7 +1823,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleSetSomeUninitializedUpdateAfterB
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // storage_buffers[1]
 
     OneOffDescriptorIndexingSet ds_good(
@@ -1840,7 +1840,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleSetSomeUninitializedUpdateAfterB
         });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_good.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1891,7 +1891,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ReSubmitCommandBuffer) {
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer input_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
+    uint32_t* input_buffer_ptr = (uint32_t*)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // storage_buffers[1]
 
     OneOffDescriptorSet ds_good(m_device, {
@@ -1912,7 +1912,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ReSubmitCommandBuffer) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1993,7 +1993,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, VariableDescriptorCountAllocateAfterPipe
 
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform UBO { uint in_buffer; };
@@ -2035,7 +2035,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, VariableDescriptorCountAllocateAfterPipe
     vk::AllocateDescriptorSets(*m_device, &ds_alloc_info, &ds);
 
     vkt::Buffer in_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *in_buffer_ptr = (uint32_t *)in_buffer.Memory().Map();
+    uint32_t* in_buffer_ptr = (uint32_t*)in_buffer.Memory().Map();
     in_buffer_ptr[0] = 4;
 
     vkt::Buffer storage_buffer(*m_device, 1024, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
@@ -2073,7 +2073,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SpecConstantNullDescriptor) {
     AddRequiredFeature(vkt::Feature::nullDescriptor);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // will update to zero which is a null descriptor
         layout(constant_id = 0) const uint index = 1;
@@ -2116,7 +2116,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SpecConstantNullDescriptorBindless) {
     AddRequiredFeature(vkt::Feature::nullDescriptor);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // will update to zero which is a null descriptor
         layout(constant_id = 0) const uint index = 1;
@@ -2162,7 +2162,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, TexelFetch) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform samplerBuffer u_buffer;
@@ -2232,7 +2232,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, AtomicImage) {
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -2274,7 +2274,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, AtomicBuffer) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { uint x; } atomic_buffers[];
         void main() {
@@ -2312,7 +2312,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, StorageImage) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // VK_FORMAT_R32_UINT
         layout(set = 0, binding = 0, r32ui) uniform uimage2D storageImageArray[];
@@ -2430,7 +2430,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingPartiallyBound) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     data[0] = 0;
 
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
@@ -2439,7 +2439,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingPartiallyBound) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform foo_0 { int val; } doit;
         layout(set = 0, binding = 1) uniform foo_1 { int val; } readit;
@@ -2544,7 +2544,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BranchConditonalPostDominate) {
     RETURN_IF_SKIP(InitGpuAvFramework(layer_settings, false));
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer SSBO {
             uint a;
@@ -2607,7 +2607,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ReupdateDescriptorCount) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10079");
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2638,7 +2638,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ReupdateDescriptorCount) {
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
 
     descriptor_set0.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -2695,7 +2695,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, CooperativeMatrixUpdateAfterBind) {
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_memory_scope_semantics : enable
@@ -2759,7 +2759,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, CooperativeMatrixRuntimeArray) {
         GTEST_SKIP() << "16x16 Uint Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_EXT_nonuniform_qualifier : enable
@@ -2795,7 +2795,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, CooperativeMatrixRuntimeArray) {
     vkt::Buffer ubo_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer ssbo_buffer(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
-    auto ubo_ptr = (uint32_t *)ubo_buffer.Memory().Map();
+    auto ubo_ptr = (uint32_t*)ubo_buffer.Memory().Map();
     ubo_ptr[0] = 0;
 
     descriptor_set.WriteDescriptorBufferInfo(0, ubo_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);

--- a/tests/unit/gpu_av_descriptor_post_process.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, UpdateAfterBindImageViewTypeMismatch)
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -89,7 +89,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnly) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -155,7 +155,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnlyShaderObject) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -217,7 +217,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnlyGPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -273,7 +273,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnlyPipelineInline) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -341,7 +341,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageTypeMismatch) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];
@@ -357,7 +357,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageTypeMismatch) {
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
     vkt::Image image(*m_device, 16, 16, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
@@ -425,7 +425,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MixingProtectedResources) {
     vkt::ImageView image_view_protected = image_protected.CreateView();
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;  // access protected
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -447,7 +447,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MixingProtectedResources) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -518,7 +518,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, InvalidAtomicStorageOperation) {
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
     vkt::BufferView buffer_view(*m_device, buffer, buffer_view_format);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=3, r32f) uniform image2D si0;
         layout(set=0, binding=2, r32f) uniform image2D si1[2];
@@ -582,15 +582,15 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, UnnormalizedCoordinatesInBoundsAccess
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    //#version 450
-    // layout (set = 0, binding = 0) uniform sampler2D tex[2];
-    // layout(location=0) out vec4 color;
+    // #version 450
+    //  layout (set = 0, binding = 0) uniform sampler2D tex[2];
+    //  layout(location=0) out vec4 color;
     //
-    // void main() {
-    //    color = textureLodOffset(tex[1], vec2(0), 0, ivec2(0));
-    //}
-    // but with OpInBoundsAccessChain instead of normal generated OpAccessChain
-    const char *fsSource = R"(
+    //  void main() {
+    //     color = textureLodOffset(tex[1], vec2(0), 0, ivec2(0));
+    // }
+    //  but with OpInBoundsAccessChain instead of normal generated OpAccessChain
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_storage_buffer_storage_class"
@@ -692,7 +692,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, UnnormalizedCoordinatesCopyObject) {
     // void main() {
     //     vec4 x = textureLodOffset(tex[1], vec2(0), 0, ivec2(0));
     // }
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -836,7 +836,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_UnnormalizedCoordinatesSepar
     vkt::Sampler sampler(*m_device, sampler_ci);
 
     vkt::Buffer uniform_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *uniform_buffer_ptr = (uint32_t *)uniform_buffer.Memory().Map();
+    uint32_t* uniform_buffer_ptr = (uint32_t*)uniform_buffer.Memory().Map();
     uniform_buffer_ptr[0] = 1;  // bad_index
 
     descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
@@ -961,7 +961,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithPipelinePar
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorIndexingSet descriptor_set(m_device,
@@ -978,7 +978,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithPipelinePar
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -1029,7 +1029,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithInlineShade
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorIndexingSet descriptor_set(m_device,
@@ -1046,7 +1046,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithInlineShade
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -1107,7 +1107,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithShaderObjec
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorIndexingSet descriptor_set(m_device,
@@ -1124,7 +1124,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithShaderObjec
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -1162,7 +1162,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageMultisample) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -1224,7 +1224,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2D BaseTexture;
@@ -1235,7 +1235,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
         }
     )glsl";
 
-    const char *cs_source_ms = R"glsl(
+    const char* cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2DMS BaseTextureMS;
@@ -1340,7 +1340,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MultipleCommandBuffersSameDescriptorS
     vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView bad_view = image_3d.CreateView(VK_IMAGE_VIEW_TYPE_3D);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer SSBO {
@@ -1397,7 +1397,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageBindingRuntimeArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         #extension GL_EXT_nonuniform_qualifier : require
@@ -1438,7 +1438,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageBindingRuntimeArray) {
     vkt::ImageView uint_image_view = uint_image.CreateView();
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
 
     descriptor_set.WriteDescriptorImageInfo(0, float_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
@@ -1470,7 +1470,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageBindingPartiallyBound) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -1541,7 +1541,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DescriptorIndexingSlang) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]]
         Texture2D texture[];
         [[vk::binding(1, 0)]]
@@ -1563,7 +1563,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DescriptorIndexingSlang) {
         }
     )slang";
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 1;
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -1614,7 +1614,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageViewArrayAliasBinding) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : require
         // Using descriptor aliasing: same binding for sampler2D and sampler2DArray.
@@ -1630,7 +1630,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageViewArrayAliasBinding) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -1676,7 +1676,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, SameDescriptorAcrossSets) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s2;
         layout(set=1, binding=0) uniform sampler3D s3;
@@ -1737,7 +1737,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_SameDescriptorAcrossStagesVe
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D vertexSampler; // invalid
         vec2 vertices[3];
@@ -1750,7 +1750,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_SameDescriptorAcrossStagesVe
             unused = texture(vertexSampler, vec3(0));
         }
     )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D fragmentSampler; // valid
         layout(location=0) in vec4 unused;
@@ -1800,7 +1800,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, SameDescriptorAcrossStagesFragment) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D vertexSampler; // valid
         vec2 vertices[3];
@@ -1813,7 +1813,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, SameDescriptorAcrossStagesFragment) {
             unused = texture(vertexSampler, vec2(0));
         }
     )glsl";
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D fragmentSampler; // invalid
         layout(location=0) in vec4 unused;
@@ -1867,7 +1867,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     InitRenderTarget();
 
     // layout(set=0, binding=0) uniform sampler2D vertexSampler;
-    const char *vs_source = R"(
+    const char* vs_source = R"(
                 OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %vertexSampler %vertices %_ %gl_VertexIndex %unused
@@ -1944,7 +1944,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     )";
 
     // layout(set=0, binding=1) uniform sampler3D fragmentSampler;
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                    OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %fragmentSampler %color %unused
@@ -2023,7 +2023,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MultiEntrypoint) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %main_frag "main_frag" %fragmentSampler %color %unused_f
@@ -2196,7 +2196,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, LotsOfBindings) {
     VkShaderObj fs(*m_device, fs_source.str().c_str(), VK_SHADER_STAGE_FRAGMENT_BIT);
 
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 15;
 
     vkt::Image image(*m_device, 16, 16, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -2253,7 +2253,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_MultipleDrawsMixPipelines) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source_2d = R"glsl(
+    const char* fs_source_2d = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 color;
@@ -2262,7 +2262,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_MultipleDrawsMixPipelines) {
         }
     )glsl";
 
-    const char *fs_source_3d = R"glsl(
+    const char* fs_source_3d = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -2325,7 +2325,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MultipleDrawsMixDescriptorSets) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s2;
         layout(set=1, binding=0) uniform sampler3D s3;
@@ -2430,7 +2430,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageTypeMismatchDebugLabels) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];
@@ -2446,7 +2446,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageTypeMismatchDebugLabels) {
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
 
     vkt::Image image(*m_device, 16, 16, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -2576,7 +2576,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImportFence) {
         GTEST_SKIP() << "VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT is not exportable";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         void main() {
@@ -2639,7 +2639,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DualShaderLibraryDuplicateLayoutsDyna
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];
@@ -2655,7 +2655,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DualShaderLibraryDuplicateLayoutsDyna
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
 
     vkt::Image image(*m_device, 16, 16, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -2744,7 +2744,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DualShaderLibraryDuplicateLayoutsImmu
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];
@@ -2760,7 +2760,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DualShaderLibraryDuplicateLayoutsImmu
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
 
     vkt::Image image(*m_device, 16, 16, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -2844,7 +2844,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasDepthSamplers) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    char const* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : require
 
@@ -2874,7 +2874,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasDepthSamplers) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
     buffer_ptr[1] = 1;
     buffer_ptr[2] = 0;
@@ -2923,7 +2923,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ReachMaxErrorLoggerLimitUnkown) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
 

--- a/tests/unit/gpu_av_descriptor_post_process_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process_positive.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+/* Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, MixingProtectedResources) {
     vkt::ImageView image_view_protected = image_protected.CreateView();
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -74,7 +74,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, MixingProtectedResources) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -113,7 +113,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingPartiallyBound) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -151,7 +151,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingPartiallyBound) {
     vkt::ImageView uint_image_view = uint_image.CreateView();
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     *data = 0;
 
     descriptor_set.WriteDescriptorImageInfo(0, float_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
@@ -185,7 +185,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingPartiallyBoundDescri
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -243,12 +243,12 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingPartiallyBoundDescri
         uint32_t padding[3];
         float data[4];
     };
-    Payload *payload = (Payload *)buffer.Memory().Map();
+    Payload* payload = (Payload*)buffer.Memory().Map();
     payload->index = 0;
 
     vkt::Buffer descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
-    uint8_t *descriptor_data = reinterpret_cast<uint8_t *>(descriptor_buffer.Memory().Map());
+    uint8_t* descriptor_data = reinterpret_cast<uint8_t*>(descriptor_buffer.Memory().Map());
 
     VkDeviceSize image_offset = ds_layout.GetDescriptorBufferBindingOffset(0);
     VkDeviceSize buffer_offset = ds_layout.GetDescriptorBufferBindingOffset(1);
@@ -309,7 +309,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingRuntimeArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_EXT_samplerless_texture_functions : require
@@ -345,7 +345,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingRuntimeArray) {
     vkt::ImageView uint_image_view = uint_image.CreateView();
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     *data = 0;
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, float_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
@@ -372,7 +372,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisample) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -429,7 +429,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSets) 
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2D BaseTexture;
@@ -440,7 +440,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSets) 
         }
     )glsl";
 
-    const char *cs_source_ms = R"glsl(
+    const char* cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2DMS BaseTextureMS;
@@ -512,7 +512,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
     AddRequiredFeature(vkt::Feature::descriptorBindingPartiallyBound);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2D BaseTexture;
@@ -522,7 +522,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
             dummy = texture(sampler2D(BaseTexture, BaseTextureSampler), vec2(0));
         }
     )glsl";
-    const char *cs_source_ms = R"glsl(
+    const char* cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2DMS BaseTextureMS;
@@ -604,7 +604,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDispatches) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -617,7 +617,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDispatches) {
         }
     )glsl";
 
-    const char *cs_source_ms = R"glsl(
+    const char* cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -707,7 +707,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, NonMultisampleMismatchWithPipeline) {
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorIndexingSet descriptor_set(m_device,
@@ -724,7 +724,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, NonMultisampleMismatchWithPipeline) {
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // mySampler[0] is bad
         // mySampler[1] is good
@@ -773,7 +773,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, SharedDescriptorDifferentOpVariableId
     vkt::ImageView image_view = image.CreateView();
 
     vkt::Buffer buffer(*m_device, 60, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
 
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
@@ -783,7 +783,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, SharedDescriptorDifferentOpVariableId
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source0 = R"glsl(
+    const char* cs_source0 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[];
@@ -802,7 +802,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, SharedDescriptorDifferentOpVariableId
 
     // This is the same shader as above, but the goal is to make sure the OpVariable ID are different as the descriptor is being
     // aliased
-    const char *cs_source1 = R"(
+    const char* cs_source1 = R"(
                OpCapability Shader
                OpCapability RuntimeDescriptorArray
                OpMemoryModel Logical GLSL450
@@ -878,7 +878,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, DescriptorIndexingSlang) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]]
         Texture2D texture[];
         [[vk::binding(1, 0)]]
@@ -901,7 +901,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, DescriptorIndexingSlang) {
     )slang";
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
 
     vkt::Image image(*m_device, 16, 16, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -942,7 +942,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, ZeroBindingDescriptor) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
         layout(set = 1, binding = 0) uniform texture2D textures[2];
@@ -1000,7 +1000,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, ZeroBindingDescriptor) {
     vkt::ImageView image_view = image.CreateView();
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
 
     descriptor_set.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
@@ -1033,7 +1033,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, ImageViewArrayAliasBinding) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : require
         // Using descriptor aliasing: same binding for sampler2D and sampler2DArray.
@@ -1049,7 +1049,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, ImageViewArrayAliasBinding) {
     )glsl";
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     *buffer_ptr = 0;
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -1097,7 +1097,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     InitRenderTarget();
 
     // layout(set=0, binding=0) uniform sampler2D vertexSampler;
-    const char *vs_source = R"(
+    const char* vs_source = R"(
                 OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %vertexSampler %vertices %_ %gl_VertexIndex %unused
@@ -1174,7 +1174,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     )";
 
     // layout(set=0, binding=1) uniform sampler3D fragmentSampler;
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                    OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %fragmentSampler %color %unused
@@ -1257,7 +1257,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, BranchConditonalPostDominate) {
     RETURN_IF_SKIP(InitGpuAvFramework(layer_settings));
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer SSBO {
             uint a;
@@ -1322,7 +1322,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasDepthSamplers) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    char const* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : require
 
@@ -1351,7 +1351,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasDepthSamplers) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
     buffer_ptr[1] = 1;
 
@@ -1400,7 +1400,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasDepthSamplersSlang) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"slang(
+    char const* cs_source = R"slang(
         struct SSBO {
             uint a;
             uint b;
@@ -1443,7 +1443,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasDepthSamplersSlang) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
     buffer_ptr[1] = 1;
 
@@ -1494,7 +1494,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasRuntimeDescriptorArrayHLSL) {
     InitRenderTarget();
 
     // https://godbolt.org/z/o3njdPGPs
-    const char *fs_source = R"asm(
+    const char* fs_source = R"asm(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %out_var_SV_TARGET %MyStorageBuffer %g_sampler %g_bindless_texture2D_float4 %g_bindless_texture3D_float4
@@ -1574,7 +1574,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasRuntimeDescriptorArrayHLSL) {
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
     buffer_ptr[1] = 1;
 
@@ -1587,9 +1587,11 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasRuntimeDescriptorArrayHLSL) {
     vkt::ImageView image_view_3d = image_3d.CreateView(VK_IMAGE_VIEW_TYPE_3D);
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    OneOffDescriptorIndexingSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 2, VK_SHADER_STAGE_ALL, nullptr, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},
-                                                  {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},
-                                                  {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}});
+    OneOffDescriptorIndexingSet descriptor_set(
+        m_device,
+        {{0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 2, VK_SHADER_STAGE_ALL, nullptr, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},
+         {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT},
+         {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr, VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT}});
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     descriptor_set.WriteDescriptorImageInfo(0, image_view_2d, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,

--- a/tests/unit/gpu_av_index_buffer_positive.cpp
+++ b/tests/unit/gpu_av_index_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ TEST_F(PositiveGpuAVIndexBuffer, DrawIndexedDynamicStates) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -207,7 +207,7 @@ TEST_F(PositiveGpuAVIndexBuffer, NoShaderInputsVertexIndex16) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         void main() {
@@ -272,7 +272,7 @@ TEST_F(PositiveGpuAVIndexBuffer, VertexShaderUnusedLocations) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -364,7 +364,7 @@ TEST_F(PositiveGpuAVIndexBuffer, InstanceIndex) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -452,7 +452,7 @@ TEST_F(PositiveGpuAVIndexBuffer, CmdSetVertexInputEXT) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -544,7 +544,7 @@ TEST_F(PositiveGpuAVIndexBuffer, CmdSetVertexInputEXT_CmdBindVertexBuffers2EXT) 
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -631,7 +631,7 @@ TEST_F(PositiveGpuAVIndexBuffer, IndirectDrawBadVertexIndex32) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -692,7 +692,7 @@ TEST_F(PositiveGpuAVIndexBuffer, VertexIndex32MultiDraw) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -761,7 +761,7 @@ TEST_F(PositiveGpuAVIndexBuffer, InstanceIndexVertexAttributeDivisor) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -862,7 +862,7 @@ TEST_F(PositiveGpuAVIndexBuffer, InstanceIndexVertexAttributeDivisorDynamic) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -975,9 +975,9 @@ TEST_F(PositiveGpuAVIndexBuffer, DrawIndexedIndirectWithOffset) {
     const uint32_t size = sizeof(VkDrawIndexedIndirectCommand) + offset;
 
     vkt::Buffer draw_params_buffer(*m_device, size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint8_t *data = (uint8_t *)draw_params_buffer.Memory().Map();
+    uint8_t* data = (uint8_t*)draw_params_buffer.Memory().Map();
     memset(data, 255, size);
-    auto indirect_command = reinterpret_cast<VkDrawIndexedIndirectCommand *>(data + offset);
+    auto indirect_command = reinterpret_cast<VkDrawIndexedIndirectCommand*>(data + offset);
     indirect_command->indexCount = 3u;
     indirect_command->instanceCount = 1u;
     indirect_command->firstIndex = 0u;
@@ -1003,7 +1003,7 @@ TEST_F(PositiveGpuAVIndexBuffer, Ssbo) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(set=0, binding=0) buffer InData {
@@ -1032,7 +1032,7 @@ TEST_F(PositiveGpuAVIndexBuffer, Ssbo) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_1.layout_, &descriptor_set_2.layout_});
 
     vkt::Buffer in_buffer(*m_device, sizeof(float) * 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    float *in_buffer_ptr = (float *)in_buffer.Memory().Map();
+    float* in_buffer_ptr = (float*)in_buffer.Memory().Map();
     in_buffer_ptr[0] = 1.0f;
     in_buffer_ptr[1] = 2.0f;
     in_buffer_ptr[2] = 3.0f;
@@ -1073,7 +1073,7 @@ TEST_F(PositiveGpuAVIndexBuffer, Ssbo) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float *out_buffer_ptr = (float *)out_buffer.Memory().Map();
+    float* out_buffer_ptr = (float*)out_buffer.Memory().Map();
     for (uint32_t i = 0; i < 4; ++i) {
         ASSERT_EQ(in_buffer_ptr[i], out_buffer_ptr[i]);
     }
@@ -1097,7 +1097,7 @@ TEST_F(PositiveGpuAVIndexBuffer, SsboDescriptorBuffer) {
         GTEST_SKIP() << "maxResourceDescriptorBufferBindings is not 2";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(set=0, binding=0) buffer InData {
@@ -1132,7 +1132,7 @@ TEST_F(PositiveGpuAVIndexBuffer, SsboDescriptorBuffer) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout, &ds_layout});
 
     vkt::Buffer in_buffer(*m_device, sizeof(float) * 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    float *in_buffer_ptr = (float *)in_buffer.Memory().Map();
+    float* in_buffer_ptr = (float*)in_buffer.Memory().Map();
     in_buffer_ptr[0] = 1.0f;
     in_buffer_ptr[1] = 2.0f;
     in_buffer_ptr[2] = 3.0f;
@@ -1147,8 +1147,8 @@ TEST_F(PositiveGpuAVIndexBuffer, SsboDescriptorBuffer) {
 
     vkt::Buffer in_descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
     vkt::Buffer out_descriptor_buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
-    uint8_t *in_descriptor_data = reinterpret_cast<uint8_t *>(in_descriptor_buffer.Memory().Map());
-    uint8_t *out_descriptor_data = reinterpret_cast<uint8_t *>(out_descriptor_buffer.Memory().Map());
+    uint8_t* in_descriptor_data = reinterpret_cast<uint8_t*>(in_descriptor_buffer.Memory().Map());
+    uint8_t* out_descriptor_data = reinterpret_cast<uint8_t*>(out_descriptor_buffer.Memory().Map());
 
     VkDeviceSize in_buffer_offset = ds_layout.GetDescriptorBufferBindingOffset(0);
     VkDeviceSize out_buffer_offset = ds_layout.GetDescriptorBufferBindingOffset(0);
@@ -1195,7 +1195,7 @@ TEST_F(PositiveGpuAVIndexBuffer, SsboDescriptorBuffer) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    float *out_buffer_ptr = (float *)out_buffer.Memory().Map();
+    float* out_buffer_ptr = (float*)out_buffer.Memory().Map();
     for (uint32_t i = 0; i < 4; ++i) {
         ASSERT_EQ(in_buffer_ptr[i], out_buffer_ptr[i]);
     }

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -48,16 +48,16 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
     props.limits.maxDrawIndirectCount = 1;
     fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
-    RETURN_IF_SKIP(InitState(nullptr, (features13.dynamicRendering || mesh_shader_enabled) ? (void *)&features13 : nullptr));
+    RETURN_IF_SKIP(InitState(nullptr, (features13.dynamicRendering || mesh_shader_enabled) ? (void*)&features13 : nullptr));
     InitRenderTarget();
 
     vkt::Buffer draw_buffer(*m_device, 2 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
+    VkDrawIndirectCommand* draw_ptr = static_cast<VkDrawIndirectCommand*>(draw_buffer.Memory().Map());
     memset(draw_ptr, 0, 2 * sizeof(VkDrawIndirectCommand));
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 2;  // Fits in buffer but exceeds (fake) limit
 
     CreatePipelineHelper pipe(*this);
@@ -91,7 +91,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
     }
 
     if (mesh_shader_enabled) {
-        const char *mesh_shader_source = R"glsl(
+        const char* mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -109,8 +109,8 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
         vkt::Buffer mesh_draw_buffer(*m_device, 2 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                      kHostVisibleMemProps);
 
-        VkDrawMeshTasksIndirectCommandEXT *mesh_draw_ptr =
-            static_cast<VkDrawMeshTasksIndirectCommandEXT *>(mesh_draw_buffer.Memory().Map());
+        VkDrawMeshTasksIndirectCommandEXT* mesh_draw_ptr =
+            static_cast<VkDrawMeshTasksIndirectCommandEXT*>(mesh_draw_buffer.Memory().Map());
         mesh_draw_ptr->groupCountX = 0;
         mesh_draw_ptr->groupCountY = 0;
         mesh_draw_ptr->groupCountZ = 0;
@@ -210,11 +210,11 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
 
     vkt::Buffer draw_buffer(*m_device, 2 * sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    VkDrawIndexedIndirectCommand *draw_ptr = static_cast<VkDrawIndexedIndirectCommand *>(draw_buffer.Memory().Map());
+    VkDrawIndexedIndirectCommand* draw_ptr = static_cast<VkDrawIndexedIndirectCommand*>(draw_buffer.Memory().Map());
     memset(draw_ptr, 0, 2 * sizeof(VkDrawIndexedIndirectCommand));
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 2;  // Fits in buffer but exceeds (fake) limit
 
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
@@ -261,7 +261,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     InitRenderTarget();
 
     vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
+    VkDrawIndirectCommand* draw_ptr = static_cast<VkDrawIndirectCommand*>(draw_buffer.Memory().Map());
     draw_ptr->firstInstance = 0;
     draw_ptr->firstVertex = 0;
     draw_ptr->instanceCount = 1;
@@ -271,7 +271,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
 
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 2;
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
@@ -306,7 +306,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
 
     vkt::Buffer indexed_draw_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     kHostVisibleMemProps);
-    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
+    VkDrawIndexedIndirectCommand* indexed_draw_ptr = (VkDrawIndexedIndirectCommand*)indexed_draw_buffer.Memory().Map();
     indexed_draw_ptr->indexCount = 3;
     indexed_draw_ptr->firstIndex = 0;
     indexed_draw_ptr->instanceCount = 1;
@@ -349,7 +349,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
     if (mesh_shader_enabled) {
-        const char *mesh_shader_source = R"glsl(
+        const char* mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -367,8 +367,8 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
         vkt::Buffer mesh_draw_buffer(*m_device, sizeof(VkDrawMeshTasksIndirectCommandEXT), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-        VkDrawMeshTasksIndirectCommandEXT *mesh_draw_ptr =
-            +static_cast<VkDrawMeshTasksIndirectCommandEXT *>(mesh_draw_buffer.Memory().Map());
+        VkDrawMeshTasksIndirectCommandEXT* mesh_draw_ptr =
+            +static_cast<VkDrawMeshTasksIndirectCommandEXT*>(mesh_draw_buffer.Memory().Map());
         mesh_draw_ptr->groupCountX = 0;
         mesh_draw_ptr->groupCountY = 0;
         mesh_draw_ptr->groupCountZ = 0;
@@ -431,14 +431,14 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     uint32_t buffer_size = num_commands * (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4);  // 4 byte pad between commands
 
     vkt::Buffer draw_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *draw_ptr = static_cast<uint32_t *>(draw_buffer.Memory().Map());
+    uint32_t* draw_ptr = static_cast<uint32_t*>(draw_buffer.Memory().Map());
     // Set all mesh group counts to 1
     for (uint32_t i = 0; i < num_commands * 4; ++i) {
         draw_ptr[i] = 1;
     }
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
     VkShaderObj mesh_shader(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
@@ -537,17 +537,17 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
     uint32_t buffer_size = num_commands * (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4);  // 4 byte pad between commands
 
     vkt::Buffer draw_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *draw_ptr = static_cast<uint32_t *>(draw_buffer.Memory().Map());
+    uint32_t* draw_ptr = static_cast<uint32_t*>(draw_buffer.Memory().Map());
     // Set all mesh group counts to 1
     for (uint32_t i = 0; i < num_commands * 4; ++i) {
         draw_ptr[i] = 1;
     }
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
-    const char *mesh_shader_source = R"glsl(
+    const char* mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -561,7 +561,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
         )glsl";
     VkShaderObj mesh_shader(*m_device, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
 
-    const char *task_shader_source = R"glsl(
+    const char* task_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout (local_size_x=1, local_size_y=1, local_size_z=1) in;
@@ -1006,7 +1006,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
 
     vkt::Buffer indirect_buffer(*m_device, 5 * sizeof(VkDispatchIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 kHostVisibleMemProps);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    VkDispatchIndirectCommand* ptr = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     // VkDispatchIndirectCommand[0]
     ptr->x = 4;  // over
     ptr->y = 2;
@@ -1099,7 +1099,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
 
     vkt::Buffer indirect_buffer(*m_device, 5 * sizeof(VkDispatchIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 kHostVisibleMemProps);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    VkDispatchIndirectCommand* ptr = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     // VkDispatchIndirectCommand[0]
     ptr->x = 4;  // over
     ptr->y = 2;
@@ -1195,7 +1195,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, BufferUsageFlags2) {
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_ci.size = sizeof(VkDispatchIndirectCommand);
     vkt::Buffer indirect_buffer(*m_device, buffer_ci, kHostVisibleMemProps);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    VkDispatchIndirectCommand* ptr = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     ptr->x = 4;  // over
     ptr->y = 2;
     ptr->z = 1;

--- a/tests/unit/gpu_av_indirect_buffer_positive.cpp
+++ b/tests/unit/gpu_av_indirect_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, BasicTraceRaysMultipleStages) {
 
     // Set shaders
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require // Requires SPIR-V 1.5 (Vulkan 1.2)
 
@@ -62,7 +62,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, BasicTraceRaysMultipleStages) {
     )glsl";
     pipeline.SetGlslRayGenShader(ray_gen);
 
-    const char *miss = R"glsl(
+    const char* miss = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
 
@@ -76,7 +76,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, BasicTraceRaysMultipleStages) {
     )glsl";
     pipeline.AddGlslMissShader(miss);
 
-    const char *closest_hit = R"glsl(
+    const char* closest_hit = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
 
@@ -137,14 +137,14 @@ TEST_F(PositiveGpuAVIndirectBuffer, Mesh) {
     uint32_t buffer_size = mesh_commands * (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4);  // 4 byte pad between commands
 
     vkt::Buffer draw_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *draw_ptr = static_cast<uint32_t *>(draw_buffer.Memory().Map());
+    uint32_t* draw_ptr = static_cast<uint32_t*>(draw_buffer.Memory().Map());
     // Set all mesh group counts to 1
     for (uint32_t i = 0; i < mesh_commands * 4; ++i) {
         draw_ptr[i] = 1;
     }
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
     VkShaderObj mesh_shader(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
@@ -187,14 +187,14 @@ TEST_F(PositiveGpuAVIndirectBuffer, MeshSingleCommand) {
     uint32_t buffer_size = mesh_commands * (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4);  // 4 byte pad between commands
 
     vkt::Buffer draw_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *draw_ptr = static_cast<uint32_t *>(draw_buffer.Memory().Map());
+    uint32_t* draw_ptr = static_cast<uint32_t*>(draw_buffer.Memory().Map());
     // Set all mesh group counts to 1
     for (uint32_t i = 0; i < mesh_commands * 4; ++i) {
         draw_ptr[i] = 1;
     }
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    uint32_t* count_ptr = static_cast<uint32_t*>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
     VkShaderObj mesh_shader(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
@@ -260,7 +260,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, PipelineAndShaderObjectComputeDispatchIndire
 
     vkt::Buffer dispatch_params_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                        kHostVisibleMemProps);
-    auto &indirect_dispatch_parameters = *static_cast<VkDispatchIndirectCommand *>(dispatch_params_buffer.Memory().Map());
+    auto& indirect_dispatch_parameters = *static_cast<VkDispatchIndirectCommand*>(dispatch_params_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1u;
     indirect_dispatch_parameters.y = 1u;
     indirect_dispatch_parameters.z = 1u;
@@ -296,13 +296,13 @@ TEST_F(PositiveGpuAVIndirectBuffer, RestoreStress) {
 
     vkt::Buffer dispatch_params_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                        kHostVisibleMemProps);
-    auto &indirect_dispatch_parameters = *static_cast<VkDispatchIndirectCommand *>(dispatch_params_buffer.Memory().Map());
+    auto& indirect_dispatch_parameters = *static_cast<VkDispatchIndirectCommand*>(dispatch_params_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1u;
     indirect_dispatch_parameters.y = 1u;
     indirect_dispatch_parameters.z = 1u;
 
     // used for all stage types
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint x;
@@ -406,7 +406,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, BufferUsageFlags2) {
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_ci.size = sizeof(VkDispatchIndirectCommand);
     vkt::Buffer indirect_buffer(*m_device, buffer_ci, kHostVisibleMemProps);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    VkDispatchIndirectCommand* ptr = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     ptr->x = 1;
     ptr->y = 1;
     ptr->z = 1;

--- a/tests/unit/gpu_av_mesh.cpp
+++ b/tests/unit/gpu_av_mesh.cpp
@@ -22,7 +22,7 @@ TEST_F(NegativeGpuAVMesh, PrimitiveCount) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(triangles, max_vertices = 3, max_primitives = 1) out;
@@ -44,7 +44,7 @@ TEST_F(NegativeGpuAVMesh, PrimitiveCount) {
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 60;
     buffer_ptr[1] = 1;
 

--- a/tests/unit/gpu_av_mesh_positive.cpp
+++ b/tests/unit/gpu_av_mesh_positive.cpp
@@ -80,7 +80,7 @@ TEST_F(PositiveGpuAVMesh, MultipleSetMeshOutput) {
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 0;
     buffer_ptr[1] = 3;
     buffer_ptr[2] = 1;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -151,7 +151,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlock) {
     descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK;
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, NULL);
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) buffer StorageBuffer { uint index; } u_index;
@@ -176,7 +176,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlock) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     ASSERT_TRUE(*data = test_data);
 }
 
@@ -241,7 +241,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
     }
 
     // Now be sure that recovery from an unavailable descriptor set works and that uninstrumented shaders are used
-    std::vector<const vkt::DescriptorSetLayout *> layouts(set_count);
+    std::vector<const vkt::DescriptorSetLayout*> layouts(set_count);
     for (uint32_t i = 0; i < set_count; i++) {
         layouts[i] = &descriptor_set.layout_;
     }
@@ -252,7 +252,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
     vkt::PipelineLayout pl_layout(*m_device, layouts);
     m_errorMonitor->VerifyFound();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) buffer StorageBuffer { uint index; } u_index;
@@ -280,7 +280,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
 
         pl_layout.Destroy();
 
-        uint32_t *data = (uint32_t *)buffer.Memory().Map();
+        uint32_t* data = (uint32_t*)buffer.Memory().Map();
         if (*data != test_data)
             m_errorMonitor->SetError("Pipeline recovery when resources unavailable not functioning as expected");
         *data = 0;
@@ -302,7 +302,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
         vk::CmdDispatch(m_command_buffer, 1, 1, 1);
         m_command_buffer.End();
         m_default_queue->SubmitAndWait(m_command_buffer);
-        uint32_t *data = (uint32_t *)buffer.Memory().Map();
+        uint32_t* data = (uint32_t*)buffer.Memory().Map();
         if (*data != test_data) m_errorMonitor->SetError("Using shader after pipeline recovery not functioning as expected");
         *data = 0;
         buffer.Memory().Unmap();
@@ -320,7 +320,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockUninitialized) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO { uint out_buffer; };
         layout(set = 0, binding = 1) uniform InlineUBO {
@@ -385,7 +385,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockUninitializedUpdateAfterBind) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO { uint out_buffer; };
         layout(set = 0, binding = 1) uniform InlineUBO {
@@ -457,7 +457,7 @@ TEST_F(PositiveGpuAV, SetSSBOBindDescriptor) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(constant_id=0) const uint _const_2_0 = 1;
         layout(constant_id=1) const uint _const_3_0 = 1;
@@ -518,7 +518,7 @@ TEST_F(PositiveGpuAV, SetSSBOPushDescriptor) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(constant_id=0) const uint _const_2_0 = 1;
         layout(constant_id=1) const uint _const_3_0 = 1;
@@ -629,7 +629,7 @@ TEST_F(PositiveGpuAV, MutableBuffer) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(constant_id=0) const uint _const_2_0 = 1;
         layout(constant_id=1) const uint _const_3_0 = 1;
@@ -823,7 +823,7 @@ TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
         GTEST_SKIP() << "Tests requires Vulkan 1.1 exactly";
     }
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout (set = 1, binding = 0) uniform sampler2D samplerColor;
         layout(location = 0) out vec4 color;
@@ -884,7 +884,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
 
     vkt::Buffer draw_buffer(*m_device, 4 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    auto draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
+    auto draw_ptr = static_cast<VkDrawIndirectCommand*>(draw_buffer.Memory().Map());
     for (uint32_t i = 0; i < 4; i++) {
         draw_ptr->vertexCount = 3;
         draw_ptr->instanceCount = 1;
@@ -908,7 +908,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
     // Now with an offset and indexed draw
     vkt::Buffer indexed_draw_buffer(*m_device, 4 * sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     kHostVisibleMemProps);
-    auto indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
+    auto indexed_draw_ptr = (VkDrawIndexedIndirectCommand*)indexed_draw_buffer.Memory().Map();
     for (uint32_t i = 0; i < 4; i++) {
         indexed_draw_ptr->indexCount = 3;
         indexed_draw_ptr->instanceCount = 1;
@@ -956,21 +956,21 @@ TEST_F(PositiveGpuAV, SwapchainImage) {
 }
 
 class PositiveGpuAVParameterized : public GpuAVTest,
-                                   public ::testing::WithParamInterface<std::tuple<std::vector<const char *>, uint32_t>> {};
+                                   public ::testing::WithParamInterface<std::tuple<std::vector<const char*>, uint32_t>> {};
 
 TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
     TEST_DESCRIPTION("Validate illegal firstInstance values");
     AddRequiredFeature(vkt::Feature::multiDrawIndirect);
     AddRequiredFeature(vkt::Feature::drawIndirectFirstInstance);
 
-    std::vector<const char *> setting_names = std::get<0>(GetParam());
+    std::vector<const char*> setting_names = std::get<0>(GetParam());
     const uint32_t setting_values = std::get<1>(GetParam());
 
     std::vector<VkLayerSettingEXT> layer_settings(setting_names.size());
     std::vector<VkBool32> layer_settings_values(setting_names.size());
     for (const auto [setting_name_i, setting_name] : vvl::enumerate(setting_names)) {
-        VkLayerSettingEXT &layer_setting = layer_settings[setting_name_i];
-        VkBool32 &layer_setting_value = layer_settings_values[setting_name_i];
+        VkLayerSettingEXT& layer_setting = layer_settings[setting_name_i];
+        VkBool32& layer_setting_value = layer_settings_values[setting_name_i];
 
         layer_setting_value = (setting_values & (1u << setting_name_i)) ? VK_TRUE : VK_FALSE;
         layer_setting = {OBJECT_LAYER_NAME, setting_name, VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &layer_setting_value};
@@ -982,7 +982,7 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
 
     vkt::Buffer draw_buffer(*m_device, 4 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             kHostVisibleMemProps);
-    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
+    VkDrawIndirectCommand* draw_ptr = static_cast<VkDrawIndirectCommand*>(draw_buffer.Memory().Map());
     for (uint32_t i = 0; i < 4; i++) {
         draw_ptr->vertexCount = 3;
         draw_ptr->instanceCount = 1;
@@ -1007,7 +1007,7 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
     // Now with an offset and indexed draw
     vkt::Buffer indexed_draw_buffer(*m_device, 4 * sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     kHostVisibleMemProps);
-    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
+    VkDrawIndexedIndirectCommand* indexed_draw_ptr = (VkDrawIndexedIndirectCommand*)indexed_draw_buffer.Memory().Map();
     for (uint32_t i = 0; i < 4; i++) {
         indexed_draw_ptr->indexCount = 3;
         indexed_draw_ptr->instanceCount = 1;
@@ -1029,12 +1029,12 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
-static std::string GetGpuAvSettingsCombinationTestName(const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType> &info) {
-    std::vector<const char *> setting_names = std::get<0>(info.param);
+static std::string GetGpuAvSettingsCombinationTestName(const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType>& info) {
+    std::vector<const char*> setting_names = std::get<0>(info.param);
     const uint32_t setting_values = std::get<1>(info.param);
     std::ostringstream test_name;
     for (auto [setting_name_i, setting_name] : vvl::enumerate(setting_names)) {
-        const char *enabled_str = (setting_values & (1u << setting_name_i)) ? "_1" : "_0";
+        const char* enabled_str = (setting_values & (1u << setting_name_i)) ? "_1" : "_0";
         if (setting_name_i != 0) {
             test_name << "_";
         }
@@ -1049,32 +1049,32 @@ static std::string GetGpuAvSettingsCombinationTestName(const testing::TestParamI
 // is based on the number of settings in the settings list. If you have N settings, you want your range end to be uint32_t(1) << N
 INSTANTIATE_TEST_SUITE_P(GpuAvShaderInstrumentationMainSettings, PositiveGpuAVParameterized,
 
-                         ::testing::Combine(::testing::Values(std::vector<const char *>(
+                         ::testing::Combine(::testing::Values(std::vector<const char*>(
                                                 {"gpuav_descriptor_checks", "gpuav_buffer_address_oob", "gpuav_validate_ray_query",
                                                  "gpuav_select_instrumented_shaders"})),
                                             ::testing::Range(uint32_t(0), uint32_t(1) << 4)),
 
-                         [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType> &info) {
+                         [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType>& info) {
                              return GetGpuAvSettingsCombinationTestName(info);
                          });
 
 INSTANTIATE_TEST_SUITE_P(GpuAvMainSettings, PositiveGpuAVParameterized,
 
-                         ::testing::Combine(::testing::Values(std::vector<const char *>({"gpuav_shader_instrumentation",
-                                                                                         "gpuav_buffers_validation"})),
+                         ::testing::Combine(::testing::Values(std::vector<const char*>({"gpuav_shader_instrumentation",
+                                                                                        "gpuav_buffers_validation"})),
                                             ::testing::Range(uint32_t(0), uint32_t(1) << 2)),
 
-                         [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType> &info) {
+                         [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType>& info) {
                              return GetGpuAvSettingsCombinationTestName(info);
                          });
 
 INSTANTIATE_TEST_SUITE_P(GpuAvBufferContentValidationSettings, PositiveGpuAVParameterized,
-                         ::testing::Combine(::testing::Values(std::vector<const char *>(
+                         ::testing::Combine(::testing::Values(std::vector<const char*>(
                                                 {"gpuav_indirect_draws_buffers", "gpuav_indirect_dispatches_buffers",
                                                  "gpuav_indirect_trace_rays_buffers", "gpuav_buffer_copies"})),
                                             ::testing::Range(uint32_t(0), uint32_t(1) << 4)),
 
-                         [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType> &info) {
+                         [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType>& info) {
                              return GetGpuAvSettingsCombinationTestName(info);
                          });
 
@@ -1088,7 +1088,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 kHostVisibleMemProps);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
+    auto& indirect_draw_parameters = *static_cast<VkDrawIndirectCommand*>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
@@ -1126,7 +1126,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
     plci.pPushConstantRanges = push_constant_ranges.data();
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1154,7 +1154,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
         )glsl";
     VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1200,7 +1200,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto storage_buffer_ptr = static_cast<int32_t *>(storage_buffer.Memory().Map());
+    auto storage_buffer_ptr = static_cast<int32_t*>(storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], i);
     }
@@ -1226,7 +1226,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
     // Graphics pipeline
     // ---
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1254,7 +1254,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
         )glsl";
     VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1295,7 +1295,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 kHostVisibleMemProps);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
+    auto& indirect_draw_parameters = *static_cast<VkDrawIndirectCommand*>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
@@ -1309,7 +1309,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
     // Compute pipeline
     // ---
 
-    const char *compute_source = R"glsl(
+    const char* compute_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1354,8 +1354,8 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
 
     vkt::Buffer indirect_dispatch_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                     kHostVisibleMemProps);
-    auto &indirect_dispatch_parameters =
-        *static_cast<VkDispatchIndirectCommand *>(indirect_dispatch_parameters_buffer.Memory().Map());
+    auto& indirect_dispatch_parameters =
+        *static_cast<VkDispatchIndirectCommand*>(indirect_dispatch_parameters_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1;
     indirect_dispatch_parameters.y = 1;
     indirect_dispatch_parameters.z = 1;
@@ -1384,12 +1384,12 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto compute_storage_buffer_ptr = static_cast<int32_t *>(compute_storage_buffer.Memory().Map());
+    auto compute_storage_buffer_ptr = static_cast<int32_t*>(compute_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(compute_storage_buffer_ptr[i], int_count + i);
     }
 
-    auto graphics_storage_buffer_ptr = static_cast<int32_t *>(graphics_storage_buffer.Memory().Map());
+    auto graphics_storage_buffer_ptr = static_cast<int32_t*>(graphics_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(graphics_storage_buffer_ptr[i], i);
     }
@@ -1404,7 +1404,7 @@ TEST_F(PositiveGpuAV, PipelineLayoutMixing) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 kHostVisibleMemProps);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
+    auto& indirect_draw_parameters = *static_cast<VkDrawIndirectCommand*>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
@@ -1475,7 +1475,7 @@ TEST_F(PositiveGpuAV, SharedPipelineLayoutSubset) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
@@ -1550,7 +1550,7 @@ TEST_F(PositiveGpuAV, SharedPipelineLayoutSubsetWithUnboundDescriptorSet) {
     pipeline_layout_ci.setLayoutCount = 3;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 {
             int a;
@@ -1713,7 +1713,7 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
     command_layout_ci.pTokens = tokens;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    const char *shader_source_1 = R"glsl(
+    const char* shader_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -1722,7 +1722,7 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
             x[48] = 0; // invalid!
         }
     )glsl";
-    const char *shader_source_2 = R"glsl(
+    const char* shader_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -1731,7 +1731,7 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
             x[24] = 0; // invalid!
         }
     )glsl";
-    const char *shader_source_3 = R"glsl(
+    const char* shader_source_3 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -1793,9 +1793,9 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    uint32_t *block_buffer_ptr = (uint32_t *)block_buffer.Memory().Map();
+    uint32_t* block_buffer_ptr = (uint32_t*)block_buffer.Memory().Map();
     block_buffer_ptr[0] = 2;  // pick pipeline 2
-    VkDispatchIndirectCommand *indirect_command_ptr = (VkDispatchIndirectCommand *)(block_buffer_ptr + 1);
+    VkDispatchIndirectCommand* indirect_command_ptr = (VkDispatchIndirectCommand*)(block_buffer_ptr + 1);
     indirect_command_ptr->x = 1;
     indirect_command_ptr->y = 1;
     indirect_command_ptr->z = 1;
@@ -1944,9 +1944,9 @@ TEST_F(PositiveGpuAV, FailedSampler) {
     VkSampler sampler_handle;
 
     struct Alloc {
-        static VKAPI_ATTR void *VKAPI_CALL alloc(void *, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
-        static VKAPI_ATTR void *VKAPI_CALL reallocFunc(void *, void *, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
-        static VKAPI_ATTR void VKAPI_CALL freeFunc(void *, void *){};
+        static VKAPI_ATTR void* VKAPI_CALL alloc(void*, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
+        static VKAPI_ATTR void* VKAPI_CALL reallocFunc(void*, void*, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
+        static VKAPI_ATTR void VKAPI_CALL freeFunc(void*, void*) {};
     };
     const VkAllocationCallbacks bad_allocator = {nullptr, Alloc::alloc, Alloc::reallocFunc, Alloc::freeFunc, nullptr, nullptr};
 
@@ -2077,7 +2077,7 @@ TEST_F(PositiveGpuAV, MixDynamicNormalRenderPass) {
     const vkt::PipelineLayout g_pipeline_layout(*m_device, {&descriptor_set1.layout_}, {pc_ranges});
     const vkt::PipelineLayout c_pipeline_layout(*m_device, {&descriptor_set2.layout_}, {pc_ranges});
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(push_constant) uniform PushConstants {
             uint a[4];
@@ -2114,7 +2114,7 @@ TEST_F(PositiveGpuAV, MixDynamicNormalRenderPass) {
 
     vkt::Buffer dispatch_params_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                        kHostVisibleMemProps);
-    auto &indirect_dispatch_parameters = *static_cast<VkDispatchIndirectCommand *>(dispatch_params_buffer.Memory().Map());
+    auto& indirect_dispatch_parameters = *static_cast<VkDispatchIndirectCommand*>(dispatch_params_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1u;
     indirect_dispatch_parameters.y = 1u;
     indirect_dispatch_parameters.z = 1u;

--- a/tests/unit/gpu_av_ray_hit_object.cpp
+++ b/tests/unit/gpu_av_ray_hit_object.cpp
@@ -27,7 +27,7 @@ TEST_F(NegativeGpuAVRayHitObject, NegativeTmin) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -54,7 +54,7 @@ TEST_F(NegativeGpuAVRayHitObject, NegativeTmin) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = -1.0f;  // negative tmin
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -82,7 +82,7 @@ TEST_F(NegativeGpuAVRayHitObject, TmaxLessThanTmin) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -109,7 +109,7 @@ TEST_F(NegativeGpuAVRayHitObject, TmaxLessThanTmin) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 10.0f;  // tmin
     ptr[1] = 5.0f;   // tmax < tmin
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
@@ -138,7 +138,7 @@ TEST_F(NegativeGpuAVRayHitObject, OriginNaN) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -166,7 +166,7 @@ TEST_F(NegativeGpuAVRayHitObject, OriginNaN) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 1.0f;
     ptr[1] = 0.0f;  // division by zero -> inf, fract(inf) = NaN
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
@@ -195,7 +195,7 @@ TEST_F(NegativeGpuAVRayHitObject, OriginNonFinite) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -223,7 +223,7 @@ TEST_F(NegativeGpuAVRayHitObject, OriginNonFinite) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 0.0f;  // causes division by zero -> +infinity
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -251,7 +251,7 @@ TEST_F(NegativeGpuAVRayHitObject, BothSkipFlags) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -279,7 +279,7 @@ TEST_F(NegativeGpuAVRayHitObject, BothSkipFlags) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = 0x100 | 0x200;  // SkipTrianglesKHR | SkipAABBsKHR
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -307,7 +307,7 @@ TEST_F(NegativeGpuAVRayHitObject, OpaqueFlags) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -334,7 +334,7 @@ TEST_F(NegativeGpuAVRayHitObject, OpaqueFlags) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = 0x1 | 0x2;  // OpaqueKHR | NoOpaqueKHR
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -362,7 +362,7 @@ TEST_F(NegativeGpuAVRayHitObject, SkipAndCullFlags) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -390,7 +390,7 @@ TEST_F(NegativeGpuAVRayHitObject, SkipAndCullFlags) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = 0x100 | 0x10;  // SkipTrianglesKHR | CullBackFacingTrianglesKHR
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -419,7 +419,7 @@ TEST_F(NegativeGpuAVRayHitObject, SkipTrianglesWithPipelineSkipAABBs) {
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -447,7 +447,7 @@ TEST_F(NegativeGpuAVRayHitObject, SkipTrianglesWithPipelineSkipAABBs) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = 0x100;  // SkipTrianglesKHR
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -476,7 +476,7 @@ TEST_F(NegativeGpuAVRayHitObject, SkipAABBsWithPipelineSkipTriangles) {
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -504,7 +504,7 @@ TEST_F(NegativeGpuAVRayHitObject, SkipAABBsWithPipelineSkipTriangles) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = 0x200;  // SkipAABBsKHR
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -533,7 +533,7 @@ TEST_F(NegativeGpuAVRayHitObject, MotionTimeOutOfRange) {
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -561,7 +561,7 @@ TEST_F(NegativeGpuAVRayHitObject, MotionTimeOutOfRange) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 1.5f;  // time > 1.0, invalid
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -604,7 +604,7 @@ TEST_F(NegativeGpuAVRayHitObject, SBTIndexExceedsLimit) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_ray_query : require
@@ -634,7 +634,7 @@ TEST_F(NegativeGpuAVRayHitObject, SBTIndexExceedsLimit) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = reorder_props.maxShaderBindingTableRecordIndex + 1;  // Exceed the limit
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -662,7 +662,7 @@ TEST_F(NegativeGpuAVRayHitObject, TraceReorderExecuteNegativeTmin) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -689,7 +689,7 @@ TEST_F(NegativeGpuAVRayHitObject, TraceReorderExecuteNegativeTmin) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = -1.0f;  // negative tmin
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -717,7 +717,7 @@ TEST_F(NegativeGpuAVRayHitObject, TraceMotionReorderExecuteNegativeTmin) {
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -745,7 +745,7 @@ TEST_F(NegativeGpuAVRayHitObject, TraceMotionReorderExecuteNegativeTmin) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = -1.0f;  // negative tmin
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -774,7 +774,7 @@ TEST_F(NegativeGpuAVRayHitObject, TraceMotionReorderExecuteTimeOutOfRange) {
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -802,7 +802,7 @@ TEST_F(NegativeGpuAVRayHitObject, TraceMotionReorderExecuteTimeOutOfRange) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 1.5f;  // time > 1.0, invalid
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();

--- a/tests/unit/gpu_av_ray_hit_object_positive.cpp
+++ b/tests/unit/gpu_av_ray_hit_object_positive.cpp
@@ -56,7 +56,7 @@ TEST_F(PositiveGpuAVRayHitObject, TraceRayBasic) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -103,7 +103,7 @@ TEST_F(PositiveGpuAVRayHitObject, DynamicTminTmax) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -135,7 +135,7 @@ TEST_F(PositiveGpuAVRayHitObject, DynamicTminTmax) {
 
     pipeline.Build();
 
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 0.1f;    // tmin
     ptr[1] = 100.0f;  // tmax
 
@@ -158,7 +158,7 @@ TEST_F(PositiveGpuAVRayHitObject, DynamicRayFlags) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -191,7 +191,7 @@ TEST_F(PositiveGpuAVRayHitObject, DynamicRayFlags) {
     pipeline.Build();
 
     // Test with valid flag combination: OpaqueKHR | CullBackFacingTrianglesKHR
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = 0x1 | 0x10;  // OpaqueKHR | CullBackFacingTrianglesKHR
 
     m_command_buffer.Begin();
@@ -213,7 +213,7 @@ TEST_F(PositiveGpuAVRayHitObject, DynamicRayFlagsSkipTriangles) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -247,7 +247,7 @@ TEST_F(PositiveGpuAVRayHitObject, DynamicRayFlagsSkipTriangles) {
     pipeline.Build();
 
     // SkipTrianglesKHR alone is valid (no pipeline SKIP_AABBS flag)
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     ptr[0] = 0x100;  // SkipTrianglesKHR
 
     m_command_buffer.Begin();
@@ -269,7 +269,7 @@ TEST_F(PositiveGpuAVRayHitObject, TraceReorderExecuteBasic) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -316,7 +316,7 @@ TEST_F(PositiveGpuAVRayHitObject, TraceRayMotionValidTime) {
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -350,7 +350,7 @@ TEST_F(PositiveGpuAVRayHitObject, TraceRayMotionValidTime) {
     pipeline.Build();
 
     // Test with time = 0.5 (valid)
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 0.5f;
 
     m_command_buffer.Begin();
@@ -383,7 +383,7 @@ TEST_F(PositiveGpuAVRayHitObject, TraceMotionReorderExecuteValidTime) {
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_shader_invocation_reorder : require
@@ -417,7 +417,7 @@ TEST_F(PositiveGpuAVRayHitObject, TraceMotionReorderExecuteValidTime) {
     pipeline.Build();
 
     // Test with time = 0.5 (valid)
-    auto *ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     ptr[0] = 0.5f;
 
     m_command_buffer.Begin();
@@ -450,7 +450,7 @@ TEST_F(PositiveGpuAVRayHitObject, SBTIndexWithinLimit) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         #extension GL_EXT_ray_query : require
@@ -480,7 +480,7 @@ TEST_F(PositiveGpuAVRayHitObject, SBTIndexWithinLimit) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto *ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto* ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     // Use 0 which is always valid
     ptr[0] = 0;
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+/* Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     TEST_DESCRIPTION("Ray query with a negative value for Ray TMin");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -58,7 +58,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     pipeline.descriptor_set_.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = -2.0f;  // t_min
     uniform_buffer_ptr[1] = 42.0f;  // t_max
 
@@ -79,7 +79,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     TEST_DESCRIPTION("Ray query with a Ray TMax less than Ray TMin");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -110,7 +110,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     pipeline.descriptor_set_.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 9.9f;  // t_min
     uniform_buffer_ptr[1] = 9.8f;  // t_max
     m_command_buffer.Begin();
@@ -130,7 +130,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set ray flags");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -159,7 +159,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     pipeline.descriptor_set_.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0x100 | 0x200;  // SkipTrianglesKHR and SkipAABBsKHR
 
     m_command_buffer.Begin();
@@ -179,7 +179,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set ray flags");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -208,7 +208,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
     pipeline.descriptor_set_.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0x1 | 0x2;  // OpaqueKHR and NoOpaqueKHR
 
     m_command_buffer.Begin();
@@ -228,7 +228,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
     TEST_DESCRIPTION("Ray query with a Ray Origin as a NaN");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -260,7 +260,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
     pipeline.descriptor_set_.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 1.0f;  // x
     uniform_buffer_ptr[1] = 0.0f;  // y
 
@@ -281,7 +281,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
     TEST_DESCRIPTION("Ray query with a Ray Origin as a non finite value");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -313,7 +313,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
     pipeline.descriptor_set_.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0.0f;  // t_min
     uniform_buffer_ptr[1] = 0.0f;  // t_max
 
@@ -334,7 +334,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
     TEST_DESCRIPTION("rayQueryInitializeEXT is never called, make sure we don't hang with an uninit query object");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -367,7 +367,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
     pipeline.descriptor_set_.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
-    auto buffer_ptr = static_cast<float *>(buffer.Memory().Map());
+    auto buffer_ptr = static_cast<float*>(buffer.Memory().Map());
     buffer_ptr[0] = -4.0f;  // t_min
 
     m_command_buffer.Begin();
@@ -391,7 +391,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninit) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -420,7 +420,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninit) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer ssbo(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_ptr = static_cast<float *>(ssbo.Memory().Map());
+    auto buffer_ptr = static_cast<float*>(ssbo.Memory().Map());
     buffer_ptr[0] = -16.0f;
 
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, ssbo, 0, 4096, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -454,7 +454,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninitSelectShaders) {
     AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
     std::vector<VkLayerSettingEXT> layer_settings(2);
     layer_settings[0] = {OBJECT_LAYER_NAME, "gpuav_select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    std::array<const char *, 3> shader_regexes = {{"vertex_foo", "fragment_.*", ".*ray.*"}};
+    std::array<const char*, 3> shader_regexes = {{"vertex_foo", "fragment_.*", ".*ray.*"}};
     layer_settings[1] = {OBJECT_LAYER_NAME, "gpuav_shaders_to_instrument", VK_LAYER_SETTING_TYPE_STRING_EXT, size32(shader_regexes),
                          shader_regexes.data()};
 
@@ -462,7 +462,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninitSelectShaders) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -482,7 +482,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninitSelectShaders) {
         }
     )glsl";
     pipeline.SetGlslRayGenShader(ray_gen);
-    VkShaderObj &ray_gen_shader = pipeline.GetRayGenShader(0);
+    VkShaderObj& ray_gen_shader = pipeline.GetRayGenShader(0);
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_SHADER_MODULE;
     name_info.pObjectName = "my_oh_my_ray_gen";
@@ -497,7 +497,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninitSelectShaders) {
     pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer ssbo(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto buffer_ptr = static_cast<float *>(ssbo.Memory().Map());
+    auto buffer_ptr = static_cast<float*>(ssbo.Memory().Map());
     buffer_ptr[0] = -16.0f;
 
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, ssbo, 0, 4096, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -528,7 +528,7 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
     RETURN_IF_SKIP(InitGpuAVRayQuery());
     InitRenderTarget();
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -565,7 +565,7 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto buffer_ptr = static_cast<float *>(buffer.Memory().Map());
+    auto buffer_ptr = static_cast<float*>(buffer.Memory().Map());
     buffer_ptr[0] = -4.0f;  // t_min
 
     m_command_buffer.Begin();

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+/* Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     TEST_DESCRIPTION("Ray query in a compute shader");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -74,7 +74,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set t_min and t_max");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -109,7 +109,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
     // Ray query with t_min dynamically set to 0
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
+    auto uniform_buffer_ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     {
         uniform_buffer_ptr[0] = 0.0f;   // t_min
         uniform_buffer_ptr[1] = 42.0f;  // t_max
@@ -137,7 +137,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set ray flags");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -171,7 +171,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
 
     // Ray query with t_min dynamically set to 0
     {
-        auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+        auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
         uniform_buffer_ptr[0] = 4u | 16u;  // gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsCullBackFacingTrianglesEXT
     }
     m_command_buffer.Begin();
@@ -191,7 +191,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     AddRequiredFeature(vkt::Feature::rayTraversalPrimitiveCulling);
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -224,7 +224,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     pipeline.descriptor_set_.UpdateDescriptorSets();
 
     {
-        auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
+        auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
         uniform_buffer_ptr[0] = 4u | 0x100;  // gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsSkipTrianglesEXT
     }
     m_command_buffer.Begin();
@@ -243,7 +243,7 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     RETURN_IF_SKIP(InitGpuAVRayQuery());
     InitRenderTarget();
 
-    const char *vertex_source = R"glsl(
+    const char* vertex_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -291,7 +291,7 @@ TEST_F(PositiveGpuAVRayQuery, RayTracingBasic) {
 
     // Set ray gen shader
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
     #version 460
 
     #extension GL_EXT_ray_query : require

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -37,7 +37,7 @@ TEST_F(NegativeGpuAVRayTracing, CmdTraceRaysIndirect) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
         layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
@@ -75,21 +75,21 @@ TEST_F(NegativeGpuAVRayTracing, CmdTraceRaysIndirect) {
 
     VkTraceRaysIndirectCommandKHR trace_rays_dim{rt_pipeline_props.maxRayDispatchInvocationCount + 1, 1, 1};
 
-    uint8_t *ray_query_dimensions_buffer_1_ptr = (uint8_t *)trace_rays_big_width.Memory().Map();
+    uint8_t* ray_query_dimensions_buffer_1_ptr = (uint8_t*)trace_rays_big_width.Memory().Map();
     std::memcpy(ray_query_dimensions_buffer_1_ptr, &trace_rays_dim, sizeof(trace_rays_dim));
 
     trace_rays_dim = {1, rt_pipeline_props.maxRayDispatchInvocationCount + 1, 1};
 
     vkt::Buffer trace_rays_big_height(*m_device, 4096, buffer_usage, vkt::device_address);
 
-    uint8_t *ray_query_dimensions_buffer_2_ptr = (uint8_t *)trace_rays_big_height.Memory().Map();
+    uint8_t* ray_query_dimensions_buffer_2_ptr = (uint8_t*)trace_rays_big_height.Memory().Map();
     std::memcpy(ray_query_dimensions_buffer_2_ptr, &trace_rays_dim, sizeof(trace_rays_dim));
 
     trace_rays_dim = {1, 1, rt_pipeline_props.maxRayDispatchInvocationCount + 1};
 
     vkt::Buffer trace_ray_big_depth(*m_device, 4096, buffer_usage, vkt::device_address);
 
-    uint8_t *ray_query_dimensions_buffer_3_ptr = (uint8_t *)trace_ray_big_depth.Memory().Map();
+    uint8_t* ray_query_dimensions_buffer_3_ptr = (uint8_t*)trace_ray_big_depth.Memory().Map();
     std::memcpy(ray_query_dimensions_buffer_3_ptr, &trace_rays_dim, sizeof(trace_rays_dim));
 
     m_command_buffer.Begin();
@@ -154,7 +154,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
 
     // Set shaders
 
-    const char *ray_gen = R"glsl(
+    const char* ray_gen = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require // Requires SPIR-V 1.5 (Vulkan 1.2)
         #extension GL_EXT_buffer_reference : enable
@@ -178,7 +178,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
     )glsl";
     pipeline.SetGlslRayGenShader(ray_gen);
 
-    const char *miss = R"glsl(
+    const char* miss = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
 
@@ -190,7 +190,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
     )glsl";
     pipeline.AddGlslMissShader(miss);
 
-    const char *closest_hit = R"glsl(
+    const char* closest_hit = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require
 
@@ -215,7 +215,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
     // Create uniform_buffer
     vkt::Buffer rt_params_buffer(*m_device, 4 * sizeof(float), 0, vkt::device_address);  // missing space for Tmin and Tmax
     vkt::Buffer uniform_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(uniform_buffer.Memory().Map());
     data[0] = rt_params_buffer.Address();
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer, 0, 16, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
@@ -229,7 +229,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
         m_errorMonitor->SetDesiredWarning(
             "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
             "pipelines created with it");
-        std::vector<const vkt::DescriptorSetLayout *> desc_set_layouts(max_bound_desc_sets);
+        std::vector<const vkt::DescriptorSetLayout*> desc_set_layouts(max_bound_desc_sets);
         for (uint32_t i = 0; i < max_bound_desc_sets; i++) {
             desc_set_layouts[i] = &pipeline.GetDescriptorSet().layout_;
         }
@@ -238,7 +238,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
     }
 
     // Then use the maximum allowed number of sets
-    std::vector<const vkt::DescriptorSetLayout *> des_set_layouts(max_bound_desc_sets - 1);
+    std::vector<const vkt::DescriptorSetLayout*> des_set_layouts(max_bound_desc_sets - 1);
     for (uint32_t i = 0; i < max_bound_desc_sets - 1; i++) {
         des_set_layouts[i] = &pipeline.GetDescriptorSet().layout_;
     }
@@ -301,7 +301,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferRayGenShader) {
     vkt::as::BuildGeometryInfoKHR cubes_tlas =
         vkt::as::blueprint::GetCubesTLAS(*m_device, m_command_buffer, *m_default_queue, cube_blas);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         struct UniformBuffer {
             uint ray_payload_i;
@@ -389,7 +389,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferRayGenShader) {
 
         m_command_buffer.End();
 
-        uint32_t *uniform_buffer_ptr = (uint32_t *)uniform_buffer.Memory().Map();
+        uint32_t* uniform_buffer_ptr = (uint32_t*)uniform_buffer.Memory().Map();
 
         {
             uniform_buffer_ptr[0] = 25;
@@ -443,7 +443,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferMissShader) {
     vkt::as::BuildGeometryInfoKHR cubes_tlas =
         vkt::as::blueprint::GetCubesTLAS(*m_device, m_command_buffer, *m_default_queue, cube_blas);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         struct UniformBuffer {
             uint ray_payload_i;
@@ -529,7 +529,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferMissShader) {
 
         m_command_buffer.End();
 
-        uint32_t *uniform_buffer_ptr = (uint32_t *)uniform_buffer.Memory().Map();
+        uint32_t* uniform_buffer_ptr = (uint32_t*)uniform_buffer.Memory().Map();
 
         {
             uniform_buffer_ptr[0] = 25;
@@ -582,7 +582,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferClosetHitShader) {
     std::shared_ptr<vkt::as::BuildGeometryInfoKHR> cube_blas;
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::GetCubesTLAS(*m_device, m_command_buffer, *m_default_queue, cube_blas);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         struct UniformBuffer {
             uint ray_payload_i;
@@ -669,7 +669,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferClosetHitShader) {
 
         m_command_buffer.End();
 
-        uint32_t *uniform_buffer_ptr = (uint32_t *)uniform_buffer.Memory().Map();
+        uint32_t* uniform_buffer_ptr = (uint32_t*)uniform_buffer.Memory().Map();
 
         {
             uniform_buffer_ptr[0] = 25;
@@ -721,7 +721,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferTwoClosetHitShader) {
     std::shared_ptr<vkt::as::BuildGeometryInfoKHR> cube_blas;
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::GetCubesTLAS(*m_device, m_command_buffer, *m_default_queue, cube_blas);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         struct UniformBuffer {
             uint ray_payload_i;
@@ -828,7 +828,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferTwoClosetHitShader) {
 
         m_command_buffer.End();
 
-        uint32_t *uniform_buffer_ptr = (uint32_t *)uniform_buffer.Memory().Map();
+        uint32_t* uniform_buffer_ptr = (uint32_t*)uniform_buffer.Memory().Map();
 
         {
             uniform_buffer_ptr[0] = 25;
@@ -887,7 +887,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferRayGenShaderGPL) {
     vkt::as::BuildGeometryInfoKHR cubes_tlas =
         vkt::as::blueprint::GetCubesTLAS(*m_device, m_command_buffer, *m_default_queue, cube_blas);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         struct UniformBuffer {
             uint ray_payload_i;
@@ -969,7 +969,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferRayGenShaderGPL) {
     }
     vkt::Buffer debug_buffer(*m_device, 16 * sizeof(uint32_t),
                              VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, kHostVisibleMemProps);
-    uint32_t *debug_buffer_ptr = (uint32_t *)debug_buffer.Memory().Map();
+    uint32_t* debug_buffer_ptr = (uint32_t*)debug_buffer.Memory().Map();
     memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
     pipeline.GetDescriptorIndexingSet().WriteDescriptorBufferInfo(10, debug_buffer, 0, VK_WHOLE_SIZE,
@@ -994,7 +994,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferRayGenShaderGPL) {
 
         m_command_buffer.End();
 
-        uint32_t *uniform_buffer_ptr = (uint32_t *)uniform_buffer.Memory().Map();
+        uint32_t* uniform_buffer_ptr = (uint32_t*)uniform_buffer.Memory().Map();
         {
             uniform_buffer_ptr[0] = 42;
             SCOPED_TRACE("Out of Bounds");
@@ -1054,7 +1054,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferMissShaderGPL) {
     vkt::as::BuildGeometryInfoKHR cubes_tlas =
         vkt::as::blueprint::GetCubesTLAS(*m_device, m_command_buffer, *m_default_queue, cube_blas);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         struct UniformBuffer {
             uint ray_payload_i;
@@ -1137,7 +1137,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferMissShaderGPL) {
     }
     vkt::Buffer debug_buffer(*m_device, 16 * sizeof(uint32_t),
                              VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, kHostVisibleMemProps);
-    uint32_t *debug_buffer_ptr = (uint32_t *)debug_buffer.Memory().Map();
+    uint32_t* debug_buffer_ptr = (uint32_t*)debug_buffer.Memory().Map();
     memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
     pipeline.GetDescriptorIndexingSet().WriteDescriptorBufferInfo(10, debug_buffer, 0, VK_WHOLE_SIZE,
@@ -1162,7 +1162,7 @@ TEST_F(NegativeGpuAVRayTracing, ArrayOOBBufferMissShaderGPL) {
 
         m_command_buffer.End();
 
-        uint32_t *uniform_buffer_ptr = (uint32_t *)uniform_buffer.Memory().Map();
+        uint32_t* uniform_buffer_ptr = (uint32_t*)uniform_buffer.Memory().Map();
         {
             uniform_buffer_ptr[0] = 42;
             SCOPED_TRACE("Out of Bounds");
@@ -1247,7 +1247,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidBlasReference1) {
 
     cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas.GetDstAS()->handle(), cube_instance_2);
 
-    cube_instances[0].UpdateAccelerationStructureInstance(0, [](VkAccelerationStructureInstanceKHR &instance) {
+    cube_instances[0].UpdateAccelerationStructureInstance(0, [](VkAccelerationStructureInstanceKHR& instance) {
         instance.accelerationStructureReference = static_cast<uint64_t>(0xbaadbeef);
     });
 
@@ -1269,10 +1269,10 @@ TEST_F(NegativeGpuAVRayTracing, InvalidBlasReference1) {
     // Buffer used to count invocations for the 3 shaders
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    auto debug_buffer_ptr = static_cast<uint32_t *>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
 
@@ -1414,7 +1414,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidBlasReference2) {
 
     tlas_1[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas.GetDstAS()->handle(), cube_instance_2);
 
-    tlas_1[0].UpdateAccelerationStructureInstance(0, [](VkAccelerationStructureInstanceKHR &instance) {
+    tlas_1[0].UpdateAccelerationStructureInstance(0, [](VkAccelerationStructureInstanceKHR& instance) {
         instance.accelerationStructureReference = static_cast<uint64_t>(0x10);
     });
 
@@ -1468,10 +1468,10 @@ TEST_F(NegativeGpuAVRayTracing, InvalidBlasReference2) {
     // Buffer used to count invocations for the 3 shaders
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    auto debug_buffer_ptr = static_cast<uint32_t *>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
 
@@ -1658,10 +1658,10 @@ TEST_F(NegativeGpuAVRayTracing, InvalidBlasReference3) {
     // Buffer used to count invocations for the 3 shaders
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    auto debug_buffer_ptr = static_cast<uint32_t *>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
 
@@ -1821,10 +1821,10 @@ TEST_F(NegativeGpuAVRayTracing, InvalidBlasReference4) {
     // Buffer used to count invocations for the 3 shaders
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    auto debug_buffer_ptr = static_cast<uint32_t *>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
 
@@ -1999,10 +1999,10 @@ TEST_F(NegativeGpuAVRayTracing, BLASBuiltAndUsedInTLAS) {
     // Buffer used to count invocations for the 3 shaders
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    auto debug_buffer_ptr = static_cast<uint32_t *>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
 
@@ -2163,10 +2163,10 @@ TEST_F(NegativeGpuAVRayTracing, BLASUpdatedAndUsedInTLAS) {
     // Buffer used to count invocations for the 3 shaders
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    auto debug_buffer_ptr = static_cast<uint32_t *>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
 
@@ -2341,10 +2341,10 @@ TEST_F(NegativeGpuAVRayTracing, TLASinBLASlist) {
     // Buffer used to count invocations for the 3 shaders
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    auto debug_buffer_ptr = static_cast<uint32_t *>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
 
-    const char *slang_shader = R"slang(
+    const char* slang_shader = R"slang(
         [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
         [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
 
@@ -2441,8 +2441,8 @@ TEST_F(NegativeGpuAVRayTracing, OutOfBoundsIndex) {
 
     vkt::as::GeometryKHR cube(vkt::as::blueprint::GeometryCubeOnDeviceInfo(*m_device));
 
-    vkt::Buffer &cube_index_buffer = cube.GetTrianglesDeviceIndexBuffer();
-    auto index_buffer_ptr = static_cast<uint32_t *>(cube_index_buffer.Memory().Map());
+    vkt::Buffer& cube_index_buffer = cube.GetTrianglesDeviceIndexBuffer();
+    auto index_buffer_ptr = static_cast<uint32_t*>(cube_index_buffer.Memory().Map());
     index_buffer_ptr[0] = 30;
     index_buffer_ptr[6] = 42;
     index_buffer_ptr[35] = 666;
@@ -2539,7 +2539,7 @@ TEST_F(NegativeGpuAVRayTracing, OutOfBoundsIndex3) {
 
     vkt::Buffer index_buffer(*m_device, sizeof(indices[0]) * indices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-    auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.Memory().Map());
+    auto index_buffer_ptr = static_cast<uint32_t*>(index_buffer.Memory().Map());
     std::copy(indices.begin(), indices.end(), index_buffer_ptr);
     index_buffer.Memory().Unmap();
 
@@ -2704,7 +2704,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate) {
 
     vkt::Buffer index_buffer(*m_device, sizeof(indices[0]) * indices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-    auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.Memory().Map());
+    auto index_buffer_ptr = static_cast<uint32_t*>(index_buffer.Memory().Map());
     std::copy(indices.begin(), indices.end(), index_buffer_ptr);
     index_buffer.Memory().Unmap();
 
@@ -2724,7 +2724,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate) {
 
     {
         SCOPED_TRACE("Update index buffer values");
-        index_buffer_ptr = static_cast<uint32_t *>(cube_blas.GetGeometries()[0].GetTrianglesDeviceIndexBuffer().Memory().Map());
+        index_buffer_ptr = static_cast<uint32_t*>(cube_blas.GetGeometries()[0].GetTrianglesDeviceIndexBuffer().Memory().Map());
 
         index_buffer_ptr[0] = 0;
         index_buffer_ptr[5] = 2;
@@ -2752,7 +2752,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate) {
         constexpr uint32_t index_buffer_2_dword_offset = index_buffer_2_byte_offset / sizeof(uint32_t);
         vkt::Buffer index_buffer_2(*m_device, sizeof(indices[0]) * indices.size() + index_buffer_2_byte_offset, buffer_usage,
                                    kHostVisibleMemProps, &alloc_flags);
-        auto index_buffer_2_ptr = static_cast<uint32_t *>(index_buffer_2.Memory().Map());
+        auto index_buffer_2_ptr = static_cast<uint32_t*>(index_buffer_2.Memory().Map());
         std::copy(indices.begin(), indices.end(), index_buffer_2_ptr + index_buffer_2_dword_offset);
 
         index_buffer_2_ptr[0 + index_buffer_2_dword_offset] = 0;
@@ -2817,7 +2817,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2) {
 
         vkt::Buffer index_buffer(*m_device, sizeof(indices[0]) * indices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-        auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.Memory().Map());
+        auto index_buffer_ptr = static_cast<uint32_t*>(index_buffer.Memory().Map());
         std::copy(indices.begin(), indices.end(), index_buffer_ptr);
         index_buffer.Memory().Unmap();
 
@@ -2846,8 +2846,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2) {
 
     {
         SCOPED_TRACE("Update index buffer values");
-        auto index_buffer_ptr =
-            static_cast<uint32_t *>(cube_blas.GetGeometries()[1].GetTrianglesDeviceIndexBuffer().Memory().Map());
+        auto index_buffer_ptr = static_cast<uint32_t*>(cube_blas.GetGeometries()[1].GetTrianglesDeviceIndexBuffer().Memory().Map());
         index_buffer_ptr[0] = 0;
         index_buffer_ptr[5] = 2;
         index_buffer_ptr[indices.size() - 1] = 1;
@@ -2873,7 +2872,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2) {
         constexpr uint32_t index_buffer_2_dword_offset = index_buffer_2_byte_offset / sizeof(uint32_t);
         vkt::Buffer index_buffer_2(*m_device, sizeof(indices[0]) * indices.size() + index_buffer_2_byte_offset, buffer_usage,
                                    kHostVisibleMemProps, &alloc_flags);
-        auto index_buffer_2_ptr = static_cast<uint32_t *>(index_buffer_2.Memory().Map());
+        auto index_buffer_2_ptr = static_cast<uint32_t*>(index_buffer_2.Memory().Map());
         std::copy(indices.begin(), indices.end(), index_buffer_2_ptr + index_buffer_2_dword_offset);
 
         index_buffer_2_ptr[0 + index_buffer_2_dword_offset] = 0;
@@ -2912,7 +2911,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2) {
         constexpr uint32_t index_buffer_2_dword_offset = index_buffer_2_byte_offset / sizeof(uint32_t);
         vkt::Buffer index_buffer_2(*m_device, sizeof(indices[0]) * indices.size() + index_buffer_2_byte_offset, buffer_usage,
                                    kHostVisibleMemProps, &alloc_flags);
-        auto index_buffer_2_ptr = static_cast<uint32_t *>(index_buffer_2.Memory().Map());
+        auto index_buffer_2_ptr = static_cast<uint32_t*>(index_buffer_2.Memory().Map());
         std::copy(indices.begin(), indices.end(), index_buffer_2_ptr + index_buffer_2_dword_offset);
 
         index_buffer_2_ptr[0 + index_buffer_2_dword_offset] = 0;
@@ -2972,7 +2971,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2Uint16) {
 
         vkt::Buffer index_buffer(*m_device, sizeof(indices[0]) * indices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-        auto index_buffer_ptr = static_cast<uint16_t *>(index_buffer.Memory().Map());
+        auto index_buffer_ptr = static_cast<uint16_t*>(index_buffer.Memory().Map());
         std::copy(indices.begin(), indices.end(), index_buffer_ptr);
         index_buffer.Memory().Unmap();
 
@@ -3001,8 +3000,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2Uint16) {
 
     {
         SCOPED_TRACE("Update index buffer values");
-        auto index_buffer_ptr =
-            static_cast<uint16_t *>(cube_blas.GetGeometries()[1].GetTrianglesDeviceIndexBuffer().Memory().Map());
+        auto index_buffer_ptr = static_cast<uint16_t*>(cube_blas.GetGeometries()[1].GetTrianglesDeviceIndexBuffer().Memory().Map());
         index_buffer_ptr[5] = 2;
         index_buffer_ptr[indices.size() - 1] = 1;
         cube_blas.GetGeometries()[1].GetTrianglesDeviceIndexBuffer().Memory().Unmap();
@@ -3025,7 +3023,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2Uint16) {
         constexpr uint32_t index_buffer_2_word_offset = index_buffer_2_byte_offset / sizeof(uint16_t);
         vkt::Buffer index_buffer_2(*m_device, sizeof(indices[0]) * indices.size() + index_buffer_2_byte_offset, buffer_usage,
                                    kHostVisibleMemProps, &alloc_flags);
-        auto index_buffer_2_ptr = static_cast<uint16_t *>(index_buffer_2.Memory().Map());
+        auto index_buffer_2_ptr = static_cast<uint16_t*>(index_buffer_2.Memory().Map());
         std::copy(indices.begin(), indices.end(), index_buffer_2_ptr + index_buffer_2_word_offset);
 
         index_buffer_2_ptr[5 + index_buffer_2_word_offset] = 2;
@@ -3061,7 +3059,7 @@ TEST_F(NegativeGpuAVRayTracing, InvalidIndexBufferUpdate2Uint16) {
         constexpr uint32_t index_buffer_2_word_offset = index_buffer_2_byte_offset / sizeof(uint16_t);
         vkt::Buffer index_buffer_2(*m_device, sizeof(indices[0]) * indices.size() + index_buffer_2_byte_offset, buffer_usage,
                                    kHostVisibleMemProps, &alloc_flags);
-        auto index_buffer_2_ptr = static_cast<uint16_t *>(index_buffer_2.Memory().Map());
+        auto index_buffer_2_ptr = static_cast<uint16_t*>(index_buffer_2.Memory().Map());
         std::copy(indices.begin(), indices.end(), index_buffer_2_ptr + index_buffer_2_word_offset);
 
         index_buffer_2_ptr[5 + index_buffer_2_word_offset] = 2;
@@ -3129,7 +3127,7 @@ TEST_F(NegativeGpuAVRayTracing, VertexBufferUpdate) {
 
     vkt::Buffer vertex_buffer(*m_device, sizeof(vertices[0]) * vertices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-    auto vertex_buffer_ptr = static_cast<Vertex *>(vertex_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<Vertex*>(vertex_buffer.Memory().Map());
     std::copy(vertices.begin(), vertices.end(), vertex_buffer_ptr);
     vertex_buffer.Memory().Unmap();
 
@@ -3160,7 +3158,7 @@ TEST_F(NegativeGpuAVRayTracing, VertexBufferUpdate) {
         vertices_copy[7].x = -42.0f;
         vkt::Buffer vertex_buffer_2(*m_device, sizeof(vertices_copy[0]) * vertices_copy.size(), buffer_usage, kHostVisibleMemProps,
                                     &alloc_flags);
-        auto vertex_buffer_2_ptr = static_cast<Vertex *>(vertex_buffer_2.Memory().Map());
+        auto vertex_buffer_2_ptr = static_cast<Vertex*>(vertex_buffer_2.Memory().Map());
         std::copy(vertices_copy.begin(), vertices_copy.end(), vertex_buffer_2_ptr);
         vertex_buffer_2.Memory().Unmap();
 
@@ -3193,7 +3191,7 @@ TEST_F(NegativeGpuAVRayTracing, VertexBufferUpdate) {
         const uint32_t vertex_buffer_3_sizeof_vertex_offset = vertex_buffer_3_byte_offset / sizeof(Vertex);
         vkt::Buffer vertex_buffer_3(*m_device, sizeof(vertices[0]) * vertices.size() + vertex_buffer_3_byte_offset, buffer_usage,
                                     kHostVisibleMemProps, &alloc_flags);
-        auto vertex_buffer_3_ptr = static_cast<Vertex *>(vertex_buffer_3.Memory().Map());
+        auto vertex_buffer_3_ptr = static_cast<Vertex*>(vertex_buffer_3.Memory().Map());
         std::copy(vertices.begin(), vertices.end(), vertex_buffer_3_ptr + vertex_buffer_3_sizeof_vertex_offset);
         vertex_buffer_3.Memory().Unmap();
 
@@ -3257,7 +3255,7 @@ TEST_F(NegativeGpuAVRayTracing, VertexBufferUpdateStridedVerticesNoIndexBuffer) 
 
     vkt::Buffer vertex_buffer(*m_device, vertex_stride * vertices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-    auto vertex_buffer_ptr = static_cast<uint8_t *>(vertex_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<uint8_t*>(vertex_buffer.Memory().Map());
 
     for (uint32_t vertex_i = 0; vertex_i < vertices.size(); ++vertex_i) {
         std::memcpy(vertex_buffer_ptr + vertex_i * vertex_stride, vertices.data() + vertex_i, sizeof(Vertex));
@@ -3292,7 +3290,7 @@ TEST_F(NegativeGpuAVRayTracing, VertexBufferUpdateStridedVerticesNoIndexBuffer) 
         vertices_copy[8].x = NAN;
         vkt::Buffer vertex_buffer_2(*m_device, vertex_stride * vertices_copy.size(), buffer_usage, kHostVisibleMemProps,
                                     &alloc_flags);
-        auto vertex_buffer_2_ptr = static_cast<uint8_t *>(vertex_buffer_2.Memory().Map());
+        auto vertex_buffer_2_ptr = static_cast<uint8_t*>(vertex_buffer_2.Memory().Map());
         for (uint32_t vertex_i = 0; vertex_i < vertices_copy.size(); ++vertex_i) {
             std::memcpy(vertex_buffer_2_ptr + vertex_i * vertex_stride, vertices_copy.data() + vertex_i, sizeof(Vertex));
         }
@@ -3372,7 +3370,7 @@ TEST_F(NegativeGpuAVRayTracing, VertexBufferUpdateStridedVerticesIndexBuffer) {
 
     vkt::Buffer vertex_buffer(*m_device, vertex_stride * vertices.size(), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
-    auto vertex_buffer_ptr = static_cast<uint8_t *>(vertex_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<uint8_t*>(vertex_buffer.Memory().Map());
 
     for (uint32_t vertex_i = 0; vertex_i < vertices.size(); ++vertex_i) {
         std::memcpy(vertex_buffer_ptr + vertex_i * vertex_stride, vertices.data() + vertex_i, sizeof(Vertex));
@@ -3414,7 +3412,7 @@ TEST_F(NegativeGpuAVRayTracing, VertexBufferUpdateStridedVerticesIndexBuffer) {
         vertices_copy[8].x = NAN;
         vkt::Buffer vertex_buffer_2(*m_device, vertex_stride * vertices_copy.size(), buffer_usage, kHostVisibleMemProps,
                                     &alloc_flags);
-        auto vertex_buffer_2_ptr = static_cast<uint8_t *>(vertex_buffer_2.Memory().Map());
+        auto vertex_buffer_2_ptr = static_cast<uint8_t*>(vertex_buffer_2.Memory().Map());
         for (uint32_t vertex_i = 0; vertex_i < vertices_copy.size(); ++vertex_i) {
             std::memcpy(vertex_buffer_2_ptr + vertex_i * vertex_stride, vertices_copy.data() + vertex_i, sizeof(Vertex));
         }

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2024-2025 The Khronos Group Inc.
- * Copyright (c) 2024-2025 Valve Corporation
- * Copyright (c) 2024-2025 LunarG, Inc.
+ * Copyright (c) 2024-2026 The Khronos Group Inc.
+ * Copyright (c) 2024-2026 Valve Corporation
+ * Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 class NegativeGpuAVShaderDebugInfo : public GpuAVBufferDeviceAddressTest {
   public:
-    void BasicSingleStorageBufferComputeOOB(const char *shader, const char *error);
+    void BasicSingleStorageBufferComputeOOB(const char* shader, const char* error);
 };
 
 // shader must have a SSBO at (set = 0, binding = 0)
-void NegativeGpuAVShaderDebugInfo::BasicSingleStorageBufferComputeOOB(const char *shader, const char *error) {
+void NegativeGpuAVShaderDebugInfo::BasicSingleStorageBufferComputeOOB(const char* shader, const char* error) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
@@ -36,7 +36,7 @@ void NegativeGpuAVShaderDebugInfo::BasicSingleStorageBufferComputeOOB(const char
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
@@ -57,7 +57,7 @@ void NegativeGpuAVShaderDebugInfo::BasicSingleStorageBufferComputeOOB(const char
 TEST_F(NegativeGpuAVShaderDebugInfo, OpLine) {
     TEST_DESCRIPTION("Make sure basic OpLine works");
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -109,7 +109,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, OpLine) {
 TEST_F(NegativeGpuAVShaderDebugInfo, OpLineColumn) {
     TEST_DESCRIPTION("Make sure the column in OpLine will add value to show which part the error occured");
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -168,7 +168,7 @@ void main() {
 TEST_F(NegativeGpuAVShaderDebugInfo, OpSourceContinued) {
     TEST_DESCRIPTION("Make sure can find source in OpSourceContinued");
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -227,7 +227,7 @@ layout(buffer_reference, std430) readonly buffer IndexBuffer { int indices[]; };
 TEST_F(NegativeGpuAVShaderDebugInfo, BadLineNumber) {
     TEST_DESCRIPTION("OpLine gives a line number not in the source");
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -288,7 +288,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslang) {
 
     // Manually ran:
     //   glslangValidator -V -g in.comp -o out.spv --target-env vulkan1.2
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -365,7 +365,7 @@ void main() {
 TEST_F(NegativeGpuAVShaderDebugInfo, GlslLineDerective) {
     TEST_DESCRIPTION("Use the #line derective in GLSL");
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -437,7 +437,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfo) {
 
     // Manually ran:
     //   glslangValidator -V -gV in.comp -o out.spv --target-env vulkan1.2
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                        OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -547,7 +547,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfo) {
 
 // Manually ran:
 //   glslangValidator -V -gVS in.comp -o out.spv --target-env vulkan1.2
-static const char *kBasicGlslShaderSource = R"(
+static const char* kBasicGlslShaderSource = R"(
               OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -689,7 +689,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfoWithSourceShader
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -718,7 +718,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderDebugInfoColumns) {
     TEST_DESCRIPTION("DebugLine has a Column Start and Column End");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -796,7 +796,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderDebugSourceContinued) {
     TEST_DESCRIPTION("Make sure can find source in DebugSourceContinued");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -876,7 +876,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderDebugLineMultiLine) {
     TEST_DESCRIPTION("DebugLine has a Line Start and Line End");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -953,7 +953,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BadShaderDebugLineStart) {
     TEST_DESCRIPTION("DebugLine Line Start has bad value");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1029,7 +1029,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BadShaderDebugLineEnd) {
     TEST_DESCRIPTION("DebugLine Line End has bad value");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1116,7 +1116,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicDXC) {
     // Manually ran:
     //   dxc -spirv -T cs_6_0 -E main -fspv-target-env=vulkan1.2 -fspv-extension=SPV_KHR_non_semantic_info
     //   -fspv-debug=vulkan-with-source in.hlsl
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -1226,7 +1226,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, NoLineInFunctionFirst) {
     TEST_DESCRIPTION("Test if first function listed, has no debug info, we don't use the functions after it");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1353,7 +1353,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, NoLineInFunctionLast) {
     TEST_DESCRIPTION("Test if last function listed, has no debug info, we don't use the functions before it");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1486,7 +1486,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PipelineHandles) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1506,14 +1506,14 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PipelineHandles) {
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr};
     pipe.CreateComputePipeline();
 
-    const char *pipe_name = "bad_pipeline";
+    const char* pipe_name = "bad_pipeline";
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_PIPELINE;
     name_info.objectHandle = (uint64_t)pipe.Handle();
     name_info.pObjectName = pipe_name;
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
 
-    const char *cb_name = "bad_command_buffer";
+    const char* cb_name = "bad_command_buffer";
     name_info.objectType = VK_OBJECT_TYPE_COMMAND_BUFFER;
     name_info.objectHandle = (uint64_t)m_command_buffer.handle();
     name_info.pObjectName = cb_name;
@@ -1521,7 +1521,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PipelineHandles) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1570,7 +1570,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderObjectHandle) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -1582,7 +1582,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderObjectHandle) {
     VkShaderStageFlagBits shader_stages[] = {VK_SHADER_STAGE_COMPUTE_BIT};
     const vkt::Shader comp_shader(*m_device, shader_stages[0], GLSLToSPV(shader_stages[0], comp_src), &descriptorSetLayout);
 
-    const char *object_name = "bad_shader_object";
+    const char* object_name = "bad_shader_object";
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_SHADER_EXT;
     name_info.objectHandle = (uint64_t)comp_shader.handle();
@@ -1613,7 +1613,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, CommandBufferCommandIndex) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1635,7 +1635,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, CommandBufferCommandIndex) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1677,7 +1677,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfo) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1701,7 +1701,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfo) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1731,7 +1731,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel1) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1755,7 +1755,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel1) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1792,7 +1792,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel2) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1816,7 +1816,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel2) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1855,7 +1855,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel3) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1879,7 +1879,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel3) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -1932,7 +1932,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel4) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1956,7 +1956,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel4) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -2019,7 +2019,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, DISABLED_StageInfoWithDebugLabel5) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -2043,7 +2043,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, DISABLED_StageInfoWithDebugLabel5) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -2113,7 +2113,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel6) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -2137,7 +2137,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel6) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -2173,8 +2173,8 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel6) {
     vk::CmdEndDebugUtilsLabelEXT(cb_2);
 
     vk::CmdBindPipeline(cb_2, VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe);
-    vk::CmdBindDescriptorSets(cb_2, VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe.pipeline_layout_, 0, 1,
-                              &bad_pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdBindDescriptorSets(cb_2, VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe.pipeline_layout_, 0, 1, &bad_pipe.descriptor_set_.set_,
+                              0, nullptr);
     vk::CmdDispatch(cb_2, 2, 1, 1);
 
     // End of region 0
@@ -2203,7 +2203,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel7) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -2227,7 +2227,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel7) {
 
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    auto data = static_cast<VkDeviceAddress*>(in_buffer.Memory().Map());
     data[0] = block_buffer.Address();
 
     bad_pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -2282,7 +2282,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PostProcessingDebugLabelMultipleCommandBuff
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -2373,7 +2373,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, IndirectCommandDebugLabel) {
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer indirect_buffer(*m_device, 1024, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    VkDispatchIndirectCommand* ptr = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     ptr[0].x = 1;
     ptr[0].y = 1;
     ptr[0].z = 1;
@@ -2422,7 +2422,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderInternalId) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_shader = R"glsl(
+    const char* cs_shader = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { mat4 x; };
         void main() {
@@ -2467,7 +2467,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PostProcess) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                OpCapability Shader
           %2 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -2598,7 +2598,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PostProcessSlangGPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -2804,7 +2804,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ReachMaxActionsCommandValidationLimitUnknow
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0) buffer foo {
@@ -2864,7 +2864,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ReachMaxErrorLoggerLimitUnkown) {
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer indirect_buffer(*m_device, 1024, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
+    VkDispatchIndirectCommand* ptr = static_cast<VkDispatchIndirectCommand*>(indirect_buffer.Memory().Map());
     ptr[0].x = 1;
     ptr[0].y = 1;
     ptr[0].z = 1;

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Nintendo
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Nintendo
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 kHostVisibleMemProps);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
+    auto& indirect_draw_parameters = *static_cast<VkDrawIndirectCommand*>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
@@ -74,7 +74,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
     plci.pPushConstantRanges = push_constant_ranges.data();
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -103,7 +103,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
 
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -153,7 +153,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto storage_buffer_ptr = static_cast<int32_t *>(storage_buffer.Memory().Map());
+    auto storage_buffer_ptr = static_cast<int32_t*>(storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], i);
     }
@@ -180,7 +180,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
     // Graphics pipeline
     // ---
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -209,7 +209,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
 
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -251,7 +251,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 kHostVisibleMemProps);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
+    auto& indirect_draw_parameters = *static_cast<VkDrawIndirectCommand*>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
@@ -268,7 +268,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
     // Compute pipeline
     // ---
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -314,8 +314,8 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
 
     vkt::Buffer indirect_dispatch_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                     kHostVisibleMemProps);
-    auto &indirect_dispatch_parameters =
-        *static_cast<VkDispatchIndirectCommand *>(indirect_dispatch_parameters_buffer.Memory().Map());
+    auto& indirect_dispatch_parameters =
+        *static_cast<VkDispatchIndirectCommand*>(indirect_dispatch_parameters_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1;
     indirect_dispatch_parameters.y = 1;
     indirect_dispatch_parameters.z = 1;
@@ -344,12 +344,12 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    auto compute_storage_buffer_ptr = static_cast<int32_t *>(compute_storage_buffer.Memory().Map());
+    auto compute_storage_buffer_ptr = static_cast<int32_t*>(compute_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(compute_storage_buffer_ptr[i], int_count + i);
     }
 
-    auto graphics_storage_buffer_ptr = static_cast<int32_t *>(graphics_storage_buffer.Memory().Map());
+    auto graphics_storage_buffer_ptr = static_cast<int32_t*>(graphics_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(graphics_storage_buffer_ptr[i], i);
     }
@@ -390,8 +390,8 @@ TEST_F(PositiveGpuAVShaderObject, DispatchShaderObjectAndPipeline) {
 
     vkt::Buffer indirect_dispatch_parameters_buffer(*m_device, sizeof(VkDispatchIndirectCommand),
                                                     VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
-    auto &indirect_dispatch_parameters =
-        *static_cast<VkDispatchIndirectCommand *>(indirect_dispatch_parameters_buffer.Memory().Map());
+    auto& indirect_dispatch_parameters =
+        *static_cast<VkDispatchIndirectCommand*>(indirect_dispatch_parameters_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1u;
     indirect_dispatch_parameters.y = 1u;
     indirect_dispatch_parameters.z = 1u;

--- a/tests/unit/gpu_av_shader_sanitizer.cpp
+++ b/tests/unit/gpu_av_shader_sanitizer.cpp
@@ -22,7 +22,7 @@
 class NegativeGpuAVShaderSanitizer : public GpuAVGpuAVShaderSanitizer {};
 
 TEST_F(NegativeGpuAVShaderSanitizer, DivideByZeroUDivScalar) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout(set=0, binding=0) buffer SSBO {
             uint index;
@@ -38,7 +38,7 @@ TEST_F(NegativeGpuAVShaderSanitizer, DivideByZeroUDivScalar) {
 }
 
 TEST_F(NegativeGpuAVShaderSanitizer, DivideByZeroSDivScalar) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout(set=0, binding=0) buffer SSBO {
             int index;
@@ -54,7 +54,7 @@ TEST_F(NegativeGpuAVShaderSanitizer, DivideByZeroSDivScalar) {
 }
 
 TEST_F(NegativeGpuAVShaderSanitizer, DivideByZeroUDivVector) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout(set=0, binding=0) buffer SSBO {
             uvec4 index;
@@ -70,7 +70,7 @@ TEST_F(NegativeGpuAVShaderSanitizer, DivideByZeroUDivVector) {
 }
 
 TEST_F(NegativeGpuAVShaderSanitizer, DivideByZeroSDivVector) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout(set=0, binding=0) buffer SSBO {
             ivec2 index;

--- a/tests/unit/gpu_av_shader_sanitizer_positive.cpp
+++ b/tests/unit/gpu_av_shader_sanitizer_positive.cpp
@@ -23,7 +23,7 @@
 class PositiveGpuAVShaderSanitizer : public GpuAVGpuAVShaderSanitizer {};
 
 // Set a single SSBO to all zero
-void GpuAVGpuAVShaderSanitizer::SimpleZeroComputeTest(const char *shader, int source_type, const char *expected_error,
+void GpuAVGpuAVShaderSanitizer::SimpleZeroComputeTest(const char* shader, int source_type, const char* expected_error,
                                                       uint32_t error_count) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
@@ -34,7 +34,7 @@ void GpuAVGpuAVShaderSanitizer::SimpleZeroComputeTest(const char *shader, int so
     pipe.CreateComputePipeline();
 
     vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    void *in_ptr = in_buffer.Memory().Map();
+    void* in_ptr = in_buffer.Memory().Map();
     memset(in_ptr, 0, 256);
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -53,7 +53,7 @@ void GpuAVGpuAVShaderSanitizer::SimpleZeroComputeTest(const char *shader, int so
 }
 
 TEST_F(PositiveGpuAVShaderSanitizer, DivideByOne) {
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout(set=0, binding=0) buffer SSBO {
             uint u_index;
@@ -141,7 +141,7 @@ TEST_F(PositiveGpuAVShaderSanitizer, ImageGather) {
     // if (condition != 0) {
     //     result = textureGather(tex, vec2(0), -1);
     // }
-    const char *cs_source = R"asm(
+    const char* cs_source = R"asm(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %_ %tex
@@ -207,7 +207,7 @@ TEST_F(PositiveGpuAVShaderSanitizer, ImageGather) {
     pipe.CreateComputePipeline();
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    void *in_ptr = buffer.Memory().Map();
+    void* in_ptr = buffer.Memory().Map();
     memset(in_ptr, 0, 64);
 
     vkt::Image image(*m_device, 16, 16, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);

--- a/tests/unit/gpu_av_shared_memory_data_race.cpp
+++ b/tests/unit/gpu_av_shared_memory_data_race.cpp
@@ -57,7 +57,7 @@ void NegativeGpuAVSharedMemoryDataRace::TestHelper(const char* shader_source, in
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, SingleScalar) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -71,7 +71,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, SingleScalar) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, SingleElementArray) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 3) in;
@@ -85,7 +85,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, SingleElementArray) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoThreadsShareValuesThroughArray) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -100,7 +100,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoThreadsShareValuesThroughArray) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoDimensionalArray) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 3) in;
@@ -115,7 +115,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoDimensionalArray) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, BasicStruct) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -139,7 +139,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, BasicStruct) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, StructVsScalar) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -160,7 +160,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, StructVsScalar) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, VectorVsScalar) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -179,7 +179,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, VectorVsScalar) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoVariables) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -202,7 +202,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoVariables) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoVectors) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -225,7 +225,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, TwoVectors) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, VectorArray) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 4) in;
@@ -245,7 +245,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, VectorArray) {
 TEST_F(NegativeGpuAVSharedMemoryDataRace, ShortIndex) {
     AddRequiredFeature(vkt::Feature::shaderInt16);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
 
@@ -264,7 +264,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, ShortIndex) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, SpecConstantArray) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -280,7 +280,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, SpecConstantArray) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, VariableName) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -547,7 +547,7 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, SlangNestedStruct) {
 }
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, SlangMultiEntryPoint) {
-    const char *shader_source = R"slang(
+    const char* shader_source = R"slang(
         RWStructuredBuffer<uint4> outputBuffer;
         groupshared uint4 a;
         groupshared uint4 b;
@@ -582,7 +582,6 @@ TEST_F(NegativeGpuAVSharedMemoryDataRace, SlangMultiEntryPoint) {
 
     TestHelper(shader_source, SPV_SOURCE_SLANG, 1);
 }
-
 
 TEST_F(NegativeGpuAVSharedMemoryDataRace, NoOpName) {
     const char* shader_source = R"(

--- a/tests/unit/gpu_av_shared_memory_data_race_positive.cpp
+++ b/tests/unit/gpu_av_shared_memory_data_race_positive.cpp
@@ -24,17 +24,18 @@ void GpuAVSharedMemoryDataRaceTest::InitSharedMemoryDataRace(uint32_t message_li
     // some tests can report a variable number of errors, depending on the order invocations
     // execute the instructions (max one error reported per invocation). message_limit should
     // be set to the minimum number of expected errors.
-    RETURN_IF_SKIP(InitGpuAvFramework({{OBJECT_LAYER_NAME, "duplicate_message_limit", VK_LAYER_SETTING_TYPE_UINT32_EXT, 1, &message_limit}}, false));
+    RETURN_IF_SKIP(InitGpuAvFramework(
+        {{OBJECT_LAYER_NAME, "duplicate_message_limit", VK_LAYER_SETTING_TYPE_UINT32_EXT, 1, &message_limit}}, false));
     RETURN_IF_SKIP(InitState());
 }
 
 class PositiveGpuAVSharedMemoryDataRace : public GpuAVSharedMemoryDataRaceTest {
   protected:
-    void TestHelper(const char *source, int source_type, spv_target_env env = SPV_ENV_VULKAN_1_2,
+    void TestHelper(const char* source, int source_type, spv_target_env env = SPV_ENV_VULKAN_1_2,
                     VkScopeKHR coopmat_scope = VK_SCOPE_DEVICE_KHR);
 };
 
-void PositiveGpuAVSharedMemoryDataRace::TestHelper(const char *shader_source, int source_type, spv_target_env env,
+void PositiveGpuAVSharedMemoryDataRace::TestHelper(const char* shader_source, int source_type, spv_target_env env,
                                                    VkScopeKHR coopmat_scope) {
     RETURN_IF_SKIP(InitSharedMemoryDataRace());
     if (source_type == SPV_SOURCE_SLANG) {
@@ -67,7 +68,7 @@ void PositiveGpuAVSharedMemoryDataRace::TestHelper(const char *shader_source, in
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, SingleScalar) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
 
@@ -82,7 +83,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, SingleScalar) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, SingleElementAccess) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -96,7 +97,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, SingleElementAccess) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoThreadsShareValuesThroughArray) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -112,7 +113,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoThreadsShareValuesThroughArray) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoDimensionalArrayBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 3) in;
@@ -128,7 +129,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoDimensionalArrayBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoDimensionalArray) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 3) in;
@@ -143,7 +144,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoDimensionalArray) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, BasicStructBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -168,7 +169,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, BasicStructBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, StructVsScalarBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -190,7 +191,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, StructVsScalarBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, VectorVsScalarBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -210,7 +211,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, VectorVsScalarBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoVariablesBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -234,7 +235,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoVariablesBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoVectorsBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -258,7 +259,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, TwoVectorsBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, MultiLoad) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -274,7 +275,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, MultiLoad) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, VectorArrayBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 4) in;
@@ -293,7 +294,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, VectorArrayBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, SpecConstantArrayBarrier) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
 
         layout(local_size_x = 2) in;
@@ -310,7 +311,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, SpecConstantArrayBarrier) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, NoLocalSize) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
 
@@ -324,7 +325,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, NoLocalSize) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, SpvEnvVulkan13) {
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
 
@@ -377,7 +378,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, SlangBasic) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, SlangNestedStruct) {
-    const char *shader_source = R"slang(
+    const char* shader_source = R"slang(
         RWStructuredBuffer<float> outputBuffer;
 
         [numthreads(2, 1, 1)]
@@ -409,7 +410,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, SlangNestedStruct) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, SlangMultiEntryPoint) {
-    const char *shader_source = R"slang(
+    const char* shader_source = R"slang(
         RWStructuredBuffer<uint4> outputBuffer;
         groupshared uint4 a;
         groupshared uint4 b;
@@ -449,7 +450,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, SlangMultiEntryPoint) {
 }
 
 TEST_F(PositiveGpuAVSharedMemoryDataRace, SlangMultiEntryPoint2) {
-    const char *shader_source = R"slang(
+    const char* shader_source = R"slang(
         RWStructuredBuffer<uint4> outputBuffer;
         groupshared uint4 a;
         groupshared uint4 b;
@@ -488,7 +489,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, SlangMultiEntryPoint2) {
 TEST_F(PositiveGpuAVSharedMemoryDataRace, LongVectorArrayBarrier) {
     AddRequiredFeature(vkt::Feature::longVector);
     AddRequiredExtensions(VK_EXT_SHADER_LONG_VECTOR_EXTENSION_NAME);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_long_vector : enable
 
@@ -513,7 +514,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, StoreBarrierCoopMatLoad) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -540,7 +541,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, CoopMatStoreBarrierLoad) {
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -573,7 +574,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, CoopMatLoadCoopMatStoreDisjoint) {
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -608,7 +609,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, StoreBarrierCoopMatLoadWorkgroup) {
     AddRequiredFeature(vkt::Feature::cooperativeMatrixFlexibleDimensions);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
     AddRequiredExtensions(VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -637,7 +638,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, CoopMatStoreBarrierLoadWorkgroup) {
     AddRequiredFeature(vkt::Feature::cooperativeMatrixFlexibleDimensions);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
     AddRequiredExtensions(VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME);
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -665,7 +666,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, CoopMatLoadCoopMatStoreDisjointVector)
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -698,7 +699,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, CoopMatLoadCoopMatStoreDisjointFloat) 
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -731,7 +732,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, CoopMatLoadCoopMatStoreDisjointVec4) {
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -765,7 +766,7 @@ TEST_F(PositiveGpuAVSharedMemoryDataRace, CoopMatLoadCoopMatStoreDisjointUint8) 
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_KHR_memory_scope_semantics : enable

--- a/tests/unit/gpu_av_spirv.cpp
+++ b/tests/unit/gpu_av_spirv.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024-2025 The Khronos Group Inc.
- * Copyright (c) 2024-2025 Valve Corporation
- * Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 The Khronos Group Inc.
+ * Copyright (c) 2024-2026 Valve Corporation
+ * Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ TEST_F(NegativeGpuAVSpirv, DISABLED_LoopHeaderPhi) {
     // The issue is the OpPhi inside the loop header, it needs to be
     // in the OpLoopMerge block for the back edge (%19) to be valid.
     // This means doing a if/else like normal breaks this.
-    const char *cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %data
@@ -95,7 +95,7 @@ TEST_F(NegativeGpuAVSpirv, DISABLED_LoopHeaderPhi) {
     pipe.CreateComputePipeline();
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     // Will get to data[4] in loop and can crash
     data[0] = 32;  // data[0]
     data[1] = 32;  // data[1]

--- a/tests/unit/gpu_av_spirv_positive.cpp
+++ b/tests/unit/gpu_av_spirv_positive.cpp
@@ -30,7 +30,7 @@ TEST_F(PositiveGpuAVSpirv, LoopPhi) {
     vkt::Buffer buffer_uniform(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
     vkt::Buffer buffer_storage(*m_device, 1024, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    uint32_t *data = (uint32_t *)buffer_uniform.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer_uniform.Memory().Map();
     data[0] = 4;  // Scene.lightCount
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -78,7 +78,7 @@ TEST_F(PositiveGpuAVSpirv, LoopPhi) {
     // OpBranch %2
     //
     // %4 = OpLabel
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -184,7 +184,7 @@ TEST_F(PositiveGpuAVSpirv, LoopHeaderPhi) {
     //         data[0] += i;
     //     }
     // }
-    const char *cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %data
@@ -236,7 +236,7 @@ TEST_F(PositiveGpuAVSpirv, LoopHeaderPhi) {
     pipe.CreateComputePipeline();
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     data[0] = 1;  // data[0]
     data[1] = 2;  // data[1]
     data[2] = 3;  // data[2]
@@ -268,7 +268,7 @@ TEST_F(PositiveGpuAVSpirv, VulkanMemoryModelDeviceScope) {
 
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
 
-    uint32_t *data = (uint32_t *)buffer.Memory().Map();
+    uint32_t* data = (uint32_t*)buffer.Memory().Map();
     data[0] = 1;
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -287,7 +287,7 @@ TEST_F(PositiveGpuAVSpirv, VulkanMemoryModelDeviceScope) {
     // void main() {
     //     foo.bar[0] = foo.bar[foo.x];
     // }
-    const char *cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
                OpCapability VulkanMemoryModel
                OpCapability PhysicalStorageBufferAddresses

--- a/tests/unit/gpu_av_vertex_attribute_fetch.cpp
+++ b/tests/unit/gpu_av_vertex_attribute_fetch.cpp
@@ -105,7 +105,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex32) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -160,7 +160,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex16) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -218,7 +218,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex8) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -273,7 +273,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex32) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -330,7 +330,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex32ShaderObject) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -380,7 +380,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawInSecondaryCmdBufferBadVertexIndex
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -416,7 +416,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawInSecondaryCmdBufferBadVertexIndex
 
     constexpr uint32_t secondary_cmd_buffer_executes_count = 2;
     for (uint32_t i = 0; i < secondary_cmd_buffer_executes_count; ++i) {
-        vkt::CommandBuffer &secondary_cmd_buffer =
+        vkt::CommandBuffer& secondary_cmd_buffer =
             secondary_cmd_buffers.emplace_back(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
         secondary_cmd_buffers_handles.push_back(secondary_cmd_buffer);
 
@@ -459,7 +459,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex16) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -514,7 +514,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex16_2) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -581,7 +581,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex8) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -639,7 +639,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex16DebugLabel) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -716,7 +716,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex32DebugLabel
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -789,7 +789,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, InstanceIndex) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -877,7 +877,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, InstanceIndexVertexAttributeDivisor) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -976,7 +976,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, InstanceIndexVertexAttributeDivisorDyn
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -1093,7 +1093,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, CmdSetVertexInputEXT) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -1184,7 +1184,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, CmdBindVertexBuffers2EXT) {
         std::array<float, 3> normal;
     };
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -1271,7 +1271,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex32MultiDraw) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {

--- a/tests/unit/gpu_av_vertex_attribute_fetch_positive.cpp
+++ b/tests/unit/gpu_av_vertex_attribute_fetch_positive.cpp
@@ -25,7 +25,7 @@ TEST_F(PositiveGpuAVVertexAttributeFetch, IndirectDrawZeroStride) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -709,10 +709,10 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
     OneOffDescriptorSet ds2(m_device, {
                                           {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                       });
-    OneOffDescriptorSet ds_immutable_sampler(m_device,
-                                             {
-                                                 {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()},
-                                             });
+    OneOffDescriptorSet ds_immutable_sampler(
+        m_device, {
+                      {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()},
+                  });
 
     // We _vs and _fs layouts are identical, but we want them to be separate handles handles for the sake layout merging
     vkt::PipelineLayout pipeline_layout_vs(*m_device, {&ds.layout_, &ds2.layout_}, {},
@@ -1119,7 +1119,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const char *tcs_src = R"glsl(
+    const char* tcs_src = R"glsl(
         #version 450
         layout(vertices=3) out;
         void main(){
@@ -1130,7 +1130,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     const auto tcs_spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, tcs_src);
     vkt::GraphicsPipelineLibraryStage tcs_stage(tcs_spv, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
 
-    const char *tes_src = R"glsl(
+    const char* tes_src = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -1375,9 +1375,10 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
     OneOffDescriptorSet ds(m_device, {
                                          {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
                                      });
-    OneOffDescriptorSet ds1(m_device, {
-                                         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
-                                     });
+    OneOffDescriptorSet ds1(
+        m_device, {
+                      {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                  });
     OneOffDescriptorSet ds2(m_device, {
                                           {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                       });

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -925,7 +925,9 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
     pr_lib.CreateGraphicsPipeline();
 
     VkPipeline libraries[3] = {
-        vi_lib, pr_lib, fs_lib,
+        vi_lib,
+        pr_lib,
+        fs_lib,
         // fragment output not needed due to rasterization being disabled
     };
     VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -499,7 +499,7 @@ TEST_F(NegativeHostImageCopy, Image1D) {
 TEST_F(NegativeHostImageCopy, Image1DMultiSampled) {
     RETURN_IF_SKIP(InitHostImageCopyTest());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "VK_SAMPLE_COUNT_2_BIT not supported";
     }
@@ -2273,7 +2273,7 @@ TEST_F(NegativeHostImageCopy, DISABLED_ImageMemoryOverlap) {
     vkt::Image image(*m_device, image_ci, kHostVisibleMemProps);
     image.SetLayout(layout);
 
-    VkDeviceAddress *data = (VkDeviceAddress *)image.Memory().Map();
+    VkDeviceAddress* data = (VkDeviceAddress*)image.Memory().Map();
 
     VkImageToMemoryCopy region = vku::InitStructHelper();
     region.pHostPointer = data;
@@ -2344,7 +2344,7 @@ TEST_F(NegativeHostImageCopy, DISABLED_ImageMemoryOverlapCompressed) {
     vkt::Image image(*m_device, image_ci, kHostVisibleMemProps);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
-    VkDeviceAddress *data = (VkDeviceAddress *)image.Memory().Map();
+    VkDeviceAddress* data = (VkDeviceAddress*)image.Memory().Map();
 
     VkMemoryToImageCopy region2 = vku::InitStructHelper();
     region2.pHostPointer = data;

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
- * Copyright (c) 2023-2025 Google, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
+ * Copyright (c) 2023-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include <algorithm>
 
-bool HostImageCopyTest::CopyLayoutSupported(const std::vector<VkImageLayout> &src_layouts,
-                                            const std::vector<VkImageLayout> &dst_layouts, VkImageLayout layout) {
+bool HostImageCopyTest::CopyLayoutSupported(const std::vector<VkImageLayout>& src_layouts,
+                                            const std::vector<VkImageLayout>& dst_layouts, VkImageLayout layout) {
     return ((std::find(src_layouts.begin(), src_layouts.end(), layout) != src_layouts.end()) &&
             (std::find(dst_layouts.begin(), dst_layouts.end(), layout) != dst_layouts.end()));
 }
@@ -62,7 +62,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
 
     std::vector<uint8_t> pixels(width * height * 4);
     // Fill image with random values
-    for (auto &channel : pixels) {
+    for (auto& channel : pixels) {
         const uint32_t r = static_cast<uint32_t>(std::rand());
         channel = static_cast<uint8_t>((r & 0xffu) | ((r >> 8) & 0xff) | ((r >> 16) & 0xff) | (r >> 24));
     }
@@ -200,7 +200,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage14) {
 
     std::vector<uint8_t> pixels(width * height * 4);
     // Fill image with random values
-    for (auto &channel : pixels) {
+    for (auto& channel : pixels) {
         const uint32_t r = static_cast<uint32_t>(std::rand());
         channel = static_cast<uint8_t>((r & 0xffu) | ((r >> 8) & 0xff) | ((r >> 16) & 0xff) | (r >> 24));
     }

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -65,13 +65,13 @@ TEST_F(NegativeImage, UsageBits) {
     // equvalent test using using KHR_copy_commands2
     if (copy_commands2) {
         const VkBufferImageCopy2 region2 = {VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2,
-                                           NULL,
-                                           region.bufferRowLength,
-                                           region.bufferImageHeight,
-                                           region.bufferImageHeight,
-                                           region.imageSubresource,
-                                           region.imageOffset,
-                                           region.imageExtent};
+                                            NULL,
+                                            region.bufferRowLength,
+                                            region.bufferImageHeight,
+                                            region.bufferImageHeight,
+                                            region.imageSubresource,
+                                            region.imageOffset,
+                                            region.imageExtent};
         VkCopyBufferToImageInfo2 buffer_to_image_info2 = {VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2, NULL, buffer,  image,
                                                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,          1,    &region2};
         // two separate errors from this call:
@@ -181,7 +181,7 @@ TEST_F(NegativeImage, SampleCounts) {
         vkt::Buffer dst_buffer(*m_device, 128 * 128 * 4, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        vkt::Image src_image(*m_device, (const VkImageCreateInfo &)image_create_info, 0);
+        vkt::Image src_image(*m_device, (const VkImageCreateInfo&)image_create_info, 0);
         m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError(
             "was created with a sample count of VK_SAMPLE_COUNT_4_BIT but must be VK_SAMPLE_COUNT_1_BIT");
@@ -2458,7 +2458,7 @@ TEST_F(NegativeImage, MaxLimitsFramebufferWidth) {
     TEST_DESCRIPTION("Create invalid image with invalid parameters exceeding physical device limits.");
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     if (dev_limits.maxFramebufferWidth == vvl::kU32Max) {
         GTEST_SKIP() << "maxFramebufferWidth is already UINT32_MAX";
     }
@@ -2479,7 +2479,7 @@ TEST_F(NegativeImage, MaxLimitsFramebufferHeight) {
     TEST_DESCRIPTION("Create invalid image with invalid parameters exceeding physical device limits.");
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     if (dev_limits.maxFramebufferHeight == vvl::kU32Max) {
         GTEST_SKIP() << "maxFramebufferHeight is already UINT32_MAX";
     }
@@ -2595,8 +2595,7 @@ TEST_F(NegativeImage, Stencil) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-    VkPhysicalDeviceImageFormatInfo2 image_format_info2 =
-        vku::InitStructHelper(&image_stencil_create_info);
+    VkPhysicalDeviceImageFormatInfo2 image_format_info2 = vku::InitStructHelper(&image_stencil_create_info);
     image_format_info2.format = image_create_info.format;
     image_format_info2.type = image_create_info.imageType;
     image_format_info2.tiling = image_create_info.tiling;
@@ -2658,7 +2657,7 @@ TEST_F(NegativeImage, StencilLimits) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     if (dev_limits.maxFramebufferWidth == vvl::kU32Max) {
         GTEST_SKIP() << "maxFramebufferWidth is already UINT32_MAX";
     }
@@ -3056,7 +3055,7 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCountWithDeviceGroup) {
     VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = 0;
     create_device_pnext.pPhysicalDevices = nullptr;
-    for (const auto &dg : physical_device_group) {
+    for (const auto& dg : physical_device_group) {
         if (dg.physicalDeviceCount > 1) {
             create_device_pnext.physicalDeviceCount = dg.physicalDeviceCount;
             create_device_pnext.pPhysicalDevices = dg.physicalDevices;
@@ -3215,7 +3214,7 @@ TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
     VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = 0;
     create_device_pnext.pPhysicalDevices = nullptr;
-    for (const auto &dg : physical_device_group) {
+    for (const auto& dg : physical_device_group) {
         if (dg.physicalDeviceCount > 1) {
             create_device_pnext.physicalDeviceCount = dg.physicalDeviceCount;
             create_device_pnext.pPhysicalDevices = dg.physicalDevices;
@@ -3412,7 +3411,7 @@ TEST_F(NegativeImage, MultiSampleImageView) {
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required VkSampleCountFlagBits are not supported; skipping";
     }
@@ -3663,7 +3662,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
         CreateImageTest(image_create_info, "VUID-VkImageCompressionControlEXT-flags-06748");
     }
 
-    const auto create_compressed_image = [&](VkFormat format, VkImageTiling imageTiling, vkt::Image &image) -> bool {
+    const auto create_compressed_image = [&](VkFormat format, VkImageTiling imageTiling, vkt::Image& image) -> bool {
         VkImageCompressionControlEXT compression_control = vku::InitStructHelper();  // specify the desired compression settings
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT;
 
@@ -3805,7 +3804,7 @@ TEST_F(NegativeImage, ImageCompressionControlMultiPlane) {
     RETURN_IF_SKIP(Init());
 
     // Image creation lambda
-    const auto create_compressed_image = [&](VkFormat format, VkImageTiling imageTiling, vkt::Image &image) -> bool {
+    const auto create_compressed_image = [&](VkFormat format, VkImageTiling imageTiling, vkt::Image& image) -> bool {
         VkImageCompressionControlEXT compression_control = vku::InitStructHelper();  // specify the desired compression settings
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT;
 

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ TEST_F(NegativeImageDrm, Basic) {
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_mod_info = vku::InitStructHelper();
     drm_format_mod_info.drmFormatModifier = mods[0];
     drm_format_mod_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    image_format_info.pNext = (void *)&drm_format_mod_info;
+    image_format_info.pNext = (void*)&drm_format_mod_info;
     vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical(), &image_format_info, &image_format_prop);
 
     {
@@ -69,7 +69,7 @@ TEST_F(NegativeImageDrm, Basic) {
     fake_plane_layout.arrayPitch = 1;
     fake_plane_layout.depthPitch = 1;
 
-    image_info.pNext = (void *)&drm_format_mod_explicit;
+    image_info.pNext = (void*)&drm_format_mod_explicit;
     m_errorMonitor->SetDesiredError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-size-02267");
     m_errorMonitor->SetDesiredError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-arrayPitch-02268");
     CreateImageTest(image_info, "VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-depthPitch-02269");
@@ -102,7 +102,7 @@ TEST_F(NegativeImageDrm, Basic2) {
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_mod_info = vku::InitStructHelper();
     drm_format_mod_info.drmFormatModifier = mods[0];
     drm_format_mod_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    image_format_info.pNext = (void *)&drm_format_mod_info;
+    image_format_info.pNext = (void*)&drm_format_mod_info;
     vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical(), &image_format_info, &image_format_prop);
 
     VkSubresourceLayout fake_plane_layout = {0, 0, 0, 0, 0};
@@ -115,7 +115,7 @@ TEST_F(NegativeImageDrm, Basic2) {
     drm_format_mod_explicit.drmFormatModifierPlaneCount = 1;
     drm_format_mod_explicit.pPlaneLayouts = &fake_plane_layout;
 
-    image_info.pNext = (void *)&drm_format_mod_explicit;
+    image_info.pNext = (void*)&drm_format_mod_explicit;
 
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
     drm_format_modifier.drmFormatModifier = mods[1];
@@ -126,20 +126,20 @@ TEST_F(NegativeImageDrm, Basic2) {
     }
     VkImage image = VK_NULL_HANDLE;
     // Postive check if only 1
-    image_info.pNext = (void *)&drm_format_mod_list;
+    image_info.pNext = (void*)&drm_format_mod_list;
     vk::CreateImage(device(), &image_info, nullptr, &image);
     vk::DestroyImage(device(), image, nullptr);
 
-    image_info.pNext = (void *)&drm_format_mod_explicit;
+    image_info.pNext = (void*)&drm_format_mod_explicit;
     vk::CreateImage(device(), &image_info, nullptr, &image);
     vk::DestroyImage(device(), image, nullptr);
 
     // Having both in pNext
-    drm_format_mod_explicit.pNext = (void *)&drm_format_mod_list;
+    drm_format_mod_explicit.pNext = (void*)&drm_format_mod_list;
     CreateImageTest(image_info, "VUID-VkImageCreateInfo-tiling-02261");
 
     // Only 1 pNext but wrong tiling
-    image_info.pNext = (void *)&drm_format_mod_list;
+    image_info.pNext = (void*)&drm_format_mod_list;
     image_info.tiling = VK_IMAGE_TILING_LINEAR;
     CreateImageTest(image_info, "VUID-VkImageCreateInfo-pNext-02262");
 }

--- a/tests/unit/image_drm_positive.cpp
+++ b/tests/unit/image_drm_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ std::vector<uint64_t> ImageDrmTest::GetFormatModifier(VkFormat format, VkFormatF
     vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props);
 
     for (uint32_t i = 0; i < mod_props.drmFormatModifierCount; ++i) {
-        auto &mod = mod_props.pDrmFormatModifierProperties[i];
+        auto& mod = mod_props.pDrmFormatModifierProperties[i];
         if (((mod.drmFormatModifierTilingFeatures & features) == features) && (plane_count == mod.drmFormatModifierPlaneCount)) {
             mods.push_back(mod.drmFormatModifier);
         }

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -115,7 +115,7 @@ TEST_F(NegativeImageLayout, Compute) {
     AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs = R"glsl(#version 450
+    const char* cs = R"glsl(#version 450
     layout(local_size_x=1) in;
     layout(set=0, binding=0) uniform sampler2D s;
     void main(){
@@ -176,7 +176,7 @@ TEST_F(NegativeImageLayout, Compute11) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
-    const char *cs = R"glsl(#version 450
+    const char* cs = R"glsl(#version 450
     layout(local_size_x=1) in;
     layout(set=0, binding=0) uniform sampler2D s;
     void main(){
@@ -218,7 +218,7 @@ TEST_F(NegativeImageLayout, MultipleCommandDispatches) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
-    const char *cs = R"glsl(
+    const char* cs = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         void main(){
@@ -283,7 +283,7 @@ TEST_F(NegativeImageLayout, DISABLED_Mutable) {
     AddRequiredFeature(vkt::Feature::mutableDescriptorType);
     RETURN_IF_SKIP(Init());
 
-    const char *cs = R"glsl(
+    const char* cs = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         void main(){
@@ -343,7 +343,7 @@ TEST_F(NegativeImageLayout, PushDescriptor) {
         VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT);
     auto pipeline_layout = vkt::PipelineLayout(*m_device, {&ds_layout});
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D tex;
         layout(location=0) out vec4 color;
@@ -813,7 +813,7 @@ TEST_F(NegativeImageLayout, MultiArrayLayers) {
     // Bind view to both layers
     vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout(set=0, binding=0) uniform sampler2DArray s;
         layout(location=0) out vec4 x;
@@ -850,7 +850,7 @@ TEST_F(NegativeImageLayout, DescriptorArrayStaticIndex) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitRenderTarget());
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         // [0] is good layout

--- a/tests/unit/image_layout_positive.cpp
+++ b/tests/unit/image_layout_positive.cpp
@@ -41,7 +41,7 @@ TEST_F(PositiveImageLayout, BarriersAndImageUsage) {
         vkt::Image img_sampled(*m_device, 32, 32, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
         vkt::Image img_input(*m_device, 128, 128, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
         const struct {
-            vkt::Image &image_obj;
+            vkt::Image& image_obj;
             VkImageLayout old_layout;
             VkImageLayout new_layout;
         } buffer_layouts[] = {
@@ -169,7 +169,7 @@ TEST_F(PositiveImageLayout, ImagelessTracking) {
                                                      VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT,
                                                      rp,
                                                      1,
-                                                     reinterpret_cast<const VkImageView *>(1),
+                                                     reinterpret_cast<const VkImageView*>(1),
                                                      attachmentWidth,
                                                      attachmentHeight,
                                                      1};
@@ -528,7 +528,7 @@ TEST_F(PositiveImageLayout, DescriptorArray) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitRenderTarget());
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform UBO { uint index; };
@@ -557,7 +557,7 @@ TEST_F(PositiveImageLayout, DescriptorArray) {
     pipe.CreateGraphicsPipeline();
 
     vkt::Buffer in_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *in_buffer_ptr = (uint32_t *)in_buffer.Memory().Map();
+    uint32_t* in_buffer_ptr = (uint32_t*)in_buffer.Memory().Map();
     in_buffer_ptr[0] = 1;
 
     vkt::Image bad_image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -903,7 +903,7 @@ TEST_F(PositiveImageLayout, DepthSliceTransitionCriteriaNotMet) {
     layout_transition.image = image;
     layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         layout (rgba8, set = 0, binding = 0) uniform image2D verifyImage;
         void main (void) {

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -39,7 +39,7 @@ TEST_F(PositiveImage, OwnershipTranfers) {
     TEST_DESCRIPTION("Valid image ownership transfers that shouldn't create errors");
     RETURN_IF_SKIP(Init());
 
-    vkt::Queue *no_gfx_queue = m_device->QueueWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
+    vkt::Queue* no_gfx_queue = m_device->QueueWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
     if (!no_gfx_queue) {
         GTEST_SKIP() << "Required queue not present (non-graphics capable required)";
     } else if ((m_device->Physical().queue_properties_[no_gfx_queue->family_index].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0) {

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -50,7 +50,7 @@ TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     fb_ci.renderPass = rp;
     fb_ci.attachmentCount = 1;
 
-    fb_ci.pAttachments  = nullptr;
+    fb_ci.pAttachments = nullptr;
     vkt::Framebuffer framebuffer_null(*m_device, fb_ci);
 
     vkt::ImageView rt_view = m_renderTargets[0]->CreateView();

--- a/tests/unit/layer_settings.cpp
+++ b/tests/unit/layer_settings.cpp
@@ -9,7 +9,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
-//stype-check off
+// stype-check off
 
 #include <cstdarg>
 #include <cstdint>
@@ -23,7 +23,7 @@ TEST_F(NegativeLayerSettings, CustomStypeStructString) {
     // Create a custom structure
     typedef struct CustomStruct {
         VkStructureType sType;
-        const void *pNext;
+        const void* pNext;
         uint32_t custom_data;
     } CustomStruct;
 
@@ -34,10 +34,11 @@ TEST_F(NegativeLayerSettings, CustomStypeStructString) {
     custom_struct.custom_data = 44;
 
     // Communicate list of structinfo pairs to layers
-    const char *id[] = {"3000300000", "24"};
+    const char* id[] = {"3000300000", "24"};
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "custom_stype_list", VK_LAYER_SETTING_TYPE_STRING_EXT,
                                        static_cast<uint32_t>(std::size(id)), &id};
-    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
+    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                              &setting};
 
     RETURN_IF_SKIP(InitFramework(&layer_setting_create_info));
     RETURN_IF_SKIP(InitState());
@@ -50,7 +51,7 @@ TEST_F(NegativeLayerSettings, CustomStypeStructString) {
     vkt::BufferView buffer_view(*m_device, bvci);
 }
 
-static std::string format(const char *message, ...) {
+static std::string format(const char* message, ...) {
     std::size_t const STRING_BUFFER(4096);
 
     assert(message != nullptr);
@@ -72,7 +73,7 @@ TEST_F(NegativeLayerSettings, CustomStypeStructStringArray) {
     // Create a custom structure
     typedef struct CustomStruct {
         VkStructureType sType;
-        const void *pNext;
+        const void* pNext;
         uint32_t custom_data;
     } CustomStruct;
 
@@ -93,15 +94,14 @@ TEST_F(NegativeLayerSettings, CustomStypeStructStringArray) {
     const std::string string_stype_b = format("%u", custom_stype_b);
     const std::string sizeof_struct = format("%d", sizeof(CustomStruct));
 
-    const char *ids[] = {
-        string_stype_a.c_str(), sizeof_struct.c_str(),
-        string_stype_b.c_str(), sizeof_struct.c_str(),
-        string_stype_a.c_str(), sizeof_struct.c_str(),
+    const char* ids[] = {
+        string_stype_a.c_str(), sizeof_struct.c_str(),  string_stype_b.c_str(),
+        sizeof_struct.c_str(),  string_stype_a.c_str(), sizeof_struct.c_str(),
     };
-    const VkLayerSettingEXT setting = {
-        OBJECT_LAYER_NAME, "custom_stype_list", VK_LAYER_SETTING_TYPE_STRING_EXT, static_cast<uint32_t>(std::size(ids)), &ids};
-    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {
-        VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
+    const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "custom_stype_list", VK_LAYER_SETTING_TYPE_STRING_EXT,
+                                       static_cast<uint32_t>(std::size(ids)), &ids};
+    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                              &setting};
 
     RETURN_IF_SKIP(InitFramework(&layer_setting_create_info));
     RETURN_IF_SKIP(InitState());
@@ -120,7 +120,7 @@ TEST_F(NegativeLayerSettings, CustomStypeStructIntegerArray) {
     // Create a custom structure
     typedef struct CustomStruct {
         VkStructureType sType;
-        const void *pNext;
+        const void* pNext;
         uint32_t custom_data;
     } CustomStruct;
 
@@ -137,16 +137,13 @@ TEST_F(NegativeLayerSettings, CustomStypeStructIntegerArray) {
     custom_struct_b.custom_data = 88;
 
     // Communicate list of structinfo pairs to layers, including a duplicate which should get filtered out
-    const uint32_t ids[] = {
-        custom_stype_a, sizeof(CustomStruct),
-        custom_stype_b, sizeof(CustomStruct),
-        custom_stype_a, sizeof(CustomStruct)
-    };
+    const uint32_t ids[] = {custom_stype_a,       sizeof(CustomStruct), custom_stype_b,
+                            sizeof(CustomStruct), custom_stype_a,       sizeof(CustomStruct)};
 
     const VkLayerSettingEXT setting[] = {
-        {OBJECT_LAYER_NAME, "custom_stype_list", VK_LAYER_SETTING_TYPE_UINT32_EXT, static_cast<uint32_t>(std::size(ids)), ids}
-    };
-    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, setting};
+        {OBJECT_LAYER_NAME, "custom_stype_list", VK_LAYER_SETTING_TYPE_UINT32_EXT, static_cast<uint32_t>(std::size(ids)), ids}};
+    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                              setting};
 
     RETURN_IF_SKIP(InitFramework(&layer_setting_create_info));
     RETURN_IF_SKIP(InitState());
@@ -206,7 +203,7 @@ TEST_F(NegativeLayerSettings, DuplicateMessageLimitZero) {
     bogus_struct.sType = static_cast<VkStructureType>(0x33333333);
     VkPhysicalDeviceProperties2KHR properties2 = vku::InitStructHelper(&bogus_struct);
 
-    const uint32_t default_value = 10; // what we set in vkconfig
+    const uint32_t default_value = 10;  // what we set in vkconfig
     for (uint32_t i = 0; i < default_value + 1; i++) {
         m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
         vk::GetPhysicalDeviceProperties2KHR(Gpu(), &properties2);
@@ -224,7 +221,7 @@ TEST_F(NegativeLayerSettings, DuplicateMessageLimitNone) {
     bogus_struct.sType = static_cast<VkStructureType>(0x33333333);
     VkPhysicalDeviceProperties2KHR properties2 = vku::InitStructHelper(&bogus_struct);
 
-    const uint32_t default_value = 10; // what we set in vkconfig
+    const uint32_t default_value = 10;  // what we set in vkconfig
     for (uint32_t i = 0; i < default_value; i++) {
         m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
         vk::GetPhysicalDeviceProperties2KHR(Gpu(), &properties2);
@@ -263,7 +260,7 @@ TEST_F(NegativeLayerSettings, DuplicateMessageLimitDisable) {
     }
 }
 
-//stype-check off
+// stype-check off
 TEST_F(NegativeLayerSettings, DuplicateMessageLimitLastWarning) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
 
@@ -301,9 +298,10 @@ TEST_F(NegativeLayerSettings, VuidIdFilterString) {
     // This test would normally produce an unexpected error or two.  Use the message filter instead of
     // the error_monitor's SetUnexpectedError to test the filtering.
 
-    const char *ids[] = {"VUID-VkRenderPassCreateInfo-pNext-01963"};
+    const char* ids[] = {"VUID-VkRenderPassCreateInfo-pNext-01963"};
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids};
-    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &setting};
 
     RETURN_IF_SKIP(InitFramework(&layer_settings_create_info));
 
@@ -334,9 +332,10 @@ TEST_F(NegativeLayerSettings, VuidFilterHexInt) {
     // This test would normally produce an unexpected error or two.  Use the message filter instead of
     // the error_monitor's SetUnexpectedError to test the filtering.
 
-    const char *ids[] = {"0xa19880e3"};
+    const char* ids[] = {"0xa19880e3"};
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids};
-    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &setting};
 
     RETURN_IF_SKIP(InitFramework(&layer_settings_create_info));
 
@@ -367,9 +366,10 @@ TEST_F(NegativeLayerSettings, VuidFilterInt) {
     // This test would normally produce an unexpected error or two.  Use the message filter instead of
     // the error_monitor's SetUnexpectedError to test the filtering.
 
-    const char *ids[] = {"2711126243"};
+    const char* ids[] = {"2711126243"};
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids};
-    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &setting};
 
     RETURN_IF_SKIP(InitFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
@@ -393,7 +393,7 @@ TEST_F(NegativeLayerSettings, VuidFilterInt) {
 }
 
 TEST_F(NegativeLayerSettings, DebugAction) {
-    const char *action = "VK_DBG_LAYER_ACTION_NOT_A_REAL_THING";
+    const char* action = "VK_DBG_LAYER_ACTION_NOT_A_REAL_THING";
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "debug_action", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &action};
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().SetDesiredWarning("was not a valid option for VK_LAYER_DEBUG_ACTION");
@@ -403,7 +403,7 @@ TEST_F(NegativeLayerSettings, DebugAction) {
 }
 
 TEST_F(NegativeLayerSettings, DebugAction2) {
-    const char *actions[2] = {"VK_DBG_LAYER_ACTION_IGNORE,VK_DBG_LAYER_ACTION_CALLBACK"};
+    const char* actions[2] = {"VK_DBG_LAYER_ACTION_IGNORE,VK_DBG_LAYER_ACTION_CALLBACK"};
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "debug_action", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, actions};
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().SetDesiredWarning("was not a valid option for VK_LAYER_DEBUG_ACTION");
@@ -413,7 +413,7 @@ TEST_F(NegativeLayerSettings, DebugAction2) {
 }
 
 TEST_F(NegativeLayerSettings, DebugAction3) {
-    const char *actions[2] = {"VK_DBG_LAYER_ACTION_DEFAULT", "VK_DBG_LAYER_ACTION_NOT_A_REAL_THING"};
+    const char* actions[2] = {"VK_DBG_LAYER_ACTION_DEFAULT", "VK_DBG_LAYER_ACTION_NOT_A_REAL_THING"};
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "debug_action", VK_LAYER_SETTING_TYPE_STRING_EXT, 2, actions};
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().SetDesiredWarning("was not a valid option for VK_LAYER_DEBUG_ACTION");
@@ -423,7 +423,7 @@ TEST_F(NegativeLayerSettings, DebugAction3) {
 }
 
 TEST_F(NegativeLayerSettings, ReportFlags) {
-    const char *report_flag = "fake";
+    const char* report_flag = "fake";
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "report_flags", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &report_flag};
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().SetDesiredWarning("was not a valid option for VK_LAYER_REPORT_FLAGS");
@@ -433,7 +433,7 @@ TEST_F(NegativeLayerSettings, ReportFlags) {
 }
 
 TEST_F(NegativeLayerSettings, ReportFlags2) {
-    const char *report_flag = "warn,fake,info";
+    const char* report_flag = "warn,fake,info";
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "report_flags", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &report_flag};
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().SetDesiredWarning("was not a valid option for VK_LAYER_REPORT_FLAGS");
@@ -443,7 +443,7 @@ TEST_F(NegativeLayerSettings, ReportFlags2) {
 }
 
 TEST_F(NegativeLayerSettings, ReportFlags3) {
-    const char *report_flag = "error,warn,info,verbose";
+    const char* report_flag = "error,warn,info,verbose";
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "report_flags", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &report_flag};
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().SetDesiredWarning("was not a valid option for VK_LAYER_REPORT_FLAGS");
@@ -454,7 +454,7 @@ TEST_F(NegativeLayerSettings, ReportFlags3) {
 
 #ifndef WIN32
 TEST_F(NegativeLayerSettings, LogFilename) {
-    const char *path[] = {"/fake/path"};
+    const char* path[] = {"/fake/path"};
     const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "log_filename", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, path};
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().SetDesiredWarning("(/fake/path) could not be opened, falling back to stdout instead");

--- a/tests/unit/legacy.cpp
+++ b/tests/unit/legacy.cpp
@@ -13,10 +13,10 @@
 #include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
 
-static const VkLayerSettingEXT kLegacySetting = {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT,
-                                                      1, &kVkTrue};
+static const VkLayerSettingEXT kLegacySetting = {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
+                                                 &kVkTrue};
 static VkLayerSettingsCreateInfoEXT kLegacySettingCreateInfo = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
-                                                                     &kLegacySetting};
+                                                                &kLegacySetting};
 
 class NegativeLegacy : public LegacyTest {};
 
@@ -63,7 +63,7 @@ TEST_F(NegativeLegacy, MultipleDifferentWarnings) {
 TEST_F(NegativeLegacy, MuteSingleWarning) {
     TEST_DESCRIPTION("Only mute of the two warnings to make sure mutting works");
 
-    const char *ids[] = {"WARNING-legacy-renderpass2"};
+    const char* ids[] = {"WARNING-legacy-renderpass2"};
     VkLayerSettingEXT layer_settings[2] = {kLegacySetting,
                                            {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids}};
 
@@ -155,7 +155,7 @@ TEST_F(NegativeLegacy, UseDeprecatedInstanceExtensions) {
 
     auto ici = GetInstanceCreateInfo();
     auto debug_info = Monitor().GetDebugCreateInfo();
-    const_cast<VkDebugUtilsMessengerCreateInfoEXT *>(debug_info)->pNext = &kLegacySettingCreateInfo;
+    const_cast<VkDebugUtilsMessengerCreateInfoEXT*>(debug_info)->pNext = &kLegacySettingCreateInfo;
     ici.pNext = debug_info;
 
     Monitor().SetDesiredWarning("WARNING-legacy-extension");
@@ -204,7 +204,7 @@ TEST_F(NegativeLegacy, LoadDeprecatedExtension) {
     RETURN_IF_SKIP(InitFramework(&kLegacySettingCreateInfo));
     RETURN_IF_SKIP(InitState());
 
-    const char *extension = VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME;
+    const char* extension = VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME;
 
     if (!DeviceExtensionSupported(extension)) {
         GTEST_SKIP() << extension << " not supported.";

--- a/tests/unit/legacy_positive.cpp
+++ b/tests/unit/legacy_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,7 @@ class PositiveLegacy : public LegacyTest {};
 
 TEST_F(PositiveLegacy, SettingExplicitOff) {
     TEST_DESCRIPTION("Turn off setting explicitly");
-    const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
-                                             &kVkFalse};
+    const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkFalse};
     VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &layer_setting};
 
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
@@ -60,10 +59,9 @@ TEST_F(PositiveLegacy, SettingDefault) {
 }
 
 TEST_F(PositiveLegacy, MuteMultipleWarnings) {
-    const char *ids[] = {"WARNING-legacy-gpdp2", "WARNING-legacy-renderpass2", "WARNING-legacy-dynamicrendering"};
-    VkLayerSettingEXT layer_settings[3] = {
-        {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
-        {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 3, ids}};
+    const char* ids[] = {"WARNING-legacy-gpdp2", "WARNING-legacy-renderpass2", "WARNING-legacy-dynamicrendering"};
+    VkLayerSettingEXT layer_settings[3] = {{OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+                                           {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 3, ids}};
     VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2, layer_settings};
 
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
@@ -87,8 +85,7 @@ TEST_F(PositiveLegacy, MuteMultipleWarnings) {
 
 TEST_F(PositiveLegacy, GetPhysicalDeviceProperties2Extension) {
     TEST_DESCRIPTION("Show Instance extensions currently only detected if enabled, not if supported");
-    const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
-                                             &kVkTrue};
+    const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
     VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &layer_setting};
 
     RETURN_IF_SKIP(InitFramework(&layer_setting_ci));

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -716,30 +716,30 @@ TEST_F(NegativeMemory, MapMemory) {
     }
     vkt::DeviceMemory mem(*m_device, alloc_info);
 
-    uint8_t *pData;
+    uint8_t* pData;
     // Attempt to map memory size 0 is invalid
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-size-00680");
-    vk::MapMemory(device(), mem, 0, 0, 0, (void **)&pData);
+    vk::MapMemory(device(), mem, 0, 0, 0, (void**)&pData);
     m_errorMonitor->VerifyFound();
     // Map memory twice
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void**)&pData));
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-memory-00678");
-    vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void **)&pData);
+    vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void**)&pData);
     m_errorMonitor->VerifyFound();
 
     // Unmap the memory to avoid re-map error
     vk::UnmapMemory(device(), mem);
     // overstep offset with VK_WHOLE_SIZE
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-offset-00679");
-    vk::MapMemory(device(), mem, allocation_size + 1, VK_WHOLE_SIZE, 0, (void **)&pData);
+    vk::MapMemory(device(), mem, allocation_size + 1, VK_WHOLE_SIZE, 0, (void**)&pData);
     m_errorMonitor->VerifyFound();
     // overstep offset w/o VK_WHOLE_SIZE
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-offset-00679");
-    vk::MapMemory(device(), mem, allocation_size + 1, VK_WHOLE_SIZE, 0, (void **)&pData);
+    vk::MapMemory(device(), mem, allocation_size + 1, VK_WHOLE_SIZE, 0, (void**)&pData);
     m_errorMonitor->VerifyFound();
     // overstep allocation w/o VK_WHOLE_SIZE
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-size-00681");
-    vk::MapMemory(device(), mem, 1, allocation_size, 0, (void **)&pData);
+    vk::MapMemory(device(), mem, 1, allocation_size, 0, (void**)&pData);
     m_errorMonitor->VerifyFound();
     // Now error due to unmapping memory that's not mapped
     m_errorMonitor->SetDesiredError("VUID-vkUnmapMemory-memory-00689");
@@ -771,9 +771,9 @@ TEST_F(NegativeMemory, MapMemoryFlush) {
     }
     vkt::DeviceMemory mem(*m_device, alloc_info);
 
-    uint8_t *pData;
+    uint8_t* pData;
     // Now map memory and cause errors due to flushing invalid ranges
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 4 * atom_size, VK_WHOLE_SIZE, 0, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 4 * atom_size, VK_WHOLE_SIZE, 0, (void**)&pData));
     VkMappedMemoryRange mem_range = vku::InitStructHelper();
     mem_range.memory = mem;
     mem_range.offset = atom_size;  // Error b/c offset less than offset of mapped mem
@@ -783,7 +783,7 @@ TEST_F(NegativeMemory, MapMemoryFlush) {
 
     // Now flush range that oversteps mapped range
     vk::UnmapMemory(device(), mem);
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size, 0, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size, 0, (void**)&pData));
     mem_range.offset = atom_size;
     mem_range.size = 4 * atom_size;  // Flushing bounds exceed mapped bounds
     m_errorMonitor->SetDesiredError("VUID-VkMappedMemoryRange-size-00685");
@@ -792,7 +792,7 @@ TEST_F(NegativeMemory, MapMemoryFlush) {
 
     // Now flush range with VK_WHOLE_SIZE that oversteps offset
     vk::UnmapMemory(device(), mem);
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 2 * atom_size, 4 * atom_size, 0, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 2 * atom_size, 4 * atom_size, 0, (void**)&pData));
     mem_range.offset = atom_size;
     mem_range.size = VK_WHOLE_SIZE;
     m_errorMonitor->SetDesiredError("VUID-VkMappedMemoryRange-size-00686");
@@ -843,10 +843,10 @@ TEST_F(NegativeMemory, MapMemoryCoherentAtomSize) {
     }
     vkt::DeviceMemory mem(*m_device, alloc_info);
 
-    uint8_t *pData;
+    uint8_t* pData;
 
     // Now with an offset NOT a multiple of the device limit
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size, 0, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size, 0, (void**)&pData));
     VkMappedMemoryRange mem_range = vku::InitStructHelper();
     mem_range.memory = mem;
     mem_range.offset = 3;  // Not a multiple of atom_size
@@ -857,7 +857,7 @@ TEST_F(NegativeMemory, MapMemoryCoherentAtomSize) {
 
     // Now with a size NOT a multiple of the device limit
     vk::UnmapMemory(device(), mem);
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size, 0, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size, 0, (void**)&pData));
     mem_range.offset = atom_size;
     mem_range.size = 2 * atom_size + 1;  // Not a multiple of atom_size
     m_errorMonitor->SetDesiredError("VUID-VkMappedMemoryRange-size-01390");
@@ -866,7 +866,7 @@ TEST_F(NegativeMemory, MapMemoryCoherentAtomSize) {
 
     // Now with VK_WHOLE_SIZE and a mapping that does not end at a multiple of atom_size nor at the end of the memory.
     vk::UnmapMemory(device(), mem);
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size + 1, 0, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, 4 * atom_size + 1, 0, (void**)&pData));
     mem_range.offset = atom_size;
     mem_range.size = VK_WHOLE_SIZE;
     m_errorMonitor->SetDesiredError("VUID-VkMappedMemoryRange-size-01389");
@@ -901,19 +901,19 @@ TEST_F(NegativeMemory, MapMemory2) {
     VkMemoryUnmapInfo unmap_info = vku::InitStructHelper();
     unmap_info.memory = memory;
 
-    uint8_t *pData;
+    uint8_t* pData;
     // Attempt to map memory size 0 is invalid
     map_info.offset = 0;
     map_info.size = 0;
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-size-07960");
-    vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     m_errorMonitor->VerifyFound();
     // Map memory twice
     map_info.offset = 0;
     map_info.size = VK_WHOLE_SIZE;
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory2KHR(device(), &map_info, (void **)&pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory2KHR(device(), &map_info, (void**)&pData));
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-memory-07958");
-    vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     m_errorMonitor->VerifyFound();
 
     // Unmap the memory to avoid re-map error
@@ -922,13 +922,12 @@ TEST_F(NegativeMemory, MapMemory2) {
     map_info.offset = allocation_size + 1;
     map_info.size = VK_WHOLE_SIZE;
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-offset-07959");
-    vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     m_errorMonitor->VerifyFound();
     // overstep allocation w/o VK_WHOLE_SIZE
-    map_info.offset = 1,
-    map_info.size = allocation_size;
+    map_info.offset = 1, map_info.size = allocation_size;
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-size-07961");
-    vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     m_errorMonitor->VerifyFound();
     // Now error due to unmapping memory that's not mapped
     m_errorMonitor->SetDesiredError("VUID-VkMemoryUnmapInfo-memory-07964");
@@ -963,7 +962,7 @@ TEST_F(NegativeMemory, MapMemWithoutHostVisibleBit) {
     }
 
     vkt::DeviceMemory memory(*m_device, mem_alloc);
-    void *mapped_address = nullptr;
+    void* mapped_address = nullptr;
 
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-memory-00682");
     m_errorMonitor->SetUnexpectedError("VUID-vkMapMemory-memory-00683");
@@ -1003,10 +1002,10 @@ TEST_F(NegativeMemory, MapMemory2WithoutHostVisibleBit) {
     map_info.memory = memory;
     map_info.offset = 0;
     map_info.size = 32;
-    uint8_t *pData;
+    uint8_t* pData;
 
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-memory-07962");
-    vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1042,7 +1041,7 @@ TEST_F(NegativeMemory, MapMemoryPlaced) {
     map_info.size = VK_WHOLE_SIZE;
 
     // No VkMemoryMapPlacedInfoEXT
-    void *pData;
+    void* pData;
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-flags-09570");
     vk::MapMemory2KHR(device(), &map_info, &pData);
     m_errorMonitor->VerifyFound();
@@ -1057,14 +1056,14 @@ TEST_F(NegativeMemory, MapMemoryPlaced) {
 
     // Reserve two more pages in case we need to deal with any alignment weirdness.
     size_t reservation_size = allocation_size + map_placed_props.minPlacedMemoryMapAlignment;
-    void *reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    void* reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     ASSERT_TRUE(reservation != MAP_FAILED);
 
     // Align up to minPlacedMemoryMapAlignment
     uintptr_t align_1 = map_placed_props.minPlacedMemoryMapAlignment - 1;
-    void *addr = reinterpret_cast<void *>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
+    void* addr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
 
-    placed_info.pPlacedAddress = ((char *)addr) + (map_placed_props.minPlacedMemoryMapAlignment / 2);
+    placed_info.pPlacedAddress = ((char*)addr) + (map_placed_props.minPlacedMemoryMapAlignment / 2);
 
     // Unaligned VkMemoryMapPlacedInfoEXT::pPlacedAddress
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapPlacedInfoEXT-pPlacedAddress-09577");
@@ -1094,11 +1093,11 @@ TEST_F(NegativeMemory, MemoryMapRangePlacedEnabled) {
 
     // Reserve two more pages in case we need to deal with any alignment weirdness.
     size_t reservation_size = allocation_size + map_placed_props.minPlacedMemoryMapAlignment;
-    void *reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    void* reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     ASSERT_TRUE(reservation != MAP_FAILED);
 
     uintptr_t align_1 = map_placed_props.minPlacedMemoryMapAlignment - 1;
-    void *addr = reinterpret_cast<void *>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
+    void* addr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
 
     VkMemoryMapPlacedInfoEXT placed_info = vku::InitStructHelper();
     placed_info.pPlacedAddress = addr;
@@ -1108,7 +1107,7 @@ TEST_F(NegativeMemory, MemoryMapRangePlacedEnabled) {
     map_info.size = VK_WHOLE_SIZE;
     map_info.offset = map_placed_props.minPlacedMemoryMapAlignment / 2;
 
-    void *pData;
+    void* pData;
     // Unaligned offset
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-flags-09573");
     vk::MapMemory2KHR(device(), &map_info, &pData);
@@ -1145,11 +1144,11 @@ TEST_F(NegativeMemory, MemoryMapRangePlacedDisabled) {
 
     // Reserve two more pages in case we need to deal with any alignment weirdness.
     size_t reservation_size = allocation_size + map_placed_props.minPlacedMemoryMapAlignment;
-    void *reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    void* reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     ASSERT_TRUE(reservation != MAP_FAILED);
 
     uintptr_t align_1 = map_placed_props.minPlacedMemoryMapAlignment - 1;
-    void *addr = reinterpret_cast<void *>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
+    void* addr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
 
     VkMemoryMapPlacedInfoEXT placed_info = vku::InitStructHelper();
     placed_info.pPlacedAddress = addr;
@@ -1159,7 +1158,7 @@ TEST_F(NegativeMemory, MemoryMapRangePlacedDisabled) {
     map_info.size = VK_WHOLE_SIZE;
     map_info.offset = map_placed_props.minPlacedMemoryMapAlignment;
 
-    void *pData;
+    void* pData;
     // Non-zero offset
     m_errorMonitor->SetDesiredError("VUID-VkMemoryMapInfo-flags-09571");
     vk::MapMemory2KHR(device(), &map_info, &pData);
@@ -1786,7 +1785,7 @@ TEST_F(NegativeMemory, BindMemory2BindInfosMultiPlane) {
     vkt::Image mp_image_a(*m_device, mp_image_create_info, vkt::no_mem);
     vkt::Image mp_image_b(*m_device, mp_image_create_info, vkt::no_mem);
 
-    auto allocate = [this](VkImage mp_image, VkDeviceMemory *mp_image_mem, VkImageAspectFlagBits plane) {
+    auto allocate = [this](VkImage mp_image, VkDeviceMemory* mp_image_mem, VkImageAspectFlagBits plane) {
         VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
         image_plane_req.planeAspect = plane;
 
@@ -1823,13 +1822,13 @@ TEST_F(NegativeMemory, BindMemory2BindInfosMultiPlane) {
     }
 
     // Try only binding part of image_b
-    bind_image_info[0].pNext = (void *)&plane_memory_info[0];
+    bind_image_info[0].pNext = (void*)&plane_memory_info[0];
     bind_image_info[0].image = mp_image_a;
     bind_image_info[0].memory = mp_image_a_mem[0];
-    bind_image_info[1].pNext = (void *)&plane_memory_info[1];
+    bind_image_info[1].pNext = (void*)&plane_memory_info[1];
     bind_image_info[1].image = mp_image_a;
     bind_image_info[1].memory = mp_image_a_mem[1];
-    bind_image_info[2].pNext = (void *)&plane_memory_info[0];
+    bind_image_info[2].pNext = (void*)&plane_memory_info[0];
     bind_image_info[2].image = mp_image_b;
     bind_image_info[2].memory = mp_image_b_mem[0];
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-02858");
@@ -1846,10 +1845,10 @@ TEST_F(NegativeMemory, BindMemory2BindInfosMultiPlane) {
 
     // Try binding image_b plane 1 twice
     // Valid case where binding disjoint and non-disjoint
-    bind_image_info[4].pNext = (void *)&plane_memory_info[1];
+    bind_image_info[4].pNext = (void*)&plane_memory_info[1];
     bind_image_info[4].image = mp_image_b;
     bind_image_info[4].memory = mp_image_b_mem[1];
-    bind_image_info[5].pNext = (void *)&plane_memory_info[1];
+    bind_image_info[5].pNext = (void*)&plane_memory_info[1];
     bind_image_info[5].image = mp_image_b;
     bind_image_info[5].memory = mp_image_b_mem[1];
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-04006");
@@ -1861,7 +1860,7 @@ TEST_F(NegativeMemory, BindMemory2BindInfosMultiPlane) {
     m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-image-07736");
     vk::BindImageMemory2KHR(device(), 1, bind_image_info);
     m_errorMonitor->VerifyFound();
-    bind_image_info[0].pNext = (void *)&plane_memory_info[0];
+    bind_image_info[0].pNext = (void*)&plane_memory_info[0];
 
     // Valid case of binding 2 disjoint image and normal image by removing duplicate
     vk::BindImageMemory2KHR(device(), 5, bind_image_info);
@@ -2792,7 +2791,7 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
     VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = 0;
     create_device_pnext.pPhysicalDevices = nullptr;
-    for (const auto &dg : physical_device_group) {
+    for (const auto& dg : physical_device_group) {
         if (dg.physicalDeviceCount > 1) {
             create_device_pnext.physicalDeviceCount = dg.physicalDeviceCount;
             create_device_pnext.pPhysicalDevices = dg.physicalDevices;
@@ -3046,7 +3045,7 @@ TEST_F(NegativeMemory, MapMemoryWithMapPlacedFlag) {
 
     vkt::DeviceMemory memory(*m_device, memory_info);
 
-    void *data;
+    void* data;
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-flags-09568");
     vk::MapMemory(device(), memory, 0u, 4u, VK_MEMORY_MAP_PLACED_BIT_EXT, &data);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
- * Copyright (c) 2023-2025 Collabora, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
+ * Copyright (c) 2023-2026 Collabora, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,8 +173,8 @@ TEST_F(PositiveMemory, MapMemory2) {
     VkMemoryUnmapInfoKHR unmap_info = vku::InitStructHelper();
     unmap_info.memory = memory;
 
-    uint32_t *pData = nullptr;
-    VkResult err = vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    uint32_t* pData = nullptr;
+    VkResult err = vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     ASSERT_EQ(VK_SUCCESS, err);
     ASSERT_TRUE(pData != nullptr);
 
@@ -184,7 +184,7 @@ TEST_F(PositiveMemory, MapMemory2) {
     map_info.size = VK_WHOLE_SIZE;
 
     pData = nullptr;
-    err = vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    err = vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     ASSERT_EQ(VK_SUCCESS, err);
     ASSERT_TRUE(pData != nullptr);
 
@@ -221,12 +221,12 @@ TEST_F(PositiveMemory, MapMemoryPlaced) {
 
     /* Reserve one more page in case we need to deal with any alignment weirdness. */
     size_t reservation_size = allocation_size + map_placed_props.minPlacedMemoryMapAlignment;
-    void *reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    void* reservation = mmap(NULL, reservation_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     ASSERT_TRUE(reservation != MAP_FAILED);
 
     /* Align up to minPlacedMemoryMapAlignment */
     uintptr_t align_1 = map_placed_props.minPlacedMemoryMapAlignment - 1;
-    void *addr = reinterpret_cast<void *>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
+    void* addr = reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(reservation) + align_1) & ~align_1);
 
     VkMemoryMapInfo map_info = vku::InitStructHelper();
     map_info.memory = memory;
@@ -238,7 +238,7 @@ TEST_F(PositiveMemory, MapMemoryPlaced) {
     placed_info.pPlacedAddress = addr;
     map_info.pNext = &placed_info;
 
-    void *pData;
+    void* pData;
     VkResult res = vk::MapMemory2KHR(device(), &map_info, &pData);
     ASSERT_EQ(VK_SUCCESS, res);
 
@@ -272,7 +272,7 @@ TEST_F(PositiveMemory, MapMemoryPlaced) {
     /* We unmapped with RESERVE above so this should be different */
     ASSERT_NE(pData, addr);
 
-    ASSERT_EQ(static_cast<uint8_t *>(pData)[0], 0x5c);
+    ASSERT_EQ(static_cast<uint8_t*>(pData)[0], 0x5c);
 
     unmap_info.flags = 0;
     res = vk::UnmapMemory2KHR(device(), &unmap_info);
@@ -378,7 +378,7 @@ TEST_F(PositiveMemory, NonCoherentMapping) {
         "Ensure that validations handling of non-coherent memory mapping while using VK_WHOLE_SIZE does not cause access "
         "violations");
     VkResult err;
-    uint8_t *pData;
+    uint8_t* pData;
     RETURN_IF_SKIP(Init());
 
     VkMemoryRequirements mem_reqs;
@@ -411,7 +411,7 @@ TEST_F(PositiveMemory, NonCoherentMapping) {
     vkt::DeviceMemory mem(*m_device, alloc_info);
 
     // Map/Flush/Invalidate using WHOLE_SIZE and zero offsets and entire mapped range
-    err = vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void **)&pData);
+    err = vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void**)&pData);
     ASSERT_EQ(VK_SUCCESS, err);
     VkMappedMemoryRange mmr = vku::InitStructHelper();
     mmr.memory = mem;
@@ -424,7 +424,7 @@ TEST_F(PositiveMemory, NonCoherentMapping) {
     vk::UnmapMemory(device(), mem);
 
     // Map/Flush/Invalidate using WHOLE_SIZE and an offset and entire mapped range
-    err = vk::MapMemory(device(), mem, 5 * atom_size, VK_WHOLE_SIZE, 0, (void **)&pData);
+    err = vk::MapMemory(device(), mem, 5 * atom_size, VK_WHOLE_SIZE, 0, (void**)&pData);
     ASSERT_EQ(VK_SUCCESS, err);
     mmr.memory = mem;
     mmr.offset = 6 * atom_size;
@@ -437,7 +437,7 @@ TEST_F(PositiveMemory, NonCoherentMapping) {
 
     // Map with offset and size
     // Flush/Invalidate subrange of mapped area with offset and size
-    err = vk::MapMemory(device(), mem, 3 * atom_size, 9 * atom_size, 0, (void **)&pData);
+    err = vk::MapMemory(device(), mem, 3 * atom_size, 9 * atom_size, 0, (void**)&pData);
     ASSERT_EQ(VK_SUCCESS, err);
     mmr.memory = mem;
     mmr.offset = 4 * atom_size;
@@ -449,7 +449,7 @@ TEST_F(PositiveMemory, NonCoherentMapping) {
     vk::UnmapMemory(device(), mem);
 
     // Map without offset and flush WHOLE_SIZE with two separate offsets
-    err = vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void **)&pData);
+    err = vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void**)&pData);
     ASSERT_EQ(VK_SUCCESS, err);
     mmr.memory = mem;
     mmr.offset = allocation_size - (4 * atom_size);
@@ -491,8 +491,8 @@ TEST_F(PositiveMemory, MappingWithMultiInstanceHeapFlag) {
 
     vkt::DeviceMemory memory(*m_device, mem_alloc);
 
-    uint32_t *pData;
-    vk::MapMemory(device(), memory, 0, VK_WHOLE_SIZE, 0, (void **)&pData);
+    uint32_t* pData;
+    vk::MapMemory(device(), memory, 0, VK_WHOLE_SIZE, 0, (void**)&pData);
     vk::UnmapMemory(device(), memory);
 }
 
@@ -531,7 +531,7 @@ TEST_F(PositiveMemory, BindImageMemoryMultiThreaded) {
     for (int i = 0; i < worker_count; ++i) {
         workers.emplace_back(worker_thread);
     }
-    for (auto &worker : workers) {
+    for (auto& worker : workers) {
         worker.join();
     }
 }
@@ -748,8 +748,8 @@ TEST_F(PositiveMemory, MapMemoryCoherentAtomSize) {
     }
     vkt::DeviceMemory mem(*m_device, alloc_info);
 
-    uint8_t *pData;
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void **)&pData));
+    uint8_t* pData;
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), mem, 0, VK_WHOLE_SIZE, 0, (void**)&pData));
     // Offset is atom size, but total memory range is not atom size
     VkMappedMemoryRange mem_range = vku::InitStructHelper();
     mem_range.memory = mem;

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -110,7 +110,7 @@ TEST_F(NegativeMesh, BasicUsage) {
     // Test pipeline creation
     {
         // can't mix mesh with vertex
-        const auto break_vp = [&](CreatePipelineHelper &helper) {
+        const auto break_vp = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo(), ms.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
@@ -118,13 +118,13 @@ TEST_F(NegativeMesh, BasicUsage) {
 
         // vertex or mesh must be present
         // 02096 overlaps with 06896
-        const auto break_vp2 = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {fs.GetStageCreateInfo()}; };
+        const auto break_vp2 = [&](CreatePipelineHelper& helper) { helper.shader_stages_ = {fs.GetStageCreateInfo()}; };
         CreatePipelineHelper::OneshotTest(*this, break_vp2, kErrorBit,
                                           std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-stage-02096",
                                                                     "VUID-VkGraphicsPipelineCreateInfo-pStages-06896"}));
 
         // vertexinput and inputassembly must be valid when vertex stage is present
-        const auto break_vp3 = [&](CreatePipelineHelper &helper) {
+        const auto break_vp3 = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.gp_ci_.pVertexInputState = nullptr;
             helper.gp_ci_.pInputAssemblyState = nullptr;
@@ -132,7 +132,7 @@ TEST_F(NegativeMesh, BasicUsage) {
         CreatePipelineHelper::OneshotTest(*this, break_vp3, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-02097");
 
         // xfb with mesh shader
-        const auto break_vp4 = [&](CreatePipelineHelper &helper) {
+        const auto break_vp4 = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {ms_xfb.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp4, kErrorBit,
@@ -144,7 +144,7 @@ TEST_F(NegativeMesh, BasicUsage) {
             {VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE}, {VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT},
             {VK_DYNAMIC_STATE_VERTEX_INPUT_EXT},
         };
-        const char *err_vuids[] = {
+        const char* err_vuids[] = {
             "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07065", "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07065",
             "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07066", "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07066",
             "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07067"};
@@ -153,7 +153,7 @@ TEST_F(NegativeMesh, BasicUsage) {
             dyn_state.dynamicStateCount = dyn_states[i].size();
             dyn_state.pDynamicStates = dyn_states[i].data();
             if (*dyn_state.pDynamicStates == VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT) continue;
-            const auto break_vp5 = [&](CreatePipelineHelper &helper) {
+            const auto break_vp5 = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {ms.GetStageCreateInfo(), fs.GetStageCreateInfo()};
                 helper.gp_ci_.pDynamicState = &dyn_state;
             };
@@ -194,7 +194,7 @@ TEST_F(NegativeMesh, ExtensionDisabled) {
     VkShaderObj fs(*m_device, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // mesh and task shaders not supported
-    const auto break_vp = [&](CreatePipelineHelper &helper) {
+    const auto break_vp = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task_shader.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
@@ -316,7 +316,7 @@ TEST_F(NegativeMesh, RuntimeSpirv) {
     VkShaderObj fs(*m_device, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // mesh and task shaders which exceeds workgroup size limits
-    const auto break_vp = [&](CreatePipelineHelper &helper) {
+    const auto break_vp = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task_shader.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit, error_vuids);
@@ -490,7 +490,7 @@ TEST_F(NegativeMesh, BasicUsageNV) {
     // Test pipeline creation
     {
         // can't mix mesh with vertex
-        const auto break_vp = [&](CreatePipelineHelper &helper) {
+        const auto break_vp = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo(), ms.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
@@ -498,13 +498,13 @@ TEST_F(NegativeMesh, BasicUsageNV) {
 
         // vertex or mesh must be present
         // 02096 overlaps with 06896
-        const auto break_vp2 = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {fs.GetStageCreateInfo()}; };
+        const auto break_vp2 = [&](CreatePipelineHelper& helper) { helper.shader_stages_ = {fs.GetStageCreateInfo()}; };
         CreatePipelineHelper::OneshotTest(*this, break_vp2, kErrorBit,
                                           std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-stage-02096",
                                                                     "VUID-VkGraphicsPipelineCreateInfo-pStages-06896"}));
 
         // vertexinput and inputassembly must be valid when vertex stage is present
-        const auto break_vp3 = [&](CreatePipelineHelper &helper) {
+        const auto break_vp3 = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.gp_ci_.pVertexInputState = nullptr;
             helper.gp_ci_.pInputAssemblyState = nullptr;
@@ -628,7 +628,7 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
     // void main() {
     //     OUT.baseID = 1;
     // }
-    const char *task_src = R"(
+    const char* task_src = R"(
                OpCapability MeshShadingNV
                OpExtension "SPV_NV_mesh_shader"
           %1 = OpExtInstImport "GLSL.std.450"
@@ -683,7 +683,7 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
     VkShaderObj fs(*m_device, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // mesh and task shaders not supported
-    const auto break_vp = [&](CreatePipelineHelper &helper) {
+    const auto break_vp = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task_shader.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
@@ -1048,15 +1048,15 @@ TEST_F(NegativeMesh, MeshTasksWorkgroupCount) {
     VkShaderObj frag_shader(*m_device, frag_src, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3);
 
     // mesh and task shaders not supported
-    const auto mesh_tasks_x = [&](CreatePipelineHelper &helper) {
+    const auto mesh_tasks_x = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task_shader_x.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(),
                                  frag_shader.GetStageCreateInfo()};
     };
-    const auto mesh_tasks_y = [&](CreatePipelineHelper &helper) {
+    const auto mesh_tasks_y = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task_shader_y.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(),
                                  frag_shader.GetStageCreateInfo()};
     };
-    const auto mesh_tasks_z = [&](CreatePipelineHelper &helper) {
+    const auto mesh_tasks_z = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task_shader_z.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(),
                                  frag_shader.GetStageCreateInfo()};
     };
@@ -1161,7 +1161,7 @@ TEST_F(NegativeMesh, DrawIndexMesh) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         taskPayloadSharedEXT uint mesh_payload[32];
@@ -1171,7 +1171,7 @@ TEST_F(NegativeMesh, DrawIndexMesh) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 32, max_primitives = 32, triangles) out;
@@ -1201,7 +1201,7 @@ TEST_F(NegativeMesh, DrawIndexMeshShaderObject) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *mesh_src = R"glsl(
+    const char* mesh_src = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 32, max_primitives = 32, triangles) out;
@@ -1347,7 +1347,7 @@ TEST_F(NegativeMesh, IncompatiblePipelineStatisticsQuery) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 3, max_primitives=1) out;

--- a/tests/unit/mesh_positive.cpp
+++ b/tests/unit/mesh_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ TEST_F(PositiveMesh, BasicUsage) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 3, max_primitives=1) out;
@@ -233,7 +233,7 @@ TEST_F(PositiveMesh, TaskAndMeshShaderNV) {
     VkShaderObj ts(*m_device, taskShaderText, VK_SHADER_STAGE_TASK_BIT_NV, SPV_ENV_VULKAN_1_2);
     VkShaderObj ms(*m_device, meshShaderText, VK_SHADER_STAGE_MESH_BIT_NV, SPV_ENV_VULKAN_1_2);
 
-    const auto break_vp = [&](CreatePipelineHelper &helper) {
+    const auto break_vp = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {ts.GetStageCreateInfo(), ms.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit);
@@ -289,7 +289,7 @@ TEST_F(PositiveMesh, MeshPerTaskNV) {
     VkShaderObj ts(*m_device, taskShaderText, VK_SHADER_STAGE_TASK_BIT_NV, SPV_ENV_VULKAN_1_2);
     VkShaderObj ms(*m_device, meshShaderText, VK_SHADER_STAGE_MESH_BIT_NV, SPV_ENV_VULKAN_1_2);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {ts.GetStageCreateInfo(), ms.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -316,7 +316,7 @@ TEST_F(PositiveMesh, DrawIndexMesh) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 32, max_primitives = 32, triangles) out;
@@ -340,7 +340,7 @@ TEST_F(PositiveMesh, DrawIndexTask) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         taskPayloadSharedEXT uint mesh_payload[32];
@@ -350,7 +350,7 @@ TEST_F(PositiveMesh, DrawIndexTask) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 32, max_primitives = 32, triangles) out;
@@ -381,7 +381,7 @@ TEST_F(PositiveMesh, MeshAndTaskShaderDerivatives) {
         GTEST_SKIP() << "meshAndTaskShaderDerivatives is not supported";
     }
 
-    const char *ms_source = R"(
+    const char* ms_source = R"(
                OpCapability ComputeDerivativeGroupQuadsKHR
                OpCapability MeshShadingEXT
                OpExtension "SPV_EXT_mesh_shader"
@@ -426,7 +426,7 @@ TEST_F(PositiveMesh, TessellationDynamicState) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 3, max_primitives=1) out;
@@ -458,7 +458,7 @@ TEST_F(PositiveMesh, TaskPayloadSharedSpecConstant) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(constant_id = 0) const int SIZE = 64;
@@ -472,7 +472,7 @@ TEST_F(PositiveMesh, TaskPayloadSharedSpecConstant) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 32, max_primitives = 32, triangles) out;

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -192,7 +192,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     std::vector<VkSubpassDependency> dependencies;
     dependencies.resize(extra_subpass_count);
     for (unsigned i = 0; i < dependencies.size(); ++i) {
-        auto &subpass_dep = dependencies[i];
+        auto& subpass_dep = dependencies[i];
         subpass_dep.srcSubpass = i;
         subpass_dep.dstSubpass = i + 1;
 
@@ -318,7 +318,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
 
     // Push constants
     {
-        const char *const vsSource = R"glsl(
+        const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo {
            mat3 m;
@@ -336,7 +336,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         pipeline_layout_info.pushConstantRangeCount = 1;
         pipeline_layout_info.pPushConstantRanges = &push_constant_range;
 
-        vkt::PipelineLayout layout(*m_device, pipeline_layout_info, std::vector<const vkt::DescriptorSetLayout *>{});
+        vkt::PipelineLayout layout(*m_device, pipeline_layout_info, std::vector<const vkt::DescriptorSetLayout*>{});
 
         CreatePipelineHelper pipe(*this);
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
@@ -393,7 +393,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         pipeline_layout_info.setLayoutCount = 1;
         pipeline_layout_info.pSetLayouts = &descriptor_set.layout_.handle();
 
-        vkt::PipelineLayout layout(*m_device, pipeline_layout_info, std::vector<vkt::DescriptorSetLayout const *>{});
+        vkt::PipelineLayout layout(*m_device, pipeline_layout_info, std::vector<vkt::DescriptorSetLayout const*>{});
 
         VkShaderObj const vs(*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
         VkShaderObj const fs(*m_device, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -457,7 +457,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         input_attribs.format = VK_FORMAT_R32G32_SFLOAT;
         input_attribs.offset = 0;
 
-        const char *const vsSource = R"glsl(
+        const char* const vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec2 input0;
         void main(){
@@ -532,7 +532,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         input_attribs.format = VK_FORMAT_R32G32_SFLOAT;
         input_attribs.offset = 0;
 
-        const char *const vsSource = R"glsl(
+        const char* const vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec2 input0;
         void main(){
@@ -652,7 +652,7 @@ TEST_F(NegativeMultiview, Features) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
-    std::vector<const char *> extension_list;
+    std::vector<const char*> extension_list;
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         extension_list.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     }
@@ -1066,7 +1066,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
 
     // tessellationShader
     {
-        const char *tcsSource = R"glsl(
+        const char* tcsSource = R"glsl(
         #version 450
         layout(vertices=3) out;
         void main(){
@@ -1074,7 +1074,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
            gl_TessLevelInner[0] = 1;
         }
         )glsl";
-        const char *tesSource = R"glsl(
+        const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -1106,7 +1106,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
     }
     // geometryShader
     {
-        const char *gsSource = R"glsl(
+        const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -1191,7 +1191,7 @@ TEST_F(NegativeMultiview, ShaderLayerBuiltInRenderPass) {
     AddRequiredFeature(vkt::Feature::multiviewGeometryShader);
     RETURN_IF_SKIP(Init());
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (triangle_strip) out;
@@ -1250,7 +1250,7 @@ TEST_F(NegativeMultiview, ShaderLayerBuiltInDynamicRendering) {
     AddRequiredFeature(vkt::Feature::multiviewGeometryShader);
     RETURN_IF_SKIP(Init());
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (triangle_strip) out;
@@ -1380,7 +1380,7 @@ TEST_F(NegativeMultiview, MeshShader) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices=81) out;

--- a/tests/unit/multiview_positive.cpp
+++ b/tests/unit/multiview_positive.cpp
@@ -158,7 +158,7 @@ TEST_F(PositiveMultiview, MeshShader) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices=81) out;

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (c) 2022 NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@
 #include "../framework/ray_tracing_objects.h"
 
 // Tests for NVIDIA-specific best practices
-const char *kEnableNVIDIAValidation = "validate_best_practices_nvidia";
+const char* kEnableNVIDIAValidation = "validate_best_practices_nvidia";
 
 static constexpr float defaultQueuePriority = 0.0f;
 
@@ -70,7 +70,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, TilingLinear) {
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_A8B8G8R8_UNORM_PACK32;
-    image_ci.extent = { 512, 512, 1 };
+    image_ci.extent = {512, 512, 1};
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -100,7 +100,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     // This should be VK_FORMAT_D24_UNORM_S8_UINT, but that's not a required format.
     image_ci.format = VK_FORMAT_A8B8G8R8_UNORM_PACK32;
-    image_ci.extent = { 512, 512, 1 };
+    image_ci.extent = {512, 512, 1};
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -113,7 +113,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
         m_errorMonitor->Finish();
     }
 
-    VkFormat formats[] = { VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT };
+    VkFormat formats[] = {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT};
 
     for (VkFormat format : formats) {
         image_ci.format = format;
@@ -246,9 +246,9 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
 
-    vkt::Queue *graphics_queue = m_device->QueuesWithGraphicsCapability()[0];
+    vkt::Queue* graphics_queue = m_device->QueuesWithGraphicsCapability()[0];
 
-    vkt::Queue *compute_queue = nullptr;
+    vkt::Queue* compute_queue = nullptr;
     for (uint32_t i = 0; i < m_device->QueuesWithComputeCapability().size(); ++i) {
         auto cqi = m_device->QueuesWithComputeCapability()[i];
         if (cqi->family_index != graphics_queue->family_index) {
@@ -261,11 +261,11 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
         GTEST_SKIP() << "Could not find a compute queue different from the graphics queue, skipping test";
     }
 
-    std::array<vkt::Queue *, 2> queues = {{graphics_queue, compute_queue}};
+    std::array<vkt::Queue*, 2> queues = {{graphics_queue, compute_queue}};
 
     auto build_geometry_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
 
-    for (vkt::Queue *queue : queues) {
+    for (vkt::Queue* queue : queues) {
         vkt::CommandPool compute_pool(*m_device, queue->family_index);
         vkt::CommandBuffer cmd_buffer(*m_device, compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
@@ -329,17 +329,23 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_ReuseAllocations) {
     memory_ai.pNext = &priority;
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-NVIDIA-AllocateMemory-ReuseAllocations");
-    { vkt::DeviceMemory memory(*m_device, memory_ai); }
+    {
+        vkt::DeviceMemory memory(*m_device, memory_ai);
+    }
 
     std::this_thread::sleep_for(std::chrono::seconds{6});
 
-    { vkt::DeviceMemory memory(*m_device, memory_ai); }
+    {
+        vkt::DeviceMemory memory(*m_device, memory_ai);
+    }
 
     m_errorMonitor->Finish();
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-NVIDIA-AllocateMemory-ReuseAllocations");
 
-    { vkt::DeviceMemory memory(*m_device, memory_ai); }
+    {
+        vkt::DeviceMemory memory(*m_device, memory_ai);
+    }
 
     m_errorMonitor->VerifyFound();
 }
@@ -520,11 +526,11 @@ TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_LargePipelineLayout)
     }
 
     VkDescriptorSetLayoutBinding large_bindings[] = {
-        { 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16, VK_SHADER_STAGE_VERTEX_BIT, nullptr },
-        { 1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr },
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
     };
     VkDescriptorSetLayoutBinding small_bindings[] = {
-        { 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16, VK_SHADER_STAGE_VERTEX_BIT, nullptr },
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
     };
 
     VkDescriptorSetLayoutCreateInfo large_set_layout_ci = vku::InitStructHelper();
@@ -572,12 +578,12 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineSwitchTessGeometryMesh) {
         GTEST_SKIP() << "Device doesn't support requried maxGeometryOutputVertices";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         void main() {}
     )glsl";
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices = 3) out;

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -188,7 +188,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
         descriptor_set.WriteDescriptorBufferView(0, view);
         descriptor_set.UpdateDescriptorSets();
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, r32f) uniform readonly imageBuffer s;
             layout(location=0) out vec4 x;
@@ -259,7 +259,7 @@ TEST_F(NegativeObjectLifetime, DescriptorSetStorageBufferDestroyed) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer SSBO { uint x; };
         void main(){
@@ -309,7 +309,7 @@ TEST_F(NegativeObjectLifetime, DISABLED_DescriptorSetMutableBufferDestroyed) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer SSBO { uint x; };
         void main(){
@@ -360,7 +360,7 @@ TEST_F(NegativeObjectLifetime, DISABLED_DescriptorSetMutableBufferArrayDestroyed
     descriptor_set.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer SSBO { uint x; } ssbo[2];
         void main(){
@@ -801,7 +801,7 @@ TEST_F(NegativeObjectLifetime, BufferViewInUseDestroyed) {
     VkResult err = vk::CreateBufferView(device(), &bvci, NULL, &view);
     ASSERT_EQ(VK_SUCCESS, err);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0, r32f) uniform readonly imageBuffer s;
         layout(location=0) out vec4 x;

--- a/tests/unit/object_lifetime_positive.cpp
+++ b/tests/unit/object_lifetime_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -179,7 +179,7 @@ TEST_F(PositiveObjectLifetime, DescriptorSetMutableBufferDestroyed) {
     descriptor_set1.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     descriptor_set1.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer SSBO { uint x; };
         // layout(set=1, binding=0) uniform UBO { uint y; };

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -228,7 +228,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
     if (nullptr == vkTrimCommandPool) m_errorMonitor->SetError("Unexpected null pointer");
     if (nullptr != vkTrimCommandPoolKHR) m_errorMonitor->SetError("Didn't receive expected null pointer");
 
-    const char *const extension = {VK_KHR_MAINTENANCE_1_EXTENSION_NAME};
+    const char* const extension = {VK_KHR_MAINTENANCE_1_EXTENSION_NAME};
     const float q_priority[] = {1.0f};
     VkDeviceQueueCreateInfo queue_ci = vku::InitStructHelper();
     queue_ci.queueFamilyIndex = 0;
@@ -301,7 +301,7 @@ TEST_F(VkPositiveLayerTest, EnumeratePhysicalDeviceGroups) {
 
     VkInstance test_instance = VK_NULL_HANDLE;
     ASSERT_EQ(VK_SUCCESS, vk::CreateInstance(&ici, nullptr, &test_instance));
-    for (const char *instance_ext_name : m_instance_extension_names) {
+    for (const char* instance_ext_name : m_instance_extension_names) {
         vk::InitInstanceExtension(test_instance, instance_ext_name);
     }
 
@@ -469,7 +469,7 @@ TEST_F(VkPositiveLayerTest, ExclusiveScissorVersionCount) {
     std::vector<VkExtensionProperties> properties(propertyCount);
     vk::EnumerateDeviceExtensionProperties(gpu_, nullptr, &propertyCount, properties.data());
     bool exclusiveScissor2 = false;
-    for (const auto &prop : properties) {
+    for (const auto& prop : properties) {
         if (strcmp(prop.extensionName, VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME) == 0) {
             if (prop.specVersion >= 2) {
                 exclusiveScissor2 = true;

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -11,7 +11,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
-//stype-check off
+// stype-check off
 
 #include <vulkan/vulkan_core.h>
 #include <algorithm>
@@ -71,7 +71,7 @@ TEST_F(VkLayerTest, VuidCheckForHashCollisions) {
 
     std::vector<uint32_t> hashes;
     hashes.reserve(GetVuidMap().size());
-    for (const auto &vuid_spec_text_pair : GetVuidMap()) {
+    for (const auto& vuid_spec_text_pair : GetVuidMap()) {
         const uint32_t hash = hash_util::VuidHash(vuid_spec_text_pair.first);
         hashes.push_back(hash);
     }
@@ -528,11 +528,11 @@ TEST_F(VkLayerTest, InvalidAllocationCallbacks) {
     VkCommandPool cmdPool;
 
     struct Alloc {
-        static VKAPI_ATTR void *VKAPI_CALL alloc(void *, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
-        static VKAPI_ATTR void *VKAPI_CALL realloc(void *, void *, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
-        static VKAPI_ATTR void VKAPI_CALL free(void *, void *){};
-        static VKAPI_ATTR void VKAPI_CALL internalAlloc(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
-        static VKAPI_ATTR void VKAPI_CALL internalFree(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
+        static VKAPI_ATTR void* VKAPI_CALL alloc(void*, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
+        static VKAPI_ATTR void* VKAPI_CALL realloc(void*, void*, size_t, size_t, VkSystemAllocationScope) { return nullptr; };
+        static VKAPI_ATTR void VKAPI_CALL free(void*, void*) {};
+        static VKAPI_ATTR void VKAPI_CALL internalAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
+        static VKAPI_ATTR void VKAPI_CALL internalFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
     };
 
     {
@@ -854,16 +854,13 @@ TEST_F(VkLayerTest, DuplicateValidPNextStructures) {
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-sType-unique");
     // in VkPhysicalDeviceProperties2 create a chain of pNext of type A -> B -> A
     // Also using different instance of struct to not trip the cycle checkings
-    VkPhysicalDeviceProtectedMemoryProperties protected_memory_properties_0 =
-        vku::InitStructHelper();
+    VkPhysicalDeviceProtectedMemoryProperties protected_memory_properties_0 = vku::InitStructHelper();
 
     VkPhysicalDeviceIDProperties id_properties = vku::InitStructHelper(&protected_memory_properties_0);
 
-    VkPhysicalDeviceProtectedMemoryProperties protected_memory_properties_1 =
-        vku::InitStructHelper(&id_properties);
+    VkPhysicalDeviceProtectedMemoryProperties protected_memory_properties_1 = vku::InitStructHelper(&id_properties);
 
-    VkPhysicalDeviceProperties2 physical_device_properties2 =
-        vku::InitStructHelper(&protected_memory_properties_1);
+    VkPhysicalDeviceProperties2 physical_device_properties2 = vku::InitStructHelper(&protected_memory_properties_1);
 
     vk::GetPhysicalDeviceProperties2(Gpu(), &physical_device_properties2);
     m_errorMonitor->VerifyFound();
@@ -1267,11 +1264,11 @@ TEST_F(VkLayerTest, GetDeviceProcAddrInstance) {
 // but need to unset variable and make sure works on Android before having CI run this
 TEST_F(VkLayerTest, DISABLED_DisplayApplicationName) {
     TEST_DESCRIPTION("Test message_format_display_application_name");
-    const char *name_0 = "first instance";
+    const char* name_0 = "first instance";
     app_info_.pApplicationName = name_0;
     RETURN_IF_SKIP(Init());
 
-    const char *name_1 = "second instance";
+    const char* name_1 = "second instance";
     app_info_.pApplicationName = name_1;
     const auto instance_create_info = GetInstanceCreateInfo();
     VkInstance instance2;

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 namespace {
 VKAPI_ATTR VkBool32 VKAPI_CALL EmptyDebugReportCallback(VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, uint64_t, size_t,
-                                                        int32_t, const char *, const char *, void *) {
+                                                        int32_t, const char*, const char*, void*) {
     return VK_FALSE;
 }
 }  // namespace
@@ -431,7 +431,7 @@ TEST_F(NegativeParent, Instance_DebugUtilsMessenger) {
     RETURN_IF_SKIP(Init());
     vkt::Instance instance2(GetInstanceCreateInfo());
 
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *) {};
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT*, DebugUtilsLabelCheckData*) {};
     DebugUtilsLabelCheckData callback_data{};
     callback_data.callback = empty_callback;
 
@@ -766,10 +766,9 @@ TEST_F(NegativeParent, UpdateDescriptorSetsTensor) {
     // allocate the descriptor set on a different device (m_second_device)
     auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
-    OneOffDescriptorSet descriptor_set(m_second_device,
-                                       {
-                                           {0, VK_DESCRIPTOR_TYPE_TENSOR_ARM, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                       });
+    OneOffDescriptorSet descriptor_set(m_second_device, {
+                                                            {0, VK_DESCRIPTOR_TYPE_TENSOR_ARM, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                        });
     descriptor_set.WriteDescriptorTensorInfo(0, &view.handle(), 0);
 
     m_errorMonitor->SetDesiredError("VUID-vkUpdateDescriptorSets-pDescriptorWrites-12324");
@@ -819,7 +818,7 @@ TEST_F(NegativeParent, FlushInvalidateMemory) {
     memory_range.offset = 0;
     memory_range.size = VK_WHOLE_SIZE;
 
-    void *pData;
+    void* pData;
     vk::MapMemory(device(), device_memory, 0, VK_WHOLE_SIZE, 0, &pData);
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-VkMappedMemoryRange-memory-device");
@@ -941,9 +940,9 @@ TEST_F(NegativeParent, MapMemory2) {
     map_info.offset = 0;
     map_info.size = memory_info.allocationSize;
 
-    uint32_t *pData = nullptr;
+    uint32_t* pData = nullptr;
     m_errorMonitor->SetDesiredError("UNASSIGNED-VkMemoryMapInfo-memory-parent");
-    vk::MapMemory2KHR(device(), &map_info, (void **)&pData);
+    vk::MapMemory2KHR(device(), &map_info, (void**)&pData);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -59,7 +59,7 @@ TEST_F(NegativePipeline, BasicCompute) {
     TEST_DESCRIPTION("Bind a compute pipeline (no subpasses)");
     RETURN_IF_SKIP(Init());
 
-    const char *cs = R"glsl(#version 450
+    const char* cs = R"glsl(#version 450
     layout(local_size_x=1) in;
     layout(set=0, binding=0) uniform block { vec4 x; };
     void main(){
@@ -205,7 +205,7 @@ TEST_F(NegativePipeline, PipelineRenderpassCompatibility) {
     att_state1.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
     att_state1.blendEnable = VK_TRUE;
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.cb_attachments_ = att_state1;
         helper.gp_ci_.pColorBlendState = nullptr;
     };
@@ -355,7 +355,7 @@ TEST_F(NegativePipeline, ShaderStageName) {
     // Attempt to Create Gfx Pipeline w/o a VS
     VkPipelineShaderStageCreateInfo shaderStage = fs.GetStageCreateInfo();  // should be: vs.GetStageCreateInfo();
 
-    auto set_info = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {shaderStage}; };
+    auto set_info = [&](CreatePipelineHelper& helper) { helper.shader_stages_ = {shaderStage}; };
     constexpr std::array vuids = {"VUID-VkGraphicsPipelineCreateInfo-pStages-06896",
                                   "VUID-VkGraphicsPipelineCreateInfo-stage-02096"};
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
@@ -379,7 +379,7 @@ TEST_F(NegativePipeline, ShaderStageBit) {
     InitRenderTarget();
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=1, local_size_y=1, local_size_z=1) in;
         void main(){
@@ -405,7 +405,7 @@ TEST_F(NegativePipeline, SampleRateFeatureDisable) {
     InitRenderTarget();
 
     // Cause the error by enabling sample shading...
-    auto set_shading_enable = [](CreatePipelineHelper &helper) { helper.ms_ci_.sampleShadingEnable = VK_TRUE; };
+    auto set_shading_enable = [](CreatePipelineHelper& helper) { helper.ms_ci_.sampleShadingEnable = VK_TRUE; };
     CreatePipelineHelper::OneshotTest(*this, set_shading_enable, kErrorBit,
                                       "VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784");
 }
@@ -417,7 +417,7 @@ TEST_F(NegativePipeline, SampleRateFeatureEnable) {
     InitRenderTarget();
 
     auto range_test = [this](float value, bool positive_test) {
-        auto info_override = [value](CreatePipelineHelper &helper) {
+        auto info_override = [value](CreatePipelineHelper& helper) {
             helper.ms_ci_.sampleShadingEnable = VK_TRUE;
             helper.ms_ci_.minSampleShading = value;
         };
@@ -443,7 +443,7 @@ TEST_F(NegativePipeline, DepthClipControlFeatureDisable) {
 
     VkPipelineViewportDepthClipControlCreateInfoEXT clip_control = vku::InitStructHelper();
     clip_control.negativeOneToOne = VK_TRUE;
-    auto set_shading_enable = [clip_control](CreatePipelineHelper &helper) { helper.vp_state_ci_.pNext = &clip_control; };
+    auto set_shading_enable = [clip_control](CreatePipelineHelper& helper) { helper.vp_state_ci_.pNext = &clip_control; };
     CreatePipelineHelper::OneshotTest(*this, set_shading_enable, kErrorBit,
                                       "VUID-VkPipelineViewportDepthClipControlCreateInfoEXT-negativeOneToOne-06470");
 }
@@ -456,11 +456,11 @@ TEST_F(NegativePipeline, SamplePNextUnknown) {
 
     VkPipelineSampleLocationsStateCreateInfoEXT sample_locations = vku::InitStructHelper();
     sample_locations.sampleLocationsInfo = vku::InitStructHelper();
-    auto good_chain = [&sample_locations](CreatePipelineHelper &helper) { helper.ms_ci_.pNext = &sample_locations; };
+    auto good_chain = [&sample_locations](CreatePipelineHelper& helper) { helper.ms_ci_.pNext = &sample_locations; };
     CreatePipelineHelper::OneshotTest(*this, good_chain, kErrorBit);
 
     VkInstanceCreateInfo instance_ci = vku::InitStructHelper();
-    auto bad_chain = [&instance_ci](CreatePipelineHelper &helper) { helper.ms_ci_.pNext = &instance_ci; };
+    auto bad_chain = [&instance_ci](CreatePipelineHelper& helper) { helper.ms_ci_.pNext = &instance_ci; };
     CreatePipelineHelper::OneshotTest(*this, bad_chain, kErrorBit, "VUID-VkPipelineMultisampleStateCreateInfo-pNext-pNext");
 }
 
@@ -577,7 +577,7 @@ TEST_F(NegativePipeline, RenderPassCustomeResolve) {
     ASSERT_TRUE(renderpass2.initialized());
 
     // shader uses gl_SamplePosition which causes the SPIR-V to include SampleRateShading capability
-    static const char *shader_source = R"glsl(
+    static const char* shader_source = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor;
         void main() {
@@ -652,7 +652,7 @@ TEST_F(NegativePipeline, CustomResolveSampleShadingImplicit) {
     AddRequiredFeature(vkt::Feature::sampleRateShading);
     RETURN_IF_SKIP(Init());
 
-    char const *vs_source = R"glsl(
+    char const* vs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 samp;
         void main(){
@@ -660,7 +660,7 @@ TEST_F(NegativePipeline, CustomResolveSampleShadingImplicit) {
         }
     )glsl";
 
-    char const *fs_source = R"glsl(
+    char const* fs_source = R"glsl(
         #version 460
         layout(location = 0) in sample vec4 samp; // implicitly sets with Sample Decoration
         layout(location = 0) out vec4 color;
@@ -874,13 +874,13 @@ TEST_F(NegativePipeline, PipelineCreationCacheControl) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const auto set_graphics_flags = [&](CreatePipelineHelper &helper) {
+    const auto set_graphics_flags = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     };
     CreatePipelineHelper::OneshotTest(*this, set_graphics_flags, kErrorBit,
                                       "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878");
 
-    const auto set_compute_flags = [&](CreateComputePipelineHelper &helper) {
+    const auto set_compute_flags = [&](CreateComputePipelineHelper& helper) {
         helper.cp_ci_.flags = VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT;
     };
     CreateComputePipelineHelper::OneshotTest(*this, set_compute_flags, kErrorBit,
@@ -944,7 +944,7 @@ TEST_F(NegativePipeline, NumBlendAttachMismatch) {
     pipe_ms_state_ci.minSampleShading = 1.0;
     pipe_ms_state_ci.pSampleMask = NULL;
 
-    const auto set_MSAA = [&](CreatePipelineHelper &helper) {
+    const auto set_MSAA = [&](CreatePipelineHelper& helper) {
         helper.ms_ci_ = pipe_ms_state_ci;
         helper.cb_ci_.attachmentCount = 0;
     };
@@ -958,7 +958,7 @@ TEST_F(NegativePipeline, ColorBlendInvalidLogicOp) {
     RETURN_IF_SKIP(Init());  // enables all supported features
     InitRenderTarget();
 
-    const auto set_shading_enable = [](CreatePipelineHelper &helper) {
+    const auto set_shading_enable = [](CreatePipelineHelper& helper) {
         helper.cb_ci_.logicOpEnable = VK_TRUE;
         helper.cb_ci_.logicOp = static_cast<VkLogicOp>(VK_LOGIC_OP_SET + 1);  // invalid logicOp to be tested
     };
@@ -972,7 +972,7 @@ TEST_F(NegativePipeline, ColorBlendUnsupportedLogicOp) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const auto set_shading_enable = [](CreatePipelineHelper &helper) { helper.cb_ci_.logicOpEnable = VK_TRUE; };
+    const auto set_shading_enable = [](CreatePipelineHelper& helper) { helper.cb_ci_.logicOpEnable = VK_TRUE; };
     CreatePipelineHelper::OneshotTest(*this, set_shading_enable, kErrorBit,
                                       "VUID-VkPipelineColorBlendStateCreateInfo-logicOpEnable-00606");
 }
@@ -986,7 +986,7 @@ TEST_F(NegativePipeline, ColorBlendUnsupportedDualSourceBlend) {
 
     VkPipelineColorBlendAttachmentState cb_attachments = {};
 
-    const auto set_dsb_src_color_enable = [&](CreatePipelineHelper &helper) { helper.cb_attachments_ = cb_attachments; };
+    const auto set_dsb_src_color_enable = [&](CreatePipelineHelper& helper) { helper.cb_attachments_ = cb_attachments; };
 
     cb_attachments.blendEnable = VK_TRUE;
     cb_attachments.srcColorBlendFactor = VK_BLEND_FACTOR_SRC1_COLOR;  // bad!
@@ -1034,7 +1034,7 @@ TEST_F(NegativePipeline, DuplicateStage) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), helper.vs_->GetStageCreateInfo(),
                                  helper.fs_->GetStageCreateInfo()};
     };
@@ -1125,7 +1125,7 @@ TEST_F(NegativePipeline, MissingEntrypoint) {
     {
         VkShaderObj fs(*m_device, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, nullptr,
                        "foo");
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-pName-00707");
@@ -1160,7 +1160,7 @@ TEST_F(NegativePipeline, MissingEntrypoint) {
 TEST_F(NegativePipeline, MissingEntrypoint2) {
     RETURN_IF_SKIP(Init());
 
-    const char *shader_source = R"(
+    const char* shader_source = R"(
         OpCapability Shader
         OpMemoryModel Logical GLSL450
         OpEntryPoint GLCompute %foo "foo"
@@ -1364,7 +1364,7 @@ TEST_F(NegativePipeline, AMDMixedAttachmentSamplesValidateGraphicsPipeline) {
     VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) { helper.ms_ci_ = ms_state_ci; };
+    const auto set_info = [&](CreatePipelineHelper& helper) { helper.ms_ci_ = ms_state_ci; };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-subpass-01505");
 }
 
@@ -1408,7 +1408,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesNV) {
         {VK_SAMPLE_COUNT_1_BIT, VK_SAMPLE_COUNT_4_BIT, VK_SAMPLE_COUNT_8_BIT, VK_FALSE, VK_FALSE, 1, true,
          "VUID-VkGraphicsPipelineCreateInfo-multisampledRenderToSingleSampled-06853"}};
 
-    for (const auto &test_case : test_cases) {
+    for (const auto& test_case : test_cases) {
         RenderPassSingleSubpass rp(*this);
         rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, test_case.color_samples, VK_IMAGE_LAYOUT_PREINITIALIZED,
                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -1425,7 +1425,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesNV) {
         // coverageModulationTableCount test.
         std::vector<float> cm_table{};
 
-        const auto break_samples = [&cmi, &rp, &ds, &cm_table, &test_case](CreatePipelineHelper &helper) {
+        const auto break_samples = [&cmi, &rp, &ds, &cm_table, &test_case](CreatePipelineHelper& helper) {
             cm_table.resize(test_case.table_count);
 
             cmi.flags = 0;
@@ -1473,7 +1473,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamples) {
         {VK_SAMPLE_COUNT_4_BIT, VK_SAMPLE_COUNT_4_BIT, VK_SAMPLE_COUNT_4_BIT, true}    // Pass
     };
 
-    for (const auto &test_case : test_cases) {
+    for (const auto& test_case : test_cases) {
         RenderPassSingleSubpass rp(*this);
         rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, test_case.color_samples, VK_IMAGE_LAYOUT_PREINITIALIZED,
                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -1494,7 +1494,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamples) {
 
         VkPipelineDepthStencilStateCreateInfo ds = vku::InitStructHelper();
 
-        const auto break_samples = [&rp, &ds, &test_case](CreatePipelineHelper &helper) {
+        const auto break_samples = [&rp, &ds, &test_case](CreatePipelineHelper& helper) {
             helper.ms_ci_.rasterizationSamples = test_case.raster_samples;
 
             helper.gp_ci_.renderPass = rp;
@@ -1568,7 +1568,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
             for (int ds = rs; ds >= 0 && !neg_comb_found; ds -= rs) {
                 for (int cs = rs / 2; cs > 0 && !neg_comb_found; cs /= 2) {
                     bool combination_found = false;
-                    for (const auto &combination : combinations) {
+                    for (const auto& combination : combinations) {
                         if (mode == combination.coverageReductionMode && rs == combination.rasterizationSamples &&
                             (ds & combination.depthStencilSamples || ds == 0) && (cs & combination.colorSamples || cs == 0)) {
                             combination_found = true;
@@ -1587,7 +1587,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
         }
     }
 
-    for (const auto &test_case : test_cases) {
+    for (const auto& test_case : test_cases) {
         RenderPassSingleSubpass rp(*this);
         rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, test_case.color_samples, VK_IMAGE_LAYOUT_UNDEFINED,
                                     VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -1602,7 +1602,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
         VkPipelineDepthStencilStateCreateInfo dss = vku::InitStructHelper();
         VkPipelineCoverageReductionStateCreateInfoNV crs = vku::InitStructHelper();
 
-        const auto break_samples = [&rp, &dss, &crs, &test_case](CreatePipelineHelper &helper) {
+        const auto break_samples = [&rp, &dss, &crs, &test_case](CreatePipelineHelper& helper) {
             crs.flags = 0;
             crs.coverageReductionMode = test_case.coverage_reduction_mode;
 
@@ -1646,7 +1646,7 @@ TEST_F(NegativePipeline, FragmentCoverageToColorNV) {
         {VK_FORMAT_R8G8B8A8_UNORM, VK_TRUE, 1, false},
     }};
 
-    for (const auto &test_case : test_cases) {
+    for (const auto& test_case : test_cases) {
         std::array<VkAttachmentDescription, 2> att = {{{}, {}}};
         att[0].format = VK_FORMAT_R8G8B8A8_UNORM;
         att[0].samples = VK_SAMPLE_COUNT_1_BIT;
@@ -1692,7 +1692,7 @@ TEST_F(NegativePipeline, FragmentCoverageToColorNV) {
 
         VkPipelineCoverageToColorStateCreateInfoNV cci = vku::InitStructHelper();
 
-        const auto break_samples = [&cci, &cbi, &rp, &test_case](CreatePipelineHelper &helper) {
+        const auto break_samples = [&cci, &cbi, &rp, &test_case](CreatePipelineHelper& helper) {
             cci.coverageToColorEnable = test_case.enabled;
             cci.coverageToColorLocation = test_case.location;
 
@@ -1734,7 +1734,7 @@ TEST_F(NegativePipeline, ViewportSwizzleNV) {
             "VUID-VkViewportSwizzleNV-x-parameter", "VUID-VkViewportSwizzleNV-y-parameter", "VUID-VkViewportSwizzleNV-z-parameter",
             "VUID-VkViewportSwizzleNV-w-parameter"};
 
-        auto break_swizzles = [&vp_swizzle_state](CreatePipelineHelper &helper) { helper.vp_state_ci_.pNext = &vp_swizzle_state; };
+        auto break_swizzles = [&vp_swizzle_state](CreatePipelineHelper& helper) { helper.vp_state_ci_.pNext = &vp_swizzle_state; };
 
         CreatePipelineHelper::OneshotTest(*this, break_swizzles, kErrorBit, expected_vuids);
     }
@@ -1755,7 +1755,7 @@ TEST_F(NegativePipeline, ViewportSwizzleNV) {
         viewports.fill({0, 0, 16, 16, 0, 1});
         scissors.fill({{0, 0}, {16, 16}});
 
-        auto break_vp_count = [&vp_swizzle_state, &viewports, &scissors](CreatePipelineHelper &helper) {
+        auto break_vp_count = [&vp_swizzle_state, &viewports, &scissors](CreatePipelineHelper& helper) {
             helper.vp_state_ci_.viewportCount = size32(viewports);
             helper.vp_state_ci_.pViewports = viewports.data();
             helper.vp_state_ci_.scissorCount = size32(scissors);
@@ -1788,7 +1788,7 @@ TEST_F(NegativePipeline, CreationFeedbackCount) {
     feedback_info.pipelineStageCreationFeedbackCount = 2;
     feedback_info.pPipelineStageCreationFeedbacks = &feedbacks[1];
 
-    auto set_feedback = [&feedback_info](CreatePipelineHelper &helper) { helper.gp_ci_.pNext = &feedback_info; };
+    auto set_feedback = [&feedback_info](CreatePipelineHelper& helper) { helper.gp_ci_.pNext = &feedback_info; };
 
     CreatePipelineHelper::OneshotTest(*this, set_feedback, kErrorBit);
 
@@ -1814,7 +1814,7 @@ TEST_F(NegativePipeline, CreationFeedbackCountCompute) {
     feedback_info.pipelineStageCreationFeedbackCount = 1;
     feedback_info.pPipelineStageCreationFeedbacks = &feedbacks[1];
 
-    const auto set_info = [&](CreateComputePipelineHelper &helper) { helper.cp_ci_.pNext = &feedback_info; };
+    const auto set_info = [&](CreateComputePipelineHelper& helper) { helper.cp_ci_.pNext = &feedback_info; };
 
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
@@ -1835,7 +1835,7 @@ TEST_F(NegativePipeline, LineRasterization) {
                                       "VUID-VkPipelineRasterizationLineStateCreateInfo-lineRasterizationMode-02769"};
         CreatePipelineHelper::OneshotTest(
             *this,
-            [&](CreatePipelineHelper &helper) {
+            [&](CreatePipelineHelper& helper) {
                 helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM;
                 helper.ms_ci_.alphaToCoverageEnable = VK_TRUE;
             },
@@ -1847,7 +1847,7 @@ TEST_F(NegativePipeline, LineRasterization) {
                                       "VUID-VkPipelineRasterizationLineStateCreateInfo-stippledLineEnable-02772"};
         CreatePipelineHelper::OneshotTest(
             *this,
-            [&](CreatePipelineHelper &helper) {
+            [&](CreatePipelineHelper& helper) {
                 helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM;
                 helper.line_state_ci_.stippledLineEnable = VK_TRUE;
             },
@@ -1859,7 +1859,7 @@ TEST_F(NegativePipeline, LineRasterization) {
                                       "VUID-VkPipelineRasterizationLineStateCreateInfo-stippledLineEnable-02771"};
         CreatePipelineHelper::OneshotTest(
             *this,
-            [&](CreatePipelineHelper &helper) {
+            [&](CreatePipelineHelper& helper) {
                 helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR;
                 helper.line_state_ci_.stippledLineEnable = VK_TRUE;
             },
@@ -1871,7 +1871,7 @@ TEST_F(NegativePipeline, LineRasterization) {
                                       "VUID-VkPipelineRasterizationLineStateCreateInfo-stippledLineEnable-02773"};
         CreatePipelineHelper::OneshotTest(
             *this,
-            [&](CreatePipelineHelper &helper) {
+            [&](CreatePipelineHelper& helper) {
                 helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH;
                 helper.line_state_ci_.stippledLineEnable = VK_TRUE;
             },
@@ -1882,7 +1882,7 @@ TEST_F(NegativePipeline, LineRasterization) {
                                       "VUID-VkPipelineRasterizationLineStateCreateInfo-stippledLineEnable-02774"};
         CreatePipelineHelper::OneshotTest(
             *this,
-            [&](CreatePipelineHelper &helper) {
+            [&](CreatePipelineHelper& helper) {
                 helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_DEFAULT;
                 helper.line_state_ci_.stippledLineEnable = VK_TRUE;
             },
@@ -1923,7 +1923,7 @@ TEST_F(NegativePipeline, NotCompatibleForSet) {
     descriptor_set.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint index; } u_index;
         layout(set = 0, binding = 1) uniform UniformStruct { ivec4 dummy; int val; } ubo;
@@ -1962,7 +1962,7 @@ TEST_F(NegativePipeline, NotCompatibleForSetIndependent) {
                                                 VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
     const vkt::PipelineLayout pipeline_layout_2(*m_device, {&descriptor_set.layout_});
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform UniformStruct { uint dummy; } ubo;
         void main() {
@@ -1988,7 +1988,7 @@ TEST_F(NegativePipeline, NotCompatibleForSetIndependent) {
 TEST_F(NegativePipeline, DescriptorSetNotBound) {
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO { uint x; };
         void main() {
@@ -2165,7 +2165,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     vkt::ImageView imageView = image.CreateView();
 
     // maps to VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
-    const char *fs_source_combined = R"glsl(
+    const char* fs_source_combined = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D samplerColor;
         layout(location=0) out vec4 color;
@@ -2177,7 +2177,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkShaderObj fs_combined(*m_device, fs_source_combined, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // maps to VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE and VK_DESCRIPTOR_TYPE_SAMPLER
-    const char *fs_source_seperate = R"glsl(
+    const char* fs_source_seperate = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform texture2D textureColor;
         layout (set=0, binding=1) uniform sampler samplers;
@@ -2193,7 +2193,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkShaderObj fs_seperate(*m_device, fs_source_seperate, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // maps to an unused image sampler that should not trigger validation as it is never sampled
-    const char *fs_source_unused = R"glsl(
+    const char* fs_source_unused = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D samplerColor;
         layout(location=0) out vec4 color;
@@ -2204,7 +2204,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkShaderObj fs_unused(*m_device, fs_source_unused, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // maps to VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER but makes sure it walks function tree to find sampling
-    const char *fs_source_function = R"glsl(
+    const char* fs_source_function = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D samplerColor;
         layout(location=0) out vec4 color;
@@ -2345,7 +2345,7 @@ TEST_F(NegativePipeline, ShaderDrawParametersNotEnabled10) {
         GTEST_SKIP() << "Test requires Vulkan exactly 1.0";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -2365,7 +2365,7 @@ TEST_F(NegativePipeline, ShaderDrawParametersNotEnabled11) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -2385,7 +2385,7 @@ TEST_F(NegativePipeline, CreateFlags) {
     InitRenderTarget();
 
     VkPipelineCreateFlags flags;
-    const auto set_info = [&](CreatePipelineHelper &helper) { helper.gp_ci_.flags = flags; };
+    const auto set_info = [&](CreatePipelineHelper& helper) { helper.gp_ci_.flags = flags; };
 
     flags = VK_PIPELINE_CREATE_DISPATCH_BASE;
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-00764");
@@ -2429,7 +2429,7 @@ TEST_F(NegativePipeline, CreateFlagsCompute) {
     RETURN_IF_SKIP(Init());
 
     VkPipelineCreateFlags flags;
-    const auto set_info = [&](CreateComputePipelineHelper &helper) { helper.cp_ci_.flags = flags; };
+    const auto set_info = [&](CreateComputePipelineHelper& helper) { helper.cp_ci_.flags = flags; };
 
     flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     m_errorMonitor->SetDesiredError("VUID-VkComputePipelineCreateInfo-None-09497");
@@ -2490,7 +2490,7 @@ TEST_F(NegativePipeline, CreateComputePipelineWithBadBasePointer) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=2, local_size_y=4) in;
         void main(){
@@ -2523,7 +2523,7 @@ TEST_F(NegativePipeline, CreateComputePipelineWithDerivatives) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=2, local_size_y=4) in;
         void main(){
@@ -2653,8 +2653,7 @@ TEST_F(NegativePipeline, DiscardRectangle) {
     uint32_t count = discard_rectangle_properties.maxDiscardRectangles + 1;
     std::vector<VkRect2D> discard_rectangles(count);
 
-    VkPipelineDiscardRectangleStateCreateInfoEXT discard_rectangle_state =
-        vku::InitStructHelper();
+    VkPipelineDiscardRectangleStateCreateInfoEXT discard_rectangle_state = vku::InitStructHelper();
     discard_rectangle_state.discardRectangleCount = count;
     discard_rectangle_state.pDiscardRectangles = discard_rectangles.data();
 
@@ -2779,8 +2778,7 @@ TEST_F(NegativePipeline, VariableSampleLocations) {
     sample_locations_info.sampleLocationsCount = valid_count;
     sample_locations_info.pSampleLocations = sample_location.data();
 
-    VkPipelineSampleLocationsStateCreateInfoEXT sample_locations_state =
-        vku::InitStructHelper();
+    VkPipelineSampleLocationsStateCreateInfoEXT sample_locations_state = vku::InitStructHelper();
     sample_locations_state.sampleLocationsEnable = VK_TRUE;
     sample_locations_state.sampleLocationsInfo = sample_locations_info;
 
@@ -2860,8 +2858,7 @@ TEST_F(NegativePipeline, RasterizationConservativeStateCreateInfo) {
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(conservative_rasterization_props);
 
-    VkPipelineRasterizationConservativeStateCreateInfoEXT conservative_state =
-        vku::InitStructHelper();
+    VkPipelineRasterizationConservativeStateCreateInfoEXT conservative_state = vku::InitStructHelper();
     conservative_state.extraPrimitiveOverestimationSize = -1.0f;
 
     CreatePipelineHelper pipe(*this);
@@ -2951,7 +2948,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessWithoutFeature) {
 
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.pDepthStencilState = &ds_ci;
         helper.gp_ci_.pColorBlendState = &cb_ci;
         helper.gp_ci_.renderPass = render_pass;
@@ -3004,7 +3001,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
     cb_ci.pAttachments = &cb_as;
     VkRenderPass render_pass_handle = VK_NULL_HANDLE;
 
-    auto create_render_pass = [&](VkPipelineDepthStencilStateCreateFlags subpass_flags, vkt::RenderPass &render_pass) {
+    auto create_render_pass = [&](VkPipelineDepthStencilStateCreateFlags subpass_flags, vkt::RenderPass& render_pass) {
         VkAttachmentDescription attachments[2] = {};
         attachments[0].flags = 0;
         attachments[0].format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -3050,7 +3047,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
         render_pass.Init(*this->m_device, rpci);
     };
 
-    auto set_flgas_pipeline_createinfo = [&](CreatePipelineHelper &helper) {
+    auto set_flgas_pipeline_createinfo = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.pDepthStencilState = &ds_ci;
         helper.gp_ci_.pColorBlendState = &cb_ci;
         helper.gp_ci_.renderPass = render_pass_handle;
@@ -3088,7 +3085,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
     }
 
     if (rasterization_order_features.rasterizationOrderDepthAttachmentAccess) {
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(early_fragment_tests) in;
             layout(location = 0) out vec4 uFragColor;
@@ -3099,7 +3096,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
 
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto set_stages_pipeline_createinfo = [&](CreatePipelineHelper &helper) {
+        auto set_stages_pipeline_createinfo = [&](CreatePipelineHelper& helper) {
             helper.gp_ci_.pDepthStencilState = &ds_ci;
             helper.gp_ci_.pColorBlendState = &cb_ci;
             helper.gp_ci_.renderPass = render_pass_handle;
@@ -3124,14 +3121,14 @@ TEST_F(NegativePipeline, MismatchedRenderPassAndPipelineAttachments) {
 
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-renderPass-07609");
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
                 #version 450
 
                 void main() {
                 }
             )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
                 #version 450
 
                 void main() {
@@ -3163,7 +3160,7 @@ TEST_F(NegativePipeline, IncompatibleScissorCountAndViewportCount) {
 
     VkViewport viewports[2] = {{0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}};
 
-    auto set_viewport_state_createinfo = [&](CreatePipelineHelper &helper) {
+    auto set_viewport_state_createinfo = [&](CreatePipelineHelper& helper) {
         helper.vp_state_ci_.viewportCount = 2;
         helper.vp_state_ci_.pViewports = viewports;
     };
@@ -3208,7 +3205,7 @@ TEST_F(NegativePipeline, ShaderTileImage) {
 
     if (shader_tile_image_features.shaderTileImageDepthReadAccess) {
         auto fs = VkShaderObj::CreateFromASM(this, kShaderTileImageDepthReadSpv, VK_SHADER_STAGE_FRAGMENT_BIT);
-        auto pipeline_createinfo = [&](CreatePipelineHelper &helper) {
+        auto pipeline_createinfo = [&](CreatePipelineHelper& helper) {
             ds_ci.depthWriteEnable = true;
 
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
@@ -3236,7 +3233,7 @@ TEST_F(NegativePipeline, ShaderTileImage) {
         ds_ci.front = stencil_state;
         ds_ci.back = stencil_state;
 
-        auto pipeline_createinfo = [&](CreatePipelineHelper &helper) {
+        auto pipeline_createinfo = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.gp_ci_.pDepthStencilState = &ds_ci;
             helper.gp_ci_.renderPass = VK_NULL_HANDLE;
@@ -3255,7 +3252,7 @@ TEST_F(NegativePipeline, ShaderTileImage) {
         rp.CreateRenderPass();
 
         // Check if the colorAttachmentRead capability enable, renderpass should be null
-        auto pipeline_createinfo = [&](CreatePipelineHelper &helper) {
+        auto pipeline_createinfo = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.gp_ci_.renderPass = rp;
         };
@@ -3272,7 +3269,7 @@ TEST_F(NegativePipeline, ShaderTileImage) {
         pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
         pipeline_rendering_info.stencilAttachmentFormat = VK_FORMAT_UNDEFINED;
 
-        auto pipeline_createinfo_with_ms = [&](CreatePipelineHelper &helper) {
+        auto pipeline_createinfo_with_ms = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.gp_ci_.pMultisampleState = &ms_ci;
             helper.gp_ci_.renderPass = VK_NULL_HANDLE;
@@ -3337,7 +3334,7 @@ TEST_F(NegativePipeline, RasterStateWithDepthBiasRepresentationInfo) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const auto create_pipe_with_depth_bias_representation = [this](VkDepthBiasRepresentationInfoEXT &depth_bias_representation) {
+    const auto create_pipe_with_depth_bias_representation = [this](VkDepthBiasRepresentationInfoEXT& depth_bias_representation) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
         VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper(&depth_bias_representation);
@@ -3676,7 +3673,7 @@ TEST_F(NegativePipeline, GeometryShaderConservativeRasterization) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (points) out;
@@ -3744,14 +3741,14 @@ TEST_F(NegativePipeline, PipelineCreationFlags2CacheControl) {
 
     VkPipelineCreateFlags2CreateInfo flags2 = vku::InitStructHelper();
 
-    const auto set_graphics_flags = [&](CreatePipelineHelper &helper) {
+    const auto set_graphics_flags = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.pNext = &flags2;
         flags2.flags = VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     };
     CreatePipelineHelper::OneshotTest(*this, set_graphics_flags, kErrorBit,
                                       "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878");
 
-    const auto set_compute_flags = [&](CreateComputePipelineHelper &helper) {
+    const auto set_compute_flags = [&](CreateComputePipelineHelper& helper) {
         helper.cp_ci_.pNext = &flags2;
         flags2.flags = VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT;
     };
@@ -3821,7 +3818,7 @@ TEST_F(NegativePipeline, ViewportStateScissorOverflow) {
     VkRect2D scissor_x = {{vvl::kI32Max / 2, 0}, {vvl::kI32Max / 2 + 64, 64}};
     VkRect2D scissor_y = {{0, vvl::kI32Max / 2}, {64, vvl::kI32Max / 2 + 64}};
 
-    const auto break_vp_x = [&](CreatePipelineHelper &helper) {
+    const auto break_vp_x = [&](CreatePipelineHelper& helper) {
         helper.vp_state_ci_.viewportCount = 1;
         helper.vp_state_ci_.pViewports = &viewport;
         helper.vp_state_ci_.scissorCount = 1;
@@ -3830,7 +3827,7 @@ TEST_F(NegativePipeline, ViewportStateScissorOverflow) {
     CreatePipelineHelper::OneshotTest(*this, break_vp_x, kErrorBit,
                                       std::vector<std::string>({"VUID-VkPipelineViewportStateCreateInfo-offset-02822"}));
 
-    const auto break_vp_y = [&](CreatePipelineHelper &helper) {
+    const auto break_vp_y = [&](CreatePipelineHelper& helper) {
         helper.vp_state_ci_.viewportCount = 1;
         helper.vp_state_ci_.pViewports = &viewport;
         helper.vp_state_ci_.scissorCount = 1;
@@ -3850,7 +3847,7 @@ TEST_F(NegativePipeline, ViewportStateScissorNegative) {
     VkRect2D scissor_x = {{-64, 0}, {256, 256}};
     VkRect2D scissor_y = {{0, -64}, {256, 256}};
 
-    const auto break_vp_x = [&](CreatePipelineHelper &helper) {
+    const auto break_vp_x = [&](CreatePipelineHelper& helper) {
         helper.vp_state_ci_.viewportCount = 1;
         helper.vp_state_ci_.pViewports = &viewport;
         helper.vp_state_ci_.scissorCount = 1;
@@ -3858,7 +3855,7 @@ TEST_F(NegativePipeline, ViewportStateScissorNegative) {
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp_x, kErrorBit, "VUID-VkPipelineViewportStateCreateInfo-x-02821");
 
-    const auto break_vp_y = [&](CreatePipelineHelper &helper) {
+    const auto break_vp_y = [&](CreatePipelineHelper& helper) {
         helper.vp_state_ci_.viewportCount = 1;
         helper.vp_state_ci_.pViewports = &viewport;
         helper.vp_state_ci_.scissorCount = 1;
@@ -3927,13 +3924,13 @@ TEST_F(NegativePipeline, PipelinePropertiesIdentifierEXT) {
     VkPipelinePropertiesIdentifierEXT pipeline_props = vku::InitStructHelper(&pipeline_info);
 
     m_errorMonitor->SetDesiredError("VUID-VkPipelinePropertiesIdentifierEXT-pNext-pNext");
-    vk::GetPipelinePropertiesEXT(device(), &pipeline_info, (VkBaseOutStructure *)&pipeline_props);
+    vk::GetPipelinePropertiesEXT(device(), &pipeline_info, (VkBaseOutStructure*)&pipeline_props);
     m_errorMonitor->VerifyFound();
 
     pipeline_props.pNext = nullptr;
     pipeline_props.sType = VK_STRUCTURE_TYPE_PIPELINE_INFO_KHR;
     m_errorMonitor->SetDesiredError("VUID-VkPipelinePropertiesIdentifierEXT-sType-sType");
-    vk::GetPipelinePropertiesEXT(device(), &pipeline_info, (VkBaseOutStructure *)&pipeline_props);
+    vk::GetPipelinePropertiesEXT(device(), &pipeline_info, (VkBaseOutStructure*)&pipeline_props);
     m_errorMonitor->VerifyFound();
 }
 // stype-check on
@@ -4037,9 +4034,9 @@ TEST_F(NegativePipeline, Viewport) {
     // test viewport and scissor arrays
     struct TestCase {
         uint32_t viewport_count;
-        VkViewport *viewports;
+        VkViewport* viewports;
         uint32_t scissor_count;
-        VkRect2D *scissors;
+        VkRect2D* scissors;
 
         std::vector<std::string> vuids;
     };
@@ -4091,8 +4088,8 @@ TEST_F(NegativePipeline, Viewport) {
           "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04130", "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04131"}},
     };
 
-    for (const auto &test_case : test_cases) {
-        const auto break_vp = [&test_case](CreatePipelineHelper &helper) {
+    for (const auto& test_case : test_cases) {
+        const auto break_vp = [&test_case](CreatePipelineHelper& helper) {
             helper.vp_state_ci_.viewportCount = test_case.viewport_count;
             helper.vp_state_ci_.pViewports = test_case.viewports;
             helper.vp_state_ci_.scissorCount = test_case.scissor_count;

--- a/tests/unit/pipeline_advanced_blend.cpp
+++ b/tests/unit/pipeline_advanced_blend.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ TEST_F(NegativePipelineAdvancedBlend, BlendOps) {
     memset(attachment_states, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
 
     // only 1 attachment state, different blend op values
-    const auto set_info_different = [&](CreatePipelineHelper &helper) {
+    const auto set_info_different = [&](CreatePipelineHelper& helper) {
         attachment_states[0].blendEnable = VK_TRUE;
         attachment_states[0].colorBlendOp = VK_BLEND_OP_HSL_COLOR_EXT;
         attachment_states[0].alphaBlendOp = VK_BLEND_OP_MULTIPLY_EXT;
@@ -55,7 +55,7 @@ TEST_F(NegativePipelineAdvancedBlend, BlendOps) {
 
     // Test is if independent blend is not supported
     if (!blend_operation_advanced.advancedBlendIndependentBlend && blend_operation_advanced.advancedBlendMaxColorAttachments > 1) {
-        const auto set_info_color = [&](CreatePipelineHelper &helper) {
+        const auto set_info_color = [&](CreatePipelineHelper& helper) {
             attachment_states[0].blendEnable = VK_TRUE;
             attachment_states[0].colorBlendOp = VK_BLEND_OP_MIN;
             attachment_states[0].alphaBlendOp = VK_BLEND_OP_MIN;

--- a/tests/unit/pipeline_binary.cpp
+++ b/tests/unit/pipeline_binary.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,13 +72,13 @@ TEST_F(NegativePipelineBinary, ReleaseCapturedDataAllocator) {
     RETURN_IF_SKIP(Init());
 
     struct Alloc {
-        static VKAPI_ATTR void *VKAPI_CALL alloc(void *, size_t size, size_t, VkSystemAllocationScope) { return malloc(size); };
-        static VKAPI_ATTR void *VKAPI_CALL reallocFunc(void *, void *original, size_t size, size_t, VkSystemAllocationScope) {
+        static VKAPI_ATTR void* VKAPI_CALL alloc(void*, size_t size, size_t, VkSystemAllocationScope) { return malloc(size); };
+        static VKAPI_ATTR void* VKAPI_CALL reallocFunc(void*, void* original, size_t size, size_t, VkSystemAllocationScope) {
             return realloc(original, size);
         };
-        static VKAPI_ATTR void VKAPI_CALL freeFunc(void *, void *ptr) { free(ptr); };
-        static VKAPI_ATTR void VKAPI_CALL internalAlloc(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
-        static VKAPI_ATTR void VKAPI_CALL internalFree(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
+        static VKAPI_ATTR void VKAPI_CALL freeFunc(void*, void* ptr) { free(ptr); };
+        static VKAPI_ATTR void VKAPI_CALL internalAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
+        static VKAPI_ATTR void VKAPI_CALL internalFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
     };
     const VkAllocationCallbacks allocator = {nullptr, Alloc::alloc, Alloc::reallocFunc, Alloc::freeFunc, nullptr, nullptr};
 
@@ -174,13 +174,13 @@ TEST_F(NegativePipelineBinary, Destroy) {
     pipe.CreateComputePipeline(true, true);
 
     struct Alloc {
-        static VKAPI_ATTR void *VKAPI_CALL alloc(void *, size_t size, size_t, VkSystemAllocationScope) { return malloc(size); };
-        static VKAPI_ATTR void *VKAPI_CALL reallocFunc(void *, void *original, size_t size, size_t, VkSystemAllocationScope) {
+        static VKAPI_ATTR void* VKAPI_CALL alloc(void*, size_t size, size_t, VkSystemAllocationScope) { return malloc(size); };
+        static VKAPI_ATTR void* VKAPI_CALL reallocFunc(void*, void* original, size_t size, size_t, VkSystemAllocationScope) {
             return realloc(original, size);
         };
-        static VKAPI_ATTR void VKAPI_CALL freeFunc(void *, void *ptr) { free(ptr); };
-        static VKAPI_ATTR void VKAPI_CALL internalAlloc(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
-        static VKAPI_ATTR void VKAPI_CALL internalFree(void *, size_t, VkInternalAllocationType, VkSystemAllocationScope){};
+        static VKAPI_ATTR void VKAPI_CALL freeFunc(void*, void* ptr) { free(ptr); };
+        static VKAPI_ATTR void VKAPI_CALL internalAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
+        static VKAPI_ATTR void VKAPI_CALL internalFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {};
     };
     const VkAllocationCallbacks allocator = {nullptr, Alloc::alloc, Alloc::reallocFunc, Alloc::freeFunc, nullptr, nullptr};
 

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -102,7 +102,7 @@ TEST_F(NegativePipelineLayout, ExcessSubsampledPerStageDescriptors) {
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
     pipeline_layout_ci.setLayoutCount = 1;
     pipeline_layout_ci.pSetLayouts = &ds_layout.handle();
-    const char *max_sampler_vuid = "VUID-VkPipelineLayoutCreateInfo-pImmutableSamplers-03566";
+    const char* max_sampler_vuid = "VUID-VkPipelineLayoutCreateInfo-pImmutableSamplers-03566";
     m_errorMonitor->SetDesiredError(max_sampler_vuid);
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci, {&ds_layout});
     m_errorMonitor->VerifyFound();
@@ -358,8 +358,7 @@ TEST_F(NegativePipelineLayout, ExcessDescriptorsOverall) {
     uint32_t sum_samplers = m_device->Physical().limits_.maxDescriptorSetSamplers;
     uint32_t sum_input_attachments = m_device->Physical().limits_.maxDescriptorSetInputAttachments;
 
-    VkPhysicalDeviceDescriptorIndexingProperties descriptor_indexing_properties =
-        vku::InitStructHelper();
+    VkPhysicalDeviceDescriptorIndexingProperties descriptor_indexing_properties = vku::InitStructHelper();
     if (descriptor_indexing) {
         GetPhysicalDeviceProperties2(descriptor_indexing_properties);
     }
@@ -694,7 +693,7 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatch) {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout (std140, set = 0, binding = 0) uniform buf {
             mat4 mvp;
@@ -744,7 +743,7 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0, nullptr);
 
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main"
@@ -782,13 +781,13 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
 
     // Should be VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
 
-    const auto set_sampled_image = [&](CreatePipelineHelper &helper) {
+    const auto set_sampled_image = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_[0] = {1, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr};
     };
     CreatePipelineHelper::OneshotTest(*this, set_sampled_image, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07990");
 
-    const auto set_sampler = [&](CreatePipelineHelper &helper) {
+    const auto set_sampler = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_[0] = {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr};
     };
@@ -828,7 +827,7 @@ TEST_F(NegativePipelineLayout, DescriptorNotAccessible) {
                                          {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT /*!*/, nullptr},
                                      });
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout (std140, set = 0, binding = 0) uniform buf {
             mat4 mvp;
@@ -878,7 +877,7 @@ TEST_F(NegativePipelineLayout, MissingDescriptor) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) buffer block { vec4 x; };
@@ -909,7 +908,7 @@ TEST_F(NegativePipelineLayout, MultiplePushDescriptorSets) {
                                 VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT);
     }
     std::vector<VkDescriptorSetLayout> ds_vk_layouts;
-    for (const auto &ds_layout : ds_layouts) {
+    for (const auto& ds_layout : ds_layouts) {
         ds_vk_layouts.push_back(ds_layout);
     }
 
@@ -968,7 +967,7 @@ TEST_F(NegativePipelineLayout, InlineUniformBlockArray) {
                                        0, nullptr, 0, nullptr, &pool_inline_info);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO0 { uint ssbo; };
@@ -1004,7 +1003,7 @@ TEST_F(NegativePipelineLayout, InlineUniformBlockArrayOf1) {
                                        0, nullptr, 0, nullptr, &pool_inline_info);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO0 { uint ssbo; };

--- a/tests/unit/pipeline_layout_positive.cpp
+++ b/tests/unit/pipeline_layout_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,16 +17,18 @@
 class PositivePipelineLayout : public VkLayerTest {};
 
 TEST_F(PositivePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
-    TEST_DESCRIPTION("HLSL will sometimes produce a SAMPLED_IMAGE / SAMPLER on the same slot that is same as COMBINED_IMAGE_SAMPLER");
+    TEST_DESCRIPTION(
+        "HLSL will sometimes produce a SAMPLED_IMAGE / SAMPLER on the same slot that is same as COMBINED_IMAGE_SAMPLER");
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0, nullptr);
 
-    OneOffDescriptorSet descriptor_set(m_device, {
-                                                     {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                                 });
+    OneOffDescriptorSet descriptor_set(m_device,
+                                       {
+                                           {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                       });
 
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main"

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -56,7 +56,7 @@ TEST_F(PositivePipeline, MissingDescriptorUnused) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) buffer block { vec4 x; };
@@ -79,7 +79,7 @@ TEST_F(PositivePipeline, FragmentShadingRate) {
     AddRequiredFeature(vkt::Feature::primitiveFragmentShadingRate);
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) buffer block { vec4 x; };
@@ -99,7 +99,7 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsSampler) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) uniform sampler s;
@@ -125,7 +125,7 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsImage) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) uniform texture2D t;
@@ -152,7 +152,7 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsBoth) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) uniform texture2D t;
@@ -178,12 +178,12 @@ TEST_F(PositivePipeline, IgnoredMultisampleState) {
 
     const uint64_t fake_address_64 = 0xCDCDCDCDCDCDCDCD;
     const uint64_t fake_address_32 = 0xCDCDCDCD;
-    void *bad_pointer = sizeof(void *) == 8 ? reinterpret_cast<void *>(fake_address_64) : reinterpret_cast<void *>(fake_address_32);
+    void* bad_pointer = sizeof(void*) == 8 ? reinterpret_cast<void*>(fake_address_64) : reinterpret_cast<void*>(fake_address_32);
 
     CreatePipelineHelper pipe(*this);
     pipe.VertexShaderOnly();
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pipe.gp_ci_.pMultisampleState = reinterpret_cast<const VkPipelineMultisampleStateCreateInfo *>(bad_pointer);
+    pipe.gp_ci_.pMultisampleState = reinterpret_cast<const VkPipelineMultisampleStateCreateInfo*>(bad_pointer);
     pipe.CreateGraphicsPipeline();
 }
 
@@ -192,7 +192,7 @@ TEST_F(PositivePipeline, CreateComputePipelineWithDerivatives) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         layout(local_size_x=2, local_size_y=4) in;
         void main(){
@@ -255,8 +255,8 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
 
     const uint64_t fake_address_64 = 0xCDCDCDCDCDCDCDCD;
     const uint64_t fake_address_32 = 0xCDCDCDCD;
-    void *hopefully_undereferencable_pointer =
-        sizeof(void *) == 8 ? reinterpret_cast<void *>(fake_address_64) : reinterpret_cast<void *>(fake_address_32);
+    void* hopefully_undereferencable_pointer =
+        sizeof(void*) == 8 ? reinterpret_cast<void*>(fake_address_64) : reinterpret_cast<void*>(fake_address_32);
 
     VkShaderObj vs(*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -338,12 +338,12 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
             stages,
             &pipeline_vertex_input_state_create_info,
             &pipeline_input_assembly_state_create_info,
-            reinterpret_cast<const VkPipelineTessellationStateCreateInfo *>(hopefully_undereferencable_pointer),
-            reinterpret_cast<const VkPipelineViewportStateCreateInfo *>(hopefully_undereferencable_pointer),
+            reinterpret_cast<const VkPipelineTessellationStateCreateInfo*>(hopefully_undereferencable_pointer),
+            reinterpret_cast<const VkPipelineViewportStateCreateInfo*>(hopefully_undereferencable_pointer),
             &pipeline_rasterization_state_create_info,
             &pipeline_multisample_state_create_info,
-            reinterpret_cast<const VkPipelineDepthStencilStateCreateInfo *>(hopefully_undereferencable_pointer),
-            reinterpret_cast<const VkPipelineColorBlendStateCreateInfo *>(hopefully_undereferencable_pointer),
+            reinterpret_cast<const VkPipelineDepthStencilStateCreateInfo*>(hopefully_undereferencable_pointer),
+            reinterpret_cast<const VkPipelineColorBlendStateCreateInfo*>(hopefully_undereferencable_pointer),
             nullptr,  // dynamic states
             pipeline_layout,
             m_renderPass,
@@ -406,8 +406,8 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
             &pipeline_viewport_state_create_info,
             &pipeline_rasterization_state_create_info,
             &pipeline_multisample_state_create_info,
-            reinterpret_cast<const VkPipelineDepthStencilStateCreateInfo *>(hopefully_undereferencable_pointer),
-            reinterpret_cast<const VkPipelineColorBlendStateCreateInfo *>(hopefully_undereferencable_pointer),
+            reinterpret_cast<const VkPipelineDepthStencilStateCreateInfo*>(hopefully_undereferencable_pointer),
+            reinterpret_cast<const VkPipelineColorBlendStateCreateInfo*>(hopefully_undereferencable_pointer),
             nullptr,  // dynamic states
             pipeline_layout,
             render_pass,
@@ -429,9 +429,9 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
             nullptr,  // pNext
             0,        // flags
             1,
-            reinterpret_cast<const VkViewport *>(hopefully_undereferencable_pointer),
+            reinterpret_cast<const VkViewport*>(hopefully_undereferencable_pointer),
             1,
-            reinterpret_cast<const VkRect2D *>(hopefully_undereferencable_pointer)};
+            reinterpret_cast<const VkRect2D*>(hopefully_undereferencable_pointer)};
 
         const VkPipelineDepthStencilStateCreateInfo pipeline_depth_stencil_state_create_info{
             VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
@@ -663,7 +663,7 @@ TEST_F(PositivePipeline, AttachmentUnused) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
@@ -686,7 +686,7 @@ TEST_F(PositivePipeline, AttachmentUnused) {
         VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attachment_descriptions, 1, subpass_descriptions, 0, nullptr};
     vkt::RenderPass render_pass(*m_device, render_pass_info);
 
-    const auto override_info = [&](CreatePipelineHelper &helper) {
+    const auto override_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.gp_ci_.renderPass = render_pass;
     };
@@ -792,7 +792,7 @@ TEST_F(PositivePipeline, SamplerDataForCombinedImageSampler) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                    OpCapability Shader
                    OpMemoryModel Logical GLSL450
                    OpEntryPoint Fragment %main "main"
@@ -1007,7 +1007,7 @@ TEST_F(PositivePipeline, PervertexNVShaderAttributes) {
 
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out PerVertex {
@@ -1026,7 +1026,7 @@ TEST_F(PositivePipeline, PervertexNVShaderAttributes) {
                 }
             )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
                 #version 450
 
                 #extension GL_NV_fragment_shader_barycentric : enable
@@ -1092,7 +1092,7 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
     fpvkSetPhysicalDeviceFormatProperties2EXT(Gpu(), image_view_format, fmt_props);
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"(
+    const char* csSource = R"(
                   OpCapability Shader
                   OpCapability StorageImageWriteWithoutFormat
              %1 = OpExtInstImport "GLSL.std.450"
@@ -1206,7 +1206,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineRasterizationOrderAttachmentAcces
     cb_ci.pAttachments = &cb_as;
     VkRenderPass render_pass_handle = VK_NULL_HANDLE;
 
-    auto create_render_pass = [&](VkPipelineDepthStencilStateCreateFlags subpass_flags, vkt::RenderPass &render_pass) {
+    auto create_render_pass = [&](VkPipelineDepthStencilStateCreateFlags subpass_flags, vkt::RenderPass& render_pass) {
         VkAttachmentDescription attachments[2] = {};
         attachments[0].flags = 0;
         attachments[0].format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -1252,7 +1252,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineRasterizationOrderAttachmentAcces
         render_pass.Init(*this->m_device, rpci);
     };
 
-    auto set_flgas_pipeline_createinfo = [&](CreatePipelineHelper &helper) {
+    auto set_flgas_pipeline_createinfo = [&](CreatePipelineHelper& helper) {
         helper.gp_ci_.pDepthStencilState = &ds_ci;
         helper.gp_ci_.pColorBlendState = &cb_ci;
         helper.gp_ci_.renderPass = render_pass_handle;
@@ -1316,7 +1316,7 @@ TEST_F(PositivePipeline, DualBlendShader) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location = 0, index = 0) out vec4 c1;
         layout(location = 0, index = 1) out vec4 c2;
@@ -1370,7 +1370,7 @@ TEST_F(PositivePipeline, CreationFeedbackCount0) {
     feedback_info.pPipelineCreationFeedback = &feedbacks[0];
     feedback_info.pipelineStageCreationFeedbackCount = 0;
 
-    auto set_feedback = [&feedback_info](CreatePipelineHelper &helper) { helper.gp_ci_.pNext = &feedback_info; };
+    auto set_feedback = [&feedback_info](CreatePipelineHelper& helper) { helper.gp_ci_.pNext = &feedback_info; };
 
     CreatePipelineHelper::OneshotTest(*this, set_feedback, kErrorBit);
 }
@@ -1429,7 +1429,7 @@ TEST_F(PositivePipeline, ViewportSwizzleNV) {
         vp_swizzle_state.viewportCount = size32(viewports);
         vp_swizzle_state.pViewportSwizzles = swizzle.data();
 
-        auto break_vp_count = [&vp_swizzle_state, &viewports, &scissors](CreatePipelineHelper &helper) {
+        auto break_vp_count = [&vp_swizzle_state, &viewports, &scissors](CreatePipelineHelper& helper) {
             helper.vp_state_ci_.viewportCount = size32(viewports);
             helper.vp_state_ci_.pViewports = viewports.data();
             helper.vp_state_ci_.scissorCount = size32(scissors);
@@ -1448,7 +1448,7 @@ TEST_F(PositivePipeline, ViewportSwizzleNV) {
         vp_swizzle_state.viewportCount = size32(viewports);
         vp_swizzle_state.pViewportSwizzles = swizzle.data();
 
-        auto break_vp_count = [&vp_swizzle_state, &viewports, &scissors](CreatePipelineHelper &helper) {
+        auto break_vp_count = [&vp_swizzle_state, &viewports, &scissors](CreatePipelineHelper& helper) {
             helper.vp_state_ci_.viewportCount = 1;
             helper.vp_state_ci_.pViewports = viewports.data();
             helper.vp_state_ci_.scissorCount = 1;
@@ -1475,7 +1475,7 @@ TEST_F(PositivePipeline, RasterStateWithDepthBiasRepresentationInfo) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const auto create_pipe_with_depth_bias_representation = [this](VkDepthBiasRepresentationInfoEXT &depth_bias_representation) {
+    const auto create_pipe_with_depth_bias_representation = [this](VkDepthBiasRepresentationInfoEXT& depth_bias_representation) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
         pipe.rs_state_ci_.pNext = &depth_bias_representation;
@@ -2250,7 +2250,7 @@ TEST_F(PositivePipeline, DisableShaderValidation) {
     RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint x; // something to trigger pipeline validation
@@ -2286,7 +2286,7 @@ TEST_F(PositivePipeline, DisableShaderValidationMaintenance5) {
     RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint x; // something to trigger pipeline validation
@@ -2337,7 +2337,7 @@ TEST_F(PositivePipeline, DisableShaderValidationGPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *frag_shader = R"glsl(
+    const char* frag_shader = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint x; // something to trigger pipeline validation
@@ -2394,7 +2394,7 @@ TEST_F(PositivePipeline, DisableShaderValidationMesh) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : enable
         layout(max_vertices = 3, max_primitives=1) out;
@@ -2504,7 +2504,7 @@ TEST_F(PositivePipeline, FramebufferMixedSamplesWithCoverageReductionTruncateNV)
     uint32_t combination_count = 0u;
     vk::GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(gpu_, &combination_count, nullptr);
     std::vector<VkFramebufferMixedSamplesCombinationNV> combinations(combination_count);
-    for (auto &combination : combinations) {
+    for (auto& combination : combinations) {
         combination = vku::InitStructHelper();
     }
     vk::GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(gpu_, &combination_count, combinations.data());
@@ -2515,7 +2515,7 @@ TEST_F(PositivePipeline, FramebufferMixedSamplesWithCoverageReductionTruncateNV)
     VkSampleCountFlagBits color_samples = VK_SAMPLE_COUNT_1_BIT;
 
     bool found = false;
-    for (const auto &combination : combinations) {
+    for (const auto& combination : combinations) {
         if (combination.coverageReductionMode == coverage_reduction_mode &&
             combination.rasterizationSamples == rasterization_samples &&
             (combination.depthStencilSamples == VK_SAMPLE_COUNT_4_BIT) && (combination.colorSamples == VK_SAMPLE_COUNT_1_BIT)) {
@@ -2549,7 +2549,7 @@ TEST_F(PositivePipeline, FramebufferMixedSamplesWithCoverageReductionTruncateNV)
     cmi.coverageModulationTableCount = 1;
     cmi.pCoverageModulationTable = &cm_table;
 
-    const auto break_samples = [&cmi, &rp, &ds, &rasterization_samples](CreatePipelineHelper &helper) {
+    const auto break_samples = [&cmi, &rp, &ds, &rasterization_samples](CreatePipelineHelper& helper) {
         helper.ms_ci_.pNext = &cmi;
         helper.ms_ci_.rasterizationSamples = rasterization_samples;
         helper.ms_ci_.sampleShadingEnable = VK_TRUE;

--- a/tests/unit/pipeline_topology.cpp
+++ b/tests/unit/pipeline_topology.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ TEST_F(NegativePipelineTopology, PolygonMode) {
     rs_ci.lineWidth = 1.0f;
     rs_ci.rasterizerDiscardEnable = VK_TRUE;
 
-    auto set_polygonMode = [&](CreatePipelineHelper &helper) { helper.rs_state_ci_ = rs_ci; };
+    auto set_polygonMode = [&](CreatePipelineHelper& helper) { helper.rs_state_ci_ = rs_ci; };
 
     // Set polygonMode to POINT while the non-solid fill mode feature is disabled.
     // Introduce failure by setting unsupported polygon mode
@@ -51,7 +51,7 @@ TEST_F(NegativePipelineTopology, PolygonMode) {
 }
 
 // Create VS declaring PointSize but not writing to it
-static const char *NoPointSizeVertShader = R"glsl(
+static const char* NoPointSizeVertShader = R"glsl(
     #version 450
     vec2 vertices[3];
     out gl_PerVertex
@@ -75,7 +75,7 @@ TEST_F(NegativePipelineTopology, PointSize) {
 
     VkShaderObj vs(*m_device, NoPointSizeVertShader, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -99,7 +99,7 @@ TEST_F(NegativePipelineTopology, PointSizeNonDynamicAndRestricted) {
 
     VkShaderObj vs(*m_device, NoPointSizeVertShader, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -123,7 +123,7 @@ TEST_F(NegativePipelineTopology, PointSizeNonDynamicAndUnrestricted) {
 
     VkShaderObj vs(*m_device, NoPointSizeVertShader, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -154,7 +154,7 @@ TEST_F(NegativePipelineTopology, PointSizeDynamicAndRestricted) {
     dyn_state_ci.dynamicStateCount = 1;
     dyn_state_ci.pDynamicStates = &dyn_state;
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.dyn_state_ci_ = dyn_state_ci;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
@@ -175,7 +175,7 @@ TEST_F(NegativePipelineTopology, PrimitiveTopology) {
 
     VkPrimitiveTopology topology;
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = topology;
         helper.ia_ci_.primitiveRestartEnable = VK_TRUE;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
@@ -232,10 +232,10 @@ TEST_F(NegativePipelineTopology, PrimitiveTopologyListRestart) {
 
     VkPrimitiveTopology topology;
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = topology;
         helper.ia_ci_.primitiveRestartEnable = VK_TRUE;
-        helper.shader_stages_ = { vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo() };
+        helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
 
     topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
@@ -257,8 +257,8 @@ TEST_F(NegativePipelineTopology, PatchListNoTessellation) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    auto set_info = [&](CreatePipelineHelper &helper) { helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST; };
-    const char *vuid = IsExtensionsEnabled(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME)
+    auto set_info = [&](CreatePipelineHelper& helper) { helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST; };
+    const char* vuid = IsExtensionsEnabled(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME)
                            ? "VUID-VkGraphicsPipelineCreateInfo-topology-08889"
                            : "VUID-VkGraphicsPipelineCreateInfo-topology-08889";
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuid);
@@ -275,7 +275,7 @@ TEST_F(NegativePipelineTopology, FillRectangleNV) {
 
     VkPolygonMode polygon_mode = VK_POLYGON_MODE_LINE;
 
-    auto set_polygon_mode = [&polygon_mode](CreatePipelineHelper &helper) { helper.rs_state_ci_.polygonMode = polygon_mode; };
+    auto set_polygon_mode = [&polygon_mode](CreatePipelineHelper& helper) { helper.rs_state_ci_.polygonMode = polygon_mode; };
 
     // Set unsupported polygon mode VK_POLYGON_MODE_LINE
     CreatePipelineHelper::OneshotTest(*this, set_polygon_mode, kErrorBit,

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ TEST_F(PositivePipelineTopology, PointSizeGeomShaderDontEmit) {
     InitRenderTarget();
 
     // Never calls OpEmitVertex
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -77,7 +77,7 @@ TEST_F(PositivePipelineTopology, PointSizeGeomShaderDontEmit) {
     VkShaderObj vs(*m_device, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(*m_device, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
@@ -90,7 +90,7 @@ TEST_F(PositivePipelineTopology, LoosePointSizeWrite) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *LoosePointSizeWrite = R"(
+    const char* LoosePointSizeWrite = R"(
                                        OpCapability Shader
                                   %1 = OpExtInstImport "GLSL.std.450"
                                        OpMemoryModel Logical GLSL450
@@ -172,7 +172,7 @@ TEST_F(PositivePipelineTopology, LoosePointSizeWrite) {
 TEST_F(PositivePipelineTopology, PointSizeStructMemberWritten) {
     TEST_DESCRIPTION("Write built-in PointSize within a struct");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1); // At least 1.1 is required for maintenance4
+    SetTargetApiVersion(VK_API_VERSION_1_1);  // At least 1.1 is required for maintenance4
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::maintenance4);
     RETURN_IF_SKIP(Init());
@@ -402,7 +402,7 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
 
     InitRenderTarget();
 
-    const char *tcsSource = R"glsl(
+    const char* tcsSource = R"glsl(
         #version 450
         layout(vertices = 3) out;
         void main(){
@@ -410,7 +410,7 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
            gl_TessLevelInner[0] = 1;
         }
     )glsl";
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -418,7 +418,7 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
            gl_Position.w = 1.0f;
         }
     )glsl";
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (triangle_strip) out;
@@ -535,7 +535,7 @@ TEST_F(PositivePipelineTopology, PointSizeMaintenance5) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *source = R"glsl(
+    const char* source = R"glsl(
         #version 450
         vec2 vertices[3];
         out gl_PerVertex
@@ -553,7 +553,7 @@ TEST_F(PositivePipelineTopology, PointSizeMaintenance5) {
 
     VkShaderObj vs(*m_device, source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -494,7 +494,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
 
     // Attempt to use isolines in the TES shader when not available
     {
-        const char *tes_source = R"glsl(
+        const char* tes_source = R"glsl(
             #version 450
             layout(isolines, equal_spacing, cw) in;
             void main() {
@@ -510,7 +510,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
 
     // Attempt to use point_mode in the TES shader when not available
     {
-        const char *tes_source = R"glsl(
+        const char* tes_source = R"glsl(
             #version 450
             layout(triangles, point_mode) in;
             void main() {
@@ -531,7 +531,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
 
     // Attempt to use interpolation functions when not supported
     {
-        const char *vs_source = R"glsl(
+        const char* vs_source = R"glsl(
             #version 450
             layout(location = 0) out vec4 c;
             void main() {
@@ -541,7 +541,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
         )glsl";
         VkShaderObj vs_obj(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-        const char *fs_source = R"glsl(
+        const char* fs_source = R"glsl(
             #version 450
             layout(location = 0) in vec4 c;
             layout(location = 0) out vec4 frag_out;
@@ -594,8 +594,8 @@ TEST_F(VkPortabilitySubsetTest, PortabilitySubsetColorBlendFactor) {
 
 TEST_F(VkPortabilitySubsetTest, InstanceCreateEnumerate) {
     TEST_DESCRIPTION("Validate creating instances with VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR.");
-    std::vector<const char *> enabled_extensions = {VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
-                                                    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME};
+    std::vector<const char*> enabled_extensions = {VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+                                                   VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME};
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     GTEST_SKIP() << "Android doesn't support Debug Utils";

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -909,7 +909,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdUpdateBuffer-commandBuffer-01813");
-        vk::CmdUpdateBuffer(m_command_buffer, buffer_protected, 0, 4, (void *)update_data);
+        vk::CmdUpdateBuffer(m_command_buffer, buffer_protected, 0, 4, (void*)update_data);
         m_errorMonitor->VerifyFound();
 
         m_command_buffer.BeginRenderPass(rp, framebuffer, render_area.extent.width, render_area.extent.height);
@@ -978,7 +978,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdUpdateBuffer-commandBuffer-01814");
-        vk::CmdUpdateBuffer(protectedCommandBuffer, buffer_unprotected, 0, 4, (void *)update_data);
+        vk::CmdUpdateBuffer(protectedCommandBuffer, buffer_unprotected, 0, 4, (void*)update_data);
         m_errorMonitor->VerifyFound();
 
         protectedCommandBuffer.BeginRenderPass(rp, framebuffer, render_area.extent.width, render_area.extent.height);
@@ -1104,7 +1104,7 @@ TEST_F(NegativeProtectedMemory, RayQuery) {
     InitRenderTarget();
 
     // kFragmentMinimalGlsl but with added OpCapability RayQueryKHR
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability RayQueryKHR
                OpExtension "SPV_KHR_ray_query"

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,7 +173,7 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
         const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout, &ds_layout, &push_ds_layout, &ds_layout});
         ASSERT_TRUE(pipeline_layout.initialized());
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=2) layout(binding=0) uniform foo { vec4 y; } bar;
@@ -205,7 +205,7 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
         const VkWriteDescriptorSet descriptor_write =
             vkt::Device::WriteDescriptorSet(vkt::DescriptorSet(), 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, &buffer_info);
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=3) layout(binding=0) uniform foo { vec4 y; } bar;
@@ -236,9 +236,9 @@ TEST_F(PositivePushDescriptor, CreateDescriptorSetBindingWithIgnoredSamplers) {
     RETURN_IF_SKIP(Init());
     const uint64_t fake_address_64 = 0xCDCDCDCDCDCDCDCD;
     const uint64_t fake_address_32 = 0xCDCDCDCD;
-    const void *fake_pointer =
-        sizeof(void *) == 8 ? reinterpret_cast<void *>(fake_address_64) : reinterpret_cast<void *>(fake_address_32);
-    const VkSampler *hopefully_undereferencable_pointer = reinterpret_cast<const VkSampler *>(fake_pointer);
+    const void* fake_pointer =
+        sizeof(void*) == 8 ? reinterpret_cast<void*>(fake_address_64) : reinterpret_cast<void*>(fake_address_32);
+    const VkSampler* hopefully_undereferencable_pointer = reinterpret_cast<const VkSampler*>(fake_pointer);
 
     // regular descriptors
     {

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -37,7 +37,7 @@ TEST_F(NegativeQuery, PerformanceCreation) {
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
-        for (auto &c : counters) {
+        for (auto& c : counters) {
             c = vku::InitStructHelper();
         }
         vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
@@ -113,7 +113,7 @@ TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
-        for (auto &c : counters) {
+        for (auto& c : counters) {
             c = vku::InitStructHelper();
         }
         vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
@@ -226,7 +226,7 @@ TEST_F(NegativeQuery, PerformanceCounterRenderPassScope) {
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
-        for (auto &c : counters) {
+        for (auto& c : counters) {
             c = vku::InitStructHelper();
         }
         vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
@@ -317,7 +317,7 @@ TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
-        for (auto &c : counters) {
+        for (auto& c : counters) {
             c = vku::InitStructHelper();
         }
         vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
@@ -453,7 +453,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
-        for (auto &c : counters) {
+        for (auto& c : counters) {
             c = vku::InitStructHelper();
         }
         vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
@@ -674,7 +674,7 @@ TEST_F(NegativeQuery, PerformanceResetAndBegin) {
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
-        for (auto &c : counters) {
+        for (auto& c : counters) {
             c = vku::InitStructHelper();
         }
         vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
@@ -2425,7 +2425,7 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     AddRequiredFeature(vkt::Feature::performanceCounterQueryPools);
     RETURN_IF_SKIP(Init());
 
-    vkt::Queue *queue0 = m_default_queue;
+    vkt::Queue* queue0 = m_default_queue;
     auto queue1_family = m_device->ComputeOnlyQueueFamily();
     if (!queue1_family.has_value()) {
         GTEST_SKIP() << "Can't find two different queue families";

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -624,7 +624,8 @@ TEST_F(PositiveQuery, QueryPoolResetBit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkQueryPoolCreateInfo qpci = vkt::QueryPool::CreateInfo(VK_QUERY_TYPE_PIPELINE_STATISTICS, 1, VK_QUERY_POOL_CREATE_RESET_BIT_KHR);
+    VkQueryPoolCreateInfo qpci =
+        vkt::QueryPool::CreateInfo(VK_QUERY_TYPE_PIPELINE_STATISTICS, 1, VK_QUERY_POOL_CREATE_RESET_BIT_KHR);
     qpci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT;
     vkt::QueryPool query_pool(*m_device, qpci);
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -909,7 +909,7 @@ TEST_F(NegativeRayTracing, CopyMemoryToAccelerationStructureHostAddress) {
     blas->Create();
 
     VkDeviceOrHostAddressConstKHR output_data;
-    output_data.hostAddress = reinterpret_cast<void *>(0x00000021);
+    output_data.hostAddress = reinterpret_cast<void*>(0x00000021);
 
     VkCopyMemoryToAccelerationStructureInfoKHR info = vku::InitStructHelper();
     info.dst = blas->handle();
@@ -949,7 +949,7 @@ TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
     blas->Create();
 
     uint8_t output[4096];
-    uint8_t *aligned_output = reinterpret_cast<uint8_t *>(Align<uintptr_t>(reinterpret_cast<uintptr_t>(output), 16));
+    uint8_t* aligned_output = reinterpret_cast<uint8_t*>(Align<uintptr_t>(reinterpret_cast<uintptr_t>(output), 16));
     VkDeviceOrHostAddressConstKHR output_data;
     output_data.hostAddress = aligned_output;
 
@@ -1805,7 +1805,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.SetUpdateDstAccelStructSizeBeforeBuild(false);
         std::vector<VkAccelerationStructureGeometryKHR> geometries;
-        for (const auto &geometry : blas.GetGeometries()) {
+        for (const auto& geometry : blas.GetGeometries()) {
             geometries.emplace_back(geometry.GetVkObj());
         }
         blas.GetInfo().pGeometries = geometries.data();  // .ppGeometries is set in .BuildCmdBuffer()
@@ -1902,7 +1902,7 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
     {
         std::vector<vkt::Buffer> dst_blas_buffers(build_info_count);
         std::vector<vkt::as::BuildGeometryInfoKHR> build_infos;
-        for (auto &dst_blas_buffer : dst_blas_buffers) {
+        for (auto& dst_blas_buffer : dst_blas_buffers) {
             dst_blas_buffer.InitNoMemory(*m_device, dst_blas_buffer_ci);
             vk::BindBufferMemory(device(), dst_blas_buffer, buffer_memory, 0);
 
@@ -2015,7 +2015,7 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory2) {
         std::vector<vkt::as::BuildGeometryInfoKHR> build_infos;
 
         VkDeviceAddress ref_address = 0;
-        for (auto &scratch_buffer : scratch_buffers) {
+        for (auto& scratch_buffer : scratch_buffers) {
             scratch_buffer = std::make_shared<vkt::Buffer>(*m_device, scratch_buffer_ci, vkt::no_mem);
             vk::BindBufferMemory(device(), scratch_buffer->handle(), buffer_memory, 0);
 
@@ -2219,7 +2219,7 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureToMemoryKHR) {
 
     std::vector<uint8_t> data(4096, 0);
     VkDeviceOrHostAddressKHR output_data;
-    output_data.hostAddress = reinterpret_cast<void *>(Align<uintptr_t>(reinterpret_cast<uintptr_t>(data.data()), 16));
+    output_data.hostAddress = reinterpret_cast<void*>(Align<uintptr_t>(reinterpret_cast<uintptr_t>(data.data()), 16));
     VkCopyAccelerationStructureToMemoryInfoKHR copy_info = vku::InitStructHelper();
     copy_info.src = blas->handle();
     copy_info.dst = output_data;
@@ -4152,7 +4152,7 @@ TEST_F(NegativeRayTracing, BuildPartitionedAccelerationStructureInfo) {
                              vkt::device_address);
 
     int input = instance_count;
-    auto *data = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    auto* data = static_cast<uint32_t*>(count_buffer.Memory().Map());
     memcpy(data, &input, sizeof(input));
     VkDeviceAddress count_buffer_address = count_buffer.Address();
 
@@ -4312,8 +4312,8 @@ TEST_F(NegativeRayTracing, BuildPartitionedAccelerationStrutureInfoBadMemory) {
         writePartitionArgs.push_back(writePartition);
     }
 
-    auto *write_partition_data =
-        static_cast<VkPartitionedAccelerationStructureWritePartitionTranslationDataNV *>(write_partition_buffer.Memory().Map());
+    auto* write_partition_data =
+        static_cast<VkPartitionedAccelerationStructureWritePartitionTranslationDataNV*>(write_partition_buffer.Memory().Map());
     memcpy(write_partition_data, writePartitionArgs.data(),
            partition_count * sizeof(VkPartitionedAccelerationStructureWritePartitionTranslationDataNV));
     VkDeviceAddress write_partition_buffer_address = write_partition_buffer.Address();
@@ -4330,7 +4330,7 @@ TEST_F(NegativeRayTracing, BuildPartitionedAccelerationStrutureInfoBadMemory) {
                                 VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
                                     VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
                                 vkt::device_address);
-    auto *src_info_data = static_cast<VkBuildPartitionedAccelerationStructureIndirectCommandNV *>(src_info_buffer.Memory().Map());
+    auto* src_info_data = static_cast<VkBuildPartitionedAccelerationStructureIndirectCommandNV*>(src_info_buffer.Memory().Map());
     memcpy(src_info_data, ptlas_ops.data(), sizeof(VkBuildPartitionedAccelerationStructureIndirectCommandNV));
     VkDeviceAddress src_info_buffer_address = src_info_buffer.Address();
 
@@ -4406,7 +4406,7 @@ TEST_F(NegativeRayTracing, DISABLED_CmdBuildPartitionedAccelerationStructures) {
         vkt::device_address);
     // store the value into count buffer
     int input = instance_count;
-    auto *data = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    auto* data = static_cast<uint32_t*>(count_buffer.Memory().Map());
     memcpy(data, &input, sizeof(input));
     VkDeviceAddress count_buffer_address = count_buffer.Address();
     // constant size here is irrelevant, this test just check the feature enabled
@@ -4519,7 +4519,7 @@ TEST_F(NegativeRayTracing, CmdBuildClusterAccelerationStructureIndirect) {
         *m_device, sizeof(uint32_t),
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
         vkt::device_address);
-    auto *count_data = static_cast<uint32_t *>(src_count_buffer.Memory().Map());
+    auto* count_data = static_cast<uint32_t*>(src_count_buffer.Memory().Map());
     memcpy(count_data, &input_num, sizeof(input_num));
 
     VkClusterAccelerationStructureCommandsInfoNV command_info = vku::InitStructHelper();
@@ -4598,7 +4598,7 @@ TEST_F(NegativeRayTracing, CmdBuildClusterAccelerationStructureIndirectBadMemory
         *m_device, 10 * sizeof(uint32_t),
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
         vkt::device_address);
-    auto *index_data = static_cast<uint32_t *>(index_buffer.Memory().Map());
+    auto* index_data = static_cast<uint32_t*>(index_buffer.Memory().Map());
     memcpy(index_data, index_data_f, sizeof(index_data_f));
 
     vkt::Buffer src_info_buffer(
@@ -4628,8 +4628,8 @@ TEST_F(NegativeRayTracing, CmdBuildClusterAccelerationStructureIndirectBadMemory
     triClusterTemplateArg.opacityMicromapIndexBuffer = 0;
     triClusterTemplateArg.instantiationBoundingBoxLimit = 0;
 
-    auto *src_info_data =
-        static_cast<VkClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV *>(src_info_buffer.Memory().Map());
+    auto* src_info_data =
+        static_cast<VkClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV*>(src_info_buffer.Memory().Map());
     memcpy(src_info_data, &triClusterTemplateArg, sizeof(triClusterTemplateArg));
 
     vkt::Buffer src_count_buffer(
@@ -4637,7 +4637,7 @@ TEST_F(NegativeRayTracing, CmdBuildClusterAccelerationStructureIndirectBadMemory
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
         vkt::device_address);
     uint32_t input_num = 1;
-    auto *count_data = static_cast<uint32_t *>(src_count_buffer.Memory().Map());
+    auto* count_data = static_cast<uint32_t*>(src_count_buffer.Memory().Map());
     memcpy(count_data, &input_num, sizeof(input_num));
 
     VkClusterAccelerationStructureCommandsInfoNV command_info = vku::InitStructHelper();
@@ -4777,7 +4777,7 @@ TEST_F(NegativeRayTracing, DISABLED_ClusterAccelerationStructureCommandsInfo) {
         *m_device, sizeof(uint32_t),
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
         vkt::device_address);
-    auto *count_data = static_cast<uint32_t *>(src_count_buffer.Memory().Map());
+    auto* count_data = static_cast<uint32_t*>(src_count_buffer.Memory().Map());
     memcpy(count_data, &input_num, sizeof(input_num));
 
     VkClusterAccelerationStructureCommandsInfoNV command_info = vku::InitStructHelper();
@@ -5015,7 +5015,7 @@ TEST_F(NegativeRayTracing, ClusterAccelerationStructureTriangleClusterInput) {
         *m_device, sizeof(uint32_t),
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
         vkt::device_address);
-    auto *count_data = static_cast<uint32_t *>(src_count_buffer.Memory().Map());
+    auto* count_data = static_cast<uint32_t*>(src_count_buffer.Memory().Map());
     memcpy(count_data, &input_num, sizeof(input_num));
 
     vkt::Buffer implicit_buffer(*m_device, clas_size_info.accelerationStructureSize + 256,
@@ -5423,7 +5423,7 @@ TEST_F(NegativeRayTracing, CmdBuildClusterAccelerationStructureIndirectValidatio
                                     VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
                                 vkt::device_address);
 
-    auto *data = static_cast<uint32_t *>(count_buffer.Memory().Map());
+    auto* data = static_cast<uint32_t*>(count_buffer.Memory().Map());
     memcpy(data, &total_triangles, sizeof(total_triangles));
     VkDeviceAddress count_buffer_address = count_buffer.Address();
 
@@ -5452,7 +5452,7 @@ TEST_F(NegativeRayTracing, CmdBuildClusterAccelerationStructureIndirectValidatio
     vkt::Buffer count_buffer_wrong_usage(*m_device, sizeof(uint32_t),
                                          VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
                                          vkt::device_address);
-    auto *data_wrong = static_cast<uint32_t *>(count_buffer_wrong_usage.Memory().Map());
+    auto* data_wrong = static_cast<uint32_t*>(count_buffer_wrong_usage.Memory().Map());
     memcpy(data_wrong, &total_triangles, sizeof(total_triangles));
     command_info.dstImplicitData = implicit_buffer.Address();
     command_info.srcInfosCount = count_buffer_wrong_usage.Address();
@@ -5560,7 +5560,7 @@ TEST_F(NegativeRayTracing, DescriptorBuffers) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    uint8_t buffer[256]; // (max accelerationStructureDescriptorSize)
+    uint8_t buffer[256];  // (max accelerationStructureDescriptorSize)
     VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
     dgi.type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
     dgi.data.accelerationStructure = 0xbaadbeef;
@@ -5750,7 +5750,6 @@ TEST_F(NegativeRayTracing, MisalignedPrimitiveOffset5) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
-
 
 TEST_F(NegativeRayTracing, DestroyedDeviceAddressRange) {
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -17,8 +17,8 @@
 #include "../framework/descriptor_helper.h"
 #include <algorithm>
 
-void RayTracingTest::NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2KHR *features2 /*= nullptr*/,
-                                                      VkValidationFeaturesEXT *enabled_features /*= nullptr*/) {
+void RayTracingTest::NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2KHR* features2 /*= nullptr*/,
+                                                      VkValidationFeaturesEXT* enabled_features /*= nullptr*/) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -51,7 +51,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     validation_features.pEnabledValidationFeatures = validation_feature_enables;
     validation_features.disabledValidationFeatureCount = 4;
     validation_features.pDisabledValidationFeatures = validation_feature_disables;
-    RETURN_IF_SKIP(InitFramework(gpu_assisted ? (void *)&validation_features : (void *)&kDisableMessageLimit));
+    RETURN_IF_SKIP(InitFramework(gpu_assisted ? (void*)&validation_features : (void*)&kDisableMessageLimit));
     bool descriptor_indexing = IsExtensionsEnabled(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 
     if (gpu_assisted && IsPlatformMockICD()) {
@@ -78,11 +78,11 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
         GTEST_SKIP() << "Did not find required ray tracing properties";
     }
 
-    vkt::Queue *ray_tracing_queue = m_default_queue;
+    vkt::Queue* ray_tracing_queue = m_default_queue;
     uint32_t ray_tracing_queue_family_index = 0;
 
     // If supported, run on the compute only queue.
-    vkt::Queue *compute_only_queue = m_device->ComputeOnlyQueue();
+    vkt::Queue* compute_only_queue = m_device->ComputeOnlyQueue();
     if (compute_only_queue) {
         ray_tracing_queue = compute_only_queue;
         ray_tracing_queue_family_index = compute_only_queue->family_index;
@@ -108,8 +108,8 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     aabb_buffer.Init(*m_device, aabb_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps, nullptr,
                      vvl::make_span(&ray_tracing_queue_family_index, 1));
 
-    uint8_t *mapped_aabb_buffer_data = (uint8_t *)aabb_buffer.Memory().Map();
-    std::memcpy(mapped_aabb_buffer_data, (uint8_t *)aabbs.data(), static_cast<std::size_t>(aabb_buffer_size));
+    uint8_t* mapped_aabb_buffer_data = (uint8_t*)aabb_buffer.Memory().Map();
+    std::memcpy(mapped_aabb_buffer_data, (uint8_t*)aabbs.data(), static_cast<std::size_t>(aabb_buffer_size));
     aabb_buffer.Memory().Unmap();
 
     VkGeometryNV geometry = vku::InitStructHelper();
@@ -155,8 +155,8 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     instance_buffer.Init(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps, nullptr,
                          vvl::make_span(&ray_tracing_queue_family_index, 1));
 
-    uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.Memory().Map();
-    std::memcpy(mapped_instance_buffer_data, (uint8_t *)instances.data(), static_cast<std::size_t>(instance_buffer_size));
+    uint8_t* mapped_instance_buffer_data = (uint8_t*)instance_buffer.Memory().Map();
+    std::memcpy(mapped_instance_buffer_data, (uint8_t*)instances.data(), static_cast<std::size_t>(instance_buffer_size));
     instance_buffer.Memory().Unmap();
 
     VkAccelerationStructureInfoNV top_level_as_info = vku::InitStructHelper();
@@ -216,8 +216,8 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                                                     VK_SHADER_STAGE_CLOSEST_HIT_BIT_NV | VK_SHADER_STAGE_MISS_BIT_NV |
                                                     VK_SHADER_STAGE_INTERSECTION_BIT_NV | VK_SHADER_STAGE_CALLABLE_BIT_NV;
 
-    void *layout_pnext = nullptr;
-    void *allocate_pnext = nullptr;
+    void* layout_pnext = nullptr;
+    void* allocate_pnext = nullptr;
     VkDescriptorPoolCreateFlags pool_create_flags = 0;
     VkDescriptorSetLayoutCreateFlags layout_create_flags = 0;
     VkDescriptorBindingFlags ds_binding_flags[3] = {};
@@ -310,7 +310,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&ds.layout_});
     const vkt::PipelineLayout pipeline_layout_variable(*m_device, {&ds_variable.layout_});
 
-    const auto SetImagesArrayLength = [](const std::string &shader_template, const std::string &length_str) {
+    const auto SetImagesArrayLength = [](const std::string& shader_template, const std::string& length_str) {
         const std::string to_replace = "IMAGES_ARRAY_LENGTH";
 
         std::string result = shader_template;
@@ -591,12 +591,12 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     const std::string call_source_runtime = SetImagesArrayLength(call_source_template, "");
 
     struct TestCase {
-        const std::string &rgen_shader_source;
-        const std::string &ahit_shader_source;
-        const std::string &chit_shader_source;
-        const std::string &miss_shader_source;
-        const std::string &intr_shader_source;
-        const std::string &call_shader_source;
+        const std::string& rgen_shader_source;
+        const std::string& ahit_shader_source;
+        const std::string& chit_shader_source;
+        const std::string& miss_shader_source;
+        const std::string& intr_shader_source;
+        const std::string& call_shader_source;
         bool variable_length;
         uint32_t rgen_index;
         uint32_t ahit_index;
@@ -604,7 +604,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
         uint32_t miss_index;
         uint32_t intr_index;
         uint32_t call_index;
-        const char *expected_error;
+        const char* expected_error;
     };
 
     std::vector<TestCase> tests;
@@ -665,7 +665,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
 
     // Iteration 0 tests with no descriptor set bound (to sanity test "draw" validation). Iteration 1
     // tests what's in the test case vector.
-    for (const auto &test : tests) {
+    for (const auto& test : tests) {
         if (gpu_assisted) {
             m_errorMonitor->SetDesiredError(test.expected_error);
         }
@@ -754,7 +754,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                                                                     static_cast<std::size_t>(shader_binding_table_buffer_size),
                                                                     shader_binding_table_data.data()));
 
-        uint8_t *mapped_shader_binding_table_data = (uint8_t *)shader_binding_table_buffer.Memory().Map();
+        uint8_t* mapped_shader_binding_table_data = (uint8_t*)shader_binding_table_buffer.Memory().Map();
         std::memcpy(mapped_shader_binding_table_data, shader_binding_table_data.data(), shader_binding_table_data.size());
         shader_binding_table_buffer.Memory().Unmap();
 
@@ -794,7 +794,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
 
         ray_tracing_command_buffer.End();
         // Update the index of the texture that the shaders should read
-        uint32_t *mapped_storage_buffer_data = (uint32_t *)storage_buffer.Memory().Map();
+        uint32_t* mapped_storage_buffer_data = (uint32_t*)storage_buffer.Memory().Map();
         mapped_storage_buffer_data[0] = test.rgen_index;
         mapped_storage_buffer_data[1] = test.ahit_index;
         mapped_storage_buffer_data[2] = test.chit_index;
@@ -814,7 +814,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
         m_errorMonitor->VerifyFound();
 
         if (gpu_assisted) {
-            mapped_storage_buffer_data = (uint32_t *)storage_buffer.Memory().Map();
+            mapped_storage_buffer_data = (uint32_t*)storage_buffer.Memory().Map();
             ASSERT_TRUE(mapped_storage_buffer_data[6] == 1);
             ASSERT_TRUE(mapped_storage_buffer_data[7] == 2);
             ASSERT_TRUE(mapped_storage_buffer_data[8] == 3);
@@ -940,7 +940,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                                /*width=*/1, /*height=*/1, /*depth=*/1);
 
             m_errorMonitor->VerifyFound();
-            const auto &limits = m_device->Physical().limits_;
+            const auto& limits = m_device->Physical().limits_;
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdTraceRaysNV-width-02469");
             uint32_t invalid_width = limits.maxComputeWorkGroupCount[0] + 1;
@@ -1054,17 +1054,17 @@ TEST_F(NegativeRayTracingNV, ValidateGeometry) {
     constexpr std::array aabbs = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f};
     constexpr std::array transforms = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
 
-    uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo.Memory().Map();
-    std::memcpy(mapped_vbo_buffer_data, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
+    uint8_t* mapped_vbo_buffer_data = (uint8_t*)vbo.Memory().Map();
+    std::memcpy(mapped_vbo_buffer_data, (uint8_t*)vertices.data(), sizeof(float) * vertices.size());
 
-    uint8_t *mapped_ibo_buffer_data = (uint8_t *)ibo.Memory().Map();
-    std::memcpy(mapped_ibo_buffer_data, (uint8_t *)indicies.data(), sizeof(uint32_t) * indicies.size());
+    uint8_t* mapped_ibo_buffer_data = (uint8_t*)ibo.Memory().Map();
+    std::memcpy(mapped_ibo_buffer_data, (uint8_t*)indicies.data(), sizeof(uint32_t) * indicies.size());
 
-    uint8_t *mapped_tbo_buffer_data = (uint8_t *)tbo.Memory().Map();
-    std::memcpy(mapped_tbo_buffer_data, (uint8_t *)transforms.data(), sizeof(float) * transforms.size());
+    uint8_t* mapped_tbo_buffer_data = (uint8_t*)tbo.Memory().Map();
+    std::memcpy(mapped_tbo_buffer_data, (uint8_t*)transforms.data(), sizeof(float) * transforms.size());
 
-    uint8_t *mapped_aabbbo_buffer_data = (uint8_t *)aabbbo.Memory().Map();
-    std::memcpy(mapped_aabbbo_buffer_data, (uint8_t *)aabbs.data(), sizeof(float) * aabbs.size());
+    uint8_t* mapped_aabbbo_buffer_data = (uint8_t*)aabbbo.Memory().Map();
+    std::memcpy(mapped_aabbbo_buffer_data, (uint8_t*)aabbs.data(), sizeof(float) * aabbs.size());
 
     VkGeometryNV valid_geometry_triangles = vku::InitStructHelper();
     valid_geometry_triangles.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_NV;
@@ -1091,7 +1091,7 @@ TEST_F(NegativeRayTracingNV, ValidateGeometry) {
     valid_geometry_aabbs.geometry.aabbs.offset = 0;
     valid_geometry_aabbs.geometry.aabbs.stride = 24;
 
-    const auto GetCreateInfo = [](const VkGeometryNV &geometry) {
+    const auto GetCreateInfo = [](const VkGeometryNV& geometry) {
         VkAccelerationStructureCreateInfoNV as_create_info = vku::InitStructHelper();
         as_create_info.info = vku::InitStructHelper();
         as_create_info.info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV;

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -667,7 +667,7 @@ TEST_F(NegativeRayTracingPipelineNV, StageCreationFeedbackCount) {
     feedback_info.pipelineStageCreationFeedbackCount = 2;
     feedback_info.pPipelineStageCreationFeedbacks = &feedbacks[1];
 
-    auto set_feedback = [&feedback_info](nv::rt::RayTracingPipelineHelper &helper) { helper.rp_ci_.pNext = &feedback_info; };
+    auto set_feedback = [&feedback_info](nv::rt::RayTracingPipelineHelper& helper) { helper.rp_ci_.pNext = &feedback_info; };
 
     feedback_info.pipelineStageCreationFeedbackCount = 3;
     nv::rt::RayTracingPipelineHelper::OneshotPositiveTest(*this, set_feedback);

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -763,8 +763,8 @@ TEST_F(PositiveRayTracingPipeline, PartitionedAccelerationStructureDescriptorTem
     vkt::as::BuildGeometryInfoKHR tlas(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, m_command_buffer));
     VkDeviceAddress as_address = tlas.GetDstAS()->GetBufferDeviceAddress();
 
-    OneOffDescriptorSet descriptor_set(m_device,
-                                       {{0, VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV, 1, VK_SHADER_STAGE_ALL, nullptr}});
+    OneOffDescriptorSet descriptor_set(
+        m_device, {{0, VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV, 1, VK_SHADER_STAGE_ALL, nullptr}});
 
     // Create a descriptor update template for PTLAS
     VkDescriptorUpdateTemplateEntry template_entry = {};

--- a/tests/unit/ray_tracing_pipeline_positive_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive_nv.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,6 @@ TEST_F(PositiveRayTracingPipelineNV, BasicUsage) {
 
     RETURN_IF_SKIP(InitState());
 
-    auto ignore_update = [](nv::rt::RayTracingPipelineHelper &) {};
+    auto ignore_update = [](nv::rt::RayTracingPipelineHelper&) {};
     nv::rt::RayTracingPipelineHelper::OneshotPositiveTest(*this, ignore_update);
 }

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -26,11 +26,11 @@
 
 class NegativeRenderPass : public VkLayerTest {
   public:
-    void TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR &create_info, const std::vector<const char *> &vuids);
+    void TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR& create_info, const std::vector<const char*>& vuids);
 };
 
-void NegativeRenderPass::TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR &create_info,
-                                                  const std::vector<const char *> &vuids) {
+void NegativeRenderPass::TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR& create_info,
+                                                  const std::vector<const char*>& vuids) {
     for (auto vuid : vuids) {
         m_errorMonitor->SetDesiredError(vuid);
     }
@@ -1170,7 +1170,7 @@ TEST_F(NegativeRenderPass, BeginRenderArea) {
     m_renderPassBeginInfo.renderArea.extent.width = 257;
     m_renderPassBeginInfo.renderArea.extent.height = 256;
 
-    const char *vuid = "VUID-VkRenderPassBeginInfo-pNext-02852";
+    const char* vuid = "VUID-VkRenderPassBeginInfo-pNext-02852";
     CreateRenderPassBeginTest(m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
 
     m_renderPassBeginInfo.renderArea.offset.x = 1;
@@ -1314,7 +1314,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>(nullptr, VK_NULL_HANDLE, VK_NULL_HANDLE, VkRect2D{{0, 0}, {128u, 128u}},
                                                            2u, clearValues);
 
-    auto test_layout_helper = [this, &rpci, &rp_begin, rp2Supported, &fbci](const char *rp1_vuid, const char *rp2_vuid) {
+    auto test_layout_helper = [this, &rpci, &rp_begin, rp2Supported, &fbci](const char* rp1_vuid, const char* rp2_vuid) {
         vkt::RenderPass rp_invalid(*m_device, rpci);
         fbci.renderPass = rp_invalid;
         vkt::Framebuffer fb_invalid(*m_device, fbci);
@@ -1406,8 +1406,8 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
     // Closure to create a render pass with just a depth/stencil image used as an input attachment (not a depth attachment!).
     // This image purposely has not VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.
     // The layout of the depth and stencil aspects of this image can be defined separately, allowing to trigger different errors.
-    auto test = [this](VkImageLayout depth_initial_layout, VkImageLayout stencil_initial_layout, const char *rp1_vuid,
-                       const char *rp2_vuid) {
+    auto test = [this](VkImageLayout depth_initial_layout, VkImageLayout stencil_initial_layout, const char* rp1_vuid,
+                       const char* rp2_vuid) {
         // Create an input attachment with a depth stencil format, without VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
         VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
         vkt::Image input_image(*m_device, 128, 128, depth_stencil_format, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
@@ -1456,7 +1456,7 @@ TEST_F(NegativeRenderPass, BeginStencilFormat) {
 
     // Closure to create a render pass with just a depth/stencil image with specified format.
     // The layout is set to have more or less components than what this format has, triggering an error.
-    auto test = [this](VkFormat depth_stencil_format, VkImageLayout depth_stencil_attachment_ref_layout, const char *vuid) {
+    auto test = [this](VkFormat depth_stencil_format, VkImageLayout depth_stencil_attachment_ref_layout, const char* vuid) {
         VkImageFormatProperties imageFormatProperties;
         VkResult res;
         res = vk::GetPhysicalDeviceImageFormatProperties(gpu_, depth_stencil_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
@@ -2507,7 +2507,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
             #version 450
             layout(set = 0, binding = 0) uniform sampler2D depth;
             void main(){

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -984,7 +984,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     vkt::Framebuffer framebuffer_separate(*m_device, render_pass_separate, 1, &view.handle(), 1, 1);
     vkt::Framebuffer framebuffer_combined(*m_device, render_pass_combined, 1, &view.handle(), 1, 1);
 
-    for (auto &barrier : barriers) {
+    for (auto& barrier : barriers) {
         vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
                                nullptr, 0, nullptr, 1, &barrier);
     }

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -317,7 +317,7 @@ TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
     tests[1].required_format_feature = VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG;
     tests[1].err_msg = "VUID-vkCmdDraw-None-02692";
 
-    for (auto &test_struct : tests) {
+    for (auto& test_struct : tests) {
         for (std::pair<VkFormat, FormatTypes> cur_format_pair : formats_to_check) {
             VkFormatProperties props = {};
             vk::GetPhysicalDeviceFormatProperties(Gpu(), cur_format_pair.first, &props);
@@ -360,7 +360,7 @@ TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
 
     InitRenderTarget();
 
-    for (const auto &test_struct : tests) {
+    for (const auto& test_struct : tests) {
         if (test_struct.format == VK_FORMAT_UNDEFINED) {
             printf("Could not find a testable format for filter %d.  Skipping test for said filter.\n", test_struct.filter);
             continue;
@@ -388,7 +388,7 @@ TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
         vkt::ImageView view = mpimage.CreateView();
 
         CreatePipelineHelper pipe(*this);
-        VkShaderObj *fs = nullptr;
+        VkShaderObj* fs = nullptr;
 
         if (test_struct.format_type == FLOAT) {
             fs = new VkShaderObj(*m_device, kFragmentSamplerGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -455,7 +455,7 @@ TEST_F(NegativeSampler, LinearReductionModeMinMax) {
     sampler_ci.compareEnable = VK_FALSE;
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D bad;
         layout(location=0) out vec4 color;
@@ -818,7 +818,7 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
     descriptor_set.WriteDescriptorImageInfo(0, view, sampler);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 x;
@@ -871,7 +871,7 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefinedNonCombined) {
     descriptor_set.WriteDescriptorImageInfo(1, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler s;
         layout(set=0, binding=1) uniform texture2D t;
@@ -930,7 +930,7 @@ TEST_F(NegativeSampler, DISABLED_CustomBorderColorFormatUndefinedNonCombinedMult
     descriptor_set1.WriteDescriptorImageInfo(3, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     descriptor_set1.UpdateDescriptorSets();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=2) uniform sampler s;
         layout(set=1, binding=3) uniform texture2D t;
@@ -1374,7 +1374,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesInBoundsAccess) {
     // }
     //
     // but with OpInBoundsAccessChain instead of normal generated OpAccessChain
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -1465,7 +1465,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCopyObject) {
     // void main() {
     //     vec4 x = textureLodOffset(tex, vec2(0), 0, ivec2(0));
     // }
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -1604,7 +1604,7 @@ TEST_F(NegativeSampler, ShareOpSampledImage) {
     //     color = texture(sampler2D(si_good, s1), vec2(0));
     //     color += texture(sampler2D(si_good, s1), vec2(color.x));
     // }
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color
@@ -1736,8 +1736,7 @@ TEST_F(NegativeSampler, BorderColorSwizzle) {
     AddRequiredExtensions(VK_EXT_BORDER_COLOR_SWIZZLE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    VkSamplerBorderColorComponentMappingCreateInfoEXT border_color_component_mapping =
-        vku::InitStructHelper();
+    VkSamplerBorderColorComponentMappingCreateInfoEXT border_color_component_mapping = vku::InitStructHelper();
     border_color_component_mapping.components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
                                                  VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY};
 

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -216,7 +216,7 @@ TEST_F(NegativeSecondaryCommandBuffer, ExecuteCommandsTo) {
 TEST_F(NegativeSecondaryCommandBuffer, SimultaneousUseTwoExecutes) {
     RETURN_IF_SKIP(Init());
 
-    const char *simultaneous_use_message = "VUID-vkCmdExecuteCommands-pCommandBuffers-00092";
+    const char* simultaneous_use_message = "VUID-vkCmdExecuteCommands-pCommandBuffers-00092";
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
@@ -240,7 +240,7 @@ TEST_F(NegativeSecondaryCommandBuffer, SimultaneousUseSingleExecute) {
     // variation on previous test executing the same CB twice in the same
     // CmdExecuteCommands call
 
-    const char *simultaneous_use_message = "VUID-vkCmdExecuteCommands-pCommandBuffers-00093";
+    const char* simultaneous_use_message = "VUID-vkCmdExecuteCommands-pCommandBuffers-00093";
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
@@ -339,7 +339,7 @@ TEST_F(NegativeSecondaryCommandBuffer, ExecuteWithLayoutMismatch) {
     VkImageMemoryBarrier image_barrier =
         image.ImageMemoryBarrier(0, 0, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL, image_sub_range);
 
-    auto pipeline = [&image_barrier](const vkt::CommandBuffer &cb, VkImageLayout old_layout, VkImageLayout new_layout) {
+    auto pipeline = [&image_barrier](const vkt::CommandBuffer& cb, VkImageLayout old_layout, VkImageLayout new_layout) {
         image_barrier.oldLayout = old_layout;
         image_barrier.newLayout = new_layout;
         vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
@@ -396,7 +396,7 @@ TEST_F(NegativeSecondaryCommandBuffer, ExecuteWithLayoutMismatchUseGenericLayout
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                             VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D color_image;
         void main() {

--- a/tests/unit/secondary_command_buffer_positive.cpp
+++ b/tests/unit/secondary_command_buffer_positive.cpp
@@ -329,7 +329,7 @@ TEST_F(PositiveSecondaryCommandBuffer, Sync2ImageLayouts) {
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                             VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D color_image;
         void main() {

--- a/tests/unit/shader_64bit_indexing.cpp
+++ b/tests/unit/shader_64bit_indexing.cpp
@@ -21,7 +21,7 @@ TEST_F(NegativeShader64BitIndexing, Length64) {
     AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_64bit_indexing : enable
         layout(set = 0, binding = 0) readonly buffer B { float x[]; } b;
@@ -47,7 +47,7 @@ TEST_F(NegativeShader64BitIndexing, ShaderObjectLength64) {
     AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_64bit_indexing : enable
         layout(set = 0, binding = 0) readonly buffer B { float x[]; } b;
@@ -77,7 +77,7 @@ TEST_F(NegativeShader64BitIndexing, UntypedPointerLength64) {
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
                OpCapability UntypedPointersKHR
                OpCapability Int64
@@ -128,7 +128,7 @@ TEST_F(NegativeShader64BitIndexing, CoopVecMul) {
     AddRequiredExtensions(VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
@@ -161,7 +161,7 @@ TEST_F(NegativeShader64BitIndexing, CoopVecLoad) {
     AddRequiredExtensions(VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
@@ -189,7 +189,7 @@ TEST_F(NegativeShader64BitIndexing, PipelineMissingEnable) {
     AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_64bit_indexing : enable
         layout(set = 0, binding = 0) readonly buffer B { float x[]; } b;
@@ -219,7 +219,7 @@ TEST_F(NegativeShader64BitIndexing, ShaderMissingEnable) {
     AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_64bit_indexing : enable
         layout(set = 0, binding = 0) readonly buffer B { float x[]; } b;

--- a/tests/unit/shader_64bit_indexing_positive.cpp
+++ b/tests/unit/shader_64bit_indexing_positive.cpp
@@ -22,7 +22,7 @@ TEST_F(PositiveShader64BitIndexing, PragmaEnableLength64) {
     AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_64bit_indexing : enable
         #pragma shader_64bit_indexing
@@ -44,7 +44,7 @@ TEST_F(PositiveShader64BitIndexing, PipelineEnableLength64) {
     AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_64bit_indexing : enable
         layout(set = 0, binding = 0) readonly buffer B { float x[]; } b;
@@ -72,7 +72,7 @@ TEST_F(PositiveShader64BitIndexing, ShaderObjectEnableLength64) {
     AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_64bit_indexing : enable
         layout(set = 0, binding = 0) readonly buffer B { float x[]; } b;
@@ -100,7 +100,7 @@ TEST_F(PositiveShader64BitIndexing, UntypedPointerLength64) {
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
                OpCapability UntypedPointersKHR
                OpCapability Int64
@@ -153,7 +153,7 @@ TEST_F(PositiveShader64BitIndexing, CoopVecMul) {
     AddRequiredExtensions(VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
@@ -188,7 +188,7 @@ TEST_F(PositiveShader64BitIndexing, CoopVecLoad) {
     AddRequiredExtensions(VK_NV_COOPERATIVE_VECTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_EXT_shader_explicit_arithmetic_types : enable

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -188,7 +188,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeSpecConstant) {
     const VkPhysicalDeviceLimits limits = m_device->Physical().limits_;
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(local_size_x_id = 3, local_size_y_id = 4) in;
         void main(){}
@@ -455,7 +455,7 @@ TEST_F(NegativeShaderCompute, WorkgroupMemoryExplicitLayout) {
 
     // WorkgroupMemoryExplicitLayoutKHR
     {
-        const char *spv_source = R"(
+        const char* spv_source = R"(
                OpCapability Shader
                OpCapability WorkgroupMemoryExplicitLayoutKHR
                OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
@@ -489,7 +489,7 @@ TEST_F(NegativeShaderCompute, WorkgroupMemoryExplicitLayout) {
 
     // WorkgroupMemoryExplicitLayout8BitAccessKHR (shaderInt8)
     {
-        const char *spv_source = R"(
+        const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int8
                OpCapability WorkgroupMemoryExplicitLayout8BitAccessKHR
@@ -524,7 +524,7 @@ TEST_F(NegativeShaderCompute, WorkgroupMemoryExplicitLayout) {
 
     // WorkgroupMemoryExplicitLayout16BitAccessKHR (shaderInt16)
     {
-        const char *spv_source = R"(
+        const char* spv_source = R"(
                OpCapability Shader
                OpCapability Float16
                OpCapability Int16
@@ -568,7 +568,7 @@ TEST_F(NegativeShaderCompute, WorkgroupMemoryExplicitLayout) {
     // workgroupMemoryExplicitLayoutScalarBlockLayout feature
     // will fail from not passing --workgroup-scalar-block-layout in spirv-val
     {
-        const char *spv_source = R"(
+        const char* spv_source = R"(
                OpCapability Shader
                OpCapability WorkgroupMemoryExplicitLayoutKHR
                OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
@@ -604,7 +604,7 @@ TEST_F(NegativeShaderCompute, ZeroInitializeWorkgroupMemory) {
     TEST_DESCRIPTION("Test initializing workgroup memory in compute shader");
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -636,7 +636,7 @@ TEST_F(NegativeShaderCompute, LocalSizeIdExecutionMode) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -665,7 +665,7 @@ TEST_F(NegativeShaderCompute, LocalSizeIdExecutionModeMaintenance5) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -250,7 +250,7 @@ TEST_F(PositiveShaderCompute, SharedMemorySpecConstantOp) {
         GTEST_SKIP() << "Supported compute shader shared memory size is too small";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
@@ -275,7 +275,7 @@ TEST_F(PositiveShaderCompute, SharedMemory) {
     RETURN_IF_SKIP(Init());
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         shared uint a;
         shared float b;
@@ -304,7 +304,7 @@ TEST_F(PositiveShaderCompute, ZeroInitializeWorkgroupMemoryFeature) {
     AddRequiredFeature(vkt::Feature::shaderZeroInitializeWorkgroupMemory);
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -326,6 +326,6 @@ TEST_F(PositiveShaderCompute, ZeroInitializeWorkgroupMemoryFeature) {
         )";
 
     auto cs = VkShaderObj::CreateFromASM(this, spv_source, VK_SHADER_STAGE_COMPUTE_BIT);
-    const auto set_info = [&cs](CreateComputePipelineHelper &helper) { helper.cs_ = std::move(cs); };
+    const auto set_info = [&cs](CreateComputePipelineHelper& helper) { helper.cs_ = std::move(cs); };
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ TEST_F(NegativeShaderCooperativeMatrix, SpecInfo) {
     RETURN_IF_SKIP(InitCooperativeMatrixKHR());
 
     // https://godbolt.org/z/Ys7faYaav but now validated at GLSL level, so have SPIR-V
-    const char *cs_source = R"asm(
+    const char* cs_source = R"asm(
             OpCapability Shader
             OpCapability Float16
             OpCapability VulkanMemoryModel
@@ -119,7 +119,7 @@ TEST_F(NegativeShaderCooperativeMatrix, SpecInfoNV) {
     RETURN_IF_SKIP(InitState(nullptr, &memory_model_features));
 
     // https://godbolt.org/z/Kbx1PsraY but now validated at GLSL level, so have SPIR-V
-    const char *cs_source = R"asm(
+    const char* cs_source = R"asm(
                OpCapability Shader
                OpCapability Float16
                OpCapability VulkanMemoryModel
@@ -201,7 +201,7 @@ TEST_F(NegativeShaderCooperativeMatrix, UnsupportedStageUint32) {
         GTEST_SKIP() << "Cannot execute test due to vertex stage expected to be unsupported";
     }
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -242,7 +242,7 @@ TEST_F(NegativeShaderCooperativeMatrix, UnsupportedStageFloat16) {
         GTEST_SKIP() << "Cannot execute test due to vertex stage expected to be unsupported";
     }
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -280,7 +280,7 @@ TEST_F(NegativeShaderCooperativeMatrix, ParametersMatchProperties) {
     }
 
     // Tests are assume that Float16 3*5 is not available
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -312,7 +312,7 @@ TEST_F(NegativeShaderCooperativeMatrix, DimXMultipleSubgroupSize) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -367,7 +367,7 @@ TEST_F(NegativeShaderCooperativeMatrix, DimXMultipleSubgroupSizeWorkgroupScope) 
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -421,7 +421,7 @@ TEST_F(NegativeShaderCooperativeMatrix, SameScope) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -483,7 +483,7 @@ TEST_F(NegativeShaderCooperativeMatrix, WorkgroupScope) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -522,7 +522,7 @@ TEST_F(NegativeShaderCooperativeMatrix, WorkgroupScopeMaxDimensions) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -583,7 +583,7 @@ TEST_F(NegativeShaderCooperativeMatrix, WorkgroupScopeMaxSharedMemory) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -646,7 +646,7 @@ TEST_F(NegativeShaderCooperativeMatrix, MatchSizeWithProperties) {
         GTEST_SKIP() << "Valid Property found, need invalid to test";
     }
 
-    const char *source = R"glsl(
+    const char* source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -723,7 +723,7 @@ TEST_F(NegativeShaderCooperativeMatrix, SignedCheck) {
         OpFunctionEnd
     )glsl";
 
-    const auto remove_str = [](const std::string &shader_template, const std::string &removestr) {
+    const auto remove_str = [](const std::string& shader_template, const std::string& removestr) {
         std::string result = shader_template;
         auto position = result.find(removestr);
         assert(position != std::string::npos);
@@ -731,8 +731,8 @@ TEST_F(NegativeShaderCooperativeMatrix, SignedCheck) {
         return result;
     };
     const struct {
-        const char *remove;
-        const char *expect;
+        const char* remove;
+        const char* expect;
     } subtests[] = {
         {"MatrixASignedComponentsKHR|", "VUID-RuntimeSpirv-OpCooperativeMatrixMulAddKHR-10060"},
         {"MatrixBSignedComponentsKHR|", "VUID-RuntimeSpirv-OpCooperativeMatrixMulAddKHR-10060"},
@@ -740,14 +740,14 @@ TEST_F(NegativeShaderCooperativeMatrix, SignedCheck) {
         {"|MatrixResultSignedComponentsKHR", "VUID-RuntimeSpirv-OpCooperativeMatrixMulAddKHR-10060"},
     };
 
-    for (const auto &x: subtests) {
+    for (const auto& x : subtests) {
         const std::string cs_source_str = remove_str(cs_source_template, std::string(x.remove));
-        const char *css = cs_source_str.c_str();
+        const char* css = cs_source_str.c_str();
         CreateComputePipelineHelper pipe(*this);
 
         pipe.cs_ = VkShaderObj(*m_device, css, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM);
 
-        for (const auto &y : subtests) {
+        for (const auto& y : subtests) {
             if (x.remove == y.remove) {
                 // Set expected message
                 m_errorMonitor->SetDesiredError(y.expect);
@@ -787,7 +787,7 @@ TEST_F(NegativeShaderCooperativeMatrix, RequiredVulkanVersionPipeline) {
     const vkt::DescriptorSetLayout dsl(*m_device, {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
     const vkt::PipelineLayout pipeline_layout(*m_device, {&dsl});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_shader_subgroup_basic : enable
@@ -830,7 +830,7 @@ TEST_F(NegativeShaderCooperativeMatrix, RequiredVulkanVersionShaderObject) {
 
     const vkt::DescriptorSetLayout dsl(*m_device, {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_shader_subgroup_basic : enable

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,7 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixKHR) {
 
     VkCooperativeMatrixPropertiesKHR subgroup_prop = vku::InitStructHelper();
     bool found_scope_subgroup = false;
-    for (const auto &prop : helper.coop_matrix_props) {
+    for (const auto& prop : helper.coop_matrix_props) {
         // We only have the 16-bit features enabled, but 32-bit also works
         if (prop.scope == VK_SCOPE_SUBGROUP_KHR && !helper.Has8BitComponentType(prop) && !helper.Has64BitComponentType(prop)) {
             found_scope_subgroup = true;
@@ -85,7 +85,7 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixKHR) {
          }
     )glsl";
 
-    auto replace = [](std::string &str, const std::string &from, const std::string &to) {
+    auto replace = [](std::string& str, const std::string& from, const std::string& to) {
         size_t pos;
         while ((pos = str.find(from)) != std::string::npos) str.replace(pos, from.length(), to);
     };
@@ -118,7 +118,7 @@ TEST_F(PositiveShaderCooperativeMatrix, RequiredSubgroupSize) {
     const vkt::DescriptorSetLayout dsl(*m_device, {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
     const vkt::PipelineLayout pipeline_layout(*m_device, {&dsl});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_shader_subgroup_basic : enable
@@ -173,7 +173,7 @@ TEST_F(PositiveShaderCooperativeMatrix, RequiredVulkanVersionPipeline) {
     const vkt::DescriptorSetLayout dsl(*m_device, {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
     const vkt::PipelineLayout pipeline_layout(*m_device, {&dsl});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_shader_subgroup_basic : enable
@@ -216,7 +216,7 @@ TEST_F(PositiveShaderCooperativeMatrix, RequiredVulkanVersionShaderObject) {
     const vkt::DescriptorSetLayout dsl(*m_device,
                                        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
          #version 450 core
          #pragma use_vulkan_memory_model
          #extension GL_KHR_shader_subgroup_basic : enable
@@ -247,7 +247,7 @@ TEST_F(PositiveShaderCooperativeMatrix, BFloat16) {
     AddRequiredFeature(vkt::Feature::shaderBFloat16CooperativeMatrix);
     RETURN_IF_SKIP(InitCooperativeMatrixKHR());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         #extension GL_EXT_bfloat16 : require
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
@@ -273,7 +273,7 @@ TEST_F(PositiveShaderCooperativeMatrix, Float8) {
     AddRequiredFeature(vkt::Feature::shaderInt8);
     RETURN_IF_SKIP(InitCooperativeMatrixKHR());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         #extension GL_EXT_float_e4m3 : require
         #extension GL_EXT_shader_explicit_arithmetic_types : enable

--- a/tests/unit/shader_cooperative_vector.cpp
+++ b/tests/unit/shader_cooperative_vector.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
- * Copyright (c) 2023-2025 NVIDIA Corporation
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
+ * Copyright (c) 2023-2026 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ class NegativeShaderCooperativeVector : public VkLayerTest {
   public:
     void SetupConvertCooperativeVectorMatrixNVTest();
     void SetupCmdConvertCooperativeVectorMatrixNVTest();
-    void RunSPIRVTest(const char *expected_error, const char *shaderBody, uint32_t count = 1);
+    void RunSPIRVTest(const char* expected_error, const char* shaderBody, uint32_t count = 1);
 
     VkConvertCooperativeVectorMatrixInfoNV info;
     size_t dstSize;
@@ -294,7 +294,7 @@ TEST_F(NegativeShaderCooperativeVector, DeviceConvertUnsupportedMatrixType) {
     m_errorMonitor->VerifyFound();
 }
 
-void NegativeShaderCooperativeVector::RunSPIRVTest(const char *expected_error, const char *shaderBody, uint32_t count) {
+void NegativeShaderCooperativeVector::RunSPIRVTest(const char* expected_error, const char* shaderBody, uint32_t count) {
     RETURN_IF_SKIP(SetupConvertCooperativeVectorMatrixNVTest());
 
     std::string shader_source = std::string(R"(

--- a/tests/unit/shader_cooperative_vector_positive.cpp
+++ b/tests/unit/shader_cooperative_vector_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 NVIDIA Corporation
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ TEST_F(PositiveShaderCooperativeVector, CooperativeVectorSPIRV) {
         GTEST_SKIP() << "cooperativeVectorTrainingFloat16Accumulation not supported";
     }
 
-    const char *vt_source = R"glsl(
+    const char* vt_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_KHR_shader_subgroup_basic : enable
@@ -144,7 +144,7 @@ TEST_F(PositiveShaderCooperativeVector, CooperativeVectorTraingingSPIRV) {
 
     const vkt::DescriptorSetLayout dsl(*m_device, {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr});
 
-    const char *vt_source = R"glsl(
+    const char* vt_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_KHR_shader_subgroup_basic : enable

--- a/tests/unit/shader_debug_info.cpp
+++ b/tests/unit/shader_debug_info.cpp
@@ -22,7 +22,7 @@ TEST_F(NegativeShaderDebugInfo, FileName1) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -76,7 +76,7 @@ TEST_F(NegativeShaderDebugInfo, FileName2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -132,7 +132,7 @@ TEST_F(NegativeShaderDebugInfo, FileName3) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -188,7 +188,7 @@ TEST_F(NegativeShaderDebugInfo, FileName4) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -561,7 +561,7 @@ TEST_F(NegativeShaderDebugInfo, WriteLessComponent) {
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"

--- a/tests/unit/shader_image_access.cpp
+++ b/tests/unit/shader_image_access.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 LunarG, Inc.
- * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ TEST_F(NegativeShaderImageAccess, FunctionOpImage) {
     // }
     //
     // but instead of passing the OpTypePointer, passes a OpImage to function
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color
@@ -109,7 +109,7 @@ TEST_F(NegativeShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform isampler2D s; // accessed
         layout(set=0, binding=1) uniform usampler2D u; // not accessed
@@ -163,7 +163,7 @@ TEST_F(NegativeShaderImageAccess, UnnormalizedCoordinatesFunction) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (set = 0, binding = 0) uniform sampler2D tex;
 
@@ -215,7 +215,7 @@ TEST_F(NegativeShaderImageAccess, MultisampleMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2DMS s;
         layout(location=0) out vec4 color;
@@ -262,7 +262,7 @@ TEST_F(NegativeShaderImageAccess, AliasImageMultisample) {
     TEST_DESCRIPTION("Same binding used for Multisampling and non-Multisampling");
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -319,7 +319,7 @@ TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 color;
@@ -399,7 +399,7 @@ TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipelineArray) {
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -462,7 +462,7 @@ TEST_F(NegativeShaderImageAccess, MultipleFunctionCalls) {
     sampler_ci.compareEnable = VK_FALSE;
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D good_a;
         layout (set=0, binding=1) uniform sampler2D bad;
@@ -512,7 +512,7 @@ TEST_F(NegativeShaderImageAccess, AliasImageBinding) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7677");
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -545,9 +545,9 @@ TEST_F(NegativeShaderImageAccess, AliasImageBinding) {
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, float_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL, 0);
+                                                  VK_IMAGE_LAYOUT_GENERAL, 0);
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, uint_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL, 1);
+                                                  VK_IMAGE_LAYOUT_GENERAL, 1);
     pipe.descriptor_set_.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
@@ -564,7 +564,7 @@ TEST_F(NegativeShaderImageAccess, AliasImageBindingArrayType) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9553");
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         // This should be an GLSL error, if both of these are accessed (without PARTIALLY_BOUND), you need to satisfy both, which is impossible
         layout(set = 0, binding = 0) uniform sampler2D uPlanetTextures[2];
@@ -612,7 +612,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform texture2D kTextures2D;
         layout (set = 0, binding = 1) uniform sampler kSamplers;
@@ -676,7 +676,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBindingArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform texture2D kTextures2D[2];
         layout (set = 0, binding = 1) uniform sampler kSamplers[2];
@@ -741,7 +741,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBindingArrayFunction) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform texture2D kTextures2D[2];
         layout (set = 0, binding = 1) uniform sampler kSamplers[2];
@@ -810,7 +810,7 @@ TEST_F(NegativeShaderImageAccess, DISABLED_FunctionDescriptorIndexing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform sampler2D tex[3];
         layout (location=0) out vec4 color;

--- a/tests/unit/shader_image_access_positive.cpp
+++ b/tests/unit/shader_image_access_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 LunarG, Inc.
- * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToVariable) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
         layout(set = 0, binding = 0) uniform texture2D texture_image;
@@ -48,7 +48,7 @@ TEST_F(PositiveShaderImageAccess, MultipleFunctionParameterToVariable) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
         layout(set = 0, binding = 0) uniform texture2D texture_image;
@@ -81,7 +81,7 @@ TEST_F(PositiveShaderImageAccess, DifferentFunctionParameterToVariable) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
 
@@ -115,7 +115,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToLoad) {
     //    int foo(texture2D func_texture) { return textureSize(func_texture, 0).x; }
     //    void main() {  int x = foo(texture_image); }
     // But replaced so the OpFunctionCall takes a OpLoad instead of OpVariable
-    const char *csSource = R"(
+    const char* csSource = R"(
                OpCapability Shader
                OpCapability ImageQuery
                OpMemoryModel Logical GLSL450
@@ -168,7 +168,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToVariableSampledImage) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
 
@@ -202,7 +202,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToLoadSampledImage) {
     //    int foo(texture2D func_texture) { return texture(sampler2D(func_texture,  func_sampler), vec2(0.0)); }
     //    void main() {  vec4 x = foo(texture_image, sampler_descriptor); }
     // But replaced so the OpFunctionCall takes a OpLoad instead of OpVariable
-    const char *csSource = R"(
+    const char* csSource = R"(
                 OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -265,7 +265,7 @@ TEST_F(PositiveShaderImageAccess, CopyObjectFromLoad) {
     // This is simple
     //    int x = textureSize(texture_image, 0).x;
     // but with inserted OpCopyObject calls
-    const char *csSource = R"(
+    const char* csSource = R"(
                OpCapability Shader
                OpCapability ImageQuery
                OpMemoryModel Logical GLSL450
@@ -311,7 +311,7 @@ TEST_F(PositiveShaderImageAccess, UndefImage) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"(
+    const char* csSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -362,7 +362,7 @@ TEST_F(PositiveShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform isampler2D s; // not accessed (so ignored)
         layout(set=0, binding=1) uniform usampler2D u; // accessed
@@ -444,7 +444,7 @@ TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
     sampler_ci.compareEnable = VK_FALSE;
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D bad; // never accessed
         layout (set=0, binding=1) uniform sampler2D good;
@@ -489,7 +489,7 @@ TEST_F(PositiveShaderImageAccess, DISABLED_ExtraUnusedInvalidDescriptor) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout (set = 1, binding = 0) uniform textureCube kTexturesCube[2];
         layout (set = 0, binding = 1) uniform sampler kSamplers;
@@ -547,7 +547,7 @@ TEST_F(PositiveShaderImageAccess, FunctionDescriptorIndexing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform sampler2D tex[3];
         layout (location=0) out vec4 color;
@@ -600,7 +600,7 @@ TEST_F(PositiveShaderImageAccess, AliasImageBinding) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7677");
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -628,9 +628,9 @@ TEST_F(PositiveShaderImageAccess, AliasImageBinding) {
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, float_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL, 0);
+                                                  VK_IMAGE_LAYOUT_GENERAL, 0);
     pipe.descriptor_set_.WriteDescriptorImageInfo(0, float_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL, 1);
+                                                  VK_IMAGE_LAYOUT_GENERAL, 1);
     pipe.descriptor_set_.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -353,7 +353,7 @@ TEST_F(NegativeShaderInterface, FragmentInputNotProvided) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float x;
         layout(location=0) out vec4 color;
@@ -363,7 +363,7 @@ TEST_F(NegativeShaderInterface, FragmentInputNotProvided) {
     )glsl";
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -377,7 +377,7 @@ TEST_F(NegativeShaderInterface, FragmentInputNotProvidedInBlock) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         in block { layout(location=0) float x; } ins;
         layout(location=0) out vec4 color;
@@ -388,7 +388,7 @@ TEST_F(NegativeShaderInterface, FragmentInputNotProvidedInBlock) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -400,7 +400,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out int x;
         void main(){
@@ -408,7 +408,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -420,7 +420,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
@@ -432,7 +432,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch2) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out int x;
         void main(){
@@ -440,7 +440,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch2) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -452,7 +452,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch2) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         // Flipped here
         helper.shader_stages_ = {fs.GetStageCreateInfo(), vs.GetStageCreateInfo()};
     };
@@ -467,7 +467,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchInBlock) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         out block { layout(location=0) int x; } outs;
         void main(){
@@ -475,7 +475,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchInBlock) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         in block { layout(location=0) float x; } ins; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -487,7 +487,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchInBlock) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
@@ -500,14 +500,14 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
            gl_Position = vec4(1.0);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 x;
         layout(location=0) out vec4 color;
@@ -519,7 +519,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSize) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maintenance4-06817");
@@ -533,7 +533,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchLongVectorSize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
@@ -541,7 +541,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchLongVectorSize) {
         }
     )glsl";
     // fs declares a vec3 input
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability LongVectorEXT
                OpExtension "SPV_EXT_long_vector"
@@ -568,7 +568,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchLongVectorSize) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maintenance4-06817");
@@ -580,7 +580,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -600,7 +600,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct) {
         }
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -623,7 +623,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
@@ -636,7 +636,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct64bit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
 
@@ -654,7 +654,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct64bit) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -675,7 +675,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct64bit) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
@@ -687,7 +687,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockArrayOfStruct) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -707,7 +707,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockArrayOfStruct) {
         }
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -730,7 +730,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockArrayOfStruct) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
@@ -745,7 +745,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructInnerArraySize) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -765,7 +765,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructInnerArraySize) {
         }
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -788,7 +788,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructInnerArraySize) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     // Both are errors, depending on compiler, the order of variables listed will hit one before the other
@@ -805,7 +805,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuterArraySize) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -825,7 +825,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuterArraySize) {
         }
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -848,7 +848,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuterArraySize) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -864,7 +864,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructArraySizeVertex) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -884,7 +884,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructArraySizeVertex) {
         }
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -907,7 +907,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructArraySizeVertex) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     // Both are errors, depending on compiler, the order of variables listed will hit one before the other
@@ -924,7 +924,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuter2DArraySize) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -940,7 +940,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuter2DArraySize) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -960,7 +960,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuter2DArraySize) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -973,7 +973,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructType64bit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
 
@@ -997,7 +997,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructType64bit) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1023,7 +1023,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructType64bit) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
@@ -1035,7 +1035,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1058,7 +1058,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1085,7 +1085,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -1099,7 +1099,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByLocation) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         out block { layout(location=1) float x; } outs;
         void main(){
@@ -1107,7 +1107,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByLocation) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         in block { layout(location=0) float x; } ins;
         layout(location=0) out vec4 color;
@@ -1119,7 +1119,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByLocation) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -1133,7 +1133,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByComponent) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         out block { layout(location=0, component=0) float x; } outs;
         void main(){
@@ -1141,7 +1141,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByComponent) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         in block { layout(location=0, component=1) float x; } ins;
         layout(location=0) out vec4 color;
@@ -1153,7 +1153,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByComponent) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -1168,7 +1168,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchShaderObject) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out int x;
         void main(){
@@ -1176,7 +1176,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchShaderObject) {
            gl_Position = vec4(1);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -1208,14 +1208,14 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSizeShaderObject) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
            gl_Position = vec4(1.0);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 x;
         layout(location=0) out vec4 color;
@@ -1279,7 +1279,7 @@ TEST_F(NegativeShaderInterface, VertexOutputNotConsumed) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float x;
         void main(){
@@ -1289,7 +1289,7 @@ TEST_F(NegativeShaderInterface, VertexOutputNotConsumed) {
     )glsl";
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "WARNING-Shader-OutputNotConsumed");
@@ -1304,7 +1304,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
     InitRenderTarget();
 
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) out float r;
@@ -1317,7 +1317,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) in vec3 rgb;
@@ -1330,14 +1330,14 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
     }
 
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v;
@@ -1347,7 +1347,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) in float a;
@@ -1361,14 +1361,14 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "WARNING-Shader-OutputNotConsumed");
     }
 
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v;
@@ -1379,7 +1379,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) in vec4 v;
@@ -1392,14 +1392,14 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
     }
 
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v;
@@ -1410,7 +1410,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
                 #version 450
 
                 layout (location = 0) out vec4 color;
@@ -1421,14 +1421,14 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
     }
 
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v1;
@@ -1443,7 +1443,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
                 #version 450
 
                 layout (location = 0) in vec3 v1;
@@ -1457,7 +1457,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1476,7 +1476,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputLocation0) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -1489,7 +1489,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputIndex1) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    const char *fs_src = R"glsl(
+    const char* fs_src = R"glsl(
         #version 460
         layout(location = 0, index = 1) out vec4 c0;
         void main() {
@@ -1502,7 +1502,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputIndex1) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -1516,7 +1516,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputNoAlpha) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 x;
         void main(){
@@ -1529,7 +1529,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputNoAlpha) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -1542,7 +1542,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayIndex) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=1) out vec4 fragData[3];
         void main() {
@@ -1555,7 +1555,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayIndex) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -1568,7 +1568,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayVec3) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 fragData[4];
         void main() {
@@ -1581,7 +1581,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayVec3) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -1597,13 +1597,13 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][2][2] x;
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float[4][3][2] x; // 2 extra Locations
         layout(location=0) out float color;
@@ -1613,7 +1613,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -1628,13 +1628,13 @@ TEST_F(NegativeShaderInterface, MultidimensionalArrayDim) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][2][2] x;
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float[17] x; // 1 extra Locations
         layout(location=0) out float color;
@@ -1644,7 +1644,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArrayDim) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -1661,7 +1661,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray64bit) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) out f64vec3[2][2][2] x; // take 2 locations each (total 16)
@@ -1669,7 +1669,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray64bit) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) flat in f64vec3[2][3][2] x;
@@ -1680,7 +1680,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray64bit) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -1692,13 +1692,13 @@ TEST_F(NegativeShaderInterface, PackingInsideArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) out float[2] x;
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) in float x;
         layout(location = 1, component = 0) in float y;
@@ -1709,7 +1709,7 @@ TEST_F(NegativeShaderInterface, PackingInsideArray) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-08743");
@@ -1723,7 +1723,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputNotWritten) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor; // not written to
         void main() {}
@@ -1744,7 +1744,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputNotWrittenDynamicRendering) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor; // not written to
         void main() {}
@@ -1779,15 +1779,14 @@ TEST_F(NegativeShaderInterface, FragmentOutputNotWrittenDynamicRenderingShaderOb
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor; // not written to
         void main() {}
     )glsl";
 
     const vkt::Shader vert_shader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
-    const vkt::Shader frag_shader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fs_source));
+    const vkt::Shader frag_shader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fs_source));
 
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
@@ -1808,7 +1807,7 @@ TEST_F(NegativeShaderInterface, DISABLED_FragmentOutputNotWrittenArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor[2];
         void main(){
@@ -1850,7 +1849,7 @@ TEST_F(NegativeShaderInterface, DISABLED_FragmentOutputNotWrittenArrayDynamicRen
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor[2];
         void main(){
@@ -1906,7 +1905,7 @@ TEST_F(NegativeShaderInterface, CreatePipelineFragmentOutputTypeMismatch) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out ivec4 x; /* not UNORM */
         void main(){
@@ -1916,7 +1915,7 @@ TEST_F(NegativeShaderInterface, CreatePipelineFragmentOutputTypeMismatch) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "Undefined-Value-ShaderFragmentOutputMismatch");
@@ -1928,7 +1927,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputTypeMismatchDynamicRendering) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location=0) out ivec4 x; /* not UNORM */
         void main(){
@@ -1967,7 +1966,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputTypeMismatchDynamicRenderingLocalR
     InitDynamicRenderTarget(VK_FORMAT_R8G8B8A8_SINT);
     InitDynamicRenderTarget(VK_FORMAT_R8G8B8A8_UNORM);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location=0) out ivec4 x; /* not UNORM */
         void main(){
@@ -2077,7 +2076,7 @@ TEST_F(NegativeShaderInterface, CreatePipelineFragmentOutputNotConsumed) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(location=1) out vec4 y; /* no matching attachment for this */
@@ -2101,7 +2100,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputNotConsumedDynamicRendering) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(location=1) out vec4 y; /* no matching attachment for this */
@@ -2139,7 +2138,7 @@ TEST_F(NegativeShaderInterface, InvalidStaticSpirv) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %fragCoord %block_var
@@ -2176,7 +2175,7 @@ TEST_F(NegativeShaderInterface, InvalidStaticSpirvMaintenance5) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"
@@ -2218,7 +2217,7 @@ TEST_F(NegativeShaderInterface, InvalidStaticSpirvMaintenance5Compute) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -2262,7 +2261,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBuffer) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"(
+    const char* vs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2302,7 +2301,7 @@ TEST_F(NegativeShaderInterface, MultipleFragmentAttachment) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7923");
     RETURN_IF_SKIP(Init());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color0;
         layout(location=1) out vec4 color1;
@@ -2350,7 +2349,7 @@ TEST_F(NegativeShaderInterface, MultipleFragmentAttachmentDynamicRendering) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color0;
         layout(location=1) out vec4 color1;
@@ -2415,7 +2414,7 @@ TEST_F(NegativeShaderInterface, MissingInputAttachmentIndex) {
     // }
     //
     // missing OpDecorate %xs InputAttachmentIndex 0
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability InputAttachment
                OpMemoryModel Logical GLSL450
@@ -2478,7 +2477,7 @@ TEST_F(NegativeShaderInterface, MissingInputAttachmentIndexArray) {
     // }
     //
     // missing OpDecorate %xs InputAttachmentIndex 0
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability InputAttachment
                OpMemoryModel Logical GLSL450
@@ -2536,7 +2535,7 @@ TEST_F(NegativeShaderInterface, MissingInputAttachmentIndexShaderObject) {
     // }
     //
     // missing OpDecorate %xs InputAttachmentIndex 0
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability InputAttachment
                OpMemoryModel Logical GLSL450
@@ -2588,7 +2587,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBufferArray) {
     RETURN_IF_SKIP(Init())
     InitRenderTarget();
 
-    const char *vs_source = R"(
+    const char* vs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2637,7 +2636,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBufferLinkedList) {
     RETURN_IF_SKIP(Init())
     InitRenderTarget();
 
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2687,7 +2686,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBufferNested) {
     RETURN_IF_SKIP(Init())
     InitRenderTarget();
 
-    const char *fs_source = R"(
+    const char* fs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2785,7 +2784,7 @@ TEST_F(NegativeShaderInterface, DISABLED_NestedStructInBlock) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    auto set_info = [&](CreatePipelineHelper &info) { info.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()}; };
+    auto set_info = [&](CreatePipelineHelper& info) { info.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()}; };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
 }
 

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -25,7 +25,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputComponents) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) out vec2 rg;
@@ -71,7 +71,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputComponents) {
             )glsl";
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) in float r;
@@ -115,7 +115,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputComponents) {
             )glsl";
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -127,7 +127,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputStructComponents) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
                 #version 450
 
                 struct R {
@@ -144,7 +144,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputStructComponents) {
             )glsl";
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
                 #version 450
 
                 struct R {
@@ -161,7 +161,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputStructComponents) {
             )glsl";
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -181,7 +181,7 @@ TEST_F(PositiveShaderInterface, RelaxedBlockLayout) {
     // "Structure id 2 decorated as Block for variable in Uniform storage class
     // must follow standard uniform buffer layout rules: member 1 at offset 4 is not aligned to 16"
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                   OpCapability Shader
                   OpMemoryModel Logical GLSL450
                   OpEntryPoint Vertex %main "main"
@@ -221,7 +221,7 @@ TEST_F(PositiveShaderInterface, UboStd430Layout) {
     // must follow standard uniform buffer layout rules: member 0 is an array
     // with stride 4 not satisfying alignment to 16"
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main"
@@ -264,7 +264,7 @@ TEST_F(PositiveShaderInterface, ScalarBlockLayout) {
     // "Structure id 2 decorated as Block for variable in Uniform storage class
     // must follow standard uniform buffer layout rules: member 1 at offset 4 is not aligned to 16"
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                   OpCapability Shader
                   OpMemoryModel Logical GLSL450
                   OpEntryPoint Vertex %main "main"
@@ -299,7 +299,7 @@ TEST_F(PositiveShaderInterface, FragmentOutputNotWrittenMasked) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor;
         void main() {}
@@ -359,14 +359,14 @@ TEST_F(PositiveShaderInterface, RelaxedTypeMatch) {
         "1.3) device extension:"
         "fundamental type must match, and producer side must have at least as many components");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1); // At least 1.1 is required for maintenance4
+    SetTargetApiVersion(VK_API_VERSION_1_1);  // At least 1.1 is required for maintenance4
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::maintenance4);
     RETURN_IF_SKIP(Init());
 
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 x;
         layout(location=1) out ivec3 y;
@@ -376,7 +376,7 @@ TEST_F(PositiveShaderInterface, RelaxedTypeMatch) {
            x = vec3(0); y = ivec3(0); z = vec3(0);
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         layout(location=0) in float x;
@@ -402,7 +402,7 @@ TEST_F(PositiveShaderInterface, TessPerVertex) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *tcsSource = R"glsl(
+    const char* tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -412,7 +412,7 @@ TEST_F(PositiveShaderInterface, TessPerVertex) {
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    const char *tesSource = R"glsl(
+    const char* tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) in int x[];
@@ -448,7 +448,7 @@ TEST_F(PositiveShaderInterface, GeometryInputBlockPositive) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
 
         layout(location = 0) out VertexData { vec4 x; } gs_out;
@@ -458,7 +458,7 @@ TEST_F(PositiveShaderInterface, GeometryInputBlockPositive) {
         }
     )glsl";
 
-    const char *gsSource = R"glsl(
+    const char* gsSource = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices=3) out;
@@ -484,7 +484,7 @@ TEST_F(PositiveShaderInterface, InputAttachment) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -524,7 +524,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentMissingNotRead) {
     // void main() {
     //     // (not actually called) color = subpassLoad(xs[0]);
     // }
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability InputAttachment
                OpMemoryModel Logical GLSL450
@@ -558,7 +558,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentMissingNotRead) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     };
@@ -582,7 +582,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
 
     // use static array of 2 and index into element 1 to read
     {
-        const char *fs_source = R"glsl(
+        const char* fs_source = R"glsl(
             #version 460
             layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[2];
             layout(location=0) out vec4 color;
@@ -592,7 +592,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         )glsl";
         VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
             helper.gp_ci_.renderPass = rp;
@@ -602,7 +602,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
 
     // use undefined size array and index into element 1 to read
     {
-        const char *fs_source = R"glsl(
+        const char* fs_source = R"glsl(
             #version 460
             layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[];
             layout(location=0) out vec4 color;
@@ -612,7 +612,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         )glsl";
         VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
             helper.gp_ci_.renderPass = rp;
@@ -623,7 +623,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
     // Array of size 1
     // loads from index 0, but not the invalid index 0 since has offset of 3
     {
-        const char *fs_source = R"glsl(
+        const char* fs_source = R"glsl(
             #version 460
             layout(input_attachment_index=3, set=0, binding=0) uniform subpassInput xs[1];
             layout(location=0) out vec4 color;
@@ -633,7 +633,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         )glsl";
         VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
             helper.gp_ci_.renderPass = rp;
@@ -643,7 +643,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
 
     // Index from non-zero
     {
-        const char *fs_source = R"glsl(
+        const char* fs_source = R"glsl(
             #version 460
             layout(input_attachment_index=2, set=0, binding=0) uniform subpassInput xs[2];
             layout(location=0) out vec4 color;
@@ -653,7 +653,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         )glsl";
         VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
 
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
             helper.gp_ci_.renderPass = rp;
@@ -681,7 +681,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentRuntimeArray) {
 
     // use OpTypeRuntimeArray and index into it
     // This is something that is needed to be validated at draw time, so should not be an error
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : require
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[];
@@ -693,14 +693,13 @@ TEST_F(PositiveShaderInterface, InputAttachmentRuntimeArray) {
     )glsl";
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                 {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
         helper.gp_ci_.renderPass = rp;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
-
 }
 TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
     TEST_DESCRIPTION("Input Attachment sharing same variable, but different aspect");
@@ -720,7 +719,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
     rp.CreateRenderPass();
 
     // Depth and Stencil use same index, but valid because differnet image aspect masks
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
             #version 460
             layout(input_attachment_index = 0, set = 0, binding = 0) uniform subpassInput i_color;
             layout(input_attachment_index = 1, set = 0, binding = 1) uniform subpassInput i_depth;
@@ -736,7 +735,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
         )glsl";
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                 {1, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
@@ -757,7 +756,7 @@ TEST_F(PositiveShaderInterface, FragmentOutputNotConsumedButAlphaToCoverageEnabl
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.ms_ci_ = ms_state_ci;
         helper.cb_ci_.attachmentCount = 0;
     };
@@ -770,7 +769,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageOutputIndex0) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    const char *fs_src = R"glsl(
+    const char* fs_src = R"glsl(
         #version 460
         layout(location = 0, index = 0) out vec4 c0;
         void main() {
@@ -783,7 +782,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageOutputIndex0) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -971,7 +970,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageOffsetToAlpha) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0, component = 3) out float x;
         void main(){
@@ -984,7 +983,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageOffsetToAlpha) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -997,7 +996,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         // Just need to declare variable
         layout(location=0) out vec4 fragData[4];
@@ -1010,7 +1009,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageArray) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.ms_ci_ = ms_state_ci;
     };
@@ -1026,7 +1025,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockStructArray) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct S {
             float b;
@@ -1042,7 +1041,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockStructArray) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct S {
             float b;
@@ -1062,7 +1061,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockStructArray) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1074,7 +1073,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructLastElementArra
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1097,7 +1096,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructLastElementArra
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1124,7 +1123,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructLastElementArra
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1136,7 +1135,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1159,7 +1158,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1186,7 +1185,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1198,13 +1197,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][2][2] x;
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float[4][2][2] x;
         layout(location=0) out float color;
@@ -1214,7 +1213,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1229,13 +1228,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayVertex) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][3][2] x;
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float[4][2][2] x;
         layout(location=0) out float color;
@@ -1245,7 +1244,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayVertex) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1260,13 +1259,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][3][2] x; // 24 locations
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float[3][2][4] x; // 24 locations
         layout(location=0) out float color;
@@ -1276,7 +1275,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1291,13 +1290,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims2) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][3][2] x; // 24 locations
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) in float[24] x;
         layout(location=0) out float color;
@@ -1307,7 +1306,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims2) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1324,7 +1323,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray64bit) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is too low";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) out f64vec3[2][2] x; // take 2 locations each (total 8)
@@ -1332,7 +1331,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray64bit) {
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) flat in f64vec3[2][2] x;
@@ -1343,7 +1342,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray64bit) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1354,7 +1353,7 @@ TEST_F(PositiveShaderInterface, MultipleFragmentAttachment) {
     RETURN_IF_SKIP(Init());
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color[2];
         void main() {
@@ -1402,7 +1401,7 @@ TEST_F(PositiveShaderInterface, MissingInputAttachmentIndex) {
     // }
     //
     // missing OpDecorate %xs InputAttachmentIndex 0
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability InputAttachment
                OpMemoryModel Logical GLSL450
@@ -1504,7 +1503,7 @@ TEST_F(PositiveShaderInterface, FragmentOutputTypeDynamicRenderingLocalReadTypeR
     InitDynamicRenderTarget(VK_FORMAT_R8G8B8A8_UNORM);
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
 
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
@@ -1561,13 +1560,13 @@ TEST_F(PositiveShaderInterface, NonZeroComponentArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) out float[2] x;
         void main() {}
     )glsl";
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) in float[2] x;
         layout(location=0) out float color;
@@ -1595,7 +1594,7 @@ TEST_F(PositiveShaderInterface, PackingInsideArray) {
     // layout(location = 0, component = 1) out float[2] x;
     // layout(location = 1, component = 0) out int y;
     // layout(location = 1, component = 2) out int z;
-    const char *vs_source1 = R"(
+    const char* vs_source1 = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %x %y %z
@@ -1625,7 +1624,7 @@ TEST_F(PositiveShaderInterface, PackingInsideArray) {
 
     VkShaderObj vs1(*m_device, vs_source1, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    const char *vs_source2 = R"glsl(
+    const char* vs_source2 = R"glsl(
         #version 450
         layout(location = 0, component = 0) out float x;
         layout(location = 0, component = 1) out float[2] y;

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsInput) {
     //     int x = gl_SampleMaskIn[3]; // Exceed sample mask input array size
     //     uFragColor = vec4(0,1,0,1) * x;
     // }
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %gl_SampleMaskIn %uFragColor
@@ -72,7 +72,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsInput) {
     )";
     VkShaderObj fs(*m_device, source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    const auto inputPipeline = [&](CreatePipelineHelper &helper) {
+    const auto inputPipeline = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, inputPipeline, kErrorBit,
@@ -93,7 +93,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsOutput) {
     //    gl_SampleMask[3] = 1; // Exceed sample mask output array size
     //    uFragColor = vec4(0,1,0,1);
     // }
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %gl_SampleMask %uFragColor
@@ -128,7 +128,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsOutput) {
     )";
     VkShaderObj fs(*m_device, source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    const auto outputPipeline = [&](CreatePipelineHelper &helper) {
+    const auto outputPipeline = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, outputPipeline, kErrorBit,
@@ -144,7 +144,7 @@ TEST_F(NegativeShaderLimits, MinAndMaxTexelGatherOffset) {
         GTEST_SKIP() << "test needs minTexelGatherOffset greater than -100 and maxTexelGatherOffset less than 100";
     }
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -213,7 +213,7 @@ TEST_F(NegativeShaderLimits, MinAndMaxTexelOffset) {
         GTEST_SKIP() << "test needs minTexelGatherOffset greater than -100 and maxTexelGatherOffset less than 100";
     }
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -286,7 +286,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentDualSrcAttachments) {
     }
     InitRenderTarget(count);
 
-    const char *fs_src = R"glsl(
+    const char* fs_src = R"glsl(
         #version 460
         layout(location = 0) out vec4 c0;
         layout(location = 1) out vec4 c1;
@@ -432,7 +432,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachments) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c0;
         layout(location=1) out vec4 c1;
@@ -459,7 +459,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachmentsArray) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c[5];
         void main(){
@@ -478,7 +478,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachmentsArrayAtEnd) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=3) out vec4 c[2];
         void main(){
@@ -504,7 +504,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentCombinedOutputResources) {
     fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     RETURN_IF_SKIP(InitState());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(set = 0, binding=0) buffer SSBO_0 {
             uint a;
@@ -552,7 +552,7 @@ TEST_F(NegativeShaderLimits, MaxLongVectorComponentCount) {
 
     VkShaderObj fs(*m_device, fsSource.str().c_str(), VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto outputPipeline = [&](CreatePipelineHelper &helper) {
+    const auto outputPipeline = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, outputPipeline, kErrorBit, "VUID-RuntimeSpirv-longVector-12296");
@@ -595,7 +595,7 @@ TEST_F(NegativeShaderLimits, MaxLongVectorIdComponentCount) {
     VkShaderObj fs(*m_device, fsSource.str().c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL,
                    &specialization_info);
 
-    const auto outputPipeline = [&](CreatePipelineHelper &helper) {
+    const auto outputPipeline = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, outputPipeline, kErrorBit, "VUID-RuntimeSpirv-longVector-12296");

--- a/tests/unit/shader_limits_positive.cpp
+++ b/tests/unit/shader_limits_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ TEST_F(PositiveShaderLimits, MaxSampleMaskWords) {
     InitRenderTarget();
 
     // Valid input of sample mask
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -33,7 +33,7 @@ TEST_F(PositiveShaderLimits, MaxSampleMaskWords) {
     )glsl";
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto validPipeline = [&](CreatePipelineHelper &helper) {
+    const auto validPipeline = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, validPipeline, kErrorBit);
@@ -154,7 +154,7 @@ TEST_F(PositiveShaderLimits, MeshSharedMemoryAtLimit) {
 
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -192,7 +192,7 @@ TEST_F(PositiveShaderLimits, TaskSharedMemoryAtLimit) {
     VkShaderObj task(*m_device, task_source.str().c_str(), VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_2);
     VkShaderObj mesh(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task.GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -211,7 +211,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachments) {
     }
     InitRenderTarget(count);
 
-    const char *fs_src = R"glsl(
+    const char* fs_src = R"glsl(
         #version 460
         layout(location = 0) out vec4 c0;
         layout(location = 1) out vec4 c1;
@@ -257,7 +257,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachmentsDynamicEnabled) {
     }
     InitRenderTarget(count);
 
-    const char *fs_src = R"glsl(
+    const char* fs_src = R"glsl(
         #version 460
         layout(location = 0) out vec4 c0;
         layout(location = 1) out vec4 c1;
@@ -298,7 +298,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentOutputAttachments) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c0;
         layout(location=1) out vec4 c1;
@@ -326,7 +326,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentOutputAttachmentsArray) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c[4];
         void main(){
@@ -348,7 +348,7 @@ TEST_F(PositiveShaderLimits, MaxLongVectorComponentCount) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_EXT_long_vector : enable
         vector<float, 1024> v;
@@ -358,7 +358,7 @@ TEST_F(PositiveShaderLimits, MaxLongVectorComponentCount) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto outputPipeline = [&](CreatePipelineHelper &helper) {
+    const auto outputPipeline = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, outputPipeline, kErrorBit);
@@ -372,7 +372,7 @@ TEST_F(PositiveShaderLimits, MaxLongVectorIdComponentCount) {
     InitRenderTarget();
 
     // the spec constant is initialized to an invalid value but overridden to a supported value
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_EXT_long_vector : enable
         layout(constant_id = 0) const uint Count = 999999999;
@@ -396,7 +396,7 @@ TEST_F(PositiveShaderLimits, MaxLongVectorIdComponentCount) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL, &specialization_info);
 
-    const auto outputPipeline = [&](CreatePipelineHelper &helper) {
+    const auto outputPipeline = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, outputPipeline, kErrorBit);

--- a/tests/unit/shader_mesh.cpp
+++ b/tests/unit/shader_mesh.cpp
@@ -44,7 +44,7 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimit) {
 
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
@@ -97,7 +97,7 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout) {
 
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
@@ -137,7 +137,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantDefault) {
 
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
@@ -191,7 +191,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantSet) {
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL,
                      &specialization_info);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
@@ -252,7 +252,7 @@ TEST_F(NegativeShaderMesh, MeshAndTaskShaderDerivatives) {
         GTEST_SKIP() << "meshAndTaskShaderDerivatives is supported";
     }
 
-    const char *ms_source = R"(
+    const char* ms_source = R"(
                OpCapability ComputeDerivativeGroupQuadsKHR
                OpCapability MeshShadingEXT
                OpExtension "SPV_EXT_mesh_shader"
@@ -347,7 +347,7 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadMemoryOverLimit) {
 
     VkShaderObj task(*m_device, task_source.str().c_str(), VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_2);
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task.GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshPayloadAndSharedMemorySize-08755");
@@ -371,7 +371,7 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadSpecConstantSet) {
     const uint32_t max_mesh_payload_and_shared_memory_size = mesh_shader_properties.maxMeshPayloadAndSharedMemorySize;
     const uint32_t max_mesh_payload_and_shared_ints = max_mesh_payload_and_shared_memory_size / 4;
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(constant_id = 0) const int SIZE = 64;
@@ -385,7 +385,7 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadSpecConstantSet) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(max_vertices = 3, max_primitives=1) out;

--- a/tests/unit/shader_mesh_positive.cpp
+++ b/tests/unit/shader_mesh_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ TEST_F(PositiveShaderMesh, MeshShaderPayloadMemoryOverLimit) {
 
     VkShaderObj task(*m_device, task_source.str().c_str(), VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_2);
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task.GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -96,7 +96,7 @@ TEST_F(PositiveShaderMesh, MeshShaderPayloadSpecConstantSet) {
     const uint32_t max_mesh_payload_and_shared_memory_size = mesh_shader_properties.maxMeshPayloadAndSharedMemorySize;
     const uint32_t max_mesh_payload_and_shared_ints = max_mesh_payload_and_shared_memory_size / 4;
 
-    const char *task_source = R"glsl(
+    const char* task_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(constant_id = 0) const int SIZE = 64;
@@ -110,7 +110,7 @@ TEST_F(PositiveShaderMesh, MeshShaderPayloadSpecConstantSet) {
         }
     )glsl";
 
-    const char *mesh_source = R"glsl(
+    const char* mesh_source = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(max_vertices = 3, max_primitives=1) out;
@@ -139,7 +139,7 @@ TEST_F(PositiveShaderMesh, MeshShaderPayloadSpecConstantSet) {
 
     VkShaderObj task(*m_device, task_source, VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_2);
     VkShaderObj mesh(*m_device, mesh_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL, &spec_info);
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {task.GetStageCreateInfo(), mesh.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -16,7 +16,7 @@
 #include "../framework/shader_templates.h"
 #include "utils/math_utils.h"
 
-void ShaderObjectTest::InitBasicShaderObject(void *instance_pnext) {
+void ShaderObjectTest::InitBasicShaderObject(void* instance_pnext) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
@@ -620,9 +620,9 @@ TEST_F(PositiveShaderObject, FailCreateShaders) {
     while (pCode % 16 != 0) {
         pCode += 1;
     }
-    std::memcpy(reinterpret_cast<void *>(pCode), create_infos[fail_index].pCode, create_infos[fail_index].codeSize);
+    std::memcpy(reinterpret_cast<void*>(pCode), create_infos[fail_index].pCode, create_infos[fail_index].codeSize);
     create_infos[fail_index].codeType = VK_SHADER_CODE_TYPE_BINARY_EXT;
-    create_infos[fail_index].pCode = reinterpret_cast<const void *>(pCode);
+    create_infos[fail_index].pCode = reinterpret_cast<const void*>(pCode);
 
     VkResult res = vk::CreateShadersEXT(*m_device, 20u, create_infos, nullptr, shaders);
     ASSERT_EQ(res, VK_INCOMPATIBLE_SHADER_BINARY_EXT);
@@ -1298,7 +1298,7 @@ TEST_F(PositiveShaderObject, DrawWithBinaryShaders) {
         // Allocate enough space to guarantee 16 byte alignment
         std::vector<uint8_t> data(data_size + 15);
         // Get 16 byte aligned pointer
-        void *storage_ptr = reinterpret_cast<void *>(Align(reinterpret_cast<uintptr_t>(data.data()), (uintptr_t)16));
+        void* storage_ptr = reinterpret_cast<void*>(Align(reinterpret_cast<uintptr_t>(data.data()), (uintptr_t)16));
 
         vk::GetShaderBinaryDataEXT(*m_device, shaders[i], &data_size, storage_ptr);
 
@@ -1915,11 +1915,11 @@ TEST_F(PositiveShaderObject, IdenticallyDefinedLayouts) {
     InitDynamicRenderTarget();
 
     OneOffDescriptorSet descriptor_set1(m_device, {
-                                                     {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                                 });
+                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  });
     OneOffDescriptorSet descriptor_set2(m_device, {
-                                                     {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                                 });
+                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  });
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set1.layout_});
 
     const vkt::Shader vert_shader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, &descriptor_set1.layout_.handle());

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ TEST_F(NegativeShaderPushConstants, NotDeclared) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x; } consts;
         void main(){
@@ -194,7 +194,7 @@ TEST_F(NegativeShaderPushConstants, NotInLayout) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x; } consts;
         void main(){
@@ -234,7 +234,7 @@ TEST_F(NegativeShaderPushConstants, Range) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x[4]; } constants;
         void main(){
@@ -297,7 +297,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     InitRenderTarget();
 
     // push constant range: 0-99
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo {
            bool b;
@@ -321,7 +321,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     )glsl";
 
     // push constant range: 0 - 95
-    const char *const fsSource = R"glsl(
+    const char* const fsSource = R"glsl(
         #version 450
         struct foo1{
            int i[4];
@@ -410,7 +410,7 @@ TEST_F(NegativeShaderPushConstants, BufferDeviceAddress) {
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(Init());
 
-    const char *shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16, std430) buffer BDA {
@@ -457,7 +457,7 @@ TEST_F(NegativeShaderPushConstants, MultipleEntryPoint) {
     // void main(){
     //     uFragColor = vec4(0.0);
     // }
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main_f "main" %4
@@ -540,7 +540,7 @@ TEST_F(NegativeShaderPushConstants, SpecConstantSize) {
     TEST_DESCRIPTION("Use SpecConstant to adjust size of Push Constant Block");
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         layout (constant_id = 0) const int my_array_size = 1;
         layout (push_constant) uniform my_buf {
@@ -585,7 +585,7 @@ TEST_F(NegativeShaderPushConstants, ArrayOf8Bit) {
     // storagePushConstant8 is not enabled
     RETURN_IF_SKIP(Init());
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_8bit_storage: enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -611,7 +611,7 @@ TEST_F(NegativeShaderPushConstants, StructOf8Bit) {
     // storagePushConstant8 is not enabled
     RETURN_IF_SKIP(Init());
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_8bit_storage: enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -644,7 +644,7 @@ TEST_F(NegativeShaderPushConstants, ArrayOfStructOf8Bit) {
     // storagePushConstant8 is not enabled
     RETURN_IF_SKIP(Init());
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_8bit_storage: enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable

--- a/tests/unit/shader_push_constants_positive.cpp
+++ b/tests/unit/shader_push_constants_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ TEST_F(PositiveShaderPushConstants, OverlappingPushConstantRange) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x[8]; } constants;
         void main(){
@@ -30,7 +30,7 @@ TEST_F(PositiveShaderPushConstants, OverlappingPushConstantRange) {
         }
     )glsl";
 
-    const char *const fsSource = R"glsl(
+    const char* const fsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x[4]; } constants;
         layout(location=0) out vec4 o;
@@ -143,7 +143,7 @@ TEST_F(PositiveShaderPushConstants, MultipleEntryPointVert) {
                              "main_v");
         VkShaderObj const fs(*m_device, vert_first.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM,
                              nullptr, "main_f");
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.pipeline_layout_ci_ = pipeline_layout_info;
         };
@@ -156,7 +156,7 @@ TEST_F(PositiveShaderPushConstants, MultipleEntryPointVert) {
                              "main_v");
         VkShaderObj const fs(*m_device, frag_first.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM,
                              nullptr, "main_f");
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.pipeline_layout_ci_ = pipeline_layout_info;
         };
@@ -252,7 +252,7 @@ TEST_F(PositiveShaderPushConstants, MultipleEntryPointFrag) {
                              "main_v");
         VkShaderObj const fs(*m_device, vert_first.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM,
                              nullptr, "main_f");
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.pipeline_layout_ci_ = pipeline_layout_info;
         };
@@ -265,7 +265,7 @@ TEST_F(PositiveShaderPushConstants, MultipleEntryPointFrag) {
                              "main_v");
         VkShaderObj const fs(*m_device, frag_first.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM,
                              nullptr, "main_f");
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.pipeline_layout_ci_ = pipeline_layout_info;
         };
@@ -278,7 +278,7 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { layout(offset = 16) vec4 x; } constants;
         void main(){
@@ -418,7 +418,7 @@ TEST_F(PositiveShaderPushConstants, StaticallyUnused) {
     VkPipelineLayoutCreateInfo pipeline_layout_info = {
         VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, &push_constant_range};
 
-    const char *vsSourceUnused = R"glsl(
+    const char* vsSourceUnused = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x; } consts;
         void main(){
@@ -426,7 +426,7 @@ TEST_F(PositiveShaderPushConstants, StaticallyUnused) {
         }
     )glsl";
 
-    const char *vsSourceEmpty = R"glsl(
+    const char* vsSourceEmpty = R"glsl(
         #version 450
         void main(){
            gl_Position = vec4(1.0);
@@ -475,7 +475,7 @@ TEST_F(PositiveShaderPushConstants, OffsetVector) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
 
         layout(push_constant) uniform Material {
@@ -516,7 +516,7 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferBasic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *const vsSource = R"glsl(
+    const char* const vsSource = R"glsl(
         #version 450
 
         #extension GL_EXT_buffer_reference : enable
@@ -566,7 +566,7 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferVertFrag) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vertex_source = R"glsl(
+    const char* vertex_source = R"glsl(
         #version 450
 
         #extension GL_EXT_buffer_reference : enable
@@ -588,7 +588,7 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferVertFrag) {
         )glsl";
     const VkShaderObj vs(*m_device, vertex_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
         #version 450
 
         #extension GL_EXT_buffer_reference : enable
@@ -640,7 +640,7 @@ TEST_F(PositiveShaderPushConstants, MultipleStructs) {
     //
     // layout(push_constant) uniform pc_a { layout(offset = 32) vec4 x; } a;
     // layout(push_constant) uniform pc_b { layout(offset = 16) vec4 x; } b;
-    const char *source = R"(
+    const char* source = R"(
                  OpCapability Shader
                  OpMemoryModel Logical GLSL450
                  OpEntryPoint Vertex %1 "main"
@@ -699,7 +699,7 @@ TEST_F(PositiveShaderPushConstants, SpecConstantSizeDefault) {
     TEST_DESCRIPTION("Use SpecConstant to adjust size of Push Constant Block, but use default value");
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         layout (constant_id = 2) const int my_array_size = 1;
         layout (push_constant) uniform my_buf {
@@ -724,7 +724,7 @@ TEST_F(PositiveShaderPushConstants, SpecConstantSizeSet) {
     TEST_DESCRIPTION("Use SpecConstant to adjust size of Push Constant Block");
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         layout (constant_id = 0) const int my_array_size = 256;
         layout (push_constant) uniform my_buf {
@@ -775,7 +775,7 @@ TEST_F(PositiveShaderPushConstants, Storage8BitPointers) {
     // void main(uint8_t* input) {
     //     result[0] = (int)input[0];
     // }
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Int8
                OpCapability Shader

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -48,7 +48,7 @@ TEST_F(NegativeShaderSpirv, CodeSize) {
         VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
 
         constexpr icd_spv_header spv = {};
-        module_create_info.pCode = reinterpret_cast<const uint32_t *>(&spv);
+        module_create_info.pCode = reinterpret_cast<const uint32_t*>(&spv);
         module_create_info.codeSize = 4;
 
         m_errorMonitor->SetDesiredError("Invalid SPIR-V header");
@@ -150,7 +150,7 @@ TEST_F(NegativeShaderSpirv, Magic) {
     constexpr uint32_t bad_magic = 4175232508U;
     constexpr icd_spv_header spv = {bad_magic};
 
-    module_create_info.pCode = reinterpret_cast<const uint32_t *>(&spv);
+    module_create_info.pCode = reinterpret_cast<const uint32_t*>(&spv);
     module_create_info.codeSize = sizeof(spv);
 
     m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08738");
@@ -170,7 +170,7 @@ TEST_F(NegativeShaderSpirv, MagicMaintenance5) {
     constexpr icd_spv_header spv = {bad_magic};
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
-    module_create_info.pCode = reinterpret_cast<const uint32_t *>(&spv);
+    module_create_info.pCode = reinterpret_cast<const uint32_t*>(&spv);
     module_create_info.codeSize = sizeof(spv);
 
     VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&module_create_info);
@@ -198,7 +198,7 @@ TEST_F(NegativeShaderSpirv, MagicMaintenance5Compute) {
     constexpr icd_spv_header spv = {bad_magic};
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
-    module_create_info.pCode = reinterpret_cast<const uint32_t *>(&spv);
+    module_create_info.pCode = reinterpret_cast<const uint32_t*>(&spv);
     module_create_info.codeSize = sizeof(spv);
 
     VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&module_create_info);
@@ -361,7 +361,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageBuffer8BitAccess
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_8bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -379,7 +379,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
     }
     // uniformAndStorageBuffer8BitAccess
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_8bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -398,7 +398,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storagePushConstant8
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_8bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -417,7 +417,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageBuffer16BitAccess - Float
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -435,7 +435,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // uniformAndStorageBuffer16BitAccess - Float
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -454,7 +454,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storagePushConstant16 - Float
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -473,7 +473,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageInputOutput16 - Float
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -490,7 +490,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
         m_errorMonitor->VerifyFound();
 
         // Need to match in/out
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -509,7 +509,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageBuffer16BitAccess - Int
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -528,7 +528,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // uniformAndStorageBuffer16BitAccess - Int
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -548,7 +548,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storagePushConstant16 - Int
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -567,7 +567,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageInputOutput16 - Int
     {
-        const char *vsSource = R"glsl(
+        const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -584,7 +584,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
         m_errorMonitor->VerifyFound();
 
         // Need to match in/out
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -609,7 +609,7 @@ TEST_F(NegativeShaderSpirv, InputOutput8Bit) {
     AddRequiredFeature(vkt::Feature::shaderInt8);
     RETURN_IF_SKIP(Init());
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_8bit_storage: enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -623,7 +623,7 @@ TEST_F(NegativeShaderSpirv, InputOutput8Bit) {
     VkShaderObj const vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0);
     m_errorMonitor->VerifyFound();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_8bit_storage: enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -650,7 +650,7 @@ TEST_F(NegativeShaderSpirv, SpirvStatelessMaintenance5) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_8bit_storage: enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -677,7 +677,7 @@ TEST_F(NegativeShaderSpirv, SpirvStatelessMaintenance5) {
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-uniformAndStorageBuffer8BitAccess-06329");  // feature
-    m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740", 2);     // Int8
+    m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740", 2);               // Int8
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -764,7 +764,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
     if (float16Int8.shaderInt8 == VK_TRUE) {
         // storageBuffer8BitAccess
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int8
                OpExtension "SPV_KHR_8bit_storage"
@@ -794,7 +794,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // uniformAndStorageBuffer8BitAccess
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int8
                OpExtension "SPV_KHR_8bit_storage"
@@ -823,7 +823,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // storagePushConstant8
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int8
                OpExtension "SPV_KHR_8bit_storage"
@@ -853,7 +853,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
     if (float16Int8.shaderFloat16 == VK_TRUE) {
         // storageBuffer16BitAccess - float
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Float16
                OpExtension "SPV_KHR_16bit_storage"
@@ -883,7 +883,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // uniformAndStorageBuffer16BitAccess - float
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Float16
                OpExtension "SPV_KHR_16bit_storage"
@@ -912,7 +912,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // storagePushConstant16 - float
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Float16
                OpExtension "SPV_KHR_16bit_storage"
@@ -940,7 +940,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // storageInputOutput16 - float
         {
-            const char *vs_source = R"(
+            const char* vs_source = R"(
                OpCapability Shader
                OpCapability Float16
                OpExtension "SPV_KHR_16bit_storage"
@@ -963,7 +963,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
             auto vs = VkShaderObj::CreateFromASM(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
             m_errorMonitor->VerifyFound();
 
-            const char *fs_source = R"(
+            const char* fs_source = R"(
                OpCapability Shader
                OpCapability Float16
                OpExtension "SPV_KHR_16bit_storage"
@@ -997,7 +997,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
     if (features2.features.shaderInt16 == VK_TRUE) {
         // storageBuffer16BitAccess - int
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int16
                OpExtension "SPV_KHR_16bit_storage"
@@ -1027,7 +1027,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // uniformAndStorageBuffer16BitAccess - int
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int16
                OpExtension "SPV_KHR_16bit_storage"
@@ -1056,7 +1056,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // storagePushConstant16 - int
         {
-            const char *spv_source = R"(
+            const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int16
                OpExtension "SPV_KHR_16bit_storage"
@@ -1084,7 +1084,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
 
         // storageInputOutput16 - int
         {
-            const char *vs_source = R"(
+            const char* vs_source = R"(
                OpCapability Shader
                OpCapability Int16
                OpExtension "SPV_KHR_16bit_storage"
@@ -1106,7 +1106,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
             auto vs = VkShaderObj::CreateFromASM(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
             m_errorMonitor->VerifyFound();
 
-            const char *fs_source = R"(
+            const char* fs_source = R"(
                OpCapability Shader
                OpCapability Int16
                OpExtension "SPV_KHR_16bit_storage"
@@ -1148,7 +1148,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
         //   X b;
         //   uint8_t c;
         // } Data;
-        const char *spv_source = R"(
+        const char* spv_source = R"(
                OpCapability Shader
                OpCapability Int8
                OpCapability Int16
@@ -1197,7 +1197,7 @@ TEST_F(NegativeShaderSpirv, ReadShaderClock) {
     InitRenderTarget();
 
     // Device scope using GL_EXT_shader_realtime_clock
-    const char *vsSourceDevice = R"glsl(
+    const char* vsSourceDevice = R"glsl(
         #version 450
         #extension GL_EXT_shader_realtime_clock: enable
         void main(){
@@ -1210,7 +1210,7 @@ TEST_F(NegativeShaderSpirv, ReadShaderClock) {
     m_errorMonitor->VerifyFound();
 
     // Subgroup scope using ARB_shader_clock
-    const char *vsSourceScope = R"glsl(
+    const char* vsSourceScope = R"glsl(
         #version 450
         #extension GL_ARB_shader_clock: enable
         void main(){
@@ -1231,7 +1231,7 @@ TEST_F(NegativeShaderSpirv, SpecializationApplied) {
     InitRenderTarget();
 
     // Size an array using a specialization constant of default value equal to 1.
-    const char *fs_src = R"(
+    const char* fs_src = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -1275,7 +1275,7 @@ TEST_F(NegativeShaderSpirv, SpecializationApplied) {
         &data,
     };
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.shader_stages_[1].pSpecializationInfo = &specialization_info;
     };
@@ -1288,7 +1288,7 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBounds) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const float r = 0.0f;
         layout(location = 0) out vec4 uFragColor;
@@ -1309,7 +1309,7 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBounds) {
         &data,
     };
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.shader_stages_[1].pSpecializationInfo = &specialization_info;
     };
@@ -1325,7 +1325,7 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBoundsWithIdentifier) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout (constant_id = 0) const float x = 0.0f;
         void main(){
@@ -1372,7 +1372,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeOutOfBounds) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const float r = 0.0f;
         layout(location = 0) out vec4 uFragColor;
@@ -1393,7 +1393,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeOutOfBounds) {
         &data,
     };
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.shader_stages_[1].pSpecializationInfo = &specialization_info;
     };
@@ -1406,7 +1406,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeZero) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *cs_src = R"glsl(
+    const char* cs_src = R"glsl(
         #version 450
         layout (constant_id = 0) const int c = 3;
         layout (local_size_x = 1) in;
@@ -1453,7 +1453,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeMismatch) {
     // layout (constant_id = 2) const float c = 3.0f;
     // layout (constant_id = 3) const bool d = true;
     // layout (constant_id = 4) const bool f = false;
-    const char *cs_src = R"(
+    const char* cs_src = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -1499,7 +1499,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeMismatch) {
     };
 
     VkShaderObj cs;
-    const auto set_info = [&cs](CreateComputePipelineHelper &helper) { helper.cs_ = std::move(cs); };
+    const auto set_info = [&cs](CreateComputePipelineHelper& helper) { helper.cs_ = std::move(cs); };
 
     // Sanity check
     cs = VkShaderObj::CreateFromASM(this, cs_src, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, &specialization_info);
@@ -1575,12 +1575,12 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeMismatchInt8) {
     };
 
     VkShaderObj cs;
-    const auto set_info = [&cs](CreateComputePipelineHelper &helper) { helper.cs_ = std::move(cs); };
+    const auto set_info = [&cs](CreateComputePipelineHelper& helper) { helper.cs_ = std::move(cs); };
 
     // #extension GL_EXT_shader_explicit_arithmetic_types_int8 : enable
     // layout (constant_id = 0) const int8_t a = int8_t(3);
     // layout (constant_id = 1) const uint8_t b = uint8_t(3);
-    const char *cs_int8 = R"(
+    const char* cs_int8 = R"(
             OpCapability Shader
             OpCapability Int8
             OpMemoryModel Logical GLSL450
@@ -1659,11 +1659,11 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeMismatchFloat64) {
     };
 
     VkShaderObj cs;
-    const auto set_info = [&cs](CreateComputePipelineHelper &helper) { helper.cs_ = std::move(cs); };
+    const auto set_info = [&cs](CreateComputePipelineHelper& helper) { helper.cs_ = std::move(cs); };
 
     // #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
     // layout (constant_id = 0) const float64_t a = 3.0f;
-    const char *cs_float64 = R"(
+    const char* cs_float64 = R"(
             OpCapability Shader
             OpCapability Float64
             OpMemoryModel Logical GLSL450
@@ -1713,7 +1713,7 @@ TEST_F(NegativeShaderSpirv, DuplicatedSpecializationConstantID) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const float r = 0.0f;
         layout(location = 0) out vec4 uFragColor;
@@ -1738,7 +1738,7 @@ TEST_F(NegativeShaderSpirv, DuplicatedSpecializationConstantID) {
     specialization_info.dataSize = sizeof(uint32_t);
     specialization_info.pData = &data;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.shader_stages_[1].pSpecializationInfo = &specialization_info;
     };
@@ -1752,7 +1752,7 @@ TEST_F(NegativeShaderSpirv, ShaderModuleCheckCapability) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                   OpCapability ImageRect
                   OpEntryPoint Vertex %main "main"
           %main = OpFunction %void None %3
@@ -1772,7 +1772,7 @@ TEST_F(NegativeShaderSpirv, ShaderNotEnabled) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         void main(){
@@ -1790,7 +1790,7 @@ TEST_F(NegativeShaderSpirv, ShaderImageFootprintEnabled) {
     AddRequiredExtensions(VK_NV_SHADER_IMAGE_FOOTPRINT_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_NV_shader_texture_footprint  : require
         layout(set=0, binding=0) uniform sampler2D s;
@@ -1816,7 +1816,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderBarycentricEnabled) {
     AddRequiredExtensions(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_NV_fragment_shader_barycentric : require
         layout(location=0) out float value;
@@ -1836,7 +1836,7 @@ TEST_F(NegativeShaderSpirv, ComputeShaderDerivativesEnabled) {
     AddRequiredExtensions(VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_NV_compute_shader_derivatives : require
         layout(local_size_x=2, local_size_y=4) in;
@@ -1860,7 +1860,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderInterlockEnabled) {
     AddRequiredExtensions(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_ARB_fragment_shader_interlock : require
         layout(sample_interlock_ordered) in;
@@ -1879,7 +1879,7 @@ TEST_F(NegativeShaderSpirv, DemoteToHelperInvocation) {
     AddRequiredExtensions(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_EXT_demote_to_helper_invocation : require
         void main(){
@@ -1903,7 +1903,7 @@ TEST_F(NegativeShaderSpirv, NoUniformBufferStandardLayout10) {
     // layout(std430, set = 0, binding = 0) uniform ubo430 {
     //     float floatArray430[8];
     // };
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -1944,7 +1944,7 @@ TEST_F(NegativeShaderSpirv, NoUniformBufferStandardLayout12) {
     // layout(std430, set = 0, binding = 0) uniform ubo430 {
     //     float floatArray430[8];
     // };
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -1990,7 +1990,7 @@ TEST_F(NegativeShaderSpirv, NoScalarBlockLayout10) {
     //
     // Note: using BufferBlock for Vulkan 1.0
     // Note: Relaxed Block Layout would also make this valid if enabled
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -2028,7 +2028,7 @@ TEST_F(NegativeShaderSpirv, NoScalarBlockLayout12) {
     //     layout(offset = 0) vec3 a;
     //     layout(offset = 12) vec2 b;
     // };
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -2066,7 +2066,7 @@ TEST_F(NegativeShaderSpirv, SubgroupRotate) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"glsl(
+    const char* source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -2088,7 +2088,7 @@ TEST_F(NegativeShaderSpirv, SubgroupRotateClustered) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"glsl(
+    const char* source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -2110,7 +2110,7 @@ TEST_F(NegativeShaderSpirv, DeviceMemoryScope) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0) buffer ssbo { uint y; };
@@ -2132,7 +2132,7 @@ TEST_F(NegativeShaderSpirv, QueueFamilyMemoryScope) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0) buffer ssbo { uint y; };
@@ -2152,7 +2152,7 @@ TEST_F(NegativeShaderSpirv, DeviceMemoryScopeDebugInfo) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    const char *csSource = R"(
+    const char* csSource = R"(
                OpCapability Shader
           %2 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -2314,7 +2314,7 @@ TEST_F(NegativeShaderSpirv, DISABLED_ImageFormatTypeMismatchWithZeroExtend) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    const char *csSource = R"(
+    const char* csSource = R"(
                      OpCapability Shader
                      OpCapability StorageImageExtendedFormats
                      OpMemoryModel Logical GLSL450
@@ -2364,7 +2364,7 @@ TEST_F(NegativeShaderSpirv, DISABLED_SpecConstantTextureIndex) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
         #version 400
         #extension GL_ARB_separate_shader_objects : enable
         #extension GL_ARB_shading_language_420pack : enable
@@ -2398,7 +2398,7 @@ TEST_F(NegativeShaderSpirv, SpecConstantArraySize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
         #version 450
         layout (constant_id = 0) const int array_size = 4;
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -2429,7 +2429,7 @@ TEST_F(NegativeShaderSpirv, DescriptorCountConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (set = 0, binding = 0) uniform sampler2D tex[3];
         layout (location = 0) out vec4 out_color;
@@ -2451,7 +2451,7 @@ TEST_F(NegativeShaderSpirv, DescriptorCountSpecConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const int index = 2;
         layout (set = 0, binding = 0) uniform sampler2D tex[index];
@@ -2479,7 +2479,7 @@ TEST_F(NegativeShaderSpirv, DescriptorCountSpecConstantOp) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const int index = 2;
         // The length is now a OpSpecConstantOp
@@ -2512,7 +2512,7 @@ TEST_F(NegativeShaderSpirv, DescriptorCountConstantRuntimeArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform sampler2D tex[];
@@ -2541,7 +2541,7 @@ TEST_F(NegativeShaderSpirv, InvalidExtension) {
 
     InitRenderTarget();
 
-    const char *vertex_source = R"spirv(
+    const char* vertex_source = R"spirv(
                OpCapability Shader
                OpExtension "GL_EXT_scalar_block_layout"
           %1 = OpExtInstImport "GLSL.std.450"
@@ -2576,7 +2576,7 @@ TEST_F(NegativeShaderSpirv, FPFastMathDefault) {
     }
 
     // Missing NotNaN
-    const char *spv_source = R"(
+    const char* spv_source = R"(
         OpCapability Shader
         OpCapability FloatControls2
         OpExtension "SPV_KHR_float_controls2"
@@ -2622,7 +2622,7 @@ TEST_F(NegativeShaderSpirv, FPFastMathMode) {
     }
 
     // Missing NotNaN
-    const char *spv_source = R"(
+    const char* spv_source = R"(
         OpCapability Shader
         OpCapability FloatControls2
         OpExtension "SPV_KHR_float_controls2"
@@ -2661,7 +2661,7 @@ TEST_F(NegativeShaderSpirv, ScalarBlockLayoutShaderCache) {
     RETURN_IF_SKIP(Init());
 
     // Matches glsl from other ScalarBlockLayoutShaderCache test
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference : require
         #extension GL_EXT_scalar_block_layout : require
@@ -2695,7 +2695,7 @@ TEST_F(NegativeShaderSpirv, ImageGatherOffsetMaintenance8) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability ImageGatherExtended
                OpMemoryModel Logical GLSL450
@@ -2789,7 +2789,7 @@ TEST_F(NegativeShaderSpirv, ShaderViewportIndexLayerEXT) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -2812,7 +2812,7 @@ TEST_F(NegativeShaderSpirv, ShaderRelaxedExtendedInstruction) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2880,7 +2880,7 @@ TEST_F(NegativeShaderSpirv, Bitwise32bitMaintenance9) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
     RETURN_IF_SKIP(Init());  // missing maintenance9
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
         void main() {
@@ -2901,7 +2901,7 @@ TEST_F(NegativeShaderSpirv, ShaderFma32) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability FMAKHR
                OpExtension "SPV_KHR_fma"
@@ -2955,7 +2955,7 @@ TEST_F(NegativeShaderSpirv, ShaderFmaNon32) {
     AddRequiredFeature(vkt::Feature::shaderFloat16);
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability Float16
                OpCapability Float64
@@ -3034,7 +3034,7 @@ TEST_F(NegativeShaderSpirv, ShaderUniformBufferUnsizedArray) {
     // Missing shaderUniformBufferUnsizedArray
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %_ %__0

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -29,7 +29,7 @@ TEST_F(PositiveShaderSpirv, NonSemanticInfo) {
 
     // compute shader using a non-semantic extended instruction set.
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                    OpCapability Shader
                    OpExtension "SPV_KHR_non_semantic_info"
    %non_semantic = OpExtInstImport "NonSemantic.Validation.Test"
@@ -183,7 +183,7 @@ TEST_F(PositiveShaderSpirv, CapabilityExtension1of2) {
     InitRenderTarget();
 
     // Vertex shader using viewport array capability
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -209,7 +209,7 @@ TEST_F(PositiveShaderSpirv, CapabilityExtension2of2) {
     InitRenderTarget();
 
     // Vertex shader using viewport array capability
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -233,7 +233,7 @@ TEST_F(PositiveShaderSpirv, ShaderViewportIndexLayerEXT) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -256,7 +256,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature) {
         GTEST_SKIP() << "requires Vulkan 1.0 exactly";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -265,7 +265,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature) {
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL_TRY);
 
     if (VK_SUCCESS == vs.InitFromGLSLTry()) {
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -283,7 +283,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature11) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -293,7 +293,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature11) {
 
     // make sure using SPIR-V 1.3 as extension is core and not needed in Vulkan then
     if (VK_SUCCESS == vs.InitFromGLSLTry()) {
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -317,7 +317,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithFeature) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -327,7 +327,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithFeature) {
 
     // make sure using SPIR-V 1.3 as extension is core and not needed in Vulkan then
     if (VK_SUCCESS == vs.InitFromGLSLTry()) {
-        const auto set_info = [&](CreatePipelineHelper &helper) {
+        const auto set_info = [&](CreatePipelineHelper& helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -348,7 +348,7 @@ TEST_F(PositiveShaderSpirv, Std430SpirvOptFlags10) {
 
     const VkShaderObj vs(*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
 #version 450
 #extension GL_ARB_separate_shader_objects:enable
 #extension GL_EXT_samplerless_texture_functions:require
@@ -397,7 +397,7 @@ TEST_F(PositiveShaderSpirv, Std430SpirvOptFlags12) {
 
     const VkShaderObj vs(*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
 #version 450
 #extension GL_ARB_separate_shader_objects:enable
 #extension GL_EXT_samplerless_texture_functions:require
@@ -557,7 +557,7 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
         5,
         entries,
         sizeof(uint8_t) * 8,
-        reinterpret_cast<void *>(data),
+        reinterpret_cast<void*>(data),
     };
 
     CreateComputePipelineHelper pipe(*this);
@@ -584,9 +584,9 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 
     // Make sure spec constants were updated correctly
-    void *pData;
+    void* pData;
     ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), buffer.Memory(), 0, VK_WHOLE_SIZE, 0, &pData));
-    uint32_t *ssbo_data = reinterpret_cast<uint32_t *>(pData);
+    uint32_t* ssbo_data = reinterpret_cast<uint32_t*>(pData);
     ASSERT_EQ(ssbo_data[0], 0x02);
     ASSERT_EQ(ssbo_data[1], 0x05040302);
     ASSERT_EQ(ssbo_data[2], 0x06050403);
@@ -713,7 +713,7 @@ TEST_F(PositiveShaderSpirv, OpTypeStructRuntimeArray) {
     // %float = OpTypeFloat 32
     // %ra = OpTypeRuntimeArray %float
     // %struct = OpTypeStruct %ra
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer sb {
             float values[];
@@ -752,7 +752,7 @@ TEST_F(PositiveShaderSpirv, UnnormalizedCoordinatesNotSampled) {
 
     VkShaderObj vs(*m_device, kMinimalShaderGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fsSource = R"(
+    const char* fsSource = R"(
                OpCapability Shader
                OpCapability ImageBuffer
                OpMemoryModel Logical GLSL450
@@ -897,7 +897,7 @@ TEST_F(PositiveShaderSpirv, SpecializeInt8) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_src = R"(
+    const char* fs_src = R"(
                OpCapability Shader
                OpCapability Int8
           %1 = OpExtInstImport "GLSL.std.450"
@@ -947,7 +947,7 @@ TEST_F(PositiveShaderSpirv, SpecializeInt16) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_src = R"(
+    const char* fs_src = R"(
                OpCapability Shader
                OpCapability Int16
           %1 = OpExtInstImport "GLSL.std.450"
@@ -996,7 +996,7 @@ TEST_F(PositiveShaderSpirv, SpecializeInt32) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_src = R"(
+    const char* fs_src = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -1045,7 +1045,7 @@ TEST_F(PositiveShaderSpirv, SpecializeInt64) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fs_src = R"(
+    const char* fs_src = R"(
                OpCapability Shader
                OpCapability Int64
           %1 = OpExtInstImport "GLSL.std.450"
@@ -1095,7 +1095,7 @@ TEST_F(PositiveShaderSpirv, SpecializationUnused) {
     InitRenderTarget();
 
     // layout (constant_id = 2) const int a = 3;
-    const char *cs_src = R"(
+    const char* cs_src = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -1298,7 +1298,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
     // 8 bit int test (not 8 bit float support in Vulkan)
     if ((support_8_bit == true) && (float_16_int_8_features.shaderInt8 == VK_TRUE)) {
         if (storage_8_bit_features.storageBuffer8BitAccess == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_8bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -1310,7 +1310,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
             };
@@ -1318,7 +1318,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_8_bit_features.uniformAndStorageBuffer8BitAccess == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_8bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -1330,7 +1330,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
             };
@@ -1338,7 +1338,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_8_bit_features.storagePushConstant8 == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_8bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -1353,7 +1353,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 4};
             VkPipelineLayoutCreateInfo pipeline_layout_info{
                 VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, &push_constant_range};
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.pipeline_layout_ci_ = pipeline_layout_info;
             };
@@ -1364,7 +1364,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
     // 16 bit float tests
     if ((support_16_bit == true) && (float_16_int_8_features.shaderFloat16 == VK_TRUE)) {
         if (storage_16_bit_features.storageBuffer16BitAccess == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1376,7 +1376,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
             };
@@ -1384,7 +1384,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.uniformAndStorageBuffer16BitAccess == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1396,7 +1396,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
             };
@@ -1404,7 +1404,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storagePushConstant16 == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1419,7 +1419,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 4};
             VkPipelineLayoutCreateInfo pipeline_layout_info{
                 VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, &push_constant_range};
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.pipeline_layout_ci_ = pipeline_layout_info;
             };
@@ -1427,7 +1427,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storageInputOutput16 == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1440,7 +1440,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
             // Need to match in/out
-            const char *fsSource = R"glsl(
+            const char* fsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1452,7 +1452,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             };
             CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1462,7 +1462,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
     // 16 bit int tests
     if ((support_16_bit == true) && (features2.features.shaderInt16 == VK_TRUE)) {
         if (storage_16_bit_features.storageBuffer16BitAccess == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1474,7 +1474,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
             };
@@ -1482,7 +1482,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.uniformAndStorageBuffer16BitAccess == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1494,7 +1494,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
             };
@@ -1502,7 +1502,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storagePushConstant16 == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1517,7 +1517,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 4};
             VkPipelineLayoutCreateInfo pipeline_layout_info{
                 VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, &push_constant_range};
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.pipeline_layout_ci_ = pipeline_layout_info;
             };
@@ -1525,7 +1525,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storageInputOutput16 == VK_TRUE) {
-            const char *vsSource = R"glsl(
+            const char* vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1538,7 +1538,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
             // Need to match in/out
-            const char *fsSource = R"glsl(
+            const char* fsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1550,7 +1550,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             )glsl";
             VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_1);
 
-            const auto set_info = [&](CreatePipelineHelper &helper) {
+            const auto set_info = [&](CreatePipelineHelper& helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             };
             CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1564,7 +1564,7 @@ TEST_F(PositiveShaderSpirv, SubgroupRotate) {
     AddRequiredFeature(vkt::Feature::shaderSubgroupRotate);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"glsl(
+    const char* source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -1583,7 +1583,7 @@ TEST_F(PositiveShaderSpirv, SubgroupRotateClustered) {
     AddRequiredFeature(vkt::Feature::shaderSubgroupRotateClustered);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"glsl(
+    const char* source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -1604,7 +1604,7 @@ TEST_F(PositiveShaderSpirv, ReadShaderClockDevice) {
     InitRenderTarget();
 
     // Device scope using GL_EXT_shader_realtime_clock
-    const char *vsSourceDevice = R"glsl(
+    const char* vsSourceDevice = R"glsl(
         #version 450
         #extension GL_EXT_shader_realtime_clock: enable
         void main(){
@@ -1614,7 +1614,7 @@ TEST_F(PositiveShaderSpirv, ReadShaderClockDevice) {
     )glsl";
     VkShaderObj vs_device(*m_device, vsSourceDevice, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs_device.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1629,7 +1629,7 @@ TEST_F(PositiveShaderSpirv, ReadShaderClockSubgroup) {
     InitRenderTarget();
 
     // Subgroup scope using ARB_shader_clock
-    const char *vsSourceScope = R"glsl(
+    const char* vsSourceScope = R"glsl(
         #version 450
         #extension GL_ARB_shader_clock: enable
         void main(){
@@ -1639,7 +1639,7 @@ TEST_F(PositiveShaderSpirv, ReadShaderClockSubgroup) {
     )glsl";
     VkShaderObj vs_subgroup(*m_device, vsSourceScope, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs_subgroup.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -1654,7 +1654,7 @@ TEST_F(PositiveShaderSpirv, PhysicalStorageBufferStructRecursion) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *cs_src = R"glsl(
+    const char* cs_src = R"glsl(
 #version 450 core
 #extension GL_EXT_buffer_reference : enable
 
@@ -1689,7 +1689,7 @@ TEST_F(PositiveShaderSpirv, OpCopyObjectSampler) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vertex_source = R"glsl(
+    const char* vertex_source = R"glsl(
 #version 450
 
 layout(location=0) out int idx;
@@ -1701,7 +1701,7 @@ void main() {
         )glsl";
     const VkShaderObj vs(*m_device, vertex_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
 #version 450
 #extension GL_EXT_nonuniform_qualifier : require
 
@@ -1733,7 +1733,7 @@ TEST_F(PositiveShaderSpirv, SpecConstantTextureArrayTessellation) {
     TEST_DESCRIPTION("Reproduces https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6370");
     AddRequiredFeature(vkt::Feature::tessellationShader);
     RETURN_IF_SKIP(Init());
-    const char *source = R"glsl(
+    const char* source = R"glsl(
 #version 440
 layout(triangles, equal_spacing, cw) in;
 
@@ -1761,7 +1761,7 @@ void main() {
 TEST_F(PositiveShaderSpirv, SpecConstantTextureArrayVertex) {
     TEST_DESCRIPTION("Reproduces https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6370");
     RETURN_IF_SKIP(Init());
-    const char *source = R"glsl(
+    const char* source = R"glsl(
 #version 450
 layout(constant_id = 0) const int MAX_NUM_DESCRIPTOR_IMAGES = 100;
 
@@ -1782,7 +1782,7 @@ TEST_F(PositiveShaderSpirv, SpecConstantTextureIndexDefault) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fragment_source = R"glsl(
+    const char* fragment_source = R"glsl(
         #version 450
         layout (location = 0) out vec4 out_color;
 
@@ -1806,7 +1806,7 @@ TEST_F(PositiveShaderSpirv, SpecConstantTextureIndexValue) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fragment_source = R"(
+    const char* fragment_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %out_color
@@ -1860,7 +1860,7 @@ TEST_F(PositiveShaderSpirv, DescriptorCountSpecConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         // over VkDescriptorSetLayoutBinding::descriptorCount
         layout (constant_id = 0) const int index = 4;
@@ -1877,7 +1877,7 @@ TEST_F(PositiveShaderSpirv, DescriptorCountSpecConstant) {
     const VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL,
                          &specialization_info);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
     };
@@ -1892,7 +1892,7 @@ TEST_F(PositiveShaderSpirv, PhysicalStorageBufferGlslang6) {
 
     RETURN_IF_SKIP(Init());
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_buffer_reference : enable
         layout (push_constant, std430) uniform Block { int identity[32]; } pc;
@@ -1924,7 +1924,7 @@ TEST_F(PositiveShaderSpirv, ShaderFloatControl2) {
         GTEST_SKIP() << "shaderSignedZeroInfNanPreserveFloat32 not supported";
     }
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
         OpCapability Shader
         OpCapability FloatControls2
         OpExtension "SPV_KHR_float_controls2"
@@ -1967,7 +1967,7 @@ TEST_F(PositiveShaderSpirv, FPFastMathMode) {
         GTEST_SKIP() << "shaderSignedZeroInfNanPreserveFloat32 is supported";
     }
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
         OpCapability Shader
         OpCapability FloatControls2
         OpExtension "SPV_KHR_float_controls2"
@@ -2004,7 +2004,7 @@ TEST_F(PositiveShaderSpirv, ScalarBlockLayoutShaderCache) {
     RETURN_IF_SKIP(Init());
 
     // Matches glsl from other ScalarBlockLayoutShaderCache test
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference : require
         #extension GL_EXT_scalar_block_layout : require
@@ -2041,7 +2041,7 @@ TEST_F(PositiveShaderSpirv, BFloat16) {
     AddRequiredFeature(vkt::Feature::shaderBFloat16Type);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
 
         #extension GL_EXT_bfloat16 : require
@@ -2102,7 +2102,7 @@ TEST_F(PositiveShaderSpirv, BFloat16DotProduct) {
     AddRequiredFeature(vkt::Feature::shaderBFloat16DotProduct);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
         #extension GL_EXT_bfloat16 : require
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
@@ -2128,7 +2128,7 @@ TEST_F(PositiveShaderSpirv, Float8) {
     AddRequiredFeature(vkt::Feature::shaderInt8);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450 core
 
         #extension GL_EXT_float_e4m3 : require
@@ -2199,7 +2199,7 @@ TEST_F(PositiveShaderSpirv, ExtendedTypesEnabled) {
         GTEST_SKIP() << "Required features not supported";
     }
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_arithmetic : enable
         #extension GL_EXT_shader_subgroup_extended_types_float16 : enable
@@ -2224,7 +2224,7 @@ TEST_F(PositiveShaderSpirv, RayQueryPositionFetch) {
     AddRequiredFeature(vkt::Feature::rayTracingPositionFetch);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : enable
         #extension GL_EXT_ray_tracing_position_fetch : enable
@@ -2256,7 +2256,7 @@ TEST_F(PositiveShaderSpirv, ImageGatherOffsetMaintenance8) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability ImageGatherExtended
                OpMemoryModel Logical GLSL450
@@ -2297,7 +2297,7 @@ TEST_F(PositiveShaderSpirv, NonSemanticInfoEnabled) {
         GTEST_SKIP() << "VK_KHR_shader_non_semantic_info not supported";
     }
 
-    const char *source = R"(
+    const char* source = R"(
                    OpCapability Shader
                    OpExtension "SPV_KHR_non_semantic_info"
    %non_semantic = OpExtInstImport "NonSemantic.Validation.Test"
@@ -2329,7 +2329,7 @@ TEST_F(PositiveShaderSpirv, ShaderRelaxedExtendedInstruction) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2398,7 +2398,7 @@ TEST_F(PositiveShaderSpirv, Bitwise32bitMaintenance9) {
     AddRequiredFeature(vkt::Feature::maintenance9);
     RETURN_IF_SKIP(Init());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
 
@@ -2487,7 +2487,7 @@ TEST_F(PositiveShaderSpirv, ShaderFma) {
     AddRequiredFeature(vkt::Feature::shaderFmaFloat32);
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability FMAKHR
                OpExtension "SPV_KHR_fma"

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
     }
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"(
+    const char* csSource = R"(
                OpCapability Shader
                OpCapability StorageImageReadWithoutFormat
           %1 = OpExtInstImport "GLSL.std.450"
@@ -101,7 +101,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWrite) {
     }
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"(
+    const char* csSource = R"(
                   OpCapability Shader
                   OpCapability StorageImageWriteWithoutFormat
              %1 = OpExtInstImport "GLSL.std.450"
@@ -193,7 +193,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
     }
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"(
+    const char* csSource = R"(
                OpCapability Shader
                OpCapability StorageImageReadWithoutFormat
           %1 = OpExtInstImport "GLSL.std.450"
@@ -337,7 +337,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
     }
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"(
+    const char* csSource = R"(
                   OpCapability Shader
                   OpCapability StorageImageWriteWithoutFormat
              %1 = OpExtInstImport "GLSL.std.450"
@@ -443,7 +443,7 @@ TEST_F(NegativeShaderStorageImage, MissingNonReadableDecorationFormatRead) {
     }
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"(
+    const char* csSource = R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -500,7 +500,7 @@ TEST_F(NegativeShaderStorageImage, MissingNonWritableDecorationFormatWrite) {
     }
 
     // Make sure compute pipeline has a compute shader stage set
-    const char *csSource = R"(
+    const char* csSource = R"(
                   OpCapability Shader
              %1 = OpExtInstImport "GLSL.std.450"
                   OpMemoryModel Logical GLSL450
@@ -547,7 +547,7 @@ TEST_F(NegativeShaderStorageImage, WriteLessComponent) {
     // imageStore(storageImage, ivec2(1, 1), uvec3(1, 1, 1));
     //
     // Rgba8ui == 4-component but only writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %var
@@ -597,7 +597,7 @@ TEST_F(NegativeShaderStorageImage, WriteLessComponentCopyObject) {
     // imageStore(storageImage, ivec2(1, 1), uvec3(1, 1, 1));
     //
     // Rgba8ui == 4-component but only writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %var
@@ -652,7 +652,7 @@ TEST_F(NegativeShaderStorageImage, WriteSpecConstantLessComponent) {
     // imageStore(storageImage, ivec2(1, 1), uvec3(1, sc, sc + 1));
     //
     // Rgba8ui == 4-component but only writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %var
@@ -718,7 +718,7 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteLessComponent) {
     // imageStore(storageImage, ivec2(1, 1), uvec3(1, 1, 1));
     //
     // Unknown will become a 4-component but writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability StorageImageWriteWithoutFormat
                OpMemoryModel Logical GLSL450
@@ -797,7 +797,7 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
     // imageStore(storageImage, ivec2(1, 1), vec3(1, 1, 1));
     //
     // only have 3 components
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability StorageImageWriteWithoutFormat
                OpMemoryModel Logical GLSL450

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ TEST_F(PositiveShaderStorageImage, WriteMoreComponent) {
     // imageStore(storageImage, ivec2(1, 1), uvec3(1, 1, 1));
     //
     // Rg32ui == 2-component but writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability StorageImageExtendedFormats
                OpMemoryModel Logical GLSL450
@@ -100,7 +100,7 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteMoreComponent) {
     // imageStore(storageImage, ivec2(1, 1), uvec3(1, 1, 1));
     //
     // Unknown will become a 2-component but writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability StorageImageExtendedFormats
                OpCapability StorageImageWriteWithoutFormat
@@ -178,7 +178,7 @@ TEST_F(PositiveShaderStorageImage, WriteSpecConstantMoreComponent) {
     // imageStore(storageImage, ivec2(1, 1), uvec3(1, sc, sc + 1));
     //
     // Rg32ui == 2-component but writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability StorageImageExtendedFormats
                OpMemoryModel Logical GLSL450
@@ -258,7 +258,7 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
 
     // The vertex and fragment shader are just a passthrough
     // The compute shader has the invalid OpImageWrite
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability StorageImageWriteWithoutFormat
                OpMemoryModel Logical GLSL450

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ TEST_F(NegativeShaderStorageTexel, WriteLessComponent) {
     // imageStore(storageTexelBuffer, 1, uvec3(1, 1, 1));
     //
     // Rgba8ui == 4-component but only writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability ImageBuffer
                OpCapability StorageImageExtendedFormats
@@ -81,7 +81,7 @@ TEST_F(NegativeShaderStorageTexel, UnknownWriteLessComponent) {
     // imageStore(storageTexelBuffer, 1, uvec3(1, 1, 1));
     //
     // Unknown will become a 4-component but writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability ImageBuffer
                OpCapability StorageImageWriteWithoutFormat
@@ -159,7 +159,7 @@ TEST_F(NegativeShaderStorageTexel, ComponentTypeMismatch) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) writeonly uniform iimageBuffer storageTexelBuffer;
         void main() {
@@ -203,7 +203,7 @@ TEST_F(NegativeShaderStorageTexel, FormatComponentTypeMismatch) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, R8ui) writeonly uniform uimageBuffer storageTexelBuffer;
         void main() {
@@ -247,7 +247,7 @@ TEST_F(NegativeShaderStorageTexel, FormatComponentTypeMismatch2) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, R32ui) writeonly uniform uimageBuffer storageTexelBuffer;
         void main() {
@@ -308,7 +308,7 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     fmt_props_3.bufferFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
     fpvkSetPhysicalDeviceFormatProperties2EXT(Gpu(), format, fmt_props);
 
-    const char *csSource = R"(
+    const char* csSource = R"(
                   OpCapability Shader
                   OpCapability ImageBuffer
                   OpCapability StorageImageWriteWithoutFormat

--- a/tests/unit/shader_storage_texel_positive.cpp
+++ b/tests/unit/shader_storage_texel_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ TEST_F(PositiveShaderStorageTexel, BufferWriteMoreComponent) {
     // imageStore(storageTexelBuffer, 1, uvec3(1, 1, 1));
     //
     // Rg32ui == 2-component but writing 3 texels to it
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpCapability ImageBuffer
                OpCapability StorageImageExtendedFormats
@@ -83,4 +83,3 @@ TEST_F(PositiveShaderStorageTexel, BufferWriteMoreComponent) {
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 }
-

--- a/tests/unit/shader_untyped.cpp
+++ b/tests/unit/shader_untyped.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,7 +57,7 @@ TEST_F(NegativeShaderUntyped, FragmentStoresAndAtomicsFeatureBuffer) {
 
     VkShaderObj fs(*m_device, spirv.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_1, SPV_SOURCE_ASM);
 
-    auto info_override = [&](CreatePipelineHelper &info) {
+    auto info_override = [&](CreatePipelineHelper& info) {
         info.shader_stages_ = {info.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         info.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     };
@@ -74,7 +74,7 @@ TEST_F(NegativeShaderUntyped, ZeroInitializeWorkgroupMemory) {
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
     RETURN_IF_SKIP(Init());
 
-    const char *spv_source = R"(
+    const char* spv_source = R"(
                OpCapability Shader
                OpCapability WorkgroupMemoryExplicitLayoutKHR
                OpCapability UntypedPointersKHR

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
- * Copyright (c) 2023-2025 Collabora, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
+ * Copyright (c) 2023-2026 Collabora, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,8 +206,8 @@ TEST_F(PositiveSparseImage, BindMetadata) {
     vk::GetImageSparseMemoryRequirements(device(), image, &sparse_reqs_count, sparse_reqs.data());
 
     // Find requirements for metadata aspect
-    const VkSparseImageMemoryRequirements *metadata_reqs = nullptr;
-    for (auto const &aspect_sparse_reqs : sparse_reqs) {
+    const VkSparseImageMemoryRequirements* metadata_reqs = nullptr;
+    for (auto const& aspect_sparse_reqs : sparse_reqs) {
         if ((aspect_sparse_reqs.formatProperties.aspectMask & VK_IMAGE_ASPECT_METADATA_BIT) != 0) {
             metadata_reqs = &aspect_sparse_reqs;
         }
@@ -281,7 +281,7 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
     ds.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     ds.UpdateDescriptorSets();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         #extension GL_ARB_sparse_texture2 : enable
 
@@ -352,7 +352,7 @@ TEST_F(PositiveSparseImage, BindImage) {
     bind_info.imageBindCount = 1;
     bind_info.pImageBinds = &image_memory_bind_info;
 
-    vkt::Queue *sparse_queue = m_device->QueuesWithSparseCapability()[0];
+    vkt::Queue* sparse_queue = m_device->QueuesWithSparseCapability()[0];
     vk::QueueBindSparse(sparse_queue->handle(), 1, &bind_info, VK_NULL_HANDLE);
     sparse_queue->Wait();
 }

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -53,16 +53,16 @@ TEST_F(NegativeSubgroup, Properties) {
     }
 
     std::string vsSource;
-    std::vector<const char *> errors;
+    std::vector<const char*> errors;
     // There is no 'supportedOperations' check due to it would be redundant to the Capability check done first in VUID 01091 since
     // each 'supportedOperations' flag is 1:1 map to a SPIR-V Capability
-    const char *operation_vuid = "VUID-VkShaderModuleCreateInfo-pCode-08740";
-    const char *stage_vuid = "VUID-RuntimeSpirv-None-06343";
-    const char *quad_vuid = "VUID-RuntimeSpirv-None-06342";
+    const char* operation_vuid = "VUID-VkShaderModuleCreateInfo-pCode-08740";
+    const char* stage_vuid = "VUID-RuntimeSpirv-None-06343";
+    const char* quad_vuid = "VUID-RuntimeSpirv-None-06342";
 
     // Same pipeline creation for each subgroup test
-    auto subgroup_test = [this](std::string source, const std::vector<const char *> &errors) {
-        for (const auto &error : errors) m_errorMonitor->SetDesiredError(error);
+    auto subgroup_test = [this](std::string source, const std::vector<const char*>& errors) {
+        for (const auto& error : errors) m_errorMonitor->SetDesiredError(error);
         VkShaderObj vs(*m_device, source.c_str(), VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
         if (!errors.empty()) {
             m_errorMonitor->VerifyFound();
@@ -276,7 +276,7 @@ TEST_F(NegativeSubgroup, ExtendedTypesDisabled) {
         GTEST_SKIP() << "Required features not supported";
     }
 
-    const char *csSource = R"glsl(
+    const char* csSource = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_arithmetic : enable
         #extension GL_EXT_shader_subgroup_extended_types_float16 : enable
@@ -528,7 +528,7 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlStage) {
         GTEST_SKIP() << "Vertex shader subgroup not supported.";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_basic : require
         void main() {
@@ -552,7 +552,7 @@ TEST_F(NegativeSubgroup, SubgroupUniformControlFlow) {
     AddRequiredExtensions(VK_KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const char *source = R"(
+    const char* source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_subgroup_uniform_control_flow"
           %1 = OpExtInstImport "GLSL.std.450"

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -570,7 +570,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     const std::vector<VkSubpassDescription> subpasses(1u, subpass);
 
     const auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, size32(attachmentDescs), attachmentDescs.data(),
-                                                            size32(subpasses), subpasses.data(), 0u, nullptr);
+                                                              size32(subpasses), subpasses.data(), 0u, nullptr);
     vkt::RenderPass rp(*m_device, rpci);
     vkt::Framebuffer fb(*m_device, rp, 1, &view_input.handle(), 64, 64);
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -580,7 +580,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     {
         // input index is wrong, it doesn't exist in supbass input attachments and the set and binding is undefined
         // It causes desired failures.
-        const char *fsSource_fail = R"glsl(
+        const char* fsSource_fail = R"glsl(
             #version 450
             layout(input_attachment_index=1, set=0, binding=1) uniform subpassInput x;
             void main() {
@@ -601,7 +601,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     }
 
     {  // Binds input attachment
-        const char *fsSource = R"glsl(
+        const char* fsSource = R"glsl(
             #version 450
             layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
             void main() {
@@ -821,7 +821,9 @@ TEST_F(NegativeSubpass, SubpassDependencyMasksSync2) {
     }
 
     dependency.pNext = &mem_barrier;  // srcStageMask should be ignored now
-    { vkt::RenderPass render_pass(*m_device, rpci); }
+    {
+        vkt::RenderPass render_pass(*m_device, rpci);
+    }
 
     mem_barrier.srcStageMask = 0x8000000000000000ULL;  // not real value
     {
@@ -890,7 +892,7 @@ TEST_F(NegativeSubpass, InputAttachmentMissing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -901,7 +903,7 @@ TEST_F(NegativeSubpass, InputAttachmentMissing) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     };
@@ -916,7 +918,7 @@ TEST_F(NegativeSubpass, InputAttachmentMissingArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[1];
         layout(location=0) out vec4 color;
@@ -927,7 +929,7 @@ TEST_F(NegativeSubpass, InputAttachmentMissingArray) {
 
     VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     };
@@ -1088,7 +1090,7 @@ TEST_F(NegativeSubpass, InputAttachmentSharingVariable) {
 
     // There are 2 OpLoad/OpAccessChain that point the same OpVariable
     // Make sure we are not just taking the first load and checking all loads on a variable
-    const char *fs_source = R"glsl(
+    const char* fs_source = R"glsl(
         #version 460
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[2];
         layout(location=0) out vec4 color;
@@ -1099,7 +1101,7 @@ TEST_F(NegativeSubpass, InputAttachmentSharingVariable) {
     )glsl";
     VkShaderObj fs(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
         helper.gp_ci_.renderPass = renderPass;

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -223,7 +223,7 @@ TEST_F(PositiveSubpass, InputAttachmentMissingSpecConstant2) {
     rp.AddInputAttachment(1, VK_IMAGE_LAYOUT_GENERAL);
     rp.CreateRenderPass();
 
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const int index = 4; // over VkDescriptorSetLayoutBinding::descriptorCount
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[index];

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -526,7 +526,7 @@ TEST_F(NegativeSyncObject, Barriers) {
         vkt::Image img_sampled(*m_device, 32, 32, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
         vkt::Image img_input(*m_device, 128, 128, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
         struct BadBufferTest {
-            vkt::Image &image_obj;
+            vkt::Image& image_obj;
             VkImageLayout bad_layout;
             std::string msg_code;
         };
@@ -633,7 +633,7 @@ TEST_F(NegativeSyncObject, Barriers) {
         }
         // clang-format on
 
-        for (const auto &test : bad_buffer_layouts) {
+        for (const auto& test : bad_buffer_layouts) {
             const VkImageLayout bad_layout = test.bad_layout;
             // Skip layouts that require maintenance2 support
             if ((maintenance2 == false) && ((bad_layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL) ||
@@ -958,7 +958,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
         vkt::Image img_sampled(*m_device, 32, 32, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
         vkt::Image img_input(*m_device, 128, 128, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
         struct BadBufferTest {
-            vkt::Image &image_obj;
+            vkt::Image& image_obj;
             VkImageLayout bad_layout;
             std::string msg_code;
         };
@@ -1065,7 +1065,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
         }
         // clang-format on
 
-        for (const auto &test : bad_buffer_layouts) {
+        for (const auto& test : bad_buffer_layouts) {
             const VkImageLayout bad_layout = test.bad_layout;
             // Skip layouts that require maintenance2 support
             if ((maintenance2 == false) && ((bad_layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL) ||
@@ -1253,20 +1253,20 @@ TEST_F(NegativeSyncObject, BarrierQueueFamilyOneFamily) {
     conc_test.Init(&families);
     {
         // src
-        const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
-        const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
+        const char* img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
+        const char* buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
         conc_test(img_vuid, buf_vuid, submit_family, VK_QUEUE_FAMILY_IGNORED);
     }
     {
         // dst
-        const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09054";
-        const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09051";
+        const char* img_vuid = "VUID-VkImageMemoryBarrier-None-09054";
+        const char* buf_vuid = "VUID-VkBufferMemoryBarrier-None-09051";
         conc_test(img_vuid, buf_vuid, VK_QUEUE_FAMILY_IGNORED, submit_family);
     }
     {
         // neither
-        const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
-        const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
+        const char* img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
+        const char* buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
         conc_test(img_vuid, buf_vuid, submit_family, submit_family);
     }
     conc_test(VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED);
@@ -1647,8 +1647,8 @@ TEST_F(NegativeSyncObject, BarrierQueueFamilyWithMemExt2) {
     BarrierQueueFamilyTestHelper conc_test(&test_context);
 
     conc_test.Init(&families);
-    const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
-    const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
+    const char* img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
+    const char* buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
     conc_test(img_vuid, buf_vuid, submit_family, submit_family);
     conc_test(VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED);
     conc_test(VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_EXTERNAL_KHR);

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -31,7 +31,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
-    vkt::Queue *no_gfx_queue = m_device->NonGraphicsQueue();
+    vkt::Queue* no_gfx_queue = m_device->NonGraphicsQueue();
     if (!no_gfx_queue) {
         GTEST_SKIP() << "Required queue not present (non-graphics capable required)";
     }
@@ -81,7 +81,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
-    vkt::Queue *no_gfx_queue = m_device->NonGraphicsQueue();
+    vkt::Queue* no_gfx_queue = m_device->NonGraphicsQueue();
     if (!no_gfx_queue) {
         GTEST_SKIP() << "Required queue not present (non-graphics capable required)";
     }
@@ -1322,13 +1322,13 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
 struct FenceSemRaceData {
     VkDevice device{VK_NULL_HANDLE};
     VkSemaphore sem{VK_NULL_HANDLE};
-    std::atomic<bool> *bailout{nullptr};
+    std::atomic<bool>* bailout{nullptr};
     uint64_t wait_value{0};
     uint64_t timeout{kWaitTimeout};
     uint32_t iterations{100000};
 };
 
-void WaitTimelineSem(FenceSemRaceData *data) {
+void WaitTimelineSem(FenceSemRaceData* data) {
     uint64_t wait_value = data->wait_value;
     VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
     wait_info.semaphoreCount = 1;
@@ -1432,9 +1432,9 @@ TEST_F(PositiveSyncObject, SubmitFenceButWaitIdle) {
 }
 
 struct SemBufferRaceData {
-    SemBufferRaceData(vkt::Device &dev_) : dev(dev_), sem(dev_, VK_SEMAPHORE_TYPE_TIMELINE) {}
+    SemBufferRaceData(vkt::Device& dev_) : dev(dev_), sem(dev_, VK_SEMAPHORE_TYPE_TIMELINE) {}
 
-    vkt::Device &dev;
+    vkt::Device& dev;
     vkt::Semaphore sem;
     uint64_t start_wait_value{0};
     uint64_t timeout_ns{kWaitTimeout};
@@ -1463,7 +1463,7 @@ struct SemBufferRaceData {
         }
     }
 
-    void Run(vkt::CommandPool &command_pool, ErrorMonitor &error_mon) {
+    void Run(vkt::CommandPool& command_pool, ErrorMonitor& error_mon) {
         uint64_t gpu_wait_value, gpu_signal_value;
         VkResult err;
         start_wait_value = 2;
@@ -2044,7 +2044,7 @@ TEST_F(PositiveSyncObject, ImageOwnershipTransferNormalizeSubresourceRange) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
-    vkt::Queue *transfer_queue = m_device->TransferOnlyQueue();
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
     if (!transfer_queue) {
         GTEST_SKIP() << "Transfer-only queue is not present";
     }

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -2858,7 +2858,7 @@ TEST_F(NegativeSyncVal, RenderPassWithWrongDepthStencilInitialLayout) {
 
     m_command_buffer.Begin();
     VkClearValue clear = {};
-    std::array<VkClearValue, 2> clear_values = { {clear, clear} };
+    std::array<VkClearValue, 2> clear_values = {{clear, clear}};
     m_renderPassBeginInfo.pClearValues = clear_values.data();
     m_renderPassBeginInfo.clearValueCount = clear_values.size();
     m_renderPassBeginInfo.renderArea = {{0, 0}, {32, 32}};
@@ -4136,7 +4136,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     constexpr size_t kNumDescriptors = 6;
 
     std::array<VkDescriptorBindingFlags, kNumDescriptors> ds_binding_flags;
-    for (auto &elem : ds_binding_flags) {
+    for (auto& elem : ds_binding_flags) {
         elem = VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT;
     }
 

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -28,8 +28,7 @@ static const std::array syncval_disables = {
     VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
     VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
 
-
-void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings) {
+void VkSyncValTest::InitSyncValFramework(const SyncValSettings* p_sync_settings) {
     std::vector<VkLayerSettingEXT> settings;
 
     static const SyncValSettings test_default_sync_settings = [] {
@@ -42,7 +41,7 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
         settings.load_op_after_store_op_validation = true;
         return settings;
     }();
-    const SyncValSettings &sync_settings = p_sync_settings ? *p_sync_settings : test_default_sync_settings;
+    const SyncValSettings& sync_settings = p_sync_settings ? *p_sync_settings : test_default_sync_settings;
 
     const auto submit_time_validation = static_cast<VkBool32>(sync_settings.submit_time_validation);
     settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT,
@@ -73,7 +72,7 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
     InitFramework(&validation_features);
 }
 
-void VkSyncValTest::InitSyncVal(const SyncValSettings *p_sync_settings) {
+void VkSyncValTest::InitSyncVal(const SyncValSettings* p_sync_settings) {
     RETURN_IF_SKIP(InitSyncValFramework(p_sync_settings));
     RETURN_IF_SKIP(InitState());
 }
@@ -1031,7 +1030,7 @@ TEST_F(PositiveSyncVal, GetSemaphoreCounterFromMultipleThreads) {
         ADD_FAILURE() << "The waiting time for the worker threads exceeded the maximum limit: " << wait_time << " seconds.";
         bailout.store(true);
     }
-    for (auto &waiter : waiters) {
+    for (auto& waiter : waiters) {
         waiter.join();
     }
     signaling_thread.join();
@@ -1199,7 +1198,7 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
     gfx_pipe.CreateGraphicsPipeline();
 
     // Read from image 2 or 3
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0, rgba8) uniform image2D image_array[];
@@ -1264,7 +1263,7 @@ TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
     gfx_pipe.CreateGraphicsPipeline();
 
     // Read from image 1
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D image_array[];
         void main() {
@@ -1329,7 +1328,7 @@ TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
     gfx_pipe.CreateGraphicsPipeline();
 
     // Read from texel buffer 1
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8ui) uniform uimageBuffer texel_buffer_array[];
         void main() {
@@ -1406,7 +1405,7 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
     descriptor_set.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D image;
         void main() {
@@ -1524,7 +1523,7 @@ TEST_F(PositiveSyncVal, QSTransitionAndRead) {
     descriptor_set.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D image;
         void main() {
@@ -1710,7 +1709,7 @@ TEST_F(PositiveSyncVal, QSSynchronizedWritesAndAsyncWait) {
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState());
 
-    vkt::Queue *transfer_queue = m_device->TransferOnlyQueue();
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
     if (!transfer_queue) {
         GTEST_SKIP() << "Transfer-only queue is not present";
     }
@@ -2158,7 +2157,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedUniformBufferRegions) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_a, copy_dst_area_size, uniform_data_size, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform buffer_a { uint x[8]; } constants;
         void main(){
@@ -2213,7 +2212,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_a, 0, uniform_data_size, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform buffer_a { uint x[8]; } constants;
         void main(){
@@ -2273,7 +2272,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions2) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_a, 0, uniform_data_size, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform buffer_a { uint x[8]; } constants;
         void main(){
@@ -2317,7 +2316,7 @@ TEST_F(PositiveSyncVal, ImageUsedInShaderWithoutAccess) {
     descriptor_set.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, rgba8) uniform image2D image;
         void main(){
@@ -2366,7 +2365,7 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoDispatches) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer ssbo { uint data[]; };
         void main(){
@@ -2398,7 +2397,7 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoSubmits) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer ssbo { uint data[]; };
         void main(){
@@ -2440,7 +2439,7 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoDispatches2) {
     descriptor_set.WriteDescriptorBufferInfo(1, data_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer i_am_counter { uint counter[]; };
         layout(set=0, binding=1) buffer i_am_data { uint data[]; };
@@ -2477,7 +2476,7 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoSubmits2) {
     descriptor_set.WriteDescriptorBufferInfo(1, data_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer i_am_counter { uint counter[]; };
         layout(set=0, binding=1) buffer i_am_data { uint data[]; };
@@ -2517,7 +2516,7 @@ TEST_F(PositiveSyncVal, QueueFamilyOwnershipTransfer) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncVal());
 
-    vkt::Queue *transfer_queue = m_device->TransferOnlyQueue();
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
     if (!transfer_queue) {
         GTEST_SKIP() << "Transfer-only queue is needed";
     }
@@ -2863,7 +2862,7 @@ TEST_F(PositiveSyncVal, CmdDispatchBase) {
     descriptor_set.WriteDescriptorBufferInfo(1, buffer_b, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer buffer_a { uint values_a[]; };
         layout(set=0, binding=1) buffer buffer_b { uint values_b[]; };
@@ -3020,7 +3019,7 @@ TEST_F(PositiveSyncVal, TwoExternalDependenciesSyncLayoutTransitions) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D color_image0;
         layout(set=0, binding=1) uniform sampler2D color_image1;
@@ -3852,9 +3851,9 @@ TEST_F(PositiveSyncVal, ApplyManyGlobalBarriers) {
 
     m_command_buffer.Begin();
     for (size_t i = 0; i < accesses.size() - 1; i++) {
-        const auto &access_a = accesses[i];
+        const auto& access_a = accesses[i];
         for (size_t k = i + 1; k < accesses.size(); k++) {
-            const auto &access_b = accesses[k];
+            const auto& access_b = accesses[k];
 
             VkMemoryBarrier2 global_barrier = vku::InitStructHelper();
             global_barrier.srcStageMask = access_a.first;

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024-2025 The Khronos Group Inc.
- * Copyright (c) 2024-2025 Valve Corporation
- * Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 The Khronos Group Inc.
+ * Copyright (c) 2024-2026 Valve Corporation
+ * Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -440,8 +440,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, FrameSynchronization2) {
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     for (int i = 1; i <= N; i++) {
         m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, i));
-        while (semaphore.GetCounterValue() != i)
-            ;
+        while (semaphore.GetCounterValue() != i);
     }
     m_device->Wait();
 }

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -321,20 +321,20 @@ TEST_F(PositiveSyncValWsi, RecreateBuffer) {
         current_fence.Wait(kWaitTimeout);
         current_fence.Reset();
 
-        auto &src_buffer = src_buffers[image_index];
+        auto& src_buffer = src_buffers[image_index];
         src_buffer.Destroy();
         src_buffer = vkt::Buffer(*m_device, 1024, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
 
-        auto &dst_buffer = dst_buffers[image_index];
+        auto& dst_buffer = dst_buffers[image_index];
         dst_buffer.Destroy();
         dst_buffer = vkt::Buffer(*m_device, 1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-        auto &command_buffer = command_buffers[image_index];
+        auto& command_buffer = command_buffers[image_index];
         command_buffer.Begin();
         command_buffer.Copy(src_buffer, dst_buffer);
         command_buffer.End();
 
-        auto &submit_semaphore = submit_semaphores[image_index];
+        auto& submit_semaphore = submit_semaphores[image_index];
         m_default_queue->Submit(command_buffer, vkt::Signal(submit_semaphore));
         m_default_queue->Present(m_swapchain, image_index, submit_semaphore);
         std::swap(acquire_fences[image_index], current_fence);
@@ -383,7 +383,7 @@ TEST_F(PositiveSyncValWsi, RecreateImage) {
         current_fence.Wait(kWaitTimeout);
         current_fence.Reset();
 
-        auto &dst_image = dst_images[image_index];
+        auto& dst_image = dst_images[image_index];
         dst_image.Destroy();
         dst_image = vkt::Image(*m_device, width, height, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
@@ -401,13 +401,13 @@ TEST_F(PositiveSyncValWsi, RecreateImage) {
         layout_transition.image = dst_image;
         layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-        auto &command_buffer = command_buffers[image_index];
+        auto& command_buffer = command_buffers[image_index];
         command_buffer.Begin();
         command_buffer.Barrier(layout_transition);
         vk::CmdCopyBufferToImage(command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
         command_buffer.End();
 
-        auto &submit_semaphore = submit_semaphores[image_index];
+        auto& submit_semaphore = submit_semaphores[image_index];
         m_default_queue->Submit(command_buffer, vkt::Signal(submit_semaphore));
         m_default_queue->Present(m_swapchain, image_index, submit_semaphore);
         std::swap(acquire_fences[image_index], current_fence);

--- a/tests/unit/tensor.cpp
+++ b/tests/unit/tensor.cpp
@@ -754,8 +754,8 @@ TEST_F(NegativeTensor, BindTensorIncompatibleExportHandleType) {
     req_info.tensor = tensor;
     VkMemoryRequirements2 mem_reqs = vku::InitStructHelper();
     vk::GetTensorMemoryRequirementsARM(device(), &req_info, &mem_reqs);
-    const auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, mem_reqs.memoryRequirements, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                                                    &export_memory_info);
+    const auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, mem_reqs.memoryRequirements,
+                                                                    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &export_memory_info);
     vkt::DeviceMemory memory(*m_device, alloc_info);
 
     VkBindTensorMemoryInfoARM bind_info = vku::InitStructHelper();
@@ -799,7 +799,7 @@ TEST_F(NegativeTensor, BindTensorImportMemoryHandleType) {
     GetPhysicalDeviceProperties2(memory_host_props);
     auto alignment = memory_host_props.minImportedHostPointerAlignment;
     auto alloc_size = ((tensor_mem_reqs.size + alignment - 1) / alignment) * alignment;
-    void *host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alignment));
+    void* host_memory = ::operator new((size_t)alloc_size, std::align_val_t(alignment));
     if (!host_memory) {
         GTEST_SKIP() << "Failed to allocate host memory";
     }
@@ -812,7 +812,7 @@ TEST_F(NegativeTensor, BindTensorImportMemoryHandleType) {
     alloc_info.pNext = &import_info;
     alloc_info.allocationSize = alloc_size;
     m_device->Physical().SetMemoryType(tensor_mem_reqs.memoryTypeBits, &alloc_info,
-        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT|VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+                                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     vkt::DeviceMemory memory(*m_device, alloc_info);
 
     // Bind tensor (with handle_type1) and memory (with handle_type2)
@@ -1493,7 +1493,7 @@ TEST_F(NegativeTensor, CopyTensorRegionDimensionCountZero) {
 
     // in turn, set each one of the 3 relevant vectors to point to some dummy data
     // NOTE: the only reason we use the tensor pDimensions is to avoid VU 09689 on pExtent
-    const int64_t *dimensions = src_tensor.Description().pDimensions;
+    const int64_t* dimensions = src_tensor.Description().pDimensions;
     const std::vector<uint64_t> udims(dimensions, dimensions + src_tensor.Description().dimensionCount);
     for (int i = 0; i < 3; i++) {
         regions[0].pSrcOffset = nullptr;
@@ -1645,8 +1645,8 @@ TEST_F(NegativeTensor, DestroyTensorViewInUse) {
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
-    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1, &pipe.descriptor_set_.set_, 0,
-                              nullptr);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
+                              &pipe.descriptor_set_.set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
@@ -2435,7 +2435,7 @@ TEST_F(NegativeTensor, DispatchShaderSpirvWrongFormat) {
 
         m_command_buffer.Begin();
         vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
-                                &pipe.descriptor_set_.set_, 0, nullptr);
+                                  &pipe.descriptor_set_.set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpTypeTensorARM-09906");
@@ -2454,7 +2454,7 @@ TEST_F(NegativeTensor, WrongStageInShader) {
     RETURN_IF_SKIP(InitBasicTensor());
 
     // trivial geometry shader with a dummy OpTypeTensorARM instruction thrown in
-    const char *spirv_string = R"(
+    const char* spirv_string = R"(
                OpCapability TensorsARM
                OpCapability Shader
                OpCapability Geometry

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -302,14 +302,14 @@ TEST_F(PositiveThreading, Queue) {
     constexpr auto test_duration = seconds{2};
     const auto timer_begin = steady_clock::now();
 
-    const auto &testing_thread1 = [&]() {
+    const auto& testing_thread1 = [&]() {
         for (auto timer_now = steady_clock::now(); timer_now - timer_begin < test_duration; timer_now = steady_clock::now()) {
             VkQueue dummy_q;
             vk::GetDeviceQueue(device_h, queue_family, queue_index, &dummy_q);
         }
     };
 
-    const auto &testing_thread2 = [&]() {
+    const auto& testing_thread2 = [&]() {
         for (auto timer_now = steady_clock::now(); timer_now - timer_begin < test_duration; timer_now = steady_clock::now()) {
             VkSubmitInfo si = vku::InitStructHelper();
             si.commandBufferCount = 1;
@@ -320,7 +320,7 @@ TEST_F(PositiveThreading, Queue) {
         }
     };
 
-    const auto &testing_thread3 = [&]() {
+    const auto& testing_thread3 = [&]() {
         for (auto timer_now = steady_clock::now(); timer_now - timer_begin < test_duration; timer_now = steady_clock::now()) {
             queue_mutex.lock();
             ASSERT_EQ(VK_SUCCESS, vk::QueueWaitIdle(queue_h));
@@ -329,7 +329,7 @@ TEST_F(PositiveThreading, Queue) {
     };
 
     std::array<std::thread, 3> threads = {std::thread(testing_thread1), std::thread(testing_thread2), std::thread(testing_thread3)};
-    for (auto &t : threads) t.join();
+    for (auto& t : threads) t.join();
 
     vk::QueueWaitIdle(queue_h);
 }
@@ -350,7 +350,7 @@ TEST_F(PositiveThreading, GetPhysicalDeviceFeatures) {
         std::vector<VkPhysicalDevice> physical_devices(physical_device_count);
         vk::EnumeratePhysicalDevices(instance, &physical_device_count, physical_devices.data());
 
-        const auto &thread = [&](uint32_t id) {
+        const auto& thread = [&](uint32_t id) {
             VkPhysicalDeviceFeatures features;
             vk::GetPhysicalDeviceFeatures(physical_devices[id % physical_device_count], &features);
         };
@@ -358,7 +358,7 @@ TEST_F(PositiveThreading, GetPhysicalDeviceFeatures) {
         for (uint32_t i = 0u; i < thread_count; ++i) {
             threads[i] = std::thread(thread, i);
         }
-        for (auto &t : threads) {
+        for (auto& t : threads) {
             t.join();
         }
 
@@ -384,7 +384,7 @@ TEST_F(PositiveThreading, ObjectTrackerPoisoning) {
         }
     };
     std::array<std::thread, 2> threads = {std::thread(thread_func), std::thread(thread_func)};
-    for (auto &t : threads) t.join();
+    for (auto& t : threads) t.join();
 }
 
 TEST_F(PositiveThreading, InternallySynchronizedQueues) {
@@ -449,7 +449,7 @@ TEST_F(PositiveThreading, InternallySynchronizedQueues) {
     };
     std::array<std::thread, 2> threads = {std::thread(thread_func, cmd_buffer1.handle()),
                                           std::thread(thread_func, cmd_buffer2.handle())};
-    for (auto &t : threads) {
+    for (auto& t : threads) {
         t.join();
     }
 

--- a/tests/unit/tile_memory_heap_positive.cpp
+++ b/tests/unit/tile_memory_heap_positive.cpp
@@ -48,7 +48,7 @@ TEST_F(PositiveTileMemoryHeap, BasicBuffer) {
     vk::BindBufferMemory(device(), buffer, buffer_memory, 0);
 
     // Create Compute Shader to write to Tile Memory Buffer
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { float tileMemBuffer; };
         void main() {
@@ -86,7 +86,7 @@ TEST_F(PositiveTileMemoryHeap, NullTileMemoryBind) {
     vkt::Buffer buffer(*m_device, vkt::Buffer::CreateInfo(4096, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT));
 
     // Create Compute Shader to write to Tile Memory Buffer
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { float writeBuffer; };
         void main() {

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -16,7 +16,7 @@
 #include "../framework/pipeline_helper.h"
 
 // Basic Vertex shader with Xfb OpExecutionMode added
-static const char *kXfbVsSource = R"asm(
+static const char* kXfbVsSource = R"asm(
                OpCapability Shader
                OpCapability TransformFeedback
                OpMemoryModel Logical GLSL450
@@ -569,7 +569,7 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
         m_command_buffer.End();
     }
 
-    std::vector<const char *> device_extension_names;
+    std::vector<const char*> device_extension_names;
     device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     vkt::Device test_device(Gpu(), device_extension_names);
     vkt::CommandPool commandPool(test_device, 0);
@@ -738,7 +738,7 @@ TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
     }
 
     if (transform_feedback_props.transformFeedbackStreamsLinesTriangles == VK_FALSE) {
-        const char *gsSource = R"asm(
+        const char* gsSource = R"asm(
                OpCapability Geometry
                OpCapability TransformFeedback
                OpCapability GeometryStreams

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -37,7 +37,7 @@ TEST_F(NegativeVertexInput, AttributeFormat) {
 
     input_attribs.location = 0;
 
-    auto set_info = [&](CreatePipelineHelper &helper) {
+    auto set_info = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &input_binding;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
@@ -55,7 +55,7 @@ TEST_F(NegativeVertexInput, DivisorExtension) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT pdvad_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(pdvad_props);
 
@@ -107,8 +107,8 @@ TEST_F(NegativeVertexInput, DivisorExtension) {
     }
     // clang-format on
 
-    for (const auto &test_case : test_cases) {
-        const auto bad_divisor_state = [&test_case, &vibdd, &pvids_ci, &vibd](CreatePipelineHelper &helper) {
+    for (const auto& test_case : test_cases) {
+        const auto bad_divisor_state = [&test_case, &vibdd, &pvids_ci, &vibd](CreatePipelineHelper& helper) {
             vibdd.binding = test_case.div_binding;
             vibdd.divisor = test_case.div_divisor;
             vibd.binding = test_case.desc_binding;
@@ -146,7 +146,7 @@ TEST_F(NegativeVertexInput, DivisorDisabled) {
         GTEST_SKIP() << "This device does not support vertexBindingDivisors";
     }
 
-    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper &helper) {
+    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper& helper) {
         helper.vi_ci_.pNext = &pvids_ci;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexBindingDescriptions = &vibd;
@@ -174,7 +174,7 @@ TEST_F(NegativeVertexInput, DivisorInstanceRateZero) {
     vibd.stride = 12;
     vibd.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
 
-    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper &helper) {
+    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper& helper) {
         helper.vi_ci_.pNext = &pvids_ci;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexBindingDescriptions = &vibd;
@@ -192,7 +192,7 @@ TEST_F(NegativeVertexInput, DivisorExtensionKHR) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
+    const VkPhysicalDeviceLimits& dev_limits = m_device->Physical().limits_;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR pdvad_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(pdvad_props);
 
@@ -244,8 +244,8 @@ TEST_F(NegativeVertexInput, DivisorExtensionKHR) {
     }
     // clang-format on
 
-    for (const auto &test_case : test_cases) {
-        const auto bad_divisor_state = [&test_case, &vibdd, &pvids_ci, &vibd](CreatePipelineHelper &helper) {
+    for (const auto& test_case : test_cases) {
+        const auto bad_divisor_state = [&test_case, &vibdd, &pvids_ci, &vibd](CreatePipelineHelper& helper) {
             vibdd.binding = test_case.div_binding;
             vibdd.divisor = test_case.div_divisor;
             vibd.binding = test_case.desc_binding;
@@ -284,7 +284,7 @@ TEST_F(NegativeVertexInput, DivisorDisabledKHR) {
         GTEST_SKIP() << "This device does not support vertexBindingDivisors";
     }
 
-    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper &helper) {
+    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper& helper) {
         helper.vi_ci_.pNext = &pvids_ci;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexBindingDescriptions = &vibd;
@@ -313,7 +313,7 @@ TEST_F(NegativeVertexInput, DivisorInstanceRateZeroKHR) {
     vibd.stride = 12;
     vibd.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
 
-    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper &helper) {
+    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper& helper) {
         helper.vi_ci_.pNext = &pvids_ci;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexBindingDescriptions = &vibd;
@@ -342,7 +342,7 @@ TEST_F(NegativeVertexInput, DivisorInstanceRateZero14) {
     vibd.stride = 12;
     vibd.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
 
-    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper &helper) {
+    const auto instance_rate = [&pvids_ci, &vibd](CreatePipelineHelper& helper) {
         helper.vi_ci_.pNext = &pvids_ci;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexBindingDescriptions = &vibd;
@@ -363,7 +363,7 @@ TEST_F(NegativeVertexInput, InputBindingMaxVertexInputBindings) {
     VkVertexInputBindingDescription vertex_input_binding_description{};
     vertex_input_binding_description.binding = m_device->Physical().limits_.maxVertexInputBindings;
 
-    const auto set_binding = [&](CreatePipelineHelper &helper) {
+    const auto set_binding = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
     };
@@ -382,7 +382,7 @@ TEST_F(NegativeVertexInput, InputBindingMaxVertexInputBindingStride) {
     VkVertexInputBindingDescription vertex_input_binding_description{};
     vertex_input_binding_description.stride = m_device->Physical().limits_.maxVertexInputBindingStride + 1;
 
-    const auto set_binding = [&](CreatePipelineHelper &helper) {
+    const auto set_binding = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
     };
@@ -401,7 +401,7 @@ TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputAttributes) {
     VkVertexInputAttributeDescription vertex_input_attribute_description{};
     vertex_input_attribute_description.location = m_device->Physical().limits_.maxVertexInputAttributes;
 
-    const auto set_attribute = [&](CreatePipelineHelper &helper) {
+    const auto set_attribute = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexAttributeDescriptions = &vertex_input_attribute_description;
         helper.vi_ci_.vertexAttributeDescriptionCount = 1;
     };
@@ -423,7 +423,7 @@ TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputBindings) {
     VkVertexInputAttributeDescription vertex_input_attribute_description{};
     vertex_input_attribute_description.binding = m_device->Physical().limits_.maxVertexInputBindings;
 
-    const auto set_attribute = [&](CreatePipelineHelper &helper) {
+    const auto set_attribute = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexAttributeDescriptions = &vertex_input_attribute_description;
         helper.vi_ci_.vertexAttributeDescriptionCount = 1;
     };
@@ -456,7 +456,7 @@ TEST_F(NegativeVertexInput, AttributeDescriptionOffset) {
     VkVertexInputAttributeDescription vertex_input_attribute_description{};
     vertex_input_attribute_description.format = VK_FORMAT_R8_UNORM;
     vertex_input_attribute_description.offset = maxVertexInputAttributeOffset + 1;
-    const auto set_attribute = [&](CreatePipelineHelper &helper) {
+    const auto set_attribute = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexAttributeDescriptions = &vertex_input_attribute_description;
@@ -491,7 +491,7 @@ TEST_F(NegativeVertexInput, BindingDescriptions) {
     input_attrib.format = VK_FORMAT_R32G32B32_SFLOAT;
     input_attrib.offset = 0;
 
-    const auto set_Info = [&](CreatePipelineHelper &helper) {
+    const auto set_Info = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = input_bindings.data();
         helper.vi_ci_.vertexBindingDescriptionCount = binding_count;
         helper.vi_ci_.pVertexAttributeDescriptions = &input_attrib;
@@ -530,7 +530,7 @@ TEST_F(NegativeVertexInput, AttributeDescriptions) {
     // Let the last input_attribs description use binding which is not defined
     input_attribs[attribute_count - 1].binding = 1;
 
-    const auto set_Info = [&](CreatePipelineHelper &helper) {
+    const auto set_Info = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &input_binding;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexAttributeDescriptions = input_attribs.data();
@@ -614,7 +614,7 @@ TEST_F(NegativeVertexInput, VertextBinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec4 y;
@@ -660,7 +660,7 @@ TEST_F(NegativeVertexInput, VertextBindingNonLinear) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec4 y;
@@ -704,7 +704,7 @@ TEST_F(NegativeVertexInput, VertextBindingMultipleLocations) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec4 y;
@@ -750,7 +750,7 @@ TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=1) in vec4 x;
         layout(location=2) in vec4 y;
@@ -844,7 +844,7 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
     input_attribs[2].format = VK_FORMAT_R32G32B32A32_SFLOAT;
     input_attribs[2].offset = offsetof(VboEntry, input2);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec2 input0;
         layout(location = 1) in vec4 input1;
@@ -908,7 +908,7 @@ TEST_F(NegativeVertexInput, BindVertexOffset) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float x;
         void main(){
@@ -949,7 +949,7 @@ TEST_F(NegativeVertexInput, VertexStride) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float x;
         void main(){
@@ -992,7 +992,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicInput) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float x;
         void main(){
@@ -1041,7 +1041,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStride) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float x;
         void main(){
@@ -1087,7 +1087,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStrideArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float x;
         layout(location = 1) in float y;
@@ -1137,7 +1137,7 @@ TEST_F(NegativeVertexInput, VertexStrideDoubleDynamicStride) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float x;
         void main(){
@@ -1202,7 +1202,7 @@ TEST_F(NegativeVertexInput, AttributeNotConsumed) {
     memset(&input_attrib, 0, sizeof(input_attrib));
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &input_binding;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexAttributeDescriptions = &input_attrib;
@@ -1225,7 +1225,7 @@ TEST_F(NegativeVertexInput, AttributeLocationMismatch) {
     memset(&input_attrib, 0, sizeof(input_attrib));
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &input_binding;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
         helper.vi_ci_.pVertexAttributeDescriptions = &input_attrib;
@@ -1317,7 +1317,7 @@ TEST_F(NegativeVertexInput, AttributeNotProvided) {
     )glsl";
     VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-07904");
@@ -1337,7 +1337,7 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatch) {
     memset(&input_attrib, 0, sizeof(input_attrib));
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in int x; /* attrib provided float */
         void main(){
@@ -1346,7 +1346,7 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatch) {
     )glsl";
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
         helper.vi_ci_.pVertexBindingDescriptions = &input_binding;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
@@ -1429,7 +1429,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeSecondLocation) {
     //         layout(location = 4) ivec4 x;
     //         layout(location = 6) uvec4 y;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -1474,7 +1474,8 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation) {
     VkVertexInputBindingDescription input_binding = {0, 24, VK_VERTEX_INPUT_RATE_VERTEX};
 
     VkVertexInputAttributeDescription input_attribs[2] = {
-        {4, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0}, {5, 0, VK_FORMAT_R32G32B32A32_SINT, 0},  // should be uint
+        {4, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0},
+        {5, 0, VK_FORMAT_R32G32B32A32_SINT, 0},  // should be uint
     };
 
     // This is not valid GLSL (but is valid SPIR-V) - would look like:
@@ -1482,7 +1483,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation) {
     //         vec4 x;
     //         uvec4 y;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -1526,7 +1527,7 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatchDynamic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in int x; /* attrib provided float */
         void main(){
@@ -1580,7 +1581,7 @@ TEST_F(NegativeVertexInput, AttributeBindingConflict) {
     memset(&input_attrib, 0, sizeof(input_attrib));
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* attrib provided float */
         void main(){
@@ -1590,7 +1591,7 @@ TEST_F(NegativeVertexInput, AttributeBindingConflict) {
 
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
         helper.vi_ci_.pVertexBindingDescriptions = input_bindings;
         helper.vi_ci_.vertexBindingDescriptionCount = 2;
@@ -1613,7 +1614,7 @@ TEST_F(NegativeVertexInput, Attribute64bitInputAttribute) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450 core
         layout(location = 0) in float pos; // 32-bit
         void main() {}
@@ -1647,7 +1648,7 @@ TEST_F(NegativeVertexInput, Attribute64bitShaderInput) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in float64_t pos;
@@ -1682,7 +1683,7 @@ TEST_F(NegativeVertexInput, Attribute64bitUnusedComponent) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in f64vec2 pos;
@@ -1730,7 +1731,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation64bit) {
     //         float64 y;
     //         ivec4 z;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpCapability Float64
                OpMemoryModel Logical Simple
@@ -1898,7 +1899,7 @@ TEST_F(NegativeVertexInput, NoBoundVertexBuffer) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         void main(){}
@@ -1961,7 +1962,7 @@ TEST_F(NegativeVertexInput, ResetCmdSetVertexInput) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in uvec4 x;
         void main(){}
@@ -2009,7 +2010,7 @@ TEST_F(NegativeVertexInput, VertexInputRebinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float a;
         layout(location = 1) in float b;

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -36,7 +36,7 @@ TEST_F(PositiveVertexInput, AttributeMatrixType) {
         input_attribs[i].location = i;
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in mat2x4 x;
         void main(){
@@ -74,7 +74,7 @@ TEST_F(PositiveVertexInput, AttributeArrayType) {
         input_attribs[i].location = i;
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x[2];
         void main(){
@@ -111,7 +111,7 @@ TEST_F(PositiveVertexInput, AttributeStructType) {
     //     in VertexIn {
     //         layout(location = 4) vec4 x;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -166,7 +166,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeWithArray) {
     //         layout(location = 4) vec4 y[2];
     //         layout(location = 1) vec3 x;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -220,7 +220,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeSecondLocation) {
     //         layout(location = 4) ivec4 x;
     //         layout(location = 6) uvec4 y;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -272,7 +272,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation) {
     //         vec4 x;
     //         uvec4 y;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -325,7 +325,7 @@ TEST_F(PositiveVertexInput, AttributeComponents) {
         input_attribs[i].location = i;
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec3 y1;
@@ -335,7 +335,7 @@ TEST_F(PositiveVertexInput, AttributeComponents) {
            gl_Position = x + vec4(y1, y2) + z;
         }
     )glsl";
-    const char *fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(location=0, component=0) out float color0;
         layout(location=0, component=1) out float color1;
@@ -408,7 +408,7 @@ TEST_F(PositiveVertexInput, CreatePipeline64BitAttributes) {
     input_attribs[3].offset = 96;
     input_attribs[3].format = VK_FORMAT_R64G64B64A64_SFLOAT;
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in dmat4 x;
         void main(){
@@ -442,7 +442,7 @@ TEST_F(PositiveVertexInput, VertexAttribute64bit) {
 
     vkt::Buffer vtx_buf(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in float64_t pos;
@@ -473,7 +473,7 @@ TEST_F(PositiveVertexInput, VertexAttribute64bitExtraInput) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in float64_t pos; // Uses only 1 of the 4 components
@@ -518,7 +518,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation64bit) {
     //         float64 y;
     //         ivec4 z;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpCapability Float64
                OpMemoryModel Logical Simple
@@ -564,7 +564,7 @@ TEST_F(PositiveVertexInput, Attribute64bitMissingComponent) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in f64vec2 pos;
@@ -805,7 +805,7 @@ TEST_F(PositiveVertexInput, InputBindingMaxVertexInputBindingStrideDynamic) {
     VkVertexInputBindingDescription vertex_input_binding_description{};
     vertex_input_binding_description.stride = m_device->Physical().limits_.maxVertexInputBindingStride + 1;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
         helper.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
         helper.vi_ci_.vertexBindingDescriptionCount = 1;
@@ -894,7 +894,7 @@ TEST_F(PositiveVertexInput, LegacyVertexAttributes) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in int x; /* attrib provided float */
         void main(){
@@ -939,14 +939,14 @@ TEST_F(PositiveVertexInput, ResetCmdSetVertexInput) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source_int = R"glsl(
+    const char* vs_source_int = R"glsl(
         #version 450
         layout(location=0) in uvec4 x;
         void main(){}
     )glsl";
     VkShaderObj vs_int(*m_device, vs_source_int, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const char *vs_source_float = R"glsl(
+    const char* vs_source_float = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         void main(){}
@@ -1000,7 +1000,7 @@ TEST_F(PositiveVertexInput, VertexAttributeRobustness) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vs_source = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x; /* not provided */
         void main(){
@@ -1022,7 +1022,7 @@ TEST_F(PositiveVertexInput, VertexAttributeRobustnessDynamic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec4 x;
         layout(location = 1) in vec4 y;
@@ -1071,7 +1071,7 @@ TEST_F(PositiveVertexInput, VertexInputRebinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location = 0) in float a;
 
@@ -1132,7 +1132,7 @@ TEST_F(PositiveVertexInput, UnusedInputBinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec4 y;
@@ -1175,7 +1175,7 @@ TEST_F(PositiveVertexInput, UnusedInputBindingDynamic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec4 y;
@@ -1356,7 +1356,7 @@ TEST_F(PositiveVertexInput, AttributeNotProvided) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x; /* not provided */
         void main(){
@@ -1365,7 +1365,7 @@ TEST_F(PositiveVertexInput, AttributeNotProvided) {
     )glsl";
     VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const auto set_info = [&](CreatePipelineHelper &helper) {
+    const auto set_info = [&](CreatePipelineHelper& helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -476,7 +476,8 @@ TEST_F(NegativeVideo, BindVideoSessionMemory) {
         GTEST_SKIP() << "Test can only run if video session needs memory bindings";
     }
 
-    std::vector<VkVideoSessionMemoryRequirementsKHR> mem_reqs(mem_req_count, vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>());
+    std::vector<VkVideoSessionMemoryRequirementsKHR> mem_reqs(mem_req_count,
+                                                              vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>());
     ASSERT_EQ(VK_SUCCESS, vk::GetVideoSessionMemoryRequirementsKHR(device(), context.Session(), &mem_req_count, mem_reqs.data()));
 
     std::vector<VkDeviceMemory> session_memory;
@@ -2149,7 +2150,7 @@ TEST_F(NegativeVideoBestPractices, BindVideoSessionMemory) {
     // Create a buffer to get non-video-related memory requirements
     VkBufferCreateInfo buffer_create_info =
         vku::InitStruct<VkBufferCreateInfo>(nullptr, static_cast<VkBufferCreateFlags>(0), static_cast<VkDeviceSize>(4096),
-                                          static_cast<VkBufferUsageFlags>(VK_BUFFER_USAGE_TRANSFER_SRC_BIT));
+                                            static_cast<VkBufferUsageFlags>(VK_BUFFER_USAGE_TRANSFER_SRC_BIT));
     vkt::Buffer buffer(*m_device, buffer_create_info);
     VkMemoryRequirements buf_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer, &buf_mem_reqs);

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2021-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 LunarG, Inc.
+/* Copyright (c) 2021-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 LunarG, Inc.
  * Copyright (c) 2021 NVIDIA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -198,8 +198,7 @@ class ViewportInheritanceTestData {
                           bool inheritedViewportScissor2D, bool extended_dynamic_state_multi_viewport,
                           bool disable_multi_viewport = false) {
         VkPhysicalDeviceExtendedDynamicStateFeaturesEXT ext = vku::InitStructHelper();
-        VkPhysicalDeviceInheritedViewportScissorFeaturesNV nv =
-            vku::InitStructHelper(&ext);
+        VkPhysicalDeviceInheritedViewportScissorFeaturesNV nv = vku::InitStructHelper(&ext);
         VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&nv);
         VkPhysicalDevice gpu = p_framework->Gpu();
 
@@ -285,9 +284,9 @@ class ViewportInheritanceTestData {
         // Need some static viewport/scissors if no dynamic state. Their values don't really matter; the only purpose
         // of static viewport/scissor pipelines is to test messing up the dynamic state.
         std::vector<VkViewport> static_viewports;
-        std::vector<VkRect2D>   static_scissors;
+        std::vector<VkRect2D> static_scissors;
         if (!dynamic_viewport_scissor) {
-            VkViewport viewport { 0, 0, 128, 128, 0, 1 };
+            VkViewport viewport{0, 0, 128, 128, 0, 1};
             static_viewports = std::vector<VkViewport>(viewport_scissor_count, viewport);
             static_scissors.resize(viewport_scissor_count);
         }
@@ -298,8 +297,9 @@ class ViewportInheritanceTestData {
                                                             static_viewports.data(),
                                                             viewport_scissor_count,
                                                             static_scissors.data()};
-        const VkPipelineDynamicStateCreateInfo& dynamic_state =
-            dynamic_viewport_scissor == false ? kStaticState : viewport_scissor_count == 0 ? kDynamicStateWithCount : kDynamicState;
+        const VkPipelineDynamicStateCreateInfo& dynamic_state = dynamic_viewport_scissor == false ? kStaticState
+                                                                : viewport_scissor_count == 0     ? kDynamicStateWithCount
+                                                                                                  : kDynamicState;
 
         VkGraphicsPipelineCreateInfo info = {VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
                                              nullptr,
@@ -347,8 +347,8 @@ class ViewportInheritanceTestData {
 
     // Begin the render pass, with subpass contents provided by secondary command buffers.
     void BeginRenderPass(VkCommandBuffer cmd) const {
-        VkRenderPassBeginInfo info =
-            vku::InitStruct<VkRenderPassBeginInfo>(nullptr, m_renderPass, m_framebuffer, VkRect2D{{0, 0}, {128u, 128u}}, 0u, nullptr);
+        VkRenderPassBeginInfo info = vku::InitStruct<VkRenderPassBeginInfo>(nullptr, m_renderPass, m_framebuffer,
+                                                                            VkRect2D{{0, 0}, {128u, 128u}}, 0u, nullptr);
         vk::CmdBeginRenderPass(cmd, &info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     }
 
@@ -388,10 +388,10 @@ class ViewportInheritanceTestData {
     VkResult BeginSubpassCommandBuffer(VkCommandBuffer cmd, uint32_t inherited_viewport_count,
                                        const VkViewport* p_viewport_depths) const {
         VkCommandBufferInheritanceViewportScissorInfoNV viewport_scissor = {
-            VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV, nullptr,
-            inherited_viewport_count != 0, inherited_viewport_count, p_viewport_depths };
-        VkCommandBufferInheritanceInfo inheritance = {
-            VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, &viewport_scissor, m_renderPass, 0, m_framebuffer };
+            VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV, nullptr, inherited_viewport_count != 0,
+            inherited_viewport_count, p_viewport_depths};
+        VkCommandBufferInheritanceInfo inheritance = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, &viewport_scissor,
+                                                      m_renderPass, 0, m_framebuffer};
         VkCommandBufferBeginInfo info = {
             VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
             VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT, &inheritance};
@@ -544,7 +544,7 @@ TEST_F(NegativeViewportInheritance, BasicUsage) {
     // Check that the validation layers DON'T report mismatched viewport depth when the secondary command buffer does not actually
     // consume the viewport in drawing commands (weird corner case).
     VkCommandBuffer no_draw_cmd = test_data.MakeBeginSubpassCommandBuffer(pool, 1, test_data.kViewportDepthOnlyArray);
-    test_data.BindGraphicsPipeline(no_draw_cmd, true, 1); // but no subsequent draw call.
+    test_data.BindGraphicsPipeline(no_draw_cmd, true, 1);  // but no subsequent draw call.
     vk::EndCommandBuffer(no_draw_cmd);
 
     for (int should_fail = 0; should_fail < 2; ++should_fail) {
@@ -590,8 +590,8 @@ TEST_F(NegativeViewportInheritance, BasicUsage) {
         } else {
         }
         VkCommandBufferInheritanceViewportScissorInfoNV viewport_scissor = {
-            VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV, nullptr, should_fail ? VK_TRUE : VK_FALSE,
-            0, test_data.kViewportArray /* avoid null pointer crash still */ };
+            VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV, nullptr, should_fail ? VK_TRUE : VK_FALSE, 0,
+            test_data.kViewportArray /* avoid null pointer crash still */};
         VkCommandBuffer cmd =
             test_data.MakeBeginSecondaryCommandBuffer(pool, VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT, &viewport_scissor);
         // vk::EndCommandBuffer(cmd); // seg faults.
@@ -693,7 +693,7 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
     vk::EndCommandBuffer(draw_cmd);
 
     VkCommandBuffer primary_cmd = test_data.MakeBeginPrimaryCommandBuffer(pool);
-    vk::CmdSetViewport(primary_cmd, 0, 1, test_data.kViewportArray); // inadequate, needs with count
+    vk::CmdSetViewport(primary_cmd, 0, 1, test_data.kViewportArray);  // inadequate, needs with count
     vk::CmdSetScissor(primary_cmd, 0, 1, test_data.kScissorArray);
     test_data.BeginRenderPass(primary_cmd);
     vk::CmdExecuteCommands(primary_cmd, 1, &draw_cmd);
@@ -707,7 +707,7 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
         if (should_fail) m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07850");  // viewport
 
         test_data.BeginSubpassCommandBuffer(draw_cmd, should_fail ? 1 : 2, test_data.kViewportDepthOnlyArray);
-        test_data.BindGraphicsPipeline(draw_cmd, true, 2); // Uses 2 viewports
+        test_data.BindGraphicsPipeline(draw_cmd, true, 2);  // Uses 2 viewports
         vk::CmdDraw(draw_cmd, 3, 1, 0, 0);
         if (i & 2) {
             // Uses only 1 viewport, should not cause us to "forget" the earlier need for 2 viewports.
@@ -780,12 +780,13 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
             case 2:
                 secondaries[0] = set_state_cmd;
                 secondaries[1] = draw_cmd;
-                secondaries[2] = static_state_cmd; // Okay as it's after the drawing commands.
+                secondaries[2] = static_state_cmd;  // Okay as it's after the drawing commands.
                 secondaries_count = 3;
                 break;
-            case 3: default:
+            case 3:
+            default:
                 secondaries[0] = set_state_cmd;
-                secondaries[1] = static_state_cmd; // Trashes the dynamic state
+                secondaries[1] = static_state_cmd;  // Trashes the dynamic state
                 secondaries[2] = draw_cmd;
                 secondaries_count = 3;
                 break;
@@ -817,7 +818,8 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
         vk::EndCommandBuffer(draw_cmd);
 
         test_data.BeginSubpassCommandBuffer(set_state_fixed_count_cmd, 0, nullptr);
-        vk::CmdSetViewport(set_state_fixed_count_cmd, 1, 1, i == 2 ? &test_data.kViewportArray[1] : &test_data.kViewportAlternateDepthArray[1]);
+        vk::CmdSetViewport(set_state_fixed_count_cmd, 1, 1,
+                           i == 2 ? &test_data.kViewportArray[1] : &test_data.kViewportAlternateDepthArray[1]);
         vk::CmdSetScissor(set_state_fixed_count_cmd, 1, 1, &test_data.kScissorArray[1]);
         vk::EndCommandBuffer(set_state_fixed_count_cmd);
 
@@ -847,8 +849,7 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
         viewports[1] = test_data.kViewportArray[1];
         if (inherited_incorrect_depth) {
             viewports[2] = test_data.kViewportAlternateDepthArray[2];  // Will be a problem only when using all 3 viewports.
-        }
-        else {
+        } else {
             viewports[2] = test_data.kViewportArray[2];
         }
 
@@ -868,8 +869,7 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
         if (state_in_secondary) {
             set_state_cmd = set_state_with_count_cmd;
             test_data.BeginSubpassCommandBuffer(set_state_cmd, 0, nullptr);
-        }
-        else {
+        } else {
             set_state_cmd = primary_cmd;
         }
         uint32_t count = should_fail ? 3 : 2;
@@ -883,8 +883,7 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
         if (state_in_secondary) {
             VkCommandBuffer secondaries[] = {set_state_cmd, draw_cmd};
             vk::CmdExecuteCommands(primary_cmd, 2, secondaries);
-        }
-        else {
+        } else {
             vk::CmdExecuteCommands(primary_cmd, 1, &draw_cmd);
         }
         vk::CmdEndRenderPass(primary_cmd);
@@ -951,8 +950,7 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
         GTEST_SKIP() << "Test internal failure: " << test_data.FailureReason();
     }
 
-    VkCommandBufferInheritanceViewportScissorInfoNV viewport_scissor =
-        vku::InitStructHelper();
+    VkCommandBufferInheritanceViewportScissorInfoNV viewport_scissor = vku::InitStructHelper();
     viewport_scissor.viewportScissor2D = VK_TRUE;
     viewport_scissor.viewportDepthCount = 1;
     viewport_scissor.pViewportDepths = test_data.kViewportArray;
@@ -1062,8 +1060,7 @@ const VkPipelineMultisampleStateCreateInfo ViewportInheritanceTestData::kMultisa
     VK_SAMPLE_COUNT_1_BIT,
 };
 
-const VkPipelineDepthStencilStateCreateInfo ViewportInheritanceTestData::kDepthStencilState =
-    vku::InitStructHelper();
+const VkPipelineDepthStencilStateCreateInfo ViewportInheritanceTestData::kDepthStencilState = vku::InitStructHelper();
 
 const VkPipelineColorBlendAttachmentState ViewportInheritanceTestData::kBlendAttachmentState = {
     VK_FALSE,
@@ -1090,14 +1087,14 @@ const VkPipelineDynamicStateCreateInfo ViewportInheritanceTestData::kStaticState
 
 static const std::array<VkDynamicState, 2> kDynamicStateArray = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
 const VkPipelineDynamicStateCreateInfo ViewportInheritanceTestData::kDynamicState = {
-    VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, nullptr, 0,
-    static_cast<uint32_t>(kDynamicStateArray.size()), kDynamicStateArray.data()};
+    VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, nullptr, 0, static_cast<uint32_t>(kDynamicStateArray.size()),
+    kDynamicStateArray.data()};
 
 static const std::array<VkDynamicState, 2> kDynamicStateWithCountArray = {VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT,
                                                                           VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT};
 const VkPipelineDynamicStateCreateInfo ViewportInheritanceTestData::kDynamicStateWithCount = {
-    VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, nullptr, 0,
-    static_cast<uint32_t>(kDynamicStateWithCountArray.size()), kDynamicStateWithCountArray.data()};
+    VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, nullptr, 0, static_cast<uint32_t>(kDynamicStateWithCountArray.size()),
+    kDynamicStateWithCountArray.data()};
 
 const VkViewport ViewportInheritanceTestData::kViewportArray[32] = {
     {0.0f, 0.0f, 128.0f, 128.0f, 0.00f, 1.00f}, {0.0f, 0.0f, 128.0f, 128.0f, 0.01f, 0.99f},

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -195,7 +195,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
 
 TEST_F(NegativeWsi, SwapchainImage) {
     TEST_DESCRIPTION("Swapchain images with invalid parameters");
-    const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
+    const char* vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
 
     AddSurfaceExtension();
     AddRequiredFeature(vkt::Feature::sparseBinding);
@@ -612,7 +612,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages) {
     m_errorMonitor->VerifyFound();
 
     std::vector<VkFence> fence_handles;
-    for (const auto &fence : fences) {
+    for (const auto& fence : fences) {
         fence_handles.push_back(fence.handle());
     }
 
@@ -687,7 +687,7 @@ TEST_F(NegativeWsi, SwapchainNotSupported) {
     vkt::Device test_device(Gpu(), device_create_info);
 
     // Initialize extensions manually because we don't use InitState() in this test
-    for (const char *device_ext_name : m_device_extension_names) {
+    for (const char* device_ext_name : m_device_extension_names) {
         vk::InitDeviceExtension(instance(), test_device, device_ext_name);
     }
 
@@ -748,7 +748,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages2KHR) {
     m_errorMonitor->VerifyFound();
 
     std::vector<VkFence> fence_handles;
-    for (const auto &fence : fences) {
+    for (const auto& fence : fences) {
         fence_handles.push_back(fence.handle());
     }
 
@@ -1209,7 +1209,7 @@ TEST_F(NegativeWsi, DeviceMask) {
         if ((group_props[i].physicalDeviceCount > 1) && !test_run) {
             for (uint32_t j = 0; j < group_props[i].physicalDeviceCount; j++) {
                 if (tgt == group_props[i].physicalDevices[j]) {
-                    void *data;
+                    void* data;
                     VkDeviceMemory mi_mem;
                     alloc_flags_info.deviceMask = 3;
                     err = vk::AllocateMemory(device(), &alloc_info, NULL, &mi_mem);
@@ -3036,26 +3036,26 @@ TEST_F(NegativeWsi, CreatingWaylandSurface) {
     AddRequiredExtensions(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    wl_display *display = nullptr;
-    wl_registry *registry = nullptr;
-    wl_surface *surface = nullptr;
-    wl_compositor *compositor = nullptr;
+    wl_display* display = nullptr;
+    wl_registry* registry = nullptr;
+    wl_surface* surface = nullptr;
+    wl_compositor* compositor = nullptr;
     {
         display = wl_display_connect(nullptr);
         if (!display) {
             GTEST_SKIP() << "couldn't create wayland surface";
         }
 
-        auto global = [](void *data, struct wl_registry *registry, uint32_t id, const char *interface, uint32_t version) {
+        auto global = [](void* data, struct wl_registry* registry, uint32_t id, const char* interface, uint32_t version) {
             (void)version;
             const std::string_view interface_str = interface;
             if (interface_str == "wl_compositor") {
-                auto compositor = reinterpret_cast<wl_compositor **>(data);
-                *compositor = reinterpret_cast<wl_compositor *>(wl_registry_bind(registry, id, &wl_compositor_interface, 1));
+                auto compositor = reinterpret_cast<wl_compositor**>(data);
+                *compositor = reinterpret_cast<wl_compositor*>(wl_registry_bind(registry, id, &wl_compositor_interface, 1));
             }
         };
 
-        auto global_remove = [](void *data, struct wl_registry *registry, uint32_t id) {
+        auto global_remove = [](void* data, struct wl_registry* registry, uint32_t id) {
             (void)data;
             (void)registry;
             (void)id;
@@ -3120,7 +3120,7 @@ TEST_F(NegativeWsi, CreatingXcbSurface) {
     AddRequiredExtensions(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    xcb_connection_t *xcb_connection = xcb_connect(nullptr, nullptr);
+    xcb_connection_t* xcb_connection = xcb_connect(nullptr, nullptr);
     ASSERT_TRUE(xcb_connection);
 
     // NOTE: This is technically an invalid window! (There is no width/height)
@@ -3172,7 +3172,7 @@ TEST_F(NegativeWsi, CreatingX11Surface) {
         GTEST_SKIP() << "Test requires working display\n";
     }
 
-    Display *x11_display = XOpenDisplay(nullptr);
+    Display* x11_display = XOpenDisplay(nullptr);
     ASSERT_TRUE(x11_display != nullptr);
 
     const int screen = DefaultScreen(x11_display);
@@ -3344,7 +3344,7 @@ TEST_F(NegativeWsi, QueuePresentWaitingSameSemaphore) {
     fence.Wait(kWaitTimeout);
     SetPresentImageLayout(images[image_index]);
 
-    vkt::Queue *other = m_device->QueuesWithGraphicsCapability()[1];
+    vkt::Queue* other = m_device->QueuesWithGraphicsCapability()[1];
 
     m_default_queue->Submit(vkt::no_cmd, vkt::Wait(semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT));
 
@@ -5977,7 +5977,7 @@ TEST_F(NegativeWsi, PresentTimingsOutOfOrder) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;
@@ -6107,7 +6107,7 @@ TEST_F(NegativeWsi, PresentTimingsStageCount) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;
@@ -6237,7 +6237,7 @@ TEST_F(NegativeWsi, TimeDomain) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;
@@ -6349,7 +6349,7 @@ TEST_F(NegativeWsi, GetSwapchainTimeDomainProperties) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;
@@ -6438,7 +6438,7 @@ TEST_F(NegativeWsi, PresentTimingQueueUnset) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;
@@ -6542,7 +6542,7 @@ TEST_F(NegativeWsi, InvalidTimeDomainId) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -21,7 +21,7 @@ std::optional<VkPhysicalDeviceGroupProperties> WsiTest::FindPhysicalDeviceGroup(
     std::vector<VkPhysicalDeviceGroupProperties> physical_device_groups(physical_device_group_count,
                                                                         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, physical_device_groups.data());
-    for (const auto &physical_device_group : physical_device_groups) {
+    for (const auto& physical_device_group : physical_device_groups) {
         for (uint32_t k = 0; k < physical_device_group.physicalDeviceCount; k++) {
             if (physical_device_group.physicalDevices[k] == Gpu()) {
                 return physical_device_group;
@@ -113,7 +113,7 @@ TEST_F(PositiveWsi, CreateXcbSurface) {
     AddRequiredExtensions(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    xcb_connection_t *xcb_connection = xcb_connect(nullptr, nullptr);
+    xcb_connection_t* xcb_connection = xcb_connect(nullptr, nullptr);
     ASSERT_TRUE(xcb_connection);
 
     // NOTE: This is technically an invalid window! (There is no width/height)
@@ -148,7 +148,7 @@ TEST_F(PositiveWsi, CreateX11Surface) {
         GTEST_SKIP() << "Test requires working display\n";
     }
 
-    Display *x11_display = XOpenDisplay(nullptr);
+    Display* x11_display = XOpenDisplay(nullptr);
     ASSERT_TRUE(x11_display != nullptr);
 
     const int screen = DefaultScreen(x11_display);
@@ -1056,7 +1056,7 @@ TEST_F(PositiveWsi, DestroySwapchainWithBoundImages) {
     std::vector<vkt::Image> images(m_surface_capabilities.minImageCount);
 
     int i = 0;
-    for (auto &image : images) {
+    for (auto& image : images) {
         image.InitNoMemory(*m_device, image_create_info);
         VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper();
         bind_swapchain_info.swapchain = m_swapchain;
@@ -1463,7 +1463,7 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
         }
         // Add new frame
         frames.emplace_back(Frame{vkt::Semaphore(*m_device), vkt::Semaphore(*m_device), vkt::Fence(*m_device), i});
-        const Frame &frame = frames.back();
+        const Frame& frame = frames.back();
 
         const uint32_t image_index = m_swapchain.AcquireNextImage(frame.image_acquired, kWaitTimeout);
 
@@ -2300,10 +2300,10 @@ TEST_F(PositiveWsi, ExampleHowToReusePresentSemaphores2) {
 
     int frame_index = 0;
     for (uint32_t i = 0; i < 10; i++) {
-        vkt::Fence &present_fence = present_fences[frame_index];
-        vkt::CommandBuffer &command_buffer = command_buffers[frame_index];
-        vkt::Semaphore &acquire_semaphore = acquire_semaphores[frame_index];
-        vkt::Semaphore &present_semaphore = present_semaphores[frame_index];
+        vkt::Fence& present_fence = present_fences[frame_index];
+        vkt::CommandBuffer& command_buffer = command_buffers[frame_index];
+        vkt::Semaphore& acquire_semaphore = acquire_semaphores[frame_index];
+        vkt::Semaphore& present_semaphore = present_semaphores[frame_index];
 
         present_fence.Wait(kWaitTimeout);
         present_fence.Reset();
@@ -2419,15 +2419,15 @@ TEST_F(PositiveWsi, ProgressOnPresentOnlyQueue) {
     // Increase frame count and observe that the test does not continuously allocate memory.
     const int frame_count = 100;
     for (int i = 0; i < frame_count; i++) {
-        const vkt::Fence &frame_fence = frame_fences[frame_index];
-        const vkt::Semaphore &acquire_semaphore = acquire_semaphores[frame_index];
-        vkt::CommandBuffer &command_buffer = command_buffers[frame_index];
+        const vkt::Fence& frame_fence = frame_fences[frame_index];
+        const vkt::Semaphore& acquire_semaphore = acquire_semaphores[frame_index];
+        vkt::CommandBuffer& command_buffer = command_buffers[frame_index];
 
         frame_fence.Wait(kWaitTimeout);
         frame_fence.Reset();
 
         const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
-        const vkt::Semaphore &present_wait_semaphore = present_wait_semaphores[image_index];
+        const vkt::Semaphore& present_wait_semaphore = present_wait_semaphores[image_index];
 
         command_buffer.Begin();
         command_buffer.End();
@@ -2947,7 +2947,7 @@ TEST_F(PositiveWsi, PresentTimings) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;
@@ -3199,7 +3199,7 @@ TEST_F(PositiveWsi, PresentTimingsFull) {
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
 
     bool found = false;
-    for (const auto &available_mode : present_modes) {
+    for (const auto& available_mode : present_modes) {
         if (available_mode == present_mode) {
             found = true;
             break;
@@ -3312,7 +3312,7 @@ TEST_F(PositiveWsi, PresentIdWaitAndAcquireSemaphoreReuse) {
 
     // Frame 0
     const uint32_t frame0_image_index = m_swapchain.AcquireNextImage(acquire_semaphore_a, kWaitTimeout);
-    const vkt::Semaphore &frame0_submit_done_semaphore = submit_done_semaphores[frame0_image_index];
+    const vkt::Semaphore& frame0_submit_done_semaphore = submit_done_semaphores[frame0_image_index];
     m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore_a), vkt::Signal(frame0_submit_done_semaphore));
 
     present_id_value = 1;
@@ -3320,7 +3320,7 @@ TEST_F(PositiveWsi, PresentIdWaitAndAcquireSemaphoreReuse) {
 
     // Frame 1
     const uint32_t frame1_image_index = m_swapchain.AcquireNextImage(acquire_semaphore_b, kWaitTimeout);
-    const vkt::Semaphore &frame1_submit_done_semaphore = submit_done_semaphores[frame1_image_index];
+    const vkt::Semaphore& frame1_submit_done_semaphore = submit_done_semaphores[frame1_image_index];
     m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore_b), vkt::Signal(frame1_submit_done_semaphore));
 
     present_id_value = 2;
@@ -3373,7 +3373,7 @@ TEST_F(PositiveWsi, PresentIdWaitAndAcquireSemaphoreReuse2) {
 
     // Frame 0
     const uint32_t frame0_image_index = swapchain.AcquireNextImage(acquire_semaphore_a, kWaitTimeout);
-    const vkt::Semaphore &frame0_submit_done_semaphore = submit_done_semaphores[frame0_image_index];
+    const vkt::Semaphore& frame0_submit_done_semaphore = submit_done_semaphores[frame0_image_index];
     m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore_a), vkt::Signal(frame0_submit_done_semaphore));
 
     present_id_value = 1;
@@ -3381,7 +3381,7 @@ TEST_F(PositiveWsi, PresentIdWaitAndAcquireSemaphoreReuse2) {
 
     // Frame 1
     const uint32_t frame1_image_index = swapchain.AcquireNextImage(acquire_semaphore_b, kWaitTimeout);
-    const vkt::Semaphore &frame1_submit_done_semaphore = submit_done_semaphores[frame1_image_index];
+    const vkt::Semaphore& frame1_submit_done_semaphore = submit_done_semaphores[frame1_image_index];
     m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore_b), vkt::Signal(frame1_submit_done_semaphore));
 
     present_id_value = 2;

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -120,7 +120,7 @@ TEST_F(NegativeYcbcr, Sampler) {
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.minFilter = VK_FILTER_NEAREST;  // Different than chromaFilter
     sampler_info.magFilter = VK_FILTER_LINEAR;
-    sampler_info.pNext = (void *)&sampler_ycbcr_info;
+    sampler_info.pNext = (void*)&sampler_ycbcr_info;
     CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-minFilter-01645");
 
     sampler_info.magFilter = VK_FILTER_NEAREST;
@@ -1614,7 +1614,7 @@ TEST_F(NegativeYcbcr, DisjointImageWithDrmFormatModifier) {
     vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props);
 
     for (uint32_t i = 0; i < mod_props.drmFormatModifierCount; ++i) {
-        auto &mod = mod_props.pDrmFormatModifierProperties[i];
+        auto& mod = mod_props.pDrmFormatModifierProperties[i];
         if (((mod.drmFormatModifierTilingFeatures &
               (VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT | VK_FORMAT_FEATURE_DISJOINT_BIT)) ==
              (VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT | VK_FORMAT_FEATURE_DISJOINT_BIT))) {
@@ -1775,7 +1775,7 @@ TEST_F(NegativeYcbcr, TexelFetchNonArrayPartiallyBound) {
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo(&conversion_info));
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
-    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    uint32_t* buffer_ptr = (uint32_t*)buffer.Memory().Map();
     buffer_ptr[0] = 1;
 
     OneOffDescriptorIndexingSet descriptor_set(
@@ -2086,7 +2086,7 @@ TEST_F(NegativeYcbcr, DescriptorIndexCombinedSampledImage) {
                                        });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : require
         layout(set = 0, binding = 0) uniform sampler2D ycbcr[4];
@@ -2174,7 +2174,7 @@ TEST_F(NegativeYcbcr, DescriptorIndexSlang) {
                                        });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    const char *cs_source = R"slang(
+    const char* cs_source = R"slang(
         [[vk::binding(0, 0)]]
         uniform Sampler2D ycbcr[4];
 
@@ -2220,7 +2220,7 @@ TEST_F(NegativeYcbcr, DescriptorIndexShaderObject) {
                                            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                                        });
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : require
         layout(set = 0, binding = 0) uniform sampler2D ycbcr[4];


### PR DESCRIPTION
The "global reset" to just use Clang-Format 22 because seems clang-format 18 to 22 has a major regression and causing us to go back and forth which is annoying

(will be adding this to `.git-blame-ignore-revs`)

This now enforces version 22 and prints this if you get the CI error

<img width="1226" height="390" alt="Screenshot from 2026-03-18 15-40-38" src="https://github.com/user-attachments/assets/98c3cd38-6517-4d27-83fa-afa4ff5db9a4" />
