### PR TITLE
layers: Fix optional array check

### DIFF
--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -3606,6 +3606,10 @@ bool Context::ValidatePnextStructContents(const Location& loc, const VkBaseOutSt
                                       AllVkPipelineLayoutCreateFlagBits, structure->flags, kOptionalFlags,
                                       "VUID-VkPipelineLayoutCreateInfo-flags-parameter", nullptr, false);
 
+                skip |= ValidateArray(pNext_loc.dot(Field::setLayoutCount), pNext_loc.dot(Field::pSetLayouts),
+                                      structure->setLayoutCount, &structure->pSetLayouts, false, true, kVUIDUndefined,
+                                      "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-parameter");
+
                 skip |= ValidateArray(pNext_loc.dot(Field::pushConstantRangeCount), pNext_loc.dot(Field::pPushConstantRanges),
                                       structure->pushConstantRangeCount, &structure->pPushConstantRanges, false, true,
                                       kVUIDUndefined, "VUID-VkPipelineLayoutCreateInfo-pPushConstantRanges-parameter");
@@ -5400,10 +5404,10 @@ bool Context::ValidatePnextStructContents(const Location& loc, const VkBaseOutSt
             if (is_const_param) {
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkSwapchainPresentFenceInfoKHR);
                 VkSwapchainPresentFenceInfoKHR* structure = (VkSwapchainPresentFenceInfoKHR*)header;
-                skip |= ValidateArray(pNext_loc.dot(Field::swapchainCount), pNext_loc.dot(Field::pFences),
-                                      structure->swapchainCount, &structure->pFences, true, false,
-                                      "VUID-VkSwapchainPresentFenceInfoKHR-swapchainCount-arraylength",
-                                      "VUID-VkSwapchainPresentFenceInfoKHR-pFences-parameter");
+                skip |=
+                    ValidateArray(pNext_loc.dot(Field::swapchainCount), pNext_loc.dot(Field::pFences), structure->swapchainCount,
+                                  &structure->pFences, true, true, "VUID-VkSwapchainPresentFenceInfoKHR-swapchainCount-arraylength",
+                                  "VUID-VkSwapchainPresentFenceInfoKHR-pFences-parameter");
             }
         } break;
 
@@ -6903,7 +6907,7 @@ bool Context::ValidatePnextStructContents(const Location& loc, const VkBaseOutSt
                 VkWriteDescriptorSetAccelerationStructureNV* structure = (VkWriteDescriptorSetAccelerationStructureNV*)header;
                 skip |=
                     ValidateArray(pNext_loc.dot(Field::accelerationStructureCount), pNext_loc.dot(Field::pAccelerationStructures),
-                                  structure->accelerationStructureCount, &structure->pAccelerationStructures, true, false,
+                                  structure->accelerationStructureCount, &structure->pAccelerationStructures, true, true,
                                   "VUID-VkWriteDescriptorSetAccelerationStructureNV-accelerationStructureCount-arraylength",
                                   "VUID-VkWriteDescriptorSetAccelerationStructureNV-pAccelerationStructures-parameter");
             }
@@ -8023,7 +8027,7 @@ bool Context::ValidatePnextStructContents(const Location& loc, const VkBaseOutSt
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkWriteDescriptorSetTensorARM);
                 VkWriteDescriptorSetTensorARM* structure = (VkWriteDescriptorSetTensorARM*)header;
                 skip |= ValidateArray(pNext_loc.dot(Field::tensorViewCount), pNext_loc.dot(Field::pTensorViews),
-                                      structure->tensorViewCount, &structure->pTensorViews, true, false,
+                                      structure->tensorViewCount, &structure->pTensorViews, true, true,
                                       "VUID-VkWriteDescriptorSetTensorARM-tensorViewCount-arraylength",
                                       "VUID-VkWriteDescriptorSetTensorARM-pTensorViews-parameter");
             }
@@ -8437,7 +8441,7 @@ bool Context::ValidatePnextStructContents(const Location& loc, const VkBaseOutSt
                     (VkWriteDescriptorSetPartitionedAccelerationStructureNV*)header;
                 skip |= ValidateArray(
                     pNext_loc.dot(Field::accelerationStructureCount), pNext_loc.dot(Field::pAccelerationStructures),
-                    structure->accelerationStructureCount, &structure->pAccelerationStructures, true, false,
+                    structure->accelerationStructureCount, &structure->pAccelerationStructures, true, true,
                     "VUID-VkWriteDescriptorSetPartitionedAccelerationStructureNV-accelerationStructureCount-arraylength",
                     "VUID-VkWriteDescriptorSetPartitionedAccelerationStructureNV-pAccelerationStructures-parameter");
             }
@@ -8561,7 +8565,7 @@ bool Context::ValidatePnextStructContents(const Location& loc, const VkBaseOutSt
                 VkWriteDescriptorSetAccelerationStructureKHR* structure = (VkWriteDescriptorSetAccelerationStructureKHR*)header;
                 skip |=
                     ValidateArray(pNext_loc.dot(Field::accelerationStructureCount), pNext_loc.dot(Field::pAccelerationStructures),
-                                  structure->accelerationStructureCount, &structure->pAccelerationStructures, true, false,
+                                  structure->accelerationStructureCount, &structure->pAccelerationStructures, true, true,
                                   "VUID-VkWriteDescriptorSetAccelerationStructureKHR-accelerationStructureCount-arraylength",
                                   "VUID-VkWriteDescriptorSetAccelerationStructureKHR-pAccelerationStructures-parameter");
             }
@@ -10706,6 +10710,10 @@ bool Device::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipeli
                                       AllVkPipelineLayoutCreateFlagBits, pCreateInfo->flags, kOptionalFlags,
                                       "VUID-VkPipelineLayoutCreateInfo-flags-parameter", nullptr, false);
 
