### PR TITLE
layers: Add submit time validation placeholders

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -345,6 +345,8 @@ vvl_sources = [
   "layers/state_tracker/state_tracker.cpp",
   "layers/state_tracker/state_tracker.h",
   "layers/state_tracker/submission_reference.h",
+  "layers/state_tracker/submit_time_tracker.cpp",
+  "layers/state_tracker/submit_time_tracker.h",
   "layers/state_tracker/subresource_adapter.cpp",
   "layers/state_tracker/subresource_adapter.h",
   "layers/state_tracker/tensor_state.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -427,6 +427,8 @@ target_sources(vvl PRIVATE
     state_tracker/state_tracker.cpp
     state_tracker/state_tracker.h
     state_tracker/submission_reference.h
+    state_tracker/submit_time_tracker.cpp
+    state_tracker/submit_time_tracker.h
     state_tracker/subresource_adapter.cpp
     state_tracker/subresource_adapter.h
     state_tracker/vertex_index_buffer_state.cpp

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -290,6 +290,7 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
                                  chained_device_group_struct->commandBufferCount, submit.commandBufferCount);
             }
         }
+        skip |= submit_time_tracker.ProcessSubmissionBatch(submit);
     }
 
     return skip;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -32,6 +32,7 @@
 #include "state_tracker/query_state.h"
 #include "state_tracker/vertex_index_buffer_state.h"
 #include "state_tracker/event_map.h"
+#include "state_tracker/submit_time_tracker.h"
 #include "state_tracker/subresource_adapter.h"
 
 #include "containers/custom_containers.h"
@@ -226,9 +227,13 @@ class CoreChecks : public vvl::DeviceProxy {
     spv_target_env spirv_environment;
     stateless::SpirvValidator stateless_spirv_validator;
 
+    // Tracks submission batches for submit time validation
+    vvl::SubmitTimeTracker submit_time_tracker;
+
     CoreChecks(vvl::DispatchDevice* dev, core::Instance* instance_vo)
         : vvl::DeviceProxy(dev, instance_vo, LayerObjectTypeCoreValidation),
-          stateless_spirv_validator(dev->debug_report, dev->stateless_device_data, dev->settings.disabled[shader_validation]) {}
+          stateless_spirv_validator(dev->debug_report, dev->stateless_device_data, dev->settings.disabled[shader_validation]),
+          submit_time_tracker(*this) {}
 
     ReadLockGuard ReadLock() const override;
     WriteLockGuard WriteLock() override;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -43,6 +43,7 @@
 
 namespace vvl {
 struct AllocateDescriptorSetsData;
+struct SubmissionBatch;
 class Fence;
 class DescriptorPool;
 class DescriptorSet;
@@ -2350,6 +2351,15 @@ class DeviceProxy : public vvl::BaseDevice {
     virtual void Created(vvl::DescriptorSet& state) {}
     virtual void Created(vvl::ShaderObject& state) {}
     virtual void Created(vvl::Pipeline& state){};
+
+    // Validate submission batch and update state if necessary.
+    // Called by SubmitTimeTracker and protected by the mutex. Only one batch is processed at a time.
+    //
+    // NOTE: Classic Validate/Record split made it a challenge to synchronize threaded queues,
+    // especialy when timeline signal resolves pending work on another queue.
+    // This became increasingly important after the spec allowed internally synchronized queues,
+    // meaning the same queue can be used from multiple threads.
+    virtual bool ProcessSubmissionBatch(SubmissionBatch& batch) { return false; }
 
     // callbacks for image layout validation, which is implemented in both core validation and gpu-av
     // TODO - It would be nice to have a way to not need a duplicate copy in both CoreChecks and GPU-AV code

--- a/layers/state_tracker/submit_time_tracker.cpp
+++ b/layers/state_tracker/submit_time_tracker.cpp
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "state_tracker/submit_time_tracker.h"
+#include "state_tracker/state_tracker.h"
+
+bool vvl::SubmitTimeTracker::ProcessSubmissionBatch(const VkSubmitInfo& submit_info) const {
+    // TODO: initialize from submmit_info or update interface to accept SubmissionBatch directly
+    SubmissionBatch batch;
+
+    bool skip = false;
+    std::lock_guard lock(submit_time_mutex_);
+    {
+        skip |= validator_.ProcessSubmissionBatch(batch);
+    }
+    return skip;
+}

--- a/layers/state_tracker/submit_time_tracker.h
+++ b/layers/state_tracker/submit_time_tracker.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace vvl {
+
+class DeviceProxy;
+class CommandBuffer;
+
+struct SubmissionBatch {
+    std::vector<std::shared_ptr<CommandBuffer>> command_buffers;
+};
+
+// Tracks submission batches for submit time validation.
+// Submit time validation is performed during queue submit calls
+// such as QueueSubmit, QueuePresent, etc.
+//
+// Batches with no unresolved dependencies are validated immediately.
+// Batches with pending timeline waits are stored until a subsequent
+// queue operation specifies a resolving signal.
+// vkSignalSemaphore that resolves a pending wait triggers validation.
+//
+// Validations that depend on actual completion of queue operations
+// are not handled by this subsystem.
+class SubmitTimeTracker {
+  public:
+    SubmitTimeTracker(DeviceProxy& validator) : validator_(validator) {}
+    bool ProcessSubmissionBatch(const VkSubmitInfo& batch) const;
+
+  private:
+    DeviceProxy& validator_;
+
+    // Submit time validation runs under mutex. This encompasses both validation and update.
+    mutable std::mutex submit_time_mutex_;
+};
+
+}  // namespace vvl


### PR DESCRIPTION
That's initial placeholder code. Most implementation logic will be in SubmitTimeTracker which is easy to remove if something does not work.

This will resolve dependencies of submitted batches and run submit time validation as part queue submit calls. The goal is to move some parts of submit time validation from the queue thread (moved there to solve some issues) back to QueueSubmit calls.

Postponing submit time validation to run in the queue thread solved the problem with resolving proper batch order but introduced issues related to chronological order of submit time events (QueueSubmit and queue thread run in different timelines, so this approach fails when interaction between objects from different timelines are needed). The planned solution solves this problem since everything runs on the same queue submit timeline and this also properly resolves batch order based on semaphore dependencies. This approach is already implemented in syncval, the goal is to implement here a unified and cleaned up version of it.