### PR TITLE
layers: Remove dynamic rendering submit time layout check

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -1121,67 +1121,6 @@ bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuf
     return skip;
 }
 
-void CoreChecks::EnqueueValidateDynamicRenderingImageBarrierLayouts(const Location barrier_loc, vvl::CommandBuffer& cb_state,
-                                                                    const ImageBarrier& image_barrier) {
-    if (!cb_state.active_render_pass || !cb_state.active_render_pass->UsesDynamicRendering()) {
-        return;
-    }
-    const VkRenderingInfo& rendering_info = *cb_state.active_render_pass->dynamic_rendering_begin_rendering_info.ptr();
-    std::shared_ptr<const CommandBufferImageLayoutMap> image_layout_map = cb_state.GetImageLayoutMap(image_barrier.image);
-
-    auto& cb_sub_state = core::SubState(cb_state);
-
-    auto process_image_view = [&image_barrier, &image_layout_map, &cb_sub_state,
-                               &barrier_loc](const vvl::ImageView& image_view_state) {
-        // Skip attachments that use different image than a barrier
-        if (image_barrier.image != image_view_state.image_state->VkHandle()) {
-            return;
-        }
-        // Skip images that already have image layout specified so layout validation was done at record time
-        if (image_layout_map) {
-            auto any_range_pred = [](const LayoutRange&, const ImageLayoutState&) { return true; };
-            if (ForEachMatchingLayoutMapRange(*image_layout_map, RangeGenerator(image_view_state.range_generator),
-                                              any_range_pred)) {
-                return;
-            }
-        }
-        // Enqueue distinct subresource ranges for this image.
-        // Then during submit time the layouts of these subresources are validated against allowed values
-        auto& enqueued_subresources = cb_sub_state.submit_validate_dynamic_rendering_barrier_subresources[image_barrier.image];
-        auto it = std::find_if(enqueued_subresources.begin(), enqueued_subresources.end(), [&image_view_state](const auto& entry) {
-            return entry.first == image_view_state.normalized_subresource_range;
-        });
-        if (it == enqueued_subresources.end()) {
-            enqueued_subresources.emplace_back(
-                std::make_pair(image_view_state.normalized_subresource_range, vvl::LocationCapture(barrier_loc)));
-        }
-    };
-
-    for (auto color_attachment_idx : GetUsedColorAttachments(cb_state)) {
-        if (color_attachment_idx >= rendering_info.colorAttachmentCount) {
-            continue;
-        }
-        const auto& color_attachment = rendering_info.pColorAttachments[color_attachment_idx];
-        if (const auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView)) {
-            process_image_view(*image_view_state);
-        }
-    }
-    if (rendering_info.pDepthAttachment) {
-        const AttachmentInfo& attachment =
-            cb_state.active_attachments[cb_state.GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Depth)];
-        if (attachment.image_view) {
-            process_image_view(*attachment.image_view);
-        }
-    }
-    if (rendering_info.pStencilAttachment) {
-        const AttachmentInfo& attachment =
-            cb_state.active_attachments[cb_state.GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type::Stencil)];
-        if (attachment.image_view) {
-            process_image_view(*attachment.image_view);
-        }
-    }
-}
-
 void CoreChecks::RecordTransitionImageLayout(vvl::CommandBuffer& cb_state, const ImageBarrier& mem_barrier,
                                              const vvl::Image& image_state) {
     if (enabled_features.synchronization2) {

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -636,11 +636,8 @@ void CommandBufferSubState::RecordBarriers(uint32_t buffer_barrier_count, const 
         Location barrier_loc(loc.function, vvl::Struct::VkImageMemoryBarrier, vvl::Field::pImageMemoryBarriers, i);
         const ImageBarrier img_barrier(image_barriers[i], src_stage_mask, dst_stage_mask);
         validator.RecordBarrierValidationInfo(barrier_loc, base, img_barrier, *image_state, qfo_transfer_image_barriers);
-        validator.EnqueueValidateImageBarrierAttachment(barrier_loc, *this, img_barrier);
-        validator.EnqueueValidateDynamicRenderingImageBarrierLayouts(barrier_loc, base, img_barrier);
-
-        // Update layouts at the end. Submit time enqueuing logic above needs pre-update layout map.
         validator.RecordTransitionImageLayout(base, img_barrier, *image_state);
+        validator.EnqueueValidateImageBarrierAttachment(barrier_loc, *this, img_barrier);
     }
 }
 
@@ -657,11 +654,8 @@ void CommandBufferSubState::RecordBarriers2(const VkDependencyInfo& dep_info, co
         Location barrier_loc(loc.function, vvl::Struct::VkImageMemoryBarrier2, vvl::Field::pImageMemoryBarriers, i);
         const ImageBarrier img_barrier(dep_info.pImageMemoryBarriers[i]);
         validator.RecordBarrierValidationInfo(barrier_loc, base, img_barrier, *image_state, qfo_transfer_image_barriers);
-        validator.EnqueueValidateImageBarrierAttachment(barrier_loc, *this, img_barrier);
-        validator.EnqueueValidateDynamicRenderingImageBarrierLayouts(barrier_loc, base, img_barrier);
-
-        // Update layouts at the end. Submit time enqueuing logic above needs pre-update layout map.
         validator.RecordTransitionImageLayout(base, img_barrier, *image_state);
+        validator.EnqueueValidateImageBarrierAttachment(barrier_loc, *this, img_barrier);
     }
     if (const auto tensor_barrier_dep_info = vku::FindStructInPNextChain<VkTensorDependencyInfoARM>(dep_info.pNext)) {
         const Location tensor_dep_info_loc(loc.function, vvl::Struct::VkTensorDependencyInfoARM, vvl::Field::pNext);
@@ -1083,7 +1077,6 @@ void CommandBufferSubState::ResetCBState() {
 
     // Submit time validation
     queue_submit_functions.clear();
-    submit_validate_dynamic_rendering_barrier_subresources.clear();
     event_updates.clear();
     cmd_execute_commands_functions.clear();
     query_updates.clear();
@@ -1180,47 +1173,8 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
     }
 }
 
-void CommandBufferSubState::SubmitTimeValidate() {
-    for (const auto& [image, subresources] : submit_validate_dynamic_rendering_barrier_subresources) {
-        const auto image_state = validator.Get<vvl::Image>(image);
-        if (!image_state) {
-            continue;
-        }
-        const auto global_layout_map = image_state->layout_map.get();
-        ASSERT_AND_CONTINUE(global_layout_map);
-        auto global_layout_map_guard = image_state->LayoutMapReadLock();
-
-        for (const std::pair<VkImageSubresourceRange, vvl::LocationCapture>& entry : subresources) {
-            const VkImageSubresourceRange& subresource = entry.first;
-            const Location& barrier_loc = entry.second.Get();
-            subresource_adapter::RangeGenerator range_gen(image_state->subresource_encoder, subresource);
-            ForEachMatchingLayoutMapRange(
-                *global_layout_map, std::move(range_gen),
-                [this, &barrier_loc, &image_state](const ImageLayoutMap::key_type& range, const VkImageLayout& layout) {
-                    if (layout != VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ && layout != VK_IMAGE_LAYOUT_GENERAL) {
-                        const auto& vuid =
-                            GetDynamicRenderingBarrierVUID(barrier_loc, vvl::DynamicRenderingBarrierError::kImageLayout);
-                        const LogObjectList objlist(base.Handle(), image_state->Handle());
-                        const Location& image_loc = barrier_loc.dot(vvl::Field::image);
-                        const VkImageSubresource subresource =
-                            static_cast<VkImageSubresource>(image_state->subresource_encoder.Decode(range.begin));
-                        return validator.LogError(vuid, objlist, image_loc, "(%s, %s) has layout %s.",
-                                                  validator.FormatHandle(image_state->Handle()).c_str(),
-                                                  string_VkImageSubresource(subresource).c_str(), string_VkImageLayout(layout));
-                    }
-                    return false;
-                });
-        }
-    }
-}
-
 void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
     for (const auto& submission : submissions) {
-        for (auto& cb : submission.cb_submissions) {
-            auto guard = cb.cb->ReadLock();
-            CommandBufferSubState& cb_substate = SubState(*cb.cb);
-            cb_substate.SubmitTimeValidate();
-        }
         submit_time_tracker->ProcessQueueSubmission(VkHandle(), submission);
     }
 }

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -132,8 +132,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     void RecordExecuteCommand(vvl::CommandBuffer &secondary_command_buffer, uint32_t cmd_index, const Location &loc) final;
 
