### PR TITLE
layers: Path to removing VK_LAYER_CUSTOM_STYPE_LIST

### DIFF
--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -916,10 +916,10 @@ static const char* GetDefaultPrefix() {
 }
 #endif  // !defined(BUILD_SELF_VVL)
 
-// Global list of sType,size identifiers
-std::vector<std::pair<uint32_t, uint32_t>>& GetCustomStypeInfo() {
-    static std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
-    return custom_stype_info;
+// This is a (less than desired) way to allow Statless validation tracking a setting
+bool& HasCustomStypeInfo() {
+    static bool allow_custom_types = false;
+    return allow_custom_types;
 }
 
 #if !defined(BUILD_SELF_VVL)
@@ -961,7 +961,7 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
     std::vector<std::string> setting_warnings;
 
     // If not cleared, garbage has been seen in some Android run effecting the error message
-    GetCustomStypeInfo().clear();
+    HasCustomStypeInfo() = false;
 
     VkuLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
     auto layer_setting_create_info = vkuFindLayerSettingsCreateInfo(settings_data->create_info);
@@ -1007,7 +1007,13 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_CUSTOM_STYPE_LIST)) {
-        vkuGetLayerSettingValues(layer_setting_set, VK_LAYER_CUSTOM_STYPE_LIST, GetCustomStypeInfo());
+        // We use to support this, but feel no one is using this
+        // As a transition, we will allow to be used and just skip the 1 VU check if anything is set
+        // (added after SDK 1.4.341)
+        setting_warnings.emplace_back(
+            "VK_LAYER_CUSTOM_STYPE_LIST is set, but currently the feature seems unused, we plan to drop this support, so please "
+            "report if seeing this warning");
+        HasCustomStypeInfo() = true;
     }
 
     GpuAVSettings& gpuav_settings = *settings_data->gpuav_settings;

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -137,4 +137,4 @@ const std::vector<std::string> &GetEnableFlagNameHelper();
 // Process validation features, flags and settings specified through extensions, a layer settings file, or environment variables
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data);
 
-std::vector<std::pair<uint32_t, uint32_t>> &GetCustomStypeInfo();
+bool& HasCustomStypeInfo();

--- a/layers/stateless/sl_utils.cpp
+++ b/layers/stateless/sl_utils.cpp
@@ -236,6 +236,10 @@ bool Context::ValidateStructPnext(const Location& loc, const void* next, size_t 
                                   const char* stype_vuid, const bool is_const_param) const {
     bool skip = false;
 
+    if (HasCustomStypeInfo()) {
+        return skip;
+    }
+
     if (next != nullptr) {
         vvl::unordered_set<const void*> cycle_check;
         vvl::unordered_set<VkStructureType, vvl::hash<int>> unique_stype_check;
@@ -246,7 +250,7 @@ bool Context::ValidateStructPnext(const Location& loc, const void* next, size_t 
             "header, in which case the use of %s is undefined and may not work correctly with validation enabled";
 
         const Location pNext_loc = loc.dot(Field::pNext);
-        if ((allowed_type_count == 0) && (GetCustomStypeInfo().empty())) {
+        if (allowed_type_count == 0) {
             std::string message = "must be NULL.\n";
             message += disclaimer;
             skip |=
@@ -268,40 +272,29 @@ bool Context::ValidateStructPnext(const Location& loc, const void* next, size_t 
                         unique_stype_check.insert(current->sType);
                     }
 
-                    // Search custom stype list -- if sType found, skip this entirely
-                    bool custom = false;
-                    for (const auto& item : GetCustomStypeInfo()) {
-                        if (item.first == current->sType) {
-                            custom = true;
-                            break;
+                    if (std::find(start, end, current->sType) == end) {
+                        const std::string type_name = string_VkStructureType(current->sType);
+                        if (type_name.compare("Unhandled VkStructureType") == 0) {
+                            std::string message = "chain includes a structure with unknown VkStructureType (%" PRIu32 ").\n%s\n";
+                            message += disclaimer;
+                            skip |= log.LogError(pnext_vuid, error_obj.handle, pNext_loc, message.c_str(), current->sType,
+                                                 PrintPNextChain(Struct::Empty, next).c_str(), header_version,
+                                                 pNext_loc.Fields().c_str());
+                        } else {
+                            std::string message = "chain includes a structure with unexpected VkStructureType %s.\n%s\n";
+                            message += disclaimer;
+                            skip |= log.LogError(pnext_vuid, error_obj.handle, pNext_loc, message.c_str(), type_name.c_str(),
+                                                 PrintPNextChain(Struct::Empty, next).c_str(), header_version,
+                                                 pNext_loc.Fields().c_str());
                         }
                     }
-                    if (!custom) {
-                        if (std::find(start, end, current->sType) == end) {
-                            const std::string type_name = string_VkStructureType(current->sType);
-                            if (type_name.compare("Unhandled VkStructureType") == 0) {
-                                std::string message =
-                                    "chain includes a structure with unknown VkStructureType (%" PRIu32 ").\n%s\n";
-                                message += disclaimer;
-                                skip |= log.LogError(pnext_vuid, error_obj.handle, pNext_loc, message.c_str(), current->sType,
-                                                     PrintPNextChain(Struct::Empty, next).c_str(), header_version,
-                                                     pNext_loc.Fields().c_str());
-                            } else {
-                                std::string message = "chain includes a structure with unexpected VkStructureType %s.\n%s\n";
-                                message += disclaimer;
-                                skip |= log.LogError(pnext_vuid, error_obj.handle, pNext_loc, message.c_str(), type_name.c_str(),
-                                                     PrintPNextChain(Struct::Empty, next).c_str(), header_version,
-                                                     pNext_loc.Fields().c_str());
-                            }
-                        }
-                        // Send Location without pNext field so the pNext() connector can be used
-                        skip |= ValidatePnextStructContents(loc, current, pnext_vuid, is_const_param);
-                        skip |= ValidatePnextStructExtension(loc, current);
-                        // pNext contents for vkGetPhysicalDeviceProperties2KHR() is no longer checked.
-                        if (loc.function == Func::vkGetPhysicalDeviceFeatures2 ||
-                            loc.function == Func::vkGetPhysicalDeviceFeatures2KHR || loc.function == Func::vkCreateDevice) {
-                            skip |= ValidatePnextFeatureStructContents(loc, current, pnext_vuid, is_const_param);
-                        }
+                    // Send Location without pNext field so the pNext() connector can be used
+                    skip |= ValidatePnextStructContents(loc, current, pnext_vuid, is_const_param);
+                    skip |= ValidatePnextStructExtension(loc, current);
+                    // pNext contents for vkGetPhysicalDeviceProperties2KHR() is no longer checked.
+                    if (loc.function == Func::vkGetPhysicalDeviceFeatures2 ||
+                        loc.function == Func::vkGetPhysicalDeviceFeatures2KHR || loc.function == Func::vkCreateDevice) {
+                        skip |= ValidatePnextFeatureStructContents(loc, current, pnext_vuid, is_const_param);
                     }
                 }
                 current = reinterpret_cast<const VkBaseOutStructure*>(current->pNext);

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,7 +15,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "98ca45a888a8cb90f527f48a73c347232baefdfe",
+            "commit": "e2f236b273bfcd9c665306fdd53451b923d659ab",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
To go with https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/376

This doesn't fully remove `VK_LAYER_CUSTOM_STYPE_LIST`, but instead of searching the list, it just "turns off" the `ValidateStructPnext` all together if the user is passing in a list, this way to not provide a false positive to current users