### PR TITLE
layers: Rework some RT validation

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -1437,15 +1437,15 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
 
     auto src_as_state = Get<vvl::AccelerationStructureKHR>(as_info.src);
     if (src_as_state) {
-        if (src_as_state->UsesCreateInfo1()) {
-            if (auto as_buffer = src_as_state->GetFirstValidBuffer(*device_state)) {
-                skip |= ValidateMemoryIsBoundToBuffer(device, *as_buffer.state, info_loc.dot(Field::src),
-                                                      "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
-            }
+        const vvl::BufferAndOffset src_as_buffer = src_as_state->GetFirstValidBuffer(*device_state);
+        if (!src_as_buffer || src_as_buffer.state->Destroyed()) {
+            skip |= LogError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718", as_info.src,
+                             info_loc.dot(Field::srcAccelerationStructure), "is backed by %s buffer.",
+                             (!src_as_buffer ? "an invalid" : "a destroyed"));
         } else {
-            BufferAddressValidation<0> buffer_address_validator = {};
-            skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::src), LogObjectList(handle),
-                                                                   src_as_state->GetEffectiveDeviceAddressRange().address);
+            skip |= ValidateMemoryIsBoundToBuffer(LogObjectList(as_info.src, src_as_buffer.state->VkHandle()), *src_as_buffer.state,
+                                                  info_loc.dot(Field::srcAccelerationStructure),
+                                                  "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
         }
 
         if (as_info.mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR && src_as_state->GetBuildInfo().has_value()) {
@@ -1459,9 +1459,15 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
         }
     }
     auto dst_as_state = Get<vvl::AccelerationStructureKHR>(as_info.dst);
-    if (dst_as_state && dst_as_state->UsesCreateInfo1()) {
-        if (auto dst_as_buffer = dst_as_state->GetFirstValidBuffer(*device_state)) {
-            skip |= ValidateMemoryIsBoundToBuffer(device, *dst_as_buffer.state, info_loc.dot(Field::dst),
+    if (dst_as_state) {
+        const vvl::BufferAndOffset dst_as_buffer = dst_as_state->GetFirstValidBuffer(*device_state);
+        if (!dst_as_buffer || dst_as_buffer.state->Destroyed()) {
+            skip |= LogError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03719", as_info.dst,
+                             info_loc.dot(Field::dstAccelerationStructure), "is backed by %s buffer.",
+                             (!dst_as_buffer ? "an invalid" : "a destroyed"));
+        } else {
+            skip |= ValidateMemoryIsBoundToBuffer(LogObjectList(as_info.dst, dst_as_buffer.state->VkHandle()), *dst_as_buffer.state,
+                                                  info_loc.dot(Field::dstAccelerationStructure),
                                                   "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03719");
         }
     }
@@ -1572,16 +1578,17 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkComman
     skip |= ValidateCmd(*cb_state, error_obj.location);
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
-    if (auto src_as = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
-        if (src_as->UsesCreateInfo1()) {
-            if (auto src_as_buffer = src_as->GetFirstValidBuffer(*device_state)) {
-                skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_buffer.state, info_loc.dot(Field::src),
-                                                      "VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");
-            }
+    if (auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
+        const vvl::BufferAndOffset src_as_buffer = src_as_state->GetFirstValidBuffer(*device_state);
+        if (!src_as_buffer || src_as_buffer.state->Destroyed()) {
+            const LogObjectList objlist(commandBuffer, pInfo->src);
+            skip |= LogError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559", objlist,
+                             info_loc.dot(Field::srcAccelerationStructure), "is backed by %s buffer.",
+                             (!src_as_buffer ? "an invalid" : "a destroyed"));
         } else {
-            BufferAddressValidation<0> buffer_address_validator = {};
-            skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::src), LogObjectList(commandBuffer),
-                                                                   src_as->GetEffectiveDeviceAddressRange().address);
+            skip |= ValidateMemoryIsBoundToBuffer(LogObjectList(commandBuffer, pInfo->src, src_as_buffer.state->VkHandle()),
+                                                  *src_as_buffer.state, info_loc.dot(Field::srcAccelerationStructure),
+                                                  "VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");
         }
     }
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -5791,6 +5791,94 @@ TEST_F(NegativeRayTracing, DestroyedDeviceAddressRange) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure2KHR) {
+    TEST_DESCRIPTION(
+        "Test CmdCopyAccelerationStructureKHR with AS created with version 2 of create info, and the buffer backing either src or "
+        "dst has been destroyed.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DEVICE_ADDRESS_COMMANDS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::deviceAddressCommands);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    auto blas_no_buf = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096);
+    blas_no_buf->SetCreateWithVersion2(true);
+    blas_no_buf->SetAddressFlags(VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR);
+    blas_no_buf->Create();
+    blas_no_buf->GetBuffer().Destroy();
+
+    auto valid_blas = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096);
+    valid_blas->SetCreateWithVersion2(true);
+    valid_blas->SetAddressFlags(VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR);
+    valid_blas->Create();
+
+    VkCopyAccelerationStructureInfoKHR copy_info = vku::InitStructHelper();
+    copy_info.src = blas_no_buf->handle();
+    copy_info.dst = valid_blas->handle();
+    copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
+
+    m_command_buffer.Begin();
+
+    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
+    vk::CmdCopyAccelerationStructureKHR(m_command_buffer, &copy_info);
+    m_errorMonitor->VerifyFound();
+
+    copy_info.src = valid_blas->handle();
+    copy_info.dst = blas_no_buf->handle();
+    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03719");
+    vk::CmdCopyAccelerationStructureKHR(m_command_buffer, &copy_info);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemory2KHR) {
+    TEST_DESCRIPTION(
+        "vkCmdCopyAccelerationStructureToMemoryKHR with src AS created with version 2 of create info, "
+        "where the backing buffer has been destroyed");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DEVICE_ADDRESS_COMMANDS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::deviceAddressCommands);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    auto blas_no_buf = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096);
+    blas_no_buf->SetCreateWithVersion2(true);
+    blas_no_buf->SetAddressFlags(VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR);
+    blas_no_buf->Create();
+    blas_no_buf->GetBuffer().Destroy();
+
+    VkDeviceOrHostAddressKHR dst_addr{};
+    dst_addr.deviceAddress = Align<VkDeviceAddress>(0xbaadbeef, 256);
+    VkCopyAccelerationStructureToMemoryInfoKHR copy_info = vku::InitStructHelper();
+    copy_info.src = blas_no_buf->handle();
+    copy_info.dst = dst_addr;
+    copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
+
+    m_command_buffer.Begin();
+
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");
+    vk::CmdCopyAccelerationStructureToMemoryKHR(m_command_buffer, &copy_info);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeRayTracing, CreateInfo2DestroyBuffer) {
     TEST_DESCRIPTION("Use create info version 2, destroy buffer after creation and try to use AS in a build");
 


### PR DESCRIPTION
Following up on changes to AS state tracking,
unify how validation is done for VUs checking buffer memory state, independently from how ASes were created.