### PR TITLE
layer: Remove unused queue state code

### DIFF
--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -62,14 +62,14 @@ void vvl::QueueSubmission::EndUse() {
     }
 }
 
-vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) {
+uint64_t vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) {
     if (!submissions.empty()) {
         submissions.back().is_last_submission = true;
     }
     for (auto& item : sub_states_) {
         item.second->PreSubmit(submissions);
     }
-    PreSubmitResult result;
+    uint64_t last_batch_seq = 0;
     for (QueueSubmission& submission : submissions) {
         for (CommandBufferSubmission& cb_submission : submission.cb_submissions) {
             auto cb_guard = cb_submission.cb->WriteLock();
@@ -84,7 +84,7 @@ vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& s
         // Note that this relies on the external synchonization requirements for the
         // VkQueue
         submission.seq = ++seq_;
-        result.submission_seq = submission.seq;
+        last_batch_seq = submission.seq;
         submission.BeginUse();
         for (SemaphoreInfo& wait : submission.wait_semaphores) {
             wait.semaphore->EnqueueWait(SubmissionReference(this, submission.seq), wait.payload);
@@ -108,7 +108,7 @@ vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& s
             }
         }
     }
-    return result;
+    return last_batch_seq;
 }
 
 void vvl::Queue::Notify(uint64_t until_seq) {
@@ -266,20 +266,14 @@ void vvl::Queue::Destroy() {
 void vvl::Queue::PostSubmit() {
     auto guard = Lock();
     if (!submissions_.empty()) {
-        PostSubmit(submissions_.back());
-    }
-}
-
-void vvl::Queue::PostSubmit(QueueSubmission& submission) {
-    for (auto& item : sub_states_) {
-        item.second->PostSubmit(submissions_);
-    }
-
-    // If dealing with external fences, the app might call vkWaitForFences, but might not and we might not know when the queue
-    // submission is done. If we find adding a "big lock" here is slow for real cases, we could have something run in a background
-    // thread calling vkGetFenceStatus to check for us. (This would require a good thing to test against)
-    if (submission.has_external_fence) {
-        submission.fence->NotifyAndWait(submission.loc.Get());
+        for (auto& item : sub_states_) {
+            item.second->PostSubmit(submissions_);
+        }
+        // Wait on the external fence because we may not be able to track when it's signaled
+        QueueSubmission& submission = submissions_.back();
+        if (submission.has_external_fence) {
+            submission.fence->NotifyAndWait(submission.loc.Get());
+        }
     }
 }
 

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -130,11 +130,6 @@ static inline std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTime
     return std::chrono::steady_clock::now() + std::chrono::seconds(timeout_seconds);
 }
 
-struct PreSubmitResult {
-    uint64_t last_submission_seq = 0;
-    uint64_t submission_seq = 0;
-};
-
 class Queue : public StateObject, public SubStateManager<QueueSubState> {
   public:
     Queue(DeviceState& device_state, VkQueue handle, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
@@ -152,9 +147,11 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
     VkQueue VkHandle() const { return handle_.Cast<VkQueue>(); }
     VkQueueFlags GetQueueFlags() const { return queue_family_properties_.queueFlags; }
 
-    // called from the various PreCallRecordQueueSubmit() methods
-    PreSubmitResult PreSubmit(std::vector<QueueSubmission> &&submissions);
-    // called from the various PostCallRecordQueueSubmit() methods
+    // Called from the various PreCallRecordQueueSubmit() methods.
+    // Returns seq number associated with the last QueueSubmission batch
+    uint64_t PreSubmit(std::vector<QueueSubmission>&& submissions);
+
+    // Called from the various PostCallRecordQueueSubmit() methods
     void PostSubmit();
 
     // Tell the queue thread that submissions up to and including the submission with
@@ -205,9 +202,6 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
     const std::deque<QueueSubmission> &Submissions() { return submissions_; }
 
   protected:
-    // called from the various PostCallRecordQueueSubmit() methods
-    void PostSubmit(QueueSubmission &submission);
-
     // called when the worker thread decides a submissions has finished executing
     void Retire(QueueSubmission &submission);
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4453,8 +4453,8 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
 
     auto queue_state = Get<Queue>(queue);
     queue_state->is_used_for_presentation = true;
-    PreSubmitResult result = queue_state->PreSubmit(std::move(present_submissions));
-    const SubmissionReference present_submission_ref(queue_state.get(), result.submission_seq);
+    const uint64_t last_present_seq = queue_state->PreSubmit(std::move(present_submissions));
+    const SubmissionReference present_submission_ref(queue_state.get(), last_present_seq);
 
     if (!queue_state->is_used_for_regular_submits) {
         queue_state->UpdatePresentOnlyQueueProgress(*this);
@@ -4476,7 +4476,7 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
         // If the present timing queue reports as full, any waits would have been enqueued and therefore need to
         // be tracked here, however the presentation will be dropped
         if (local_result == VK_ERROR_PRESENT_TIMING_QUEUE_FULL_EXT) {
-            queue_state->Notify(result.submission_seq);
+            queue_state->Notify(last_present_seq);
             for (const auto& semaphore : present_wait_semaphores) {
                 semaphore->ClearSwapchainWaitInfo();
             }
@@ -4511,9 +4511,9 @@ void DeviceState::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentIn
         swapchain_data->PresentImage(pPresentInfo->pImageIndices[i], present_id, present_submission_ref, present_wait_semaphores);
     }
 
-    // wait on fence as we don't know when it will be signaled if external
+    // Wait on the external fence because we may not be able to track when it's signaled
     if (has_external_fence) {
-        queue_state->NotifyAndWait(record_obj.location, result.submission_seq);
+        queue_state->NotifyAndWait(record_obj.location, last_present_seq);
     }
 }
 


### PR DESCRIPTION
`PreSubmitResult` struct - only single member is used now, return it directly 
`PostSubmit` method - the second overload is not needed