### PR TITLE
sync: Fix WaitForFences for destroyed swapchain

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -249,15 +249,11 @@ void SyncValidator::UpdateFenceHostSyncPoint(VkFence fence, FenceHostSyncPoint&&
 }
 
 void SyncValidator::WaitForFence(VkFence fence) {
-    auto fence_it = waitable_fences_.find(fence);
-    if (fence_it != waitable_fences_.end()) {
-        // The fence may no longer be waitable for several valid reasons.
+    if (auto fence_it = waitable_fences_.find(fence); fence_it != waitable_fences_.end()) {
         FenceHostSyncPoint& wait_for = fence_it->second;
-        if (wait_for.acquired.Invalid()) {
-            // This is just a normal fence wait
+        if (wait_for.queue_id != kQueueIdInvalid) {
             ApplyTaggedWait(wait_for.queue_id, wait_for.tag, {}, wait_for.queue_sync_tags);
-        } else {
-            // This a fence wait for a present operation
+        } else if (!wait_for.acquired.Invalid()) {
             ApplyAcquireWait(wait_for.acquired);
         }
         waitable_fences_.erase(fence_it);

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -1118,3 +1118,19 @@ TEST_F(PositiveSyncValWsi, ConcurrentPresentAndSubmit) {
     thread.join();
     monitor_.SetBailout(nullptr);
 }
+
+TEST_F(PositiveSyncValWsi, WaitAcquireFenceForDestoryedSwapchain) {
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(InitSyncVal());
+    RETURN_IF_SKIP(InitSurface());
+    InitSwapchainInfo();
+
+    const SurfaceInformation surface_info = GetSwapchainInfo(m_surface);
+    const VkSwapchainCreateInfoKHR swapchain_ci = GetDefaultSwapchainCreateInfo(m_surface, surface_info);
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    vkt::Fence fence(*m_device);
+    [[maybe_unused]] const uint32_t image_index = swapchain.AcquireNextImage(fence, kWaitTimeout);
+    swapchain.Destroy();
+    fence.Wait(kWaitTimeout);
+}


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12126. @ziga-lunarg applied the same exploit to syncval.

`SyncValidator::WaitForFence` was broken. It decided that if there is no swapchain it has to be a queue wait. But it was a swapchain acquire wait, it just the swapchain was deleted.