### PR TITLE
layers: Track swapchain in-use status

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -732,6 +732,16 @@ bool CoreChecks::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwap
                                    error_obj.location.dot(Field::pCreateInfo));
 }
 
+bool CoreChecks::PreCallValidateDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
+    const VkAllocationCallbacks* pAllocator, const ErrorObject& error_obj) const {
+    bool skip = false;
+
+    if (auto swapchain_state = Get<vvl::Swapchain>(swapchain)) {
+        skip |= ValidateObjectNotInUse(swapchain_state.get(), error_obj.location, "VUID-vkDestroySwapchainKHR-swapchain-01282");
+    }
+    return skip;
+}
+
 void CoreChecks::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                   const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     if (auto swapchain_state = Get<vvl::Swapchain>(swapchain)) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2223,6 +2223,8 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
                                            const ErrorObject& error_obj) const override;
+    bool PreCallValidateDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator,
+                                            const ErrorObject& error_obj) const override;
     void PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator,
                                           const RecordObject& record_obj) override;
 

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -39,6 +39,9 @@ void vvl::QueueSubmission::BeginUse() {
     if (fence) {
         fence->BeginUse();
     }
+    if (swapchain) {
+        swapchain->BeginUse();
+    }
 }
 
 void vvl::QueueSubmission::EndUse() {
@@ -53,6 +56,9 @@ void vvl::QueueSubmission::EndUse() {
     }
     if (fence) {
         fence->EndUse();
+    }
+    if (swapchain) {
+        swapchain->EndUse();
     }
 }
 
@@ -211,8 +217,8 @@ void vvl::Queue::UpdatePresentOnlyQueueProgress(const DeviceState& device_state)
         assert(is_used_for_presentation && !is_used_for_regular_submits);
         small_unordered_map<VkSwapchainKHR, uint32_t, 4> active_presentations;
         for (const QueueSubmission& submission : submissions_) {
-            assert(submission.swapchain != VK_NULL_HANDLE);
-            active_presentations[submission.swapchain]++;
+            assert(submission.swapchain);
+            active_presentations[submission.swapchain->VkHandle()]++;
         }
         // Search for the swapchain with too many enqueued presentation requests
         VkSwapchainKHR swapchain = VK_NULL_HANDLE;
