### PR TITLE
sync: Make Present and SignalSemaphore validate only

### DIFF
--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -422,7 +422,7 @@ class QueueSyncState {
 
     // Unresolved batches state management.
     // The Validate phase makes request to update the list of unresolved batches by calling SetPendingUnresolvedBatches.
-    // Then the Record phase actually updates the list of unresolved batches by calling ApplyPendingLastBatch.
+    // Then the Record phase actually updates the list of unresolved batches by calling ApplyPendingUnresolvedBatches.
     // Pending unresovled batches is a mutable state. It relies on the queue external synchronization.
     const std::vector<UnresolvedBatch> &UnresolvedBatches() const { return unresolved_batches_; }
     void SetPendingUnresolvedBatches(std::vector<UnresolvedBatch> &&unresolved_batches) const;
@@ -457,6 +457,13 @@ struct QueueSubmitCmdState {
     std::shared_ptr<const QueueSyncState> queue;
     SignalsUpdate signals_update;
     QueueSubmitCmdState(const SyncValidator &sync_validator) : signals_update(sync_validator) {}
+};
+
+struct QueuePresentCmdState {
+    std::shared_ptr<const QueueSyncState> queue;
+    SignalsUpdate signals_update;
+    PresentedImages presented_images;
+    QueuePresentCmdState(const SyncValidator& sync_validator) : signals_update(sync_validator) {}
 };
 
 }  // namespace syncval

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2280,13 +2280,6 @@ void SyncValidator::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordOb
     host_waitable_semaphores_.clear();
 }
 
-struct QueuePresentCmdState {
-    std::shared_ptr<const QueueSyncState> queue;
-    SignalsUpdate signals_update;
-    PresentedImages presented_images;
-    QueuePresentCmdState(const SyncValidator& sync_validator) : signals_update(sync_validator) {}
-};
-
 bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                                    const ErrorObject& error_obj) const {
     bool skip = false;
@@ -2298,7 +2291,9 @@ bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresen
 
     ClearPending();
 
-    vvl::TlsGuard<QueuePresentCmdState> cmd_state(&skip, *this);
+    QueuePresentCmdState cmd_state_obj(*this);
+    QueuePresentCmdState* cmd_state = &cmd_state_obj;
+
     cmd_state->queue = GetQueueSyncStateShared(queue);
     if (!cmd_state->queue) return skip;  // Invalid Queue
 
@@ -2337,6 +2332,10 @@ bool SyncValidator::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresen
     if (!skip) {
         cmd_state->queue->SetPendingLastBatch(std::move(batch));
     }
+
+    if (!skip) {
+        const_cast<SyncValidator*>(this)->RecordQueuePresent(queue, cmd_state);
+    }
     return skip;
 }
 
@@ -2361,22 +2360,11 @@ uint32_t SyncValidator::SetupPresentInfo(const VkPresentInfoKHR& present_info, Q
     return static_cast<uint32_t>(presented_images.size());
 }
 
-void SyncValidator::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
-                                                  const RecordObject& record_obj) {
+void SyncValidator::RecordQueuePresent(VkQueue queue, QueuePresentCmdState* cmd_state) {
     stats.UpdateAccessStats(*this);
     stats.UpdateMemoryStats();
 
     if (!syncval_settings.submit_time_validation) {
-        return;
-    }
-
-    // The earliest return (when enabled), must be *after* the TlsGuard, as it is the TlsGuard that cleans up the cmd_state
-    // static payload
-    vvl::TlsGuard<QueuePresentCmdState> cmd_state;
-
-    // See vvl::Device::PostCallRecordQueuePresentKHR for spec excerpt supporting
-    if (record_obj.result == VK_ERROR_OUT_OF_HOST_MEMORY || record_obj.result == VK_ERROR_OUT_OF_DEVICE_MEMORY ||
-        record_obj.result == VK_ERROR_DEVICE_LOST) {
         return;
     }
 
@@ -2571,8 +2559,6 @@ bool SyncValidator::ValidateQueueSubmit(VkQueue queue, uint32_t submitCount, con
     if (!skip) {
         const_cast<SyncValidator*>(this)->RecordQueueSubmit(queue, fence, cmd_state);
     }
-
-    // Note that if we skip, guard cleans up for us, but cannot release the reserved tag range
     return skip;
 }
 
@@ -2754,7 +2740,10 @@ bool SyncValidator::PreCallValidateSignalSemaphore(VkDevice device, const VkSema
     std::lock_guard lock_guard(queue_mutex_);
 
     ClearPending();
-    vvl::TlsGuard<QueueSubmitCmdState> cmd_state(&skip, *this);
+
+    QueueSubmitCmdState cmd_state_obj(*this);
+    QueueSubmitCmdState* cmd_state = &cmd_state_obj;
+
     SignalsUpdate& signals_update = cmd_state->signals_update;
 
     auto semaphore_state = Get<vvl::Semaphore>(pSignalInfo->semaphore);
@@ -2771,6 +2760,10 @@ bool SyncValidator::PreCallValidateSignalSemaphore(VkDevice device, const VkSema
 
     signals.emplace_back(SignalInfo(semaphore_state, pSignalInfo->value));
     skip |= PropagateTimelineSignals(signals_update, error_obj);
+
+    if (!skip) {
+        const_cast<SyncValidator*>(this)->RecordSignalSemaphore(device, cmd_state);
+    }
     return skip;
 }
 
@@ -2779,29 +2772,16 @@ bool SyncValidator::PreCallValidateSignalSemaphoreKHR(VkDevice device, const VkS
     return PreCallValidateSignalSemaphore(device, pSignalInfo, error_obj);
 }
 
-void SyncValidator::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
-                                                  const RecordObject& record_obj) {
+void SyncValidator::RecordSignalSemaphore(VkDevice device, QueueSubmitCmdState* cmd_state) {
     if (!syncval_settings.submit_time_validation) {
         return;
     }
 
-    // The earliest return (when enabled), must be *after* the TlsGuard, as it is the TlsGuard that cleans up the cmd_state
-    // static payload
-    vvl::TlsGuard<QueueSubmitCmdState> cmd_state;
-
-    if (record_obj.result != VK_SUCCESS) {
-        return;
-    }
     ApplySignalsUpdate(cmd_state->signals_update, nullptr);
     for (const auto& qs : queue_sync_states_) {
         qs->ApplyPendingLastBatch();
         qs->ApplyPendingUnresolvedBatches();
     }
-}
-
-void SyncValidator::PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
-                                                     const RecordObject& record_obj) {
-    PostCallRecordSignalSemaphore(device, pSignalInfo, record_obj);
 }
 
 void SyncValidator::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -484,8 +484,7 @@ class SyncValidator : public vvl::DeviceProxy {
                                         const ErrorObject &error_obj) const override;
     uint32_t SetupPresentInfo(const VkPresentInfoKHR &present_info, QueueBatchContext::Ptr &batch,
                               PresentedImages &presented_images) const;
-    void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
-                                       const RecordObject &record_obj) override;
+    void RecordQueuePresent(VkQueue queue, QueuePresentCmdState* cmd_state);
     void PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
                                            VkFence fence, uint32_t *pImageIndex, const RecordObject &record_obj) override;
     void PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo, uint32_t *pImageIndex,
