### PR TITLE
layers: Check for destroyed swapchain

### DIFF
--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -91,7 +91,7 @@ void vvl::Fence::NotifyAndWait(const Location& loc) {
                 queue_ = nullptr;
                 seq_ = 0;
                 // Update the swapchain image acquire state if the fence was used by the acquire operation
-                if (acquired_image_swapchain_) {
+                if (acquired_image_swapchain_ && !acquired_image_swapchain_->Destroyed()) {
                     assert(acquired_image_index_ != vvl::kNoIndex32);
                     acquired_image_swapchain_->images[acquired_image_index_].acquire_fence_status = AcquireSyncStatus::WasWaitedOn;
                     acquired_image_swapchain_.reset();

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -134,7 +134,7 @@ void vvl::Semaphore::EnqueueWait(const SubmissionReference& wait_submit, uint64_
     auto guard = WriteLock();
     if (type == VK_SEMAPHORE_TYPE_BINARY) {
         // Update the swapchain image acquire state if the semaphore was used by the acquire operation
-        if (acquired_image_swapchain_) {
+        if (acquired_image_swapchain_ && !acquired_image_swapchain_->Destroyed()) {
             assert(acquired_image_index_ != vvl::kNoIndex32);
             acquired_image_swapchain_->images[acquired_image_index_].acquire_semaphore_status = AcquireSyncStatus::WasWaitedOn;
             acquired_image_swapchain_.reset();

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -3446,3 +3446,38 @@ TEST_F(PositiveWsi, SharedPresentLayout2) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
+
+TEST_F(PositiveWsi, WaitAcquireFenceForDestoryedSwapchain) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12122");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSurface());
+    InitSwapchainInfo();
+
+    const SurfaceInformation surface_info = GetSwapchainInfo(m_surface);
+    const VkSwapchainCreateInfoKHR swapchain_ci = GetDefaultSwapchainCreateInfo(m_surface, surface_info);
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    vkt::Fence fence(*m_device);
+    [[maybe_unused]] const uint32_t image_index = swapchain.AcquireNextImage(fence, kWaitTimeout);
+    swapchain.Destroy();
+    fence.Wait(kWaitTimeout);
+}
+
+TEST_F(PositiveWsi, WaitAcquireSemaphoreForDestoryedSwapchain) {
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSurface());
+    InitSwapchainInfo();
+
+    const SurfaceInformation surface_info = GetSwapchainInfo(m_surface);
+    const VkSwapchainCreateInfoKHR swapchain_ci = GetDefaultSwapchainCreateInfo(m_surface, surface_info);
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    vkt::Semaphore semaphore(*m_device);
+    [[maybe_unused]] const uint32_t image_index = swapchain.AcquireNextImage(semaphore, kWaitTimeout);
+    swapchain.Destroy();
+
+    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(semaphore));
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12122

In the issue the swapchain was destroyed after it was retired (used as oldSwapchain)