### PR TITLE
scripts: Update SPIR-V

### DIFF
--- a/layers/vulkan/generated/spirv_grammar_helper.cpp
+++ b/layers/vulkan/generated/spirv_grammar_helper.cpp
@@ -767,6 +767,10 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpMemberDecorateIdEXT";
         case spv::OpConstantSizeOfEXT:
             return "OpConstantSizeOfEXT";
+        case spv::OpConstantDataKHR:
+            return "OpConstantDataKHR";
+        case spv::OpSpecConstantDataKHR:
+            return "OpSpecConstantDataKHR";
         case spv::OpHitObjectRecordHitMotionNV:
             return "OpHitObjectRecordHitMotionNV";
         case spv::OpHitObjectRecordHitWithIndexMotionNV:
@@ -1655,6 +1659,8 @@ const char* string_SpvDecoration(uint32_t decoration) {
             return "ArrayStrideIdEXT";
         case spv::DecorationOffsetIdEXT:
             return "OffsetIdEXT";
+        case spv::DecorationUTFEncodedKHR:
+            return "UTFEncodedKHR";
         case spv::DecorationOverrideCoverageNV:
             return "OverrideCoverageNV";
         case spv::DecorationPassthroughNV:
@@ -2609,6 +2615,8 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpUntypedImageTexelPointerEXT, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpMemberDecorateIdEXT, {{OperandKind::Id, OperandKind::Literal, OperandKind::ValueEnum}}},
         {spv::OpConstantSizeOfEXT, {{OperandKind::Id}}},
+        {spv::OpConstantDataKHR, {{OperandKind::Literal}}},
+        {spv::OpSpecConstantDataKHR, {{OperandKind::Literal}}},
         {spv::OpHitObjectRecordHitMotionNV, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpHitObjectRecordHitWithIndexMotionNV, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpHitObjectRecordMissMotionNV, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},

