### PR TITLE
layers: Add Debug Descriptor Dump

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -286,6 +286,7 @@ vvl_sources = [
   "layers/state_tracker/descriptor_set_layouts.h",
   "layers/state_tracker/descriptor_sets.cpp",
   "layers/state_tracker/descriptor_sets.h",
+  "layers/state_tracker/debug_descriptor_dump.cpp",
   "layers/state_tracker/device_generated_commands_state.cpp",
   "layers/state_tracker/device_generated_commands_state.h",
   "layers/state_tracker/device_memory_state.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -368,6 +368,7 @@ target_sources(vvl PRIVATE
     state_tracker/descriptor_set_layouts.h
     state_tracker/descriptor_sets.cpp
     state_tracker/descriptor_sets.h
+    state_tracker/debug_descriptor_dump.cpp
     state_tracker/device_generated_commands_state.cpp
     state_tracker/device_generated_commands_state.h
     state_tracker/device_memory_state.cpp

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1169,6 +1169,14 @@
                                     }
                                 }
                             ]
+                        },
+                        {
+                            "key": "debug_dump_descriptors",
+                            "label": "Dump Descriptors",
+                            "view": "DEBUG",
+                            "description": "Dump VK_EXT_descriptor_buffer/VK_EXT_descriptor_heap descriptor information for draw/dispatch/traceRays",
+                            "type": "BOOL",
+                            "default": false
                         }
                     ]
                 },

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -118,6 +118,8 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
     const bool skip_checking_limit =
         // We want to print DebugPrintf message forever, otherwise user will mistake duplicate limit for things not printing
         (vuid_hash == 0x4fe1fef9) ||
+        // DEBUG-DUMP-DESCRIPTOR
+        (vuid_hash == 0xc039618c) ||
         // GPU-AV gives lots of warnings on setup to inform user which settings we are adjusting under them
         (vuid_hash == 0x86fe6721);
 

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -174,6 +174,12 @@ const char* VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
 // Debug settings used for internal development
 const char* VK_LAYER_DEBUG_DISABLE_SPIRV_VAL = "debug_disable_spirv_val";
 
+// Used for working with VK_EXT_descriptor_buffer/VK_EXT_descriptor_heap
+// Every draw/dispatch/traceRays dump out information about the bound descriptor buffer/heap
+// Currently done inside core validation (PreCallValidate) and state_tracker.
+// (This allows for testing with GPU-AV + self_validation).
+const char* VK_LAYER_DEBUG_DUMP_DESCRIPTORS = "debug_dump_descriptors";
+
 // DebugPrintf (which is now part of GPU-AV internally)
 // ---
 // Quick, single setting to turn on DebugPrintf
@@ -717,6 +723,10 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuL
         report_flags |= kWarningBit;
     }
 
+    if (settings_data->global_settings->debug_dump_descriptors) {
+        report_flags |= kInformationBit;
+    }
+
     // Flag as default if these settings are not from a vk_layer_settings.txt file
     const bool default_layer_callback = (debug_action & VK_DBG_LAYER_ACTION_DEFAULT) != 0;
 
