### PR TITLE
sync: Fix SignalSemaphore race condition

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2746,6 +2746,13 @@ bool SyncValidator::PreCallValidateSignalSemaphore(VkDevice device, const VkSema
     if (!syncval_settings.submit_time_validation) {
         return skip;
     }
+    // Although SignalSemaphore does not run on the queue, the signalling can resolve
+    // previously submitted batches that are waiting for this signal, and this will
+    // initiate validation that touches queue state. That's why queue mutex is used here.
+    // NOTE: that's in addition that we call ClearPending, which itself needs queue mutex
+    // (but clear pending can go away in the future)
+    std::lock_guard lock_guard(queue_mutex_);
+
     ClearPending();
     vvl::TlsGuard<QueueSubmitCmdState> cmd_state(&skip, *this);
     SignalsUpdate& signals_update = cmd_state->signals_update;

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -773,3 +773,25 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitForFencesWithTimelineSignalBatches)
 
     m_default_queue->Wait();
 }
+
+TEST_F(PositiveSyncValTimelineSemaphore, ConcurrentHostSignalAndSubmit) {
+    TEST_DESCRIPTION("Concurrently signal timeline semaphore on the host and Submit to the queue");
+    RETURN_IF_SKIP(InitTimelineSemaphore());
+
+    const int N = 2000;
+    std::thread thread([&] {
+        vkt::Fence fence(*m_device);
+        for (int i = 0; i < N; i++) {
+            m_default_queue->Submit(vkt::no_cmd, fence);
+            fence.Wait(kWaitTimeout);
+            fence.Reset();
+        }
+    });
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+    {
+        for (int i = 0; i < N; i++) {
+            semaphore.Signal(i + 1);
+        }
+    }
+    thread.join();
+}


### PR DESCRIPTION
Similar to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11925 but for `vkSignalSemaphore`. 
The race condition triggered by the test fired assert in `SyncValidator::ApplyTaggedWait`.
Now all `ClearPending` calls are covered.