--- a/layers/vulkan/generated/spirv_grammar_helper.h
+++ b/layers/vulkan/generated/spirv_grammar_helper.h
@@ -329,6 +329,8 @@ static constexpr bool OpcodeHasType(uint32_t opcode) {
         case spv::OpBufferPointerEXT:
         case spv::OpUntypedImageTexelPointerEXT:
         case spv::OpConstantSizeOfEXT:
+        case spv::OpConstantDataKHR:
+        case spv::OpSpecConstantDataKHR:
         case spv::OpHitObjectGetWorldToObjectNV:
         case spv::OpHitObjectGetObjectToWorldNV:
         case spv::OpHitObjectGetObjectRayDirectionNV:
@@ -805,6 +807,8 @@ static constexpr bool OpcodeHasResult(uint32_t opcode) {
         case spv::OpBufferPointerEXT:
         case spv::OpUntypedImageTexelPointerEXT:
         case spv::OpConstantSizeOfEXT:
+        case spv::OpConstantDataKHR:
+        case spv::OpSpecConstantDataKHR:
         case spv::OpHitObjectGetWorldToObjectNV:
         case spv::OpHitObjectGetObjectToWorldNV:
         case spv::OpHitObjectGetObjectRayDirectionNV:

--- a/layers/vulkan/generated/spirv_tools_commit_id.h
+++ b/layers/vulkan/generated/spirv_tools_commit_id.h
@@ -23,4 +23,4 @@
 
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "2c75d08e3b31a673726ce6be80ab528250247064"
+#define SPIRV_TOOLS_COMMIT_ID "8b3a3c79b6ecaae7bd11ff20261aea532ce268c2"

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -298,8 +298,7 @@ const std::unordered_multimap<uint32_t, RequiredSpirvInfo>& GetSpirvCapabilites(
         {spv::CapabilityDotProductFloat16AccFloat16VALVE, {0, &DeviceFeatures::shaderMixedFloatDotProductFloat16AccFloat16, nullptr, ""}},
         {spv::CapabilityDotProductBFloat16AccVALVE, {0, &DeviceFeatures::shaderMixedFloatDotProductBFloat16Acc, nullptr, ""}},
         {spv::CapabilityDotProductFloat8AccFloat32VALVE, {0, &DeviceFeatures::shaderMixedFloatDotProductFloat8AccFloat32, nullptr, ""}},
-        // Not found in current SPIR-V Headers
-        // {spv::CapabilityConstantDataKHR, {0, &DeviceFeatures::shaderConstantData, nullptr, ""}},
+        {spv::CapabilityConstantDataKHR, {0, &DeviceFeatures::shaderConstantData, nullptr, ""}},
         {spv::CapabilityAbortKHR, {0, &DeviceFeatures::shaderAbort, nullptr, ""}},
     };
     // clang-format on
@@ -691,6 +690,8 @@ static inline const char* string_SpvCapability(uint32_t input_value) {
             return "AbortKHR";
         case spv::CapabilityDescriptorHeapEXT:
             return "DescriptorHeapEXT";
+        case spv::CapabilityConstantDataKHR:
+            return "ConstantDataKHR";
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case spv::CapabilityPoisonFreezeKHR:
             return "PoisonFreezeKHR";
@@ -1281,6 +1282,7 @@ static inline const char* SpvCapabilityRequirements(uint32_t capability) {
     {spv::CapabilityDotProductFloat16AccFloat16VALVE, "VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE::shaderMixedFloatDotProductFloat16AccFloat16"},
     {spv::CapabilityDotProductBFloat16AccVALVE, "VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE::shaderMixedFloatDotProductBFloat16Acc"},
     {spv::CapabilityDotProductFloat8AccFloat32VALVE, "VkPhysicalDeviceShaderMixedFloatDotProductFeaturesVALVE::shaderMixedFloatDotProductFloat8AccFloat32"},
+    {spv::CapabilityConstantDataKHR, "VkPhysicalDeviceShaderConstantDataFeaturesKHR::shaderConstantData"},
     {spv::CapabilityAbortKHR, "VkPhysicalDeviceShaderAbortFeaturesKHR::shaderAbort"},
     };
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -29,7 +29,7 @@
             "sub_dir": "SPIRV-Headers",
             "build_dir": "SPIRV-Headers/build",
             "install_dir": "SPIRV-Headers/build/install",
-            "commit": "39e5d40a325973b9204d1b660eb3e026cd75fc3f"
+            "commit": "ad9184e76a66b1001c29db9b0a3e87f646c64de0"
         },
         {
             "name": "SPIRV-Tools",
@@ -43,7 +43,7 @@
                 "-DSPIRV_SKIP_TESTS=ON",
                 "-DSPIRV_SKIP_EXECUTABLES=OFF"
             ],
-            "commit": "2c75d08e3b31a673726ce6be80ab528250247064"
+            "commit": "8b3a3c79b6ecaae7bd11ff20261aea532ce268c2"
         },
         {
             "name": "mimalloc",
@@ -84,7 +84,7 @@
             "sub_dir": "glslang",
             "build_dir": "glslang/build",
             "install_dir": "glslang/build/install",
-            "commit": "7fb81fa42fb713e354807f9abab42ba7967691c3",
+            "commit": "aa8e19e05f8b30d14b894fb2d94875bb6c8be3c6",
             "cmake_options": [
                 "-DENABLE_OPT=OFF"
             ],

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -811,11 +811,13 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderDebugSourceContinued) {
 #extension GL_EXT_buffer_reference : enable
 layout(buffer_reference, std430) readonly buffer IndexBuffer {
     int indices[];
-};"
+};
+"
          %s2 = OpString "layout(set = 0, binding = 0) buffer foo {
     IndexBuffer data;
     int x;
-};"
+};
+"
          %s3 = OpString "void main() {
     x = data.indices[16];
 }"


### PR DESCRIPTION
pulls in the needed fixes to add support for `SPV_KHR_constant_data`/`VK_KHR_shader_constant_data` (https://github.com/KhronosGroup/SPIRV-Tools/pull/6646)