### PR TITLE
layers: Fix handling SourceContinue

### DIFF
--- a/layers/error_message/spirv_logging.cpp
+++ b/layers/error_message/spirv_logging.cpp
@@ -50,6 +50,32 @@ struct SpirvLoggingInfo {
     std::string reported_filename;
 };
 
+static void AppendSourceText(const char* text, std::vector<std::string>& out_source_lines) {
+    if (!text) {
+        return;
+    }
+
+    // Handle first line case
+    if (out_source_lines.empty() && text[0] != '\0') {
+        out_source_lines.emplace_back("");
+    }
+
+    for (const char* c = text; *c != '\0'; ++c) {
+        if (*c == '\n') {
+            out_source_lines.emplace_back("");
+        } else if (*c == '\r') {
+            // Look for "\r\n" to avoid double-line breaking
+            if (*(c + 1) == '\n') {
+                continue;
+            }
+            out_source_lines.emplace_back("");
+        } else {
+            // Append to the current "active" line
+            out_source_lines.back() += *c;
+        }
+    }
+};
+
 // Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
 // Split the single string into a vector of strings, one for each line, for easier processing.
 static void ReadOpSource(const std::vector<uint32_t>& instructions, const uint32_t reported_file_id,
@@ -59,22 +85,13 @@ static void ReadOpSource(const std::vector<uint32_t>& instructions, const uint32
         const uint32_t instruction = instructions[offset];
         const uint32_t length = Length(instruction);
         const uint32_t opcode = Opcode(instruction);
-        if (opcode != spv::OpSource || length < 5 || instructions[offset + 3] != reported_file_id) {
-            offset += length;
-            continue;
+        if (opcode == spv::OpSource && length >= 5 && instructions[offset + 3] == reported_file_id) {
+            const char* source_text = reinterpret_cast<const char*>(&instructions[offset + 4]);
+            AppendSourceText(source_text, out_source_lines);
+            offset += length;  // point to next instruction after OpSource
+            break;
         }
-
-        // OpSource has been found
-        std::istringstream in_stream;
-        std::string current_line;
-        const char* str = reinterpret_cast<const char*>(&instructions[offset + 4]);
-        in_stream.str(str);
-        while (std::getline(in_stream, current_line)) {
-            out_source_lines.emplace_back(current_line);
-        }
-
-        offset += length;  // point to next instruction after OpSource
-        break;
+        offset += length;
     }
 
     // Look for OpSourceContinued, it must be right after
@@ -86,13 +103,8 @@ static void ReadOpSource(const std::vector<uint32_t>& instructions, const uint32
             break;
         }
 
-        std::istringstream in_stream;
-        std::string current_line;
-        const char* str = reinterpret_cast<const char*>(&instructions[offset + 1]);
-        in_stream.str(str);
-        while (std::getline(in_stream, current_line)) {
-            out_source_lines.emplace_back(current_line);
-        }
+        const char* continue_text = reinterpret_cast<const char*>(&instructions[offset + 1]);
+        AppendSourceText(continue_text, out_source_lines);
         offset += length;
     }
 }
