### PR TITLE
layers: Better DEVICE_LOST in use error messages

### DIFF
--- a/docs/error_messages.md
+++ b/docs/error_messages.md
@@ -28,7 +28,7 @@ Here we see a few things, listed in the order they appear
 2. The [VUID](https://github.com/KhronosGroup/Vulkan-Guide/blob/main/chapters/validation_overview.adoc#valid-usage-id-vuid)
 3. Message ID
     - This is just a hash of the VUID used internally to detect if the message duplication rate was hit
-4. Which function the error occured at
+4. Which function the error occurred at
 5. The faulty parameter / struct member
     - Helps if there is an array to know which index it is in
 6. The "main message"

--- a/docs/error_object.md
+++ b/docs/error_object.md
@@ -10,7 +10,7 @@ The `chassis.cpp` holds the single `ErrorObject` reference which is passed to al
 
 ## Location
 
-It is very important to know "where" in a function call the error occured, this is where the `Location` object comes in.
+It is very important to know "where" in a function call the error occurred, this is where the `Location` object comes in.
 
 inside `chassis.cpp` we generate the starting `Location` for `ErrorObject`. From here inside each function, we can append what we need
 

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -185,7 +185,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                          "on active %s before it has completed. You must check "
                          "command buffer fence before this call.%s",
                          FormatHandle(commandBuffer).c_str(),
-                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command buffer must be freed)" : "");
+                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the command buffer must be freed)" : "");
     }
     const Location begin_info_loc = error_obj.location.dot(Field::pBeginInfo);
     if (cb_state->IsPrimary()) {
@@ -521,7 +521,7 @@ bool CoreChecks::PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer
         const LogObjectList objlist(commandBuffer, cmd_pool);
         skip |= LogError("VUID-vkResetCommandBuffer-commandBuffer-00045", objlist, error_obj.location, "(%s) is in use.%s",
                          FormatHandle(commandBuffer).c_str(),
-                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command buffers must be freed)" : "");
+                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the command buffers must be freed)" : "");
     }
 
     return skip;
@@ -1381,7 +1381,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                  "(%s) is pending and can't execute again because it was not recorded with "
                                  "VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT.%s",
                                  FormatHandle(secondary_cb).c_str(),
