### PR TITLE
layers: Turn 08608 into a warning

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -841,16 +841,16 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
     if (unset_status_pipeline.any()) {
         const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
-        skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::DYNAMIC_STATE_ALL_SET_08608), objlist, loc,
-                         "%s doesn't set up %s, but since the vkCmdBindPipeline, the related dynamic state commands (%s) have been "
-                         "called in this command buffer.",
-                         FormatHandle(pipeline).c_str(), DynamicStatesToString(unset_status_pipeline).c_str(),
-                         DynamicStatesCommandsToString(unset_status_pipeline).c_str());
-        // Dynamic state was not set, will produce garbage when trying to read to values
-        return skip;
+        // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4495
+        // It is not invalid to set dynamic state here, but we should warn the user what they are doing may lead to values not being
+        // what they think it should have been
+        skip |= LogWarning("WARNING-Ignored-DynamicState", objlist, loc,
+                           "%s was not created with full VkDynamicState, since the last vkCmdBindPipeline and this %s, the "
+                           "following commands have been ignored and didn't set the state you may think they did.\n%s",
+                           FormatHandle(pipeline).c_str(), String(loc.function),
+                           DynamicStatesCommandsToString(unset_status_pipeline).c_str());
     }
 
-    // Once we know for sure state was set, check value is valid
     skip |= ValidateDrawDynamicStatePipelineValue(last_bound_state, pipeline, loc);
     skip |= ValidateDrawDynamicStatePipelineViewportScissor(last_bound_state, pipeline, loc);
 
