### PR TITLE
layers: Move submit time validation to pre-submit

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -290,11 +290,6 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
                                  chained_device_group_struct->commandBufferCount, submit.commandBufferCount);
             }
         }
-        // Run submit time validation only if skip is not set. This is mostly for vvl testing,
-        // some tests expect that submit state is not updated if regular validation fails
-        if (!skip) {
-            skip |= submit_time_tracker.ProcessSubmitInfo(submit, queue, submit_loc);
-        }
     }
 
     return skip;
@@ -453,11 +448,6 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
         if (suspended_render_pass_instance) {
             skip |= LogError("VUID-VkSubmitInfo2-commandBuffer-06010", queue, submit_loc,
                              "has a suspended render pass instance that was not resumed.");
-        }
-        // Run submit time validation only if skip is not set. This is mostly for vvl testing,
-        // some tests expect that submit state is not updated if regular validation fails
-        if (!skip) {
-            skip |= submit_time_tracker.ProcessSubmitInfo(submit, queue, submit_loc);
         }
     }
 

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -41,7 +41,7 @@ void CoreChecks::Created(vvl::CommandBuffer& cb) {
 }
 
 void CoreChecks::Created(vvl::Queue& queue) {
-    queue.SetSubState(container_type, std::make_unique<core::QueueSubState>(queue));
+    queue.SetSubState(container_type, std::make_unique<core::QueueSubState>(queue, submit_time_tracker));
 }
 
 namespace core {
@@ -1221,6 +1221,7 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
             CommandBufferSubState& cb_substate = SubState(*cb.cb);
             cb_substate.SubmitTimeValidate();
         }
+        submit_time_tracker->ProcessQueueSubmission(VkHandle(), submission);
     }
 }
 

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -244,12 +244,15 @@ static inline const CommandBufferSubState &SubState(const vvl::CommandBuffer &cb
 
 class QueueSubState : public vvl::QueueSubState {
   public:
-    QueueSubState(vvl::Queue& q) : vvl::QueueSubState(q) {}
+    QueueSubState(vvl::Queue& q, vvl::SubmitTimeTracker& submit_time_tracker)
+        : vvl::QueueSubState(q), submit_time_tracker(&submit_time_tracker) {}
 
-    void PreSubmit(std::vector<vvl::QueueSubmission> &submissions) override;
+    void PreSubmit(std::vector<vvl::QueueSubmission>& submissions) override;
 
     // Override Retire to validate submissions in the order defined by synchronization
     void Retire(vvl::QueueSubmission&) override;
+
+    vvl::SubmitTimeTracker* submit_time_tracker = nullptr;
 };
 
 }  // namespace core

--- a/layers/state_tracker/submit_time_tracker.cpp
+++ b/layers/state_tracker/submit_time_tracker.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "state_tracker/submit_time_tracker.h"
+#include "state_tracker/queue_state.h"
 #include "state_tracker/semaphore_state.h"
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/wsi_state.h"
@@ -34,27 +35,32 @@ void SubmitTimeTracker::OnDestroyTimelineSemaphore(VkSemaphore timeline) {
     timeline_signals_.erase(timeline);
 }
 