-    // Called from the Queue state
-    void SubmitTimeValidate();
     // Called from the Command Buffer state
     void Submit(vvl::Queue &queue_state, uint32_t perf_submit_pass, const Location &loc) final;
 
@@ -201,10 +199,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     // Validation functions run at primary CB queue submit time
     using QueueCallback = std::function<bool(const class vvl::Queue &queue_state, const vvl::CommandBuffer &cb_state)>;
     std::vector<QueueCallback> queue_submit_functions;
-
-    // The subresources from dynamic rendering barriers that can't be validated during record time.
-    vvl::unordered_map<VkImage, std::vector<std::pair<VkImageSubresourceRange, vvl::LocationCapture>>>
-        submit_validate_dynamic_rendering_barrier_subresources;
 
     using EventCallback = std::function<bool(vvl::CommandBuffer &cb_state, bool do_validate, EventMap &local_event_signal_info,
                                              VkQueue waiting_queue, const Location &loc)>;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -336,8 +336,6 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidatePipelineVertexDivisors(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     void EnqueueValidateImageBarrierAttachment(const Location& loc, core::CommandBufferSubState& cb_sub_state,
                                                const ImageBarrier& barrier);
-    void EnqueueValidateDynamicRenderingImageBarrierLayouts(const Location barrier_loc, vvl::CommandBuffer& cb_state,
-                                                            const ImageBarrier& image_barrier);
     bool ValidateImageBarrierAttachment(const Location& barrier_loc, vvl::CommandBuffer const& cb_state,
                                         const vvl::Framebuffer& fb_state, uint32_t active_subpass,
                                         const vku::safe_VkSubpassDescription2& sub_desc, const VkRenderPass rp_handle,


### PR DESCRIPTION
Originally introduced here: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10083.
Validation was at submit time and the tests did queue->Submit() to validate.

Then https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10946 discovered it's always possible to do this at record time - attachment config specifies layout, so it's tracked inside the command buffer. Then, the general image layout submit time validation can detect if there's a mismatch with attachment info's layout . The tests were updated to catch VUIDs at record time, but submit time functionality was not removed.