@@ -1476,10 +1476,12 @@ bool CoreChecks::ValidateTraceRaysDynamicStateSetStatus(const LastBound& last_bo
     } else {
         if (cb_state.dynamic_state_status.rtx_stack_size_pipeline) {
             const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
-            skip |= LogError(
-                CreateActionVuid(loc.function, vvl::ActionVUID::DYNAMIC_STATE_ALL_SET_08608), objlist, loc,
-                "%s doesn't set up VK_DYNAMIC_STATE_RAY_TRACING_PIPELINE_STACK_SIZE_KHR,  but since the vkCmdBindPipeline, the "
-                "related dynamic state commands (vkCmdSetRayTracingPipelineStackSizeKHR) have been called in this command buffer.",
+            // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4495
+            // We decided this is not invalid, but should be a warning to the user
+            skip |= LogWarning(
+                "WARNING-Ignored-vkCmdSetRayTracingPipelineStackSizeKHR", objlist, loc,
+                "%s doesn't set up VK_DYNAMIC_STATE_RAY_TRACING_PIPELINE_STACK_SIZE_KHR, but since the last vkCmdBindPipeline, "
+                "vkCmdSetRayTracingPipelineStackSizeKHR was called and will have no impact on the stack size.",
                 FormatHandle(pipeline).c_str());
         }
     }

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3856,13 +3856,19 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
         const auto rendering_color_attachment_count = cb_state.GetDynamicRenderingColorAttachmentCount();
         if (color_attachment_count != rendering_color_attachment_count) {
             const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
+            std::ostringstream ss;
+            ss << "Currently bound " << FormatHandle(pipeline)
+               << " was created with VkPipelineRenderingCreateInfo::colorAttachmentCount ("
+               << pipeline_rendering_ci.colorAttachmentCount << ") which must be equal to "
+               << (rp_state.use_dynamic_rendering ? "VkRenderingInfo" : "VkCommandBufferInheritanceRenderingInfo")
+               << "::colorAttachmentCount (" << rendering_color_attachment_count << ").\n";
+            if (pipeline_rendering_ci.colorAttachmentCount == 0 && pipeline.RasterizationDisabled()) {
+                ss << "Hint: Because rasterizerDiscardEnable was set to true, the colorAttachmentCount is ignored and "
+                      "vkCmdBeginRendering should match this.\n";
+            }
+            ss << "The dynamicRenderingUnusedAttachments feature allows a way to remove this restriction.";
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::DYNAMIC_RENDERING_COLOR_COUNT_06179), objlist, loc,
-                             "Currently bound %s was created with VkPipelineRenderingCreateInfo::colorAttachmentCount (%" PRIu32
-                             ") which must be equal to %s::colorAttachmentCount (%" PRIu32
-                             ").\nThe dynamicRenderingUnusedAttachments feature allows a way to remove this restriction.",
-                             FormatHandle(pipeline).c_str(), pipeline_rendering_ci.colorAttachmentCount,
-                             rp_state.use_dynamic_rendering ? "VkRenderingInfo" : "VkCommandBufferInheritanceRenderingInfo",
-                             rendering_color_attachment_count);
+                             "%s", ss.str().c_str());
         }
     }
 

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -780,6 +780,7 @@ std::string CreateActionVuid(vvl::Func function, const ActionVUID id) {
         // ### VUID-vkCmdDraw-maintenance4-08602
         case ActionVUID::PUSH_CONSTANT_08602: suffix = "maintenance4-08602"; break;
 
+        // TODO - Remove https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8149
         // ### VUID-vkCmdDraw-None-08608
         case ActionVUID::DYNAMIC_STATE_ALL_SET_08608: suffix = "None-08608"; break;
 

--- a/layers/vulkan/generated/dynamic_state_helper.cpp
+++ b/layers/vulkan/generated/dynamic_state_helper.cpp
@@ -3,8 +3,8 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 
 // NOLINTBEGIN
 
+#include <sstream>
 #include "state_tracker/pipeline_state.h"
 
 VkDynamicState ConvertToDynamicState(CBDynamicState dynamic_state) {
@@ -350,17 +351,16 @@ std::string DynamicStatesToString(CBDynamicFlags const& dynamic_states) {
 }
 
 std::string DynamicStatesCommandsToString(CBDynamicFlags const& dynamic_states) {
-    std::string ret;
+    std::ostringstream ss;
     // enum is not zero based
     for (int index = 1; index < CB_DYNAMIC_STATE_STATUS_NUM; ++index) {
         CBDynamicState status = static_cast<CBDynamicState>(index);
         if (dynamic_states[status]) {
-            if (!ret.empty()) ret.append(", ");
-            ret.append(DescribeDynamicStateCommand(status));
+            ss << " - " << DescribeDynamicStateCommand(status) << " (pipeline missing "
+               << string_VkDynamicState(ConvertToDynamicState(status)) << ")\n";
         }
     }
-    if (ret.empty()) ret.append("(Unknown Dynamic State)");
-    return ret;
+    return ss.str().c_str();
 }
 
 std::string DescribeDynamicStateCommand(CBDynamicState dynamic_state) {

--- a/layers/vulkan/generated/dynamic_state_helper.h
+++ b/layers/vulkan/generated/dynamic_state_helper.h
@@ -3,8 +3,8 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/generators/dynamic_state_generator.py
+++ b/scripts/generators/dynamic_state_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2023-2025 The Khronos Group Inc.
+# Copyright (c) 2023-2026 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -515,8 +515,8 @@ class DynamicStateOutputGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2023-2025 Valve Corporation
-            * Copyright (c) 2023-2025 LunarG, Inc.
+            * Copyright (c) 2023-2026 Valve Corporation
+            * Copyright (c) 2023-2026 LunarG, Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.
@@ -606,6 +606,7 @@ class DynamicStateOutputGenerator(BaseGenerator):
     def generateSource(self):
         out = []
         out.append('''
+            #include <sstream>
             #include "state_tracker/pipeline_state.h"
 
             VkDynamicState ConvertToDynamicState(CBDynamicState dynamic_state) {
@@ -659,17 +660,16 @@ class DynamicStateOutputGenerator(BaseGenerator):
             }
 
             std::string DynamicStatesCommandsToString(CBDynamicFlags const& dynamic_states) {
-                std::string ret;
+                std::ostringstream ss;
                 // enum is not zero based
                 for (int index = 1; index < CB_DYNAMIC_STATE_STATUS_NUM; ++index) {
                     CBDynamicState status = static_cast<CBDynamicState>(index);
                     if (dynamic_states[status]) {
-                        if (!ret.empty()) ret.append(", ");
-                        ret.append(DescribeDynamicStateCommand(status));
+                        ss << " - " << DescribeDynamicStateCommand(status) << " (pipeline missing "
+                        << string_VkDynamicState(ConvertToDynamicState(status)) << ")\\n";
                     }
                 }
-                if (ret.empty()) ret.append("(Unknown Dynamic State)");
-                return ret;
+                return ss.str().c_str();
             }
             ''')
 

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -3878,7 +3878,6 @@ TEST_F(NegativeDynamicState, SettingCommands) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
@@ -3891,7 +3890,7 @@ TEST_F(NegativeDynamicState, SettingCommands) {
     vk::CmdSetScissor(m_command_buffer, 0, 1, &scissor);
     vk::CmdSetLineWidth(m_command_buffer, 1);
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08608");
+    m_errorMonitor->SetDesiredWarning("WARNING-Ignored-DynamicState");
     vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
@@ -4526,7 +4525,7 @@ TEST_F(NegativeDynamicState, SetAfterStaticPipeline) {
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_static);
     vk::CmdSetLineWidth(m_command_buffer, 1.0f);
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08608");
+    m_errorMonitor->SetDesiredWarning("WARNING-Ignored-DynamicState");
     vk::CmdDraw(m_command_buffer, 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
 
@@ -4672,11 +4671,46 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
     depth_bias_representation.depthBiasRepresentation = VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORMAT_EXT;
     vk::CmdSetDepthBias2EXT(m_command_buffer, &depth_bias_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08608");
+    m_errorMonitor->SetDesiredWarning("WARNING-Ignored-DynamicState");
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeDynamicState, IgnoredFragmentShaderStage) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10897");
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
+    VkPipelineRenderingCreateInfo pipeline_rendering_ci = vku::InitStructHelper();
+    pipeline_rendering_ci.colorAttachmentCount = 1;
+    pipeline_rendering_ci.pColorAttachmentFormats = &color_format;
+
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_ci);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK);
+    pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
+    pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
+    pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
+    pipe.CreateGraphicsPipeline();
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.colorAttachmentCount = 0;
+    rendering_info.layerCount = 1;
+    rendering_info.renderArea = GetRenderTargetArea();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdSetStencilCompareMask(m_command_buffer, VK_STENCIL_FACE_FRONT_BIT, 1);
+    m_errorMonitor->SetDesiredWarning("WARNING-Ignored-DynamicState");
+    vk::CmdDraw(m_command_buffer, 3u, 1u, 0u, 0u);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
 

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -2081,7 +2081,7 @@ TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe);
     vk::CmdSetPrimitiveTopology(m_command_buffer, VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08608");
+    m_errorMonitor->SetDesiredWarning("WARNING-Ignored-DynamicState");
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10897
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11929
(from https://gitlab.khronos.org/vulkan/vulkan/-/issues/4495)

New message

```
Validation Warning: [ WARNING-Ignored-DynamicState ] | MessageID = 0xdbf513dc
vkCmdDraw(): VkPipeline 0x110000000011 was not created with full VkDynamicState, since the last vkCmdBindPipeline and this vkCmdDraw, the following commands have been ignored and didn't set the state you may think they did.
 - vkCmdSetViewport (pipeline missing VK_DYNAMIC_STATE_VIEWPORT)
 - vkCmdSetScissor (pipeline missing VK_DYNAMIC_STATE_SCISSOR)
 - vkCmdSetLineWidth (pipeline missing VK_DYNAMIC_STATE_LINE_WIDTH)
```