### PR TITLE
layers: Rework AS state tracking

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -313,6 +313,7 @@ vvl_sources = [
   "layers/state_tracker/query_state.h",
   "layers/state_tracker/queue_state.cpp",
   "layers/state_tracker/queue_state.h",
+  "layers/state_tracker/ray_tracing_state.cpp",
   "layers/state_tracker/ray_tracing_state.h",
   "layers/state_tracker/render_pass_state.cpp",
   "layers/state_tracker/render_pass_state.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -402,6 +402,7 @@ target_sources(vvl PRIVATE
     state_tracker/tensor_state.h
     state_tracker/queue_state.cpp
     state_tracker/queue_state.h
+    state_tracker/ray_tracing_state.cpp
     state_tracker/ray_tracing_state.h
     state_tracker/render_pass_state.cpp
     state_tracker/render_pass_state.h

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -133,51 +133,60 @@ bool CoreChecks::ValidateAccelStructsMemoryDoNotOverlap(const Location& function
                                                         const char* vuid) const {
     bool skip = false;
 
-    const vvl::Buffer& buffer_a = *accel_struct_a.buffer_state;
-    const vvl::Buffer& buffer_b = *accel_struct_b.buffer_state;
+    const vvl::BufferAndOffset& buffer_a = accel_struct_a.GetFirstValidBuffer(*device_state);
+    const vvl::BufferAndOffset& buffer_b = accel_struct_b.GetFirstValidBuffer(*device_state);
+    if (!buffer_a || !buffer_b) {
+        return skip;
+    }
+    const vvl::range<VkDeviceSize> range_a(buffer_a.offset, accel_struct_a.GetSize());
+    const vvl::range<VkDeviceSize> range_b(buffer_b.offset, accel_struct_b.GetSize());
 
-    const vvl::range<VkDeviceSize> range_a(accel_struct_a.GetOffset(), accel_struct_a.GetSize());
-    const vvl::range<VkDeviceSize> range_b(accel_struct_b.GetOffset(), accel_struct_b.GetSize());
-
-    if (const auto [memory, overlap_range] = buffer_a.GetResourceMemoryOverlap(range_a, &buffer_b, range_b);
+    if (const auto [memory, overlap_range] = buffer_a.state->GetResourceMemoryOverlap(range_a, buffer_b.state, range_b);
         memory != VK_NULL_HANDLE) {
-        objlist.add(accel_struct_a.Handle(), buffer_a.Handle(), accel_struct_b.Handle(), buffer_b.Handle());
+        objlist.add(accel_struct_a.Handle(), buffer_a.state->Handle(), accel_struct_b.Handle(), buffer_b.state->Handle());
 
-        skip |= LogError(vuid, objlist, function_loc,
-                         "memory backing buffer (%s) used as storage for %s (%s) overlaps memory backing buffer (%s) used as "
-                         "storage for %s (%s). Overlapped memory is (%s) on range %s.",
-                         FormatHandle(buffer_a).c_str(), loc_a.Fields().c_str(), FormatHandle(accel_struct_a.Handle()).c_str(),
-                         FormatHandle(buffer_b).c_str(), loc_b.Fields().c_str(), FormatHandle(accel_struct_b.Handle()).c_str(),
-                         FormatHandle(memory).c_str(), string_range_hex(overlap_range).c_str());
+        skip |=
+            LogError(vuid, objlist, function_loc,
+                     "memory backing buffer (%s) used as storage for %s (%s) overlaps memory backing buffer (%s) used as "
+                     "storage for %s (%s). Overlapped memory is (%s) on range %s.",
+                     FormatHandle(*buffer_a.state).c_str(), loc_a.Fields().c_str(), FormatHandle(accel_struct_a.Handle()).c_str(),
+                     FormatHandle(*buffer_b.state).c_str(), loc_b.Fields().c_str(), FormatHandle(accel_struct_b.Handle()).c_str(),
+                     FormatHandle(memory).c_str(), string_range_hex(overlap_range).c_str());
     }
 
     return skip;
 }
 
 // Check to see if host-visible memory was bound to this buffer
-bool CoreChecks::ValidateAccelStructBufferMemoryIsHostVisible(const vvl::AccelerationStructureKHR& accel_struct,
-                                                              const Location& buffer_loc, const char* vuid) const {
-    bool result = false;
-    result |= ValidateMemoryIsBoundToBuffer(device, *accel_struct.buffer_state, buffer_loc, vuid);
-    if (!result) {
-        if (const auto memory_state = accel_struct.buffer_state->MemoryState()) {
-            if ((phys_dev_mem_props.memoryTypes[memory_state->allocate_info.memoryTypeIndex].propertyFlags &
-                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0) {
-                const LogObjectList objlist(accel_struct.Handle(), accel_struct.buffer_state->Handle(), memory_state->Handle());
-                result |=
-                    LogError(vuid, objlist, buffer_loc, "has been created with a buffer whose bound memory is not host visible.");
-            }
+bool CoreChecks::ValidateAccelStructBufferMemoryIsHostVisible(const vvl::AccelerationStructureKHR& as, const Location& buffer_loc,
+                                                              const char* vuid) const {
+    bool skip = false;
+    const auto as_buffer = as.GetFirstValidBuffer(*device_state);
+    if (!as_buffer) {
+        return skip;
+    }
+    skip |= ValidateMemoryIsBoundToBuffer(device, *as_buffer.state, buffer_loc, vuid);
+    if (const auto memory_state = as_buffer.state->MemoryState()) {
+        if ((phys_dev_mem_props.memoryTypes[memory_state->allocate_info.memoryTypeIndex].propertyFlags &
+             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0) {
+            const LogObjectList objlist(as.Handle(), as_buffer.state->Handle(), memory_state->Handle());
+            skip |= LogError(vuid, objlist, buffer_loc, "has been created with a buffer whose bound memory is not host visible.");
         }
     }
-    return result;
+
+    return skip;
 }
 
-bool CoreChecks::ValidateAccelStructBufferMemoryIsNotMultiInstance(const vvl::AccelerationStructureKHR& accel_struct,
+bool CoreChecks::ValidateAccelStructBufferMemoryIsNotMultiInstance(const vvl::AccelerationStructureKHR& as,
                                                                    const Location& accel_struct_loc, const char* vuid) const {
     bool skip = false;
-    if (const vvl::DeviceMemory* memory_state = accel_struct.buffer_state->MemoryState()) {
+    const auto as_buffer = as.GetFirstValidBuffer(*device_state);
+    if (!as_buffer) {
+        return skip;
+    }
+    if (const vvl::DeviceMemory* memory_state = as_buffer.state->MemoryState()) {
         if (memory_state->multi_instance) {
-            const LogObjectList objlist(accel_struct.Handle(), accel_struct.buffer_state->Handle(), memory_state->Handle());
+            const LogObjectList objlist(as.Handle(), as_buffer.state->Handle(), memory_state->Handle());
             skip |= LogError(vuid, objlist, accel_struct_loc,
                              "has been created with a buffer bound to memory (%s) that was allocated with multiple instances.",
                              FormatHandle(memory_state->Handle()).c_str());

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -263,11 +263,10 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
 
         if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
             src_as_state && info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
-            if (src_as_state->buffer_state && !src_as_state->buffer_state->sparse) {
-                const vvl::range<VkDeviceAddress> src_as_range = src_as_state->device_address_range;
-
+            if (const vvl::range<VkDeviceAddress> src_as_range = src_as_state->GetVvlEffectiveDeviceAddressRange();
+                !src_as_range.empty()) {
                 if (dst_as_state && dst_as_state->VkHandle() != src_as_state->VkHandle()) {
-                    const vvl::range<VkDeviceAddress> dst_as_range = dst_as_state->device_address_range;
+                    const vvl::range<VkDeviceAddress> dst_as_range = dst_as_state->GetVvlEffectiveDeviceAddressRange();
 
                     if (const vvl::range<VkDeviceAddress> dst_as_src_as_intersection = dst_as_range & src_as_range;
                         dst_as_src_as_intersection.non_empty()) {
@@ -324,9 +323,9 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
         }
 
         if (dst_as_state) {
-            if (dst_as_state->buffer_state && !dst_as_state->buffer_state->sparse) {
-                const AddressRange dst_as_address_range = {dst_as_state->device_address_range, info_i,
-                                                           AddressRangeOrigin::DstAccelStruct};
+            if (const vvl::range<VkDeviceAddress> dst_as_range = dst_as_state->GetVvlEffectiveDeviceAddressRange();
+                !dst_as_range.empty()) {
+                const AddressRange dst_as_address_range = {dst_as_range, info_i, AddressRangeOrigin::DstAccelStruct};
                 const std::optional<AddressRange> overlapped_address_range = insert_address(address_ranges, dst_as_address_range);
                 if (overlapped_address_range.has_value()) {
                     switch (overlapped_address_range->origin) {
@@ -462,16 +461,20 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureDeviceAddressKHR(VkDevic
                          device_state->physical_device_count);
     }
 
-    if (const auto accel_struct = Get<vvl::AccelerationStructureKHR>(pInfo->accelerationStructure)) {
+    if (const auto as = Get<vvl::AccelerationStructureKHR>(pInfo->accelerationStructure)) {
         const Location info_loc = error_obj.location.dot(Field::pInfo);
-        skip |= ValidateMemoryIsBoundToBuffer(device, *accel_struct->buffer_state,
-                                              info_loc.dot(Field::accelerationStructure).dot(Field::buffer),
-                                              "VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09541");
+        const auto as_buffer = as->GetFirstValidBuffer(*device_state);
+        if (!as_buffer) {
+            return skip;
+        }
+        skip |=
+            ValidateMemoryIsBoundToBuffer(device, *as_buffer.state, info_loc.dot(Field::accelerationStructure).dot(Field::buffer),
+                                          "VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09541");
 
-        if (!(accel_struct->buffer_state->usage & VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT)) {
+        if (!(as_buffer.state->usage & VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT)) {
             skip |= LogError("VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09542", LogObjectList(device),
                              info_loc.dot(Field::accelerationStructure).dot(Field::buffer), "was created with usage flag(s) %s.",
-                             string_VkBufferUsageFlags2(accel_struct->buffer_state->usage).c_str());
+                             string_VkBufferUsageFlags2(as_buffer.state->usage).c_str());
         }
     }
 
@@ -582,9 +585,9 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
                 if (info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR &&
                     info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
                     const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
-                    if (src_as_state && src_as_state->build_info_khr.has_value()) {
-                        if (geom_i < src_as_state->build_range_infos.size()) {
-                            if (const uint32_t recorded_primitive_count = src_as_state->build_range_infos[geom_i].primitiveCount;
+                    if (src_as_state && src_as_state->GetBuildInfo().has_value()) {
+                        if (geom_i < src_as_state->GetBuildRangeInfos().size()) {
+                            if (const uint32_t recorded_primitive_count = src_as_state->GetBuildRangeInfos()[geom_i].primitiveCount;
                                 recorded_primitive_count != geometry_build_range_primitive_count) {
                                 const Location pp_build_range_info_loc(info_loc.function, Field::ppBuildRangeInfos, info_i);
                                 const LogObjectList objlist(cmd_buffer, info.srcAccelerationStructure);
@@ -876,49 +879,49 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoUpdate(const vvl:
                                                                       const VulkanTypedHandle& handle) const {
     bool skip = false;
 
-    if (!src_as_state.build_info_khr.has_value()) {
+    if (!src_as_state.GetBuildInfo().has_value()) {
         return skip;
     }
-    if (!(src_as_state.build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR)) {
+    if (!(src_as_state.GetBuildInfo()->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR)) {
         const LogObjectList objlist(handle, info.srcAccelerationStructure);
         skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::IsBuilt_03667), objlist, info_loc.dot(Field::mode),
                          "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure has been previously "
                          "constructed with flags %s.",
-                         string_VkBuildAccelerationStructureFlagsKHR(src_as_state.build_info_khr->flags).c_str());
+                         string_VkBuildAccelerationStructureFlagsKHR(src_as_state.GetBuildInfo()->flags).c_str());
     }
 
-    if (info.flags != src_as_state.build_info_khr->flags) {
+    if (info.flags != src_as_state.GetBuildInfo()->flags) {
         const LogObjectList objlist(handle, info.srcAccelerationStructure);
         skip |=
             LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameFlags_03759), objlist, info_loc.dot(Field::mode),
                      "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but %s (%s) must have the same value as "
                      "specified when srcAccelerationStructure was last built (%s).",
                      info_loc.dot(Field::flags).Fields().c_str(), string_VkBuildAccelerationStructureFlagsKHR(info.flags).c_str(),
-                     string_VkBuildAccelerationStructureFlagsKHR(src_as_state.build_info_khr->flags).c_str());
+                     string_VkBuildAccelerationStructureFlagsKHR(src_as_state.GetBuildInfo()->flags).c_str());
     }
 
-    if (info.type != src_as_state.build_info_khr->type) {
+    if (info.type != src_as_state.GetBuildInfo()->type) {
         const LogObjectList objlist(handle, info.srcAccelerationStructure);
         skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameType_03760), objlist, info_loc.dot(Field::mode),
                          "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but type (%s) must have the same value as "
                          "specified when srcAccelerationStructure was last built (%s).",
                          string_VkAccelerationStructureTypeKHR(info.type),
-                         string_VkAccelerationStructureTypeKHR(src_as_state.build_info_khr->type));
+                         string_VkAccelerationStructureTypeKHR(src_as_state.GetBuildInfo()->type));
     }
 
-    if (info.geometryCount != src_as_state.build_info_khr->geometryCount) {
+    if (info.geometryCount != src_as_state.GetBuildInfo()->geometryCount) {
         const LogObjectList objlist(handle, info.srcAccelerationStructure);
         skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameCount_03758), objlist, info_loc.dot(Field::mode),
                          "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR,"
                          " but geometryCount (%" PRIu32
                          ") must have the same value as specified when "
                          "srcAccelerationStructure was last built (%" PRIu32 ").",
-                         info.geometryCount, src_as_state.build_info_khr->geometryCount);
+                         info.geometryCount, src_as_state.GetBuildInfo()->geometryCount);
     } else if (info.pGeometries || info.ppGeometries) {
         for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
             const VkAccelerationStructureGeometryKHR& updated_geometry = rt::GetGeometry(info, geom_i);
             const VkAccelerationStructureGeometryKHR& last_geometry =
-                rt::GetGeometry(*src_as_state.build_info_khr.value().ptr(), geom_i);
+                rt::GetGeometry(*src_as_state.GetBuildInfo().value().ptr(), geom_i);
 
             const Location geometry_ptr_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
 
@@ -1038,14 +1041,15 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
         if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
-            if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && src_as_state->use_create_info_1) {
-                if (!src_as_state->buffer_state) {
+            if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && src_as_state->UsesCreateInfo1()) {
+                const auto src_as_buffer = src_as_state->GetFirstValidBuffer(*device_state);
+                if (!src_as_buffer) {
                     const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
                     skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03708", objlist, info_loc.dot(Field::mode),
                                      "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
                                      "srcAccelerationStructure is not valid.");
                 } else {
-                    skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_state->buffer_state,
+                    skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_buffer.state,
                                                           info_loc.dot(Field::srcAccelerationStructure),
                                                           "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03708");
                 }
@@ -1055,9 +1059,14 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
         }
 
         if (const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
-            if (dst_as_state->use_create_info_1) {
-                skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state,
-                                                      info_loc.dot(Field::dstAccelerationStructure),
+            const auto dst_as_buffer = dst_as_state->GetFirstValidBuffer(*device_state);
+            if (!dst_as_buffer || dst_as_buffer.state->Destroyed()) {
+                const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
+                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03707", objlist,
+                                 info_loc.dot(Field::dstAccelerationStructure), "is backed by an invalid or destroyed buffer.");
+            } else {
+                skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_buffer.state,
+                                                      info_loc.dot(Field::srcAccelerationStructure),
                                                       "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03707");
             }
 
@@ -1115,7 +1124,7 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
         }
 
         if (dst_as_state) {
-            if (dst_as_state->use_create_info_2) {
+            if (dst_as_state->UsesCreateInfo2()) {
                 skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11703", info.dstAccelerationStructure,
                                  info_loc.dot(Field::dstAccelerationStructure),
                                  "was created with vkCreateAccelerationStructure2KHR, but needs to be created with "
@@ -1174,7 +1183,7 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
             }
         }
 
-        if (src_as_state && src_as_state->use_create_info_2) {
+        if (src_as_state && src_as_state->UsesCreateInfo2()) {
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
                 skip |=
                     LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11706", device, info_loc.dot(Field::mode),
@@ -1192,7 +1201,7 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
 
             const Location geometry_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
 
-            if (src_as_state && src_as_state->use_create_info_2) {
+            if (src_as_state && src_as_state->UsesCreateInfo2()) {
                 skip |=
                     LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11704", device, geometry_loc.dot(Field::geometryType),
                              "is VK_GEOMETRY_TYPE_INSTANCES_KHR, but srcAccelerationStructure was created with "
@@ -1201,9 +1210,9 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
 
             const VkAccelerationStructureBuildRangeInfoKHR& build_range = ppBuildRangeInfos[info_i][geom_i];
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && src_as_state &&
-                src_as_state->build_info_khr.has_value()) {
-                if (geom_i < src_as_state->build_range_infos.size()) {
-                    if (const uint32_t recorded_primitive_count = src_as_state->build_range_infos[geom_i].primitiveCount;
+                src_as_state->GetBuildInfo().has_value()) {
+                if (geom_i < src_as_state->GetBuildRangeInfos().size()) {
+                    if (const uint32_t recorded_primitive_count = src_as_state->GetBuildRangeInfos()[geom_i].primitiveCount;
                         recorded_primitive_count != build_range.primitiveCount) {
                         const LogObjectList objlist(info.srcAccelerationStructure);
                         skip |=
@@ -1289,29 +1298,33 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
 
         if (auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
-                if (src_as_state->use_create_info_1) {
-                    if (!src_as_state->buffer_state) {
-                        const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
-                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708", objlist,
-                                         info_loc.dot(Field::mode),
-                                         "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
-                                         "srcAccelerationStructure is not valid.");
-                    } else {
-                        skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_state->buffer_state,
-                                                              info_loc.dot(Field::srcAccelerationStructure),
-                                                              "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708");
-                    }
+                const auto src_as_buffer = src_as_state->GetFirstValidBuffer(*device_state);
+                if (!src_as_buffer) {
+                    const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
+                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708", objlist,
+                                     info_loc.dot(Field::mode),
+                                     "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
+                                     "srcAccelerationStructure is not valid.");
+                } else {
+                    skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_buffer.state,
+                                                          info_loc.dot(Field::srcAccelerationStructure),
+                                                          "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708");
                 }
-
                 skip |= ValidateAccelerationStructureBuildGeometryInfoUpdate(*src_as_state, info, info_loc, error_obj.handle);
             }
         }
 
         if (auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
-            skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state,
-                                                  info_loc.dot(Field::dstAccelerationStructure),
-                                                  "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03707");
-
+            const auto dst_as_buffer = dst_as_state->GetFirstValidBuffer(*device_state);
+            if (!dst_as_buffer || dst_as_buffer.state->Destroyed()) {
+                const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
+                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03707", objlist,
+                                 info_loc.dot(Field::dstAccelerationStructure), "is backed by an invalid or destroyed buffer.");
+            } else {
+                skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_buffer.state,
+                                                      info_loc.dot(Field::srcAccelerationStructure),
+                                                      "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03707");
+            }
             skip |= ValidateAccelerationStructureBuildDst(*dst_as_state, info, info_loc, error_obj.handle);
         }
 
@@ -1350,18 +1363,18 @@ bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevic
         skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*as_state, as_loc,
                                                                   "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03784");
 
-        if (as_state->build_info_khr.has_value()) {
+        if (as_state->GetBuildInfo().has_value()) {
             if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR) {
-                if (!(as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
+                if (!(as_state->GetBuildInfo()->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                     const LogObjectList objlist(device, pAccelerationStructures[i]);
                     skip |= LogError("VUID-vkWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431", objlist,
                                      as_loc, "has flags %s.",
-                                     string_VkBuildAccelerationStructureFlagsKHR(as_state->build_info_khr->flags).c_str());
+                                     string_VkBuildAccelerationStructureFlagsKHR(as_state->GetBuildInfo()->flags).c_str());
                 }
             }
         }
 
-        if (as_state->use_create_info_2) {
+        if (as_state->UsesCreateInfo2()) {
             skip |= LogError("VUID-vkWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-11592", device, as_loc,
                              "was created with vkCreateAccelerationStructure2KHR, but needs to be created with "
                              "vkCreateAccelerationStructureKHR");
@@ -1399,15 +1412,19 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
         auto as_state = Get<vvl::AccelerationStructureKHR>(pAccelerationStructures[i]);
         ASSERT_AND_CONTINUE(as_state);
 
-        skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *as_state->buffer_state, as_loc.dot(Field::buffer),
+        const auto as_buffer = as_state->GetFirstValidBuffer(*device_state);
+        if (!as_buffer) {
+            return skip;
+        }
+        skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *as_buffer.state, as_loc.dot(Field::buffer),
                                               "VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-buffer-03736");
 
-        if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR && as_state->build_info_khr.has_value()) {
-            if (!(as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
+        if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR && as_state->GetBuildInfo().has_value()) {
+            if (!(as_state->GetBuildInfo()->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                 skip |=
                     LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431", commandBuffer,
                              as_loc, "was built with %s, but queryType is VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR.",
-                             string_VkBuildAccelerationStructureFlagsKHR(as_state->build_info_khr->flags).c_str());
+                             string_VkBuildAccelerationStructureFlagsKHR(as_state->GetBuildInfo()->flags).c_str());
             }
         }
     }
@@ -1420,19 +1437,19 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
 
     auto src_as_state = Get<vvl::AccelerationStructureKHR>(as_info.src);
     if (src_as_state) {
-        if (src_as_state->use_create_info_1) {
-            if (auto buffer_state = Get<vvl::Buffer>(src_as_state->GetBuffer())) {
-                skip |= ValidateMemoryIsBoundToBuffer(device, *buffer_state, info_loc.dot(Field::src),
+        if (src_as_state->UsesCreateInfo1()) {
+            if (auto as_buffer = src_as_state->GetFirstValidBuffer(*device_state)) {
+                skip |= ValidateMemoryIsBoundToBuffer(device, *as_buffer.state, info_loc.dot(Field::src),
                                                       "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
             }
         } else {
             BufferAddressValidation<0> buffer_address_validator = {};
             skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::src), LogObjectList(handle),
-                                                                   src_as_state->buffer_device_address);
+                                                                   src_as_state->GetEffectiveDeviceAddressRange().address);
         }
 
-        if (as_info.mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR && src_as_state->build_info_khr.has_value()) {
-            if (!(src_as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
+        if (as_info.mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR && src_as_state->GetBuildInfo().has_value()) {
+            if (!(src_as_state->GetBuildInfo()->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                 const LogObjectList objlist(handle, as_info.src);
                 skip |= LogError("VUID-VkCopyAccelerationStructureInfoKHR-src-03411", objlist, info_loc.dot(Field::src),
                                  "(%s) must have been built with VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR"
@@ -1442,9 +1459,9 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
         }
     }
     auto dst_as_state = Get<vvl::AccelerationStructureKHR>(as_info.dst);
-    if (dst_as_state && dst_as_state->use_create_info_1) {
-        if (auto buffer_state = Get<vvl::Buffer>(dst_as_state->GetBuffer())) {
-            skip |= ValidateMemoryIsBoundToBuffer(device, *buffer_state, info_loc.dot(Field::dst),
+    if (dst_as_state && dst_as_state->UsesCreateInfo1()) {
+        if (auto dst_as_buffer = dst_as_state->GetFirstValidBuffer(*device_state)) {
+            skip |= ValidateMemoryIsBoundToBuffer(device, *dst_as_buffer.state, info_loc.dot(Field::dst),
                                                   "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03719");
         }
     }
@@ -1496,7 +1513,7 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureKHR(VkDevice device, Vk
         skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*src_accel_state, info_loc.dot(Field::src),
                                                                   "VUID-vkCopyAccelerationStructureKHR-buffer-03780");
 
-        if (src_accel_state->use_create_info_2) {
+        if (src_accel_state->UsesCreateInfo2()) {
             skip |= LogError("VUID-vkCopyAccelerationStructureKHR-src-11588", device, info_loc.dot(Field::srcAccelerationStructure),
                              "was created with vkCreateAccelerationStructure2KHR, but needs to be created with "
                              "vkCreateAccelerationStructureKHR");
@@ -1510,7 +1527,7 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureKHR(VkDevice device, Vk
         skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*dst_accel_state, info_loc.dot(Field::dst),
                                                                   "VUID-vkCopyAccelerationStructureKHR-buffer-03781");
 
-        if (dst_accel_state->use_create_info_2) {
+        if (dst_accel_state->UsesCreateInfo2()) {
             skip |= LogError("VUID-vkCopyAccelerationStructureKHR-dst-11589", device, info_loc.dot(Field::dstAccelerationStructure),
                              "was created with vkCreateAccelerationStructure2KHR, but needs to be created with "
                              "vkCreateAccelerationStructureKHR");
@@ -1526,16 +1543,16 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice de
     skip |= ValidateDeferredOperation(device, deferredOperation, error_obj.location.dot(Field::deferredOperation),
                                       "VUID-vkCopyAccelerationStructureToMemoryKHR-deferredOperation-03678");
 
-    if (const auto src_accel_struct = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
+    if (const auto src_as = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
         const Location info_loc = error_obj.location.dot(Field::pInfo);
 
-        if (src_accel_struct->use_create_info_1) {
-            if (auto buffer_state = Get<vvl::Buffer>(src_accel_struct->GetBuffer())) {
-                skip |= ValidateAccelStructBufferMemoryIsHostVisible(*src_accel_struct, info_loc.dot(Field::src),
+        if (src_as->UsesCreateInfo1()) {
+            if (auto src_as_buffer = src_as->GetFirstValidBuffer(*device_state)) {
+                skip |= ValidateAccelStructBufferMemoryIsHostVisible(*src_as, info_loc.dot(Field::src),
                                                                      "VUID-vkCopyAccelerationStructureToMemoryKHR-pInfo-03731");
 
                 skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(
-                    *src_accel_struct, info_loc.dot(Field::src), "VUID-vkCopyAccelerationStructureToMemoryKHR-buffer-03783");
+                    *src_as, info_loc.dot(Field::src), "VUID-vkCopyAccelerationStructureToMemoryKHR-buffer-03783");
             }
         } else {
             skip |= LogError("VUID-vkCopyAccelerationStructureToMemoryKHR-src-11678", device, info_loc.dot(Field::src),
@@ -1555,16 +1572,16 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkComman
     skip |= ValidateCmd(*cb_state, error_obj.location);
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
-    if (auto src_accel_struct = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
-        if (src_accel_struct->use_create_info_1) {
-            if (auto buffer_state = Get<vvl::Buffer>(src_accel_struct->GetBuffer())) {
-                skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, info_loc.dot(Field::src),
+    if (auto src_as = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
+        if (src_as->UsesCreateInfo1()) {
+            if (auto src_as_buffer = src_as->GetFirstValidBuffer(*device_state)) {
+                skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_buffer.state, info_loc.dot(Field::src),
                                                       "VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");
             }
         } else {
             BufferAddressValidation<0> buffer_address_validator = {};
             skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::src), LogObjectList(commandBuffer),
-                                                                   src_accel_struct->buffer_device_address);
+                                                                   src_as->GetEffectiveDeviceAddressRange().address);
         }
     }
 
@@ -1592,7 +1609,7 @@ bool CoreChecks::PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevice de
 
         skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*dst_accel_state, info_loc.dot(Field::dst),
                                                                   "VUID-vkCopyMemoryToAccelerationStructureKHR-buffer-03782");
-        if (dst_accel_state->use_create_info_2) {
+        if (dst_accel_state->UsesCreateInfo2()) {
             skip |= LogError("VUID-vkCopyMemoryToAccelerationStructureKHR-dst-11677", device, info_loc.dot(Field::dst),
                              "was created with vkCreateAccelerationStructure2KHR, but needs to be created with "
                              "vkCreateAccelerationStructureKHR");
@@ -1610,9 +1627,12 @@ bool CoreChecks::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkComman
     skip |= ValidateCmd(*cb_state, error_obj.location);
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
-    if (auto accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
-        skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *accel_state->buffer_state, info_loc.dot(Field::dst),
-                                              "VUID-vkCmdCopyMemoryToAccelerationStructureKHR-buffer-03745");
+    if (auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
+        auto dst_as_buffer = dst_as_state->GetFirstValidBuffer(*device_state);
+        if (dst_as_buffer) {
+            skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_buffer.state, info_loc.dot(Field::dst),
+                                                  "VUID-vkCmdCopyMemoryToAccelerationStructureKHR-buffer-03745");
+        }
     }
 
     const VkDeviceAddress src_address = pInfo->src.deviceAddress;

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -1184,8 +1184,8 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                                  DescribeDescriptor(resource_variable, index, descriptor_type).c_str(), FormatHandle(acc).c_str(),
                                  DescribeInstruction().c_str());
             }
-        } else if (acc_node->buffer_state) {
-            for (const auto& mem_binding : acc_node->buffer_state->GetInvalidMemory()) {
+        } else if (auto as_buffer = acc_node->GetFirstValidBuffer(*dev_proxy.device_state)) {
+            for (const auto& mem_binding : as_buffer.state->GetInvalidMemory()) {
                 const LogObjectList objlist(this->objlist, descriptor_set.Handle());
                 skip |= LogError(vuids->descriptor_buffer_bit_set_08114, objlist, loc.Get(),
                                  "the %s is using acceleration structure %s that references invalid memory %s.%s",

--- a/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
@@ -454,15 +454,16 @@ void TLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
 
             uint32_t written_count = 0;
             for (const vvl::AccelerationStructureKHR* as : gpuav.device_state->as_with_addresses.array) {
-                as_addresses_ptr[written_count] = as->acceleration_structure_address;
+                as_addresses_ptr[written_count] = as->GetAccelerationStructureAddress();
                 uint32_t metadata = 0;
-                const bool is_buffer_destroyed = as->buffer_state && !as->buffer_state->Destroyed();
-                const bool is_buffer_bound_to_memory = is_buffer_destroyed && as->buffer_state->IsMemoryBound();
-                metadata |= SET_BUILD_AS_METADATA_BUFFER_STATUS(is_buffer_destroyed);
+                const auto as_buf = as->GetFirstValidBuffer(*gpuav.device_state);
+                const bool is_buffer_alive = as_buf && !as_buf.state->Destroyed();
+                const bool is_buffer_bound_to_memory = is_buffer_alive && as_buf.state->IsMemoryBound();
+                metadata |= SET_BUILD_AS_METADATA_BUFFER_STATUS(is_buffer_alive);
                 metadata |= SET_BUILD_AS_METADATA_AS_TYPE(as->GetType());
                 metadata |= SET_BUILD_AS_METADATA_BUFFER_MEMORY_STATUS(is_buffer_bound_to_memory);
                 as_metadatas_ptr[written_count] = metadata;
-                const vvl::range<VkDeviceAddress> as_buffer_addr_range = as->device_address_range;
+                const vvl::range<VkDeviceAddress> as_buffer_addr_range = as->GetVvlEffectiveDeviceAddressRange();
                 as_buffer_addr_ranges_ptr[2 * written_count] = as_buffer_addr_range.begin;
                 as_buffer_addr_ranges_ptr[2 * written_count + 1] = as_buffer_addr_range.end;
 
@@ -496,7 +497,7 @@ void TLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
             auto blas_built_in_cmd_buffer_ptr = (uint64_t*)(blas_built_in_cmd_buffer.offset_mapped_ptr);
             for (const auto [i, blas_built_in_cmd] : vvl::enumerate(blas_built_in_cmd_array)) {
                 const vvl::range<VkDeviceAddress> blas_built_in_cmd_buffer_addr_range =
-                    blas_built_in_cmd.blas->device_address_range;
+                    blas_built_in_cmd.blas->GetVvlEffectiveDeviceAddressRange();
                 blas_built_in_cmd_buffer_ptr[2 * i] = blas_built_in_cmd_buffer_addr_range.begin;
                 blas_built_in_cmd_buffer_ptr[2 * i + 1] = blas_built_in_cmd_buffer_addr_range.end;
             }
@@ -603,14 +604,14 @@ void TLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
         const auto as_found_it =
             std::find_if(gpuav.device_state->as_with_addresses.array.begin(), gpuav.device_state->as_with_addresses.array.end(),
                          [blas_in_tlas_addr](vvl::AccelerationStructureKHR* as) {
-                             return as->acceleration_structure_address == blas_in_tlas_addr;
+                             return as->GetAccelerationStructureAddress() == blas_in_tlas_addr;
                          });
         std::stringstream ss_as;
         std::stringstream ss_as_buffer;
         if (as_found_it != gpuav.device_state->as_with_addresses.array.end()) {
             ss_as << "Acceleration structure corresponding to reference: " << gpuav.FormatHandle((*as_found_it)->VkHandle());
-            if ((*as_found_it)->buffer_state) {
-                ss_as_buffer << "(" << gpuav.FormatHandle((*as_found_it)->buffer_state->VkHandle()) << ") ";
+            if (const auto as_buffer = (*as_found_it)->GetFirstValidBuffer(*gpuav.device_state)) {
+                ss_as_buffer << "(" << gpuav.FormatHandle(as_buffer.state->VkHandle()) << ") ";
             }
         } else {
             ss_as << "Could not map acceleration structure reference to its corresponding handle, " << vvl_bug_msg;
@@ -669,21 +670,29 @@ void TLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
                 const BlasBuiltInCmd& blas_built_in_cmd = blas_built_in_cmd_array[blas_built_in_cmd_i];
                 std::stringstream error_ss;
                 if (as_found_it != gpuav.device_state->as_with_addresses.array.end()) {
-                    const vvl::range<VkDeviceAddress> blas_in_tlas_buffer_addr_range = (*as_found_it)->device_address_range;
+                    const vvl::range<VkDeviceAddress> blas_in_tlas_buffer_addr_range =
+                        (*as_found_it)->GetVvlEffectiveDeviceAddressRange();
                     const vvl::range<VkDeviceAddress> blas_built_in_cmd_buffer_addr_range =
-                        blas_built_in_cmd.blas->device_address_range;
+                        blas_built_in_cmd.blas->GetVvlEffectiveDeviceAddressRange();
                     const vvl::range<VkDeviceAddress> overlap =
                         blas_in_tlas_buffer_addr_range & blas_built_in_cmd_buffer_addr_range;
                     assert(overlap.non_empty());
                     const VkAccelerationStructureKHR blas_built_in_cmd_handle = blas_built_in_cmd.blas->VkHandle();
                     const VkAccelerationStructureKHR blas_in_tlas_handle = (*as_found_it)->VkHandle();
+                    const auto blas_cmd_as_buffer = blas_built_in_cmd.blas->GetFirstValidBuffer(*gpuav.device_state);
+                    const auto blas_tlas_as_buffer = (*as_found_it)->GetFirstValidBuffer(*gpuav.device_state);
                     if (blas_built_in_cmd_handle != blas_in_tlas_handle) {
-                        error_ss << "pInfos[" << blas_built_in_cmd.p_info_i << "].dstAccelerationStructure ("
-                                 << gpuav.FormatHandle(blas_built_in_cmd.blas->VkHandle()) << "), backed by buffer ("
-                                 << gpuav.FormatHandle(blas_built_in_cmd.blas->buffer_state->VkHandle())
-                                 << "), overlaps on buffer address range " << vvl::string_range_hex(overlap) << " with buffer ("
-                                 << gpuav.FormatHandle((*as_found_it)->buffer_state->VkHandle()) << ") of BLAS ("
-                                 << gpuav.FormatHandle((*as_found_it)->VkHandle()) << "), referenced in " << invalid_blas_loc_str;
+                        if (!blas_cmd_as_buffer || !blas_tlas_as_buffer) {
+                            error_ss << "Could not retrieve buffer information, " << vvl_bug_msg;
+                        } else {
+                            error_ss << "pInfos[" << blas_built_in_cmd.p_info_i << "].dstAccelerationStructure ("
+                                     << gpuav.FormatHandle(blas_built_in_cmd.blas->VkHandle()) << "), backed by buffer ("
+                                     << gpuav.FormatHandle(blas_cmd_as_buffer.state->VkHandle())
+                                     << "), overlaps on buffer address range " << vvl::string_range_hex(overlap) << " with buffer ("
+                                     << gpuav.FormatHandle(blas_tlas_as_buffer.state->VkHandle()) << ") of BLAS ("
+                                     << gpuav.FormatHandle((*as_found_it)->VkHandle()) << "), referenced in "
+                                     << invalid_blas_loc_str;
+                        }
                     } else {
                         error_ss << "pInfos[" << blas_built_in_cmd.p_info_i << "].dstAccelerationStructure ("
                                  << gpuav.FormatHandle(blas_built_in_cmd.blas->VkHandle())

--- a/layers/state_tracker/ray_tracing_state.cpp
+++ b/layers/state_tracker/ray_tracing_state.cpp
@@ -1,0 +1,149 @@
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "state_tracker/ray_tracing_state.h"
+
+#include "state_tracker/state_tracker.h"
+
+namespace vvl {
+
+AccelerationStructureKHR::AccelerationStructureKHR(vvl::DeviceState& device_state,
+                                                   const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
+                                                   VkAccelerationStructureKHR handle)
+    : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR),
+      create_info(std::in_place_type<CreateInfo1>, pCreateInfo, device_state.Get<vvl::Buffer>(pCreateInfo->buffer)) {
+    auto& ci_1 = std::get<CreateInfo1>(create_info);
+    if (ci_1.buffer_state) {
+        VkDeviceAddress buffer_address = 0;
+        if (ci_1.buffer_state->deviceAddress != 0) {
+            buffer_address = ci_1.buffer_state->deviceAddress;
+        } else if (ci_1.buffer_state->Binding()) {
+            buffer_address = device_state.GetBufferDeviceAddressHelper(ci_1.buffer_state->VkHandle());
+        }
+        device_address_range = {buffer_address + pCreateInfo->offset, pCreateInfo->size};
+    }
+}
+
+AccelerationStructureKHR::AccelerationStructureKHR(vvl::DeviceState& device_state,
+                                                   const VkAccelerationStructureCreateInfo2KHR* pCreateInfo,
+                                                   VkAccelerationStructureKHR handle)
+    : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR),
+      create_info(std::in_place_type<vku::safe_VkAccelerationStructureCreateInfo2KHR>, pCreateInfo),
+      device_address_range(pCreateInfo->addressRange) {}
+
+AccelerationStructureKHR::~AccelerationStructureKHR() {
+    if (!Destroyed()) {
+        Destroy();
+    }
+}
+
+void AccelerationStructureKHR::LinkChildNodes() {
+    if (auto* ci_1 = std::get_if<CreateInfo1>(&create_info)) {
+        if (ci_1->buffer_state) {
+            ci_1->buffer_state->AddParent(this);
+        }
+    }
+}
+
+void AccelerationStructureKHR::Destroy() {
+    for (auto& item : sub_states_) {
+        item.second->Destroy();
+    }
+    if (auto* ci_1 = std::get_if<CreateInfo1>(&create_info)) {
+        if (ci_1->buffer_state) {
+            ci_1->buffer_state->RemoveParent(this);
+            ci_1->buffer_state = nullptr;
+        }
+    }
+    StateObject::Destroy();
+}
+
+void AccelerationStructureKHR::NotifyInvalidate(const StateObject::NodeList& invalid_nodes, bool unlink) {
+    for (auto& item : sub_states_) {
+        item.second->NotifyInvalidate(invalid_nodes, unlink);
+    }
+    StateObject::NotifyInvalidate(invalid_nodes, unlink);
+}
+
+void AccelerationStructureKHR::Build(const VkAccelerationStructureBuildGeometryInfoKHR* pInfo, const bool is_host,
+                                     const VkAccelerationStructureBuildRangeInfoKHR* build_range_info) {
+    if (!GetBuildInfo().has_value()) {
+        build_geometry_info = vku::safe_VkAccelerationStructureBuildGeometryInfoKHR();
+    }
+    build_geometry_info->initialize(pInfo, is_host, build_range_info);
+};
+
+void AccelerationStructureKHR::UpdateBuildRangeInfos(const VkAccelerationStructureBuildRangeInfoKHR* p_build_range_infos,
+                                                     uint32_t geometry_count) {
+    build_range_infos.resize(geometry_count);
+    for (const auto [i, build_range] : vvl::enumerate(p_build_range_infos, geometry_count)) {
+        build_range_infos[i] = build_range;
+    }
+}
+
+bool AccelerationStructureKHR::UsesCreateInfo1() const { return std::get_if<CreateInfo1>(&create_info) != nullptr; }
+
+bool AccelerationStructureKHR::UsesCreateInfo2() const {
+    return std::get_if<vku::safe_VkAccelerationStructureCreateInfo2KHR>(&create_info) != nullptr;
+}
+
+BufferAndOffset AccelerationStructureKHR::GetFirstValidBuffer(const vvl::DeviceState& device_state) const {
+    if (const auto* ci_1 = std::get_if<CreateInfo1>(&create_info)) {
+        return {ci_1->buffer_state.get(), ci_1->ci.offset};
+    }
+
+    const auto& ci_2 = std::get<vku::safe_VkAccelerationStructureCreateInfo2KHR>(create_info);
+    const auto buffer_states = device_state.GetBuffersByAddress(ci_2.addressRange.address);
+    const vvl::range<VkDeviceAddress> as_addr_range{ci_2.addressRange.address, ci_2.addressRange.address + ci_2.addressRange.size};
+    for (const auto& as_buffer : buffer_states) {
+        if ((as_buffer->usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) &&
+            as_buffer->DeviceAddressRange().includes(as_addr_range)) {
+            return {as_buffer, ci_2.addressRange.address - as_buffer->deviceAddress};
+        }
+    }
+    return {nullptr, 0};
+}
+
+VkAccelerationStructureCreateFlagsKHR AccelerationStructureKHR::GetCreateFlags() const {
+    if (const auto* ci_1 = std::get_if<CreateInfo1>(&create_info)) {
+        return ci_1->ci.createFlags;
+    }
+    return std::get<vku::safe_VkAccelerationStructureCreateInfo2KHR>(create_info).createFlags;
+}
+
+VkDeviceSize AccelerationStructureKHR::GetSize() const {
+    if (const auto* ci_1 = std::get_if<CreateInfo1>(&create_info)) {
+        return ci_1->ci.size;
+    }
+    return device_address_range.size;
+}
+
+VkAccelerationStructureTypeKHR AccelerationStructureKHR::GetType() const {
+    if (const auto* ci_1 = std::get_if<CreateInfo1>(&create_info)) {
+        return ci_1->ci.type;
+    }
+    return std::get<vku::safe_VkAccelerationStructureCreateInfo2KHR>(create_info).type;
+}
+
+VkDeviceAddressRangeKHR AccelerationStructureKHR::GetEffectiveDeviceAddressRange() const { return device_address_range; }
+
+vvl::range<VkDeviceAddress> AccelerationStructureKHR::GetVvlEffectiveDeviceAddressRange() const {
+    const VkDeviceAddressRangeKHR khr_device_address_range = GetEffectiveDeviceAddressRange();
+    return {khr_device_address_range.address, khr_device_address_range.address + khr_device_address_range.size};
+}
+
+}  // namespace vvl

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -106,109 +106,79 @@ inline void AccelerationStructureNV::NotifyInvalidate(const StateObject::NodeLis
 
 class AccelerationStructureKHRSubState;
 
+struct BufferAndOffset {
+    vvl::Buffer *const state{};
+    VkDeviceSize offset{};
+    explicit operator bool() const { return state != nullptr; }
+};
+
 class AccelerationStructureKHR : public StateObject, public SubStateManager<AccelerationStructureKHRSubState> {
   public:
-    AccelerationStructureKHR(VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
-                             std::shared_ptr<Buffer> &&buf_state, const VkDeviceAddress buffer_device_address)
-        : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR),
-          buffer_state(buf_state),
-          buffer_device_address(buffer_device_address),
-          use_create_info_1(true),
-          use_create_info_2(false),
-          create_flags(pCreateInfo->createFlags),
-          offset(pCreateInfo->offset),
-          size(pCreateInfo->size),
-          type(pCreateInfo->type),
-          device_address_range(GetDeviceAddressRange()) {}
-    AccelerationStructureKHR(VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfo2KHR *pCreateInfo,
-                             std::shared_ptr<Buffer> &&buf_state, const VkDeviceAddress buffer_device_address)
-        : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR),
-          buffer_state(buf_state),
-          buffer_device_address(buffer_device_address),
-          use_create_info_1(false),
-          use_create_info_2(true),
-          create_flags(pCreateInfo->createFlags),
-          offset(pCreateInfo->addressRange.address - buffer_state->deviceAddress),
-          size(pCreateInfo->addressRange.size),
-          type(pCreateInfo->type),
-          device_address_range(pCreateInfo->addressRange.address,
-                               pCreateInfo->addressRange.address + pCreateInfo->addressRange.size) {}
+    AccelerationStructureKHR(vvl::DeviceState &device_state, const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
+                             VkAccelerationStructureKHR handle);
+
+    AccelerationStructureKHR(vvl::DeviceState &device_state, const VkAccelerationStructureCreateInfo2KHR *pCreateInfo,
+                             VkAccelerationStructureKHR handle);
     AccelerationStructureKHR(const AccelerationStructureKHR &rh_obj) = delete;
 
-    virtual ~AccelerationStructureKHR() {
-        if (!Destroyed()) {
-            Destroy();
-        }
-    }
+    virtual ~AccelerationStructureKHR();
 
     VkAccelerationStructureKHR VkHandle() const { return handle_.Cast<VkAccelerationStructureKHR>(); }
 
-    void LinkChildNodes() override {
-        // Connect child node(s), which cannot safely be done in the constructor.
-        buffer_state->AddParent(this);
-    }
+    void LinkChildNodes() override;
 
     void Destroy() override;
     void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) override;
 
     void Build(const VkAccelerationStructureBuildGeometryInfoKHR *pInfo, const bool is_host,
-               const VkAccelerationStructureBuildRangeInfoKHR *build_range_info) {
-        if (!build_info_khr.has_value()) {
-            build_info_khr = vku::safe_VkAccelerationStructureBuildGeometryInfoKHR();
-        }
-        build_info_khr->initialize(pInfo, is_host, build_range_info);
-    };
+               const VkAccelerationStructureBuildRangeInfoKHR *build_range_info);
 
-    void UpdateBuildRangeInfos(const VkAccelerationStructureBuildRangeInfoKHR *p_build_range_infos, uint32_t geometry_count) {
-        build_range_infos.resize(geometry_count);
-        for (const auto [i, build_range] : vvl::enumerate(p_build_range_infos, geometry_count)) {
-            build_range_infos[i] = build_range;
-        }
-    }
+    void UpdateBuildRangeInfos(const VkAccelerationStructureBuildRangeInfoKHR *p_build_range_infos, uint32_t geometry_count);
 
-    VkAccelerationStructureCreateFlagsKHR GetCreateFlags() const { return create_flags; }
-    VkBuffer GetBuffer() const { return buffer_state->VkHandle(); }
-    VkDeviceSize GetOffset() const { return offset; }
-    VkDeviceSize GetSize() const { return size; }
-    VkAccelerationStructureTypeKHR GetType() const { return type; }
-
-    uint64_t opaque_handle = 0;
-    std::shared_ptr<vvl::Buffer> buffer_state{};
-    // Used in case buffer_state->deviceAddress is 0 (happens if app never queried address)
-    const VkDeviceAddress buffer_device_address = 0;
-    VkDeviceAddress acceleration_structure_address = 0;
-    std::optional<vku::safe_VkAccelerationStructureBuildGeometryInfoKHR> build_info_khr{};
-    std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos{};
-
-    // VK_KHR_device_address_commands added a 2nd, much different, way to create the AS.
-    // Some VUs depend on which one was used
-    const bool use_create_info_1;
-    // Created with a VkDeviceAddress (VK_KHR_device_address_commands)
-    const bool use_create_info_2;
-
-  private:
-    const VkAccelerationStructureCreateFlagsKHR create_flags = 0;
-    const VkDeviceSize offset = 0;
-    const VkDeviceSize size = 0;
-    const VkAccelerationStructureTypeKHR type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
-
-    vvl::range<VkDeviceAddress> GetDeviceAddressRange() const {
-        if (!buffer_state) {
-            return {};
-        }
-        if (buffer_state->deviceAddress != 0) {
-            return {buffer_state->deviceAddress + offset, buffer_state->deviceAddress + offset + size};
-        }
-        return {buffer_device_address + offset, buffer_device_address + offset + size};
-    }
-
-  public:
+    bool UsesCreateInfo1() const;
+    bool UsesCreateInfo2() const;
+    // returns:
+    // - pointer to buffer backing AS (can be null)
+    // - offset in that buffer AS is stored at
+    // For AS created with create info version 1, always returns the buffer the AS was created with
+    // For AS created with create info version 2, returns a valid buffer with a device address range
+    // containing the VkDeviceAddressRangeKHR supplied at creation time.
+    // Given that in some scenarios address ranges lifespan does not match that of buffers it pertains to,
+    // the returned buffer should NOT be stored and assumed to always be backing the AS.
+    BufferAndOffset GetFirstValidBuffer(const vvl::DeviceState &device_state) const;
+    VkAccelerationStructureCreateFlagsKHR GetCreateFlags() const;
+    VkDeviceSize GetSize() const;
+    VkAccelerationStructureTypeKHR GetType() const;
     // Returns the device address range effectively occupied by the acceleration structure,
     // as defined by its creation info.
     // It does NOT take into account the acceleration structure address as returned by
     // vkGetAccelerationStructureDeviceAddress, this address may be at an offset
     // of the buffer range backing the acceleration structure
-    const vvl::range<VkDeviceAddress> device_address_range;
+    VkDeviceAddressRangeKHR GetEffectiveDeviceAddressRange() const;
+    vvl::range<VkDeviceAddress> GetVvlEffectiveDeviceAddressRange() const;
+    uint64_t GetOpaqueHandle() const { return opaque_handle; }
+    VkDeviceAddress GetAccelerationStructureAddress() const { return acceleration_structure_address; }
+    void SetAccelerationStructureAddress(VkDeviceAddress addr) { acceleration_structure_address = addr; }
+    const std::optional<vku::safe_VkAccelerationStructureBuildGeometryInfoKHR> &GetBuildInfo() const { return build_geometry_info; }
+    void SetBuildInfo(const std::optional<vku::safe_VkAccelerationStructureBuildGeometryInfoKHR> &info) {
+        build_geometry_info = info;
+    }
+    const std::vector<VkAccelerationStructureBuildRangeInfoKHR> &GetBuildRangeInfos() const { return build_range_infos; }
+
+  private:
+    struct CreateInfo1 {
+        CreateInfo1(const VkAccelerationStructureCreateInfoKHR *pCreateInfo, std::shared_ptr<vvl::Buffer> buffer)
+            : ci(pCreateInfo), buffer_state(std::move(buffer)) {}
+        vku::safe_VkAccelerationStructureCreateInfoKHR ci;
+        std::shared_ptr<vvl::Buffer> buffer_state;
+    };
+
+    std::variant<CreateInfo1, vku::safe_VkAccelerationStructureCreateInfo2KHR> create_info;
+    VkDeviceAddressRangeKHR device_address_range{};
+    uint64_t opaque_handle = 0;
+    VkDeviceAddress acceleration_structure_address = 0;
+    std::optional<vku::safe_VkAccelerationStructureBuildGeometryInfoKHR> build_geometry_info;
+    std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos{};
 };
 
 class AccelerationStructureKHRSubState {
@@ -222,23 +192,5 @@ class AccelerationStructureKHRSubState {
 
     AccelerationStructureKHR &base;
 };
-
-inline void AccelerationStructureKHR::Destroy() {
-    for (auto &item : sub_states_) {
-        item.second->Destroy();
-    }
-    if (buffer_state) {
-        buffer_state->RemoveParent(this);
-        buffer_state = nullptr;
-    }
-    StateObject::Destroy();
-}
-
-inline void AccelerationStructureKHR::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &item : sub_states_) {
-        item.second->NotifyInvalidate(invalid_nodes, unlink);
-    }
-    StateObject::NotifyInvalidate(invalid_nodes, unlink);
-}
 
 }  // namespace vvl

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -98,7 +98,7 @@ void DeviceState::RemoveSubState(LayerObjectTypeId id) {
     ForEachShared<vvl::ShaderObject>([id](std::shared_ptr<vvl::ShaderObject> state) { state->RemoveSubState(id); });
 }
 
-VkDeviceAddress DeviceState::GetBufferDeviceAddressHelper(VkBuffer buffer, const DeviceExtensions* exts = nullptr) const {
+VkDeviceAddress DeviceState::GetBufferDeviceAddressHelper(VkBuffer buffer, const DeviceExtensions* exts) const {
     // GPU-AV needs to pass in the modified extensions, since it may turn on BDA on its own
     if (!exts) {
         exts = &extensions;
@@ -2768,24 +2768,6 @@ void DeviceState::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
     Add(CreateAccelerationStructureState(*pAccelerationStructure, pCreateInfo));
 }
 
-std::shared_ptr<AccelerationStructureKHR> DeviceState::CreateAccelerationStructureState(
-    VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR* create_info,
-    std::shared_ptr<Buffer>&& buf_state) {
-    // If the buffer's device address has not been queried,
-    // get it here. Since it is used for the purpose of
-    // validation, do not try to update buffer_state, since
-    // it only tracks application state.
-    VkDeviceAddress buffer_address = 0;
-    if (buf_state) {
-        if (buf_state->deviceAddress != 0) {
-            buffer_address = buf_state->deviceAddress;
-        } else if (buf_state->Binding()) {
-            buffer_address = GetBufferDeviceAddressHelper(buf_state->VkHandle());
-        }
-    }
-    return std::make_shared<AccelerationStructureKHR>(handle, create_info, std::move(buf_state), buffer_address);
-}
-
 void DeviceState::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
                                                                const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator,
@@ -2794,8 +2776,7 @@ void DeviceState::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    auto buffer_state = Get<Buffer>(pCreateInfo->buffer);
-    Add(CreateAccelerationStructureState(*pAccelerationStructure, pCreateInfo, std::move(buffer_state)));
+    Add(std::make_shared<AccelerationStructureKHR>(*this, pCreateInfo, *pAccelerationStructure));
 }
 
 void DeviceState::PostCallRecordCreateAccelerationStructure2KHR(VkDevice device,
@@ -2806,16 +2787,7 @@ void DeviceState::PostCallRecordCreateAccelerationStructure2KHR(VkDevice device,
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-    // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11880
-    const auto buffer_states = GetBuffersByAddress(pCreateInfo->addressRange.address);
-    for (const auto buffer_state : buffer_states) {
-        if (buffer_state->usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) {
-            auto buffer_state_ptr = Get<Buffer>(buffer_state->VkHandle());
-            Add(std::make_shared<AccelerationStructureKHR>(*pAccelerationStructure, pCreateInfo, std::move(buffer_state_ptr),
-                                                           pCreateInfo->addressRange.address));
-            break;
-        }
-    }
+    Add(std::make_shared<AccelerationStructureKHR>(*this, pCreateInfo, *pAccelerationStructure));
 }
 
 void DeviceState::PostCallRecordBuildAccelerationStructuresKHR(
@@ -3001,7 +2973,7 @@ void DeviceState::PreCallRecordDestroyAccelerationStructureKHR(VkDevice device, 
                                                                const VkAllocationCallbacks* pAllocator,
                                                                const RecordObject& record_obj) {
     if (auto as_state = Get<vvl::AccelerationStructureKHR>(accelerationStructure)) {
-        if (as_state->acceleration_structure_address != 0) {
+        if (as_state->GetAccelerationStructureAddress() != 0) {
             WriteLockGuard lock(as_with_addresses.array_mutex);
             auto as_found_it = std::find(as_with_addresses.array.begin(), as_with_addresses.array.end(), as_state.get());
             while (as_found_it != as_with_addresses.array.end()) {
@@ -3011,7 +2983,7 @@ void DeviceState::PreCallRecordDestroyAccelerationStructureKHR(VkDevice device, 
 
                 as_found_it = std::find(as_with_addresses.array.begin() + i, as_with_addresses.array.end(), as_state.get());
             }
-            as_state->acceleration_structure_address = 0;
+            as_state->SetAccelerationStructureAddress(0);
         }
     }
     Destroy<AccelerationStructureKHR>(accelerationStructure);
@@ -5749,7 +5721,7 @@ void DeviceState::PostCallRecordCopyAccelerationStructureKHR(VkDevice device, Vk
     auto src_as_state = Get<AccelerationStructureKHR>(pInfo->src);
     auto dst_as_state = Get<AccelerationStructureKHR>(pInfo->dst);
     if (dst_as_state && src_as_state) {
-        dst_as_state->build_info_khr = src_as_state->build_info_khr;
+        dst_as_state->SetBuildInfo(src_as_state->GetBuildInfo());
     }
 }
 
@@ -5762,7 +5734,7 @@ void DeviceState::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer 
     auto src_as_state = Get<AccelerationStructureKHR>(pInfo->src);
     auto dst_as_state = Get<AccelerationStructureKHR>(pInfo->dst);
     if (dst_as_state && src_as_state) {
-        dst_as_state->build_info_khr = src_as_state->build_info_khr;
+        dst_as_state->SetBuildInfo(src_as_state->GetBuildInfo());
         if (!disabled[command_buffer_state]) {
             cb_state->AddChild(dst_as_state);
             cb_state->AddChild(src_as_state);
@@ -6573,7 +6545,7 @@ void DeviceState::PostCallRecordGetAccelerationStructureDeviceAddressKHR(VkDevic
         return;
     }
     if (auto as_state = Get<vvl::AccelerationStructureKHR>(pInfo->accelerationStructure)) {
-        as_state->acceleration_structure_address = record_obj.device_address;
+        as_state->SetAccelerationStructureAddress(record_obj.device_address);
         WriteLockGuard lock(as_with_addresses.array_mutex);
         if (as_with_addresses.array.capacity() <= (as_with_addresses.array.size() + 1)) {
             as_with_addresses.array.reserve(as_with_addresses.array.capacity() * 2);
@@ -6593,12 +6565,12 @@ small_vector<const vvl::AccelerationStructureKHR*, 2> DeviceState::GetAccelerati
     ReadLockGuard lock(as_with_addresses.array_mutex);
     auto as_found_it =
         std::find_if(as_with_addresses.array.begin(), as_with_addresses.array.end(),
-                     [address](vvl::AccelerationStructureKHR* as) { return as->acceleration_structure_address == address; });
+                     [address](vvl::AccelerationStructureKHR* as) { return as->GetAccelerationStructureAddress() == address; });
 
     while (as_found_it != as_with_addresses.array.end()) {
         as_vector.emplace_back(*as_found_it);
         as_found_it = std::find_if(as_found_it + 1, as_with_addresses.array.end(), [address](vvl::AccelerationStructureKHR* as) {
-            return as->acceleration_structure_address == address;
+            return as->GetAccelerationStructureAddress() == address;
         });
     }
     return as_vector;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -680,7 +680,7 @@ class DeviceState : public vvl::base::Device {
         return found_it->second;
     }
 
-    VkDeviceAddress GetBufferDeviceAddressHelper(VkBuffer buffer, const DeviceExtensions* exts) const;
+    VkDeviceAddress GetBufferDeviceAddressHelper(VkBuffer buffer, const DeviceExtensions* exts = nullptr) const;
 
     // From the spec:
     // If multiple VkBuffer objects are bound to overlapping ranges of VkDeviceMemory, implementations may return
@@ -859,9 +859,6 @@ class DeviceState : public vvl::base::Device {
                                                      const VkAllocationCallbacks* pAllocator,
                                                      const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::AccelerationStructureKHR> CreateAccelerationStructureState(
-        VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR* create_info,
-        std::shared_ptr<vvl::Buffer>&& buf_state);
     void PostCallRecordCreateAccelerationStructureKHR(VkDevice device, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator,
                                                       VkAccelerationStructureKHR* pAccelerationStructure,

--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -653,19 +653,21 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                             continue;
                         }
                         const vvl::AccelerationStructureKHR* accel = accel_descriptor->GetAccelerationStructureStateKHR();
-                        if (!accel || !accel->buffer_state) {
+                        if (!accel) {
                             continue;
                         }
-                        const AccessRange range = MakeRange(*accel->buffer_state, accel->GetOffset(), accel->GetSize());
-                        auto hazard = current_context_->DetectHazard(*accel->buffer_state, sync_index, range);
-                        // TODO: figure out what is the purpose of SuppressedBoundDescriptorWAW and do we still need it?
-                        if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
-                            LogObjectList objlist(cb_state_->Handle(), accel->buffer_state->Handle(), pipe->Handle());
-                            const std::string resource_description = sync_state_.FormatHandle(accel->Handle());
-                            const std::string error = error_messages_.AccelerationStructureDescriptorError(
-                                hazard, *this, loc.function, resource_description, *pipe, variable.decorations.set, *descriptor_set,
-                                descriptor_type, variable.decorations.binding, index, stage_state.GetStage());
-                            skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
+                        if (const vvl::BufferAndOffset as_buffer = accel->GetFirstValidBuffer(cb_state_->dev_data)) {
+                            const AccessRange range = MakeRange(*as_buffer.state, as_buffer.offset, accel->GetSize());
+                            auto hazard = current_context_->DetectHazard(*as_buffer.state, sync_index, range);
+                            // TODO: figure out what is the purpose of SuppressedBoundDescriptorWAW and do we still need it?
+                            if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
+                                LogObjectList objlist(cb_state_->Handle(), as_buffer.state->Handle(), pipe->Handle());
+                                const std::string resource_description = sync_state_.FormatHandle(accel->Handle());
+                                const std::string error = error_messages_.AccelerationStructureDescriptorError(
+                                    hazard, *this, loc.function, resource_description, *pipe, variable.decorations.set,
+                                    *descriptor_set, descriptor_type, variable.decorations.binding, index, stage_state.GetStage());
+                                skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
+                            }
                         }
                         break;
                     }
@@ -792,12 +794,14 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                             continue;
                         }
                         const vvl::AccelerationStructureKHR* accel = accel_descriptor->GetAccelerationStructureStateKHR();
-                        if (!accel || !accel->buffer_state) {
+                        if (!accel) {
                             continue;
                         }
-                        const AccessRange range = MakeRange(*accel->buffer_state, accel->GetOffset(), accel->GetSize());
-                        const ResourceUsageTagEx tag_ex = AddCommandHandle(tag, accel->Handle());
-                        current_context_->UpdateAccessState(*accel->buffer_state, sync_index, range, tag_ex);
+                        if (const vvl::BufferAndOffset as_buffer = accel->GetFirstValidBuffer(cb_state_->dev_data)) {
+                            const AccessRange range = MakeRange(*as_buffer.state, as_buffer.offset, accel->GetSize());
+                            const ResourceUsageTagEx tag_ex = AddCommandHandle(tag, accel->Handle());
+                            current_context_->UpdateAccessState(*as_buffer.state, sync_index, range, tag_ex);
+                        }
                         break;
                     }
                     // TODO: INLINE_UNIFORM_BLOCK_EXT

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2908,30 +2908,34 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
         }
         // Validate access to source acceleration structure
         if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
-            const AccessRange range = MakeRange(src_accel->GetOffset(), src_accel->GetSize());
-            auto hazard = context.DetectHazard(*src_accel->buffer_state,
-                                               SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ, range);
-            if (hazard.IsHazard()) {
-                const LogObjectList objlist(commandBuffer, src_accel->buffer_state->Handle(), src_accel->Handle());
-                const std::string resource_description = FormatHandle(src_accel->buffer_state->VkHandle());
-                const std::string error = error_messages_.AccelerationStructureError(
-                    hazard, cb_context, error_obj.location.function, resource_description, range, info.srcAccelerationStructure,
-                    info_loc.dot(Field::srcAccelerationStructure));
-                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+            if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
+                const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
+                auto hazard = context.DetectHazard(*src_as_buffer.state,
+                                                   SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ, range);
+                if (hazard.IsHazard()) {
+                    const LogObjectList objlist(commandBuffer, src_as_buffer.state->Handle(), src_accel->Handle());
+                    const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
+                    const std::string error = error_messages_.AccelerationStructureError(
+                        hazard, cb_context, error_obj.location.function, resource_description, range, info.srcAccelerationStructure,
+                        info_loc.dot(Field::srcAccelerationStructure));
+                    skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+                }
             }
         }
         // Validate access to the acceleration structure being built
         if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
-            const AccessRange dst_range = MakeRange(dst_accel->GetOffset(), dst_accel->GetSize());
-            auto hazard = context.DetectHazard(*dst_accel->buffer_state,
-                                               SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, dst_range);
-            if (hazard.IsHazard()) {
-                const LogObjectList objlist(commandBuffer, dst_accel->buffer_state->Handle(), dst_accel->Handle());
-                const std::string resource_description = FormatHandle(dst_accel->buffer_state->VkHandle());
-                const std::string error = error_messages_.AccelerationStructureError(
-                    hazard, cb_context, error_obj.location.function, resource_description, dst_range, info.dstAccelerationStructure,
-                    info_loc.dot(Field::dstAccelerationStructure));
-                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+            if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
+                const AccessRange dst_range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
+                auto hazard = context.DetectHazard(*dst_as_buffer.state,
+                                                   SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, dst_range);
+                if (hazard.IsHazard()) {
+                    const LogObjectList objlist(commandBuffer, dst_as_buffer.state->Handle(), dst_accel->Handle());
+                    const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
+                    const std::string error = error_messages_.AccelerationStructureError(
+                        hazard, cb_context, error_obj.location.function, resource_description, dst_range,
+                        info.dstAccelerationStructure, info_loc.dot(Field::dstAccelerationStructure));
+                    skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+                }
             }
         }
         // Validate geometry buffers
@@ -3014,17 +3018,21 @@ void SyncValidator::PostCallRecordCmdBuildAccelerationStructuresKHR(
         // If the source is the same as the destination then no need to record READ
         // (destination update will replace access with WRITE anyway).
         if (src_accel && src_accel != dst_accel) {
-            const AccessRange range = MakeRange(src_accel->GetOffset(), src_accel->GetSize());
-            const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_accel->buffer_state->Handle());
-            context.UpdateAccessState(*src_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ,
-                                      range, tag_ex);
+            if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
+                const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
+                const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_as_buffer.state->Handle());
+                context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_READ,
+                                          range, tag_ex);
+            }
         }
         // Record destination acceleration structure access (WRITE)
         if (dst_accel) {
-            const AccessRange dst_range = MakeRange(dst_accel->GetOffset(), dst_accel->GetSize());
-            const ResourceUsageTagEx dst_tag_ex = cb_context.AddCommandHandle(tag, dst_accel->buffer_state->Handle());
-            context.UpdateAccessState(*dst_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE,
-                                      dst_range, dst_tag_ex);
+            if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
+                const AccessRange dst_range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
+                const ResourceUsageTagEx dst_tag_ex = cb_context.AddCommandHandle(tag, dst_as_buffer.state->Handle());
+                context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE,
+                                          dst_range, dst_tag_ex);
+            }
         }
         // Record geometry buffer acceses (READ)
         const VkAccelerationStructureBuildRangeInfoKHR* p_range_infos = ppBuildRangeInfos[i];
@@ -3081,27 +3089,33 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuff
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
     if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
-        const AccessRange range = MakeRange(src_accel->GetOffset(), src_accel->GetSize());
-        auto hazard =
-            context.DetectHazard(*src_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
-        if (hazard.IsHazard()) {
-            const LogObjectList objlist(cb_state->Handle(), src_accel->buffer_state->Handle(), src_accel->Handle());
-            const std::string resource_description = FormatHandle(src_accel->buffer_state->VkHandle());
-            const std::string error = error_messages_.AccelerationStructureError(
-                hazard, cb_context, error_obj.location.function, resource_description, range, pInfo->src, info_loc.dot(Field::src));
-            skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+        if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
+            auto hazard =
+                context.DetectHazard(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
+            if (hazard.IsHazard()) {
+                const LogObjectList objlist(cb_state->Handle(), src_as_buffer.state->Handle(), src_accel->Handle());
+                const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
+                const std::string error =
+                    error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
+                                                               resource_description, range, pInfo->src, info_loc.dot(Field::src));
+                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+            }
         }
     }
     if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
-        const AccessRange range = MakeRange(dst_accel->GetOffset(), dst_accel->GetSize());
-        auto hazard =
-            context.DetectHazard(*dst_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
-        if (hazard.IsHazard()) {
-            const LogObjectList objlist(cb_state->Handle(), dst_accel->buffer_state->Handle(), dst_accel->Handle());
-            const std::string resource_description = FormatHandle(dst_accel->buffer_state->VkHandle());
-            const std::string error = error_messages_.AccelerationStructureError(
-                hazard, cb_context, error_obj.location.function, resource_description, range, pInfo->dst, info_loc.dot(Field::dst));
-            skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+        if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
+            auto hazard =
+                context.DetectHazard(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
+            if (hazard.IsHazard()) {
+                const LogObjectList objlist(cb_state->Handle(), dst_as_buffer.state->Handle(), dst_accel->Handle());
+                const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
+                const std::string error =
+                    error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
+                                                               resource_description, range, pInfo->dst, info_loc.dot(Field::dst));
+                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+            }
         }
     }
     return skip;
@@ -3117,16 +3131,20 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffe
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
     if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
-        const AccessRange range = MakeRange(src_accel->GetOffset(), src_accel->GetSize());
-        const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_accel->buffer_state->Handle());
-        context.UpdateAccessState(*src_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range,
-                                  tag_ex);
+        if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
+            const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_as_buffer.state->Handle());
+            context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range,
+                                      tag_ex);
+        }
     }
     if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
-        const AccessRange range = MakeRange(dst_accel->GetOffset(), dst_accel->GetSize());
-        const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_accel->buffer_state->Handle());
-        context.UpdateAccessState(*dst_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range,
-                                  tag_ex);
+        if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
+            const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_as_buffer.state->Handle());
+            context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range,
+                                      tag_ex);
+        }
     }
 }
 
@@ -3141,15 +3159,18 @@ bool SyncValidator::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkCom
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
     if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
-        const AccessRange range = MakeRange(src_accel->GetOffset(), src_accel->GetSize());
-        auto hazard =
-            context.DetectHazard(*src_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
-        if (hazard.IsHazard()) {
-            const LogObjectList objlist(cb_state->Handle(), src_accel->buffer_state->Handle(), src_accel->Handle());
-            const std::string resource_description = FormatHandle(src_accel->buffer_state->VkHandle());
-            const std::string error = error_messages_.AccelerationStructureError(
-                hazard, cb_context, error_obj.location.function, resource_description, range, pInfo->src, info_loc.dot(Field::src));
-            skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+        if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
+            auto hazard =
+                context.DetectHazard(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range);
+            if (hazard.IsHazard()) {
+                const LogObjectList objlist(cb_state->Handle(), src_as_buffer.state->Handle(), src_accel->Handle());
+                const std::string resource_description = FormatHandle(src_as_buffer.state->VkHandle());
+                const std::string error =
+                    error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
+                                                               resource_description, range, pInfo->src, info_loc.dot(Field::src));
+                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+            }
         }
     }
 
@@ -3171,10 +3192,12 @@ void SyncValidator::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkComm
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
     if (const auto src_accel = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
-        const AccessRange range = MakeRange(src_accel->GetOffset(), src_accel->GetSize());
-        const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_accel->buffer_state->Handle());
-        context.UpdateAccessState(*src_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range,
-                                  tag_ex);
+        if (const vvl::BufferAndOffset src_as_buffer = src_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(src_as_buffer.offset, src_accel->GetSize());
+            const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, src_as_buffer.state->Handle());
+            context.UpdateAccessState(*src_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_READ, range,
+                                      tag_ex);
+        }
     }
 }
 
@@ -3189,15 +3212,18 @@ bool SyncValidator::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkCom
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
     if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
-        const AccessRange range = MakeRange(dst_accel->GetOffset(), dst_accel->GetSize());
-        auto hazard =
-            context.DetectHazard(*dst_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
-        if (hazard.IsHazard()) {
-            const LogObjectList objlist(cb_state->Handle(), dst_accel->buffer_state->Handle(), dst_accel->Handle());
-            const std::string resource_description = FormatHandle(dst_accel->buffer_state->VkHandle());
-            const std::string error = error_messages_.AccelerationStructureError(
-                hazard, cb_context, error_obj.location.function, resource_description, range, pInfo->dst, info_loc.dot(Field::dst));
-            skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+        if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
+            auto hazard =
+                context.DetectHazard(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range);
+            if (hazard.IsHazard()) {
+                const LogObjectList objlist(cb_state->Handle(), dst_as_buffer.state->Handle(), dst_accel->Handle());
+                const std::string resource_description = FormatHandle(dst_as_buffer.state->VkHandle());
+                const std::string error =
+                    error_messages_.AccelerationStructureError(hazard, cb_context, error_obj.location.function,
+                                                               resource_description, range, pInfo->dst, info_loc.dot(Field::dst));
+                skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
+            }
         }
     }
 
@@ -3219,10 +3245,12 @@ void SyncValidator::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkComm
     const ResourceUsageTag tag = cb_context.NextCommandTag(record_obj.location.function);
 
     if (const auto dst_accel = Get<vvl::AccelerationStructureKHR>(pInfo->dst)) {
-        const AccessRange range = MakeRange(dst_accel->GetOffset(), dst_accel->GetSize());
-        const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_accel->buffer_state->Handle());
-        context.UpdateAccessState(*dst_accel->buffer_state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range,
-                                  tag_ex);
+        if (const vvl::BufferAndOffset dst_as_buffer = dst_accel->GetFirstValidBuffer(*device_state)) {
+            const AccessRange range = MakeRange(dst_as_buffer.offset, dst_accel->GetSize());
+            const ResourceUsageTagEx tag_ex = cb_context.AddCommandHandle(tag, dst_as_buffer.state->Handle());
+            context.UpdateAccessState(*dst_as_buffer.state, SYNC_ACCELERATION_STRUCTURE_COPY_ACCELERATION_STRUCTURE_WRITE, range,
+                                      tag_ex);
+        }
     }
 }
 

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -21,7 +21,9 @@
 
 class NegativeGpuAVRayTracing : public GpuAVRayTracingTest {};
 
-TEST_F(NegativeGpuAVRayTracing, CmdTraceRaysIndirect) {
+// In practice, tracing more rays than the driver allows will likely crash it
+// so disable this test
+TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirect) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::rayTracingPipeline);

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -5790,3 +5790,32 @@ TEST_F(NegativeRayTracing, DestroyedDeviceAddressRange) {
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeRayTracing, CreateInfo2DestroyBuffer) {
+    TEST_DESCRIPTION("Use create info version 2, destroy buffer after creation and try to use AS in a build");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DEVICE_ADDRESS_COMMANDS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::deviceAddressCommands);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    blas.GetDstAS()->SetCreateWithVersion2(true);
+    blas.GetDstAS()->SetAddressFlags(VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR);
+    blas.GetDstAS()->Create();
+
+    blas.GetDstAS()->GetBuffer().Destroy();
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03707");
+    blas.BuildCmdBuffer(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11880

Follow up to addition of 2nd version of AS create info using buffer address ranges instead of VkBuffer

@artem-lunarg I touched sync val a bit, goal was to avoid validation if the info it needs happens to no be available (almost never in practice)