### PR TITLE
tests: Add shared present layout tests

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -2356,22 +2356,24 @@ std::vector<VkImage> Swapchain::GetImages() const {
 }
 
 std::vector<vkt::CommandBuffer> Swapchain::RecordTransitionToPresentLayout(const vkt::Device& device,
-                                                                           const vkt::CommandPool& command_pool) const {
+                                                                           const vkt::CommandPool& command_pool,
+                                                                           VkImageLayout present_layout) const {
     const std::vector<VkImage> swapchain_images = GetImages();
     std::vector<vkt::CommandBuffer> command_buffers;
     command_buffers.reserve(swapchain_images.size());
     for (size_t i = 0; i < swapchain_images.size(); i++) {
         auto& cb = command_buffers.emplace_back(device, command_pool);
         cb.Begin();
-        cb.TransitionLayout(swapchain_images[i], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+        cb.TransitionLayout(swapchain_images[i], VK_IMAGE_LAYOUT_UNDEFINED, present_layout);
         cb.End();
     }
     return command_buffers;
 }
 
-bool Swapchain::TryTransitionToPresentLayout(const vkt::Device& device, vkt::Queue& queue, const vkt::CommandPool& command_pool) {
+bool Swapchain::TryTransitionToPresentLayout(const vkt::Device& device, vkt::Queue& queue, const vkt::CommandPool& command_pool,
+                                             VkImageLayout present_layout) {
     const std::vector<VkImage> swapchain_images = GetImages();
-    auto transition_to_present_cbs = RecordTransitionToPresentLayout(device, command_pool);
+    auto transition_to_present_cbs = RecordTransitionToPresentLayout(device, command_pool, present_layout);
     std::vector<bool> is_transitioned(swapchain_images.size(), false);
     vkt::Fence fence(device);
 

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1411,12 +1411,14 @@ class Swapchain : public internal::NonDispHandle<VkSwapchainKHR> {
     std::vector<VkImage> GetImages() const;
 
     // Each command buffer records layout transition to present layout for corresponding swapchain image
-    std::vector<vkt::CommandBuffer> RecordTransitionToPresentLayout(const vkt::Device& device,
-                                                                    const vkt::CommandPool& command_pool) const;
+    std::vector<vkt::CommandBuffer> RecordTransitionToPresentLayout(
+        const vkt::Device& device, const vkt::CommandPool& command_pool,
+        VkImageLayout present_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) const;
 
     // Return true if *all* swapchain images were transitioned.
     // We don't have a guarantee its always possible because the ordering of the acquired images is unspecified
-    bool TryTransitionToPresentLayout(const vkt::Device& device, vkt::Queue& queue, const vkt::CommandPool& command_pool);
+    bool TryTransitionToPresentLayout(const vkt::Device& device, vkt::Queue& queue, const vkt::CommandPool& command_pool,
+                                      VkImageLayout present_layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     uint32_t AcquireNextImage(const Semaphore &image_acquired, uint64_t timeout, VkResult *result = nullptr);
     uint32_t AcquireNextImage(const Fence &image_acquired, uint64_t timeout, VkResult *result = nullptr);

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -14,6 +14,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "../framework/render_pass_helper.h"
 #include "containers/container_utils.h"
 #include "generated/vk_function_pointers.h"
 #include <algorithm>
@@ -6927,4 +6928,55 @@ TEST_F(NegativeWsi, TransitionImageMissingAcquireSemaphoreOrFenceWait) {
     m_errorMonitor->SetDesiredError("UNASSIGNED-non-acquired-swapchain-image-used");
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeWsi, SharedPresentLayout) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7897
+    TEST_DESCRIPTION("SHARED_PRESENT layout is not special and must match expected layout");
+    AddSurfaceExtension();
+    AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+
+    // Pre-transition swapchain image to SHARED_PRESENT layout.
+    // We are allowed to use SHARED_PRESENT both for present and rendering, but layout matching
+    // rules stay the same. If API specifies expected layout then it must match current layout
+    // during execution on device. If we are going to use SHARED_PRESENT layout for all usages,
+    // then all APIs must specify SHARED_PRESENT as expected layout.
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool,
+                                                  VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
+    }
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    const vkt::Fence fence(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(fence, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
+
+    // Render pass specifies COLOR_ATTACHMENT_OPTIMAL that does not match SHARED_PRESENT
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(m_surface_formats[0].format, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                                         VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    render_pass.AddColorAttachment(0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    render_pass.CreateRenderPass();
+
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
+    image_view_ci.image = swapchain_images[image_index];
+    image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    image_view_ci.format = m_surface_formats[0].format;
+    image_view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkt::ImageView image_view(*m_device, image_view_ci);
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 1, 1);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 1, 1);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    monitor_.SetDesiredError("VUID-vkCmdDraw-None-09600");
+    m_default_queue->Submit(m_command_buffer);
+    monitor_.VerifyFound();
+    m_default_queue->Wait();
 }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -10,6 +10,7 @@
  */
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "../framework/render_pass_helper.h"
 #include <thread>
 
 std::optional<VkPhysicalDeviceGroupProperties> WsiTest::FindPhysicalDeviceGroup() {
@@ -3368,4 +3369,80 @@ TEST_F(PositiveWsi, MultipleCreateDisplay) {
     display_surface_info.displayMode = display_mode[0];
     vk::CreateDisplayPlaneSurfaceKHR(instance(), &display_surface_info, nullptr, &surface);
     vk::DestroySurfaceKHR(instance(), surface, nullptr);
+}
+
+TEST_F(PositiveWsi, SharedPresentLayout) {
+    TEST_DESCRIPTION("Use single SHARED_PRESENT layout both for rendering and presentation");
+    AddSurfaceExtension();
+    AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    if (!m_swapchain.TryTransitionToPresentLayout(*m_device, *m_default_queue, m_command_pool,
+                                                  VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)) {
+        GTEST_SKIP() << "Failed to pre-transition swapchain images";
+    }
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    const vkt::Fence fence(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(fence, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(m_surface_formats[0].format, VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR,
+                                         VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR);
+    render_pass.AddColorAttachment(0, VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR);
+    render_pass.CreateRenderPass();
+
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
+    image_view_ci.image = swapchain_images[image_index];
+    image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    image_view_ci.format = m_surface_formats[0].format;
+    image_view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkt::ImageView image_view(*m_device, image_view_ci);
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 1, 1);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 1, 1);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveWsi, SharedPresentLayout2) {
+    AddSurfaceExtension();
+    AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+
+    const vkt::Fence fence(*m_device);
+    const uint32_t image_index = m_swapchain.AcquireNextImage(fence, kWaitTimeout);
+    fence.Wait(kWaitTimeout);
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(m_surface_formats[0].format, VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR,
+                                         VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR);
+    render_pass.AddColorAttachment(0, VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR);
+    render_pass.CreateRenderPass();
+
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
+    image_view_ci.image = swapchain_images[image_index];
+    image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    image_view_ci.format = m_surface_formats[0].format;
+    image_view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkt::ImageView image_view(*m_device, image_view_ci);
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 1, 1);
+
+    m_command_buffer.Begin();
+    m_command_buffer.TransitionLayout(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR);
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
 }


### PR DESCRIPTION
The negative tests generates the same message as https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7897 and shows that it is likely not a VVL issue. Vulkan allows to use `VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR` in multiple context (e.g. both rendering and present) but this does not void layout matching rules.

In the referenced issue, the app uses `VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR` layout for everything, but some API (barrier, render pass setup, etc.) mentions `VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL` and this is detected as mismatch (should be `VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR` all the way).

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7897
