### PR TITLE
layers: Move invalidating pipeline/shaderObject to LastBound

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1562,7 +1562,8 @@ void CommandBuffer::RecordExecuteGeneratedCommands(const VkGeneratedCommandsInfo
 }
 
 void CommandBuffer::RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipeline& pipeline) {
-    BindLastBoundPipeline(ConvertToVvlBindPoint(bind_point), &pipeline);
+    auto& last_bound = lastBound[ConvertToVvlBindPoint(bind_point)];
+    last_bound.BindPipeline(&pipeline);
 
     for (auto& item : sub_states_) {
         item.second->RecordBindPipeline(bind_point, pipeline);
@@ -1625,6 +1626,11 @@ void CommandBuffer::RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipe
     }
 
     dirty_static_state = false;
+}
+
+void CommandBuffer::RecordBindShaderObject(VkShaderStageFlagBits shader_stage, vvl::ShaderObject* shader_object_state) {
+    auto& last_bound = lastBound[ConvertStageToVvlBindPoint(shader_stage)];
+    last_bound.BindShaderObject(shader_stage, shader_object_state);
 }
 
 // Helper for descriptor set (and buffer) updates.
@@ -2379,21 +2385,6 @@ bool CommandBuffer::HasExternalFormatResolveAttachment() const {
                VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID;
     }
     return false;
-}
-
-void CommandBuffer::InvalidateShaderObjects(VkPipelineBindPoint pipeline_bind_point) {
-    auto& last_bound = lastBound[ConvertToVvlBindPoint(pipeline_bind_point)];
-    for (uint32_t i = 0; i < kShaderObjectStageCount; ++i) {
-        last_bound.shader_object_bound[i] = false;
-        last_bound.shader_object_states[i] = nullptr;
-    }
-}
-
-void CommandBuffer::BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject* shader_object_state) {
-    auto& last_bound_state = lastBound[ConvertStageToVvlBindPoint(shader_stage)];
-    const auto stage_index = static_cast<uint32_t>(VkShaderStageToShaderObjectStage(shader_stage));
-    last_bound_state.shader_object_bound[stage_index] = true;
-    last_bound_state.shader_object_states[stage_index] = shader_object_state;
 }
 
 // Only called for Graphics and during Multiview

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -712,6 +712,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordSetDepthCompareOp(VkCompareOp depth_compare_op);
     void RecordSetDepthTestEnable(VkBool32 depth_test_enable);
     void RecordBindPipeline(VkPipelineBindPoint bind_point, vvl::Pipeline &pipeline);
+    void RecordBindShaderObject(VkShaderStageFlagBits shader_stage, vvl::ShaderObject* shader_object_state);
 
     void RecordBindIndexbuffer(const Location& loc);
     void RecordSetPrimitiveRestartIndex(uint32_t primitive_restart_index, const Location& loc);
@@ -812,12 +813,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     uint32_t GetViewMask() const;
 
     bool HasExternalFormatResolveAttachment() const;
-
-    inline void BindLastBoundPipeline(vvl::BindPoint bind_point, vvl::Pipeline *pipe_state) {
-        lastBound[bind_point].pipeline_state = pipe_state;
-    }
-    void InvalidateShaderObjects(VkPipelineBindPoint pipeline_bind_point);
-    void BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject *shader_object_state);
 
     bool IsPrimary() const { return allocate_info.level == VK_COMMAND_BUFFER_LEVEL_PRIMARY; }
     bool IsSecondary() const { return allocate_info.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY; }

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -46,6 +46,26 @@ void LastBound::UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorS
 
 bool LastBound::IsDynamic(const CBDynamicState state) const { return !pipeline_state || pipeline_state->IsDynamic(state); }
 
+void LastBound::BindPipeline(vvl::Pipeline* pipe_state) {
+    pipeline_state = pipe_state;
+
+    // Mark any previous shader object binds as invalidated vkspec.html#shaders-objects-pipeline-interaction
+    for (uint32_t i = 0; i < kShaderObjectStageCount; ++i) {
+        shader_object_bound[i] = false;
+        shader_object_states[i] = nullptr;
+    }
+}
+
+void LastBound::BindShaderObject(VkShaderStageFlagBits shader_stage, vvl::ShaderObject* shader_object_state) {
+    const auto stage_index = static_cast<uint32_t>(VkShaderStageToShaderObjectStage(shader_stage));
+    shader_object_bound[stage_index] = true;
+    shader_object_states[stage_index] = shader_object_state;
+
+    // We use this to mark any previous pipeline bounds are invalidated now
+    // vkspec.html#shaders-objects-pipeline-interaction
+    pipeline_state = nullptr;
+}
+
 void LastBound::Reset() {
     pipeline_state = nullptr;
     for (uint32_t i = 0; i < kShaderObjectStageCount; ++i) {

--- a/layers/state_tracker/last_bound_state.h
+++ b/layers/state_tracker/last_bound_state.h
@@ -84,6 +84,9 @@ struct LastBound {
     // Ordered bound set tracking where index is set# that given set is bound to
     std::vector<DescriptorSetSlot> ds_slots;
 
+    void BindPipeline(vvl::Pipeline* pipe_state);
+    void BindShaderObject(VkShaderStageFlagBits shader_stage, vvl::ShaderObject* shader_object_state);
+
     void Reset();
 
     void UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorSet> &&ds);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1924,11 +1924,8 @@ void DeviceState::PostCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer,
         if (pShaders && pShaders[i] != VK_NULL_HANDLE) {
             shader_object_state = Get<ShaderObject>(pShaders[i]).get();
         }
-        cb_state->BindShader(pStages[i], shader_object_state);
 
-        // We use this to mark any previous pipeline bounds are invalidated now
-        // vkspec.html#shaders-objects-pipeline-interaction
-        cb_state->BindLastBoundPipeline(ConvertStageToVvlBindPoint(pStages[i]), nullptr);
+        cb_state->RecordBindShaderObject(pStages[i], shader_object_state);
     }
 }
 
@@ -2696,9 +2693,6 @@ void DeviceState::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, V
     auto pipeline_state = Get<Pipeline>(pipeline);
     ASSERT_AND_RETURN(pipeline_state);
     cb_state->RecordBindPipeline(pipelineBindPoint, *pipeline_state);
-
-    // Mark any previous shader object binds as invalidated vkspec.html#shaders-objects-pipeline-interaction
-    cb_state->InvalidateShaderObjects(pipelineBindPoint);
 
     if (!disabled[command_buffer_state]) {
         cb_state->AddChild(pipeline_state);


### PR DESCRIPTION
follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12139#discussion_r3132290333

We have the `LastBound` class to track... the last bound stuff, it should be in charge of invalidating the pipeline/shaderObject, not the `vvl::CommandBuffer` object

This moves this logic into `LastBound`