@@ -508,10 +507,7 @@ class SyncValidator : public vvl::DeviceProxy {
                                         const ErrorObject &error_obj) const override;
     bool PreCallValidateSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
                                            const ErrorObject &error_obj) const override;
-    void PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                       const RecordObject &record_obj) override;
-    void PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
-                                          const RecordObject &record_obj) override;
+    void RecordSignalSemaphore(VkDevice device, QueueSubmitCmdState* cmd_state);
     void PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
                                       const RecordObject &record_obj) override;
     void PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -879,20 +879,15 @@ TEST_F(PositiveSyncVal, WriteToImageAfterTransition) {
 TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     TEST_DESCRIPTION("Signal semaphore on the host and wait on the host");
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitSyncValFramework());
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitSyncVal());
     if (IsPlatformMockICD()) {
         // Mock does not support proper ordering of events, e.g. wait can return before signal
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     constexpr uint64_t max_signal_value = 10'000;
-
-    VkSemaphoreTypeCreateInfo semaphore_type_info = vku::InitStructHelper();
-    semaphore_type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&semaphore_type_info);
-    vkt::Semaphore semaphore(*m_device, create_info);
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
     std::atomic<bool> bailout{false};
     m_errorMonitor->SetBailout(&bailout);
@@ -901,10 +896,7 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     auto signaling_thread = std::thread{[&] {
         uint64_t last_signalled_value = 0;
         while (last_signalled_value != max_signal_value) {
-            VkSemaphoreSignalInfo signal_info = vku::InitStructHelper();
-            signal_info.semaphore = semaphore;
-            signal_info.value = ++last_signalled_value;
-            ASSERT_EQ(VK_SUCCESS, vk::SignalSemaphore(*m_device, &signal_info));
+            ASSERT_EQ(VK_SUCCESS, semaphore.Signal(++last_signalled_value));
             if (bailout.load()) {
                 break;
             }
@@ -913,12 +905,7 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     // Wait for each signal
     uint64_t wait_value = 1;
     while (wait_value <= max_signal_value) {
-        VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
-        wait_info.flags = VK_SEMAPHORE_WAIT_ANY_BIT;
-        wait_info.semaphoreCount = 1;
-        wait_info.pSemaphores = &semaphore.handle();
-        wait_info.pValues = &wait_value;
-        ASSERT_EQ(VK_SUCCESS, vk::WaitSemaphores(*m_device, &wait_info, vvl::kU64Max));
+        ASSERT_EQ(VK_SUCCESS, semaphore.Wait(wait_value, vvl::kU64Max));
         ++wait_value;
         if (bailout.load()) {
             break;


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8637 from 2 years ago which says "we can remove pending variables in the following PRs."

This PR is a preparation and it makes `QueuePresent` and `SignalSemaphore` works similar to `QueueSubmit` in a sense that everything in done in Validate method. 

Syncval queue operations do most of the work in Validate stage and use Record only to assign the computed values.  Using Record this way required intorduction of *pending varaibles* and it was a permanent source of complexity. Adding support of timeline semaphores few years ago moved us closer to removing pending variables  but it was never done.

This PR makes pending variables unnecessary (they move data only within a single function). The plan to remove them in the next PR is nothing major is missed.