### PR TITLE
gpuav: init VmaVulkanFunctions functions to 0 to avoid uninitialized values

### DIFF
--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -158,7 +158,7 @@ static VKAPI_ATTR void VKAPI_CALL gpuVkCmdCopyBuffer(VkCommandBuffer commandBuff
 
 static VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device,
                                   VmaAllocator* pAllocator) {
-    VmaVulkanFunctions functions;
+    VmaVulkanFunctions functions = {};
     VmaAllocatorCreateInfo allocator_info = {};
     allocator_info.instance = instance;
     allocator_info.device = device;


### PR DESCRIPTION
When enabling gpuav, valgrind would complain (branch `vulkan-sdk-1.4.341.0`):

```
==45249== Conditional jump or move depends on uninitialised value(s)
==45249==    at 0x2557288C: VmaAllocator_T::ImportVulkanFunctions_Custom(VmaVulkanFunctions const*) (vk_mem_alloc.h:13231)
==45249==    by 0x2557D7E4: ImportVulkanFunctions (vk_mem_alloc.h:13139)
==45249==    by 0x2557D7E4: VmaAllocator_T::VmaAllocator_T(VmaAllocatorCreateInfo const*) (vk_mem_alloc.h:13043)
==45249==    by 0x2557DAC2: vmaCreateAllocator (vk_mem_alloc.h:15070)
==45249==    by 0x258C7330: UtilInitializeVma (gpuav_setup.cpp:190)
==45249==    by 0x258C7330: gpuav::Validator::FinishDeviceSetup(VkDeviceCreateInfo const*, Location const&) (gpuav_setup.cpp:247)
==45249==    by 0x2521DD27: vulkan_layer_chassis::CreateDevice(VkPhysicalDevice_T*, VkDeviceCreateInfo const*, VkAllocationCallbacks const*, VkDevice_T**) (chassis_manual.cpp:421)
==45249==    by 0x9562E58: loader_create_device_chain (loader.c:5539)
==45249==    by 0x9563C99: loader_layer_create_device (loader.c:4896)
==45249==    by 0x956CF59: vkCreateDevice (trampoline.c:998)
==45249==    by 0x4F53A3F: ggml_vk_get_device(unsigned long) [clone .lto_priv.0] (in /home/user/pkgbuild/src/build/bin/libggml-vulkan.so.0.9.7)
==45249==    by 0x4F8AFC7: ggml_backend_vk_host_buffer_type (in /home/user/pkgbuild/src/build/bin/libggml-vulkan.so.0.9.7)
==45249==    by 0x8CDE280: llama_model::load_tensors(llama_model_loader&) (in /usr/lib/libllama.so.0.0.8461)
==45249==    by 0x8C28FFF: ??? (in /usr/lib/libllama.so.0.0.8461)
```

`VmaAllocator_T::ImportVulkanFunctions_Custom` has this code which triggers valgrind (`x86_64/include/vma/vk_mem_alloc.h`):

```
   #if VMA_DEDICATED_ALLOCATION || VMA_VULKAN_VERSION >= 1001000
       VMA_COPY_IF_NOT_NULL(vkGetBufferMemoryRequirements2KHR);
       VMA_COPY_IF_NOT_NULL(vkGetImageMemoryRequirements2KHR);
   #endif
```

Fix this by initializing `VmaVulkanFunctions functions` to zero in `UtilInitializeVma`.