### PR TITLE
layers: Validiate layout transition of swapchain images. Part 2

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -313,13 +313,38 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location& loc, const vvl::Comm
             const bool has_layout_transition = cb_layout_state.current_layout != kInvalidLayout;
             if (has_layout_transition) {
                 if (image_state->IsSwapchainImage()) {
-                    if (!image_state->bind_swapchain->images[image_state->swapchain_image_index].acquired) {
+                    const auto& swapchain_image = image_state->bind_swapchain->images[image_state->swapchain_image_index];
+                    const bool has_wait = swapchain_image.acquire_semaphore_status == vvl::AcquireSyncStatus::WasWaitedOn ||
+                                          swapchain_image.acquire_fence_status == vvl::AcquireSyncStatus::WasWaitedOn;
+                    const bool semaphore_signal = swapchain_image.acquire_semaphore_status == vvl::AcquireSyncStatus::Signaled;
+                    const bool fence_signal = swapchain_image.acquire_fence_status == vvl::AcquireSyncStatus::Signaled;
+
+                    if (!swapchain_image.acquired) {
                         const LogObjectList objlist(cb_state.Handle(), image_state->Handle());
                         // VUID request: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4784
                         skip |= LogError("UNASSIGNED-non-acquired-swapchain-image-used", objlist, loc,
                                          "performs a layout transition on presentable %s, but the image has not been acquired from "
-                                         "%s (either never or since the last present operation)",
+                                         "%s (either never or since the last present operation).",
                                          FormatHandle(*image_state).c_str(), FormatHandle(*image_state->bind_swapchain).c_str());
+                    } else if (!has_wait && (semaphore_signal || fence_signal)) {
+                        std::ostringstream oss;
+                        const char* was_were = "was";
+                        if (semaphore_signal) {
+                            oss << FormatHandle(*swapchain_image.acquire_semaphore);
+                        }
+                        if (fence_signal) {
+                            if (semaphore_signal) {
+                                oss << " and ";
+                                was_were = "were";
+                            }
+                            oss << FormatHandle(*swapchain_image.acquire_fence);
+                        }
+                        const LogObjectList objlist(cb_state.Handle(), image_state->Handle());
+                        // VUID request: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4784
+                        skip |= LogError("UNASSIGNED-non-acquired-swapchain-image-used", objlist, loc,
+                                         "performs a layout transition on presentable %s, but %s signaled by image acquire "
+                                         "operation %s not waited on.",
+                                         FormatHandle(*image_state).c_str(), oss.str().c_str(), was_were);
                     }
                 }
             }

--- a/tests/unit/image_layout_positive.cpp
+++ b/tests/unit/image_layout_positive.cpp
@@ -148,8 +148,9 @@ TEST_F(PositiveImageLayout, ImagelessTracking) {
 
     const std::vector<VkImage> swapchain_images = m_swapchain.GetImages();
 
-    vkt::Semaphore image_acquired(*m_device);
+    vkt::Fence image_acquired(*m_device);
     const uint32_t current_buffer = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
 
     vkt::ImageView imageView = image.CreateView();
     VkFramebufferAttachmentImageInfo framebufferAttachmentImageInfo = {VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENT_IMAGE_INFO_KHR,
@@ -189,7 +190,7 @@ TEST_F(PositiveImageLayout, ImagelessTracking) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    m_default_queue->Present(m_swapchain, current_buffer, image_acquired);
+    m_default_queue->Present(m_swapchain, current_buffer, vkt::no_semaphore);
     m_default_queue->Wait();
 }
 

--- a/tests/unit/sync_val_wsi.cpp
+++ b/tests/unit/sync_val_wsi.cpp
@@ -40,7 +40,7 @@ struct NegativeSyncValWsi : public VkSyncValTest {};
         }                                                               \
     }
 
