### PR TITLE
sync: Remove SuppressedBoundDescriptorWAW heuristic

### DIFF
--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -592,7 +592,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                             hazard = current_context_->DetectHazard(*img_view_state, sync_index);
                         }
 
-                        if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
+                        if (hazard.IsHazard()) {
                             LogObjectList objlist(cb_state_->Handle(), img_view_state->Handle(), pipe->Handle());
                             const auto error = error_messages_.ImageDescriptorError(
                                 hazard, *this, loc.function, sync_state_.FormatHandle(*img_view_state), *pipe,
@@ -611,7 +611,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         const auto* buf_state = buf_view_state->buffer_state.get();
                         const AccessRange range = MakeRange(*buf_view_state);
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
-                        if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
+                        if (hazard.IsHazard()) {
                             LogObjectList objlist(cb_state_->Handle(), buf_view_state->Handle(), pipe->Handle());
                             const auto error = error_messages_.BufferDescriptorError(
                                 hazard, *this, loc.function, sync_state_.FormatHandle(*buf_view_state), *pipe,
@@ -638,7 +638,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         const auto* buf_state = buffer_descriptor->GetBufferState();
                         const AccessRange range = MakeRange(*buf_state, offset, buffer_descriptor->GetRange());
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
-                        if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
+                        if (hazard.IsHazard()) {
                             LogObjectList objlist(cb_state_->Handle(), buf_state->Handle(), pipe->Handle());
                             const auto error = error_messages_.BufferDescriptorError(
                                 hazard, *this, loc.function, sync_state_.FormatHandle(*buf_state), *pipe, variable.decorations.set,
@@ -659,8 +659,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         if (const vvl::BufferAndOffset as_buffer = accel->GetFirstValidBuffer(cb_state_->dev_data)) {
                             const AccessRange range = MakeRange(*as_buffer.state, as_buffer.offset, accel->GetSize());
                             auto hazard = current_context_->DetectHazard(*as_buffer.state, sync_index, range);
-                            // TODO: figure out what is the purpose of SuppressedBoundDescriptorWAW and do we still need it?
-                            if (hazard.IsHazard() && !sync_state_.SuppressedBoundDescriptorWAW(hazard)) {
+                            if (hazard.IsHazard()) {
                                 LogObjectList objlist(cb_state_->Handle(), as_buffer.state->Handle(), pipe->Handle());
                                 const std::string resource_description = sync_state_.FormatHandle(accel->Handle());
                                 const std::string error = error_messages_.AccelerationStructureDescriptorError(

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -760,15 +760,6 @@ bool SyncValidator::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandB
     return PreCallValidateCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, error_obj);
 }
 
-// Simple heuristic rule to detect WAW operations representing algorithmically safe or increment
-// updates to a resource which do not conflict at the byte level.
-// TODO: Revisit this rule to see if it needs to be tighter or looser
-// TODO: Add programatic control over suppression heuristics
-bool SyncValidator::SuppressedBoundDescriptorWAW(const HazardResult& hazard) const {
-    assert(hazard.IsHazard());
-    return hazard.IsWAWHazard();
-}
-
 bool SyncValidator::PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,
                                                         const ErrorObject& error_obj) const {
     return PreCallValidateCmdBeginRendering(commandBuffer, pRenderingInfo, error_obj);

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -133,7 +133,6 @@ class SyncValidator : public vvl::DeviceProxy {
                                    const RecordObject &record_obj) override;
     void PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator,
                                           const RecordObject &record_obj) override;
-    bool SuppressedBoundDescriptorWAW(const HazardResult &hazard) const;
 
     void FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -5803,14 +5803,6 @@ TEST_F(NegativeSyncVal, RenderPassStoreOpNone) {
     m_command_buffer.End();
 }
 
-// TODO: this very simple case should cause WRITE-AFTER-WRITE hazard but it passes successfully.
-// This happens because of SuppressedBoundDescriptorWAW(). Remove SuppressedBoundDescriptorWAW()
-// after SDK release. SuppressedBoundDescriptorWAW works only for command buffer validation,
-// that's why the next test (WriteSameLocationFromTwoSubmits) that uses Submit does not have this problem.
-//
-// Prevention of tricky/complex false-positives should be done by having descriptor validation feature
-// turned off as default (current plan), as opposite to solutions where syncval behaves unreliable even
-// in simple scenarios. Simple should work. Complex should be manageable.
 TEST_F(NegativeSyncVal, WriteSameLocationFromTwoDispatches) {
     TEST_DESCRIPTION("Not synchronized write to the same location causes WAW hazard");
     RETURN_IF_SKIP(InitSyncVal());
@@ -5838,10 +5830,9 @@ TEST_F(NegativeSyncVal, WriteSameLocationFromTwoDispatches) {
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1, &descriptor_set.set_,
                               0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    // TODO: enable error monitor when we fix WAW detection.
-    // m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    // m_errorMonitor->VerifyFound();
+    m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
 

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -2408,12 +2408,14 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoSubmits) {
     m_default_queue->Wait();
 }
 
-// TODO: this test does not work due to SuppressedBoundDescriptorWAW(). That workaround should be removed.
-// Two possible solutions:
-// a) Try to detect if there is atomic operation in the buffer access chain. If yes, skip validation.
-// b) If a) is hard to do, then this case is in the category that is not handled by the current heuristic
-//    and is part of "Shader access heuristic" is disabled by default direction.
-TEST_F(PositiveSyncVal, AtomicAccessFromTwoDispatches2) {
+// Does not work correctly similar to AtomicAccessFromTwoDispatches. The initial idea that using
+// atomic makes this scenario valid but currently it reports WAW (but check UPDATE comment below).
+// Try to detect if there is atomic operation in the buffer access chain. If yes, skip validation.
+//
+// UPDATE: we need to investigate if this test describes hazard free scenario. Even if different
+// dispatches write to adjacent and non-intersecting memory locations it's not clear if that's fine
+// due to non-coherent GPU accesses and I'm increasingly tend to think this might be a WAW hazard.
+TEST_F(PositiveSyncVal, DISABLED_AtomicAccessFromTwoDispatches2) {
     TEST_DESCRIPTION("Use atomic counter so parallel dispatches write to different locations");
     RETURN_IF_SKIP(InitSyncVal());
 


### PR DESCRIPTION
According to TODO:

> // TODO: this very simple case should cause WRITE-AFTER-WRITE hazard but it passes successfully.
// This happens because of SuppressedBoundDescriptorWAW(). Remove SuppressedBoundDescriptorWAW()
// after SDK release.

This allows detection of WAW hazards within the scope of shader access heuristic (limited to simple shaders and even then no guarantees)
(https://vulkan.lunarg.com/doc/view/latest/windows/khronos_validation_layer.html#shader-accesses-heuristic)