### PR TITLE
layers: Validiate layout transition of swapchain images

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -34,6 +34,7 @@
 #include "state_tracker/image_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/cmd_buffer_state.h"
+#include "state_tracker/wsi_state.h"
 #include "drawdispatch/drawdispatch_vuids.h"
 
 bool IsValidAspectMaskForFormat(VkImageAspectFlags aspect_mask, VkFormat format);
@@ -307,6 +308,22 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
                     }
                 }
             }
+
+            // Check if we transitioned swapchain image outside of acquire-present interval
+            const bool has_layout_transition = cb_layout_state.current_layout != kInvalidLayout;
+            if (has_layout_transition) {
+                if (image_state->IsSwapchainImage()) {
+                    if (!image_state->bind_swapchain->images[image_state->swapchain_image_index].acquired) {
+                        const LogObjectList objlist(cb_state.Handle(), image_state->Handle());
+                        // VUID request: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4784
+                        skip |= LogError("UNASSIGNED-non-acquired-swapchain-image-used", objlist, loc,
+                                         "performs a layout transition on presentable %s, but the image has not been acquired from "
+                                         "%s (either never or since the last present operation)",
+                                         FormatHandle(*image_state).c_str(), FormatHandle(*image_state->bind_swapchain).c_str());
+                    }
+                }
+            }
+
             if (pos->first.includes(intersected_range.end)) {
                 current_layout.seek(intersected_range.end);
             } else {

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1967,6 +1967,24 @@ void CommandBuffer::Destroy() noexcept {
 }
 CommandBuffer::~CommandBuffer() noexcept { Destroy(); }
 
+CommandBuffer::CommandBuffer(CommandBuffer&& rhs) noexcept : Handle(std::move(rhs)) {
+    dev_handle_ = rhs.dev_handle_;
+    cmd_pool_ = rhs.cmd_pool_;
+    rhs.dev_handle_ = VK_NULL_HANDLE;
+    rhs.cmd_pool_ = VK_NULL_HANDLE;
+}
+
+CommandBuffer& CommandBuffer::operator=(CommandBuffer&& rhs) noexcept {
+    Destroy();
+    dev_handle_ = rhs.dev_handle_;
+    cmd_pool_ = rhs.cmd_pool_;
+    handle_ = rhs.handle_;
+    rhs.dev_handle_ = VK_NULL_HANDLE;
+    rhs.cmd_pool_ = VK_NULL_HANDLE;
+    rhs.handle_ = VK_NULL_HANDLE;
+    return *this;
+}
+
 void CommandBuffer::Init(const Device& dev, const VkCommandBufferAllocateInfo& info) {
     VkCommandBuffer cmd;
 
@@ -2219,6 +2237,21 @@ void CommandBuffer::TransitionLayout(const vkt::Image& image, VkImageLayout old_
                            VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
 }
 
+void CommandBuffer::TransitionLayout(const VkImage image, VkImageLayout old_layout, VkImageLayout new_layout,
+                                     const VkImageSubresourceRange& subresource_range) {
+    VkImageMemoryBarrier barrier = vku::InitStructHelper();
+    barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+    barrier.oldLayout = old_layout;
+    barrier.newLayout = new_layout;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = image;
+    barrier.subresourceRange = subresource_range;
+    vk::CmdPipelineBarrier(handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                           VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
 // For positive tests, if you run with sync val, ideally want no errors.
 // Many tests need a simple quick way to sync multiple commands
 void CommandBuffer::FullMemoryBarrier() {
@@ -2320,6 +2353,41 @@ std::vector<VkImage> Swapchain::GetImages() const {
     std::vector<VkImage> images(image_count);
     vk::GetSwapchainImagesKHR(device(), handle(), &image_count, images.data());
     return images;
+}
+
+std::vector<vkt::CommandBuffer> Swapchain::RecordTransitionToPresentLayout(const vkt::Device& device,
+                                                                           const vkt::CommandPool& command_pool) const {
+    const std::vector<VkImage> swapchain_images = GetImages();
+    std::vector<vkt::CommandBuffer> command_buffers;
+    command_buffers.reserve(swapchain_images.size());
+    for (size_t i = 0; i < swapchain_images.size(); i++) {
+        auto& cb = command_buffers.emplace_back(device, command_pool);
+        cb.Begin();
+        cb.TransitionLayout(swapchain_images[i], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+        cb.End();
+    }
+    return command_buffers;
+}
+
+bool Swapchain::TryTransitionToPresentLayout(const vkt::Device& device, vkt::Queue& queue, const vkt::CommandPool& command_pool) {
+    const std::vector<VkImage> swapchain_images = GetImages();
+    auto transition_to_present_cbs = RecordTransitionToPresentLayout(device, command_pool);
+    std::vector<bool> is_transitioned(swapchain_images.size(), false);
+    vkt::Fence fence(device);
+
+    // Iterate more times than swapchain images to have a better chance to acquire all images
+    const size_t iteration_count = swapchain_images.size() * 2;
+
+    for (size_t i = 0; i < iteration_count; i++) {
+        const uint32_t image_index = AcquireNextImage(fence, kWaitTimeout);
+        fence.Wait(kWaitTimeout);
+        fence.Reset();
+        queue.SubmitAndWait(transition_to_present_cbs[image_index]);
+        queue.Present(*this, image_index, vkt::no_semaphore);
+        is_transitioned[image_index] = true;
+    }
+    queue.Wait();
+    return std::all_of(is_transitioned.begin(), is_transitioned.end(), [](bool b) { return b; });
 }
 
 uint32_t Swapchain::AcquireNextImage(const Semaphore& image_acquired, uint64_t timeout, VkResult* result) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1079,16 +1079,12 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void Destroy() noexcept;
 
     explicit CommandBuffer() : Handle() {}
-    CommandBuffer(const Device &dev, const VkCommandBufferAllocateInfo &info) { Init(dev, info); }
-    CommandBuffer(const Device &dev, const CommandPool &pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY) {
+    CommandBuffer(const Device& dev, const VkCommandBufferAllocateInfo& info) { Init(dev, info); }
+    CommandBuffer(const Device& dev, const CommandPool& pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY) {
         Init(dev, pool, level);
     }
-    CommandBuffer(CommandBuffer &&rhs) noexcept : Handle(std::move(rhs)) {
-        dev_handle_ = rhs.dev_handle_;
-        rhs.dev_handle_ = VK_NULL_HANDLE;
-        cmd_pool_ = rhs.cmd_pool_;
-        rhs.cmd_pool_ = VK_NULL_HANDLE;
-    }
+    CommandBuffer(CommandBuffer&& rhs) noexcept;
+    CommandBuffer& operator=(CommandBuffer&& rhs) noexcept;
 
     // vkAllocateCommandBuffers()
     void Init(const Device &dev, const VkCommandBufferAllocateInfo &info);
@@ -1165,6 +1161,11 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void ImageBarrier(const vkt::Image& image, VkImageLayout current_layout);
 
     void TransitionLayout(const vkt::Image& image, VkImageLayout old_layout, VkImageLayout new_layout);
+
+    // Used when vkt:Image is not available, for example, for swapchain images
+    void TransitionLayout(const VkImage image, VkImageLayout old_layout, VkImageLayout new_layout,
+                          const VkImageSubresourceRange& subresource_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1});
+
     void FullMemoryBarrier();
 
   private:
@@ -1408,6 +1409,14 @@ class Swapchain : public internal::NonDispHandle<VkSwapchainKHR> {
 
     uint32_t GetImageCount() const;
     std::vector<VkImage> GetImages() const;
+
+    // Each command buffer records layout transition to present layout for corresponding swapchain image
+    std::vector<vkt::CommandBuffer> RecordTransitionToPresentLayout(const vkt::Device& device,
+                                                                    const vkt::CommandPool& command_pool) const;
+
+    // Return true if *all* swapchain images were transitioned.
+    // We don't have a guarantee its always possible because the ordering of the acquired images is unspecified
+    bool TryTransitionToPresentLayout(const vkt::Device& device, vkt::Queue& queue, const vkt::CommandPool& command_pool);
 
     uint32_t AcquireNextImage(const Semaphore &image_acquired, uint64_t timeout, VkResult *result = nullptr);
     uint32_t AcquireNextImage(const Fence &image_acquired, uint64_t timeout, VkResult *result = nullptr);

--- a/tests/unit/sync_val_wsi.cpp
+++ b/tests/unit/sync_val_wsi.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,19 +55,25 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     // Loop through the indices until we find one we are reusing...
     // When fence is non-null this can timeout so we need to track results
     // Acquire can always timeout, so we need to track results
-    auto acquire_used_image_semaphore = [this, &image_used](const vkt::Semaphore& sem, uint32_t& index) {
+    auto acquire_used_image_semaphore = [this, &image_used, &images](const vkt::Semaphore& sem, uint32_t& index) {
         VkResult result = VK_SUCCESS;
         while (true) {
             index = m_swapchain.AcquireNextImage(sem, kWaitTimeout, &result);
             if ((result != VK_SUCCESS) || image_used[index]) break;
 
-            result = m_default_queue->Present(m_swapchain, index, sem);
+            m_command_buffer.Begin();
+            m_command_buffer.TransitionLayout(images[index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+            m_command_buffer.End();
+            m_default_queue->Submit(m_command_buffer, vkt::Wait(sem));
+            m_device->Wait();
+
+            result = m_default_queue->Present(m_swapchain, index, vkt::no_semaphore);
             if (result != VK_SUCCESS) break;
             image_used[index] = true;
         }
         return result;
     };
-    auto acquire_used_image_fence = [this, &image_used](const vkt::Fence& fence, uint32_t& index) {
+    auto acquire_used_image_fence = [this, &image_used, &images](const vkt::Fence& fence, uint32_t& index) {
         VkResult result = VK_SUCCESS;
         while (true) {
             index = m_swapchain.AcquireNextImage(fence, kWaitTimeout, &result);
@@ -75,6 +81,12 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
 
             result = fence.Wait(kWaitTimeout);
             fence.Reset();
+
+            m_command_buffer.Begin();
+            m_command_buffer.TransitionLayout(images[index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+            m_command_buffer.End();
+            m_default_queue->SubmitAndWait(m_command_buffer);
+
             m_default_queue->Present(m_swapchain, index, vkt::no_semaphore);
 
             if (result != VK_SUCCESS) break;
@@ -83,34 +95,12 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
         return result;
     };
 
-    auto write_barrier_cb = [this](const VkImage h_image, VkImageLayout from, VkImageLayout to) {
-        VkImageSubresourceRange full_image{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-        VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
-        image_barrier.srcAccessMask = 0U;
-        image_barrier.dstAccessMask = 0U;
-        image_barrier.oldLayout = from;
-        image_barrier.newLayout = to;
-        image_barrier.image = h_image;
-
-        image_barrier.subresourceRange = full_image;
-        m_command_buffer.Begin();
-        vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
-                               nullptr, 1, &image_barrier);
-        m_command_buffer.End();
-    };
-
-    // Transition swapchain images to PRESENT_SRC layout for presentation
-    for (VkImage image : images) {
-        write_barrier_cb(image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-        m_default_queue->Submit(m_command_buffer);
-        m_device->Wait();
-        m_command_buffer.Reset();
-    }
-
     uint32_t acquired_index = 0;
     REQUIRE_SUCCESS(acquire_used_image_fence(fence, acquired_index), "acquire_used_image");
 
-    write_barrier_cb(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
 
     // Look for errors between the acquire and first use...
     // No sync operations...
@@ -136,10 +126,17 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     vkt::Semaphore sem(*m_device);
     REQUIRE_SUCCESS(acquire_used_image_semaphore(sem, acquired_index), "acquire_used_image");
 
-    m_command_buffer.Reset();
-    write_barrier_cb(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
-
     // The wait mask doesn't match the operations in the command buffer
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
+    image_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    image_barrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    image_barrier.image = images[acquired_index];
+    image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    m_command_buffer.Begin();
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                           nullptr, 1, &image_barrier);
+    m_command_buffer.End();
+
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-READ");
     m_default_queue->Submit(m_command_buffer, vkt::Wait(sem, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT));
     m_errorMonitor->VerifyFound();
@@ -159,8 +156,9 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     REQUIRE_SUCCESS(acquire_used_image_fence(fence, acquired_index), "acquire_used_index");
     REQUIRE_SUCCESS(fence.Wait(kWaitTimeout), "WaitForFences");
 
-    m_command_buffer.Reset();
-    write_barrier_cb(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
 
     fence.Reset();
     m_default_queue->Submit(m_command_buffer, vkt::Signal(sem));

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -141,30 +141,12 @@ TEST_F(PositiveSyncValWsi, PresentAfterSubmitNoneDstStage) {
 TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7250");
     AddSurfaceExtension();
-    RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitSyncVal());
     RETURN_IF_SKIP(InitSwapchain());
 
     const auto swapchain_images = m_swapchain.GetImages();
-    {
-        vkt::CommandBuffer cmd(*m_device, m_command_pool);
-        cmd.Begin();
-        for (VkImage image : swapchain_images) {
-            VkImageMemoryBarrier transition = vku::InitStructHelper();
-            transition.srcAccessMask = 0;
-            transition.dstAccessMask = 0;
-            transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-            transition.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            transition.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            transition.image = image;
-            transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-            vk::CmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0,
-                                   nullptr, 1, &transition);
-        }
-        cmd.End();
-        m_default_queue->Submit(cmd);
-        m_default_queue->Wait();
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     constexpr int N = 1'000;
@@ -211,8 +193,8 @@ TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
                                         vkt::Signal(submit_semaphores[image_index]), fence);
                 m_default_queue->Present(m_swapchain, image_index, submit_semaphores[image_index]);
             }
-            vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
-            vk::ResetFences(device(), 1, &fence.handle());
+            fence.Wait(kWaitTimeout);
+            fence.Reset();
         }
         {
             // We did not synchronize with the presentation request from the last iteration.
@@ -230,9 +212,8 @@ TEST_F(PositiveSyncValWsi, WaitForFencesWithPresentBatches) {
     RETURN_IF_SKIP(InitSyncVal());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
+
+    vkt::CommandBuffer frame1_cb(*m_device, m_command_pool);
 
     vkt::Semaphore acquire_semaphore(*m_device);
     vkt::Semaphore submit_semaphore(*m_device);
@@ -251,6 +232,8 @@ TEST_F(PositiveSyncValWsi, WaitForFencesWithPresentBatches) {
         const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
 
         m_command_buffer.Begin();
+        m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED,
+                                          VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         m_command_buffer.Copy(src_buffer, buffer);
         m_command_buffer.End();
 
@@ -261,11 +244,11 @@ TEST_F(PositiveSyncValWsi, WaitForFencesWithPresentBatches) {
     {
         const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore2, kWaitTimeout);
 
-        // TODO: Present should be able to accept semaphore from Acquire directly, but due to
-        // another bug we need this intermediate sumbit. Remove it and make present to wait
-        // on image_ready_semaphore semaphore when acquire->present direct synchronization is fixed.
-        m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore2), vkt::Signal(submit_semaphore2));
+        frame1_cb.Begin();
+        frame1_cb.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+        frame1_cb.End();
 
+        m_default_queue->Submit(frame1_cb, vkt::Wait(acquire_semaphore2), vkt::Signal(submit_semaphore2));
         m_default_queue->Present(m_swapchain, image_index, submit_semaphore2);
     }
     // Frame 2
@@ -302,9 +285,6 @@ TEST_F(PositiveSyncValWsi, RecreateBuffer) {
     std::vector<vkt::Buffer> src_buffers(swapchain_images.size());
     std::vector<vkt::Buffer> dst_buffers(swapchain_images.size());
 
-    for (VkImage image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
     for (size_t i = 0; i < swapchain_images.size(); i++) {
         acquire_fences.emplace_back(*m_device);
         command_buffers.emplace_back(*m_device, m_command_pool);
@@ -331,6 +311,7 @@ TEST_F(PositiveSyncValWsi, RecreateBuffer) {
 
         auto& command_buffer = command_buffers[image_index];
         command_buffer.Begin();
+        command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         command_buffer.Copy(src_buffer, dst_buffer);
         command_buffer.End();
 
@@ -364,9 +345,6 @@ TEST_F(PositiveSyncValWsi, RecreateImage) {
     const vkt::Buffer src_buffer(*m_device, width * height * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     std::vector<vkt::Image> dst_images(swapchain_images.size());
 
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
     for (size_t i = 0; i < swapchain_images.size(); i++) {
         acquire_fences.emplace_back(*m_device);
         command_buffers.emplace_back(*m_device, m_command_pool);
@@ -391,19 +369,10 @@ TEST_F(PositiveSyncValWsi, RecreateImage) {
         region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         region.imageExtent = {width, height, 1};
 
-        VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
-        layout_transition.srcStageMask = VK_PIPELINE_STAGE_2_NONE;
-        layout_transition.srcAccessMask = VK_ACCESS_2_NONE;
-        layout_transition.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
-        layout_transition.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-        layout_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        layout_transition.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-        layout_transition.image = dst_image;
-        layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-
         auto& command_buffer = command_buffers[image_index];
         command_buffer.Begin();
-        command_buffer.Barrier(layout_transition);
+        command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+        command_buffer.TransitionLayout(dst_image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
         vk::CmdCopyBufferToImage(command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
         command_buffer.End();
 
@@ -431,8 +400,8 @@ TEST_F(PositiveSyncValWsi, ResyncWithSwapchain) {
     if (swapchain_images.size() != 2) {
         GTEST_SKIP() << "The test requires swapchain with 2 images";
     }
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
     const VkImage swapchain_image0 = swapchain_images[0];
 
@@ -544,8 +513,8 @@ TEST_F(PositiveSyncValWsi, ResyncWithSwapchain2) {
     if (swapchain_images.size() != 2) {
         GTEST_SKIP() << "The test requires swapchain with 2 images";
     }
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
     const VkImage swapchain_image0 = swapchain_images[0];
 
@@ -632,9 +601,10 @@ TEST_F(PositiveSyncValWsi, ResyncWithSwapchain3) {
     if (swapchain_images.size() != 2) {
         GTEST_SKIP() << "The test requires swapchain with 2 images";
     }
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
+
     const VkImage swapchain_image0 = swapchain_images[0];
 
     vkt::Semaphore acquire_semaphore0(*m_device);
@@ -730,9 +700,10 @@ TEST_F(PositiveSyncValWsi, ResyncWithSwapchain4) {
     if (swapchain_images.size() != 3) {
         GTEST_SKIP() << "The test requires swapchain with 3 images";
     }
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
+
     const VkImage swapchain_image0 = swapchain_images[0];
 
     vkt::Semaphore acquire_semaphore0(*m_device);
@@ -937,6 +908,9 @@ TEST_F(PositiveSyncValWsi, BindSwapchainImage) {
     RETURN_IF_SKIP(InitSyncVal());
     RETURN_IF_SKIP(InitSwapchain());
 
+    vkt::CommandBuffer cb0(*m_device, m_command_pool);
+    vkt::CommandBuffer cb1(*m_device, m_command_pool);
+
     const uint32_t image_count = m_swapchain.GetImageCount();
     if (image_count < 2) {
         GTEST_SKIP() << "The test requires swapchain with at least 2 images";
@@ -972,8 +946,6 @@ TEST_F(PositiveSyncValWsi, BindSwapchainImage) {
         bind_info.image = images.back();
 
         vk::BindImageMemory2(device(), 1, &bind_info);
-
-        images.back().SetLayout(VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
     }
 
     vkt::Semaphore acquire_semaphore0(*m_device);
@@ -983,11 +955,17 @@ TEST_F(PositiveSyncValWsi, BindSwapchainImage) {
     vkt::Semaphore submit_semaphore1(*m_device);
 
     const uint32_t image_index0 = m_swapchain.AcquireNextImage(acquire_semaphore0, kWaitTimeout);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore0), vkt::Signal(submit_semaphore0));
+    cb0.Begin();
+    cb0.TransitionLayout(images[image_index0], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    cb0.End();
+    m_default_queue->Submit(cb0, vkt::Wait(acquire_semaphore0), vkt::Signal(submit_semaphore0));
     m_default_queue->Present(m_swapchain, image_index0, submit_semaphore0);
 
     const uint32_t image_index1 = m_swapchain.AcquireNextImage(acquire_semaphore1, kWaitTimeout);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore1), vkt::Signal(submit_semaphore1));
+    cb1.Begin();
+    cb1.TransitionLayout(images[image_index1], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    cb1.End();
+    m_default_queue->Submit(cb1, vkt::Wait(acquire_semaphore1), vkt::Signal(submit_semaphore1));
     m_default_queue->Present(m_swapchain, image_index1, submit_semaphore1);
 
     m_default_queue->Wait();
@@ -1082,10 +1060,11 @@ TEST_F(PositiveSyncValWsi, PresentAfterAcquire) {
     RETURN_IF_SKIP(InitSyncVal());
     RETURN_IF_SKIP(InitSwapchain());
 
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
+
+    // Test that present can directly wait for acquire semaphore
     vkt::Semaphore acquire_semaphore(*m_device);
     const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
     m_default_queue->Present(m_swapchain, image_index, acquire_semaphore);
@@ -1099,19 +1078,14 @@ TEST_F(PositiveSyncValWsi, ConcurrentPresentAndSubmit) {
     RETURN_IF_SKIP(InitSyncVal());
     RETURN_IF_SKIP(InitSwapchain());
 
-    if (!IsPlatformMockICD()) {
-        // There is nvidia driver bug that causes device lost when you present/submit on different queues frequently.
-        // It is time dependent, reproducible only in release builds.
-        GTEST_SKIP() << "This test only runs on MockICD (until nvidia driver bug is fixed)";
-    }
     if (!m_second_queue) {
         GTEST_SKIP() << "Test requires two queues";
     }
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
+    }
 
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
     const int N = 500;
 
     // QueueSubmit on the second queue and QueuePresent on the main queue run in parallel.

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -6834,3 +6834,42 @@ TEST_F(NegativeWsi, DestroySwapchainInUse2) {
 
     m_default_queue->Wait();
 }
+
+TEST_F(NegativeWsi, TransitionImageBeforeFirstAcquire) {
+    TEST_DESCRIPTION("Transition image before first acquire call");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[0], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+    m_errorMonitor->SetDesiredError("UNASSIGNED-non-acquired-swapchain-image-used");
+    m_default_queue->Submit(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeWsi, TransitionImageAfterPresent) {
+    TEST_DESCRIPTION("Transition image after present");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    vkt::Semaphore acquire_semaphore(*m_device);
+    uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+
+    vkt::Semaphore submit_semaphore(*m_device);
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(submit_semaphore));
+    m_default_queue->Present(m_swapchain, image_index, submit_semaphore);
+
+    m_errorMonitor->SetDesiredError("UNASSIGNED-non-acquired-swapchain-image-used");
+    m_default_queue->Submit(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
+}

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -3355,15 +3355,14 @@ TEST_F(NegativeWsi, QueuePresentBinarySemaphoreNotSignaled) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-
-    const auto images = m_swapchain.GetImages();
-    for (auto image : images) {
-        SetPresentImageLayout(image);
-    }
+    const auto swapchain_images = m_swapchain.GetImages();
 
     vkt::Semaphore semaphore(*m_device);
     const uint32_t image_index = m_swapchain.AcquireNextImage(semaphore, kWaitTimeout);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(semaphore));
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(semaphore));
 
     // the semaphore has already been waited on
     m_errorMonitor->SetDesiredError("VUID-vkQueuePresentKHR-pWaitSemaphores-03268");
@@ -3384,11 +3383,7 @@ TEST_F(NegativeWsi, QueuePresentDependsOnTimelineWait) {
     if (!m_second_queue) {
         GTEST_SKIP() << "Two queues are needed";
     }
-
-    const auto images = m_swapchain.GetImages();
-    for (auto image : images) {
-        SetPresentImageLayout(image);
-    }
+    const auto swapchain_images = m_swapchain.GetImages();
 
     vkt::Semaphore timeline_semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit(vkt::no_cmd, vkt::TimelineWait(timeline_semaphore, 1));
@@ -3397,7 +3392,10 @@ TEST_F(NegativeWsi, QueuePresentDependsOnTimelineWait) {
     const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
 
     vkt::Semaphore binary_semaphore(*m_device);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(binary_semaphore));
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(binary_semaphore));
 
     // the semaphore has already been waited on
     m_errorMonitor->SetDesiredError("VUID-vkQueuePresentKHR-pWaitSemaphores-03268");
@@ -3413,9 +3411,8 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireSemaphore) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     // Acquire image using a semaphore
@@ -3433,9 +3430,8 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireSemaphore_2) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     // Acquire image using a semaphore
@@ -3443,10 +3439,8 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireSemaphore_2) {
     const uint32_t image_index = m_swapchain.AcquireNextImage(semaphore, kWaitTimeout);
 
     // Dummy submit that signals semaphore that will be waited by the present. Does not wait on the acquire semaphore.
-    m_command_buffer.Begin();
-    m_command_buffer.End();
     const vkt::Semaphore submit_semaphore(*m_device);
-    m_default_queue->Submit(m_command_buffer, vkt::Signal(submit_semaphore));
+    m_default_queue->Submit(vkt::no_cmd, vkt::Signal(submit_semaphore));
 
     // Present waits on submit semaphore. Does not wait on the acquire semaphore.
     m_errorMonitor->SetDesiredError("UNASSIGNED-VkPresentInfoKHR-pImageIndices-MissingAcquireWait");
@@ -3461,9 +3455,8 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireFence) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     // Acquire image using a fence
@@ -3478,7 +3471,7 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireFence) {
     // NOTE: this test validates vkQueuePresentKHR.
     // At this point it's fine to wait for the fence to avoid in-use errors during test exit
     // (QueueWaitIdle does not wait for the fence signaled by the non-queue operation - AcquireNextImageKHR).
-    vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
 }
 
 TEST_F(NegativeWsi, MissingWaitForImageAcquireFenceAndSemaphore) {
@@ -3486,9 +3479,8 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireFenceAndSemaphore) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     // Acquire image using a semaphore and fence
@@ -3505,7 +3497,7 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireFenceAndSemaphore) {
     // NOTE: this test validates vkQueuePresentKHR.
     // At this point it's fine to wait for the fence to avoid in-use errors during test exit
     // (QueueWaitIdle does not wait for the fence signaled by the non-queue operation - AcquireNextImageKHR).
-    vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
 }
 
 TEST_F(NegativeWsi, SwapchainAcquireImageRetired) {
@@ -4837,16 +4829,17 @@ TEST_F(NegativeWsi, SignalPresentSemaphore) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
     vkt::Semaphore acquire_semaphore(*m_device);
     uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
 
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+
     vkt::Semaphore present_semaphore(*m_device);
     // Signal present semaphore
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
     // Wait on present semaphore
     m_default_queue->Present(m_swapchain, image_index, present_semaphore);
 
@@ -4868,15 +4861,16 @@ TEST_F(NegativeWsi, SignalPresentSemaphoreAfterQueueWait) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
     vkt::Semaphore acquire_semaphore(*m_device);
     uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
 
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+
     vkt::Semaphore present_semaphore(*m_device);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
     m_default_queue->Present(m_swapchain, image_index, present_semaphore);
 
     // Workaround with QueueWait is only allowed when maintenance1 is not used.

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -339,14 +339,16 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
     bind_info.memoryOffset = 0;
 
     vk::BindImageMemory2(device(), 1, &bind_info);
-    // Can transition layout after the memory is bound
-    peer_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     const auto swapchain_images = m_swapchain.GetImages();
 
     vkt::Fence fence(*m_device);
     const uint32_t image_index = m_swapchain.AcquireNextImage(fence, kWaitTimeout);
-    vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
+    if (image_index != 0) {
+        GTEST_SKIP() << "The test is written for swapchain image 0 but acquired another image";
+    }
+    fence.Wait(kWaitTimeout);
+    peer_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     m_command_buffer.Begin();
 
@@ -393,14 +395,12 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndWaitForFence) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
-
     const vkt::Fence fence(*m_device);
     const uint32_t image_index = m_swapchain.AcquireNextImage(fence, kWaitTimeout);
-    vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
     m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore);
     m_default_queue->Wait();
 }
@@ -410,9 +410,8 @@ TEST_F(PositiveWsi, WaitForAcquireFenceAndIgnoreSemaphore) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     // Ask image acquire operation to signal both a semaphore and a fence
@@ -433,9 +432,8 @@ TEST_F(PositiveWsi, WaitForAcquireSemaphoreAndIgnoreFence) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     // Ask image acquire operation to signal both a semaphore and a fence
@@ -460,9 +458,8 @@ TEST_F(PositiveWsi, WaitForAcquireFenceThenReset) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     const vkt::Fence fence(*m_device);
@@ -480,9 +477,8 @@ TEST_F(PositiveWsi, WaitForAcquireFenceThenResetAndReuse) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     const vkt::Fence fence(*m_device);
@@ -505,9 +501,8 @@ TEST_F(PositiveWsi, WaitForAcquireSemaphoreThenSignal) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     vkt::Semaphore semaphore(*m_device);
@@ -529,9 +524,6 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
     std::vector<vkt::CommandBuffer> command_buffers;
     std::vector<vkt::Semaphore> submit_semaphores;
@@ -553,11 +545,13 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence) {
         //
         // In summary: waiting on the acquire fence (with specific frame setup) means that one of the
         // previous submission has finished execution and it should be safe to re-use corresponding command buffer.
-        vk::WaitForFences(device(), 1, &acquire_fence.handle(), VK_TRUE, kWaitTimeout);
-        vk::ResetFences(device(), 1, &acquire_fence.handle());
+        acquire_fence.Wait(kWaitTimeout);
+        acquire_fence.Reset();
 
         // There should not be in-use errors when we re-use command buffer that corresponds to the acquired image index.
         command_buffers[image_index].Begin();
+        command_buffers[image_index].TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED,
+                                                      VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         command_buffers[image_index].End();
 
         m_default_queue->Submit(command_buffers[image_index], vkt::Signal(submit_semaphores[image_index]));
@@ -566,16 +560,13 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence) {
     m_default_queue->Wait();
 }
 
-TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence3) {
+TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence2) {
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8880
-    TEST_DESCRIPTION("Test that retiring submission using acquire fence works correctly when using differnt fences.");
+    TEST_DESCRIPTION("Test that retiring submission using acquire fence works correctly when using different fences.");
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
     std::vector<vkt::Fence> acquire_fences;
     vkt::Fence acquire_fence(*m_device);  // extra acquire fence
@@ -586,14 +577,14 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence3) {
         acquire_fences.emplace_back(*m_device);
         command_buffers.emplace_back(*m_device, m_command_pool);
         command_buffers[i].Begin();
+        command_buffers[i].TransitionLayout(swapchain_images[i], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         command_buffers[i].End();
         submit_semaphores.emplace_back(*m_device);
     }
 
     const int frame_count = 10;
     for (int i = 0; i < frame_count; i++) {
-        uint32_t image_index = 0;
-        vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, acquire_fence, &image_index);
+        const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_fence, kWaitTimeout);
         acquire_fence.Wait(kWaitTimeout);
         acquire_fence.Reset();
 
@@ -1364,16 +1355,6 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
     // is very machine dependent and in some configurations the failures can be
     // extremely rare. We also found configurations (slower laptop) where it was relatively
     // easy to reproduce (still could take some time, tens of seconds and up to few minutes).
-    //
-    // NOTE: there are known bugs in the current queue progress tracking, when
-    // a submission might retire too early (happens for multiple queues, but present
-    // operation might be an example for a single queue). Reworking queue tracking
-    // from threading approach to a single manager that collects submits and resolves
-    // them on request should fix the known issues, but also will bring deterministic
-    // behavior to the issues like the one being tested here. The idea that resolve
-    // operation, even if non trivial, still will be a localized piece of code comparing
-    // to conceptually simple model of queues that process submissions one at a time
-    // but with more complex synchronization and non-deterministic behavior.
     TEST_DESCRIPTION("Check that the wait on the present fence retires present queue operation");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddSurfaceExtension();
@@ -1382,10 +1363,8 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
     AddRequiredFeature(vkt::Feature::swapchainMaintenance1);
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     struct Frame {
@@ -1413,10 +1392,9 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
         }
         // Add new frame
         frames.emplace_back(Frame{vkt::Semaphore(*m_device), vkt::Semaphore(*m_device), vkt::Fence(*m_device), i});
-        const Frame& frame = frames.back();
+        Frame& frame = frames.back();
 
         const uint32_t image_index = m_swapchain.AcquireNextImage(frame.image_acquired, kWaitTimeout);
-
         m_default_queue->Submit(vkt::no_cmd, vkt::Wait(frame.image_acquired), vkt::Signal(frame.submit_finished));
 
         VkSwapchainPresentFenceInfoEXT present_fence_info = vku::InitStructHelper();
@@ -1775,12 +1753,13 @@ TEST_F(PositiveWsi, MultiSwapchainPresentWithOneBadSwapchain) {
 
     auto cleanup_resources = [&] { m_default_queue->Wait(); };
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
     const auto swapchain_images2 = swapchain2.GetImages();
-    for (auto image2 : swapchain_images2) {
-        SetPresentImageLayout(image2);
+
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
+    }
+    if (!swapchain2.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain2 images";
     }
 
     vkt::Semaphore acquire_semaphore(*m_device);
@@ -2308,9 +2287,8 @@ TEST_F(PositiveWsi, UseAcquireFenceToDeletePresentSemaphore) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
     // Frame 0
@@ -2355,21 +2333,16 @@ TEST_F(PositiveWsi, ExampleHowToReusePresentSemaphores) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
-    // Use single fence to wait for every frame (not very effective but it's fine for testing purposes)
+    // Use fence to wait for every frame (not efficient but that's not important for this example)
     vkt::Fence frame_fence(*m_device, VK_FENCE_CREATE_SIGNALED_BIT);
 
-    // The acquire semaphore should be indexed by the current frame buffering index (0 in this case, 0/1 for double buffering).
+    // The acquire semaphore should be indexed by the current frame index (0 in this case, 0/1 for double buffering).
     vkt::Semaphore acquire_semaphore(*m_device);
 
-    // Present semaphores (signaled by submit and waited on by present) are allocated per swapchain image.
-    // When a swapchain image is acquired, we know that the previous presentation of this image has finished,
-    // so the associated semaphore is no longer in use.
-    //
-    // IMPORTANT: Present semaphores array should be indexed by the acquired image index.
+    // Present semaphores (waited on by present) are allocated per swapchain image.
+    // When a swapchain image is acquired, we know that the previous presentation of
+    // this image has finished, so the associated semaphore is no longer in use.
     std::vector<vkt::Semaphore> present_semaphores;
     for (size_t i = 0; i < swapchain_images.size(); i++) {
         present_semaphores.emplace_back(*m_device);
@@ -2380,11 +2353,17 @@ TEST_F(PositiveWsi, ExampleHowToReusePresentSemaphores) {
         frame_fence.Reset();
 
         uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
-        m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphores[image_index]),
+
+        m_command_buffer.Begin();
+        m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED,
+                                          VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+        m_command_buffer.End();
+
+        // IMPORTANT: present_semaphores must be indexed by the acquired image index
+        m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphores[image_index]),
                                 frame_fence);
         m_default_queue->Present(m_swapchain, image_index, present_semaphores[image_index]);
     }
-
     m_default_queue->Wait();
 }
 
@@ -2397,9 +2376,6 @@ TEST_F(PositiveWsi, ExampleHowToReusePresentSemaphores2) {
     RETURN_IF_SKIP(InitSwapchain());
 
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
     vkt::CommandBuffer command_buffers[2] = {vkt::CommandBuffer{*m_device, m_command_pool},
                                              vkt::CommandBuffer(*m_device, m_command_pool)};
@@ -2423,10 +2399,11 @@ TEST_F(PositiveWsi, ExampleHowToReusePresentSemaphores2) {
         present_fence.Wait(kWaitTimeout);
         present_fence.Reset();
 
-        command_buffer.Begin();
-        command_buffer.End();
+        const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
 
-        uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+        command_buffer.Begin();
+        command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+        command_buffer.End();
         m_default_queue->Submit(command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
 
         VkSwapchainPresentFenceInfoEXT present_fence_info = vku::InitStructHelper();
@@ -2447,12 +2424,12 @@ TEST_F(PositiveWsi, SignalPresentSemaphoreAfterFenceWait) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
     vkt::Semaphore acquire_semaphore(*m_device);
     uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
 
     vkt::Fence present_fence(*m_device);
     VkSwapchainPresentFenceInfoEXT present_fence_info = vku::InitStructHelper();
@@ -2460,11 +2437,11 @@ TEST_F(PositiveWsi, SignalPresentSemaphoreAfterFenceWait) {
     present_fence_info.pFences = &present_fence.handle();
 
     vkt::Semaphore present_semaphore(*m_device);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
     m_default_queue->Present(m_swapchain, image_index, present_semaphore, &present_fence_info);
 
     // Test that after waiting on the present fence it's safe to signal present semaphore again
-    vk::WaitForFences(device(), 1, &present_fence.handle(), VK_TRUE, kWaitTimeout);
+    present_fence.Wait(kWaitTimeout);
     m_default_queue->Submit(vkt::no_cmd, vkt::Signal(present_semaphore));
 
     m_default_queue->Wait();
@@ -2476,15 +2453,15 @@ TEST_F(PositiveWsi, SignalPresentSemaphoreAfterQueueWait) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
 
     vkt::Semaphore acquire_semaphore(*m_device);
     uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
 
     vkt::Semaphore present_semaphore(*m_device);
-    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
     m_default_queue->Present(m_swapchain, image_index, present_semaphore);
 
     m_default_queue->Wait();
@@ -2515,9 +2492,7 @@ TEST_F(PositiveWsi, ProgressOnPresentOnlyQueue) {
         GTEST_SKIP() << "The second queue does not support present";
     }
     const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
-    }
+
 
     std::vector<vkt::Semaphore> present_wait_semaphores;
     for (size_t i = 0; i < swapchain_images.size(); i++) {
@@ -2545,6 +2520,7 @@ TEST_F(PositiveWsi, ProgressOnPresentOnlyQueue) {
         const vkt::Semaphore& present_wait_semaphore = present_wait_semaphores[image_index];
 
         command_buffer.Begin();
+        command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         command_buffer.End();
 
         m_default_queue->Submit(command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(present_wait_semaphore), frame_fence);
@@ -2695,9 +2671,8 @@ TEST_F(PositiveWsi, DestroySemaphoreUsedByOldSwapchain) {
 
     // Create swapchain and acquire the image (but do not present it yet)
     vkt::Swapchain swapchain(*m_device, swapchain_ci);
-    const auto swapchain_images = swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
     vkt::Semaphore semaphore(*m_device);
     uint32_t image_index = swapchain.AcquireNextImage(semaphore, kWaitTimeout);
@@ -2705,12 +2680,11 @@ TEST_F(PositiveWsi, DestroySemaphoreUsedByOldSwapchain) {
     // Create new_swapchain that specifies oldSwapchain
     swapchain_ci.oldSwapchain = swapchain;
     vkt::Swapchain new_swapchain(*m_device, swapchain_ci);
-    const auto new_swapchain_images = new_swapchain.GetImages();
-    if (new_swapchain_images.size() != 2) {
+    if (new_swapchain.GetImageCount() != 2) {
         GTEST_SKIP() << "The test requires swapchain with 2 images";
     }
-    for (auto image : new_swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!new_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition new swapchain images";
     }
 
     // Present already acquired image from the old swapchain.
@@ -2772,22 +2746,21 @@ TEST_F(PositiveWsi, DestroySemaphoreUsedByOldSwapchain2) {
     swapchain_ci.presentMode = VK_PRESENT_MODE_FIFO_KHR;
 
     vkt::Swapchain swapchain(*m_device, swapchain_ci);
-    const auto swapchain_images = swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
+
     vkt::Fence fence(*m_device);
     uint32_t image_index = swapchain.AcquireNextImage(fence, kWaitTimeout);
     fence.Wait(kWaitTimeout);
 
     swapchain_ci.oldSwapchain = swapchain;
     vkt::Swapchain new_swapchain(*m_device, swapchain_ci);
-    const auto new_swapchain_images = new_swapchain.GetImages();
-    if (new_swapchain_images.size() != 2) {
+    if (new_swapchain.GetImageCount() != 2) {
         GTEST_SKIP() << "The test requires swapchain with 2 images";
     }
-    for (auto image : new_swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!new_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition new swapchain images";
     }
 
     vkt::Semaphore semaphore(*m_device);
@@ -3262,12 +3235,11 @@ TEST_F(PositiveWsi, PresentIdWaitAndAcquireSemaphoreReuse) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
 
-    const auto swapchain_images = m_swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
-    std::vector<vkt::Semaphore> submit_done_semaphores(swapchain_images.size());
+    std::vector<vkt::Semaphore> submit_done_semaphores(m_swapchain.GetImageCount());
     for (size_t i = 0; i < submit_done_semaphores.size(); i++) {
         submit_done_semaphores[i] = vkt::Semaphore(*m_device);
     }
@@ -3323,12 +3295,11 @@ TEST_F(PositiveWsi, PresentIdWaitAndAcquireSemaphoreReuse2) {
     swapchain_ci.flags = VK_SWAPCHAIN_CREATE_PRESENT_ID_2_BIT_KHR | VK_SWAPCHAIN_CREATE_PRESENT_WAIT_2_BIT_KHR;
     vkt::Swapchain swapchain(*m_device, swapchain_ci);
 
-    const auto swapchain_images = swapchain.GetImages();
-    for (auto image : swapchain_images) {
-        SetPresentImageLayout(image);
+    if (!swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
-    std::vector<vkt::Semaphore> submit_done_semaphores(swapchain_images.size());
+    std::vector<vkt::Semaphore> submit_done_semaphores(swapchain.GetImageCount());
     for (size_t i = 0; i < submit_done_semaphores.size(); i++) {
         submit_done_semaphores[i] = vkt::Semaphore(*m_device);
     }


### PR DESCRIPTION
Addresses part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/365 and fixes VVL tests that do this incorrectly.

This only catches layout transition operations outside of `[acquire, present]` region. We still need another validation when transition happens inside that region but does not wait for acquire semaphore/fence.

For this part we already had all the necessary functionality from the past PRs (image acquire status tracking, submit time validation of layout transition), so most of the work here is to fix existing tests and provide new swapchain helpers.