### PR TITLE
gpuav: Remove GL_ARB_gpu_shader_int64 check

### DIFF
--- a/layers/gpuav/shaders/instrumentation/common_descriptor_sets.h
+++ b/layers/gpuav/shaders/instrumentation/common_descriptor_sets.h
@@ -18,11 +18,7 @@
 #extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_buffer_reference_uvec2 : require
 #extension GL_EXT_scalar_block_layout : require
-#if defined(GL_ARB_gpu_shader_int64)
 #extension GL_ARB_gpu_shader_int64 : require
-#else
-#error No extension available for 64-bit integers.
-#endif
 
 #include "gpuav_error_header.h"
 #include "gpuav_shaders_constants.h"

--- a/layers/gpuav/shaders/validation_cmd/build_acceleration_structures.h
+++ b/layers/gpuav/shaders/validation_cmd/build_acceleration_structures.h
@@ -39,11 +39,7 @@ namespace gpuav {
 namespace glsl {
 using uint = uint32_t;
 #else
-#if defined(GL_ARB_gpu_shader_int64)
 #extension GL_ARB_gpu_shader_int64 : require
-#else
-#error No extension available for 64-bit integers.
-#endif
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_buffer_reference_uvec2 : require

--- a/layers/gpuav/shaders/validation_cmd/memcmp.h
+++ b/layers/gpuav/shaders/validation_cmd/memcmp.h
@@ -27,11 +27,7 @@ namespace gpuav {
 namespace glsl {
 using uint = uint32_t;
 #else
-#if defined(GL_ARB_gpu_shader_int64)
 #extension GL_ARB_gpu_shader_int64 : require
-#else
-#error No extension available for 64-bit integers.
-#endif
 #extension GL_EXT_buffer_reference : require
 #extension GL_EXT_buffer_reference2 : require
 #extension GL_EXT_buffer_reference_uvec2 : require

--- a/layers/gpuav/shaders/validation_cmd/push_data.h
+++ b/layers/gpuav/shaders/validation_cmd/push_data.h
@@ -1,6 +1,6 @@
-// Copyright (c) 2021-2025 The Khronos Group Inc.
-// Copyright (c) 2021-2025 Valve Corporation
-// Copyright (c) 2021-2025 LunarG, Inc.
+// Copyright (c) 2021-2026 The Khronos Group Inc.
+// Copyright (c) 2021-2026 Valve Corporation
+// Copyright (c) 2021-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,11 +27,7 @@ namespace gpuav {
 namespace glsl {
 using uint = uint32_t;
 #else
-#if defined(GL_ARB_gpu_shader_int64)
 #extension GL_ARB_gpu_shader_int64 : require
-#else
-#error No extension available for 64-bit integers.
-#endif
 #extension GL_EXT_buffer_reference : require
 #endif
 


### PR DESCRIPTION
@arno-lunarg this is zero usage (the spirv is the same)

the idea of checking for `GL_ARB_gpu_shader_int64` goes back to pre-Vulkan when the driver compiled the glsl and you needed to query for support