### PR TITLE
Unwrap heap mapping info with shader objects

### DIFF
--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -1052,8 +1052,10 @@ void CopyCreatePipelineFeedbackData(const void* src_chain, const void* dst_chain
     }
 }
 
-static void UnwrapMappingInfo(HandleWrapper* handle_wrapper, vvl::unordered_set<VkSamplerYcbcrConversion>& conversions,
-                              const void* pNext) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12108
+// We can have a case where 2 chained pNext can share the same handle and don't have a local copy
+// Simple answer is to just track as a set, might be a better way to do
+static void UnwrapMappingInfo(HandleWrapper* handle_wrapper, const void* pNext) {
     if (auto* mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(pNext)) {
         for (uint32_t idx2 = 0; idx2 < mapping_info->mappingCount; ++idx2) {
             const auto& mapping = mapping_info->pMappings[idx2];
@@ -1076,9 +1078,12 @@ static void UnwrapMappingInfo(HandleWrapper* handle_wrapper, vvl::unordered_set<
             }
 
             if (auto* sampler_conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(embedded_sampler_pNext)) {
-                if (sampler_conversion_info->conversion && !conversions.insert(sampler_conversion_info->conversion).second) {
-                    const_cast<VkSamplerYcbcrConversionInfo*>(sampler_conversion_info)->conversion =
-                        handle_wrapper->Unwrap(sampler_conversion_info->conversion);
+                // TODO - This is bad, we are hoping that if 2 structs are pointing to the same handle that unwrapping it twice will
+                // not be in the handle wrapping list (which very high chance it won't be)... This needs a proper, auto generated
+                // solution https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12108
+                VkSamplerYcbcrConversion unwrapped_conversion = handle_wrapper->Unwrap(sampler_conversion_info->conversion);
+                if (unwrapped_conversion != VK_NULL_HANDLE) {
+                    const_cast<VkSamplerYcbcrConversionInfo*>(sampler_conversion_info)->conversion = unwrapped_conversion;
                 }
             }
         }
@@ -1150,14 +1155,9 @@ VkResult DispatchDevice::CreateGraphicsPipelines(VkDevice device, VkPipelineCach
                 local_pCreateInfos[idx0].layout = Unwrap(pCreateInfos[idx0].layout);
             }
 
-            // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12108
-            // We can have a case where 2 chained pNext can share the same handle and don't have a local copy
-            // Simple answer is to just track as a set, might be a better way to do
-            vvl::unordered_set<VkSamplerYcbcrConversion> conversions;
-
             if (pCreateInfos[idx0].pStages) {
                 for (uint32_t idx1 = 0; idx1 < pCreateInfos[idx0].stageCount; ++idx1) {
-                    UnwrapMappingInfo(this, conversions, local_pCreateInfos[idx0].pStages[idx1].pNext);
+                    UnwrapMappingInfo(this, local_pCreateInfos[idx0].pStages[idx1].pNext);
 
                     if (pCreateInfos[idx0].pStages[idx1].module) {
                         local_pCreateInfos[idx0].pStages[idx1].module = Unwrap(pCreateInfos[idx0].pStages[idx1].module);
@@ -2784,12 +2784,11 @@ VkResult DispatchDevice::CreateShadersEXT(VkDevice device, uint32_t createInfoCo
     if (pCreateInfos) {
         var_local_pCreateInfos.resize(createInfoCount);
         local_pCreateInfos = var_local_pCreateInfos.data();
-        vvl::unordered_set<VkSamplerYcbcrConversion> conversions;
 
         for (uint32_t index0 = 0; index0 < createInfoCount; ++index0) {
             local_pCreateInfos[index0].initialize(&pCreateInfos[index0]);
 
-            UnwrapMappingInfo(this, conversions, local_pCreateInfos[index0].pNext);
+            UnwrapMappingInfo(this, local_pCreateInfos[index0].pNext);
 
             if (local_pCreateInfos[index0].pSetLayouts) {
                 for (uint32_t index1 = 0; index1 < local_pCreateInfos[index0].setLayoutCount; ++index1) {

--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -1052,6 +1052,39 @@ void CopyCreatePipelineFeedbackData(const void* src_chain, const void* dst_chain
     }
 }
 
+static void UnwrapMappingInfo(HandleWrapper* handle_wrapper, vvl::unordered_set<VkSamplerYcbcrConversion>& conversions,
+                              const void* pNext) {
+    if (auto* mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(pNext)) {
+        for (uint32_t idx2 = 0; idx2 < mapping_info->mappingCount; ++idx2) {
+            const auto& mapping = mapping_info->pMappings[idx2];
+            const void* embedded_sampler_pNext = nullptr;
+            if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT &&
+                mapping.sourceData.constantOffset.pEmbeddedSampler) {
+                embedded_sampler_pNext = mapping.sourceData.constantOffset.pEmbeddedSampler->pNext;
+            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT &&
+                       mapping.sourceData.pushIndex.pEmbeddedSampler) {
+                embedded_sampler_pNext = mapping.sourceData.pushIndex.pEmbeddedSampler->pNext;
+            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT &&
+                       mapping.sourceData.indirectIndex.pEmbeddedSampler) {
+                embedded_sampler_pNext = mapping.sourceData.indirectIndex.pEmbeddedSampler->pNext;
+            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT &&
+                       mapping.sourceData.indirectIndexArray.pEmbeddedSampler) {
+                embedded_sampler_pNext = mapping.sourceData.indirectIndexArray.pEmbeddedSampler->pNext;
+            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT &&
+                       mapping.sourceData.shaderRecordIndex.pEmbeddedSampler) {
+                embedded_sampler_pNext = mapping.sourceData.shaderRecordIndex.pEmbeddedSampler->pNext;
+            }
+
+            if (auto* sampler_conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(embedded_sampler_pNext)) {
+                if (sampler_conversion_info->conversion && !conversions.insert(sampler_conversion_info->conversion).second) {
+                    const_cast<VkSamplerYcbcrConversionInfo*>(sampler_conversion_info)->conversion =
+                        handle_wrapper->Unwrap(sampler_conversion_info->conversion);
+                }
+            }
+        }
+    }
+}
+
 VkResult DispatchDevice::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                  const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                  const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines) {
@@ -1124,38 +1157,7 @@ VkResult DispatchDevice::CreateGraphicsPipelines(VkDevice device, VkPipelineCach
 
             if (pCreateInfos[idx0].pStages) {
                 for (uint32_t idx1 = 0; idx1 < pCreateInfos[idx0].stageCount; ++idx1) {
-                    if (auto* mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(
-                            local_pCreateInfos[idx0].pStages[idx1].pNext)) {
-                        for (uint32_t idx2 = 0; idx2 < mapping_info->mappingCount; ++idx2) {
-                            const auto& mapping = mapping_info->pMappings[idx2];
-                            const void* embedded_sampler_pNext = nullptr;
-                            if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT &&
-                                mapping.sourceData.constantOffset.pEmbeddedSampler) {
-                                embedded_sampler_pNext = mapping.sourceData.constantOffset.pEmbeddedSampler->pNext;
-                            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT &&
-                                       mapping.sourceData.pushIndex.pEmbeddedSampler) {
-                                embedded_sampler_pNext = mapping.sourceData.pushIndex.pEmbeddedSampler->pNext;
-                            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT &&
-                                       mapping.sourceData.indirectIndex.pEmbeddedSampler) {
-                                embedded_sampler_pNext = mapping.sourceData.indirectIndex.pEmbeddedSampler->pNext;
-                            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT &&
-                                       mapping.sourceData.indirectIndexArray.pEmbeddedSampler) {
-                                embedded_sampler_pNext = mapping.sourceData.indirectIndexArray.pEmbeddedSampler->pNext;
-                            } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT &&
-                                       mapping.sourceData.shaderRecordIndex.pEmbeddedSampler) {
-                                embedded_sampler_pNext = mapping.sourceData.shaderRecordIndex.pEmbeddedSampler->pNext;
-                            }
-
-                            if (auto* sampler_conversion_info =
-                                    vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(embedded_sampler_pNext)) {
-                                if (sampler_conversion_info->conversion &&
-                                    !conversions.insert(sampler_conversion_info->conversion).second) {
-                                    const_cast<VkSamplerYcbcrConversionInfo*>(sampler_conversion_info)->conversion =
-                                        Unwrap(sampler_conversion_info->conversion);
-                                }
-                            }
-                        }
-                    }
+                    UnwrapMappingInfo(this, conversions, local_pCreateInfos[idx0].pStages[idx1].pNext);
 
                     if (pCreateInfos[idx0].pStages[idx1].module) {
                         local_pCreateInfos[idx0].pStages[idx1].module = Unwrap(pCreateInfos[idx0].pStages[idx1].module);
@@ -2782,8 +2784,13 @@ VkResult DispatchDevice::CreateShadersEXT(VkDevice device, uint32_t createInfoCo
     if (pCreateInfos) {
         var_local_pCreateInfos.resize(createInfoCount);
         local_pCreateInfos = var_local_pCreateInfos.data();
+        vvl::unordered_set<VkSamplerYcbcrConversion> conversions;
+
         for (uint32_t index0 = 0; index0 < createInfoCount; ++index0) {
             local_pCreateInfos[index0].initialize(&pCreateInfos[index0]);
+
+            UnwrapMappingInfo(this, conversions, local_pCreateInfos[index0].pNext);
+
             if (local_pCreateInfos[index0].pSetLayouts) {
                 for (uint32_t index1 = 0; index1 < local_pCreateInfos[index0].setLayoutCount; ++index1) {
                     local_pCreateInfos[index0].pSetLayouts[index1] = Unwrap(local_pCreateInfos[index0].pSetLayouts[index1]);

--- a/tests/unit/descriptor_heap_positive.cpp
+++ b/tests/unit/descriptor_heap_positive.cpp
@@ -3870,17 +3870,7 @@ TEST_F(PositiveDescriptorHeap, YcbcrImage) {
     }
     vkt::Image image(*m_device, image_ci);
 
-    VkSamplerYcbcrConversionCreateInfo ycbcr_conversion_ci = vku::InitStructHelper();
-    ycbcr_conversion_ci.format = format;
-    ycbcr_conversion_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
-    ycbcr_conversion_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
-    ycbcr_conversion_ci.components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
-                                      VK_COMPONENT_SWIZZLE_IDENTITY};
-    ycbcr_conversion_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_conversion_ci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_conversion_ci.chromaFilter = VK_FILTER_NEAREST;
-    ycbcr_conversion_ci.forceExplicitReconstruction = false;
-    vkt::SamplerYcbcrConversion ycbcr_conversion(*m_device, ycbcr_conversion_ci);
+    vkt::SamplerYcbcrConversion ycbcr_conversion(*m_device, format);
 
     VkSamplerYcbcrConversionInfo ycbcr_conversion_info = vku::InitStructHelper();
     ycbcr_conversion_info.conversion = ycbcr_conversion;
@@ -3905,20 +3895,20 @@ TEST_F(PositiveDescriptorHeap, YcbcrImage) {
 
     const char* vs_source = R"glsl(
         #version 450
-        layout(location = 0) out vec2 uv;
+        layout(set = 0, binding = 0) uniform sampler2D tex;
+        layout(location = 0) out vec4 uv;
         void main() {
             vec2 pos = vec2(gl_VertexIndex & 1, gl_VertexIndex >> 1);
-            uv = pos;
-            gl_Position = vec4(pos * 2.0f - 1.0f, 0.0f, 1.0f);
+            gl_Position = texture(tex, pos);
         }
     )glsl";
+
     const char* fs_source = R"glsl(
         #version 450
-        layout(location = 0) in vec2 uv;
         layout(location = 0) out vec4 color;
         layout(set = 0, binding = 0) uniform sampler2D tex;
         void main() {
-            color = texture(tex, uv);
+            color = texture(tex, vec2(0.0));
         }
     )glsl";
     VkShaderObj vs_module = VkShaderObj(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
@@ -3969,6 +3959,112 @@ TEST_F(PositiveDescriptorHeap, YcbcrImage) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
+TEST_F(PositiveDescriptorHeap, YcbcrImageDifferentMapping) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12108");
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::samplerYcbcrConversion);
+    RETURN_IF_SKIP(InitBasicDescriptorHeap());
+    InitRenderTarget();
+
+    VkFormat format = VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM;
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
+        GTEST_SKIP() << "Required formats/features not supported";
+    }
+
+    // Handle if driver has combinedImageSamplerDescriptorCount of 4 (the most it should ever possibily be)
+    const size_t ycbcr_descriptor_size = heap_props.imageDescriptorSize * 4;
+    CreateResourceHeap(ycbcr_descriptor_size);
+
+    auto image_ci =
+        vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_DST_BIT | VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT;
+    if (!IsImageFormatSupported(Gpu(), image_ci, features)) {
+        GTEST_SKIP() << "Single-plane _422 image format not supported";
+    }
+    vkt::Image image(*m_device, image_ci);
+
+    vkt::SamplerYcbcrConversion ycbcr_conversion(*m_device, format);
+
+    VkSamplerYcbcrConversionInfo ycbcr_conversion_info_v = vku::InitStructHelper();
+    ycbcr_conversion_info_v.conversion = ycbcr_conversion;
+
+    VkSamplerYcbcrConversionInfo ycbcr_conversion_info_f = vku::InitStructHelper();
+    ycbcr_conversion_info_f.conversion = ycbcr_conversion;
+
+    VkHostAddressRangeEXT resource_host;
+    resource_host.address = resource_heap_data_;
+    resource_host.size = ycbcr_descriptor_size;
+
+    VkImageViewCreateInfo view_info = image.BasicViewCreatInfo(VK_IMAGE_ASPECT_COLOR_BIT);
+    view_info.pNext = &ycbcr_conversion_info_v;
+
+    VkImageDescriptorInfoEXT image_info = vku::InitStructHelper();
+    image_info.pView = &view_info;
+    image_info.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    VkResourceDescriptorInfoEXT descriptor_info = vku::InitStructHelper();
+    descriptor_info.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    descriptor_info.data.pImage = &image_info;
+    vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &resource_host);
+
+    const char* vs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform sampler2D tex;
+        layout(location = 0) out vec4 uv;
+        void main() {
+            vec2 pos = vec2(gl_VertexIndex & 1, gl_VertexIndex >> 1);
+            gl_Position = texture(tex, pos);
+        }
+    )glsl";
+
+    const char* fs_source = R"glsl(
+        #version 450
+        layout(location = 0) out vec4 color;
+        layout(set = 0, binding = 0) uniform sampler2D tex;
+        void main() {
+            color = texture(tex, vec2(0.0));
+        }
+    )glsl";
+    VkShaderObj vs_module = VkShaderObj(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs_module = VkShaderObj(*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    VkSamplerCreateInfo sampler_info_v = SafeSaneSamplerCreateInfo(&ycbcr_conversion_info_v);
+    VkDescriptorSetAndBindingMappingEXT mapping_v;
+    mapping_v = MakeSetAndBindingMapping(0, 0, 1, VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT);
+    mapping_v.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping_v.sourceData.constantOffset = {};
+    mapping_v.sourceData.constantOffset.pEmbeddedSampler = &sampler_info_v;
+
+    VkSamplerCreateInfo sampler_info_f = SafeSaneSamplerCreateInfo(&ycbcr_conversion_info_f);
+    VkDescriptorSetAndBindingMappingEXT mapping_f;
+    mapping_f = MakeSetAndBindingMapping(0, 0, 1, VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT);
+    mapping_f.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping_f.sourceData.constantOffset = {};
+    mapping_f.sourceData.constantOffset.pEmbeddedSampler = &sampler_info_f;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info_v = vku::InitStructHelper();
+    mapping_info_v.mappingCount = 1u;
+    mapping_info_v.pMappings = &mapping_v;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info_f = vku::InitStructHelper();
+    mapping_info_f.mappingCount = 1u;
+    mapping_info_f.pMappings = &mapping_f;
+
+    VkPipelineShaderStageCreateInfo stages[2] = {vs_module.GetStageCreateInfo(), fs_module.GetStageCreateInfo()};
+    stages[0].pNext = &mapping_info_v;
+    stages[1].pNext = &mapping_info_f;
+
+    CreatePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.gp_ci_.layout = VK_NULL_HANDLE;
+    pipe.gp_ci_.stageCount = 2u;
+    pipe.gp_ci_.pStages = stages;
+    pipe.CreateGraphicsPipeline(false);
+}
+
 TEST_F(PositiveDescriptorHeap, YcbcrImageShaderObject) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -3997,17 +4093,7 @@ TEST_F(PositiveDescriptorHeap, YcbcrImageShaderObject) {
     }
     vkt::Image image(*m_device, image_ci);
 
-    VkSamplerYcbcrConversionCreateInfo ycbcr_conversion_ci = vku::InitStructHelper();
-    ycbcr_conversion_ci.format = format;
-    ycbcr_conversion_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
-    ycbcr_conversion_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
-    ycbcr_conversion_ci.components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
-                                      VK_COMPONENT_SWIZZLE_IDENTITY};
-    ycbcr_conversion_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_conversion_ci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
-    ycbcr_conversion_ci.chromaFilter = VK_FILTER_NEAREST;
-    ycbcr_conversion_ci.forceExplicitReconstruction = false;
-    vkt::SamplerYcbcrConversion ycbcr_conversion(*m_device, ycbcr_conversion_ci);
+    vkt::SamplerYcbcrConversion ycbcr_conversion(*m_device, format);
 
     VkSamplerYcbcrConversionInfo ycbcr_conversion_info = vku::InitStructHelper();
     ycbcr_conversion_info.conversion = ycbcr_conversion;
@@ -4067,8 +4153,7 @@ TEST_F(PositiveDescriptorHeap, YcbcrImageShaderObject) {
     const auto vspv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source);
     const auto fspv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fs_source);
 
-    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
-    // vert_create_info.pNext = &mapping_info;
+    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper(&mapping_info);
     vert_create_info.flags = VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT;
     vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vert_create_info.nextStage = VK_SHADER_STAGE_FRAGMENT_BIT;

--- a/tests/unit/descriptor_heap_positive.cpp
+++ b/tests/unit/descriptor_heap_positive.cpp
@@ -3968,3 +3968,144 @@ TEST_F(PositiveDescriptorHeap, YcbcrImage) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
+
+TEST_F(PositiveDescriptorHeap, YcbcrImageShaderObject) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::samplerYcbcrConversion);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::shaderObject);
+    RETURN_IF_SKIP(InitBasicDescriptorHeap());
+    InitRenderTarget();
+
+    VkFormat format = VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM;
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
+        GTEST_SKIP() << "Required formats/features not supported";
+    }
+
+    // Handle if driver has combinedImageSamplerDescriptorCount of 4 (the most it should ever possibily be)
+    const size_t ycbcr_descriptor_size = heap_props.imageDescriptorSize * 4;
+    CreateResourceHeap(ycbcr_descriptor_size);
+
+    auto image_ci =
+        vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_DST_BIT | VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT;
+    if (!IsImageFormatSupported(Gpu(), image_ci, features)) {
+        GTEST_SKIP() << "Single-plane _422 image format not supported";
+    }
+    vkt::Image image(*m_device, image_ci);
+
+    VkSamplerYcbcrConversionCreateInfo ycbcr_conversion_ci = vku::InitStructHelper();
+    ycbcr_conversion_ci.format = format;
+    ycbcr_conversion_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
+    ycbcr_conversion_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
+    ycbcr_conversion_ci.components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+                                      VK_COMPONENT_SWIZZLE_IDENTITY};
+    ycbcr_conversion_ci.xChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
+    ycbcr_conversion_ci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
+    ycbcr_conversion_ci.chromaFilter = VK_FILTER_NEAREST;
+    ycbcr_conversion_ci.forceExplicitReconstruction = false;
+    vkt::SamplerYcbcrConversion ycbcr_conversion(*m_device, ycbcr_conversion_ci);
+
+    VkSamplerYcbcrConversionInfo ycbcr_conversion_info = vku::InitStructHelper();
+    ycbcr_conversion_info.conversion = ycbcr_conversion;
+
+    VkHostAddressRangeEXT resource_host;
+    resource_host.address = resource_heap_data_;
+    resource_host.size = ycbcr_descriptor_size;
+
+    VkImageViewCreateInfo view_info = image.BasicViewCreatInfo(VK_IMAGE_ASPECT_COLOR_BIT);
+    view_info.pNext = &ycbcr_conversion_info;
+
+    VkImageDescriptorInfoEXT image_info = vku::InitStructHelper();
+    image_info.pView = &view_info;
+    image_info.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    VkResourceDescriptorInfoEXT descriptor_info = vku::InitStructHelper();
+    descriptor_info.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    descriptor_info.data.pImage = &image_info;
+    vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &resource_host);
+
+    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo(&ycbcr_conversion_info);
+
+    const char* vs_source = R"glsl(
+        #version 450
+        layout(location = 0) out vec2 uv;
+        void main() {
+            vec2 pos = vec2(gl_VertexIndex & 1, gl_VertexIndex >> 1);
+            uv = pos;
+            gl_Position = vec4(pos * 2.0f - 1.0f, 0.0f, 1.0f);
+        }
+    )glsl";
+    const char* fs_source = R"glsl(
+        #version 450
+        layout(location = 0) in vec2 uv;
+        layout(location = 0) out vec4 color;
+        layout(set = 0, binding = 0) uniform sampler2D tex1;
+        layout(set = 0, binding = 1) uniform sampler2D tex2;
+        void main() {
+            color = mix(texture(tex1, uv), texture(tex2, uv), 0.5);
+        }
+    )glsl";
+
+    VkDescriptorSetAndBindingMappingEXT mappings[2];
+    mappings[0] = MakeSetAndBindingMapping(0, 0, 1, VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset = {};
+    mappings[0].sourceData.constantOffset.pEmbeddedSampler = &sampler_info;
+    mappings[1] = MakeSetAndBindingMapping(0, 1, 1, VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset = {};
+    mappings[1].sourceData.constantOffset.pEmbeddedSampler = &sampler_info;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 2u;
+    mapping_info.pMappings = mappings;
+
+    const auto vspv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source);
+    const auto fspv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fs_source);
+
+    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
+    // vert_create_info.pNext = &mapping_info;
+    vert_create_info.flags = VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT;
+    vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
+    vert_create_info.nextStage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    vert_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
+    vert_create_info.codeSize = vspv.size() * sizeof(vspv[0]);
+    vert_create_info.pCode = vspv.data();
+    vert_create_info.pName = "main";
+    vkt::Shader vert_shader(*m_device, vert_create_info);
+
+    VkShaderCreateInfoEXT frag_create_info = vku::InitStructHelper(&mapping_info);
+    frag_create_info.flags = VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT;
+    frag_create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    frag_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
+    frag_create_info.codeSize = fspv.size() * sizeof(fspv[0]);
+    frag_create_info.pCode = fspv.data();
+    frag_create_info.pName = "main";
+    vkt::Shader frag_shader(*m_device, frag_create_info);
+
+    m_command_buffer.Begin();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
+    image_barrier.srcAccessMask = VK_ACCESS_NONE;
+    image_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    image_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    image_barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    image_barrier.image = image;
+    image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 1u, 0u, 1u};
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0u, 0u,
+                           nullptr, 0u, nullptr, 1u, &image_barrier);
+
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    SetDefaultDynamicStatesAll(m_command_buffer);
+    m_command_buffer.BindShaders(vert_shader, frag_shader);
+    BindResourceHeap();
+    vk::CmdDraw(m_command_buffer, 3u, 1u, 0u, 0u);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}


### PR DESCRIPTION
Part of #12108

@spencer-lunarg this doesn't look like a correct fix, unless I missed something. I again have a commented out line, that if enabled with result in another crash.