### PR TITLE
tests: Fix SamplerConversionDifferentHandle

### DIFF
--- a/tests/unit/sampler_positive.cpp
+++ b/tests/unit/sampler_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 #include <gtest/gtest.h>
 #include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
-#include "descriptor_helper.h"
 
 class PositiveSampler : public VkLayerTest {};
 
@@ -73,6 +72,8 @@ TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithFeature) {
 TEST_F(PositiveSampler, SamplerConversionDifferentHandle) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10920");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_6_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance6);
     AddRequiredFeature(vkt::Feature::samplerYcbcrConversion);
     RETURN_IF_SKIP(Init());
 
@@ -109,11 +110,36 @@ TEST_F(PositiveSampler, SamplerConversionDifferentHandle) {
     ycbcr_info.conversion = conversions_1;
     vkt::ImageView image_view = mpimage.CreateView(VK_IMAGE_ASPECT_PLANE_0_BIT, &ycbcr_info);
 
-    OneOffDescriptorSet descriptor_set(
-        m_device, {
-                      {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, &samplers_0.handle()},
-                  });
+    VkDescriptorSetLayoutBinding bindings{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL,
+                                          &samplers_0.handle()};
+    vkt::DescriptorSetLayout layout(*m_device, bindings);
 
-    descriptor_set.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE);
-    descriptor_set.UpdateDescriptorSets();
+    VkPhysicalDeviceMaintenance6PropertiesKHR maintenance6_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(maintenance6_props);
+
+    // Can't use OneOffDescriptorSet because need to account for YCbCr size
+    VkDescriptorPoolSize pool_sizes{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                    maintenance6_props.maxCombinedImageSamplerDescriptorCount};
+    VkDescriptorPoolCreateInfo pool_ci = vku::InitStructHelper();
+    pool_ci.flags = 0;
+    pool_ci.maxSets = 1;
+    pool_ci.poolSizeCount = 1;
+    pool_ci.pPoolSizes = &pool_sizes;
+    vkt::DescriptorPool pool(*m_device, pool_ci);
+
+    VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper();
+    ds_alloc_info.descriptorPool = pool;
+    ds_alloc_info.descriptorSetCount = 1;
+    ds_alloc_info.pSetLayouts = &layout.handle();
+    VkDescriptorSet descriptor_set;
+    vk::AllocateDescriptorSets(*m_device, &ds_alloc_info, &descriptor_set);
+
+    VkDescriptorImageInfo image_info = {VK_NULL_HANDLE, image_view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
+    descriptor_write.dstSet = descriptor_set;
+    descriptor_write.dstBinding = 0;
+    descriptor_write.descriptorCount = 1;
+    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    descriptor_write.pImageInfo = &image_info;
+    vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
 }


### PR DESCRIPTION
was failing on RADV, if you enabled maintenance6 you got the nice warning around `maxCombinedImageSamplerDescriptorCount`