### PR TITLE
sync: Rename QueueSyncState to QueueState

### DIFF
--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -400,8 +400,7 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         auto queue_state = Get<vvl::Queue>(queue);
-        if (queue_state &&
-            queue_state->queue_family_properties.queueFlags != (VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)) {
+        if (queue_state && queue_state->GetQueueFlags() != (VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)) {
             skip |= LogPerformanceWarning("BestPractices-NVIDIA-QueueBindSparse-NotAsync", queue, error_obj.location,
                                           "issued on queue %s. All binds should happen on an asynchronous copy "
                                           "queue to hide the OS scheduling and submit costs.",

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -166,7 +166,7 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
     auto queue_state = Get<vvl::Queue>(queue);
     ASSERT_AND_RETURN_SKIP(queue_state);
     CommandBufferSubmitState cb_submit_state(*this, *queue_state);
-    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->queue_family_properties.queueFlags);
+    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->GetQueueFlags());
 
     // Now verify each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
@@ -353,7 +353,7 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
     auto queue_state = Get<vvl::Queue>(queue);
     ASSERT_AND_RETURN_SKIP(queue_state);
     CommandBufferSubmitState cb_submit_state(*this, *queue_state);
-    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->queue_family_properties.queueFlags);
+    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->GetQueueFlags());
 
     // Now verify each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
@@ -698,7 +698,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
     if (skip) return skip;
 
     auto queue_state = Get<vvl::Queue>(queue);
-    const VkQueueFlags queue_flags = queue_state->queue_family_properties.queueFlags;
+    const VkQueueFlags queue_flags = queue_state->GetQueueFlags();
     if (!(queue_flags & VK_QUEUE_SPARSE_BINDING_BIT)) {
         skip |= LogError("VUID-vkQueueBindSparse-queuetype", queue, error_obj.location,
                          "queueFamilyIndex %" PRIu32 " queueFlags are %s.", queue_state->queue_family_index,

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1136,7 +1136,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
     bool skip = false;
     auto queue_state = Get<vvl::Queue>(queue);
 
-    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->queue_family_properties.queueFlags);
+    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->GetQueueFlags());
 
     const Location present_info_loc = error_obj.location.dot(Struct::VkPresentInfoKHR, Field::pPresentInfo);
     for (uint32_t i = 0; i < pPresentInfo->waitSemaphoreCount; ++i) {

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -132,10 +132,10 @@ void vvl::Queue::Wait(const Location& loc, uint64_t until_seq) {
     }
     auto wait_status = waiter.wait_until(GetCondWaitTimeout());
     if (wait_status != std::future_status::ready) {
-        dev_data_.LogError("INTERNAL-ERROR-VkQueue-state-timeout", Handle(), loc,
-                           "The Validation Layers hit a timeout waiting for queue state to update."
-                           " seq=%" PRIu64 " until=%" PRIu64,
-                           seq_.load(), until_seq);
+        device_state_.LogError("INTERNAL-ERROR-VkQueue-state-timeout", Handle(), loc,
+                               "The Validation Layers hit a timeout waiting for queue state to update."
+                               " seq=%" PRIu64 " until=%" PRIu64,
+                               seq_.load(), until_seq);
     }
 }
 
