### PR TITLE
layers: Fix DEVICE_LOST message typo

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -634,7 +634,7 @@ bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location& loc, const
 
         skip |= LogError(vuid, device, loc, "%s is already in use and is not marked for simultaneous use.%s",
                          FormatHandle(cb_state).c_str(),
-                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the queue must be used)" : "");
+                         is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the command buffer must be freed)" : "");
     }
     return skip;
 }


### PR DESCRIPTION
from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12118#pullrequestreview-4156762423