### PR TITLE
layers: Misc cleanup DescriptorHeap things

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -3240,7 +3240,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
         // If not flag, this is just a "normal" vulkan 1.0 situtation
         if (stage_state.descriptor_heap_mode) {
             for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
-                if (resource_variable.decorations.IsDescriptorSet()) {
+                if (!resource_variable.IsHeap()) {
                     skip |= LogError(
                         vvl::GetSpirvInterfaceVariableVUID(loc, vvl::SpirvInterfaceVariableError::DescriptorHeapMapping_11312),
                         module_state.handle(), loc,
@@ -3271,18 +3271,14 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
     std::unordered_set<const spirv::ResourceInterfaceVariable*> unmapped_variables;
 
     for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
-        if (!resource_variable.decorations.IsDescriptorSet()) {
+        if (resource_variable.IsHeap()) {
             continue;
         }
-        const uint32_t descriptor_set = resource_variable.decorations.set;
-        const uint32_t descriptor_binding = resource_variable.decorations.binding;
 
         bool found_mapping = false;
         for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
             const auto& mapping = mapping_info->pMappings[i];
-            if (mapping.descriptorSet != descriptor_set || descriptor_binding < mapping.firstBinding ||
-                descriptor_binding >= mapping.firstBinding + uint64_t(mapping.bindingCount) ||
-                !ResourceTypeMatchesBinding(mapping.resourceMask, resource_variable)) {
+            if (!IsResourceVaribleInMapping(mapping, resource_variable)) {
                 continue;
             }
             used_mapping_set[i] = true;

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -504,13 +504,10 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             }
 
             const uint32_t var_set = resource_variable.decorations.set;
-            const uint32_t var_binding = resource_variable.decorations.binding;
 
             for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
                 const VkDescriptorSetAndBindingMappingEXT& mapping = mapping_info->pMappings[i];
-                if (mapping.descriptorSet != var_set || var_binding < mapping.firstBinding ||
-                    var_binding >= mapping.firstBinding + uint64_t(mapping.bindingCount) ||
-                    !ResourceTypeMatchesBinding(mapping.resourceMask, resource_variable)) {
+                if (!IsResourceVaribleInMapping(mapping, resource_variable)) {
                     continue;
                 }
                 mapping_info_map[var_set].emplace_back(MappingInfo{&mapping, &resource_variable, i});

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2575,7 +2575,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
         }
     }
 
-    if (!decorations.IsDescriptorSet()) {
+    if (IsHeap()) {
         // Should only be possible with VK_EXT_descriptor_heap + Untyped Pointers
         assert(module_state.static_data_.has_descriptor_heap);
         // TODO - This works for GLSL, make sure this catches all uses

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -115,7 +115,6 @@ struct DecorationSet : public DecorationBase {
     bool HasAnyBuiltIn() const;
     bool HasInMember(FlagBit flag_bit) const;
     bool AllMemberHave(FlagBit flag_bit) const;
-    bool IsDescriptorSet() const { return set != kInvalidValue && binding != kInvalidValue; }
 };
 
 // Tracking of OpExecutionMode / OpExecutionModeId values

--- a/layers/state_tracker/shader_stage_state.cpp
+++ b/layers/state_tracker/shader_stage_state.cpp
@@ -89,12 +89,10 @@ bool ShaderStageState::ResourceHeapIsUsed() {
     }
 
     for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint->resource_interface_variables) {
-        if (resource_variable.decorations.IsDescriptorSet() && !resource_variable.is_sampler && mapping_info) {
+        if (!resource_variable.IsHeap() && !resource_variable.is_sampler && mapping_info) {
             for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
                 const auto& mapping = mapping_info->pMappings[i];
-                if (mapping.descriptorSet == resource_variable.decorations.set &&
-                    mapping.firstBinding <= resource_variable.decorations.binding &&
-                    ResourceTypeMatchesBinding(mapping.resourceMask, resource_variable) &&
+                if (IsResourceVaribleInMapping(mapping, resource_variable) &&
                     IsValueIn(mapping.source, {VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT,
                                                VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT,
                                                VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,
@@ -121,12 +119,10 @@ bool ShaderStageState::SamplerHeapIsUsed() {
     }
 
     for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint->resource_interface_variables) {
-        if (resource_variable.is_sampler && mapping_info) {
+        if (!resource_variable.IsHeap() && resource_variable.is_sampler && mapping_info) {
             for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
                 const auto& mapping = mapping_info->pMappings[i];
-                if (mapping.descriptorSet == resource_variable.decorations.set &&
-                    mapping.firstBinding <= resource_variable.decorations.binding &&
-                    ResourceTypeMatchesBinding(mapping.resourceMask, resource_variable) &&
+                if (IsResourceVaribleInMapping(mapping, resource_variable) &&
                     IsValueIn(mapping.source, {VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT,
                                                VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT,
                                                VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -161,6 +161,15 @@ void DumpSpirvToFile(const std::string& file_path, const uint32_t* spirv, size_t
     debug_file.write(reinterpret_cast<const char*>(spirv), spirv_dwords_count * sizeof(uint32_t));
 }
 
+bool IsResourceVaribleInMapping(const VkDescriptorSetAndBindingMappingEXT& mapping,
+                                const spirv::ResourceInterfaceVariable& resource_variable) {
+    const uint32_t descriptor_set = resource_variable.decorations.set;
+    const uint32_t descriptor_binding = resource_variable.decorations.binding;
+    const uint32_t last_binding = mapping.firstBinding + mapping.bindingCount;
+    return (mapping.descriptorSet == descriptor_set && descriptor_binding >= mapping.firstBinding &&
+            descriptor_binding < last_binding && ResourceTypeMatchesBinding(mapping.resourceMask, resource_variable));
+}
+
 bool ResourceTypeMatchesBinding(VkSpirvResourceTypeFlagsEXT resource_type,
                                 const spirv::ResourceInterfaceVariable& resource_variable) {
     if (resource_type == VK_SPIRV_RESOURCE_TYPE_ALL_EXT) {

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -112,6 +112,8 @@ class ValidationCache {
 
 void DumpSpirvToFile(const std::string &file_name, const uint32_t *spirv, size_t spirv_dwords_count);
 
+bool IsResourceVaribleInMapping(const VkDescriptorSetAndBindingMappingEXT& mapping,
+                                const spirv::ResourceInterfaceVariable& resource_variable);
 bool ResourceTypeMatchesBinding(VkSpirvResourceTypeFlagsEXT resource_type,
                                 const spirv::ResourceInterfaceVariable& resource_variable);
 std::string DescribeResourceTypeMismatch(VkSpirvResourceTypeFlagsEXT resource_type,


### PR DESCRIPTION
- Remove `IsDescriptorSet()` to just use `IsHeap()`
- Create a single `IsResourceVaribleInMapping` function (some spots had slightly different ways)