### PR TITLE
tests: Fix coop matrix test

### DIFF
--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -254,7 +254,7 @@ TEST_F(PositiveShaderCooperativeMatrix, BFloat16) {
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
         #extension GL_KHR_memory_scope_semantics : enable
         #extension GL_KHR_cooperative_matrix : enable
-        layout(local_size_x = 32) in;
+        layout(local_size_x = 64) in;
         void main() {
             coopmat<bfloat16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> cmA = coopmat<bfloat16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA>(3.0);
         }


### PR DESCRIPTION
Ran into:

```
Validation Error: [ VUID-VkPipelineShaderStageCreateInfo-module-08987 ] | MessageID = 0x99173a12
vkCreateComputePipelines(): pCreateInfos[0].stage shader [VK_SHADER_STAGE_COMPUTE_BIT] has a local workgroup size in the X dimension (32) is not a multiple of subgroupSize (64).
The Vulkan spec states: If module uses the OpTypeCooperativeMatrixKHR instruction with a Scope equal to Subgroup, then the local workgroup size in the X dimension of the pipeline must be a multiple of the effective subgroup size (https://docs.vulkan.org/spec/latest/chapters/pipelines.html#VUID-VkPipelineShaderStageCreateInfo-module-08987)
Objects: 1
    [0] VkShaderModule 0x50000000005
```