-TEST_F(NegativeSyncValWsi, PresentAcquire) {
+TEST_F(NegativeSyncValWsi, DISABLED_PresentAcquire) {
     TEST_DESCRIPTION("Try destroying a swapchain presentable image with vkDestroyImage");
 
     AddSurfaceExtension();
@@ -105,6 +105,7 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     // Look for errors between the acquire and first use...
     // No sync operations...
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-PRESENT");
+    fence.Wait(kWaitTimeout);
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
 
@@ -200,7 +201,7 @@ TEST_F(NegativeSyncValWsi, SubmitDoesNotWaitForAcquire) {
     // TODO: current implementation does not report that the image is still being read by the acquire
     // and at the same time it is being transitioned (there is no wait on the acquire semaphore).
     // Fix this and ensure the following submit triggers validation error.
-    m_default_queue->Submit2(m_command_buffer);
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(acquire_semaphore));
     m_device->Wait();
 }
 

--- a/tests/unit/sync_val_wsi.cpp
+++ b/tests/unit/sync_val_wsi.cpp
@@ -172,39 +172,6 @@ TEST_F(NegativeSyncValWsi, DISABLED_PresentAcquire) {
     m_device->Wait();
 }
 
-// TODO: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5240
-TEST_F(NegativeSyncValWsi, SubmitDoesNotWaitForAcquire) {
-    TEST_DESCRIPTION("Submit does not wait for the swapchain acquire semaphore");
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddSurfaceExtension();
-    AddRequiredFeature(vkt::Feature::synchronization2);
-    RETURN_IF_SKIP(InitSyncVal());
-    RETURN_IF_SKIP(InitSwapchain());
-    const vkt::Semaphore acquire_semaphore(*m_device);
-    const auto swapchain_images = m_swapchain.GetImages();
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
-
-    VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
-    layout_transition.srcStageMask = VK_PIPELINE_STAGE_2_NONE;
-    layout_transition.srcAccessMask = 0;
-    layout_transition.dstStageMask = VK_PIPELINE_STAGE_2_NONE;
-    layout_transition.dstAccessMask = 0;
-    layout_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    layout_transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    layout_transition.image = swapchain_images[image_index];
-    layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-
-    m_command_buffer.Begin();
-    m_command_buffer.Barrier(layout_transition);
-    m_command_buffer.End();
-
-    // TODO: current implementation does not report that the image is still being read by the acquire
-    // and at the same time it is being transitioned (there is no wait on the acquire semaphore).
-    // Fix this and ensure the following submit triggers validation error.
-    m_default_queue->Submit2(m_command_buffer, vkt::Wait(acquire_semaphore));
-    m_device->Wait();
-}
-
 TEST_F(NegativeSyncValWsi, PresentDoesNotWaitForSubmit2) {
     TEST_DESCRIPTION("Present does not specify semaphore to wait for submit.");
     SetTargetApiVersion(VK_API_VERSION_1_3);

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -6874,3 +6874,57 @@ TEST_F(NegativeWsi, TransitionImageAfterPresent) {
 
     m_default_queue->Wait();
 }
+
+TEST_F(NegativeWsi, TransitionImageMissingAcquireSemaphoreWait) {
+    TEST_DESCRIPTION("Transition image without waiting on acquire semaphore");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    vkt::Semaphore acquire_semaphore(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+    m_errorMonitor->SetDesiredError("UNASSIGNED-non-acquired-swapchain-image-used");
+    m_default_queue->Submit(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeWsi, TransitionImageMissingAcquireFenceWait) {
+    TEST_DESCRIPTION("Transition image without waiting on acquire fence");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    vkt::Fence fence(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(fence, kWaitTimeout);
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+    m_errorMonitor->SetDesiredError("UNASSIGNED-non-acquired-swapchain-image-used");
+    m_default_queue->Submit(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeWsi, TransitionImageMissingAcquireSemaphoreOrFenceWait) {
+    TEST_DESCRIPTION("Transition image without waiting on acquire semaphore and fence");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    vkt::Semaphore semaphore(*m_device);
+    vkt::Fence fence(*m_device);
+
+    uint32_t image_index = 0;
+    vk::AcquireNextImageKHR(*m_device, m_swapchain, kWaitTimeout, semaphore, fence, &image_index);
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+    m_command_buffer.End();
+    m_errorMonitor->SetDesiredError("UNASSIGNED-non-acquired-swapchain-image-used");
+    m_default_queue->Submit(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -3992,27 +3992,24 @@ TEST_F(NegativeWsi, PresentInfoSwapchainsDifferentPresentModes) {
     swapchain_ci.pNext = &present_modes_ci;
     vkt::Swapchain swapchain2(*m_device, swapchain_ci);
 
-    vkt::Semaphore image_acquired1(*m_device);
-    vkt::Semaphore image_acquired2(*m_device);
+    vkt::Fence image_acquired1(*m_device);
+    vkt::Fence image_acquired2(*m_device);
     const uint32_t image_index1 = swapchain1.AcquireNextImage(image_acquired1, kWaitTimeout);
     const uint32_t image_index2 = swapchain2.AcquireNextImage(image_acquired2, kWaitTimeout);
+    image_acquired1.Wait(kWaitTimeout);
+    image_acquired2.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain1.GetImages()[image_index1]);
     SetPresentImageLayout(swapchain2.GetImages()[image_index2]);
 
-    VkSemaphore acquire_semaphores[] = {image_acquired1, image_acquired2};
     VkSwapchainKHR swapchains[] = {swapchain1, swapchain2};
     uint32_t image_indices[] = {image_index1, image_index2};
-
     VkPresentInfoKHR present = vku::InitStructHelper();
-    present.waitSemaphoreCount = 2u;
-    present.pWaitSemaphores = acquire_semaphores;
     present.pSwapchains = swapchains;
     present.pImageIndices = image_indices;
     present.swapchainCount = 2;
     m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pSwapchains-09199");
     vk::QueuePresentKHR(m_default_queue->handle(), &present);
     m_errorMonitor->VerifyFound();
-    m_device->Wait();
 }
 
 TEST_F(NegativeWsi, ReleaseSwapchainImagesWithoutFeature) {
@@ -4533,8 +4530,9 @@ TEST_F(NegativeWsi, PresentSignaledFence) {
     RETURN_IF_SKIP(InitSwapchain());
 
     const auto swapchain_images = m_swapchain.GetImages();
-    const vkt::Semaphore acquire_semaphore(*m_device);
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const vkt::Fence image_acquired(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
     vkt::Fence present_fence(*m_device, VK_FENCE_CREATE_SIGNALED_BIT);
@@ -4543,7 +4541,7 @@ TEST_F(NegativeWsi, PresentSignaledFence) {
     present_fence_info.pFences = &present_fence.handle();
 
     m_errorMonitor->SetDesiredError("VUID-VkSwapchainPresentFenceInfoKHR-pFences-07758");
-    m_default_queue->Present(m_swapchain, image_index, acquire_semaphore, &present_fence_info);
+    m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore, &present_fence_info);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 }
@@ -4558,8 +4556,9 @@ TEST_F(NegativeWsi, PresentFenceInUse) {
     RETURN_IF_SKIP(InitSwapchain());
 
     const auto swapchain_images = m_swapchain.GetImages();
-    const vkt::Semaphore acquire_semaphore(*m_device);
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const vkt::Fence image_acquired(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
     vkt::Fence present_fence(*m_device);
@@ -4570,7 +4569,7 @@ TEST_F(NegativeWsi, PresentFenceInUse) {
     m_default_queue->Submit(vkt::no_cmd, present_fence);
 
     m_errorMonitor->SetDesiredError("VUID-VkSwapchainPresentFenceInfoKHR-pFences-07759");
-    m_default_queue->Present(m_swapchain, image_index, acquire_semaphore, &present_fence_info);
+    m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore, &present_fence_info);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 }
@@ -4608,9 +4607,10 @@ TEST_F(NegativeWsi, PresentMismatchedSwapchainCount) {
 
     vkt::Swapchain swapchain(*m_device, swapchain_ci);
 
-    const vkt::Semaphore acquire_semaphore(*m_device);
+    const vkt::Fence image_acquired(*m_device);
     const auto swapchain_images = swapchain.GetImages();
-    const uint32_t image_index = swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const uint32_t image_index = swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
     VkPresentModeKHR present_modes[2] = {present_mode, present_mode};
@@ -4620,9 +4620,8 @@ TEST_F(NegativeWsi, PresentMismatchedSwapchainCount) {
     present_mode_info.pPresentModes = present_modes;
 
     m_errorMonitor->SetDesiredError("VUID-VkSwapchainPresentModeInfoKHR-swapchainCount-07760");
-    m_default_queue->Present(swapchain, image_index, acquire_semaphore, &present_mode_info);
+    m_default_queue->Present(swapchain, image_index, vkt::no_semaphore, &present_mode_info);
     m_errorMonitor->VerifyFound();
-    m_default_queue->Wait();
 }
 
 TEST_F(NegativeWsi, InvalidRectLayer) {
@@ -4651,10 +4650,11 @@ TEST_F(NegativeWsi, InvalidRectLayer) {
 
     vkt::Swapchain swapchain(*m_device, swapchain_ci);
 
-    const vkt::Semaphore acquire_semaphore(*m_device);
+    const vkt::Fence image_acquired(*m_device);
 
     const auto swapchain_images = swapchain.GetImages();
-    const uint32_t image_index = swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const uint32_t image_index = swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
     VkRectLayerKHR rectangle;
@@ -4672,14 +4672,14 @@ TEST_F(NegativeWsi, InvalidRectLayer) {
     present_regions.pRegions = &present_region;
 
     m_errorMonitor->SetDesiredError("VUID-VkRectLayerKHR-layer-01262");
-    m_default_queue->Present(swapchain, image_index, acquire_semaphore, &present_regions);
+    m_default_queue->Present(swapchain, image_index, vkt::no_semaphore, &present_regions);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 
     rectangle.layer = 0u;
     rectangle.offset.x = 1;
     m_errorMonitor->SetDesiredError("VUID-VkRectLayerKHR-offset-04864");
-    m_default_queue->Present(swapchain, image_index, acquire_semaphore, &present_regions);
+    m_default_queue->Present(swapchain, image_index, vkt::no_semaphore, &present_regions);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 }
@@ -4706,9 +4706,10 @@ TEST_F(NegativeWsi, PresentWithUnsupportedQueue) {
         GTEST_SKIP() << "Surface is supported";
     }
 
-    const vkt::Semaphore acquire_semaphore(*m_device);
+    const vkt::Fence image_acquired(*m_device);
     const auto swapchain_images = m_swapchain.GetImages();
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
     vkt::Fence present_fence(*m_device);
@@ -4717,7 +4718,7 @@ TEST_F(NegativeWsi, PresentWithUnsupportedQueue) {
     present_fence_info.pFences = &present_fence.handle();
 
     m_errorMonitor->SetDesiredError("VUID-vkQueuePresentKHR-pSwapchains-01292");
-    m_device->TransferOnlyQueue()->Present(m_swapchain, image_index, acquire_semaphore, &present_fence_info);
+    m_device->TransferOnlyQueue()->Present(m_swapchain, image_index, vkt::no_semaphore, &present_fence_info);
     m_errorMonitor->VerifyFound();
     m_device->TransferOnlyQueue()->Wait();
 }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -381,12 +381,13 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
 
-    const vkt::Semaphore acquire_semaphore(*m_device);
+    const vkt::Fence image_acquired(*m_device);
     const auto swapchain_images = m_swapchain.GetImages();
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
-    m_default_queue->Present(m_swapchain, image_index, acquire_semaphore);
+    m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore);
     m_default_queue->Wait();
 }
 
@@ -1309,8 +1310,7 @@ TEST_F(PositiveWsi, PresentFenceWaitsForSubmission) {
 
         vkt::Fence submit_fence(*m_device);
         m_default_queue->Submit(m_command_buffer, submit_fence);
-
-        vk::WaitForFences(device(), 1, &submit_fence.handle(), VK_TRUE, kWaitTimeout);
+        submit_fence.Wait(kWaitTimeout);
 
         // It's safe to reset command buffer because we waited on the fence
         m_command_buffer.Reset();
@@ -1323,9 +1323,10 @@ TEST_F(PositiveWsi, PresentFenceWaitsForSubmission) {
 
         const auto swapchain_images = m_swapchain.GetImages();
         const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
-        SetPresentImageLayout(swapchain_images[image_index]);
 
         m_command_buffer.Begin();
+        m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED,
+                                          VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(submit_semaphore));
@@ -1417,10 +1418,11 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitSwapchain());
 
-    const vkt::Semaphore acquire_semaphore(*m_device);
+    const vkt::Fence image_acquired(*m_device);
 
     const auto swapchain_images = m_swapchain.GetImages();
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
     vkt::Fence present_fence(*m_device);
@@ -1428,7 +1430,7 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence) {
     present_fence_info.swapchainCount = 1;
     present_fence_info.pFences = &present_fence.handle();
 
-    m_default_queue->Present(m_swapchain, image_index, acquire_semaphore, &present_fence_info);
+    m_default_queue->Present(m_swapchain, image_index, vkt::no_semaphore, &present_fence_info);
 
     // QueueWaitIdle (and also DeviceWaitIdle) can wait for present fences.
     m_default_queue->Wait();
@@ -1452,15 +1454,16 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence2) {
     vkt::Swapchain swapchain2 =
         CreateSwapchain(surface2.Handle(), VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
 
-    const vkt::Semaphore acquire_semaphore(*m_device);
+    const vkt::Fence image_acquired(*m_device);
     const auto swapchain_images = m_swapchain.GetImages();
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
-
-    const vkt::Semaphore acquire_semaphore2(*m_device);
-    const auto swapchain_images2 = swapchain2.GetImages();
-    const uint32_t image_index2 = swapchain2.AcquireNextImage(acquire_semaphore2, kWaitTimeout);
-
+    const uint32_t image_index = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
+
+    const vkt::Fence image_acquired2(*m_device);
+    const auto swapchain_images2 = swapchain2.GetImages();
+    const uint32_t image_index2 = swapchain2.AcquireNextImage(image_acquired2, kWaitTimeout);
+    image_acquired2.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images2[image_index2]);
 
     vkt::Fence present_fence(*m_device);
@@ -1470,12 +1473,9 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence2) {
     present_fence_info.swapchainCount = 2;
     present_fence_info.pFences = present_fences;
 
-    const VkSemaphore wait_semaphores[2] = {acquire_semaphore, acquire_semaphore2};
     const VkSwapchainKHR swapchains[2] = {m_swapchain, swapchain2};
     const uint32_t image_indices[2]{image_index, image_index2};
     VkPresentInfoKHR present = vku::InitStructHelper(&present_fence_info);
-    present.waitSemaphoreCount = 2;
-    present.pWaitSemaphores = wait_semaphores;
     present.swapchainCount = 2;
     present.pSwapchains = swapchains;
     present.pImageIndices = image_indices;
@@ -1503,29 +1503,22 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentSemaphores) {
     vkt::Swapchain swapchain2 =
         CreateSwapchain(surface2.Handle(), VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
 
-    vkt::Semaphore acquire_semaphore(*m_device);
+    vkt::Fence image_acquired(*m_device);
     const auto swapchain_images = m_swapchain.GetImages();
-    const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
+    image_acquired.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images[image_index]);
 
-    vkt::Semaphore acquire_semaphore2(*m_device);
+    vkt::Fence image_acquired2(*m_device);
     const auto swapchain_images2 = swapchain2.GetImages();
-    const uint32_t image_index2 = swapchain2.AcquireNextImage(acquire_semaphore2, kWaitTimeout);
+    const uint32_t image_index2 = swapchain2.AcquireNextImage(image_acquired2, kWaitTimeout);
+    image_acquired2.Wait(kWaitTimeout);
     SetPresentImageLayout(swapchain_images2[image_index2]);
 
-    const VkSemaphore acquire_semaphores_handles[2] = {acquire_semaphore, acquire_semaphore2};
     const VkSwapchainKHR swapchain_handles[2] = {m_swapchain, swapchain2};
-    const VkPipelineStageFlags wait_stage_masks[2] = {VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT};
 
     vkt::Semaphore submit_semaphore(*m_device);
-
-    VkSubmitInfo submit_info = vku::InitStructHelper();
-    submit_info.waitSemaphoreCount = 2;
-    submit_info.pWaitSemaphores = acquire_semaphores_handles;
-    submit_info.pWaitDstStageMask = wait_stage_masks;
-    submit_info.signalSemaphoreCount = 1;
-    submit_info.pSignalSemaphores = &submit_semaphore.handle();
-    vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
+    m_default_queue->Submit(vkt::no_cmd, vkt::Signal(submit_semaphore));
 
     vkt::Fence present_fence(*m_device);
     vkt::Fence present_fence2(*m_device);

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -1817,7 +1817,7 @@ TEST_F(PositiveWsi, MultiSwapchainPresentWithOneBadSwapchain) {
 
         // The test checks that image acquire from the first swapchain does not generate validation error that no images left.
         // The second swapchain should not affect acquired image tracking in the first swapchain.
-        const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, vvl::kU64Max);
+        const uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
 
         // Do not try to acquire images from the second swapchain, it is broken.
         // Suppress error that we present not acquired image.


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/365
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5240

The restriction on non-acquired image usage is general but here we check only layout transition. This has to be practical enough because if the first operation is not a layout transition but something else (e.g. image copy), then layout mismatch will be detected, so won't be unnoticed. Then attempt to fix the layout will report about missing wait for the acquire signal. Still we might need to extend this with other operations if they do not trigger errors.