@@ -304,7 +304,7 @@ void vvl::Queue::Retire(QueueSubmission& submission) {
     // When device is lost skip updating substates which might access destroyed/garbage objects.
     // NOTE: we still need to run semaphore/fence retire routines which do not work with Vulkan
     // handles but ensure correct invariants (for example, Fence::Retire sets its std::promise)
-    if (!dev_data_.is_device_lost) {
+    if (!device_state_.is_device_lost) {
         for (auto& item : sub_states_) {
             item.second->Retire(submission);
         }

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -136,19 +136,20 @@ struct PreSubmitResult {
 
 class Queue : public StateObject, public SubStateManager<QueueSubState> {
   public:
-    Queue(DeviceState &dev_data, VkQueue handle, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
-          const VkQueueFamilyProperties &queueFamilyProperties)
+    Queue(DeviceState& device_state, VkQueue handle, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
+          const VkQueueFamilyProperties& queue_family_properties)
         : StateObject(handle, kVulkanObjectTypeQueue),
           queue_family_index(family_index),
           queue_index(queue_index),
           create_flags(flags),
-          queue_family_properties(queueFamilyProperties),
-          dev_data_(dev_data) {}
+          device_state_(device_state),
+          queue_family_properties_(queue_family_properties) {}
 
     ~Queue() { Destroy(); }
     void Destroy() override;
 
     VkQueue VkHandle() const { return handle_.Cast<VkQueue>(); }
+    VkQueueFlags GetQueueFlags() const { return queue_family_properties_.queueFlags; }
 
     // called from the various PreCallRecordQueueSubmit() methods
     PreSubmitResult PreSubmit(std::vector<QueueSubmission> &&submissions);
@@ -180,7 +181,6 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
     const uint32_t queue_index;
 
     const VkDeviceQueueCreateFlags create_flags;
-    const VkQueueFamilyProperties queue_family_properties;
 
     // Track command buffer label stack accross all command buffers submitted to this queue.
     // Access to this variable relies on external queue synchronization.
@@ -211,12 +211,12 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
     void Retire(QueueSubmission &submission);
 
   private:
+    DeviceState& device_state_;
+    const VkQueueFamilyProperties queue_family_properties_;
     uint32_t timeline_wait_count_ = 0;
 
     void ThreadFunc();
     QueueSubmission *NextSubmission();
-
-    DeviceState &dev_data_;
 
     // state related to submitting to the queue, all data members must
     // be accessed with lock_ held

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -701,8 +701,8 @@ ResourceUsageInfo QueueBatchContext::GetResourceUsageInfo(ResourceUsageTagEx tag
     ResourceUsageInfo info = GetResourceUsageInfoFromRecord(tag_ex, record, access.debug_name_provider);
 
     const BatchAccessLog::BatchRecord& batch = *access.batch;
-    if (batch.queue) {
-        info.queue = batch.queue->GetQueueState();
+    if (batch.queue_state) {
+        info.queue = batch.queue_state->GetQueue();
         info.submit_index = batch.submit_index;
         info.batch_index = batch.batch_index;
         info.batch_base_tag = batch.base_tag;

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -60,7 +60,7 @@ void SignalsUpdate::OnBinarySignal(const vvl::Semaphore& semaphore_state, const 
         }
     }
     // Register signal
-    const VkQueueFlags queue_flags = batch->GetQueueSyncState()->GetQueueFlags();
+    const VkQueueFlags queue_flags = batch->GetQueueFlags();
     const auto exec_scope = SyncExecScope::MakeSrc(queue_flags, submit_signal.stageMask, VK_PIPELINE_STAGE_2_HOST_BIT);
     binary_signal_requests.emplace(semaphore, SignalInfo(semaphore_state.shared_from_this(), batch, exec_scope, 0));
 }
@@ -83,7 +83,7 @@ bool SignalsUpdate::OnTimelineSignal(const vvl::Semaphore& semaphore_state, cons
     }
 
     // Register signal
-    const VkQueueFlags queue_flags = batch->GetQueueSyncState()->GetQueueFlags();
+    const VkQueueFlags queue_flags = batch->GetQueueFlags();
     const auto exec_scope = SyncExecScope::MakeSrc(queue_flags, submit_signal.stageMask, VK_PIPELINE_STAGE_2_HOST_BIT);
     signals.emplace_back(SignalInfo(semaphore_state.shared_from_this(), batch, exec_scope, submit_signal.value));
     return true;
@@ -268,8 +268,8 @@ void LastSynchronizedPresent::OnDestroySwapchain(VkSwapchainKHR swapchain) {
     }
 }
 
-QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state, const QueueSyncState& queue_state)
-    : CommandExecutionContext(sync_state, queue_state.GetQueueFlags()),
+QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state, const QueueState& queue_state)
+    : CommandExecutionContext(sync_state, queue_state.GetQueue()->GetQueueFlags()),
       queue_state_(&queue_state),
       tag_range_(0, 0),
       access_context_(sync_state),
@@ -307,7 +307,7 @@ void QueueBatchContext::ResolveSubmittedCommandBuffer(const AccessContext& recor
     GetCurrentAccessContext()->ResolveFromContext(QueueTagOffsetBarrierAction(GetQueueId(), offset), recorded_context);
 }
 
-VulkanTypedHandle QueueBatchContext::Handle() const { return queue_state_->Handle(); }
+VulkanTypedHandle QueueBatchContext::Handle() const { return queue_state_->GetQueue()->Handle(); }
 
 template <typename Predicate>
 void QueueBatchContext::ApplyPredicatedWait(Predicate& predicate, const LastSynchronizedPresent& last_synchronized_present) {
@@ -389,7 +389,7 @@ void QueueBatchContext::ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag,
 
     // SwapChain acquire batch contexts have no queue
     if (queue_state_ && queue_id == GetQueueId()) {
-        events_context_.ApplyTaggedWait(queue_state_->GetQueueFlags(), tag);
+        events_context_.ApplyTaggedWait(GetQueueFlags(), tag);
     }
 }
 
@@ -399,7 +399,7 @@ void QueueBatchContext::ApplyDeviceWait(const LastSynchronizedPresent& last_sync
 
     // SwapChain acquire batch contexts have no queue
     if (queue_state_) {
-        events_context_.ApplyTaggedWait(queue_state_->GetQueueFlags(), ResourceUsageRecord::kMaxIndex);
+        events_context_.ApplyTaggedWait(GetQueueFlags(), ResourceUsageRecord::kMaxIndex);
     }
 }
 
@@ -414,7 +414,7 @@ void QueueBatchContext::OnResourceDestroyed(const AccessRange& resource_range) {
 }
 
 void QueueBatchContext::BeginRenderPassReplaySetup(ReplayState& replay, const SyncOpBeginRenderPass& begin_op) {
-    current_access_context_ = replay.ReplayStateRenderPassBegin(queue_state_->GetQueueFlags(), begin_op, access_context_);
+    current_access_context_ = replay.ReplayStateRenderPassBegin(GetQueueFlags(), begin_op, access_context_);
 }
 
 void QueueBatchContext::NextSubpassReplaySetup(ReplayState& replay) {
@@ -432,7 +432,7 @@ void QueueBatchContext::ResolvePresentSemaphoreWait(const SignalInfo& signal_inf
     const AccessContext& from_context = signal_info.batch->access_context_;
     const SemaphoreScope& signal_scope = signal_info.first_scope;
     const QueueId queue_id = GetQueueId();
-    const VkQueueFlags queue_flags = queue_state_->GetQueueFlags();
+    const VkQueueFlags queue_flags = GetQueueFlags();
     SemaphoreScope wait_scope{queue_id, SyncExecScope::MakeDst(queue_flags, VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL)};
 
     // If signal queue == wait queue, signal is treated as a memory barrier with an access scope equal to the present accesses
@@ -480,7 +480,7 @@ void QueueBatchContext::ResolveSubmitSemaphoreWait(const SignalInfo& signal_info
     assert(signal_info.batch);
 
     const SemaphoreScope& signal_scope = signal_info.first_scope;
-    const VkQueueFlags queue_flags = queue_state_->GetQueueFlags();
+    const VkQueueFlags queue_flags = GetQueueFlags();
     SemaphoreScope wait_scope{GetQueueId(), SyncExecScope::MakeDst(queue_flags, wait_mask)};
 
     const AccessContext& from_context = signal_info.batch->access_context_;
@@ -564,7 +564,7 @@ bool QueueBatchContext::DoQueuePresentValidate(const Location& loc, const Presen
             const VulkanTypedHandle swapchain_handle = vvl::StateObject::Handle(presented.swapchain_state.lock());
             const VulkanTypedHandle image_handle = vvl::StateObject::Handle(presented.image);
 
-            LogObjectList objlist(queue_state_->Handle(), swapchain_handle, image_handle);
+            LogObjectList objlist(queue_state_->GetQueue()->Handle(), swapchain_handle, image_handle);
 
             std::ostringstream ss;
             ss << "swapchain image " << presented.image_index << " (";
@@ -776,8 +776,8 @@ VkSwapchainKHR QueueBatchContext::AcquireResourceRecord::GetSwapchainHandle() co
 
 std::vector<BatchContextPtr> SyncValidator::GetLastBatches(std::function<bool(const BatchContextPtr&)> filter) const {
     std::vector<BatchContextPtr> snapshot;
-    for (const QueueSyncState& queue_sync_state : queue_sync_states_) {
-        auto batch = queue_sync_state.LastBatch();
+    for (const QueueState& queue_state : queue_states_) {
+        auto batch = queue_state.LastBatch();
         if (batch && filter(batch)) {
             snapshot.emplace_back(std::move(batch));
         }
@@ -785,18 +785,12 @@ std::vector<BatchContextPtr> SyncValidator::GetLastBatches(std::function<bool(co
     return snapshot;
 }
 
-// Note that function is const, but updates mutable submit_index to allow Validate to create correct tagging for command invocation
-// scope state.
-// Given that queue submits are supposed to be externally synchronized for the same queue, this should safe without being
-// atomic... but as the ops are per submit, the performance cost is negible for the peace of mind.
-uint64_t QueueSyncState::ReserveSubmitId() { return submit_index_++; }
-
-const LastSynchronizedPresent& QueueSyncState::GetLastSynchronizedPresent() const {
+const LastSynchronizedPresent& QueueState::GetLastSynchronizedPresent() const {
     static const LastSynchronizedPresent empty;
     return last_batch_ ? last_batch_->last_synchronized_present : empty;
 }
 
-void QueueSyncState::SetLastBatch(BatchContextPtr&& last) {
+void QueueState::SetLastBatch(BatchContextPtr&& last) {
     if (last) {
         // Clean up the events data in the previous last batch on queue, as only the subsequent
         // batches have valid use for them and the QueueBatchContext::Setup calls have be copying
@@ -809,7 +803,7 @@ void QueueSyncState::SetLastBatch(BatchContextPtr&& last) {
     }
 }
 
-void QueueSyncState::SetUnresolvedBatches(std::vector<UnresolvedBatch>&& unresolved_batches) {
+void QueueState::SetUnresolvedBatches(std::vector<UnresolvedBatch>&& unresolved_batches) {
     unresolved_batches_ = std::move(unresolved_batches);
 }
 

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -30,7 +30,7 @@ namespace syncval {
 
 struct PresentedImage;
 class QueueBatchContext;
-class QueueSyncState;
+class QueueState;
 class SyncValidator;
 
 using BatchContextPtr = std::shared_ptr<QueueBatchContext>;
@@ -180,7 +180,7 @@ using PresentedImages = std::vector<PresentedImage>;
 class BatchAccessLog {
   public:
     struct BatchRecord {
-        const QueueSyncState *queue = nullptr;
+        const QueueState* queue_state = nullptr;
         uint64_t submit_index = 0;
         uint32_t batch_index = 0;
         uint32_t cb_index = 0;
@@ -261,7 +261,7 @@ struct UnresolvedBatch {
 
 // Helper struct to resolve wait-before-signal
 struct UnresolvedQueue {
-    QueueSyncState* queue_state = nullptr;
+    QueueState* queue_state = nullptr;
     std::vector<UnresolvedBatch> unresolved_batches;
     // whether unresolved state should be updated for this queue
     bool update_unresolved = false;
@@ -277,6 +277,41 @@ struct LastSynchronizedPresent {
     void Update(VkSwapchainKHR swapchain, ResourceUsageTag present_tag);
     void Merge(const LastSynchronizedPresent &other);
     void OnDestroySwapchain(VkSwapchainKHR swapchain);
+};
+
+// Queue state used by synchronization validation.
+// Contains the last batch and the list of unresolved batches.
+class QueueState {
+  public:
+    QueueState(const std::shared_ptr<vvl::Queue>& queue, QueueId id) : queue_(queue), id_(id) {}
+
+    const vvl::Queue* GetQueue() const { return queue_.get(); }
+    QueueId GetQueueId() const { return id_; }
+    uint64_t ReserveSubmitId() { return submit_index_++; }
+
+    const LastSynchronizedPresent& GetLastSynchronizedPresent() const;
+
+    BatchContextPtr LastBatch() const { return last_batch_; }
+    void SetLastBatch(BatchContextPtr&& last);
+
+    const std::vector<UnresolvedBatch>& UnresolvedBatches() const { return unresolved_batches_; }
+    void SetUnresolvedBatches(std::vector<UnresolvedBatch>&& unresolved_batches);
+
+  private:
+    std::shared_ptr<vvl::Queue> queue_;
+    QueueId id_ = 0;
+    uint64_t submit_index_ = 0;
+
+    // The last batch represents memory accesses currently tracked on the queue (contains AccessContext).
+    // It includes accesses from all previously submitted batches that do not have any unresolved waits
+    BatchContextPtr last_batch_;
+
+    // The first batch in the unresolved batches list is always due to the wait-before-signal dependency.
+    // All subsequent batches from the same queue must also be stored here because they can't be processed
+    // until the wait-before-signal dependency is resolved (respect submission order). When the first batch
+    // is resolved, we start processing other queued batches until we encoutner a batch with unresolved
+    // wait-before-signal (it becomes the new head of the list) or the list is empty.
+    std::vector<UnresolvedBatch> unresolved_batches_;
 };
 
 class QueueBatchContext : public CommandExecutionContext, public std::enable_shared_from_this<QueueBatchContext> {
@@ -309,19 +344,21 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
         vvl::Func command_;
     };
 
-    QueueBatchContext(const SyncValidator& sync_state, const QueueSyncState& queue_state);
+    QueueBatchContext(const SyncValidator& sync_state, const QueueState& queue_state);
     QueueBatchContext(const SyncValidator& sync_state);
     QueueBatchContext() = delete;
     ~QueueBatchContext();
     void Trim();
 
+    QueueId GetQueueId() const override;
     ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }
     const SyncEventsContext *GetCurrentEventsContext() const override { return &events_context_; }
-    const QueueSyncState *GetQueueSyncState() { return queue_state_; }
-    QueueId GetQueueId() const override;
+
+    VkQueueFlags GetQueueFlags() const { return queue_state_->GetQueue()->GetQueueFlags(); }
+
     ResourceUsageRange GetTagRange() const { return tag_range_; }
     const std::vector<ResourceUsageTag> &GetQueueSyncTags() const { return queue_sync_tag_; }
 
@@ -349,8 +386,6 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     void DoAcquireOperation(const PresentedImage &presented);
     void LogAcquireOperation(const PresentedImage &presented, vvl::Func command);
 
-    VulkanTypedHandle Handle() const override;
-
     template <typename Predicate>
     void ApplyPredicatedWait(Predicate &predicate, const LastSynchronizedPresent &last_synchronized_present);
     void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag, const LastSynchronizedPresent &last_synchronized_present);
@@ -374,10 +409,12 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     LastSynchronizedPresent last_synchronized_present;
 
   private:
-    void ResolvePresentSemaphoreWait(const SignalInfo &signal_info, const PresentedImages &presented_images);
+    VulkanTypedHandle Handle() const override;
+    const QueueState* GetQueueState() const { return queue_state_; }
+    void ResolvePresentSemaphoreWait(const SignalInfo& signal_info, const PresentedImages& presented_images);
 
   private:
-    const QueueSyncState *queue_state_ = nullptr;
+    const QueueState *queue_state_ = nullptr;
     ResourceUsageRange tag_range_ = ResourceUsageRange(0, 0);  // Range of tags referenced by cbs_referenced
 
     AccessContext access_context_;
@@ -389,40 +426,6 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     // (via semaphores) between this batch's queue and the corresponding queue. Stores zero
     // if there was no synchronization with that queue.
     std::vector<ResourceUsageTag> queue_sync_tag_;
-};
-
-class QueueSyncState {
-  public:
-    QueueSyncState() = default;
-    QueueSyncState(const std::shared_ptr<vvl::Queue>& queue_state, QueueId id) : id_(id), queue_state_(queue_state) {}
-
-    VulkanTypedHandle Handle() const { return queue_state_->Handle(); }
-    const vvl::Queue *GetQueueState() const { return queue_state_.get(); }
-    VkQueueFlags GetQueueFlags() const { return queue_state_->queue_family_properties.queueFlags; }
-    QueueId GetQueueId() const { return id_; }
-    uint64_t ReserveSubmitId();
-
-    const LastSynchronizedPresent &GetLastSynchronizedPresent() const;
-
-    BatchContextPtr LastBatch() const { return last_batch_; }
-    void SetLastBatch(BatchContextPtr&& last);
-
-    const std::vector<UnresolvedBatch>& UnresolvedBatches() const { return unresolved_batches_; }
-    void SetUnresolvedBatches(std::vector<UnresolvedBatch>&& unresolved_batches);
-
-  private:
-    QueueId id_ = 0;
-    std::shared_ptr<vvl::Queue> queue_state_;
-    uint64_t submit_index_ = 0;
-
-    BatchContextPtr last_batch_;
-
-    // The first batch in the unresolved batches list is always due to the wait-before-signal dependency.
-    // All subsequent batches from the same queue must also be stored here because they can't be processed
-    // until the wait-before-signal dependency is resolved (respect submission order). When the first batch
-    // is resolved, we start processing other queued batches until we uncoutner a batch with unresolved
-    // wait-before-signal (it becomes the new head of the list) or the list is empty.
-    std::vector<UnresolvedBatch> unresolved_batches_;
 };
 
 }  // namespace syncval

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -276,7 +276,7 @@ void SyncValidator::WaitForSemaphore(VkSemaphore semaphore, uint64_t value) {
     }
 
     const TimelineHostSyncPoint& sync_point = *sync_point_it;
-    const QueueSyncState& queue_state = GetQueueSyncState(sync_point.queue_id);
+    const QueueState& queue_state = GetQueueState(sync_point.queue_id);
 
     // TODO: specify queue sync tags argument similar to WaitForFence
     ApplyTaggedWait(sync_point.queue_id, sync_point.tag, queue_state.GetLastSynchronizedPresent(), {});
@@ -311,18 +311,18 @@ void SyncValidator::UpdateSyncImageMemoryBindState(uint32_t count, const VkBindI
 }
 
 QueueId SyncValidator::GetQueueId(VkQueue queue) const {
-    for (const QueueSyncState& queue_sync_state : queue_sync_states_) {
-        if (queue_sync_state.GetQueueState()->VkHandle() == queue) {
-            return queue_sync_state.GetQueueId();
+    for (const QueueState& queue_state : queue_states_) {
+        if (queue_state.GetQueue()->VkHandle() == queue) {
+            return queue_state.GetQueueId();
         }
     }
     return kQueueIdInvalid;
 }
 
-QueueSyncState& SyncValidator::GetQueueSyncState(QueueId queue_id) {
+QueueState& SyncValidator::GetQueueState(QueueId queue_id) {
     assert(queue_id != kQueueIdInvalid);
     assert(queue_id < queue_id_limit_);
-    return queue_sync_states_[queue_id];
+    return queue_states_[queue_id];
 }
 
 void SyncValidator::Created(vvl::CommandBuffer& cb_state) {
@@ -633,9 +633,9 @@ void SyncValidator::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, con
         });
         return queues;
     };
-    queue_sync_states_.reserve(device_state->Count<vvl::Queue>());
+    queue_states_.reserve(device_state->Count<vvl::Queue>());
     for (const auto& queue : get_sorted_queues()) {
-        queue_sync_states_.emplace_back(QueueSyncState(queue, queue_id_limit_++));
+        queue_states_.emplace_back(QueueState(queue, queue_id_limit_++));
     }
 
     const auto env_debug_command_number = GetEnvironment("VK_SYNCVAL_DEBUG_COMMAND_NUMBER");
@@ -652,7 +652,7 @@ void SyncValidator::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, con
 
 void SyncValidator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                                const RecordObject& record_obj) {
-    queue_sync_states_.clear();
+    queue_states_.clear();
     binary_signals_.clear();
     timeline_signals_.clear();
     waitable_fences_.clear();
@@ -2229,7 +2229,7 @@ void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObjec
     if (waited_queue == kQueueIdInvalid) {
         return;
     }
-    const QueueSyncState& queue_state = GetQueueSyncState(waited_queue);
+    const QueueState& queue_state = GetQueueState(waited_queue);
     ApplyTaggedWait(waited_queue, ResourceUsageRecord::kMaxIndex, queue_state.GetLastSynchronizedPresent(), {});
 
     // For each timeline, remove all signals signaled on the waited queue, except the last one.
@@ -2284,7 +2284,7 @@ bool SyncValidator::ProcessQueuePresent(VkQueue queue, const VkPresentInfoKHR* p
     if (queue_id == kQueueIdInvalid) {
         return skip;
     }
-    QueueSyncState& queue_state = GetQueueSyncState(queue_id);
+    QueueState& queue_state = GetQueueState(queue_id);
     const uint64_t submit_id = queue_state.ReserveSubmitId();
 
     BatchContextPtr last_batch = queue_state.LastBatch();
@@ -2463,17 +2463,17 @@ bool SyncValidator::ProcessQueueSubmit(VkQueue queue, uint32_t submitCount, cons
         return skip;
     }
 
-    QueueSyncState& queue_sync_state = GetQueueSyncState(queue_id);
+    QueueState& queue_state = GetQueueState(queue_id);
     SignalsUpdate signals_update(*this);
 
     // The submit id is a mutable automic which is not recoverable on a skip == true condition
-    uint64_t submit_id = queue_sync_state.ReserveSubmitId();
+    uint64_t submit_id = queue_state.ReserveSubmitId();
 
     // Update label stack as we progress through batches and command buffers
-    auto current_label_stack = queue_sync_state.GetQueueState()->cmdbuf_label_stack;
+    auto current_label_stack = queue_state.GetQueue()->cmdbuf_label_stack;
 
-    BatchContextPtr last_batch = queue_sync_state.LastBatch();
-    bool has_unresolved_batches = !queue_sync_state.UnresolvedBatches().empty();
+    BatchContextPtr last_batch = queue_state.LastBatch();
+    bool has_unresolved_batches = !queue_state.UnresolvedBatches().empty();
 
     BatchContextPtr new_last_batch;
     std::vector<UnresolvedBatch> new_unresolved_batches;
@@ -2481,7 +2481,7 @@ bool SyncValidator::ProcessQueueSubmit(VkQueue queue, uint32_t submitCount, cons
 
     for (uint32_t batch_idx = 0; batch_idx < submitCount; batch_idx++) {
         const VkSubmitInfo2& submit = pSubmits[batch_idx];
-        auto batch = std::make_shared<QueueBatchContext>(*this, queue_sync_state);
+        auto batch = std::make_shared<QueueBatchContext>(*this, queue_state);
 
         const auto wait_semaphores = vvl::make_span(submit.pWaitSemaphoreInfos, submit.waitSemaphoreInfoCount);
         std::vector<VkSemaphoreSubmitInfo> unresolved_waits;
@@ -2531,12 +2531,12 @@ bool SyncValidator::ProcessQueueSubmit(VkQueue queue, uint32_t submitCount, cons
     }
 
     if (new_last_batch && !skip) {
-        queue_sync_state.SetLastBatch(std::move(new_last_batch));
+        queue_state.SetLastBatch(std::move(new_last_batch));
     }
     if (!new_unresolved_batches.empty() && !skip) {
-        auto unresolved_batches = queue_sync_state.UnresolvedBatches();
+        auto unresolved_batches = queue_state.UnresolvedBatches();
         vvl::Append(unresolved_batches, new_unresolved_batches);
-        queue_sync_state.SetUnresolvedBatches(std::move(unresolved_batches));
+        queue_state.SetUnresolvedBatches(std::move(unresolved_batches));
     }
 
     // Check if timeline signals resolve existing wait-before-signal dependencies
@@ -2546,12 +2546,12 @@ bool SyncValidator::ProcessQueueSubmit(VkQueue queue, uint32_t submitCount, cons
 
     if (!skip) {
         stats.UpdateMemoryStats();
-        ApplySignalsUpdate(signals_update, queue_sync_state.LastBatch());
+        ApplySignalsUpdate(signals_update, queue_state.LastBatch());
         FenceHostSyncPoint sync_point;
-        sync_point.queue_id = queue_sync_state.GetQueueId();
+        sync_point.queue_id = queue_state.GetQueueId();
         sync_point.tag = ReserveGlobalTagRange(1).begin;
-        if (queue_sync_state.LastBatch()) {
-            sync_point.queue_sync_tags = queue_sync_state.LastBatch()->GetQueueSyncTags();
+        if (queue_state.LastBatch()) {
+            sync_point.queue_sync_tags = queue_state.LastBatch()->GetQueueSyncTags();
         }
         UpdateFenceHostSyncPoint(fence, std::move(sync_point));
     }
@@ -2562,7 +2562,7 @@ bool SyncValidator::PropagateTimelineSignals(SignalsUpdate& signals_update, cons
     bool skip = false;
     // Initialize per-queue unresolved batches state.
     std::vector<UnresolvedQueue> queues;
-    for (QueueSyncState& queue_state : queue_sync_states_) {
+    for (QueueState& queue_state : queue_states_) {
         if (!queue_state.UnresolvedBatches().empty()) {
             queues.emplace_back(UnresolvedQueue{&queue_state, queue_state.UnresolvedBatches()});
         }

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -60,7 +60,7 @@ class SyncValidator : public vvl::DeviceProxy {
     mutable std::atomic<ResourceUsageTag> tag_limit_{1};  // This is reserved in Validation phase, thus mutable and atomic
     ResourceUsageRange ReserveGlobalTagRange(size_t tag_count) const;  // Note that the tag_limit_ is mutable this has side effects
 
-    std::vector<QueueSyncState> queue_sync_states_;
+    std::vector<QueueState> queue_states_;
     QueueId queue_id_limit_ = 0;
 
     mutable std::mutex queue_mutex_;
@@ -116,7 +116,7 @@ class SyncValidator : public vvl::DeviceProxy {
     void UpdateSyncImageMemoryBindState(uint32_t count, const VkBindImageMemoryInfo *infos);
 
     QueueId GetQueueId(VkQueue queue) const;
-    QueueSyncState& GetQueueSyncState(QueueId queue_id);
+    QueueState& GetQueueState(QueueId queue_id);
     QueueId GetQueueIdLimit() const { return queue_id_limit_; }
 
     std::vector<BatchContextPtr> GetLastBatches(std::function<bool(const BatchContextPtr&)> filter) const;


### PR DESCRIPTION
It's already in `syncval` namespace.
Sync parts add mental load because there are legitimate names with "Sync" (e.g. FenceHostSyncPoint).