@@ -944,6 +954,10 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_DEBUG_DISABLE_SPIRV_VAL)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_DEBUG_DISABLE_SPIRV_VAL, global_settings.debug_disable_spirv_val);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_DEBUG_DUMP_DESCRIPTORS)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_DEBUG_DUMP_DESCRIPTORS, global_settings.debug_dump_descriptors);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_CUSTOM_STYPE_LIST)) {

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2022-2025 The Khronos Group Inc.
- * Copyright (c) 2022-2025 Valve Corporation
- * Copyright (c) 2022-2025 LunarG, Inc.
+/* Copyright (c) 2022-2026 The Khronos Group Inc.
+ * Copyright (c) 2022-2026 Valve Corporation
+ * Copyright (c) 2022-2026 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -84,6 +84,8 @@ struct GlobalSettings {
     bool fine_grained_locking = true;
 
     bool debug_disable_spirv_val = false;
+
+    bool debug_dump_descriptors = false;
 
     // Have quick way to know if user only has requsted errors as we can skip larger, expensive parts of the code if the user will
     // never see the message

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1519,6 +1519,9 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
 void CommandBuffer::RecordDraw(const Location& loc) {
     RecordCommand(loc);
     LastBound& last_bound = lastBound[vvl::BindPointGraphics];
+    if (dev_data.global_settings.debug_dump_descriptors) {
+        DebugDumpDescriptors(last_bound, loc);
+    }
     for (auto& item : sub_states_) {
         item.second->RecordActionCommand(last_bound, loc);
     }
@@ -1528,6 +1531,9 @@ void CommandBuffer::RecordDraw(const Location& loc) {
 void CommandBuffer::RecordDispatch(const Location& loc) {
     RecordCommand(loc);
     LastBound& last_bound = lastBound[vvl::BindPointCompute];
+    if (dev_data.global_settings.debug_dump_descriptors) {
+        DebugDumpDescriptors(last_bound, loc);
+    }
     for (auto& item : sub_states_) {
         item.second->RecordActionCommand(last_bound, loc);
     }
@@ -1537,6 +1543,9 @@ void CommandBuffer::RecordDispatch(const Location& loc) {
 void CommandBuffer::RecordTraceRay(const Location& loc) {
     RecordCommand(loc);
     LastBound& last_bound = lastBound[vvl::BindPointRayTracing];
+    if (dev_data.global_settings.debug_dump_descriptors) {
+        DebugDumpDescriptors(last_bound, loc);
+    }
     for (auto& item : sub_states_) {
         item.second->RecordActionCommand(last_bound, loc);
     }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -594,6 +594,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
         }
     } descriptor_heap;
 
+    void DebugDumpDescriptors(const LastBound& last_bound, const Location& loc) const;
+
     void SetDescriptorMode(vvl::DescriptorMode new_mode, vvl::Func function);
     void InvalidateDescriptorMode(vvl::DescriptorMode invalidate_mode, vvl::Func function);
 

--- a/layers/state_tracker/debug_descriptor_dump.cpp
+++ b/layers/state_tracker/debug_descriptor_dump.cpp
@@ -1,0 +1,183 @@
+/* Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/vulkan_core.h>
+#include <cstdint>
+#include <sstream>
+#include "containers/small_vector.h"
+#include "generated/dispatch_functions.h"
+#include "state_tracker/buffer_state.h"
+#include "state_tracker/cmd_buffer_state.h"
+#include "state_tracker/descriptor_mode.h"
+#include "state_tracker/pipeline_layout_state.h"
+#include "state_tracker/pipeline_state.h"
+#include "state_tracker/shader_object_state.h"
+#include "state_tracker/shader_stage_state.h"
+#include "state_tracker/state_tracker.h"
+
+namespace vvl {
+
+static size_t GetDescriptorBufferSize(const VkPhysicalDeviceDescriptorBufferPropertiesEXT& props, bool robust, VkDescriptorType type) {
+    switch(type) {
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            return props.samplerDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            return props.combinedImageSamplerDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            return props.sampledImageDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            return props.storageImageDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            return robust ? props.robustUniformTexelBufferDescriptorSize : props.uniformTexelBufferDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        return robust ? props.robustStorageTexelBufferDescriptorSize : props.storageTexelBufferDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+        return robust ? props.robustUniformBufferDescriptorSize : props.uniformBufferDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+        return robust ? props.robustStorageBufferDescriptorSize : props.storageBufferDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            return props.inputAttachmentDescriptorSize;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            return props.accelerationStructureDescriptorSize;
+        default:
+        break;
+    }
+    return 0;
+}
+
+static const char* DescribeDescriptorBufferSize(bool robust, VkDescriptorType type) {
+    switch(type) {
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            return "samplerDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            return "combinedImageSamplerDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            return "sampledImageDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            return "storageImageDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            return robust ? "robustUniformTexelBufferDescriptorSize" : "uniformTexelBufferDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+        return robust ? "robustStorageTexelBufferDescriptorSize" : "storageTexelBufferDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+        return robust ? "robustUniformBufferDescriptorSize" : "uniformBufferDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+        return robust ? "robustStorageBufferDescriptorSize" : "storageBufferDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            return "inputAttachmentDescriptorSize";
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            return "accelerationStructureDescriptorSize";
+        default:
+        break;
+    }
+    return "[Unknown]";
+}
+
+// We look at what the SPIR-V is using (from active_slots) and then using the VkDescriptorSetLayouts bound, we can figure out where the shader expects all the addresses to be read from
+void CommandBuffer::DebugDumpDescriptors(const LastBound& last_bound, const Location& loc) const {
+    DescriptorMode descriptor_mode = last_bound.GetDescriptorMode();
+    if (descriptor_mode != DescriptorModeBuffer && descriptor_mode != DescriptorModeHeap) {
+        return;
+    }
+    const vvl::CommandBuffer& cb_state = last_bound.cb_state;
+
+    std::ostringstream ss;
+    ss << "(" << dev_data.FormatHandle(cb_state.Handle()) << ")\n";
+
+    if (descriptor_mode == DescriptorModeBuffer) {
+        const bool robust_buffer = dev_data.enabled_features.robustBufferAccess;
+        ss << "vkCmdBindDescriptorBuffersEXT last bound the following descriptor buffers:\n";
+        for (uint32_t binding_i = 0; binding_i < cb_state.descriptor_buffer.binding_info.size(); binding_i++) {
+            const VkDeviceAddress address = cb_state.descriptor_buffer.binding_info[binding_i].address;
+            ss << "  - pBindingInfos[" << binding_i << "].address 0x" << std::hex << address << '\n';
+            auto buffer_states = dev_data.GetBuffersByAddress(address);
+            for (auto& buffer_state : buffer_states) {
+                ss << "    - " << buffer_state->Describe(dev_data) << "\n";
+            }
+            if (buffer_states.empty()) {
+                ss << "    - No VkBuffer found\n";
+            }
+        }
+
+        const vvl::PipelineLayout& pipeline_layout = *last_bound.desc_set_pipeline_layout;
+        ss << "vkCmdSetDescriptorBufferOffsetsEXT has bound the following with " << dev_data.FormatHandle(pipeline_layout.VkHandle()) << ":\n";
+
+        // Dumb quick way to handle the fact active_slots are per ShaderObject but one single thing for Pipeline
+        small_vector<const ActiveSlotMap*, 2> active_slot_list;
+        if (last_bound.pipeline_state) {
+            active_slot_list.emplace_back(&last_bound.pipeline_state->active_slots);
+        } else {
+            for (const auto& shader_object : last_bound.shader_object_states) {
+                if (!shader_object) {
+                    continue;
+                }
+                active_slot_list.emplace_back(&shader_object->active_slots);
+            }
+        }
+
+        for (const auto& active_slots : active_slot_list) {
+            for (const auto& [set_index, binding_req_map] : *active_slots) {
+                const vvl::DescriptorSetLayout& dsl = *pipeline_layout.set_layouts.list[set_index];
+                const auto& descriptor_buffer_binding = last_bound.ds_slots[set_index].descriptor_buffer_binding;
+
+                if (dsl.Destroyed()) {
+                    ss << "  - Set " << std::dec  << set_index << " VkDescriptorSetLayout was destroyed (TODO - Track more info in pipeline layout)";
+                    continue;
+                } else if ((dsl.GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) == 0) {
+                    ss << "  - Set " << std::dec  << set_index << " was not created with VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT";
+                    continue;
+                } else if (!descriptor_buffer_binding.has_value()) {
+                    ss << "  - Set " << std::dec  << set_index << " was never bound with offset. (WARNING - only valid if descriptor is not used in the shader)\n";
+                    continue;
+                }
+
+                const VkDeviceAddress start_address = cb_state.descriptor_buffer.binding_info[descriptor_buffer_binding->index].address + descriptor_buffer_binding->offset;
+                const VkDeviceSize dsl_size = dsl.GetLayoutSizeInBytes();
+                ss << "  - Set " << std::dec  << set_index << " is " << dsl_size << " bytes at [0x"  << std::hex << start_address << ", 0x" << (start_address + dsl_size) << "]";
+                if (cb_state.descriptor_buffer.binding_info.size() > 1) {
+                    ss << " (pBindingInfos[" << std::dec << descriptor_buffer_binding->index << "])";
+                }
+                ss << '\n';
+
+                const auto& ds_layout_def = *dsl.GetLayoutDef();
+                for (const auto& [binding_index, desc_set_reqs] : binding_req_map) {
+                    const VkDescriptorType type = ds_layout_def.GetTypeFromBinding(binding_index);
+                    const uint32_t count = ds_layout_def.GetDescriptorCountFromBinding(binding_index);
+
+                    ss << "    - Binding " << binding_index << " (" << string_VkDescriptorType(type) << ") ";
+                    const uint32_t descriptor_size = (uint32_t)GetDescriptorBufferSize(dev_data.phys_dev_ext_props.descriptor_buffer_props, robust_buffer, type);
+                    VkDeviceSize binding_offset = 0;
+                    DispatchGetDescriptorSetLayoutBindingOffsetEXT(dev_data.device, dsl.VkHandle(), binding_index, &binding_offset);
+                    ss << "with an offset of " << binding_offset << " is at [0x" << std::hex << start_address + binding_offset << ", 0x" << (start_address + binding_offset + (descriptor_size * count)) << "] (";
+                    if (count > 1) {
+                        ss << "descriptorCount [" << std::dec << count << "] times ";
+                    }
+                    ss << DescribeDescriptorBufferSize(robust_buffer, type) << " [" << std::dec << descriptor_size << "])\n";
+
+                }
+            }
+        }
+    } else if (descriptor_mode == DescriptorModeHeap) {
+        // TODO
+    }
+
+    // Don't provide a LogObjectList, embed it into the messsage instead to keep things cleaner
+    dev_data.debug_report->LogMessage(kInformationBit, "DEBUG-DUMP-DESCRIPTOR", {}, loc,
+                                      ss.str().c_str());
+}
+
+}  // namespace vvl

--- a/tests/framework/error_monitor.cpp
+++ b/tests/framework/error_monitor.cpp
@@ -110,6 +110,13 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugUtilsMessageSeverityF
     if (message_flags & error_monitor->GetMessageFlags()) {
         return error_monitor->CheckForDesiredMsg(vuid, error_message.c_str());
     }
+
+    // DEBUG-DUMP-DESCRIPTOR
+    // Want to always print it if running tests, as it otherwise gets silenced
+    if (callback_data->messageIdNumber == 0xc039618c) {
+        std::cout << error_message;
+    }
+
     return VK_FALSE;
 }
 

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -1456,6 +1456,8 @@ TEST_F(PositiveDescriptorBuffer, InputAttachment) {
     VkDeviceSize offset = 0u;
     vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0u, 1u, &buffer_index,
                                          &offset);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 1u, 1u, &buffer_index,
+                                         &offset);
 
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -374,8 +374,8 @@ TEST_F(PositiveRayTracingPipeline, DescriptorBuffer) {
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &buffer_binding_info);
     uint32_t buffer_index = 0u;
     VkDeviceSize offset = 0u;
-    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0u, 1u, &buffer_index,
-                                         &offset);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline_layout, 0u, 1u,
+                                         &buffer_index, &offset);
 
     vk::CmdTraceRaysKHR(m_command_buffer, &sbt.ray_gen_sbt, &sbt.miss_sbt, &sbt.hit_sbt, &sbt.callable_sbt, 32u, 32u, 1u);
     m_command_buffer.End();


### PR DESCRIPTION
set `VK_LAYER_DEBUG_DUMP_DESCRIPTORS=1` and VVL will dump all the useful information (that we have)

This is information to help debug, the big issue is you can have bogus things bound as long as your shader doesn't access the bogus addresses. This will use what we can statically reflect in the SPIR-V and map it to your `VkDescriptorSetLayout` to provide information. This is ment mainly for use to use in GPU-AV to debug things, but might be helpful outside as it gets more mature

-----

Example outputs from tests and real samples

```
Validation Information: [ DEBUG-DUMP-DESCRIPTOR ] | MessageID = 0xc039618c
vkCmdDispatch(): (VkCommandBuffer 0x58d92820f7d0)
vkCmdBindDescriptorBuffersEXT last bound the following descriptor buffers:
  - pBindingInfos[0].address 0x300000000
    - VkBuffer 0xb000000000b, size: 160 bytes, range: [0x300000000, 0x3000000a0)
  - pBindingInfos[1].address 0x300010000
    - VkBuffer 0xd000000000d, size: 160 bytes, range: [0x300010000, 0x3000100a0)
vkCmdSetDescriptorBufferOffsetsEXT has bound the following with VkPipelineLayout 0x40000000004:
  - Set 0 is 160 bytes at [0x300010000, 0x3000100a0] (pBindingInfos[1])
    - Binding 1 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) with an offset of 64 is at [0x300010040, 0x300010080] (storageBufferDescriptorSize [64])
    - Binding 0 (VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) with an offset of 0 is at [0x300010000, 0x300010040] (sampledImageDescriptorSize [64])
    - Binding 2 (VK_DESCRIPTOR_TYPE_SAMPLER) with an offset of 128 is at [0x300010080, 0x3000100a0] (samplerDescriptorSize [32])
```

```
Validation Information: [ DEBUG-DUMP-DESCRIPTOR ] | MessageID = 0xc039618c
vkCmdDispatch(): (VkCommandBuffer 0x616814e157d0)
vkCmdBindDescriptorBuffersEXT last bound the following descriptor buffers:
  - pBindingInfos[0].address 0x300000000
    - VkBuffer 0xb000000000b, size: 192 bytes, range: [0x300000000, 0x3000000c0)
vkCmdSetDescriptorBufferOffsetsEXT has bound the following with VkPipelineLayout 0xa000000000a:
  - Set 0 is 192 bytes at [0x300000000, 0x3000000c0]
    - Binding 0 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) with an offset of 0 is at [0x300000000, 0x3000000c0] (descriptorCount [3] times storageBufferDescriptorSize [64])

```

```
Validation Information: [ DEBUG-DUMP-DESCRIPTOR ] | MessageID = 0xc039618c
vkCmdDispatch(): (VkCommandBuffer 0x574f96a386d0)
vkCmdBindDescriptorBuffersEXT last bound the following descriptor buffers:
  - pBindingInfos[0].address 0x300000000
    - VkBuffer 0x70000000007, size: 192 bytes, range: [0x300000000, 0x3000000c0)
vkCmdSetDescriptorBufferOffsetsEXT has bound the following with VkPipelineLayout 0x60000000006:
  - Set 2 is 64 bytes at [0x300000080, 0x3000000c0]
    - Binding 0 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) with an offset of 0 is at [0x300000080, 0x3000000c0] (storageBufferDescriptorSize [64])
  - Set 0 is 64 bytes at [0x300000000, 0x300000040]
    - Binding 0 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) with an offset of 0 is at [0x300000000, 0x300000040] (storageBufferDescriptorSize [64])
  - Set 1 is 64 bytes at [0x300000040, 0x300000080]
    - Binding 0 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) with an offset of 0 is at [0x300000040, 0x300000080] (storageBufferDescriptorSize [64])

```

```
Validation Information: [ DEBUG-DUMP-DESCRIPTOR ] | MessageID = 0xc039618c
vkCmdDrawIndexed(): (VkCommandBuffer 0x5bffc2f08350)
vkCmdBindDescriptorBuffersEXT last bound the following descriptor buffers:
  - pBindingInfos[0].address 0x300010000
    - VkBuffer 0x600000000060, size: 192 bytes, range: [0x300010000, 0x3000100c0)
  - pBindingInfos[1].address 0x300020000
    - VkBuffer 0x620000000062, size: 256 bytes, range: [0x300020000, 0x300020100)
vkCmdSetDescriptorBufferOffsetsEXT has bound the following with VkPipelineLayout 0x640000000064:
  - Set 0 was never bound with offset. (WARNING - only valid if descriptor is not used in the shader)
  - Set 1 was never bound with offset. (WARNING - only valid if descriptor is not used in the shader)
  - Set 2 is 128 bytes at [0x300020080, 0x300020100] (pBindingInfos[1])
    - Binding 0 (VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) with an offset of 0 is at [0x300020080, 0x300020100] (combinedImageSamplerDescriptorSize [128])
```