-                                 is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command buffer must be freed)" : "");
+                                 is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the command buffer must be freed)" : "");
             }
             // We use an const_cast, because one cannot query a container keyed on a non-const pointer using a const pointer
             if (cb_state.linked_command_buffers.count(const_cast<vvl::CommandBuffer*>(&secondary_cb_state))) {

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -183,8 +183,9 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
     if (cb_state->InUse()) {
         skip |= LogError("VUID-vkBeginCommandBuffer-commandBuffer-00049", commandBuffer, error_obj.location,
                          "on active %s before it has completed. You must check "
-                         "command buffer fence before this call.",
-                         FormatHandle(commandBuffer).c_str());
+                         "command buffer fence before this call.%s",
+                         FormatHandle(commandBuffer).c_str(),
+                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command buffer must be freed)" : "");
     }
     const Location begin_info_loc = error_obj.location.dot(Field::pBeginInfo);
     if (cb_state->IsPrimary()) {
@@ -518,8 +519,9 @@ bool CoreChecks::PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer
 
     if (cb_state->InUse()) {
         const LogObjectList objlist(commandBuffer, cmd_pool);
-        skip |= LogError("VUID-vkResetCommandBuffer-commandBuffer-00045", objlist, error_obj.location, "(%s) is in use.",
-                         FormatHandle(commandBuffer).c_str());
+        skip |= LogError("VUID-vkResetCommandBuffer-commandBuffer-00045", objlist, error_obj.location, "(%s) is in use.%s",
+                         FormatHandle(commandBuffer).c_str(),
+                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command buffers must be freed)" : "");
     }
 
     return skip;
@@ -1377,8 +1379,9 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                 const LogObjectList objlist(commandBuffer, secondary_cb);
                 skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-00091", objlist, secondary_cb_loc,
                                  "(%s) is pending and can't execute again because it was not recorded with "
-                                 "VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT.",
-                                 FormatHandle(secondary_cb).c_str());
+                                 "VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT.%s",
+                                 FormatHandle(secondary_cb).c_str(),
+                                 is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command buffer must be freed)" : "");
             }
             // We use an const_cast, because one cannot query a container keyed on a non-const pointer using a const pointer
             if (cb_state.linked_command_buffers.count(const_cast<vvl::CommandBuffer*>(&secondary_cb_state))) {

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -664,7 +664,7 @@ bool CoreChecks::PreCallValidateResetCommandPool(VkDevice device, VkCommandPool 
             const LogObjectList objlist(cb_state->Handle(), commandPool);
             skip |= LogError("VUID-vkResetCommandPool-commandPool-00040", objlist, error_obj.location, "(%s) is in use.%s",
                              FormatHandle(cb_state->Handle()).c_str(),
-                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command pool must be destroyed)" : "");
+                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the command pool must be destroyed)" : "");
         }
     }
     return skip;

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -662,8 +662,9 @@ bool CoreChecks::PreCallValidateResetCommandPool(VkDevice device, VkCommandPool 
         auto cb_state = entry.second;
         if (cb_state->InUse()) {
             const LogObjectList objlist(cb_state->Handle(), commandPool);
-            skip |= LogError("VUID-vkResetCommandPool-commandPool-00040", objlist, error_obj.location, "(%s) is in use.",
-                             FormatHandle(cb_state->Handle()).c_str());
+            skip |= LogError("VUID-vkResetCommandPool-commandPool-00040", objlist, error_obj.location, "(%s) is in use.%s",
+                             FormatHandle(cb_state->Handle()).c_str(),
+                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the command pool must be destroyed)" : "");
         }
     }
     return skip;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -577,7 +577,7 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
         return skip;
     }
 
-    // Have the location where the VkRenderPass is reference, and where in it's creation the error occured
+    // Have the location where the VkRenderPass is reference, and where in it's creation the error occurred
     const Location rp_loc = rp_begin_loc.dot(Field::renderPass);
     // only printing Fields, but use same Function to make getting correct VUID easier
     const Location rp_create_info(rp_begin_loc.function, Field::pCreateInfo);

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -632,8 +632,8 @@ bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location& loc, const
         !(cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
         const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kCmdNotSimultaneous);
 
-        skip |= LogError(vuid, device, loc, "%s is already in use and is not marked for simultaneous use.",
-                         FormatHandle(cb_state).c_str());
+        skip |= LogError(vuid, device, loc, "%s is already in use and is not marked for simultaneous use.%s",
+                         FormatHandle(cb_state).c_str(), is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the queue must be used)" : "");
     }
     return skip;
 }

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -633,7 +633,8 @@ bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location& loc, const
         const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kCmdNotSimultaneous);
 
         skip |= LogError(vuid, device, loc, "%s is already in use and is not marked for simultaneous use.%s",
-                         FormatHandle(cb_state).c_str(), is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the queue must be used)" : "");
+                         FormatHandle(cb_state).c_str(),
+                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the queue must be used)" : "");
     }
     return skip;
 }

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -779,7 +779,8 @@ bool CoreChecks::PreCallValidateResetFences(VkDevice device, uint32_t fenceCount
         ASSERT_AND_CONTINUE(fence_state);
         if (fence_state->Scope() == vvl::Fence::kInternal && fence_state->State() == vvl::Fence::kInflight) {
             skip |= LogError("VUID-vkResetFences-pFences-01123", pFences[i], error_obj.location.dot(Field::pFences, i),
-                             "(%s) is in use.", FormatHandle(pFences[i]).c_str());
+                             "(%s) is in use.%s", FormatHandle(pFences[i]).c_str(),
+                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the fence must be destroyed)" : "");
         }
     }
     return skip;
