### PR TITLE
tests: Check for supported coopmat type in Float8 test

### DIFF
--- a/tests/framework/cooperative_matrix_helper.cpp
+++ b/tests/framework/cooperative_matrix_helper.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "cooperative_matrix_helper.h"
+#include <spirv/unified1/spirv.hpp>
 #include <vulkan/vulkan_core.h>
 #include <vulkan/utility/vk_struct_helper.hpp>
 #include "containers/container_utils.h"
@@ -118,6 +119,33 @@ bool CooperativeMatrixHelper::HasValidProperty(VkScopeKHR scope, uint32_t m, uin
         return true;
     }
 
+    return false;
+}
+
+bool CooperativeMatrixHelper::HasSupportedMatrixUse(VkScopeKHR scope, uint32_t rows, uint32_t cols, VkComponentTypeKHR type,
+                                                    uint32_t use) const {
+    for (const auto& prop : coop_matrix_props) {
+        if (prop.scope != scope) continue;
+        if (use == spv::CooperativeMatrixUseMatrixAKHR && prop.AType == type && prop.MSize == rows && prop.KSize == cols)
+            return true;
+        if (use == spv::CooperativeMatrixUseMatrixBKHR && prop.BType == type && prop.KSize == rows && prop.NSize == cols)
+            return true;
+        if (use == spv::CooperativeMatrixUseMatrixAccumulatorKHR && (prop.CType == type || prop.ResultType == type) &&
+            prop.MSize == rows && prop.NSize == cols)
+            return true;
+    }
+    for (const auto& prop : coop_matrix_flex_props) {
+        if (prop.scope != scope) continue;
+        if (use == spv::CooperativeMatrixUseMatrixAKHR && prop.AType == type && (rows % prop.MGranularity) == 0 &&
+            (cols % prop.KGranularity) == 0)
+            return true;
+        if (use == spv::CooperativeMatrixUseMatrixBKHR && prop.BType == type && (rows % prop.KGranularity) == 0 &&
+            (cols % prop.NGranularity) == 0)
+            return true;
+        if (use == spv::CooperativeMatrixUseMatrixAccumulatorKHR && (prop.CType == type || prop.ResultType == type) &&
+            (rows % prop.MGranularity) == 0 && (cols % prop.NGranularity) == 0)
+            return true;
+    }
     return false;
 }
 

--- a/tests/framework/cooperative_matrix_helper.h
+++ b/tests/framework/cooperative_matrix_helper.h
@@ -31,5 +31,6 @@ class CooperativeMatrixHelper {
     bool Has64BitComponentType(const VkCooperativeMatrixPropertiesKHR &prop) const;
     bool Has16x16UintProperty() const;
     bool HasValidProperty(VkScopeKHR scope, uint32_t m, uint32_t n, uint32_t k, VkComponentTypeKHR type) const;
+    bool HasSupportedMatrixUse(VkScopeKHR scope, uint32_t rows, uint32_t cols, VkComponentTypeKHR type, uint32_t use) const;
     const char *VkComponentTypeToGLSL(VkComponentTypeKHR type) const;
 };

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -12,6 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <spirv/unified1/spirv.hpp>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/shader_object_helper.h"
@@ -273,6 +274,12 @@ TEST_F(PositiveShaderCooperativeMatrix, Float8) {
     AddRequiredFeature(vkt::Feature::shaderInt8);
     RETURN_IF_SKIP(InitCooperativeMatrixKHR());
 
+    CooperativeMatrixHelper helper(*this);
+    if (!helper.HasSupportedMatrixUse(VK_SCOPE_SUBGROUP_KHR, 16, 32, VK_COMPONENT_TYPE_FLOAT_E4M3_NV,
+                                      spv::CooperativeMatrixUseMatrixAKHR)) {
+        GTEST_SKIP() << "desired VkCooperativeMatrixPropertiesKHR not found";
+    }
+
     const char* cs_source = R"glsl(
         #version 450 core
         #extension GL_EXT_float_e4m3 : require
@@ -281,7 +288,7 @@ TEST_F(PositiveShaderCooperativeMatrix, Float8) {
         #extension GL_KHR_cooperative_matrix : enable
         layout(local_size_x = 32) in;
         void main() {
-            coopmat<floate4m3_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> cmA = coopmat<floate4m3_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA>(3.0);
+            coopmat<floate4m3_t, gl_ScopeSubgroup, 16, 32, gl_MatrixUseA> cmA = coopmat<floate4m3_t, gl_ScopeSubgroup, 16, 32, gl_MatrixUseA>(3.0);
         }
     )glsl";
 


### PR DESCRIPTION
16x16 is not supported on NVIDIA's implementation, so changed to 16x32 and added code to query for support.

(AI-generated).