### PR TITLE
layers: Fix swapchain in-use messages

### DIFF
--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -668,21 +668,37 @@ bool CoreChecks::PreCallValidateResetCommandPool(VkDevice device, VkCommandPool 
     return skip;
 }
 
-// For given obj node, if it is use, flag a validation error and return callback result, else return false
 bool CoreChecks::ValidateObjectNotInUse(const vvl::StateObject* obj_node, const Location& loc, const char* error_code) const {
-    if (disabled[object_in_use]) {
-        return false;
-    } else if (is_device_lost) {
-        return false;  // In case of DEVICE_LOST, all execution is considered over
-    }
     bool skip = false;
-
-    const VulkanTypedHandle& obj_struct = obj_node->Handle();
-    const VulkanTypedHandle* used_handle = obj_node->InUse();
-    if (used_handle) {
-        skip |= LogError(error_code, device, loc, "can't be called on %s that is currently in use by %s.",
-                         FormatHandle(obj_struct).c_str(), FormatHandle(*used_handle).c_str());
+    if (disabled[object_in_use]) {
+        return skip;
     }
+    if (is_device_lost) {
+        return skip;  // In case of DEVICE_LOST, all execution is considered over
+    }
+    const VulkanTypedHandle* user_handle = obj_node->InUse();
+    if (!user_handle) {
+        return skip;
+    }
+
+    const VulkanTypedHandle& obj_handle = obj_node->Handle();
+
+    // Special case for a swapchain when there are no pending present queue operations,
+    // but a swapchain image is still in use by a submitted command buffer.
+    // NOTE: the common scenario where a swapchain is used by queue present operations
+    // is handled by the general error message below (the user handle has type Queue then).
+    if (obj_handle.type == kVulkanObjectTypeSwapchainKHR && user_handle->type == kVulkanObjectTypeImage) {
+        if (auto swapchain_image = Get<vvl::Image>(user_handle->Cast<VkImage>())) {
+            const VulkanTypedHandle* image_user_handle = swapchain_image->InUse();
+            skip |= LogError(error_code, device, loc, "can't be called on %s that has its %s in use by %s.",
+                             FormatHandle(obj_handle).c_str(), FormatHandle(*user_handle).c_str(),
+                             FormatHandle(*image_user_handle).c_str());
+            return skip;
+        }
+    }
+
+    skip |= LogError(error_code, device, loc, "can't be called on %s that is currently in use by %s.",
+                     FormatHandle(obj_handle).c_str(), FormatHandle(*user_handle).c_str());
     return skip;
 }
 

--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -37,8 +37,9 @@ vvl::Fence::Fence(Logger& logger, VkFence handle, const VkFenceCreateInfo* pCrea
 
 const VulkanTypedHandle* vvl::Fence::InUse() const {
     auto guard = ReadLock();
-    // Fence does not have a parent (in the sense of a VVL state object), and the value returned
-    // by the base class InUse is not useful for reporting (it is the fence's own handle)
+    // Fence does not have a parent (in the sense of VVL state object hierarchy).
+    // The typed handle returned by the base class InUse is not useful for reporting
+    // (it is the fence's own handle). Use it only to get boolean in use status.
     const bool in_use = RefcountedStateObject::InUse() != nullptr;
     if (!in_use) {
         return nullptr;

--- a/layers/state_tracker/wsi_state.cpp
+++ b/layers/state_tracker/wsi_state.cpp
@@ -22,6 +22,7 @@
 #include "state_tracker/image_state.h"
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/fence_state.h"
+#include "state_tracker/queue_state.h"
 #include "state_tracker/semaphore_state.h"
 #include "generated/dispatch_functions.h"
 
@@ -119,6 +120,31 @@ Swapchain::Swapchain(vvl::DeviceState& dev_data_, const VkSwapchainCreateInfoKHR
         present_at_absolute_time_supported = present_timing_surface_capabilities.presentAtAbsoluteTimeSupported;
         present_at_relative_time_supported = present_timing_surface_capabilities.presentAtRelativeTimeSupported;
     }
+}
+
+const VulkanTypedHandle* Swapchain::InUse() const {
+    // Swapchain's parents are swapchain images (in the sense of VVL state object hierarchy).
+    // The typed handle returned by the base class InUse is not useful for reporting
+    // (it is swapchain image). Use it only to get boolean in use status.
+    const bool in_use = RefcountedStateObject::InUse() != nullptr;
+    if (!in_use) {
+        return nullptr;
+    }
+
+    // a) either there is a queue with pending present operations
+    for (const SwapchainImage& image : images) {
+        if (image.present_submission_ref.has_value()) {
+            return &image.present_submission_ref->queue->Handle();
+        }
+    }
+    // b) or acquired swapchain image is in use (e.g. layout transition was recorded and submitted)
+    for (const SwapchainImage& image : images) {
+        if (image.image_state->InUse()) {
+            return &image.image_state->Handle();
+        }
+    }
+    assert(false && "Can't find queue that uses the swapchain or another usage of swapchain image");
+    return nullptr;
 }
 
 void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference& present_submission_ref,

--- a/layers/state_tracker/wsi_state.h
+++ b/layers/state_tracker/wsi_state.h
@@ -159,6 +159,7 @@ class Swapchain : public RefcountedStateObject, public SubStateManager<Swapchain
         }
     }
 
+    const VulkanTypedHandle* InUse() const override;
     VkSwapchainKHR VkHandle() const { return handle_.Cast<VkSwapchainKHR>(); }
 
     void PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference &present_submission_ref,

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -6634,7 +6634,7 @@ TEST_F(NegativeWsi, InvalidTimeDomainId) {
 
 TEST_F(NegativeWsi, DestroySwapchainInUse) {
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11994
-    TEST_DESCRIPTION("Delete swapchain whose image is still in use");
+    TEST_DESCRIPTION("Delete swapchain whose acquired image is in use by submitted command buffer");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddSurfaceExtension();
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -6662,7 +6662,7 @@ TEST_F(NegativeWsi, DestroySwapchainInUse) {
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
-    // Swapchain image is in use by the submitted command buffer
+    // There is no presentation but swapchain image is in use by the submitted command buffer
     m_errorMonitor->SetDesiredError("VUID-vkDestroySwapchainKHR-swapchain-01282");
     vk::DestroySwapchainKHR(*m_device, swapchain, nullptr);
     m_errorMonitor->VerifyFound();
@@ -6671,7 +6671,7 @@ TEST_F(NegativeWsi, DestroySwapchainInUse) {
 }
 
 TEST_F(NegativeWsi, DestroySwapchainInUse2) {
-    TEST_DESCRIPTION("Delete swapchain that has pending present opeation");
+    TEST_DESCRIPTION("Delete swapchain that has pending present operation");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddSurfaceExtension();
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -6702,7 +6702,7 @@ TEST_F(NegativeWsi, DestroySwapchainInUse2) {
 
     m_default_queue->Present(swapchain, image_index, vkt::no_semaphore);
 
-    // Swapchain is in use by the present operation
+    // Swapchain is in use by the present queue operation
     m_errorMonitor->SetDesiredError("VUID-vkDestroySwapchainKHR-swapchain-01282");
     vk::DestroySwapchainKHR(*m_device, swapchain, nullptr);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Follor up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12000 to fix error messages.

Original version was broken because:
> vkDestroySwapchainKHR(): can't be called on VkSwapchainKHR 0x50000000005 that is currently in use by VkSwapchainKHR 0x50000000005.

Now we have two types of messages. NegativeWsi.DestroySwapchainInUse:
> vkDestroySwapchainKHR(): can't be called on VkSwapchainKHR 0x50000000005 that has its VkImage 0x60000000006 in use by VkCommandBuffer 0x1d2c50e2060.

NegativeWsi.DestroySwapchainInUse2:
> vkDestroySwapchainKHR(): can't be called on VkSwapchainKHR 0x50000000005 that is currently in use by VkQueue 0x191c4843d10.