@@ -1578,7 +1579,8 @@ bool CoreChecks::PreCallValidateSetEvent(VkDevice device, VkEvent event, const E
     if (auto event_state = Get<vvl::Event>(event)) {
         if (event_state->InUse()) {
             skip |= LogError("VUID-vkSetEvent-event-09543", event, error_obj.location.dot(Field::event),
-                             "(%s) that is already in use by a command buffer.", FormatHandle(event).c_str());
+                             "(%s) that is already in use by a command buffer.%s", FormatHandle(event).c_str(),
+                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the event must be destroyed)" : "");
         }
         if (event_state->flags & VK_EVENT_CREATE_DEVICE_ONLY_BIT) {
             skip |= LogError("VUID-vkSetEvent-event-03941", event, error_obj.location.dot(Field::event),

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -780,7 +780,7 @@ bool CoreChecks::PreCallValidateResetFences(VkDevice device, uint32_t fenceCount
         if (fence_state->Scope() == vvl::Fence::kInternal && fence_state->State() == vvl::Fence::kInflight) {
             skip |= LogError("VUID-vkResetFences-pFences-01123", pFences[i], error_obj.location.dot(Field::pFences, i),
                              "(%s) is in use.%s", FormatHandle(pFences[i]).c_str(),
-                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the fence must be destroyed)" : "");
+                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the fence must be destroyed)" : "");
         }
     }
     return skip;
@@ -1580,7 +1580,7 @@ bool CoreChecks::PreCallValidateSetEvent(VkDevice device, VkEvent event, const E
         if (event_state->InUse()) {
             skip |= LogError("VUID-vkSetEvent-event-09543", event, error_obj.location.dot(Field::event),
                              "(%s) that is already in use by a command buffer.%s", FormatHandle(event).c_str(),
-                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occured, the event must be destroyed)" : "");
+                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the event must be destroyed)" : "");
         }
         if (event_state->flags & VK_EVENT_CREATE_DEVICE_ONLY_BIT) {
             skip |= LogError("VUID-vkSetEvent-event-03941", event, error_obj.location.dot(Field::event),

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -188,7 +188,7 @@ struct OutputRecord {
 struct BufferInfo {
     // The buffer where DebugPrintf data was written to (and need to report)
     vko::BufferRange output_mem_buffer;
-    // Same as GPU-AV, we need these to generate details in error message where error occured in the CmdBuffer
+    // Same as GPU-AV, we need these to generate details in error message where error occurred in the CmdBuffer
     VkPipelineBindPoint pipeline_bind_point;
     uint32_t action_command_index;
     // Before the draw/dispatch/etc we can save the pipeline/shaderObject that are being used

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1908,7 +1908,7 @@ static void GenerateStageMessage(std::ostringstream& ss, const uint32_t* error_r
     ss << '\n';
 }
 
-// Where we build up the error message with all the useful debug information about where the error occured
+// Where we build up the error message with all the useful debug information about where the error occurred
 std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const uint32_t* error_record,
                                                             const InstrumentedShader* instrumented_shader,
                                                             VkPipelineBindPoint pipeline_bind_point,

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -62,7 +62,7 @@ struct InstrumentedShader {
     VkPipeline pipeline;
     VkShaderModule shader_module;
     VkShaderEXT shader_object;
-    // We keep the original SPIR-V so we can match up where the error occured to map to shader source files
+    // We keep the original SPIR-V so we can match up where the error occurred to map to shader source files
     std::vector<uint32_t> original_spirv;
 };
 

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -357,7 +357,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
                         "GPUAV-Overflow-Unknown", queue, loc,
                         "An error was detected, but after internal limit of %" PRIu32
                         " draw/dispatch/traceRays commands in a command buffer, we are unable to track which validation error "
-                        "occured.\nThis can be adjusted setting env var VK_LAYER_GPUAV_MAX_INDICES_COUNT to a higher value.",
+                        "occurred.\nThis can be adjusted setting env var VK_LAYER_GPUAV_MAX_INDICES_COUNT to a higher value.",
                         gpuav_.gpuav_settings.invalid_index_command);
                     break;  // only report once
                 } else {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -226,7 +226,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     VkPipeline invalidated_state_pipe[CB_DYNAMIC_STATE_STATUS_NUM];
     std::string DescribeInvalidatedState(CBDynamicState dynamic_state) const;
 
-    // Return true if the corresponding vkCmdSet* call has occured in the command buffer.
+    // Return true if the corresponding vkCmdSet* call has occurred in the command buffer.
     // Used for calls like vkCmdSetColorBlendEnableEXT where we have both a VU for
     //   - it was called it at all
     //   - it was called for every attachment

--- a/layers/stateless/sl_tensor.cpp
+++ b/layers/stateless/sl_tensor.cpp
@@ -90,7 +90,7 @@ bool Device::ValidateTensorDescriptionARM(const VkTensorDescriptionARM& descript
                 }
                 i--;
             }
-            // if other errors above occured, i might be zero, but another error will be reported already
+            // if other errors above occurred, i might be zero, but another error will be reported already
             if (!is_packed && i > 0) {
                 skip |= LogError("VUID-VkTensorDescriptionARM-None-09740", device, description_loc,
                                  "does not define a packed tensor: pStrides[%" PRIi64 "] (%" PRIi64 ") != pStrides[%" PRIi64

--- a/scripts/gn/gn.py
+++ b/scripts/gn/gn.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-# Copyright 2023-2024 The Khronos Group Inc.
-# Copyright 2023-2024 Valve Corporation
-# Copyright 2023-2024 LunarG, Inc.
+# Copyright 2023-2026 The Khronos Group Inc.
+# Copyright 2023-2026 Valve Corporation
+# Copyright 2023-2026 LunarG, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -47,7 +47,7 @@ def main():
         print(f'Command {proc_error.cmd} failed with return code {proc_error.returncode}')
         sys.exit(proc_error.returncode)
     except Exception as unknown_error:
-        print(f'An unkown error occured: {unknown_error}')
+        print(f'An unkown error occurred: {unknown_error}')
         sys.exit(1)
 
     sys.exit(0)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2025 Valve Corporation
-# Copyright (c) 2020-2025 LunarG, Inc.
+# Copyright (c) 2020-2026 Valve Corporation
+# Copyright (c) 2020-2026 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -140,7 +140,7 @@ def Build(args):
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
         sys.exit(proc_error.returncode)
     except Exception as unknown_error:
-        print('An unknown error occured: %s', unknown_error)
+        print('An unknown error occurred: %s', unknown_error)
         sys.exit(1)
 
     sys.exit(0)
@@ -236,7 +236,7 @@ def Test(args):
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
         sys.exit(proc_error.returncode)
     except Exception as unknown_error:
-        print('An unknown error occured: %s', unknown_error)
+        print('An unknown error occurred: %s', unknown_error)
         sys.exit(1)
 
     sys.exit(0)

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -610,7 +610,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(VkQueue queue, uint32_t submit
                                                   VkFence fence) {
     // Special way to cause DEVICE_LOST
     // Picked VkExportFenceCreateInfo because needed some struct that wouldn't get cleared by validation Safe Struct
-    // ... TODO - It would be MUCH nicer to have a layer or other setting control when this occured
+    // ... TODO - It would be MUCH nicer to have a layer or other setting control when this occurred
     // For now this is used to allow Validation Layers test reacting to device losts
     if (submitCount > 0 && pSubmits) {
         auto pNext = reinterpret_cast<const VkBaseInStructure*>(pSubmits[0].pNext);

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -5212,3 +5212,44 @@ TEST_F(NegativeCommand, SetPrimitiveRestartIndex) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }
+
+// See https://gitlab.khronos.org/vulkan/vulkan/-/issues/4793
+// You are not allowed to call reset on destroyed objects
+TEST_F(NegativeCommand, DeviceLostInUse) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    RETURN_IF_SKIP(Init());
+    if (!IsPlatformMockICD()) {
+        GTEST_SKIP() << "Test only supported by MockICD";
+    }
+
+    m_command_buffer.Begin();
+    m_command_buffer.End();
+
+    vkt::Fence fence(*m_device);
+
+    // Special way to force VK_ERROR_DEVICE_LOST with MockICD
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkSubmitInfo-pNext-pNext");
+    VkExportFenceCreateInfo fault_injection = vku::InitStructHelper();
+
+    VkSubmitInfo submit_info = vku::InitStructHelper(&fault_injection);
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_command_buffer.handle();
+    VkResult result = vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, fence);
+
+    if (result != VK_ERROR_DEVICE_LOST) {
+        vk::QueueWaitIdle(m_default_queue->handle());
+        GTEST_SKIP() << "No device lost found";
+    }
+
+    m_errorMonitor->SetDesiredError("VUID-vkResetFences-pFences-01123");
+    fence.Reset();
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkResetCommandBuffer-commandBuffer-00045");
+    vk::ResetCommandBuffer(m_command_buffer, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkResetCommandPool-commandPool-00040");
+    vk::ResetCommandPool(*m_device, m_command_pool, 0);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/debug_printf_shader_debug_info.cpp
+++ b/tests/unit/debug_printf_shader_debug_info.cpp
@@ -239,7 +239,7 @@ void main() {
 }
 
 TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndex) {
-    TEST_DESCRIPTION("Make sure we print which index in the command buffer the issue occured");
+    TEST_DESCRIPTION("Make sure we print which index in the command buffer the issue occurred");
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -107,7 +107,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, OpLine) {
 }
 
 TEST_F(NegativeGpuAVShaderDebugInfo, OpLineColumn) {
-    TEST_DESCRIPTION("Make sure the column in OpLine will add value to show which part the error occured");
+    TEST_DESCRIPTION("Make sure the column in OpLine will add value to show which part the error occurred");
 
     const char* shader_source = R"(
                OpCapability Shader
@@ -1450,7 +1450,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderObjectHandle) {
 }
 
 TEST_F(NegativeGpuAVShaderDebugInfo, CommandBufferCommandIndex) {
-    TEST_DESCRIPTION("Make sure we print which index in the command buffer the issue occured");
+    TEST_DESCRIPTION("Make sure we print which index in the command buffer the issue occurred");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);

--- a/tests/unit/sync_val_reporting.cpp
+++ b/tests/unit/sync_val_reporting.cpp
@@ -609,7 +609,7 @@ TEST_F(NegativeSyncValReporting, StaleLabelCommand) {
     m_command_buffer.End();
 
     // This will detect write-after-write hazard. During error reporting debug label
-    // information says that prior read occured after the 4th label command. Attempt
+    // information says that prior read occurred after the 4th label command. Attempt
     // to access those label commands can lead to crash if out of bounds check is missing.
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
     m_default_queue->Submit(m_command_buffer);


### PR DESCRIPTION
From https://discord.com/channels/427551838099996672/1494039063416672276

error message now tell "why" it is "in use"

```
Validation Error: [ VUID-vkResetFences-pFences-01123 ] | MessageID = 0x68a5074e
vkResetFences(): pFences[0] (VkFence 0x40000000004) is in use. 
(a VK_ERROR_DEVICE_LOST has occurred, the fence must be destroyed).

Validation Error: [ VUID-vkResetCommandBuffer-commandBuffer-00045 ] | MessageID = 0x1e7883ea
vkResetCommandBuffer(): (VkCommandBuffer 0x5c68338a9720) is in use.
(a VK_ERROR_DEVICE_LOST has occurred, the command buffers must be freed).

Validation Error: [ VUID-vkResetCommandPool-commandPool-00040 ] | MessageID = 0xb53e2331
vkResetCommandPool(): (VkCommandBuffer 0x5c68338a9720) is in use.
(a VK_ERROR_DEVICE_LOST has occurred, the command pool must be destroyed).
```