### PR TITLE
layers: Add NonSemantic.Shader.DebugInfo.101 support

### DIFF
--- a/layers/error_message/spirv_logging.cpp
+++ b/layers/error_message/spirv_logging.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #include "state_tracker/shader_instruction.h"
-#include <spirv/unified1/NonSemanticShaderDebugInfo100.h>
+#include <spirv/unified1/NonSemanticShaderDebugInfo.h>
 #include <spirv/unified1/spirv.hpp>
 #include "generated/spirv_grammar_helper.h"
 
@@ -46,7 +46,7 @@ struct SpirvLoggingInfo {
     uint32_t line_number_end = 0;
     // sometimes compiler will just give zero here, so will need to ignore then
     uint32_t column_number = 0;
-    bool using_shader_debug_info = false;  // NonSemantic.Shader.DebugInfo.100
+    bool using_shader_debug_info = false;  // NonSemantic.Shader.DebugInfo.*
     std::string reported_filename;
 };
 
@@ -105,7 +105,7 @@ static void ReadDebugSource(const std::vector<uint32_t>& instructions, const uin
         const uint32_t length = Length(instruction);
         const uint32_t opcode = Opcode(instruction);
         if (opcode != spv::OpExtInst || instructions[offset + 2] != debug_source_id ||
-            instructions[offset + 4] != NonSemanticShaderDebugInfo100DebugSource) {
+            instructions[offset + 4] != NonSemanticShaderDebugInfoDebugSource) {
             offset += length;
             continue;
         }
@@ -141,7 +141,7 @@ static void ReadDebugSource(const std::vector<uint32_t>& instructions, const uin
         const uint32_t length = Length(continue_insn);
         const uint32_t opcode = Opcode(continue_insn);
 
-        if (opcode != spv::OpExtInst || instructions[offset + 4] != NonSemanticShaderDebugInfo100DebugSourceContinued) {
+        if (opcode != spv::OpExtInst || instructions[offset + 4] != NonSemanticShaderDebugInfoDebugSourceContinued) {
             break;
         }
 
@@ -344,7 +344,7 @@ void GetShaderSourceInfo(std::ostringstream& ss, const std::vector<uint32_t>& in
         logging_info.line_number_end = logging_info.line_number_start;  // OpLine only give a single line granularity
         logging_info.column_number = last_line_insn.Word(3);
     } else {
-        // NonSemanticShaderDebugInfo100DebugLine
+        // NonSemanticShaderDebugInfoDebugLine
         logging_info.using_shader_debug_info = true;
         logging_info.line_number_start = GetConstantValue(instructions, last_line_insn.Word(6));
         logging_info.line_number_end = GetConstantValue(instructions, last_line_insn.Word(7));
@@ -448,13 +448,13 @@ static uint32_t GetDebugLineOffset(const std::vector<uint32_t>& instructions, ui
 
         if (opcode == spv::OpExtInstImport) {
             const char* str = reinterpret_cast<const char*>(&instructions[offset + 2]);
-            if (strcmp(str, "NonSemantic.Shader.DebugInfo.100") == 0) {
+            if (strncmp(str, "NonSemantic.Shader.DebugInfo.", 29) == 0) {
                 shader_debug_info_set_id = instructions[offset + 1];
             }
         }
 
         if (opcode == spv::OpExtInst && instructions[offset + 3] == shader_debug_info_set_id &&
-            instructions[offset + 4] == NonSemanticShaderDebugInfo100DebugLine) {
+            instructions[offset + 4] == NonSemanticShaderDebugInfoDebugLine) {
             last_line_inst_offset = offset;
         } else if (opcode == spv::OpLine) {
             last_line_inst_offset = offset;
@@ -514,14 +514,14 @@ void FindGlobalName(std::ostringstream& ss, const std::vector<uint32_t>& instruc
 
         if (opcode == spv::OpExtInstImport) {
             const char* str = reinterpret_cast<const char*>(&instructions[offset + 2]);
-            if (strcmp(str, "NonSemantic.Shader.DebugInfo.100") == 0) {
+            if (strncmp(str, "NonSemantic.Shader.DebugInfo.", 29) == 0) {
                 shader_debug_info_set_id = instructions[offset + 1];
             }
         }
 
         // TODO - Currently to find OpTypeStruct (or things like it, we need to actually fully parse the ShaderDebugInfo)
         if (opcode == spv::OpExtInst && instructions[offset + 3] == shader_debug_info_set_id &&
-            instructions[offset + 4] == NonSemanticShaderDebugInfo100DebugGlobalVariable && instructions[offset + 12] == find_id &&
+            instructions[offset + 4] == NonSemanticShaderDebugInfoDebugGlobalVariable && instructions[offset + 12] == find_id &&
             find_opcode == spv::OpVariable) {
             ss << spirv::GetOpString(instructions, instructions[offset + 5]);
             return;

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -33,7 +33,7 @@
 #include "gpuav/shaders/gpuav_error_header.h"
 #include "gpuav/spirv/log_error_pass.h"
 #include "error_message/spirv_logging.h"
-#include <spirv/unified1/NonSemanticShaderDebugInfo100.h>
+#include <spirv/unified1/NonSemanticShaderDebugInfo.h>
 #include <spirv/unified1/spirv.hpp>
 
 #include "state_tracker/pipeline_state.h"

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -31,7 +31,7 @@
 
 #include <spirv/unified1/spirv.hpp>
 #include <spirv/1.2/GLSL.std.450.h>
-#include <spirv/unified1/NonSemanticShaderDebugInfo100.h>
+#include <spirv/unified1/NonSemanticShaderDebugInfo.h>
 #include <vulkan/vulkan_core.h>
 #include "error_message/spirv_logging.h"
 #include "utils/math_utils.h"
@@ -1221,7 +1221,7 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
                         uses_interpolate_at_sample = true;
                     }
                 } else if (set == extended.shader_debug_info) {
-                    if (ext_instruction == NonSemanticShaderDebugInfo100DebugGlobalVariable) {
+                    if (ext_instruction == NonSemanticShaderDebugInfoDebugGlobalVariable) {
                         parsed.debug_global_variables.emplace_back(&insn);
                     }
                 } else if (set == extended.tosa_001000_1) {
@@ -1252,9 +1252,9 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
                 const char* ext_name = insn.GetAsString(2);
                 if (strcmp(ext_name, "GLSL.std.450") == 0) {
                     extended.glsl_std450 = insn.ResultId();
-                } else if (strcmp(ext_name, "NonSemantic.Shader.DebugInfo.100") == 0) {
+                } else if (strncmp(ext_name, "NonSemantic.Shader.DebugInfo.", 29) == 0) {
                     extended.shader_debug_info = insn.ResultId();
-                } else if (strncmp(ext_name, "TOSA.001000.1", strlen("TOSA.001000.1")) == 0) {
+                } else if (strncmp(ext_name, "TOSA.001000.1", 13) == 0) {
                     extended.tosa_001000_1 = insn.ResultId();
                 }
                 break;
@@ -1576,7 +1576,7 @@ std::string Module::DescribeInstruction(const Instruction& error_insn) const {
     for (const auto& insn : static_data_.instructions) {
         const uint32_t opcode = insn.Opcode();
         if (opcode == spv::OpExtInst && insn.Word(3) == static_data_.extended.shader_debug_info &&
-            insn.Word(4) == NonSemanticShaderDebugInfo100DebugLine) {
+            insn.Word(4) == NonSemanticShaderDebugInfoDebugLine) {
             last_line_inst = &insn;
         } else if (opcode == spv::OpLine) {
             last_line_inst = &insn;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -344,7 +344,7 @@ struct VariableBase {
     const VkShaderStageFlagBits stage;
     VariableBase(const Module &module_state, const Instruction &insn, VkShaderStageFlagBits stage, const ParsedInfo &parsed);
 
-    const Instruction* debug_global_variable;  // DebugGlobalVariable from NonSemantic.Shader.DebugInfo.100
+    const Instruction* debug_global_variable;  // DebugGlobalVariable from NonSemantic.Shader.DebugInfo.*
     // We need to store a std::string since the original SPIR-V string can be gone when we need to print this in an error message
     const std::string debug_name;  // OpName or OpString (empty if no debug info found)
 
@@ -728,7 +728,7 @@ struct Module {
         // ID from OpExtInstImport required to know if a OpExtInst is from it
         struct ExtendedInstructionSets {
             uint32_t glsl_std450 = 0;        // GLSL.std.450
-            uint32_t shader_debug_info = 0;  // NonSemantic.Shader.DebugInfo.100
+            uint32_t shader_debug_info = 0;  // NonSemantic.Shader.DebugInfo.*
             uint32_t tosa_001000_1 = 0;      // TOSA.001000.1
         } extended;
 

--- a/layers/vulkan/generated/spirv_tools_commit_id.h
+++ b/layers/vulkan/generated/spirv_tools_commit_id.h
@@ -23,4 +23,4 @@
 
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "8b3a3c79b6ecaae7bd11ff20261aea532ce268c2"
+#define SPIRV_TOOLS_COMMIT_ID "6c0666ec2000ba74ed12df5f6e807a7f721402a1"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -43,7 +43,7 @@
                 "-DSPIRV_SKIP_TESTS=ON",
                 "-DSPIRV_SKIP_EXECUTABLES=OFF"
             ],
-            "commit": "8b3a3c79b6ecaae7bd11ff20261aea532ce268c2"
+            "commit": "6c0666ec2000ba74ed12df5f6e807a7f721402a1"
         },
         {
             "name": "mimalloc",

--- a/tests/unit/shader_debug_info.cpp
+++ b/tests/unit/shader_debug_info.cpp
@@ -767,3 +767,59 @@ void main() {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeShaderDebugInfo, Version101) {
+    // Makes sure the new Revision 101 works, which added 2 new instructions
+    // (We aren't use it, want to make sure OpExtInstImport works)
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
+    RETURN_IF_SKIP(Init());
+
+    const char* source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.101"
+          %3 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %_
+               OpExecutionMode %main LocalSize 1 1 1
+       %file = OpString "in.comp"
+       %text = OpString "#version 450
+layout(set = 0, binding = 0) buffer ssbo { uint y; };
+void main() {
+    atomicStore(y, 1u, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelease);
+}"
+               OpDecorate %ssbo Block
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %_ Binding 0
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+    %uint_68 = OpConstant %uint 68
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %ssbo = OpTypeStruct %uint
+         %18 = OpExtInst %void %1 DebugSource %file %text
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+          %_ = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %48 = OpExtInst %void %1 DebugLine %18 %uint_4 %uint_4 %uint_0 %uint_0
+         %47 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpAtomicStore %47 %int_1 %uint_68 %uint_1
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    // VUID-RuntimeSpirv-vulkanMemoryModel-06265
+    m_errorMonitor->SetDesiredError("Error occurred at in.comp:4");
+    VkShaderObj cs(*m_device, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Makes sure we handle `NonSemantic.Shader.DebugInfo.101` as it is just `NonSemantic.Shader.DebugInfo.100` with new new instructions we don't use