@@ -104,38 +116,28 @@ static void ReadDebugSource(const std::vector<uint32_t>& instructions, const uin
         const uint32_t instruction = instructions[offset];
         const uint32_t length = Length(instruction);
         const uint32_t opcode = Opcode(instruction);
-        if (opcode != spv::OpExtInst || instructions[offset + 2] != debug_source_id ||
-            instructions[offset + 4] != NonSemanticShaderDebugInfoDebugSource) {
+
+        if (opcode == spv::OpExtInst && instructions[offset + 2] == debug_source_id &&
+            instructions[offset + 4] == NonSemanticShaderDebugInfoDebugSource) {
+            // We have now found the proper OpExtInst DebugSource
+            out_file_string_id = instructions[offset + 5];
+
+            // Optional source Text not provided so nothing left to do
+            if (length >= 7) {
+                const uint32_t string_id = instructions[offset + 6];
+                const char* source_text = spirv::GetOpString(instructions, string_id);
+                if (!source_text) {
+                    return;  // error should be caught in spirv-val, but don't crash here
+                }
+                AppendSourceText(source_text, out_source_lines);
+            }
             offset += length;
-            continue;
+            break;
         }
-
-        // We have now found the proper OpExtInst DebugSource
-        out_file_string_id = instructions[offset + 5];
-
-        // Optional source Text not provided so nothing left to do
-        if (length < 7) {
-            return;
-        }
-
-        const uint32_t string_id = instructions[offset + 6];
-        const char* source_text = spirv::GetOpString(instructions, string_id);
-        if (!source_text) {
-            return;  // error should be caught in spirv-val, but don't crash here
-        }
-
-        std::istringstream in_stream;
-        std::string current_line;
-        in_stream.str(source_text);
-        while (std::getline(in_stream, current_line)) {
-            out_source_lines.emplace_back(current_line);
-        }
-
-        offset += length;  // point to next instruction after OpSource
-        break;
+        offset += length;
     }
 
-    // Look for DebugSourceContinued, it must be right after
+    // Look for any DebugSourceContinued, which must be right after if they exist
     while (offset < instructions.size()) {
         const uint32_t continue_insn = instructions[offset];
         const uint32_t length = Length(continue_insn);
@@ -150,14 +152,7 @@ static void ReadDebugSource(const std::vector<uint32_t>& instructions, const uin
         if (!continue_text) {
             return;  // error should be caught in spirv-val, but don't crash here
         }
-
-        std::istringstream in_stream;
-        std::string current_line;
-        in_stream.str(continue_text);
-        while (std::getline(in_stream, current_line)) {
-            out_source_lines.emplace_back(current_line);
-        }
-
+        AppendSourceText(continue_text, out_source_lines);
         offset += length;
     }
 }

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -178,9 +178,11 @@ TEST_F(NegativeGpuAVShaderDebugInfo, OpSourceContinued) {
           %1 = OpString "a.comp"
                OpSource GLSL 450 %1 "#version 450
 #extension GL_EXT_buffer_reference : enable
-layout(buffer_reference, std430) readonly buffer IndexBuffer { int indices[]; };"
+layout(buffer_reference, std430) readonly buffer IndexBuffer { int indices[]; };
+"
                OpSourceContinued "layout(set = 0, binding = 0) buffer foo { IndexBuffer data; int x; };"
-               OpSourceContinued "void main() {
+               OpSourceContinued "
+void main() {
     x = data.indices[16];
 }"
                OpMemberDecorate %foo 0 Offset 0

--- a/tests/unit/shader_debug_info.cpp
+++ b/tests/unit/shader_debug_info.cpp
@@ -770,7 +770,7 @@ void main() {
 
 TEST_F(NegativeShaderDebugInfo, Version101) {
     // Makes sure the new Revision 101 works, which added 2 new instructions
-    // (We aren't use it, want to make sure OpExtInstImport works)
+    // (We don't use them, but want to make sure OpExtInstImport works)
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
@@ -820,6 +820,130 @@ void main() {
 
     // VUID-RuntimeSpirv-vulkanMemoryModel-06265
     m_errorMonitor->SetDesiredError("Error occurred at in.comp:4");
+    VkShaderObj cs(*m_device, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeShaderDebugInfo, DebugSourceContinued) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
+    RETURN_IF_SKIP(Init());
+
+    const char* source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+          %3 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %_
+               OpExecutionMode %main LocalSize 1 1 1
+       %file = OpString "in.comp"
+       %text = OpString "#version 450
+"
+       %text1 = OpString "layout(set = 0, binding = 0) buffer ssbo { uint y; };"
+       %text2 = OpString "
+void main() {
+"
+       %text3 = OpString "    atomicStore(y, 1u, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelease);
+}"
+               OpDecorate %ssbo Block
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %_ Binding 0
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+    %uint_68 = OpConstant %uint 68
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %ssbo = OpTypeStruct %uint
+
+%debug_source = OpExtInst %void %1 DebugSource %file %text
+          %c1 = OpExtInst %void %1 DebugSourceContinued %text1
+          %c2 = OpExtInst %void %1 DebugSourceContinued %text2
+          %c3 = OpExtInst %void %1 DebugSourceContinued %text3
+
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+          %_ = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %48 = OpExtInst %void %1 DebugLine %debug_source %uint_4 %uint_4 %uint_0 %uint_0
+         %47 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpAtomicStore %47 %int_1 %uint_68 %uint_1
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    // VUID-RuntimeSpirv-vulkanMemoryModel-06265
+    m_errorMonitor->SetDesiredError("4:     atomicStore(y, 1u, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelease);");
+    VkShaderObj cs(*m_device, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeShaderDebugInfo, DebugSourceContinuedNoNewLine) {
+    TEST_DESCRIPTION("Found that DebugSourceContinued does not mean a new-line");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
+    RETURN_IF_SKIP(Init());
+
+    const char* source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+          %3 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %_
+               OpExecutionMode %main LocalSize 1 1 1
+       %file = OpString "in.comp"
+       %text = OpString "#version 450
+layout(set = 0, binding = 0) buffer ssbo {uint y;};
+void main() {
+    atomicStore(y, 1u, gl_ScopeDevice, "
+    ; The line is continued here
+    %text1 = OpString "gl_StorageSemanticsBuffer,"
+    %text2 = OpString " gl_SemanticsRelease);
+}"
+               OpDecorate %ssbo Block
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %_ Binding 0
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+    %uint_68 = OpConstant %uint 68
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %ssbo = OpTypeStruct %uint
+
+%debug_source = OpExtInst %void %1 DebugSource %file %text
+          %c1 = OpExtInst %void %1 DebugSourceContinued %text1
+          %c2 = OpExtInst %void %1 DebugSourceContinued %text2
+
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+          %_ = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %48 = OpExtInst %void %1 DebugLine %debug_source %uint_4 %uint_4 %uint_0 %uint_0
+         %47 = OpAccessChain %_ptr_StorageBuffer_uint %_ %int_0
+               OpAtomicStore %47 %int_1 %uint_68 %uint_1
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    // VUID-RuntimeSpirv-vulkanMemoryModel-06265
+    m_errorMonitor->SetDesiredError("4:     atomicStore(y, 1u, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelease);");
     VkShaderObj cs(*m_device, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
When using `OpSourceContinued` or `DebugSourceContinued` I made the wrong assumption that each instruction is a new line, but really it is just continuing the line, so needed to redo the string logic to append to the previous line in some cases