### PR TITLE
layers: Implement submit time tracker

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -290,7 +290,9 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
                                  chained_device_group_struct->commandBufferCount, submit.commandBufferCount);
             }
         }
-        skip |= submit_time_tracker.ProcessSubmissionBatch(submit);
+        // Perform submit time validation at the end.
+        // If submit API is used incorrectly, we want those errors to be reported first
+        skip |= submit_time_tracker.ProcessSubmitInfo(submit, queue, submit_loc);
     }
 
     return skip;
@@ -450,6 +452,9 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
             skip |= LogError("VUID-VkSubmitInfo2-commandBuffer-06010", queue, submit_loc,
                              "has a suspended render pass instance that was not resumed.");
         }
+        // Perform submit time validation at the end.
+        // If submit API is used incorrectly, we want those errors to be reported first
+        skip |= submit_time_tracker.ProcessSubmitInfo(submit, queue, submit_loc);
     }
 
     return skip;
@@ -773,6 +778,33 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                     const VkSparseImageMemoryBind& memory_bind = image_bind.pBinds[image_bind_idx];
                     skip |= ValidateSparseImageMemoryBind(image_state.get(), memory_bind, bind_loc, image_bind_loc);
                 }
+            }
+        }
+    }
+    return skip;
+}
+
+bool CoreChecks::ProcessSubmissionBatch(const std::vector<std::shared_ptr<vvl::CommandBuffer>>& command_buffers,
+                                        const Location& submit_loc) {
+    bool skip = false;
+    // Validate image layouts on the command buffer boundaries
+    {
+        vvl::unordered_map<const vvl::Image*, ImageLayoutMap> local_image_layout_map;
+        for (const auto& cb : command_buffers) {
+            if (cb) {
+                auto cb_guard = cb->ReadLock();
+                skip |= ValidateCmdBufImageLayouts(submit_loc, *cb, local_image_layout_map);
+            }
+        }
+    }
+    if (!skip) {
+        for (const auto& cb : command_buffers) {
+            if (cb) {
+                auto cb_guard = cb->WriteLock();
+                for (const vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
+                    UpdateCmdBufImageLayouts(*secondary);
+                }
+                UpdateCmdBufImageLayouts(*cb);
             }
         }
     }

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -1229,7 +1229,6 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
 
 void QueueSubState::Retire(vvl::QueueSubmission& submission) {
     queue_submission_validator_.Validate(submission);
-    queue_submission_validator_.Update(submission);
 
     auto is_query_updated_after = [this](const QueryObject& query_object) {
         auto guard = base.Lock();

--- a/layers/core_checks/cc_submit.cpp
+++ b/layers/core_checks/cc_submit.cpp
@@ -34,24 +34,6 @@ static Location GetSignaledSemaphoreLocation(const Location& submit_loc, uint32_
     return submit_loc.dot(field, index);
 }
 
-static bool FindLayouts(const vvl::Image& image_state, std::vector<VkImageLayout>& layouts) {
-    if (!image_state.layout_map) {
-        return false;
-    }
-    const auto& layout_map = *image_state.layout_map;
-    auto guard = image_state.LayoutMapReadLock();
-
-    // TODO: Make this robust for >1 aspect mask. Now it will just say ignore potential errors in this case.
-    if (layout_map.size() > image_state.GetArrayLayers() * image_state.GetMipLevels()) {
-        return false;
-    }
-
-    for (const auto& entry : layout_map) {
-        layouts.emplace_back(entry.second);
-    }
-    return true;
-}
-
 void QueueSubmissionValidator::Validate(const vvl::QueueSubmission& submission) const {
     // Ensure that timeline signals are monotonically increasing values
     for (uint32_t i = 0; i < (uint32_t)submission.signal_semaphores.size(); ++i) {
@@ -73,40 +55,5 @@ void QueueSubmissionValidator::Validate(const vvl::QueueSubmission& submission) 
                                  "(%s) signaled with value %" PRIu64 " which is smaller than the current value %" PRIu64,
                                  core_checks.FormatHandle(signal.semaphore->VkHandle()).c_str(), signal.payload, current_payload);
         }
-    }
-
-    // Validate image layouts on the command buffer boundaries
-    {
-        vvl::unordered_map<const vvl::Image*, ImageLayoutMap> local_image_layout_map;
-        for (const vvl::CommandBufferSubmission& cb_submission : submission.cb_submissions) {
-            auto cb_guard = cb_submission.cb->ReadLock();
-            core_checks.ValidateCmdBufImageLayouts(submission.loc.Get(), *cb_submission.cb, local_image_layout_map);
-        }
-    }
-
-    // Check that image being presented has correct layout
-    if (submission.swapchain) {
-        std::vector<VkImageLayout> layouts;
-        if (submission.swapchain_image && FindLayouts(*submission.swapchain_image, layouts)) {
-            for (auto layout : layouts) {
-                if (layout != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR && layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR) {
-                    core_checks.LogError(
-                        "VUID-VkPresentInfoKHR-pImageIndices-01430", submission.swapchain_image->Handle(), submission.loc.Get(),
-                        "images passed to present must be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR or "
-                        "VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR but %s is in %s.",
-                        core_checks.FormatHandle(submission.swapchain_image->Handle()).c_str(), string_VkImageLayout(layout));
-                }
-            }
-        }
-    }
-}
-
-void QueueSubmissionValidator::Update(vvl::QueueSubmission& submission) {
-    for (vvl::CommandBufferSubmission& cb_submission : submission.cb_submissions) {
-        auto cb_guard = cb_submission.cb->WriteLock();
-        for (const vvl::CommandBuffer* secondary : cb_submission.cb->linked_command_buffers) {
-            core_checks.UpdateCmdBufImageLayouts(*secondary);
-        }
-        core_checks.UpdateCmdBufImageLayouts(*cb_submission.cb);
     }
 }

--- a/layers/core_checks/cc_submit.h
+++ b/layers/core_checks/cc_submit.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,5 +36,4 @@ struct QueueSubmissionValidator {
 
     QueueSubmissionValidator(CoreChecks &core_checks) : core_checks(core_checks) {}
     void Validate(const vvl::QueueSubmission &submission) const;
-    void Update(vvl::QueueSubmission &submission);
 };

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -719,6 +719,26 @@ bool CoreChecks::PreCallValidateCreateSemaphore(VkDevice device, const VkSemapho
     return skip;
 }
 
+void CoreChecks::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                               const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
+                                               const RecordObject& record_obj) {
+    if (record_obj.result != VK_SUCCESS) {
+        return;
+    }
+    auto semaphore_state = Get<vvl::Semaphore>(*pSemaphore);
+    if (semaphore_state && semaphore_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
+        submit_time_tracker.OnCreateTimelineSemaphore(*pSemaphore, semaphore_state->initial_value);
+    }
+}
+
+void CoreChecks::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
+                                               const RecordObject& record_obj) {
+    auto semaphore_state = Get<vvl::Semaphore>(semaphore);
+    if (semaphore_state && semaphore_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
+        submit_time_tracker.OnDestroyTimelineSemaphore(semaphore);
+    }
+}
+
 bool CoreChecks::PreCallValidateWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                                   const ErrorObject& error_obj) const {
     return PreCallValidateWaitSemaphores(device, pWaitInfo, timeout, error_obj);
@@ -1627,6 +1647,10 @@ bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemapho
                          "(%" PRIu64 ") exceeds limit regarding %s semaphore %s payload (%" PRIu64 ").", pSignalInfo->value,
                          FormatHandle(*semaphore_state).c_str(), payload_type, *far_away_payload);
     }