-bool SubmitTimeTracker::ProcessSubmitInfo(const VkSubmitInfo& submit_info, VkQueue queue, const Location& submit_loc) const {
-    SubmitInfoConverter converter(submit_info);
-    return ProcessSubmitInfo(converter.submit_info2, queue, submit_loc);
-}
-
-bool SubmitTimeTracker::ProcessSubmitInfo(const VkSubmitInfo2& submit_info, VkQueue queue, const Location& submit_loc) const {
-    const auto wait_semaphores =
-        vvl::span<const VkSemaphoreSubmitInfo>(submit_info.pWaitSemaphoreInfos, submit_info.waitSemaphoreInfoCount);
-    const auto signal_semaphores =
-        vvl::span<const VkSemaphoreSubmitInfo>(submit_info.pSignalSemaphoreInfos, submit_info.signalSemaphoreInfoCount);
-
+bool SubmitTimeTracker::ProcessQueueSubmission(VkQueue queue, const QueueSubmission& submission) const {
     std::vector<std::shared_ptr<CommandBuffer>> command_buffers;
-    command_buffers.reserve(submit_info.commandBufferInfoCount);
-    for (const auto& cb_info : vvl::make_span(submit_info.pCommandBufferInfos, submit_info.commandBufferInfoCount)) {
-        // If Get returns null, store it to preserve original indexing
-        command_buffers.emplace_back(validator_.Get<CommandBuffer>(cb_info.commandBuffer));
+    command_buffers.reserve(submission.cb_submissions.size());
+    for (const auto& cb_info : submission.cb_submissions) {
+        command_buffers.emplace_back(cb_info.cb);
+    }
+
+    std::vector<VkSemaphoreSubmitInfo> wait_semaphores;
+    wait_semaphores.reserve(submission.wait_semaphores.size());
+    for (const SemaphoreInfo& wait : submission.wait_semaphores) {
+        VkSemaphoreSubmitInfo& semaphore_info = wait_semaphores.emplace_back();
+        semaphore_info.semaphore = wait.semaphore->VkHandle();
+        semaphore_info.value = wait.payload;
+    }
+
+    std::vector<VkSemaphoreSubmitInfo> signal_semaphores;
+    signal_semaphores.reserve(submission.signal_semaphores.size());
+    for (const SemaphoreInfo& signal : submission.signal_semaphores) {
+        VkSemaphoreSubmitInfo& semaphore_info = signal_semaphores.emplace_back();
+        semaphore_info.semaphore = signal.semaphore->VkHandle();
+        semaphore_info.value = signal.payload;
     }
 
     std::lock_guard lock(mutex_);
     SubmitTimeTracker& this_tracker = *const_cast<SubmitTimeTracker*>(this);
-    return this_tracker.ProcessBatch(std::move(command_buffers), wait_semaphores, signal_semaphores, queue, submit_loc);
+    return this_tracker.ProcessBatch(std::move(command_buffers), wait_semaphores, signal_semaphores, queue, submission.loc.Get());
 }
 
 bool SubmitTimeTracker::ProcessSignalSemaphore(const VkSemaphoreSignalInfo& signal_info) const {

--- a/layers/state_tracker/submit_time_tracker.h
+++ b/layers/state_tracker/submit_time_tracker.h
@@ -29,6 +29,7 @@ namespace vvl {
 
 class DeviceProxy;
 class CommandBuffer;
+struct QueueSubmission;
 
 // Batch blocked by a wait-before-signal dependency
 struct UnresolvedBatch {
@@ -59,8 +60,7 @@ class SubmitTimeTracker {
     void OnCreateTimelineSemaphore(VkSemaphore timeline, uint64_t initial_value);
     void OnDestroyTimelineSemaphore(VkSemaphore timeline);
 
-    bool ProcessSubmitInfo(const VkSubmitInfo& submit_info, VkQueue queue, const Location& submit_loc) const;
-    bool ProcessSubmitInfo(const VkSubmitInfo2& submit_info, VkQueue queue, const Location& submit_loc) const;
+    bool ProcessQueueSubmission(VkQueue queue, const QueueSubmission& submission) const;
     bool ProcessSignalSemaphore(const VkSemaphoreSignalInfo& signal_info) const;
     bool ProcessPresent(const VkPresentInfoKHR& present_info, const Location& present_info_loc) const;
 

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -1029,8 +1029,6 @@ TEST_F(NegativeImageLayout, TimelineSemaphoreOrdering) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09600");
     m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineSignal(semaphore, 1));
     m_errorMonitor->VerifyFound();
-
-    semaphore.Signal(1);
     m_device->Wait();
 }
 


### PR DESCRIPTION
Allow submit time validation to access semaphore's image acquire state initialized by `Queue::PreSubmit`.

This will allow to address the second part of of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/365.

The trade-off we don't report submit time validation error in `skip` but so far it affected only a single test (fixed here).