+        skip |= context.ValidateArray(pCreateInfo_loc.dot(Field::setLayoutCount), pCreateInfo_loc.dot(Field::pSetLayouts),
+                                      pCreateInfo->setLayoutCount, &pCreateInfo->pSetLayouts, false, true, kVUIDUndefined,
+                                      "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-parameter");
+
         skip |= context.ValidateArray(pCreateInfo_loc.dot(Field::pushConstantRangeCount),
                                       pCreateInfo_loc.dot(Field::pPushConstantRanges), pCreateInfo->pushConstantRangeCount,
                                       &pCreateInfo->pPushConstantRanges, false, true, kVUIDUndefined,
@@ -11087,7 +11095,7 @@ bool Device::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuffer,
                                        "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-parameter");
     skip |= context.ValidateRequiredHandle(loc.dot(Field::layout), layout);
     skip |= context.ValidateArray(loc.dot(Field::descriptorSetCount), loc.dot(Field::pDescriptorSets), descriptorSetCount,
-                                  &pDescriptorSets, true, false, "VUID-vkCmdBindDescriptorSets-descriptorSetCount-arraylength",
+                                  &pDescriptorSets, true, true, "VUID-vkCmdBindDescriptorSets-descriptorSetCount-arraylength",
                                   "VUID-vkCmdBindDescriptorSets-pDescriptorSets-parameter");
     skip |= context.ValidateArray(loc.dot(Field::dynamicOffsetCount), loc.dot(Field::pDynamicOffsets), dynamicOffsetCount,
                                   &pDynamicOffsets, false, true, kVUIDUndefined,
@@ -11714,7 +11722,7 @@ bool Device::PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuffer, 
     bool skip = false;
     Context context(*this, error_obj, extensions);
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= context.ValidateArray(loc.dot(Field::bindingCount), loc.dot(Field::pBuffers), bindingCount, &pBuffers, true, false,
+    skip |= context.ValidateArray(loc.dot(Field::bindingCount), loc.dot(Field::pBuffers), bindingCount, &pBuffers, true, true,
                                   "VUID-vkCmdBindVertexBuffers-bindingCount-arraylength",
                                   "VUID-vkCmdBindVertexBuffers-pBuffers-parameter");
     skip |= context.ValidateArray(loc.dot(Field::bindingCount), loc.dot(Field::pOffsets), bindingCount, &pOffsets, true, true,

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -883,7 +883,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
                 counValueRequired = 'true'  # Count value cannot be 0
                 countRequiredVuid = None # If there is a count required VUID to check
                 # Generate required/optional parameter strings for the pointer and count values
-                if member.optional or member.optionalPointer:
+                if member.optional:
                     arrayRequired = 'false'
                 if member.length:
                     # The parameter is an array with an explicit count parameter

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -6146,11 +6146,16 @@ TEST_F(NegativeDescriptors, PartitionedAccelerationStructureTypeMismatch) {
     // Try to update with VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV when the layout expects UNIFORM_BUFFER
     VkWriteDescriptorSetPartitionedAccelerationStructureNV accel_struct_info = vku::InitStructHelper();
     accel_struct_info.accelerationStructureCount = 1;
+    // We need AS count is 1 but don't need actual AS for this test
+    m_errorMonitor->SetAllowedFailureMsg(
+        "VUID-VkWriteDescriptorSetPartitionedAccelerationStructureNV-pAccelerationStructures-parameter");
+
     VkWriteDescriptorSet descriptor_write = vku::InitStructHelper(&accel_struct_info);
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV;
+
     m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-descriptorType-00319");
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -4520,6 +4520,30 @@ TEST_F(NegativeWsi, DISABLED_InitSwapchainInvalidOldSwapchain) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeWsi, PresentNullFence) {
+    TEST_DESCRIPTION("Specify null present fence");
+    AddSurfaceExtension();
+    AddRequiredExtensions(VK_KHR_SWAPCHAIN_MAINTENANCE_1_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::swapchainMaintenance1);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+
+    const vkt::Fence acquire_fence(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_fence, kWaitTimeout);
+    acquire_fence.Wait(kWaitTimeout);
+
+    const auto swapchain_images = m_swapchain.GetImages();
+    SetPresentImageLayout(swapchain_images[image_index]);
+
+    VkSwapchainPresentFenceInfoKHR present_fence_info = vku::InitStructHelper();
+    present_fence_info.swapchainCount = 1;
+    present_fence_info.pFences = nullptr;
+
+    m_errorMonitor->SetDesiredError("VUID-VkSwapchainPresentFenceInfoKHR-pFences-parameter");
+    m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore, &present_fence_info);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeWsi, PresentSignaledFence) {
     TEST_DESCRIPTION("Use a sigled fence in VkSwapchainPresentFenceInfoEXT");
     AddSurfaceExtension();


### PR DESCRIPTION
`optionalPointer` is about pointed value (not the pointer itself). Arguably vulkan_object should be updated with better naming.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11963.
The error message was valid, the issue is about `VUID-VkSwapchainPresentFenceInfoKHR-pFences-parameter` validation.

---
Rename suggestions (not part of this PR):

vulkan_object.py from:
`optionalPointer: bool # if type contains a pointer, is the pointer value optional`
to:
`optionalPointedValue: bool # if type is a pointer, is the pointed value optional`

Also part of the comment in base_generator.py from:
```
# the first is if the variable itself is optional
# the second is the value of the pointer is optional;
```
to:
```
# the first is if the variable itself is optional
# the second is used if the variable is a pointer. It determines if the pointed value is optional
```
