### PR TITLE
layers: Fix format check for VU 9921

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -3096,8 +3096,7 @@ bool CoreChecks::ValidateDataGraphConstants(const spirv::Module& module_spirv, c
             const Location vk_constant_loc = dg_shader_ci_loc.dot(Field::pConstants, vk_index);
             if (auto* tensor_desc = vku::FindStructInPNextChain<VkTensorDescriptionARM>(vk_constant.pNext)) {
                 const spirv::Instruction& element_type_instr = *module_spirv.FindDef(tensor_type_instr.Word(2));
-                const VkFormat spirv_vk_format = module_spirv.GetTensorFormat(element_type_instr);
-                if (tensor_desc->format != spirv_vk_format) {
+                if (!module_spirv.IsTensorFormatCompatible(tensor_desc->format, element_type_instr)) {
                     skip |= LogError("VUID-RuntimeSpirv-pNext-09921", device,
                                      vk_constant_loc.pNext(Struct::VkTensorDescriptionARM).dot(Field::format),
                                      "(%s) is incompatible with the element type (%s) of the spirv definition (%s)",

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -1408,8 +1408,11 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongFormat) {
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
 
-    // try a few different formats, different for sign, bit width, and type
-    for (auto format : {VK_FORMAT_R8_SINT, VK_FORMAT_R32_UINT, VK_FORMAT_R32_SFLOAT}) {
+    // try a few different formats, different for bit width, float encoding and type
+    // NOTE: VK_FORMAT_R8_SINT included as a sanity check: it is different only by sign from the actual format,
+    // meaning it is compatible, and it must NOT trigger the VU
+    for (auto format :
+         {VK_FORMAT_R8_SINT, VK_FORMAT_R8_BOOL_ARM, VK_FORMAT_R32_SINT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM}) {
         vkt::dg::DataGraphPipelineHelper pipeline(*this, params);
 
         VkTensorDescriptionARM desc = DefaultConstantTensorDesc();
@@ -1418,9 +1421,14 @@ TEST_F(NegativeDataGraph, GraphConstantTensorWrongFormat) {
         pipeline.shader_module_ci_.constantCount = 1;
         pipeline.shader_module_ci_.pConstants = &constant;
 
-        m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09921");
-        pipeline.CreateDataGraphPipeline();
-        m_errorMonitor->VerifyFound();
+        if (format == VK_FORMAT_R8_SINT) {
+            // INT check must not consider the sign, as required by TOSA function specifications
+            pipeline.CreateDataGraphPipeline();
+        } else {
+            m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09921");
+            pipeline.CreateDataGraphPipeline();
+            m_errorMonitor->VerifyFound();
+        }
     }
 }
 
@@ -1590,17 +1598,24 @@ TEST_F(NegativeDataGraph, ResourceTensorWrongFormat) {
     RETURN_IF_SKIP(Init());
 
     // try a few different formats, different for bit width, type and float encoding
+    // NOTE: VK_FORMAT_R8_SINT included as a sanity check: it is different only by sign from the actual format,
+    // meaning it is compatible, and it must NOT trigger the VU
     for (auto format :
-         {VK_FORMAT_R8_BOOL_ARM, VK_FORMAT_R32_SINT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM}) {
+         {VK_FORMAT_R8_SINT, VK_FORMAT_R8_BOOL_ARM, VK_FORMAT_R32_SINT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_SFLOAT_FPENCODING_FLOAT8E4M3_ARM}) {
         vkt::dg::DataGraphPipelineHelper pipeline(*this);
 
         auto* desc =
             const_cast<VkTensorDescriptionARM*>(vku::FindStructInPNextChain<VkTensorDescriptionARM>(pipeline.resources_[0].pNext));
         desc->format = format;
 
-        m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09923");
-        pipeline.CreateDataGraphPipeline();
-        m_errorMonitor->VerifyFound();
+        if (format == VK_FORMAT_R8_SINT) {
+            // INT check must not consider the sign, as required by TOSA function specifications
+            pipeline.CreateDataGraphPipeline();
+        } else {
+            m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09923");
+            pipeline.CreateDataGraphPipeline();
+            m_errorMonitor->VerifyFound();
+        }
     }
 }
 


### PR DESCRIPTION
- for INT types, TOSA functions require signed constants but SPIRV requires unsigned. Use sign-agnostic check, as in VU 9923