+
+    // Perform submit time validation at the end.
+    // If signal semaphore API is used incorrectly, we want those errors to be reported first
+    skip |= submit_time_tracker.ProcessSignalSemaphore(*pSignalInfo);
     return skip;
 }
 

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1257,6 +1257,10 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
         skip |= ValidateSwapchainPresentFenceInfo(queue, *pPresentInfo, *swapchain_present_fence_info, present_info_loc);
     }
 
+    // Perform submit time validation at the end.
+    // If present API is used incorrectly, we want those errors to be reported first
+    skip |= submit_time_tracker.ProcessPresent(*pPresentInfo, present_info_loc);
+
     return skip;
 }
 
@@ -1537,6 +1541,41 @@ bool CoreChecks::PreCallValidateWaitForPresent2KHR(VkDevice device, VkSwapchainK
                              error_obj.location.dot(Field::pPresentWait2Info).dot(Field::presentId),
                              "is %" PRIu64 ", but this value was never associated with the VkPresentWait2InfoKHR::presentId on %s.",
                              pPresentWait2Info->presentId, FormatHandle(swapchain).c_str());
+        }
+    }
+    return skip;
+}
+
+static bool FindLayouts(const vvl::Image& image_state, std::vector<VkImageLayout>& layouts) {
+    if (!image_state.layout_map) {
+        return false;
+    }
+    const auto& layout_map = *image_state.layout_map;
+    auto guard = image_state.LayoutMapReadLock();
+
+    // TODO: Make this robust for >1 aspect mask. Now it will just say ignore potential errors in this case.
+    if (layout_map.size() > image_state.GetArrayLayers() * image_state.GetMipLevels()) {
+        return false;
+    }
+
+    for (const auto& entry : layout_map) {
+        layouts.emplace_back(entry.second);
+    }
+    return true;
+}
+
+bool CoreChecks::ProcessPresentBatch(const vvl::Image& swapchain_image, const Location& present_info_loc) {
+    bool skip = false;
+    // Check that image being presented has correct layout
+    std::vector<VkImageLayout> layouts;
+    if (FindLayouts(swapchain_image, layouts)) {
+        for (auto layout : layouts) {
+            if (layout != VK_IMAGE_LAYOUT_PRESENT_SRC_KHR && layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR) {
+                skip |= LogError("VUID-VkPresentInfoKHR-pImageIndices-01430", swapchain_image.Handle(), present_info_loc,
+                                 "images passed to present must be in layout VK_IMAGE_LAYOUT_PRESENT_SRC_KHR or "
+                                 "VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR but %s is in %s.",
+                                 FormatHandle(swapchain_image.Handle()).c_str(), string_VkImageLayout(layout));
+            }
         }
     }
     return skip;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1107,7 +1107,6 @@ class CoreChecks : public vvl::DeviceProxy {
                                                 VkDataGraphPipelineSessionARM session,
                                                 const VkDataGraphPipelineDispatchInfoARM *pInfo,
                                                 const ErrorObject& error_obj) const override;
-
     void PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                    VkImage* pImage, const RecordObject& record_obj) override;
 
