### PR TITLE
layers: More usage of vvl::Image getter

### DIFF
--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -339,7 +339,7 @@ bool BestPractices::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
                                       VendorSpecificTag(kBPVendorAMD));
     }
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
-        skip |= ValidateClearColor(commandBuffer, dst_image->create_info.format, *pColor, error_obj.location);
+        skip |= ValidateClearColor(commandBuffer, dst_image->GetFormat(), *pColor, error_obj.location);
     }
 
     return skip;

--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -501,7 +501,7 @@ void CommandBufferSubState::RecordClearColorImage(vvl::Image& image_state, VkIma
     }
 
     if (validator.VendorCheckEnabled(kBPVendorNVIDIA)) {
-        validator.RecordClearColor(image_state.create_info.format, *color_values);
+        validator.RecordClearColor(image_state.GetFormat(), *color_values);
     }
 }
 

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -231,7 +231,7 @@ bool CoreChecks::ValidateTransferGranularityExtent(const LogObjectList& objlist,
                              string_VkExtent3D(region_extent).c_str(), string_VkExtent3D(subresource_extent).c_str());
         }
     } else {
-        const bool is_compressed = vkuFormatIsCompressed(image_state.create_info.format);
+        const bool is_compressed = vkuFormatIsCompressed(image_state.GetFormat());
         // "minImageTransferGranularity" is unit of compressed texel blocks for images having a block-compressed format, and a unit
         // of texels otherwise.
         //
@@ -240,7 +240,7 @@ bool CoreChecks::ValidateTransferGranularityExtent(const LogObjectList& objlist,
         VkExtent3D effective_region_extent = region_extent;
         VkExtent3D block_extent = {1, 1, 1};
         if (is_compressed) {
-            block_extent = vkuFormatTexelBlockExtent(image_state.create_info.format);
+            block_extent = vkuFormatTexelBlockExtent(image_state.GetFormat());
             effective_region_extent = GetTexelBlocks(region_extent, block_extent);
         }
 
@@ -276,7 +276,7 @@ bool CoreChecks::ValidateTransferGranularityExtent(const LogObjectList& objlist,
             ss << "(" << string_VkExtent3D(region_extent)
                << ") is invalid with this command buffer's queue family minImageTransferGranularity ("
                << string_VkExtent3D(granularity) << ") for copying to/from " << FormatHandle(image_state) << " ("
-               << string_VkFormat(image_state.create_info.format) << ") because both:\n";
+               << string_VkFormat(image_state.GetFormat()) << ") because both:\n";
             if (is_compressed) {
                 ss << "1) The image is in texel blocks of size (" << string_VkExtentDimensions(block_extent)
                    << ") so the texel block extent of (" << string_VkExtent3D(effective_region_extent)
@@ -362,13 +362,13 @@ struct ImageCopyRegion {
     void Init() {
         src_subresource_extent = src_state.GetEffectiveSubresourceExtent(src_subresource);
         normalized_src_layer_count = src_state.NormalizeLayerCount(src_subresource);
-        const VkFormat src_format = src_state.create_info.format;
+        const VkFormat src_format = src_state.GetFormat();
         const VkExtent3D src_block_extent = vkuFormatTexelBlockExtent(src_format);
         const bool src_is_in_blocks = !IsExtentAllOne(src_block_extent);
 
         dst_subresource_extent = dst_state.GetEffectiveSubresourceExtent(dst_subresource);
         normalized_dst_layer_count = dst_state.NormalizeLayerCount(dst_subresource);
-        const VkFormat dst_format = dst_state.create_info.format;
+        const VkFormat dst_format = dst_state.GetFormat();
         const VkExtent3D dst_block_extent = vkuFormatTexelBlockExtent(dst_format);
         const bool dst_is_in_blocks = !IsExtentAllOne(dst_block_extent);
 
@@ -432,11 +432,11 @@ struct ImageCopyRegion {
         if (is_adjusted_extent) {
             ss << "The VkImageCopy::extent [" << string_VkExtent3D(extent) << "] is adjusted to ["
                << string_VkExtent3D(dst_adjusted_extent) << "] because it is going from ";
-            if (vkuFormatIsCompressed(src_state.create_info.format)) {
+            if (vkuFormatIsCompressed(src_state.GetFormat())) {
                 ss << "compressed to uncompressed";
-            } else if (vkuFormatIsSinglePlane_422(src_state.create_info.format)) {
+            } else if (vkuFormatIsSinglePlane_422(src_state.GetFormat())) {
                 ss << "single-planar YCbCr (2x1 compressed) to uncompressed";
-            } else if (vkuFormatIsSinglePlane_422(dst_state.create_info.format)) {
+            } else if (vkuFormatIsSinglePlane_422(dst_state.GetFormat())) {
                 ss << "uncompressed to single-planar YCbCr (2x1 compressed)";
             } else {
                 ss << "uncompressed to compressed";
@@ -561,7 +561,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const RegionType& region, const v
         }
     }
 
-    const VkFormat image_format = image_state.create_info.format;
+    const VkFormat image_format = image_state.GetFormat();
 
     // if uncompressed, extent is {1,1,1} and non of this will matter
     const VkExtent3D block_extent = vkuFormatTexelBlockExtent(image_format);
@@ -731,7 +731,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer& cb_state,
     // - Depth Stencil format
     // - Multi-Planar format
     // - everything else
-    const VkFormat image_format = image_state.create_info.format;
+    const VkFormat image_format = image_state.GetFormat();
     if (vkuFormatIsDepthOrStencil(image_format)) {
         if (!IsIntegerMultipleOf(region.bufferOffset, 4)) {
             skip |= LogError(GetCopyBufferImageDeviceVUID(region_loc, vvl::CopyError::BufferOffset_07978), objlist,
@@ -1102,9 +1102,9 @@ bool CoreChecks::ValidateCopyImageRegionCommon(HandleT handle, const ImageCopyRe
     }
 
     const VkImageType src_image_type = region.src_state.GetImageType();
-    const VkFormat src_format = region.src_state.create_info.format;
+    const VkFormat src_format = region.src_state.GetFormat();
     const VkImageType dst_image_type = region.dst_state.GetImageType();
-    const VkFormat dst_format = region.dst_state.create_info.format;
+    const VkFormat dst_format = region.dst_state.GetFormat();
 
     // comparing src vs dst subresource
     {
@@ -1503,8 +1503,8 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
     ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
 
     const vvl::CommandBuffer& cb_state = *cb_state_ptr;
-    const VkFormat src_format = src_image_state->create_info.format;
-    const VkFormat dst_format = dst_image_state->create_info.format;
+    const VkFormat src_format = src_image_state->GetFormat();
+    const VkFormat dst_format = dst_image_state->GetFormat();
     const VkImageType src_image_type = src_image_state->GetImageType();
     const VkImageType dst_image_type = dst_image_state->GetImageType();
     const bool src_is_2d = (VK_IMAGE_TYPE_2D == src_image_type);
@@ -1823,7 +1823,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
                 const bool is_stencil_copy = subresource_2.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT;
 
                 if (is_subresource_1_aspect_color && (is_depth_copy || is_stencil_copy)) {
-                    const VkFormatFeatureFlags2 img_format_features = GetPotentialFormatFeatures(depth_img.create_info.format);
+                    const VkFormatFeatureFlags2 img_format_features = GetPotentialFormatFeatures(depth_img.GetFormat());
 
                     const bool invalid_depth_copy_on_compute =
                         is_depth_copy && !(img_format_features & VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_COMPUTE_QUEUE_BIT_KHR);
@@ -1865,7 +1865,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
                                     string_VkImageAspectFlags(subresource_1.aspectMask).c_str(),
                                     subresource_2_loc.dot(Field::aspectMask).Fields().c_str(),
                                     string_VkImageAspectFlags(subresource_2.aspectMask).c_str(), String(depth_img_field),
-                                    string_VkFormat(depth_img.create_info.format),
+                                    string_VkFormat(depth_img.GetFormat()),
                                     invalid_depth_copy_on_compute ? "VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_COMPUTE_QUEUE_BIT_KHR"
                                                                   : "VK_FORMAT_FEATURE_2_STENCIL_COPY_ON_COMPUTE_QUEUE_BIT_KHR",
                                     string_VkFormatFeatureFlags2(img_format_features).c_str());
@@ -1900,7 +1900,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
                                                  string_VkImageAspectFlags(subresource_1.aspectMask).c_str(),
                                                  subresource_2_loc.dot(Field::aspectMask).Fields().c_str(),
                                                  string_VkImageAspectFlags(subresource_2.aspectMask).c_str(),
-                                                 String(depth_img_field), string_VkFormat(depth_img.create_info.format),
+                                                 String(depth_img_field), string_VkFormat(depth_img.GetFormat()),
                                                  invalid_depth_copy_on_transfer
                                                      ? "VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_TRANFER_QUEUE_BIT_KHR"
                                                      : "VK_FORMAT_FEATURE_2_STENCIL_COPY_ON_TRANFER_QUEUE_BIT_KHR",
@@ -1969,7 +1969,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
         skip |=
             ValidateImageUsageFlags(commandBuffer, *dst_image_state, VK_IMAGE_USAGE_TRANSFER_DST_BIT, false, vuid, dst_image_loc);
     } else {
-        auto src_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(src_image_state->create_info.pNext);
+        auto src_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(src_image_state->GetPNext());
         if (src_separate_stencil && has_stencil_aspect &&
             ((src_separate_stencil->stencilUsage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) == 0)) {
             vuid = is_2 ? "VUID-VkCopyImageInfo2-aspect-06664" : "VUID-vkCmdCopyImage-aspect-06664";
@@ -1984,7 +1984,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
                                             src_image_loc);
         }
 
-        auto dst_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(dst_image_state->create_info.pNext);
+        auto dst_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(dst_image_state->GetPNext());
         if (dst_separate_stencil && has_stencil_aspect &&
             ((dst_separate_stencil->stencilUsage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0)) {
             vuid = is_2 ? "VUID-VkCopyImageInfo2-aspect-06665" : "VUID-vkCmdCopyImage-aspect-06665";
@@ -2093,7 +2093,7 @@ bool CoreChecks::ValidateBufferBounds(const vvl::CommandBuffer& cb_state, const 
         return skip;
     }
 
-    const VkFormat format = image_state.create_info.format;
+    const VkFormat format = image_state.GetFormat();
     bool is_multiplane = vkuFormatIsMultiplane(format);
     const VkFormat compatible_format =
         is_multiplane
@@ -2175,7 +2175,7 @@ bool CoreChecks::ValidateDeviceAddressBufferBounds(const vvl::CommandBuffer& cb_
         return skip;
     }
 
-    const VkFormat format = image_state.create_info.format;
+    const VkFormat format = image_state.GetFormat();
     bool is_multiplane = vkuFormatIsMultiplane(format);
     const VkFormat compatible_format =
         is_multiplane
@@ -2355,7 +2355,7 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
         const bool has_depth_aspect = region.imageSubresource.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT;
         const bool has_stencil_aspect = region.imageSubresource.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT;
         if (has_depth_aspect || has_stencil_aspect) {
-            const VkFormatFeatureFlags2 src_image_format_features = GetPotentialFormatFeatures(src_image_state->create_info.format);
+            const VkFormatFeatureFlags2 src_image_format_features = GetPotentialFormatFeatures(src_image_state->GetFormat());
 
             const bool invalid_depth_copy_on_compute =
                 has_depth_aspect && !(src_image_format_features & VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_COMPUTE_QUEUE_BIT_KHR);
@@ -2383,7 +2383,7 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
                             "is %s, commandBuffer was created with a VkCommandPool that does not support VK_QUEUE_GRAPHICS_BIT but "
                             "supports VK_QUEUE_COMPUTE_BIT, yet srcImage (%s) does not have the %s feature\n(features: %s).",
                             string_VkImageAspectFlags(region.imageSubresource.aspectMask).c_str(),
-                            string_VkFormat(src_image_state->create_info.format),
+                            string_VkFormat(src_image_state->GetFormat()),
                             invalid_depth_copy_on_compute ? "VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_COMPUTE_QUEUE_BIT_KHR"
                                                           : "VK_FORMAT_FEATURE_2_STENCIL_COPY_ON_COMPUTE_QUEUE_BIT_KHR",
                             string_VkFormatFeatureFlags2(src_image_format_features).c_str());
@@ -2404,7 +2404,7 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
                                      "VK_QUEUE_GRAPHICS_BIT nor VK_QUEUE_COMPUTE_BIT but supports VK_QUEUE_TRANSFER_BIT, yet "
                                      "srcImage (%s) does not have the %s feature\n(features: %s).",
                                      string_VkImageAspectFlags(region.imageSubresource.aspectMask).c_str(),
-                                     string_VkFormat(src_image_state->create_info.format),
+                                     string_VkFormat(src_image_state->GetFormat()),
                                      invalid_depth_copy_on_transfer ? "VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_TRANSFER_QUEUE_BIT_KHR"
                                                                     : "VK_FORMAT_FEATURE_2_STENCIL_COPY_ON_TRANSFER_QUEUE_BIT_KHR",
                                      string_VkFormatFeatureFlags2(src_image_format_features).c_str());
@@ -2534,7 +2534,7 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
         const bool has_depth_aspect = region.imageSubresource.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT;
         const bool has_stencil_aspect = region.imageSubresource.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT;
         if (has_depth_aspect || has_stencil_aspect) {
-            const VkFormatFeatureFlags2 dst_image_format_features = GetPotentialFormatFeatures(dst_image_state->create_info.format);
+            const VkFormatFeatureFlags2 dst_image_format_features = GetPotentialFormatFeatures(dst_image_state->GetFormat());
 
             const bool invalid_depth_copy_on_compute =
                 has_depth_aspect && !(dst_image_format_features & VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_COMPUTE_QUEUE_BIT_KHR);
@@ -2562,7 +2562,7 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
                             "is %s, commandBuffer was created with a VkCommandPool that does not support VK_QUEUE_GRAPHICS_BIT but "
                             "supports VK_QUEUE_COMPUTE_BIT, yet dstImage (%s) does not have the %s feature\n(features: %s).",
                             string_VkImageAspectFlags(region.imageSubresource.aspectMask).c_str(),
-                            string_VkFormat(dst_image_state->create_info.format),
+                            string_VkFormat(dst_image_state->GetFormat()),
                             invalid_depth_copy_on_compute ? "VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_COMPUTE_QUEUE_BIT_KHR"
                                                           : "VK_FORMAT_FEATURE_2_STENCIL_COPY_ON_COMPUTE_QUEUE_BIT_KHR",
                             string_VkFormatFeatureFlags2(dst_image_format_features).c_str());
@@ -2583,7 +2583,7 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
                                      "VK_QUEUE_GRAPHICS_BIT nor VK_QUEUE_COMPUTE_BIT but supports VK_QUEUE_TRANSFER_BIT, yet "
                                      "dstImage (%s) does not have the %s feature\n(features: %s).",
                                      string_VkImageAspectFlags(region.imageSubresource.aspectMask).c_str(),
-                                     string_VkFormat(dst_image_state->create_info.format),
+                                     string_VkFormat(dst_image_state->GetFormat()),
                                      invalid_depth_copy_on_transfer ? "VK_FORMAT_FEATURE_2_DEPTH_COPY_ON_TRANSFER_QUEUE_BIT_KHR"
                                                                     : "VK_FORMAT_FEATURE_2_STENCIL_COPY_ON_TRANSFER_QUEUE_BIT_KHR",
                                      string_VkFormatFeatureFlags2(dst_image_format_features).c_str());
@@ -2624,8 +2624,7 @@ bool CoreChecks::UsageHostTransferCheck(const vvl::Image& image_state, const VkI
     const bool has_non_stencil = (aspect_mask & ~VK_IMAGE_ASPECT_STENCIL_BIT);
 
     if (has_stencil) {
-        if (const auto image_stencil_struct =
-                vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext)) {
+        if (const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.GetPNext())) {
             if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT) == 0) {
                 skip |= LogError(vuid_09112, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                                  "(%s) includes VK_IMAGE_ASPECT_STENCIL_BIT and the image was created with "
@@ -2906,33 +2905,33 @@ bool CoreChecks::ValidateMemcpyExtents(const ImageCopyRegion& region, const Loca
 bool CoreChecks::ValidateHostCopyMultiplane(const ImageCopyRegion& region, const Location& region_loc) const {
     bool skip = false;
     const VkImageAspectFlags src_aspect_mask = region.src_subresource.aspectMask;
-    if (vkuFormatPlaneCount(region.src_state.create_info.format) == 2 &&
+    if (vkuFormatPlaneCount(region.src_state.GetFormat()) == 2 &&
         (src_aspect_mask != VK_IMAGE_ASPECT_PLANE_0_BIT && src_aspect_mask != VK_IMAGE_ASPECT_PLANE_1_BIT)) {
         skip |= LogError("VUID-VkCopyImageToImageInfo-srcImage-07981", region.src_state.Handle(),
                          region_loc.dot(Field::srcSubresource), "is %s but srcImage has 2-plane format (%s).",
-                         string_VkImageAspectFlags(src_aspect_mask).c_str(), string_VkFormat(region.src_state.create_info.format));
+                         string_VkImageAspectFlags(src_aspect_mask).c_str(), string_VkFormat(region.src_state.GetFormat()));
     }
-    if (vkuFormatPlaneCount(region.src_state.create_info.format) == 3 &&
+    if (vkuFormatPlaneCount(region.src_state.GetFormat()) == 3 &&
         (src_aspect_mask != VK_IMAGE_ASPECT_PLANE_0_BIT && src_aspect_mask != VK_IMAGE_ASPECT_PLANE_1_BIT &&
          src_aspect_mask != VK_IMAGE_ASPECT_PLANE_2_BIT)) {
         skip |= LogError("VUID-VkCopyImageToImageInfo-srcImage-07981", region.src_state.Handle(),
                          region_loc.dot(Field::srcSubresource), "is %s but srcImage has 3-plane format (%s).",
-                         string_VkImageAspectFlags(src_aspect_mask).c_str(), string_VkFormat(region.src_state.create_info.format));
+                         string_VkImageAspectFlags(src_aspect_mask).c_str(), string_VkFormat(region.src_state.GetFormat()));
     }
 
     const VkImageAspectFlags dst_aspect_mask = region.dst_subresource.aspectMask;
-    if (vkuFormatPlaneCount(region.dst_state.create_info.format) == 2 &&
+    if (vkuFormatPlaneCount(region.dst_state.GetFormat()) == 2 &&
         (dst_aspect_mask != VK_IMAGE_ASPECT_PLANE_0_BIT && dst_aspect_mask != VK_IMAGE_ASPECT_PLANE_1_BIT)) {
         skip |= LogError("VUID-VkCopyImageToImageInfo-dstImage-07981", region.dst_state.Handle(),
                          region_loc.dot(Field::dstSubresource), "is %s but dstImage has 2-plane format (%s).",
-                         string_VkImageAspectFlags(dst_aspect_mask).c_str(), string_VkFormat(region.dst_state.create_info.format));
+                         string_VkImageAspectFlags(dst_aspect_mask).c_str(), string_VkFormat(region.dst_state.GetFormat()));
     }
-    if (vkuFormatPlaneCount(region.dst_state.create_info.format) == 3 &&
+    if (vkuFormatPlaneCount(region.dst_state.GetFormat()) == 3 &&
         (dst_aspect_mask != VK_IMAGE_ASPECT_PLANE_0_BIT && dst_aspect_mask != VK_IMAGE_ASPECT_PLANE_1_BIT &&
          dst_aspect_mask != VK_IMAGE_ASPECT_PLANE_2_BIT)) {
         skip |= LogError("VUID-VkCopyImageToImageInfo-dstImage-07981", region.dst_state.Handle(),
                          region_loc.dot(Field::dstSubresource), "is %s but dstImage has 3-plane format (%s).",
-                         string_VkImageAspectFlags(dst_aspect_mask).c_str(), string_VkFormat(region.dst_state.create_info.format));
+                         string_VkImageAspectFlags(dst_aspect_mask).c_str(), string_VkFormat(region.dst_state.GetFormat()));
     }
     return skip;
 }
@@ -2947,8 +2946,8 @@ bool CoreChecks::PreCallValidateCopyImageToImage(VkDevice device, const VkCopyIm
     ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
 
     // Formats are required to match, but check each image anyway
-    const uint32_t src_plane_count = vkuFormatPlaneCount(src_image_state->create_info.format);
-    const uint32_t dst_plane_count = vkuFormatPlaneCount(dst_image_state->create_info.format);
+    const uint32_t src_plane_count = vkuFormatPlaneCount(src_image_state->GetFormat());
+    const uint32_t dst_plane_count = vkuFormatPlaneCount(dst_image_state->GetFormat());
     bool check_multiplane = ((src_plane_count == 2 || src_plane_count == 3) || (dst_plane_count == 2 || dst_plane_count == 3));
     bool check_memcpy = (info_ptr->flags & VK_HOST_IMAGE_COPY_MEMCPY);
 
@@ -3035,7 +3034,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
     const char* vuid;
 
     // src image
-    const VkFormat src_format = src_image_state->create_info.format;
+    const VkFormat src_format = src_image_state->GetFormat();
     const VkImageType src_type = src_image_state->GetImageType();
     {
         vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00233" : "VUID-vkCmdBlitImage-srcImage-00233";
@@ -3100,7 +3099,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
     }
 
     // dst image
-    const VkFormat dst_format = dst_image_state->create_info.format;
+    const VkFormat dst_format = dst_image_state->GetFormat();
     const VkImageType dst_type = dst_image_state->GetImageType();
     {
         vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00234" : "VUID-vkCmdBlitImage-dstImage-00234";
@@ -3595,11 +3594,10 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         }
     }
 
-    if (src_image_state->create_info.format != dst_image_state->create_info.format) {
+    if (src_image_state->GetFormat() != dst_image_state->GetFormat()) {
         vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-01386" : "VUID-vkCmdResolveImage-srcImage-01386";
-        skip |=
-            LogError(vuid, all_objlist, src_image_loc, "was created with format %s but dstImage format is %s.",
-                     string_VkFormat(src_image_state->create_info.format), string_VkFormat(dst_image_state->create_info.format));
+        skip |= LogError(vuid, all_objlist, src_image_loc, "was created with format %s but dstImage format is %s.",
+                         string_VkFormat(src_image_state->GetFormat()), string_VkFormat(dst_image_state->GetFormat()));
     }
 
     // For each region, the number of layers in the image subresource should not be zero
@@ -3643,19 +3641,19 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         const VkImageType src_image_type = src_image_state->GetImageType();
         const VkImageType dst_image_type = dst_image_state->GetImageType();
 
-        if (!IsValidAspectMaskForFormat(src_subresource.aspectMask, src_image_state->create_info.format)) {
+        if (!IsValidAspectMaskForFormat(src_subresource.aspectMask, src_image_state->GetFormat())) {
             skip |=
                 LogError("VUID-vkCmdResolveImage-srcSubresource-11800", src_objlist, src_subresource_loc.dot(Field::aspectMask),
                          "(%s) is invalid for image format %s. (%s)", string_VkImageAspectFlags(src_subresource.aspectMask).c_str(),
-                         string_VkFormat(src_image_state->create_info.format),
-                         DescribeValidAspectMaskForFormat(src_image_state->create_info.format).c_str());
+                         string_VkFormat(src_image_state->GetFormat()),
+                         DescribeValidAspectMaskForFormat(src_image_state->GetFormat()).c_str());
         }
-        if (!IsValidAspectMaskForFormat(dst_subresource.aspectMask, dst_image_state->create_info.format)) {
+        if (!IsValidAspectMaskForFormat(dst_subresource.aspectMask, dst_image_state->GetFormat())) {
             skip |=
                 LogError("VUID-vkCmdResolveImage-dstSubresource-11801", dst_objlist, dst_subresource_loc.dot(Field::aspectMask),
                          "(%s) is invalid for image format %s. (%s)", string_VkImageAspectFlags(dst_subresource.aspectMask).c_str(),
-                         string_VkFormat(dst_image_state->create_info.format),
-                         DescribeValidAspectMaskForFormat(dst_image_state->create_info.format).c_str());
+                         string_VkFormat(dst_image_state->GetFormat()),
+                         DescribeValidAspectMaskForFormat(dst_image_state->GetFormat()).c_str());
         }
 
         if (dst_image_type == VK_IMAGE_TYPE_3D) {
@@ -3823,10 +3821,10 @@ bool CoreChecks::ValidateResolveImageModeInfo(VkCommandBuffer commandBuffer, con
     const auto* resolve_mode_info = vku::FindStructInPNextChain<VkResolveImageModeInfoKHR>(pResolveImageInfo->pNext);
     if (!resolve_mode_info) {
         auto src_image_state = Get<vvl::Image>(pResolveImageInfo->srcImage);
-        if (vkuFormatIsDepthOrStencil(src_image_state->create_info.format)) {
+        if (vkuFormatIsDepthOrStencil(src_image_state->GetFormat())) {
             skip |= LogError("VUID-VkResolveImageInfo2-srcImage-10986", src_objlist, src_image_loc,
                              "has format %s but there is no VkResolveImageModeInfoKHR included in the pNext chain.\n%s",
-                             string_VkFormat(src_image_state->create_info.format),
+                             string_VkFormat(src_image_state->GetFormat()),
                              PrintPNextChain(Struct::VkResolveImageInfo2, pResolveImageInfo->pNext).c_str());
         }
         return skip;
@@ -3842,48 +3840,47 @@ bool CoreChecks::ValidateResolveImageModeInfo(VkCommandBuffer commandBuffer, con
 
     if (resolve_mode_info->flags &
         (VK_RESOLVE_IMAGE_SKIP_TRANSFER_FUNCTION_BIT_KHR | VK_RESOLVE_IMAGE_ENABLE_TRANSFER_FUNCTION_BIT_KHR)) {
-        if (!vkuFormatIsSRGB(src_image_state->create_info.format)) {
+        if (!vkuFormatIsSRGB(src_image_state->GetFormat())) {
             skip |= LogError("VUID-VkResolveImageInfo2-pNext-10982", all_objlist,
                              resolve_info_loc.pNext(Struct::VkResolveImageModeInfoKHR, Field::flags),
                              "is %s but pResolveImageInfo->srcImage (%s) does not use sRGB encoding.",
                              string_VkResolveImageFlagsKHR(resolve_mode_info->flags).c_str(),
-                             string_VkFormat(src_image_state->create_info.format));
+                             string_VkFormat(src_image_state->GetFormat()));
         }
-        if (!vkuFormatIsSRGB(dst_image_state->create_info.format)) {
+        if (!vkuFormatIsSRGB(dst_image_state->GetFormat())) {
             skip |= LogError("VUID-VkResolveImageInfo2-pNext-10982", all_objlist,
                              resolve_info_loc.pNext(Struct::VkResolveImageModeInfoKHR, Field::flags),
                              "is %s but pResolveImageInfo->dstImage (%s) does not use sRGB encoding.",
                              string_VkResolveImageFlagsKHR(resolve_mode_info->flags).c_str(),
-                             string_VkFormat(dst_image_state->create_info.format));
+                             string_VkFormat(dst_image_state->GetFormat()));
         }
     }
 
-    if (vkuFormatIsColor(src_image_state->create_info.format) && resolve_mode_info->resolveMode == VK_RESOLVE_MODE_NONE) {
+    if (vkuFormatIsColor(src_image_state->GetFormat()) && resolve_mode_info->resolveMode == VK_RESOLVE_MODE_NONE) {
         skip |= LogError("VUID-VkResolveImageInfo2-srcImage-10983", src_objlist, src_image_loc, "has format %s but %s is %s.",
-                         string_VkFormat(src_image_state->create_info.format),
+                         string_VkFormat(src_image_state->GetFormat()),
                          resolve_info_loc.pNext(Struct::VkResolveImageModeInfoKHR, Field::resolveMode).Fields().c_str(),
                          string_VkResolveModeFlagBits(resolve_mode_info->resolveMode));
     }
 
-    if (vkuFormatIsColor(src_image_state->create_info.format)) {
-        if (!vkuFormatIsSampledInt(src_image_state->create_info.format) &&
-            resolve_mode_info->resolveMode != VK_RESOLVE_MODE_AVERAGE_BIT) {
+    if (vkuFormatIsColor(src_image_state->GetFormat())) {
+        if (!vkuFormatIsSampledInt(src_image_state->GetFormat()) && resolve_mode_info->resolveMode != VK_RESOLVE_MODE_AVERAGE_BIT) {
             skip |= LogError("VUID-VkResolveImageInfo2-srcImage-10984", src_objlist, src_image_loc, "has format %s but %s is %s.",
-                             string_VkFormat(src_image_state->create_info.format),
+                             string_VkFormat(src_image_state->GetFormat()),
                              resolve_info_loc.pNext(Struct::VkResolveImageModeInfoKHR, Field::resolveMode).Fields().c_str(),
                              string_VkResolveModeFlagBits(resolve_mode_info->resolveMode));
         }
 
-        if (vkuFormatIsSampledInt(src_image_state->create_info.format) &&
+        if (vkuFormatIsSampledInt(src_image_state->GetFormat()) &&
             resolve_mode_info->resolveMode != VK_RESOLVE_MODE_SAMPLE_ZERO_BIT) {
             skip |= LogError("VUID-VkResolveImageInfo2-srcImage-10985", src_objlist, src_image_loc, "has format %s but %s is %s.",
-                             string_VkFormat(src_image_state->create_info.format),
+                             string_VkFormat(src_image_state->GetFormat()),
                              resolve_info_loc.pNext(Struct::VkResolveImageModeInfoKHR, Field::resolveMode).Fields().c_str(),
                              string_VkResolveModeFlagBits(resolve_mode_info->resolveMode));
         }
     }
 
-    if (vkuFormatIsDepthOrStencil(src_image_state->create_info.format)) {
+    if (vkuFormatIsDepthOrStencil(src_image_state->GetFormat())) {
         uint32_t first_region_with_depth_aspect = vvl::kNoIndex32;
         uint32_t first_region_with_stencil_aspect = vvl::kNoIndex32;
         uint32_t first_region_without_both_depth_and_stencil_aspects = vvl::kNoIndex32;
@@ -3960,13 +3957,13 @@ bool CoreChecks::ValidateResolveImageModeInfo(VkCommandBuffer commandBuffer, con
             }
         }
 
-        if (vkuFormatIsDepthAndStencil(src_image_state->create_info.format) && !phys_dev_props_core12.independentResolveNone &&
+        if (vkuFormatIsDepthAndStencil(src_image_state->GetFormat()) && !phys_dev_props_core12.independentResolveNone &&
             first_region_without_both_depth_and_stencil_aspects != vvl::kNoIndex32) {
             skip |=
                 LogError("VUID-VkResolveImageInfo2-srcImage-10992", src_objlist, src_image_loc,
                          "has format %s, VkPhysicalDeviceDepthStencilResolveProperties::indepdendentResolveNone is VK_FALSE but "
                          "pResolveImageInfo->pRegions[%" PRIu32 "] does not contain both depth and stencil aspects.",
-                         string_VkFormat(src_image_state->create_info.format), first_region_without_both_depth_and_stencil_aspects);
+                         string_VkFormat(src_image_state->GetFormat()), first_region_without_both_depth_and_stencil_aspects);
         }
     }
 

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1274,19 +1274,19 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView& view_state, VkImageLa
         }
     }
 
-    if (vkuFormatIsDepthOrStencil(image_state->create_info.format)) {
+    if (vkuFormatIsDepthOrStencil(image_state->GetFormat())) {
         if (aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) {
             if (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) {
                 skip |= LogError(
                     "VUID-VkDescriptorImageInfo-imageView-01976", objlist, image_info_loc.dot(Field::imageView),
                     "was created with an image format %s, but the image aspectMask (%s) has both STENCIL and DEPTH aspects set ",
-                    string_VkFormat(image_state->create_info.format), string_VkImageAspectFlags(aspect_mask).c_str());
+                    string_VkFormat(image_state->GetFormat()), string_VkImageAspectFlags(aspect_mask).c_str());
             }
         } else if ((aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) == 0) {
             skip |=
                 LogError("VUID-VkDescriptorImageInfo-imageView-01976", objlist, image_info_loc.dot(Field::imageView),
                          "was created with an image format %s, but the image aspectMask (%s) is missing a STENCIL or DEPTH aspects",
-                         string_VkFormat(image_state->create_info.format), string_VkImageAspectFlags(aspect_mask).c_str());
+                         string_VkFormat(image_state->GetFormat()), string_VkImageAspectFlags(aspect_mask).c_str());
         }
     }
 
@@ -2196,9 +2196,9 @@ bool CoreChecks::VerifyWriteUpdateContents(const vvl::DescriptorSet& dst_set, co
 
                     if (auto sampler_state = Get<vvl::Sampler>(sampler)) {
                         // If there is an immutable sampler then |sampler| isn't used, so the following VU does not apply.
-                        if (vkuFormatIsMultiplane(image_state->create_info.format)) {
+                        if (vkuFormatIsMultiplane(image_state->GetFormat())) {
                             // multiplane formats must be created with mutable format bit
-                            const VkFormat image_format = image_state->create_info.format;
+                            const VkFormat image_format = image_state->GetFormat();
                             if (0 == (image_state->create_info.flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
                                 const LogObjectList objlist(update.dstSet, image_state->Handle());
                                 skip |= LogError("VUID-VkDescriptorImageInfo-sampler-01564", objlist, write_loc,
@@ -5407,7 +5407,7 @@ bool CoreChecks::PreCallValidateWriteResourceDescriptorsEXT(VkDevice device, uin
                 }
             }
 
-            if (vkuFormatIsDepthOrStencil(image_state->create_info.format)) {
+            if (vkuFormatIsDepthOrStencil(image_state->GetFormat())) {
                 const VkImageAspectFlags aspect_mask = image_view_ci.subresourceRange.aspectMask;
                 if (aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) {
                     if (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) {
@@ -5415,7 +5415,7 @@ bool CoreChecks::PreCallValidateWriteResourceDescriptorsEXT(VkDevice device, uin
                                          data_loc.dot(Field::pImage).dot(Field::pView).dot(Field::image),
                                          "is a depth/stencil image (%s), but aspectMask (%s) has both STENCIL and DEPTH aspect "
                                          "set\npResources[%" PRIu32 "].type = %s",
-                                         string_VkFormat(image_state->create_info.format),
+                                         string_VkFormat(image_state->GetFormat()),
                                          string_VkImageAspectFlags(image_view_ci.subresourceRange.aspectMask).c_str(), i,
                                          string_VkDescriptorType(resource.type));
                     }
@@ -5424,7 +5424,7 @@ bool CoreChecks::PreCallValidateWriteResourceDescriptorsEXT(VkDevice device, uin
                                      data_loc.dot(Field::pImage).dot(Field::pView).dot(Field::image),
                                      "is a depth/stencil image (%s), but aspectMask (%s) is missing a STENCIL or DEPTH "
                                      "aspects\npResources[%" PRIu32 "].type = %s",
-                                     string_VkFormat(image_state->create_info.format),
+                                     string_VkFormat(image_state->GetFormat()),
                                      string_VkImageAspectFlags(image_view_ci.subresourceRange.aspectMask).c_str(), i,
                                      string_VkDescriptorType(resource.type));
                 }

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -311,19 +311,19 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image& image, VkExter
     // TODO - Want to use vvl::PnextChainExtract, but would need to cleanup (and test) rest of how we add the other pNext here
     // Note - some pNext structs that can be found in VkImageCreateInfo::pNext are not allowed in VkPhysicalDeviceImageFormatInfo2
     VkImageFormatListCreateInfo format_list = vku::InitStructHelper();
-    if (auto original_format_list = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image.create_info.pNext)) {
+    if (auto original_format_list = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image.GetPNext())) {
         format_list.pViewFormats = original_format_list->pViewFormats;
         format_list.viewFormatCount = original_format_list->viewFormatCount;
         vvl::PnextChainAdd(&external_info, &format_list);
     }
     VkImageStencilUsageCreateInfo stencil_usage = vku::InitStructHelper();
-    if (auto original_stencil_usage = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image.create_info.pNext)) {
+    if (auto original_stencil_usage = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image.GetPNext())) {
         stencil_usage.stencilUsage = original_stencil_usage->stencilUsage;
         vvl::PnextChainAdd(&external_info, &stencil_usage);
     }
     VkPhysicalDeviceImageViewImageFormatInfoEXT image_view_format = vku::InitStructHelper();
     if (auto original_image_view_format =
-            vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(image.create_info.pNext)) {
+            vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(image.GetPNext())) {
         image_view_format.imageViewType = original_image_view_format->imageViewType;
         vvl::PnextChainAdd(&external_info, &image_view_format);
     }
@@ -1187,7 +1187,7 @@ bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, con
 
     auto image_state = Get<vvl::Image>(pInfo->image);
     ASSERT_AND_RETURN_SKIP(image_state);
-    const VkFormat image_format = image_state->create_info.format;
+    const VkFormat image_format = image_state->GetFormat();
     const VkImageTiling image_tiling = image_state->GetTiling();
     const auto* image_plane_info = vku::FindStructInPNextChain<VkImagePlaneMemoryRequirementsInfo>(pInfo->pNext);
     if (!image_plane_info && image_state->disjoint) {
@@ -1956,7 +1956,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
             if (!image_state || !image_state->disjoint) {
                 continue;
             }
-            const uint32_t total_planes = vkuFormatPlaneCount(image_state->create_info.format);
+            const uint32_t total_planes = vkuFormatPlaneCount(image_state->GetFormat());
             for (uint32_t i = 0; i < total_planes; i++) {
                 if (resource.second[i] == vvl::kNoIndex32) {
                     skip |= LogError("VUID-vkBindImageMemory2-pBindInfos-02858", resource.first, error_obj.location,
@@ -2086,20 +2086,19 @@ bool CoreChecks::ValidateBindImageMemoryResource(const VkBindImageMemoryInfo& bi
         // TODO - Want to use vvl::PnextChainExtract, but would need to cleanup (and test) rest of how we add the other
         // pNext here
         VkImageFormatListCreateInfo format_list = vku::InitStructHelper();
-        if (auto original_format_list = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image_state.create_info.pNext)) {
+        if (auto original_format_list = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image_state.GetPNext())) {
             format_list.pViewFormats = original_format_list->pViewFormats;
             format_list.viewFormatCount = original_format_list->viewFormatCount;
             vvl::PnextChainAdd(&image_format_info, &format_list);
         }
         VkImageStencilUsageCreateInfo stencil_usage = vku::InitStructHelper();
-        if (auto original_stencil_usage =
-                vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext)) {
+        if (auto original_stencil_usage = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.GetPNext())) {
             stencil_usage.stencilUsage = original_stencil_usage->stencilUsage;
             vvl::PnextChainAdd(&image_format_info, &stencil_usage);
         }
         VkPhysicalDeviceImageViewImageFormatInfoEXT image_view_format = vku::InitStructHelper();
         if (auto original_image_view_format =
-                vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(image_state.create_info.pNext)) {
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(image_state.GetPNext())) {
             image_view_format.imageViewType = original_image_view_format->imageViewType;
             vvl::PnextChainAdd(&image_format_info, &image_view_format);
         }
@@ -2592,8 +2591,8 @@ bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind& bind, const 
 bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(vvl::Image const& image_state, VkImageSubresource const& subresource,
                                                                const Location& bind_loc, const Location& subresource_loc) const {
     bool skip = false;
-    skip |= ValidateImageAspectMask(image_state.VkHandle(), image_state.create_info.format, subresource.aspectMask,
-                                    image_state.disjoint, bind_loc, "VUID-VkSparseImageMemoryBindInfo-subresource-01106");
+    skip |= ValidateImageAspectMask(image_state.VkHandle(), image_state.GetFormat(), subresource.aspectMask, image_state.disjoint,
+                                    bind_loc, "VUID-VkSparseImageMemoryBindInfo-subresource-01106");
 
     if (subresource.mipLevel >= image_state.GetMipLevels()) {
         skip |=

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -396,7 +396,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                                 "VkImageCreateInfo structure",
                                 FormatHandle(metal_texture_ptr->image).c_str());
                         }
-                        auto format_plane_count = vkuFormatPlaneCount(image_info->create_info.format);
+                        auto format_plane_count = vkuFormatPlaneCount(image_info->GetFormat());
                         auto image_plane = metal_texture_ptr->plane;
                         if (!(format_plane_count > 1) && (image_plane != VK_IMAGE_ASPECT_PLANE_0_BIT)) {
                             skip |= LogError(
@@ -405,7 +405,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                                 "%s, and plane = %s, but image was created with format %s, which is not multiplaner and plane is "
                                 "required to be VK_IMAGE_ASPECT_PLANE_0_BIT",
                                 FormatHandle(metal_texture_ptr->image).c_str(), string_VkImageAspectFlags(image_plane).c_str(),
-                                string_VkFormat(image_info->create_info.format));
+                                string_VkFormat(image_info->GetFormat()));
                         }
                         if ((format_plane_count == 2) && (image_plane == VK_IMAGE_ASPECT_PLANE_2_BIT)) {
                             skip |= LogError(
@@ -415,7 +415,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                                 "cannot"
                                 "be VK_IMAGE_ASPECT_PLANE_2_BIT",
                                 FormatHandle(metal_texture_ptr->image).c_str(), string_VkImageAspectFlags(image_plane).c_str(),
-                                string_VkFormat(image_info->create_info.format));
+                                string_VkFormat(image_info->GetFormat()));
                         }
                     }
                 }
@@ -623,7 +623,7 @@ bool CoreChecks::ValidateAllocateMemoryMetal(const VkMemoryAllocateInfo& allocat
 
         // We can only validate images since we lack information to do the buffer call for the properties
         auto image_state_ptr = Get<vvl::Image>(dedicated_allocation_info->image);
-        VkFormat image_format = image_state_ptr->create_info.format;
+        VkFormat image_format = image_state_ptr->GetFormat();
         VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
         external_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_MTLTEXTURE_BIT_EXT;
         VkPhysicalDeviceImageFormatInfo2 format_info = image_state_ptr->GetImageFormatInfo2(&external_info);

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -956,7 +956,7 @@ bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer
         skip |= ValidateClearImageLayout(cb_state, image_state, pRanges[i], imageLayout, range_loc);
     }
 
-    const VkFormat format = image_state.create_info.format;
+    const VkFormat format = image_state.GetFormat();
     if (vkuFormatIsDepthOrStencil(format)) {
         skip |=
             LogError("VUID-vkCmdClearColorImage-image-00007", objlist, image_loc,
@@ -1018,7 +1018,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     const auto& image_state = *image_state_ptr;
     const Location image_loc = error_obj.location.dot(Field::image);
 
-    const VkFormat image_format = image_state.create_info.format;
+    const VkFormat image_format = image_state.GetFormat();
     const LogObjectList objlist(commandBuffer, image);
     skip |= ValidateMemoryIsBoundToImage(objlist, image_state, image_loc, "VUID-vkCmdClearDepthStencilImage-image-00010");
     skip |= ValidateCmd(cb_state, error_obj.location);
@@ -1030,7 +1030,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     skip |= ValidateProtectedImage(cb_state, image_state, image_loc, "VUID-vkCmdClearDepthStencilImage-commandBuffer-01807");
     skip |= ValidateUnprotectedImage(cb_state, image_state, image_loc, "VUID-vkCmdClearDepthStencilImage-commandBuffer-01808");
 
-    const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext);
+    const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.GetPNext());
     for (uint32_t i = 0; i < rangeCount; ++i) {
         const Location range_loc = error_obj.location.dot(Field::pRanges, i);
         skip |= ValidateCmdClearDepthSubresourceRange(image_state.create_info, pRanges[i], objlist, range_loc);
@@ -1381,7 +1381,7 @@ bool CoreChecks::ValidateImageFormatFeatureFlags(VkCommandBuffer commandBuffer, 
                 LogError(vuid, objlist, image_loc,
                          "(%s) was created with format %s and tiling %s which have VkFormatFeatureFlags2 (%s) which in turn is "
                          "missing the required feature %s.",
-                         FormatHandle(image_state).c_str(), string_VkFormat(image_state.create_info.format),
+                         FormatHandle(image_state).c_str(), string_VkFormat(image_state.GetFormat()),
                          string_VkImageTiling(image_state.GetTiling()), string_VkFormatFeatureFlags2(image_format_features).c_str(),
                          string_VkFormatFeatureFlags2(desired).c_str());
         }
@@ -1928,7 +1928,7 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create
     auto normalized_subresource_range = vvl::ImageView::NormalizeImageViewSubresourceRange(image_state, create_info);
 
     const VkImageCreateFlags image_flags = image_state.create_info.flags;
-    const VkFormat image_format = image_state.create_info.format;
+    const VkFormat image_format = image_state.GetFormat();
     const VkFormat view_format = create_info.format;
     const VkImageAspectFlags aspect_mask = create_info.subresourceRange.aspectMask;
     const VkImageType image_type = image_state.GetImageType();
@@ -1940,8 +1940,7 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create
 
     if (const auto chained_ivuci_struct = vku::FindStructInPNextChain<VkImageViewUsageCreateInfo>(create_info.pNext)) {
         if (IsExtEnabled(extensions.vk_khr_maintenance2)) {
-            const auto image_stencil_struct =
-                vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext);
+            const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.GetPNext());
             if (image_stencil_struct == nullptr) {
                 if ((image_usage | chained_ivuci_struct->usage) != image_usage) {
                     skip |=
@@ -1981,7 +1980,7 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create
     skip |= ValidateImageViewSlicedCreateInfo(create_info, image_state, normalized_subresource_range, create_info_loc);
 
     // If image used VkImageFormatListCreateInfo need to make sure a format from list is used
-    if (const auto format_list_info = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image_state.create_info.pNext);
+    if (const auto format_list_info = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image_state.GetPNext());
         format_list_info && (format_list_info->viewFormatCount > 0)) {
         bool found_format = false;
         for (uint32_t i = 0; i < format_list_info->viewFormatCount; i++) {
@@ -2322,7 +2321,7 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create
         // Ensure ImageView's format has the same number of bits and components as Image's format if format reinterpretation is
         // disabled
         if (!enabled_features.imageViewFormatReinterpretation &&
-            !FormatsEqualComponentBits(create_info.format, image_state.create_info.format)) {
+            !FormatsEqualComponentBits(create_info.format, image_state.GetFormat())) {
             skip |= LogError("VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466", create_info.image, create_info_loc,
                              "(portability error): ImageView format must have"
                              " the same number of components and bits per component as the Image's format");
@@ -2475,7 +2474,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image& image_state
                          subresource.arrayLayer, image_state.GetArrayLayers());
     }
 
-    const VkFormat image_format = image_state.create_info.format;
+    const VkFormat image_format = image_state.GetFormat();
     const bool tiling_linear_optimal =
         image_state.GetTiling() == VK_IMAGE_TILING_LINEAR || image_state.GetTiling() == VK_IMAGE_TILING_OPTIMAL;
     if (vkuFormatIsColor(image_format) && !vkuFormatIsMultiplane(image_format) && (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT) &&
@@ -2535,12 +2534,10 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image& image_state
 
             VkDrmFormatModifierPropertiesListEXT fmt_drm_props = vku::InitStructHelper();
             VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
-            DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, image_state.create_info.format,
-                                                             &fmt_props_2);
+            DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, image_state.GetFormat(), &fmt_props_2);
             std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties{fmt_drm_props.drmFormatModifierCount};
             fmt_drm_props.pDrmFormatModifierProperties = drm_properties.data();
-            DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, image_state.create_info.format,
-                                                             &fmt_props_2);
+            DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, image_state.GetFormat(), &fmt_props_2);
 
             uint32_t max_plane_count = 0u;
 
@@ -2570,7 +2567,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image& image_state
                 skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                                  "is %s for image format %s, but drmFormatModifierPlaneCount is %" PRIu32
                                  " (drmFormatModifier = %" PRIu64 ").",
-                                 string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_state.create_info.format),
+                                 string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_state.GetFormat()),
                                  max_plane_count, drm_format_properties.drmFormatModifier);
             }
         }
@@ -2651,7 +2648,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayout(VkDevice device, uint32_t 
         const auto& transition = pTransitions[i];
         const auto image_state = Get<vvl::Image>(transition.image);
         if (!image_state) continue;
-        const auto image_format = image_state->create_info.format;
+        const VkFormat image_format = image_state->GetFormat();
         const auto aspect_mask = transition.subresourceRange.aspectMask;
         const bool has_depth_mask = (aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0;
         const bool has_stencil_mask = (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) != 0;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -1185,9 +1185,10 @@ bool CoreChecks::IsCompliantSubresourceRange(const VkImageSubresourceRange& subr
     if ((subres_range.baseArrayLayer + subres_range.layerCount) > image_state.GetArrayLayers()) {
         return false;
     }
-    if (!IsValidAspectMaskForFormat(subres_range.aspectMask, image_state.create_info.format)) return false;
-    if (((vkuFormatPlaneCount(image_state.create_info.format) < 3) && (subres_range.aspectMask & VK_IMAGE_ASPECT_PLANE_2_BIT)) ||
-        ((vkuFormatPlaneCount(image_state.create_info.format) < 2) && (subres_range.aspectMask & VK_IMAGE_ASPECT_PLANE_1_BIT))) {
+    const VkFormat image_format = image_state.GetFormat();
+    if (!IsValidAspectMaskForFormat(subres_range.aspectMask, image_format)) return false;
+    if (((vkuFormatPlaneCount(image_format) < 3) && (subres_range.aspectMask & VK_IMAGE_ASPECT_PLANE_2_BIT)) ||
+        ((vkuFormatPlaneCount(image_format) < 2) && (subres_range.aspectMask & VK_IMAGE_ASPECT_PLANE_1_BIT))) {
         return false;
     }
     if (subres_range.aspectMask & VK_IMAGE_ASPECT_METADATA_BIT ||

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -85,7 +85,7 @@ void CopyBufferToImage(Validator& gpuav, const Location& loc, CommandBufferSubSt
 
     // Only need to perform validation for depth image having a depth format that is not unsigned normalized.
     // For unsigned normalized formats, depth is by definition in range [0, 1]
-    if (!IsValueIn(image_state->create_info.format, {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT})) {
+    if (!IsValueIn(image_state->GetFormat(), {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT})) {
         return;
     }
 
@@ -138,7 +138,7 @@ void CopyBufferToImage(Validator& gpuav, const Location& loc, CommandBufferSubSt
 
         auto gpu_regions_u32_ptr = (uint32_t*)copy_src_regions_mem_buffer_range.offset_mapped_ptr;
 
-        const uint32_t block_size = image_state->create_info.format == VK_FORMAT_D32_SFLOAT ? 4 : 5;
+        const uint32_t block_size = image_state->GetFormat() == VK_FORMAT_D32_SFLOAT ? 4 : 5;
         const VkExtent3D image_extent = image_state->GetExtent();
         uint32_t gpu_regions_count = 0;
         BufferImageCopy* gpu_regions_ptr =

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -527,7 +527,7 @@ static VkImageUsageFlags GetInheritedUsage(const VkImageViewCreateInfo& ci, cons
     VkImageUsageFlags usage = image_state.create_info.usage;
 
     // We can't apply the stencil usage until we get the aspectMask to know how to appply it
-    if (const auto stencil_usage_info = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext)) {
+    if (const auto stencil_usage_info = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.GetPNext())) {
         const bool stencil_aspect = (ci.subresourceRange.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) != 0;
         const bool depth_aspect = (ci.subresourceRange.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0;
         if (stencil_aspect && !depth_aspect) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -124,6 +124,7 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
 
     VkImage VkHandle() const { return handle_.Cast<VkImage>(); }
 
+    const void* GetPNext() const { return create_info.pNext; }
     VkImageType GetImageType() const { return create_info.imageType; }
     VkFormat GetFormat() const { return create_info.format; }
     VkExtent3D GetExtent() const { return create_info.extent; }

--- a/layers/state_tracker/subresource_adapter.cpp
+++ b/layers/state_tracker/subresource_adapter.cpp
@@ -328,8 +328,9 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
     // aliased resources can be done correctly.
     linear_image_ = false;
 
-    is_compressed_ = vkuFormatIsCompressed(image.create_info.format);
-    texel_block_extent_ = vkuFormatTexelBlockExtent(image.create_info.format);
+    const VkFormat image_format = image.GetFormat();
+    is_compressed_ = vkuFormatIsCompressed(image_format);
+    texel_block_extent_ = vkuFormatTexelBlockExtent(image_format);
 
     is_3_d_ = image.GetImageType() == VK_IMAGE_TYPE_3D;
     y_interleave_ = false;
@@ -341,8 +342,7 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
         VkImageSubresource subres = {};
         subres.aspectMask = static_cast<VkImageAspectFlags>(AspectBit(aspect_index));
         subres_layers.aspectMask = subres.aspectMask;
-        texel_sizes_.push_back(
-            FormatTexelSizeWithAspect(image.create_info.format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
+        texel_sizes_.push_back(FormatTexelSizeWithAspect(image_format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
         IndexType aspect_size = 0;
         for (uint32_t mip_index = 0; mip_index < limits_.mipLevel; ++mip_index) {
             subres_layers.mipLevel = mip_index;
@@ -387,7 +387,7 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
         }
         aspect_sizes_.emplace_back(aspect_size);
         aspect_extent_divisors_.emplace_back(
-            vkuFindMultiplaneExtentDivisors(image.create_info.format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
+            vkuFindMultiplaneExtentDivisors(image_format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
     }
 }
 


### PR DESCRIPTION
one more @ziga-lunarg  before https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12033

from here, next thing is moving the actual extended fields over