@@ -227,7 +233,7 @@ void vvl::Queue::UpdatePresentOnlyQueueProgress(const DeviceState& device_state)
         // Get seq to retire the oldest presentation submissions.
         if (swapchain != VK_NULL_HANDLE) {
             for (const QueueSubmission& submission : submissions_) {
-                if (submission.swapchain == swapchain) {
+                if (submission.swapchain->VkHandle() == swapchain) {
                     seq_to_advance_to = submission.seq;
                     break;
                 }

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -69,8 +69,9 @@ struct QueueSubmission {
     std::vector<SemaphoreInfo> signal_semaphores;
     std::shared_ptr<Fence> fence;
     bool has_external_fence = false;
-    // Swapchain handle if this submission represents QueuePresent request
-    VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+
+    // Swapchain is not null if this submission represents QueuePresent request
+    std::shared_ptr<Swapchain> swapchain;
     std::shared_ptr<const vvl::Image> swapchain_image;
 
     LocationCapture loc;

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -59,8 +59,9 @@ vvl::Semaphore::Semaphore(DeviceState& device, VkSemaphore handle, const VkSemap
 
 const VulkanTypedHandle* vvl::Semaphore::InUse() const {
     auto guard = ReadLock();
-    // Semaphore does not have a parent (in the sense of a VVL state object), and the value returned
-    // by the base class InUse is not useful for reporting (it is the semaphore's own handle)
+    // Semaphore does not have a parent (in the sense of VVL state object hierarchy).
+    // The typed handle returned by the base class InUse is not useful for reporting
+    // (it is the semaphore's own handle). Use it only to get boolean in use status.
     const bool in_use = RefcountedStateObject::InUse() != nullptr;
     if (!in_use) {
         return nullptr;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4393,7 +4393,7 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
             present_submission.AddFence(Get<Fence>(present_fence_info->pFences[i]));
         }
         auto swapchain = Get<Swapchain>(pPresentInfo->pSwapchains[i]);
-        present_submission.swapchain = swapchain->VkHandle();
+        present_submission.swapchain = swapchain;
         present_submission.swapchain_image = swapchain->GetSwapChainImageShared(pPresentInfo->pImageIndices[i]);
     }
 

--- a/layers/state_tracker/wsi_state.cpp
+++ b/layers/state_tracker/wsi_state.cpp
@@ -96,7 +96,7 @@ void SwapchainImage::ResetPresentWaitSemaphores() {
 }
 
 Swapchain::Swapchain(vvl::DeviceState& dev_data_, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
-    : StateObject(handle, kVulkanObjectTypeSwapchainKHR),
+    : RefcountedStateObject(handle, kVulkanObjectTypeSwapchainKHR),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       images(),

--- a/layers/state_tracker/wsi_state.h
+++ b/layers/state_tracker/wsi_state.h
@@ -87,10 +87,10 @@ struct SwapchainImage {
 // Parent -> child relationships in the object usage tree:
 //    vvl::Swapchain [N] -> [1] vvl::Surface
 //    However, only 1 swapchain for each surface can be !retired.
-class Swapchain : public StateObject, public SubStateManager<SwapchainSubState> {
+class Swapchain : public RefcountedStateObject, public SubStateManager<SwapchainSubState> {
   public:
     const vku::safe_VkSwapchainCreateInfoKHR safe_create_info;
-    const VkSwapchainCreateInfoKHR &create_info;
+    const VkSwapchainCreateInfoKHR& create_info;
 
     std::vector<VkPresentModeKHR> present_modes;
     std::vector<SwapchainImage> images;

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -4969,6 +4969,8 @@ TEST_F(NegativeWsi, PresentWait2Features) {
     m_errorMonitor->SetDesiredError("VUID-vkWaitForPresent2KHR-presentWait2-10814");
     vk::WaitForPresent2KHR(device(), swapchain, &present_wait_2_info);
     m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
 }
 
 TEST_F(NegativeWsi, PresentId2SurfaceNotSupported) {
@@ -5253,6 +5255,8 @@ TEST_F(NegativeWsi, PresentWait2SwapchainMissingFlags) {
     m_errorMonitor->SetDesiredError("VUID-vkWaitForPresent2KHR-None-10816");
     vk::WaitForPresent2KHR(device(), swapchain, &present_wait_2_info);
     m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
 }
 
 TEST_F(NegativeWsi, PresentId2InvalidEntry) {
@@ -5369,6 +5373,8 @@ TEST_F(NegativeWsi, PresentIdWait2) {
     m_errorMonitor->SetDesiredError("VUID-vkWaitForPresent2KHR-presentId-10817");
     vk::WaitForPresent2KHR(device(), swapchain, &present_wait_2_info);
     m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
 }
 
 TEST_F(NegativeWsi, PresentTimingsSwapchainCount) {
@@ -6060,6 +6066,8 @@ TEST_F(NegativeWsi, PresentTimingsOutOfOrder) {
     m_errorMonitor->SetDesiredError("VUID-vkGetPastPresentationTimingEXT-flags-12230");
     vk::GetPastPresentationTimingEXT(device(), &past_presentation_timing_info, &past_presentation_timing_properties);
     m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
 }
 
 TEST_F(NegativeWsi, PresentTimingsStageCount) {
@@ -6190,6 +6198,8 @@ TEST_F(NegativeWsi, PresentTimingsStageCount) {
     m_errorMonitor->SetDesiredError("VUID-vkGetPastPresentationTimingEXT-flags-12231");
     vk::GetPastPresentationTimingEXT(device(), &past_presentation_timing_info, &past_presentation_timing_properties);
     m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
 }
 
 TEST_F(NegativeWsi, TimeDomain) {
@@ -6596,4 +6606,82 @@ TEST_F(NegativeWsi, InvalidTimeDomainId) {
     m_errorMonitor->SetDesiredError("UNASSIGNED-VkPresentTimingInfoEXT-timeDomainId");
     m_default_queue->Present(swapchain, image_index, vkt::no_semaphore, &present_timings_info);
     m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeWsi, DestroySwapchainInUse) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11994
+    TEST_DESCRIPTION("Delete swapchain whose image is still in use");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddSurfaceExtension();
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSurface());
+
+    const SurfaceInformation surface_info = GetSwapchainInfo(m_surface);
+    VkSwapchainCreateInfoKHR swapchain_ci = GetDefaultSwapchainCreateInfo(m_surface, surface_info);
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    const auto swapchain_images = swapchain.GetImages();
+
+    vkt::Fence fence(*m_device);
+    const uint32_t image_index = swapchain.AcquireNextImage(fence, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
+
+    VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
+    layout_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    layout_transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    layout_transition.image = swapchain_images[image_index];
+    layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(layout_transition);
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer);
+
+    // Swapchain image is in use by the submitted command buffer
+    m_errorMonitor->SetDesiredError("VUID-vkDestroySwapchainKHR-swapchain-01282");
+    vk::DestroySwapchainKHR(*m_device, swapchain, nullptr);
+    m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeWsi, DestroySwapchainInUse2) {
+    TEST_DESCRIPTION("Delete swapchain that has pending present opeation");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddSurfaceExtension();
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSurface());
+
+    const SurfaceInformation surface_info = GetSwapchainInfo(m_surface);
+    VkSwapchainCreateInfoKHR swapchain_ci = GetDefaultSwapchainCreateInfo(m_surface, surface_info);
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    const auto swapchain_images = swapchain.GetImages();
+
+    vkt::Fence fence(*m_device);
+
+    const uint32_t image_index = swapchain.AcquireNextImage(fence, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
+
+    VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
+    layout_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    layout_transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    layout_transition.image = swapchain_images[image_index];
+    layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(layout_transition);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    m_default_queue->Present(swapchain, image_index, vkt::no_semaphore);
+
+    // Swapchain is in use by the present operation
+    m_errorMonitor->SetDesiredError("VUID-vkDestroySwapchainKHR-swapchain-01282");
+    vk::DestroySwapchainKHR(*m_device, swapchain, nullptr);
+    m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
 }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -566,57 +566,6 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence) {
     m_default_queue->Wait();
 }
 
-TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence2) {
-    TEST_DESCRIPTION("Test that retiring submission using acquire fence works correctly after swapchain was changed.");
-    AddSurfaceExtension();
-    RETURN_IF_SKIP(Init());
-    RETURN_IF_SKIP(InitSwapchain());
-    auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
-
-    std::vector<vkt::CommandBuffer> command_buffers;
-    std::vector<vkt::Semaphore> submit_semaphores;
-    for (size_t i = 0; i < swapchain_images.size(); i++) {
-        command_buffers.emplace_back(*m_device, m_command_pool);
-        submit_semaphores.emplace_back(*m_device);
-    }
-    const vkt::Fence acquire_fence(*m_device);
-    uint32_t image_index = m_swapchain.AcquireNextImage(acquire_fence, kWaitTimeout);
-    vk::WaitForFences(device(), 1, &acquire_fence.handle(), VK_TRUE, kWaitTimeout);
-    vk::ResetFences(device(), 1, &acquire_fence.handle());
-    command_buffers[image_index].Begin();
-    command_buffers[image_index].End();
-
-    m_default_queue->Submit(command_buffers[image_index], vkt::Signal(submit_semaphores[image_index]));
-    m_default_queue->Present(m_swapchain, image_index, submit_semaphores[image_index]);
-
-    // Here the application decides to destroy swapchain (e.g. resize event)
-    m_swapchain.Destroy();
-
-    // At this point there's a pending frame we need to sync with.
-    // WaitForFences(acquire_fence) logic can't be used, because swapchain was destroyed and its acquire
-    // fence can't be waited on. Application can use arbitrary logic to sync with the previous frames.
-    // After swapchain is re-created we can continue to use WaitForFences(acquire_fence) sync model.
-    //
-    // Here we just wait on the queue.
-    // If this line is removed we can get in-use error when begin command buffer.
-    m_default_queue->Wait();
-
-    // Create new swapchain.
-    m_swapchain = CreateSwapchain(m_surface, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
-
-    image_index = m_swapchain.AcquireNextImage(acquire_fence, kWaitTimeout);
-
-    vk::WaitForFences(device(), 1, &acquire_fence.handle(), VK_TRUE, kWaitTimeout);
-    vk::ResetFences(device(), 1, &acquire_fence.handle());
-
-    command_buffers[image_index].Begin();
-    command_buffers[image_index].End();
-    m_default_queue->Wait();
-}
-
 TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence3) {
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8880
     TEST_DESCRIPTION("Test that retiring submission using acquire fence works correctly when using differnt fences.");
@@ -1348,6 +1297,7 @@ TEST_F(PositiveWsi, AcquireImageBeforeGettingSwapchainImages) {
 
     SetPresentImageLayout(swapchain_images[image_index]);
     m_default_queue->Present(swapchain, image_index, vkt::no_semaphore);
+    m_default_queue->Wait();
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7025
@@ -2654,89 +2604,6 @@ TEST_F(PositiveWsi, SharedPresentAndPresentSemaphoreReuse) {
     // If supported, swapchain_maintenance1 should be used in such scenario.
     m_default_queue->Submit(vkt::no_cmd, vkt::Signal(semaphore));
     m_default_queue->Present(swapchain, image_index, semaphore);
-    m_default_queue->Wait();
-}
-
-TEST_F(PositiveWsi, SharedPresentReuseSemaphoreAfterDestroy) {
-    TEST_DESCRIPTION("After swapchain with shared present mode is destroyed the present semaphore can be reused");
-    AddRequiredExtensions(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
-    AddSurfaceExtension();
-    RETURN_IF_SKIP(Init());
-    RETURN_IF_SKIP(InitSurface());
-    InitSwapchainInfo();
-
-    bool found = false;
-    for (VkPresentModeKHR present_mode : m_surface_present_modes) {
-        found |= (present_mode == VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR);
-    }
-    if (!found) {
-        GTEST_SKIP() << "Cannot find shared present mode";
-    }
-
-    VkSwapchainCreateInfoKHR swapchain_ci = vku::InitStructHelper();
-    swapchain_ci.surface = m_surface;
-    swapchain_ci.minImageCount = 1;
-    swapchain_ci.imageFormat = m_surface_formats[0].format;
-    swapchain_ci.imageColorSpace = m_surface_formats[0].colorSpace;
-    swapchain_ci.imageExtent = m_surface_capabilities.minImageExtent;
-    swapchain_ci.imageArrayLayers = 1;
-    swapchain_ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;  // implementations must support
-    swapchain_ci.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    swapchain_ci.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
-    swapchain_ci.compositeAlpha = m_surface_composite_alpha;
-    swapchain_ci.presentMode = VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR;
-
-    vkt::Swapchain swapchain(*m_device, swapchain_ci);
-    const auto images = swapchain.GetImages();
-    for (auto image : images) {
-        SetPresentImageLayout(image);
-    }
-
-    vkt::Fence fence(*m_device);
-    const uint32_t image_index = swapchain.AcquireNextImage(fence, kWaitTimeout);
-    fence.Wait(kWaitTimeout);
-    fence.Reset();
-
-    vkt::Semaphore semaphore(*m_device);
-    vkt::Semaphore semaphore2(*m_device);
-
-    m_default_queue->Submit(vkt::no_cmd, vkt::Signal(semaphore));
-    m_default_queue->Present(swapchain, image_index, semaphore);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Signal(semaphore2));
-    m_default_queue->Present(swapchain, image_index, semaphore2);
-
-    swapchain_ci.minImageCount = m_surface_capabilities.minImageCount;
-    swapchain_ci.presentMode = VK_PRESENT_MODE_FIFO_KHR;
-    swapchain_ci.oldSwapchain = swapchain;
-    vkt::Swapchain swapchain2(*m_device, swapchain_ci);
-    const auto images2 = swapchain2.GetImages();
-
-    const uint32_t image_index2 = swapchain2.AcquireNextImage(fence, kWaitTimeout);
-    fence.Wait(kWaitTimeout);
-    fence.Reset();
-
-    // Destroy swapchain!
-    swapchain.Destroy();
-
-    // Transition layout manually, because SetPresentImageLayout calls QueueWaitIdle which
-    // resets semaphore swapchain state and this is not what we want for this test.
-    VkImageMemoryBarrier present_transition = vku::InitStructHelper();
-    present_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    present_transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    present_transition.image = images2[image_index2];
-    present_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-
-    m_command_buffer.Begin();
-    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
-                           0, nullptr, 1, &present_transition);
-    m_command_buffer.End();
-
-    // Test that semaphore does not assume it is still in use by swapchain that was just deleted.
-    // Swapchain2 is created with FIFO mode in order to enable semaphore-in-use-by-swapchain check
-    // (it is disabled for shared present modes)
-    m_default_queue->Submit(m_command_buffer, vkt::Signal(semaphore));
-    m_default_queue->Present(swapchain2, image_index2, semaphore);
-
     m_default_queue->Wait();
 }
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11994

Detect that swapchain is in use:
* when swapchain image is used by the submitted command buffer
* when swapchain is used on the queue (QueuePresent)

This adds validation but temporary uses default `ValidateObjectNotInUse` reporting. Will do message customization separately, default is confusing:
* Swapchain's parent is an image for in-use tracking purposes. This directly translates into the error message and is not intuitive.
*  `InUse` for swapchain likely has to be overloaded too (similar to vvl::Semaphore) to get proper message in QueuePresent case.