### PR TITLE
sync: Fix QueuePresent race condition

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2295,6 +2295,8 @@ bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresen
     // Since this early return is above the TlsGuard, the Record phase must also be.
     if (!syncval_settings.submit_time_validation) return skip;
 
+    std::lock_guard lock_guard(queue_mutex_);
+
     ClearPending();
 
     vvl::TlsGuard<QueuePresentCmdState> cmd_state(&skip, *this);
@@ -2475,7 +2477,7 @@ bool SyncValidator::ValidateQueueSubmit(VkQueue queue, uint32_t submitCount, con
     // Since this early return is above the TlsGuard, the Record phase must also be.
     if (!syncval_settings.submit_time_validation) return skip;
 
-    std::lock_guard lock_guard(queue_submit_mutex_);
+    std::lock_guard lock_guard(queue_mutex_);
 
     ClearPending();
 

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -63,7 +63,7 @@ class SyncValidator : public vvl::DeviceProxy {
     std::vector<std::shared_ptr<QueueSyncState>> queue_sync_states_;
     QueueId queue_id_limit_ = 0;
 
-    mutable std::mutex queue_submit_mutex_;
+    mutable std::mutex queue_mutex_;
 
     // Semaphore signal registry
     vvl::unordered_map<VkSemaphore, SignalInfo> binary_signals_;

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -1091,3 +1091,46 @@ TEST_F(PositiveSyncValWsi, PresentAfterAcquire) {
     m_default_queue->Present(m_swapchain, image_index, acquire_semaphore);
     m_default_queue->Wait();
 }
+
+TEST_F(PositiveSyncValWsi, ConcurrentPresentAndSubmit) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11226
+    TEST_DESCRIPTION("Present and Submit to different queues at the same time");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(InitSyncVal());
+    RETURN_IF_SKIP(InitSwapchain());
+
+    if (!IsPlatformMockICD()) {
+        // There is nvidia driver bug that causes device lost when you present/submit on different queues frequently.
+        // It is time dependent, reproducible only in release builds.
+        GTEST_SKIP() << "This test only runs on MockICD (until nvidia driver bug is fixed)";
+    }
+    if (!m_second_queue) {
+        GTEST_SKIP() << "Test requires two queues";
+    }
+
+    const auto swapchain_images = m_swapchain.GetImages();
+    for (auto image : swapchain_images) {
+        SetPresentImageLayout(image);
+    }
+    const int N = 500;
+
+    // QueueSubmit on the second queue and QueuePresent on the main queue run in parallel.
+    // It is a valid setup because submits to different queues do not require synchronization.
+    std::thread thread([&] {
+        vkt::Fence fence(*m_device);
+        for (int i = 0; i < N; i++) {
+            m_second_queue->Submit(vkt::no_cmd, fence);
+            fence.Wait(kWaitTimeout);
+            fence.Reset();
+        }
+    });
+    {
+        vkt::Semaphore acquire_semaphore(*m_device);
+        for (int i = 0; i < N; i++) {
+            const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+            m_default_queue->Present(m_swapchain, image_index, acquire_semaphore);
+            m_default_queue->Wait();
+        }
+    }
+    thread.join();
+}


### PR DESCRIPTION
`ClearPending` operations must be under queue_mutex.
In general all or most queue operations has to be under mutex but just focusing here on specific part.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11226