@@ -1580,6 +1579,9 @@ class CoreChecks : public vvl::DeviceProxy {
                                        const RecordObject& record_obj) override;
     void PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                     const RecordObject& record_obj) override;
+    bool ProcessSubmissionBatch(const std::vector<std::shared_ptr<vvl::CommandBuffer>>& command_buffers,
+                                const Location& submit_loc) override;
+    bool ProcessPresentBatch(const vvl::Image& swapchain_image, const Location& present_info_loc) override;
     bool IgnoreAllocationSize(const VkMemoryAllocateInfo& allocate_info) const;
     bool HasExternalMemoryImportSupport(const vvl::Buffer& buffer, VkExternalMemoryHandleTypeFlagBits handle_type) const;
     bool HasExternalMemoryImportSupport(const vvl::Image& image, VkExternalMemoryHandleTypeFlagBits handle_type) const;
@@ -1594,6 +1596,11 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
                                         const ErrorObject& error_obj) const override;
+    void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
+                                       const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
+                                       const RecordObject& record_obj) override;
+    void PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
+                                       const RecordObject& record_obj) override;
     bool PreCallValidateWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                        const ErrorObject& error_obj) const override;
     bool PreCallValidateWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -43,7 +43,6 @@
 
 namespace vvl {
 struct AllocateDescriptorSetsData;
-struct SubmissionBatch;
 class Fence;
 class DescriptorPool;
 class DescriptorSet;
@@ -2352,14 +2351,21 @@ class DeviceProxy : public vvl::BaseDevice {
     virtual void Created(vvl::ShaderObject& state) {}
     virtual void Created(vvl::Pipeline& state){};
 
-    // Validate submission batch and update state if necessary.
-    // Called by SubmitTimeTracker and protected by the mutex. Only one batch is processed at a time.
+    // Validate a submission batch and update state if needed.
+    // This call is protected by the global submit-time mutex.
     //
-    // NOTE: Classic Validate/Record split made it a challenge to synchronize threaded queues,
-    // especialy when timeline signal resolves pending work on another queue.
-    // This became increasingly important after the spec allowed internally synchronized queues,
-    // meaning the same queue can be used from multiple threads.
-    virtual bool ProcessSubmissionBatch(SubmissionBatch& batch) { return false; }
+    // NOTE: The classic Validate/Record split made threaded queues difficult to synchronize,
+    // especially when a timeline signal resolves pending work on another queue.
+    // This became even more important after the spec allowed internally synchronized queues,
+    // which means the same queue can be used from multiple threads
+    virtual bool ProcessSubmissionBatch(const std::vector<std::shared_ptr<vvl::CommandBuffer>>& command_buffers,
+                                        const Location& submit_loc) {
+        return false;
+    }
+
+    // Validate a submission batch and update state if needed.
+    // This call is protected by the global submit-time mutex
+    virtual bool ProcessPresentBatch(const vvl::Image& swapchain_image, const Location& present_info_loc) { return false; }
 
     // callbacks for image layout validation, which is implemented in both core validation and gpu-av
     // TODO - It would be nice to have a way to not need a duplicate copy in both CoreChecks and GPU-AV code

--- a/layers/state_tracker/submit_time_tracker.cpp
+++ b/layers/state_tracker/submit_time_tracker.cpp
@@ -16,16 +16,190 @@
  */
 
 #include "state_tracker/submit_time_tracker.h"
+#include "state_tracker/semaphore_state.h"
 #include "state_tracker/state_tracker.h"
+#include "state_tracker/wsi_state.h"
+#include "containers/container_utils.h"
+#include "utils/convert_utils.h"
 
-bool vvl::SubmitTimeTracker::ProcessSubmissionBatch(const VkSubmitInfo& submit_info) const {
-    // TODO: initialize from submmit_info or update interface to accept SubmissionBatch directly
-    SubmissionBatch batch;
+namespace vvl {
 
+void SubmitTimeTracker::OnCreateTimelineSemaphore(VkSemaphore timeline, uint64_t initial_value) {
+    std::lock_guard lock(mutex_);
+    timeline_signals_[timeline] = initial_value;
+}
+
+void SubmitTimeTracker::OnDestroyTimelineSemaphore(VkSemaphore timeline) {
+    std::lock_guard lock(mutex_);
+    timeline_signals_.erase(timeline);
+}
+
+bool SubmitTimeTracker::ProcessSubmitInfo(const VkSubmitInfo& submit_info, VkQueue queue, const Location& submit_loc) const {
+    SubmitInfoConverter converter(submit_info);
+    return ProcessSubmitInfo(converter.submit_info2, queue, submit_loc);
+}
+
+bool SubmitTimeTracker::ProcessSubmitInfo(const VkSubmitInfo2& submit_info, VkQueue queue, const Location& submit_loc) const {
+    const auto wait_semaphores =
+        vvl::span<const VkSemaphoreSubmitInfo>(submit_info.pWaitSemaphoreInfos, submit_info.waitSemaphoreInfoCount);
+    const auto signal_semaphores =
+        vvl::span<const VkSemaphoreSubmitInfo>(submit_info.pSignalSemaphoreInfos, submit_info.signalSemaphoreInfoCount);
+
+    std::vector<std::shared_ptr<CommandBuffer>> command_buffers;
+    command_buffers.reserve(submit_info.commandBufferInfoCount);
+    for (const auto& cb_info : vvl::make_span(submit_info.pCommandBufferInfos, submit_info.commandBufferInfoCount)) {
+        // If Get returns null, store it to preserve original indexing
+        command_buffers.emplace_back(validator_.Get<CommandBuffer>(cb_info.commandBuffer));
+    }
+
+    std::lock_guard lock(mutex_);
+    SubmitTimeTracker& this_tracker = *const_cast<SubmitTimeTracker*>(this);
+    return this_tracker.ProcessBatch(std::move(command_buffers), wait_semaphores, signal_semaphores, queue, submit_loc);
+}
+
+bool SubmitTimeTracker::ProcessSignalSemaphore(const VkSemaphoreSignalInfo& signal_info) const {
+    std::lock_guard lock(mutex_);
+    SubmitTimeTracker& this_tracker = *const_cast<SubmitTimeTracker*>(this);
+    return this_tracker.ProcessSignal(signal_info.semaphore, signal_info.value);
+}
+
+// NOTE: when swapchain learns how to work with timeline semaphores, this function should be
+// reworked to check for resolving timeline signals similar to ProcessBatch.
+// Current version assumes only binary semaphores are allowed (the only option as of April 2026)
+bool SubmitTimeTracker::ProcessPresent(const VkPresentInfoKHR& present_info, const Location& present_info_loc) const {
+    std::lock_guard lock(mutex_);
     bool skip = false;
-    std::lock_guard lock(submit_time_mutex_);
-    {
-        skip |= validator_.ProcessSubmissionBatch(batch);
+    for (uint32_t i = 0; i < present_info.swapchainCount; i++) {
+        if (auto swapchain_state = validator_.Get<Swapchain>(present_info.pSwapchains[i])) {
+            const uint32_t image_index = present_info.pImageIndices[i];
+            if (image_index >= swapchain_state->images.size()) {
+                continue;  // invalid image index, reported elsewhere
+            }
+            skip |= validator_.ProcessPresentBatch(*swapchain_state->images[image_index].image_state, present_info_loc);
+        }
     }
     return skip;
 }
+
+bool SubmitTimeTracker::ProcessBatch(std::vector<std::shared_ptr<CommandBuffer>>&& command_buffers,
+                                     vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
+                                     vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, VkQueue queue,
+                                     const Location& submit_loc) {
+    bool skip = false;
+    std::vector<UnresolvedBatch>& unresolved_batches = unresolved_batches_[queue];
+    std::vector<VkSemaphoreSubmitInfo> unresolved_timeline_waits = GetUnresolvedTimelineWaits(wait_semaphores);
+
+    // Add wait-before-signal batches to unresolved list and return
+    const bool has_pending_waits = !unresolved_batches.empty() || !unresolved_timeline_waits.empty();
+    if (has_pending_waits) {
+        UnresolvedBatch batch(submit_loc);
+        batch.command_buffers = std::move(command_buffers);
+        batch.unresolved_timeline_waits = std::move(unresolved_timeline_waits);
+        batch.signals.assign(signal_semaphores.begin(), signal_semaphores.end());
+        unresolved_batches.emplace_back(std::move(batch));
+        return skip;
+    }
+
+    skip |= validator_.ProcessSubmissionBatch(command_buffers, submit_loc);
+
+    const bool new_timeline_signals = RegisterTimelineSignals(signal_semaphores);
+    if (new_timeline_signals) {
+        skip |= PropagateTimelineSignals();
+    }
+    return skip;
+}
+
+bool SubmitTimeTracker::ProcessSignal(VkSemaphore timeline, uint64_t signal_value) {
+    bool skip = false;
+    auto semaphore = validator_.Get<Semaphore>(timeline);
+    if (!semaphore || semaphore->type != VK_SEMAPHORE_TYPE_TIMELINE) {
+        return skip;
+    }
+    const bool new_timeline_signal = UpdateTimelineValue(timeline, signal_value);
+    if (new_timeline_signal) {
+        skip |= PropagateTimelineSignals();
+    }
+    return skip;
+}
+
+std::vector<VkSemaphoreSubmitInfo> SubmitTimeTracker::GetUnresolvedTimelineWaits(
+    vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores) {
+    std::vector<VkSemaphoreSubmitInfo> unresolved;
+    for (const auto& wait : wait_semaphores) {
+        auto semaphore = validator_.Get<Semaphore>(wait.semaphore);
+        if (!semaphore || semaphore->type != VK_SEMAPHORE_TYPE_TIMELINE || semaphore->Scope() != Semaphore::kInternal) {
+            // Only timeline semaphores can introduce pending waits.
+            // For external semaphores we cannot reliably track signals
+            continue;
+        }
+        const uint64_t current_value = GetTimelineValue(wait.semaphore);
+        if (wait.value > current_value) {
+            unresolved.emplace_back(wait);
+        }
+    }
+    return unresolved;
+}
+
+bool SubmitTimeTracker::RegisterTimelineSignals(vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores) {
+    bool new_timeline_signals = false;
+    for (const VkSemaphoreSubmitInfo& signal : signal_semaphores) {
+        auto semaphore = validator_.Get<Semaphore>(signal.semaphore);
+        if (!semaphore || semaphore->type != VK_SEMAPHORE_TYPE_TIMELINE) {
+            continue;
+        }
+        new_timeline_signals |= UpdateTimelineValue(signal.semaphore, signal.value);
+    }
+    return new_timeline_signals;
+}
+
+bool SubmitTimeTracker::PropagateTimelineSignals() {
+    bool skip = false;
+
+    // The caller ensures we just registered new timeline signals
+    bool new_timeline_signals = true;
+
+    // Each iteration attempts to resolve pending batches using current timeline value.
+    // If a resolved batch generates new timeline signals, the loop runs again
+    while (new_timeline_signals) {
+        new_timeline_signals = false;
+
+        for (auto& [queue, batches] : unresolved_batches_) {
+            while (!batches.empty()) {
+                UnresolvedBatch& batch = batches.front();
+                if (!CanBeResolved(batch)) {
+                    break;
+                }
+                skip |= validator_.ProcessSubmissionBatch(batch.command_buffers, batch.submit_loc_capture.Get());
+                new_timeline_signals |= RegisterTimelineSignals(batch.signals);
+                batches.erase(batches.begin());
+            }
+        }
+    }
+    return skip;
+}
+
+bool SubmitTimeTracker::CanBeResolved(const UnresolvedBatch& batch) const {
+    for (const VkSemaphoreSubmitInfo& wait : batch.unresolved_timeline_waits) {
+        const uint64_t current_value = GetTimelineValue(wait.semaphore);
+        if (wait.value > current_value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+uint64_t SubmitTimeTracker::GetTimelineValue(VkSemaphore timeline) const {
+    const uint64_t current_value = vvl::FindExisting(timeline_signals_, timeline);
+    return current_value;
+}
+
+bool SubmitTimeTracker::UpdateTimelineValue(VkSemaphore timeline, uint64_t signal_value) {
+    uint64_t& current_value = vvl::FindExisting(timeline_signals_, timeline);
+    if (signal_value <= current_value) {
+        return false;  // non-increasing signal, the error should be reported elsewhere
+    }
+    current_value = signal_value;
+    return true;
+}
+
+}  // namespace vvl

--- a/layers/state_tracker/submit_time_tracker.h
+++ b/layers/state_tracker/submit_time_tracker.h
@@ -16,6 +16,9 @@
  */
 #pragma once
 
+#include "containers/custom_containers.h"
+#include "containers/span.h"
+#include "error_message/error_location.h"
 #include <vulkan/vulkan.h>
 #include <memory>
 #include <mutex>
@@ -26,31 +29,64 @@ namespace vvl {
 class DeviceProxy;
 class CommandBuffer;
 
-struct SubmissionBatch {
+// Batch blocked by a wait-before-signal dependency
+struct UnresolvedBatch {
+    UnresolvedBatch(const Location& submit_loc) : submit_loc_capture(submit_loc) {}
+
+    LocationCapture submit_loc_capture;
+
+    // Command buffers to validate when dependencies are resolved
     std::vector<std::shared_ptr<CommandBuffer>> command_buffers;
+
+    // Timeline waits that block this batch
+    std::vector<VkSemaphoreSubmitInfo> unresolved_timeline_waits;
+
+    // Semaphores to signal once all waits are resolved
+    std::vector<VkSemaphoreSubmitInfo> signals;
 };
 
-// Tracks submission batches for submit time validation.
-// Submit time validation is performed during queue submit calls
-// such as QueueSubmit, QueuePresent, etc.
+// Tracks submission batches and initiates submit time validation.
+// Submit time validation is performed during submit calls such as QueueSubmit and QueuePresent.
+// Validation that depends on actual completion of queue operations is not handled by this subsystem.
 //
 // Batches with no unresolved dependencies are validated immediately.
-// Batches with pending timeline waits are stored until a subsequent
-// queue operation specifies a resolving signal.
-// vkSignalSemaphore that resolves a pending wait triggers validation.
-//
-// Validations that depend on actual completion of queue operations
-// are not handled by this subsystem.
+// Batches with pending timeline waits are stored until a later submit call resolves the wait.
+// vkSignalSemaphore also triggers validation if it resolves a pending wait
 class SubmitTimeTracker {
   public:
     SubmitTimeTracker(DeviceProxy& validator) : validator_(validator) {}
-    bool ProcessSubmissionBatch(const VkSubmitInfo& batch) const;
+    void OnCreateTimelineSemaphore(VkSemaphore timeline, uint64_t initial_value);
+    void OnDestroyTimelineSemaphore(VkSemaphore timeline);
+
+    bool ProcessSubmitInfo(const VkSubmitInfo& submit_info, VkQueue queue, const Location& submit_loc) const;
+    bool ProcessSubmitInfo(const VkSubmitInfo2& submit_info, VkQueue queue, const Location& submit_loc) const;
+    bool ProcessSignalSemaphore(const VkSemaphoreSignalInfo& signal_info) const;
+    bool ProcessPresent(const VkPresentInfoKHR& present_info, const Location& present_info_loc) const;
 
   private:
+    bool ProcessBatch(std::vector<std::shared_ptr<vvl::CommandBuffer>>&& command_buffers,
+                      vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores,
+                      vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, VkQueue queue, const Location& submit_loc);
+    bool ProcessSignal(VkSemaphore timeline, uint64_t signal_value);
+
+    std::vector<VkSemaphoreSubmitInfo> GetUnresolvedTimelineWaits(vvl::span<const VkSemaphoreSubmitInfo> wait_semaphores);
+    bool RegisterTimelineSignals(vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores);
+    bool PropagateTimelineSignals();
+    bool CanBeResolved(const UnresolvedBatch& batch) const;
+    uint64_t GetTimelineValue(VkSemaphore timeline) const;
+    bool UpdateTimelineValue(VkSemaphore timeline, uint64_t signal_value);
+
+  private:
+    // Submit time validation and state updates run under this mutex.
+    // A batch submitted on one queue may be resolved by another due to wait-before-signal.
+    // Serializing access to this state ensures the resolving queue validates the batch
+    // immediately, rather than deferring validation until a later submit on the original queue
+    mutable std::mutex mutex_;
+
     DeviceProxy& validator_;
 
-    // Submit time validation runs under mutex. This encompasses both validation and update.
-    mutable std::mutex submit_time_mutex_;
+    vvl::unordered_map<VkSemaphore, uint64_t> timeline_signals_;
+    vvl::unordered_map<VkQueue, std::vector<UnresolvedBatch>> unresolved_batches_;
 };
 
 }  // namespace vvl

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2409,7 +2409,7 @@ bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCou
         return skip;
     }
 
-    SubmitInfoConverter submit_info(pSubmits, submitCount);
+    SubmitInfoArrayConverter submit_info(pSubmits, submitCount);
     const VkSubmitInfo2* submits = submit_info.submit_infos2.data();
 
     std::lock_guard lock_guard(queue_mutex_);

--- a/layers/utils/convert_utils.cpp
+++ b/layers/utils/convert_utils.cpp
@@ -297,7 +297,7 @@ vku::safe_VkImageMemoryBarrier2 ConvertVkImageMemoryBarrierToV2(const VkImageMem
     return vku::safe_VkImageMemoryBarrier2(&barrier2);
 }
 
-SubmitInfoConverter::SubmitInfoConverter(const VkSubmitInfo* submit_infos, uint32_t count) {
+SubmitInfoArrayConverter::SubmitInfoArrayConverter(const VkSubmitInfo* submit_infos, uint32_t count) {
     size_t wait_count = 0;
     size_t cb_count = 0;
     size_t signal_count = 0;
@@ -361,6 +361,61 @@ SubmitInfoConverter::SubmitInfoConverter(const VkSubmitInfo* submit_infos, uint3
                     }
                     current_signal->value = timeline_values->pSignalSemaphoreValues[i];
                 }
+            }
+        }
+    }
+}
+
+SubmitInfoConverter::SubmitInfoConverter(const VkSubmitInfo& submit_info) {
+    const VkSubmitInfo& info = submit_info;
+
+    VkSubmitInfo2& info2 = submit_info2;
+    info2 = vku::InitStructHelper();
+
+    wait_infos.resize(info.waitSemaphoreCount);
+    cb_infos.resize(info.commandBufferCount);
+    signal_infos.resize(info.signalSemaphoreCount);
+
+    const auto* timeline_values = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(info.pNext);
+
+    if (info.waitSemaphoreCount) {
+        info2.waitSemaphoreInfoCount = info.waitSemaphoreCount;
+        info2.pWaitSemaphoreInfos = wait_infos.data();
+        for (uint32_t i = 0; i < info.waitSemaphoreCount; i++) {
+            VkSemaphoreSubmitInfo& wait_info = wait_infos[i];
+            wait_info = vku::InitStructHelper();
+            wait_info.semaphore = info.pWaitSemaphores[i];
+            wait_info.stageMask = info.pWaitDstStageMask[i];
+            if (timeline_values) {
+                if (i >= timeline_values->waitSemaphoreValueCount) {
+                    continue;  // [core validation check]
+                }
+                wait_info.value = timeline_values->pWaitSemaphoreValues[i];
+            }
+        }
+    }
+    if (info.commandBufferCount) {
+        info2.commandBufferInfoCount = info.commandBufferCount;
+        info2.pCommandBufferInfos = cb_infos.data();
+        for (uint32_t i = 0; i < info.commandBufferCount; i++) {
+            VkCommandBufferSubmitInfo& cb_info = cb_infos[i];
+            cb_info = vku::InitStructHelper();
+            cb_info.commandBuffer = info.pCommandBuffers[i];
+        }
+    }
+    if (info.signalSemaphoreCount) {
+        info2.signalSemaphoreInfoCount = info.signalSemaphoreCount;
+        info2.pSignalSemaphoreInfos = signal_infos.data();
+        for (uint32_t i = 0; i < info.signalSemaphoreCount; i++) {
+            VkSemaphoreSubmitInfo& signal_info = signal_infos[i];
+            signal_info = vku::InitStructHelper();
+            signal_info.semaphore = info.pSignalSemaphores[i];
+            signal_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+            if (timeline_values) {
+                if (i >= timeline_values->signalSemaphoreValueCount) {
+                    continue;  // [core validation check]
+                }
+                signal_info.value = timeline_values->pSignalSemaphoreValues[i];
             }
         }
     }

--- a/layers/utils/convert_utils.h
+++ b/layers/utils/convert_utils.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,15 +25,29 @@ vku::safe_VkImageMemoryBarrier2 ConvertVkImageMemoryBarrierToV2(const VkImageMem
                                                                VkPipelineStageFlags2 srcStageMask,
                                                                VkPipelineStageFlags2 dstStageMask);
 
-// Converts array of VkSubmitInfo into array of VkSubmitInfo2.
-// Constructor performs the conversion. The result is stored into submit_infos2.
-struct SubmitInfoConverter {
-    SubmitInfoConverter(const VkSubmitInfo* submit_infos, uint32_t count);
+// Converts an array of VkSubmitInfo to an array of VkSubmitInfo2.
+// The constructor performs the conversion. The result is stored in submit_infos2.
+struct SubmitInfoArrayConverter {
+    SubmitInfoArrayConverter(const VkSubmitInfo* submit_infos, uint32_t count);
 
-    // That's the conversion result
+    // Conversion result
     std::vector<VkSubmitInfo2> submit_infos2;
 
-    // Helper structures referenced by VkSubmitInfo2 objects
+    // Objects referenced by VkSubmitInfo2 objects
+    std::vector<VkSemaphoreSubmitInfo> wait_infos;
+    std::vector<VkCommandBufferSubmitInfo> cb_infos;
+    std::vector<VkSemaphoreSubmitInfo> signal_infos;
+};
+
+// Converts a VkSubmitInfo to VkSubmitInfo2.
+// The constructor performs the conversion. The result is stored in submit_info2.
+struct SubmitInfoConverter {
+    SubmitInfoConverter(const VkSubmitInfo& submit_info);
+
+    // Conversion result
+    VkSubmitInfo2 submit_info2;
+
+    // Objects referenced by VkSubmitInfo2 object
     std::vector<VkSemaphoreSubmitInfo> wait_infos;
     std::vector<VkCommandBufferSubmitInfo> cb_infos;
     std::vector<VkSemaphoreSubmitInfo> signal_infos;

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -1030,8 +1030,10 @@ TEST_F(NegativeImageLayout, TimelineSemaphoreOrdering) {
     m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1));
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09600");
     m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineSignal(semaphore, 1));
-    m_device->Wait();
     m_errorMonitor->VerifyFound();
+
+    semaphore.Signal(1);
+    m_device->Wait();
 }
 
 TEST_F(NegativeImageLayout, DynamicRenderingColorAttachmentLayout) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -5043,21 +5043,65 @@ TEST_F(NegativeSyncVal, QSOBarrierHazard) {
                                VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
     cb1.End();
 
-    // We're going to do the copy first, then use the skip on fail, to test three different ways...
     queue0->Submit(cb0, vkt::Signal(semaphore));
-
-    // First asynchronously fail -- the pipeline barrier in B shouldn't work on queue 1
-    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-RACING-READ ");
-    queue1->Submit(cb1);
-    m_errorMonitor->VerifyFound();
-
-    // Next synchronously fail -- the pipeline barrier in B shouldn't work on queue 1
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-READ");
     queue1->Submit(cb1, vkt::Wait(semaphore, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT));
     m_errorMonitor->VerifyFound();
+    m_device->Wait();
+}
 
-    // Then prove qso works (note that with the failure, the semaphore hasn't been waited, nor the layout changed)
-    queue0->Submit(cb1, vkt::Wait(semaphore, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT));
+TEST_F(NegativeSyncVal, QSOBarrierHazardAsync) {
+    all_queue_count_ = true;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    auto [queue0, queue1] = GetTwoQueuesFromSameFamily(m_device->QueuesWithTransferCapability());
+    if (!queue0) {
+        GTEST_SKIP() << "Test requires two queues with transfer capabilities from the same queue family";
+    }
+
+    vkt::CommandPool cmd_pool(*m_device, queue0->family_index, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+
+    vkt::CommandBuffer cb0(*m_device, cmd_pool);
+    vkt::CommandBuffer cb1(*m_device, cmd_pool);
+    vkt::CommandBuffer cb2(*m_device, cmd_pool);
+
+    vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer_c(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    vkt::Semaphore semaphore(*m_device);
+
+    VkImageUsageFlags usage =
+        VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
+
+    vkt::Image image_a(*m_device, image_ci);
+    image_a.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
+    vkt::Image image_b(*m_device, image_ci);
+    image_b.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
+    VkImageSubresourceLayers all_layers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    VkOffset3D zero_offset{0, 0, 0};
+    VkExtent3D full_extent{128, 128, 1};  // <-- image type is 2D
+    VkImageCopy full_region = {all_layers, zero_offset, all_layers, zero_offset, full_extent};
+
+    cb0.Begin();
+    vk::CmdCopyImage(cb0, image_a, VK_IMAGE_LAYOUT_GENERAL, image_b, VK_IMAGE_LAYOUT_GENERAL, 1, &full_region);
+    cb0.End();
+
+    cb1.Begin();
+    image_a.ImageMemoryBarrier(cb1, VK_ACCESS_NONE, VK_ACCESS_NONE, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    cb1.End();
+
+    queue0->Submit(cb0, vkt::Signal(semaphore));
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-RACING-READ ");
+    queue1->Submit(cb1);
+    m_errorMonitor->VerifyFound();
     m_device->Wait();
 }
 

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -1153,7 +1153,7 @@ TEST_F(NegativeWsi, SwapchainPresentShared) {
     uint32_t image_index = 0;
 
     // Try to Present without Acquire...
-    m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430");
+    m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430", 2);  // no acquire + wrong image layout
     m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore);
     m_errorMonitor->VerifyFound();
 }
@@ -1743,17 +1743,12 @@ TEST_F(NegativeWsi, DisplayPresentInfoSrcRect) {
     // Invalid layout (not present)
     m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430");
     m_default_queue->Present(m_swapchain, current_buffer, image_acquired, &display_present_info);
-    m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
-
-    // TODO: remove this acquire when we move layout validation from queue thread
-    // back to QueueSubmit and implement it so it respects ordering due to timeline
-    // semaphores (resolves previous dependencies directly during queue submit).
-    current_buffer = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
 
     // Invalid rect
     display_present_info.srcRect.extent.width = swapchain_width + 1;  // Invalid
     m_errorMonitor->SetDesiredError("VUID-VkDisplayPresentInfoKHR-srcRect-01257");
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkPresentInfoKHR-pImageIndices-01430");  // still invalid layout
     m_default_queue->Present(m_swapchain, current_buffer, image_acquired, &display_present_info);
     m_errorMonitor->VerifyFound();
 }
@@ -1967,7 +1962,11 @@ TEST_F(NegativeWsi, GetSwapchainImagesCountButNotImages) {
     // This test initiates image count query, but don't need resulting value
     m_swapchain.GetImageCount();
 
-    m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430");
+    // VUID is signaled two times:
+    // 1) Image was not acquired
+    // 2) Image was not transition to present layout
+    m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430", 2);
+
     m_default_queue->Present(m_swapchain, 0, vkt::no_semaphore);
     m_errorMonitor->VerifyFound();
 }
@@ -3602,6 +3601,7 @@ TEST_F(NegativeWsi, PresentRegionsKHR) {
         regions.swapchainCount = 2;  // swapchainCount doesn't match VkPresentInfoKHR::swapchainCount
         regions.pRegions = region;
         m_errorMonitor->SetDesiredError("VUID-VkPresentRegionsKHR-swapchainCount-01260");
+        m_errorMonitor->SetAllowedFailureMsg("VUID-VkPresentInfoKHR-pImageIndices-01430");  // invalid layout
         m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore, &regions);
         m_errorMonitor->VerifyFound();
     }
@@ -3611,6 +3611,7 @@ TEST_F(NegativeWsi, PresentRegionsKHR) {
         regions.swapchainCount = 0;  // can't be zero
         regions.pRegions = region;
         m_errorMonitor->SetDesiredError("VUID-VkPresentRegionsKHR-swapchainCount-arraylength");
+        m_errorMonitor->SetAllowedFailureMsg("VUID-VkPresentInfoKHR-pImageIndices-01430");  // invalid layout
         m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore, &regions);
         m_errorMonitor->VerifyFound();
     }
@@ -4828,7 +4829,7 @@ TEST_F(NegativeWsi, SwapchainUseAfterDestroy) {
         m_errorMonitor->VerifyFound();
 
         present.pSwapchains = &swapchain2.handle();
-        m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430");
+        m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430", 2);  // not acquired + wrong layout
         vk::QueuePresentKHR(*m_default_queue, &present);
         m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
This implements the first version of submit time tracker. Track timeline signals so postponed wait-before-signal submissions can be validated directly during QueueSubmit and SignalSemaphore calls.

As a first step, move submit time image layout validation out of the queue thread and integrate it with this system.

Approximately a year ago we implemented https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10316. It was a quick solution to address the problem but that PR lists the drawbacks of running validation in queue thread (we also found new ones) and says that "the plan for the future is to implement proper ordered validation during QueueSubmit". This PR starts implementing that idea.