### PR TITLE
layers: Add render pass creation, dynamic rendering, and per-tile exe…

### DIFF
--- a/layers/chassis/dispatch_object.h
+++ b/layers/chassis/dispatch_object.h
@@ -5,6 +5,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (c) 2015-2026 Google Inc.
  * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -119,6 +120,7 @@ struct DeviceExtensionProperties {
     VkPhysicalDevicePerformanceCountersByRegionPropertiesARM renderpass_counter_by_region_props;
     VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT ray_tracing_invocation_reorder_props;
     VkPhysicalDeviceShaderLongVectorPropertiesEXT shader_long_vector_props;
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props;
 };
 
 // This object holds all static state for the device (device properties, enabled extensions/features, etc.)

--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -4,6 +4,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -495,6 +496,8 @@ StatelessDeviceData::StatelessDeviceData(DispatchInstance* instance, VkPhysicalD
                                              &phys_dev_ext_props.renderpass_counter_by_region_props);
     instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_ext_shader_long_vector,
                                              &phys_dev_ext_props.shader_long_vector_props);
+    instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_qcom_tile_shading,
+                                             &phys_dev_ext_props.tile_shading_props);
 
     // None of these "check if supported" features are possible without first having gpdp2 first
     if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -2067,6 +2067,47 @@ bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingInherited(const vvl::
     return skip;
 }
 
+bool CoreChecks::PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                            const VkPerTileBeginInfoQCOM* pPerTileBeginInfo,
+                                                            const ErrorObject& error_obj) const {
+    bool skip = false;
+    const auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto rp_state = cb_state->active_render_pass;
+
+    if (rp_state && !rp_state->has_tile_shading_enabled) {
+        const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
+        skip |= LogError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10664", objlist, error_obj.location,
+                         "current render pass doesn't have tile shading enabled.");
+    }
+
+    return skip;
+}
+
+bool CoreChecks::PreCallValidateCmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                           const VkPerTileEndInfoQCOM* pPerTileEndInfo,
+                                                           const ErrorObject& error_obj) const {
+    bool skip = false;
+    const auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
+    const auto rp_state = cb_state->active_render_pass;
+
+    if (rp_state) {
+        if (!cb_state->per_tile_execution_model_enabled) {
+            const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
+            skip |= LogError("VUID-vkCmdEndPerTileExecutionQCOM-None-10666", objlist, error_obj.location,
+                             "the command buffer doesn't have the per-tile execution model enabled "
+                             "in the current render pass.");
+        }
+
+        if (!rp_state->has_tile_shading_enabled) {
+            const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
+            skip |= LogError("VUID-vkCmdEndPerTileExecutionQCOM-None-10667", objlist, error_obj.location,
+                             "current render pass doesn't have tile shading enabled.");
+        }
+    }
+
+    return skip;
+}
+
 bool CoreChecks::PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo,
                                                        const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -2077,7 +2077,8 @@ bool CoreChecks::PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer com
     if (rp_state && !rp_state->has_tile_shading_enabled) {
         const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
         skip |= LogError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10664", objlist, error_obj.location,
-                         "current render pass doesn't have tile shading enabled.");
+                         "current render pass doesn't have tile shading enabled. (Can be enabled by using "
+                         "VkRenderPassTileShadingCreateInfoQCOM)");
     }
 
     return skip;
@@ -2095,13 +2096,14 @@ bool CoreChecks::PreCallValidateCmdEndPerTileExecutionQCOM(VkCommandBuffer comma
             const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
             skip |= LogError("VUID-vkCmdEndPerTileExecutionQCOM-None-10666", objlist, error_obj.location,
                              "the command buffer doesn't have the per-tile execution model enabled "
-                             "in the current render pass.");
+                             "in the current render pass. (Did you forget to call vkCmdBeginPerTileExecutionQCOM)");
         }
 
         if (!rp_state->has_tile_shading_enabled) {
             const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
             skip |= LogError("VUID-vkCmdEndPerTileExecutionQCOM-None-10667", objlist, error_obj.location,
-                             "current render pass doesn't have tile shading enabled.");
+                             "current render pass doesn't have tile shading enabled. (Can be enabled by using "
+                             "VkRenderPassTileShadingCreateInfoQCOM)");
         }
     }
 

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -2067,6 +2067,57 @@ bool CoreChecks::ValidateCmdExecuteCommandsDynamicRenderingInherited(const vvl::
     return skip;
 }
 
+bool CoreChecks::PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                            const VkPerTileBeginInfoQCOM* pPerTileBeginInfo,
+                                                            const ErrorObject& error_obj) const {
+    bool skip = false;
+
+    if (!enabled_features.tileShadingPerTileDispatch && !enabled_features.tileShadingPerTileDraw) {
+        skip |= LogError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10665", commandBuffer, error_obj.location,
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDispatch and "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDraw features are not enabled.");
+    }
+
+    const auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
+    ASSERT_AND_RETURN_SKIP(cb_state);
+    const auto rp_state = cb_state->active_render_pass;
+    ASSERT_AND_RETURN_SKIP(rp_state);
+
+    if (!rp_state->has_tile_shading_enabled) {
+        const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
+        skip |= LogError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10664", objlist, error_obj.location,
+                         "current render pass doesn't have tile shading enabled.");
+    }
+
+    return skip;
+}
+
+bool CoreChecks::PreCallValidateCmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                           const VkPerTileEndInfoQCOM* pPerTileEndInfo,
+                                                           const ErrorObject& error_obj) const {
+    bool skip = false;
+
+    const auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
+    ASSERT_AND_RETURN_SKIP(cb_state);
+    const auto rp_state = cb_state->active_render_pass;
+    ASSERT_AND_RETURN_SKIP(rp_state);
+
+    if (!cb_state->per_tile_execution_model_enabled) {
+        const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
+        skip |= LogError("VUID-vkCmdEndPerTileExecutionQCOM-None-10666", objlist, error_obj.location,
+                         "the command buffer doesn't have the per-tile execution model enabled "
+                         "in the current render pass.");
+    }
+
+    if (!rp_state->has_tile_shading_enabled) {
+        const LogObjectList objlist(cb_state->Handle(), rp_state->Handle());
+        skip |= LogError("VUID-vkCmdEndPerTileExecutionQCOM-None-10667", objlist, error_obj.location,
+                         "current render pass doesn't have tile shading enabled.");
+    }
+
+    return skip;
+}
+
 bool CoreChecks::PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo,
                                                        const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -654,6 +655,15 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
                                                                        pRenderPassBegin->renderArea, rp_begin_loc);
     }
 
+    if (error_obj.location.function != Func::vkCmdBeginRenderPass) {
+        const auto* rp_tile_shading_ci =
+            vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(rp_state->create_info.pNext);
+        if (rp_tile_shading_ci) {
+            skip |= ValidateRenderPassTileShadingCreateInfo(commandBuffer, nullptr, *rp_tile_shading_ci,
+                                                            rp_begin_loc.dot(Field::renderPass).dot(Field::pCreateInfo));
+        }
+    }
+
     return skip;
 }
 
@@ -773,6 +783,12 @@ bool CoreChecks::ValidateCmdEndRenderPass(const vvl::CommandBuffer& cb_state, co
         skip |= LogError(vuid, objlist, error_obj.location,
                          "query %" PRIu32 " from %s was began in subpass %" PRIu32 " but never ended.", query.slot,
                          FormatHandle(query.pool).c_str(), query.subpass);
+    }
+
+    if (cb_state.per_tile_execution_model_enabled) {
+        const LogObjectList objlist(cb_state.Handle(), rp_state.Handle());
+        skip |= LogError("VUID-vkCmdEndRenderPass-None-10653", objlist, error_obj.location,
+                         "per-tile execution model is still enabled in this command buffer.");
     }
 
     return skip;
@@ -3923,6 +3939,11 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             commandBuffer, *counters_begin_info, objlist, 1u, layer_or_view_count, pRenderingInfo->renderArea, rendering_info_loc);
     }
 
+    if (const auto* rp_tile_shading_ci =
+            vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(pRenderingInfo->pNext)) {
+        skip |= ValidateRenderPassTileShadingCreateInfo(commandBuffer, pRenderingInfo, *rp_tile_shading_ci, rendering_info_loc);
+    }
+
     return skip;
 }
 
@@ -4540,6 +4561,61 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer
     return skip;
 }
 
+bool CoreChecks::ValidateRenderPassTileShadingCreateInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
+                                                         const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                         const Location& loc_before_next) const {
+    bool skip = false;
+    const bool has_rp_enable_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0;
+
+    if (pRenderingInfo) {
+        const bool has_rp_per_tile_exec_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0;
+        const auto* fragment_density_map_info =
+                vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(pRenderingInfo->pNext);
+        if (fragment_density_map_info && fragment_density_map_info->imageView != nullptr && has_rp_enable_bit) {
+            const LogObjectList objlist(commandBuffer, fragment_density_map_info->imageView);
+            skip |= LogError("VUID-VkRenderingInfo-imageView-10643", objlist,
+                             loc_before_next.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
+                             "is not VK_NULL_HANDLE, but VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes "
+                             "VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
+                             string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+        }
+
+        for (uint32_t index = 0; index < pRenderingInfo->colorAttachmentCount; ++index) {
+            if (pRenderingInfo->pColorAttachments[index].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID &&
+                has_rp_enable_bit) {
+                const LogObjectList objlist(commandBuffer, pRenderingInfo->pColorAttachments[index].resolveImageView);
+                skip |= LogError("VUID-VkRenderingInfo-resolveMode-10644", objlist,
+                                 loc_before_next.dot(Field::pColorAttachments, index).dot(Field::resolveMode),
+                                 "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID, but "
+                                 "VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit",
+                                 string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+            }
+        }
+
+        if (has_rp_per_tile_exec_bit) {
+            skip |= LogError("VUID-vkCmdBeginRendering-flags-10642", commandBuffer,
+                             loc_before_next.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                             "(%s) includes VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit.",
+                             string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+        }
+    }
+
+    const auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
+    ASSERT_AND_RETURN_SKIP(cb_state);
+
+    if (has_rp_enable_bit && (cb_state->begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) != 0) {
+        const char* vuid = (pRenderingInfo) ? "VUID-vkCmdBeginRendering-flags-10641" : "VUID-vkCmdBeginRenderPass2-flags-10652";
+        skip |= LogError(vuid, commandBuffer,
+                         loc_before_next.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, but commandBuffer "
+                         "has been recorded with VkCommandBufferUsageFlags (%s).",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str(),
+                         string_VkCommandBufferUsageFlags(cb_state->begin_info_flags).c_str());
+    }
+
+    return skip;
+}
+
 // Flags validation error if the associated call is made inside a render pass. The apiName routine should ONLY be called outside a
 // render pass.
 bool CoreChecks::InsideRenderPass(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
@@ -4628,6 +4704,10 @@ bool CoreChecks::ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, con
         skip |=
             LogError(vuid, objlist, error_obj.location, "query %" PRIu32 " from %s was began in the render pass, but never ended.",
                      query.slot, FormatHandle(query.pool).c_str());
+    }
+    if (cb_state.per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdEndRendering-None-10645", cb_state.Handle(), error_obj.location,
+                         "per-tile execution model is still enabled in this command buffer.");
     }
 
     return skip;

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -654,6 +655,21 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
                                                                        pRenderPassBegin->renderArea, rp_begin_loc);
     }
 
+    if ((cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) != 0) {
+        if (const auto* rp_tile_shading_ci =
+                vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(rp_state->create_info.pNext)) {
+            if ((rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0) {
+                const LogObjectList objlist(commandBuffer, pRenderPassBegin->renderPass);
+                skip |= LogError("VUID-vkCmdBeginRenderPass2-flags-10652", objlist,
+                                 rp_begin_loc.dot(Field::renderPass),
+                                 "has been created with VkTileShadingRenderPassFlagsQCOM (%s), but commandBuffer "
+                                 "is being recorded with VkCommandBufferUsageFlags (%s).",
+                                 string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str(),
+                                 string_VkCommandBufferUsageFlags(cb_state.begin_info_flags).c_str());
+            }
+        }
+    }
+
     return skip;
 }
 
@@ -773,6 +789,12 @@ bool CoreChecks::ValidateCmdEndRenderPass(const vvl::CommandBuffer& cb_state, co
         skip |= LogError(vuid, objlist, error_obj.location,
                          "query %" PRIu32 " from %s was began in subpass %" PRIu32 " but never ended.", query.slot,
                          FormatHandle(query.pool).c_str(), query.subpass);
+    }
+
+    if (cb_state.per_tile_execution_model_enabled) {
+        const LogObjectList objlist(cb_state.Handle(), rp_state.Handle());
+        skip |= LogError("VUID-vkCmdEndRenderPass-None-10653", objlist, error_obj.location,
+                         "per-tile execution model is still enabled in this command buffer.");
     }
 
     return skip;
@@ -3923,6 +3945,11 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             commandBuffer, *counters_begin_info, objlist, 1u, layer_or_view_count, pRenderingInfo->renderArea, rendering_info_loc);
     }
 
+    if (const auto* rp_tile_shading_ci =
+            vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(pRenderingInfo->pNext)) {
+        skip |= ValidateBeginRenderingTileShadingCreateInfo(*cb_state, *pRenderingInfo, *rp_tile_shading_ci, rendering_info_loc);
+    }
+
     return skip;
 }
 
@@ -4540,6 +4567,55 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer
     return skip;
 }
 
+bool CoreChecks::ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                             const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                             const Location& rendering_info_loc) const {
+    bool skip = false;
+    const bool has_rp_enable_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0;
+    const bool has_rp_per_tile_exec_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0;
+    const auto* fragment_density_map_info =
+            vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext);
+
+    if (fragment_density_map_info && fragment_density_map_info->imageView != VK_NULL_HANDLE && has_rp_enable_bit) {
+        const LogObjectList objlist(cb_state.Handle(), fragment_density_map_info->imageView);
+        skip |= LogError("VUID-VkRenderingInfo-imageView-10643", objlist,
+                         rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
+                         "is not VK_NULL_HANDLE, but VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes "
+                         "VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+    }
+
+    for (uint32_t index = 0; index < rendering_info.colorAttachmentCount; ++index) {
+        if (rendering_info.pColorAttachments[index].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID &&
+            has_rp_enable_bit) {
+            const LogObjectList objlist(cb_state.Handle(), rendering_info.pColorAttachments[index].resolveImageView);
+            skip |= LogError("VUID-VkRenderingInfo-resolveMode-10644", objlist,
+                             rendering_info_loc.dot(Field::pColorAttachments, index).dot(Field::resolveMode),
+                             "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID, but "
+                             "VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit",
+                             string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+        }
+    }
+
+    if (has_rp_enable_bit && (cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) != 0) {
+        skip |= LogError("VUID-vkCmdBeginRendering-flags-10641", cb_state.Handle(),
+                         rendering_info_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, but commandBuffer "
+                         "is being recorded with VkCommandBufferUsageFlags (%s).",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str(),
+                         string_VkCommandBufferUsageFlags(cb_state.begin_info_flags).c_str());
+    }
+
+    if (has_rp_per_tile_exec_bit) {
+        skip |= LogError("VUID-vkCmdBeginRendering-flags-10642", cb_state.Handle(),
+                         rendering_info_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+    }
+
+    return skip;
+}
+
 // Flags validation error if the associated call is made inside a render pass. The apiName routine should ONLY be called outside a
 // render pass.
 bool CoreChecks::InsideRenderPass(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const {
@@ -4628,6 +4704,10 @@ bool CoreChecks::ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, con
         skip |=
             LogError(vuid, objlist, error_obj.location, "query %" PRIu32 " from %s was began in the render pass, but never ended.",
                      query.slot, FormatHandle(query.pool).c_str());
+    }
+    if (cb_state.per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdEndRendering-None-10645", cb_state.Handle(), error_obj.location,
+                         "per-tile execution model is still enabled in this command buffer.");
     }
 
     return skip;

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -794,7 +794,8 @@ bool CoreChecks::ValidateCmdEndRenderPass(const vvl::CommandBuffer& cb_state, co
     if (cb_state.per_tile_execution_model_enabled) {
         const LogObjectList objlist(cb_state.Handle(), rp_state.Handle());
         skip |= LogError("VUID-vkCmdEndRenderPass-None-10653", objlist, error_obj.location,
-                         "per-tile execution model is still enabled in this command buffer.");
+                         "per-tile execution model is still enabled in this command buffer. (Did you forget to call "
+                         "vkCmdEndPerTileExecutionQCOM)");
     }
 
     return skip;
@@ -4707,7 +4708,8 @@ bool CoreChecks::ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, con
     }
     if (cb_state.per_tile_execution_model_enabled) {
         skip |= LogError("VUID-vkCmdEndRendering-None-10645", cb_state.Handle(), error_obj.location,
-                         "per-tile execution model is still enabled in this command buffer.");
+                         "per-tile execution model is still enabled in this command buffer. (Did you forget to call "
+                         "vkCmdEndPerTileExecutionQCOM)");
     }
 
     return skip;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (C) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022-2025 RasterGrid Kft.
  *
@@ -1727,6 +1728,9 @@ class CoreChecks : public vvl::DeviceProxy {
                                                  const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
                                                          const Location& rendering_info_loc) const;
+    bool ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                     const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                     const Location& rendering_info_loc) const;
     bool PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,
                                              const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
@@ -2125,6 +2129,13 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
                                              const VkRenderPassFragmentDensityMapOffsetEndInfoEXT& fdm_offset_end_info,
                                              const Location& end_info_loc) const;
+
+    bool PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                     const VkPerTileBeginInfoQCOM* pPerTileBeginInfo,
+                                                     const ErrorObject& error_obj) const override;
+    bool PreCallValidateCmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                   const VkPerTileEndInfoQCOM* pPerTileEndInfo,
+                                                   const ErrorObject& error_obj) const override;
 
     class ViewportScissorInheritanceTracker;
     bool PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBuffersCount,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (C) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022-2025 RasterGrid Kft.
  *
@@ -1727,6 +1728,9 @@ class CoreChecks : public vvl::DeviceProxy {
                                                  const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
                                                          const Location& rendering_info_loc) const;
+    bool ValidateRenderPassTileShadingCreateInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
+                                                 const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                 const Location& loc_before_next) const;
     bool PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,
                                              const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
@@ -2125,6 +2129,13 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
                                              const VkRenderPassFragmentDensityMapOffsetEndInfoEXT& fdm_offset_end_info,
                                              const Location& end_info_loc) const;
+
+    bool PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                     const VkPerTileBeginInfoQCOM* pPerTileBeginInfo,
+                                                     const ErrorObject& error_obj) const override;
+    bool PreCallValidateCmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                   const VkPerTileEndInfoQCOM* pPerTileEndInfo,
+                                                   const ErrorObject& error_obj) const override;
 
     class ViewportScissorInheritanceTracker;
     bool PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBuffersCount,

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (c) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020,2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -323,6 +324,7 @@ void CommandBuffer::ResetCBState() {
 
     has_render_pass_instance = false;
     resumes_render_pass_instance = false;
+    per_tile_execution_model_enabled = false;
     last_suspend_state = SuspendState::Empty;
     first_action_or_sync_command = Func::Empty;
     first_rendering_info = {};
@@ -895,6 +897,7 @@ void CommandBuffer::RecordEndRenderPass(const VkSubpassEndInfo* subpass_end_info
     SetActiveSubpass(0);
     active_framebuffer = VK_NULL_HANDLE;
     sample_locations_begin_info = {};
+    per_tile_execution_model_enabled = false;
 }
 
 static void InitDefaultRenderingAttachments(CommandBuffer::RenderingAttachment& attachments, uint32_t count) {
@@ -1061,6 +1064,7 @@ void CommandBuffer::RecordEndRendering(const VkRenderingEndInfoEXT* pRenderingEn
     RecordCommand(loc);
     active_render_pass = nullptr;
     active_color_attachments_index.clear();
+    per_tile_execution_model_enabled = false;
 }
 
 void CommandBuffer::RecordBeginCustomResolve(const Location& loc) {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (c) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020,2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -318,6 +319,7 @@ void CommandBuffer::ResetCBState() {
 
     has_render_pass_instance = false;
     resumes_render_pass_instance = false;
+    per_tile_execution_model_enabled = false;
     last_suspend_state = SuspendState::Empty;
     first_action_or_sync_command = Func::Empty;
     first_rendering_info = {};
@@ -890,6 +892,7 @@ void CommandBuffer::RecordEndRenderPass(const VkSubpassEndInfo* subpass_end_info
     SetActiveSubpass(0);
     active_framebuffer = VK_NULL_HANDLE;
     sample_locations_begin_info = {};
+    per_tile_execution_model_enabled = false;
 }
 
 static void InitDefaultRenderingAttachments(CommandBuffer::RenderingAttachment& attachments, uint32_t count) {
@@ -1056,6 +1059,7 @@ void CommandBuffer::RecordEndRendering(const VkRenderingEndInfoEXT* pRenderingEn
     RecordCommand(loc);
     active_render_pass = nullptr;
     active_color_attachments_index.clear();
+    per_tile_execution_model_enabled = false;
 }
 
 void CommandBuffer::RecordBeginCustomResolve(const Location& loc) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (C) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020,2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -433,6 +434,11 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
 
     // True if the *first* render pass instance specifies VK_RENDERING_RESUMING_BIT
     bool resumes_render_pass_instance;
+
+    // Set to true when invokes vkCmdBeginPerTileExecutionQCOM
+    // Set to false when invokes vkCmdEndPerTileExecutionQCOM
+    // Also reset to false in ResetCBState, RecordEndRenderPass, RecordEndRendering
+    bool per_tile_execution_model_enabled;
 
     // During recording, this tracks the current suspension state of the command buffer.
     // When recording ends, this is the suspension state at the end of the command buffer.

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (C) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020,2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -433,6 +434,9 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
 
     // True if the *first* render pass instance specifies VK_RENDERING_RESUMING_BIT
     bool resumes_render_pass_instance;
+
+    // Track VK_QCOM_tile_shading (vkCmdBeginPerTileExecutionQCOM and vkCmdEndPerTileExecutionQCOM)
+    bool per_tile_execution_model_enabled;
 
     // During recording, this tracks the current suspension state of the command buffer.
     // When recording ends, this is the suspension state at the end of the command buffer.

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -291,6 +292,20 @@ static bool IsRenderPassMultiViewEnabled(const VkRenderPassCreateInfo2& renderpa
     return is_multiview_enabled;
 }
 
+static bool IsRenderPassTileShadingEnabled(const VkRenderPassCreateInfo2& render_pass_ci) {
+    // From the spec:
+    // To enable tile shading for a render pass object, add a VkRenderPassTileShadingCreateInfoQCOM
+    // to the pNext chain of VkRenderPassCreateInfo or VkRenderPassCreateInfo2.
+    return vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(render_pass_ci.pNext) != nullptr;
+}
+
+static bool IsRenderPassTileShadingEnabled(const VkRenderingInfo& rendering_info) {
+    // From the spec:
+    // To enable tile shading for a dynamic render pass, add a VkRenderPassTileShadingCreateInfoQCOM
+    // to the pNext chain of VkRenderingInfo.
+    return vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(rendering_info.pNext) != nullptr;
+}
+
 static void InitRenderPassState(vvl::RenderPass& render_pass) {
     auto create_info = render_pass.create_info.ptr();
 
@@ -324,7 +339,8 @@ RenderPass::RenderPass(VkRenderPass handle, VkRenderPassCreateInfo2 const* pCrea
       use_dynamic_rendering(false),
       use_dynamic_rendering_inherited(false),
       dynamic_rendering_color_attachment_count(0),
-      has_multiview_enabled(IsRenderPassMultiViewEnabled(*create_info.ptr())) {
+      has_multiview_enabled(IsRenderPassMultiViewEnabled(*create_info.ptr())),
+      has_tile_shading_enabled(IsRenderPassTileShadingEnabled(*create_info.ptr())) {
     InitRenderPassState(*this);
 }
 
@@ -340,7 +356,8 @@ RenderPass::RenderPass(VkRenderPass handle, VkRenderPassCreateInfo const* pCreat
       use_dynamic_rendering(false),
       use_dynamic_rendering_inherited(false),
       dynamic_rendering_color_attachment_count(0),
-      has_multiview_enabled(IsRenderPassMultiViewEnabled(*create_info.ptr())) {
+      has_multiview_enabled(IsRenderPassMultiViewEnabled(*create_info.ptr())),
+      has_tile_shading_enabled(IsRenderPassTileShadingEnabled(*create_info.ptr())) {
     InitRenderPassState(*this);
 }
 
@@ -352,7 +369,8 @@ RenderPass::RenderPass(const VkPipelineRenderingCreateInfo& rendering_ci)
       use_dynamic_rendering_inherited(false),
       dynamic_pipeline_rendering_create_info(&rendering_ci),
       dynamic_rendering_color_attachment_count(rendering_ci.colorAttachmentCount),
-      has_multiview_enabled(rendering_ci.viewMask != 0) {}
+      has_multiview_enabled(rendering_ci.viewMask != 0),
+      has_tile_shading_enabled(false) {}
 
 bool RenderPass::UsesColorAttachment(uint32_t subpass_num) const {
     bool result = false;
@@ -433,7 +451,8 @@ RenderPass::RenderPass(const VkRenderingInfo& rendering_info)
       use_dynamic_rendering_inherited(false),
       dynamic_rendering_begin_rendering_info(&rendering_info),
       dynamic_rendering_color_attachment_count(dynamic_rendering_begin_rendering_info.colorAttachmentCount),
-      has_multiview_enabled(rendering_info.viewMask != 0u) {}
+      has_multiview_enabled(rendering_info.viewMask != 0u),
+      has_tile_shading_enabled(IsRenderPassTileShadingEnabled(rendering_info)) {}
 
 // vkBeginCommandBuffer (dynamic rendering in secondary command buffer)
 RenderPass::RenderPass(VkCommandBufferInheritanceRenderingInfo const* pInheritanceRenderingInfo)
@@ -442,7 +461,8 @@ RenderPass::RenderPass(VkCommandBufferInheritanceRenderingInfo const* pInheritan
       use_dynamic_rendering_inherited(true),
       inheritance_rendering_info(pInheritanceRenderingInfo),
       dynamic_rendering_color_attachment_count(inheritance_rendering_info.colorAttachmentCount),
-      has_multiview_enabled(false) {}
+      has_multiview_enabled(false),
+      has_tile_shading_enabled(false) {}
 
 Framebuffer::Framebuffer(VkFramebuffer handle, const VkFramebufferCreateInfo* pCreateInfo, std::shared_ptr<RenderPass>&& rpstate,
                          std::vector<std::shared_ptr<vvl::ImageView>>&& attachments)

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,6 +88,7 @@ class RenderPass : public StateObject {
     const uint32_t dynamic_rendering_color_attachment_count;
 
     const bool has_multiview_enabled;
+    const bool has_tile_shading_enabled;
 
     // For each subpass, indices into pDependencies for that subpass's self-dependencies
     const std::vector<std::vector<uint32_t>> self_dependencies;  // [subpassCount]

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (c) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020,2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -3867,6 +3868,18 @@ void DeviceState::PostCallRecordCmdBindTileMemoryQCOM(VkCommandBuffer commandBuf
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     // The bound tile memory can be reset by the application
     cb_state->bound_tile_memory = pTileMemoryBindInfo ? Get<vvl::DeviceMemory>(pTileMemoryBindInfo->memory) : nullptr;
+}
+
+void DeviceState::PostCallRecordCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo,
+                                                             const RecordObject& record_obj) {
+    auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
+    cb_state->per_tile_execution_model_enabled = true;
+}
+
+void DeviceState::PostCallRecordCmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo,
+                                                           const RecordObject& record_obj) {
+    auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
+    cb_state->per_tile_execution_model_enabled = false;
 }
 
 void DeviceState::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
  * Copyright (c) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020,2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -3865,6 +3866,18 @@ void DeviceState::PostCallRecordCmdBindTileMemoryQCOM(VkCommandBuffer commandBuf
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     // The bound tile memory can be reset by the application
     cb_state->bound_tile_memory = pTileMemoryBindInfo ? Get<vvl::DeviceMemory>(pTileMemoryBindInfo->memory) : nullptr;
+}
+
+void DeviceState::PostCallRecordCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo,
+                                                             const RecordObject& record_obj) {
+    auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
+    cb_state->per_tile_execution_model_enabled = true;
+}
+
+void DeviceState::PostCallRecordCmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo,
+                                                           const RecordObject& record_obj) {
+    auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
+    cb_state->per_tile_execution_model_enabled = false;
 }
 
 void DeviceState::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfoKHR* pRenderingInfo,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2025 Google Inc.
  * Copyright (C) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2020,2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -1357,6 +1358,10 @@ class DeviceState : public vvl::BaseDevice {
                                                         const RecordObject& record_obj) override;
     void PostCallRecordCmdBindTileMemoryQCOM(VkCommandBuffer commandBuffer, const VkTileMemoryBindInfoQCOM* pTileMemoryBindInfo,
                                              const RecordObject& record_obj) override;
+    void PostCallRecordCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkPerTileBeginInfoQCOM* pPerTileBeginInfo,
+                                                    const RecordObject& record_obj) override;
+    void PostCallRecordCmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkPerTileEndInfoQCOM* pPerTileEndInfo,
+                                                  const RecordObject& record_obj) override;
     void PostCallRecordCmdBindDescriptorSets2(VkCommandBuffer commandBuffer,
                                               const VkBindDescriptorSetsInfo* pBindDescriptorSetsInfo,
                                               const RecordObject& record_obj) override;

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +64,72 @@ bool Device::ValidateSubpassGraphicsFlags(const VkRenderPassCreateInfo2& create_
     return skip;
 }
 
+bool Device::ValidateRenderPassTileShadingCreateInfo(const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                     const Location& rp_tile_shading_loc) const {
+    bool skip = false;
+    const bool has_rp_enable_bit = ((rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0);
+    const bool has_rp_per_tile_exec_bit = ((rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0);
+    const bool disable_tile_shading_per_tile = (!enabled_features.tileShadingPerTileDispatch && !enabled_features.tileShadingPerTileDraw);
+
+    if (!enabled_features.tileShading && has_rp_enable_bit) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShading-10658", device,
+                         rp_tile_shading_loc.dot(Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, but "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShading feature is not enabled.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+    }
+    if ((!enabled_features.tileShadingApron || !has_rp_enable_bit) &&
+        (rp_tile_shading_ci.tileApronSize.width != 0 || rp_tile_shading_ci.tileApronSize.height != 0)) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10659", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize),
+                         "are (%s), but VkRenderPassTileShadingCreateInfoQCOM::flags is (%s) "
+                         "and VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingApron feature is (%s).",
+                         string_VkExtent2D(rp_tile_shading_ci.tileApronSize).c_str(),
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str(),
+                         string_VkBool32(enabled_features.tileShadingApron).c_str());
+    }
+    if ((disable_tile_shading_per_tile || !has_rp_enable_bit) && has_rp_per_tile_exec_bit) {
+        std::stringstream conditional_ss{};
+        if (disable_tile_shading_per_tile) {
+            conditional_ss << "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDispatch and "
+                              "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDraw features are not enabled";
+        }
+        if (has_rp_enable_bit) {
+            conditional_ss << (disable_tile_shading_per_tile ? ", and " : "")
+                           << "flags also includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit";
+        }
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10660", device,
+                         rp_tile_shading_loc.dot(Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit, but %s.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str(),
+                         conditional_ss.str().c_str());
+    }
+    if (!enabled_features.tileShadingAnisotropicApron &&
+        (rp_tile_shading_ci.tileApronSize.width != rp_tile_shading_ci.tileApronSize.height)) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShadingAnisotropicApron-10661", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize),
+                         "are (%s), width isn't equal to height, but "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingAnisotropicApron feature is not enabled.",
+                         string_VkExtent2D(rp_tile_shading_ci.tileApronSize).c_str());
+    }
+    if (rp_tile_shading_ci.tileApronSize.width > phys_dev_ext_props.tile_shading_props.maxApronSize) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10662", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize).dot(Field::width),
+                         "(%" PRIu32 ") is greater than "
+                         "VkPhysicalDeviceTileShadingPropertiesQCOM::maxApronSize (%" PRIu32 ").",
+                         rp_tile_shading_ci.tileApronSize.width, phys_dev_ext_props.tile_shading_props.maxApronSize);
+    }
+    if (rp_tile_shading_ci.tileApronSize.height > phys_dev_ext_props.tile_shading_props.maxApronSize) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10663", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize).dot(Field::height),
+                         "(%" PRIu32 ") is greater than "
+                         "VkPhysicalDeviceTileShadingPropertiesQCOM::maxApronSize (%" PRIu32 ").",
+                         rp_tile_shading_ci.tileApronSize.height, phys_dev_ext_props.tile_shading_props.maxApronSize);
+    }
+
+    return skip;
+}
+
 bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info, const ErrorObject& error_obj) const {
     bool skip = false;
     const bool use_rp2 = error_obj.location.function != Func::vkCreateRenderPass;
@@ -73,6 +140,35 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     android_external_format_resolve_feature = enabled_features.externalFormatResolve;
 #endif
+
+    const auto* rp_tile_shading_ci =
+        vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(create_info.pNext);
+
+    if (rp_tile_shading_ci) {
+        const Location rp_tile_shading_loc = create_info_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM);
+        const auto* fragment_density_map_info =
+            vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
+        skip |= ValidateRenderPassTileShadingCreateInfo(*rp_tile_shading_ci, rp_tile_shading_loc);
+        if ((rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0) {
+            vuid = use_rp2 ? "VUID-vkCreateRenderPass2-flags-10649" : "VUID-vkCreateRenderPass-flags-10646";
+            skip |= LogError(vuid, device, rp_tile_shading_loc.dot( Field::flags),
+                             "(%s) includes VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit.",
+                             string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+        }
+        if (fragment_density_map_info &&
+            fragment_density_map_info->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED &&
+            (rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0) {
+            vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-fragmentDensityMapAttachment-10651" :
+                             "VUID-VkRenderPassCreateInfo-fragmentDensityMapAttachment-10648";
+            const Location fragment_density_map_loc = create_info_loc.pNext(Struct::VkRenderPassFragmentDensityMapCreateInfoEXT,
+                                                                            Field::fragmentDensityMapAttachment);
+            skip |= LogError(vuid, device, fragment_density_map_loc.dot(Field::attachment),
+                             "is (%" PRIu32 "), but VkRenderPassTileShadingCreateInfoQCOM::flags (%s) "
+                             "includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
+                             fragment_density_map_info->fragmentDensityMapAttachment.attachment,
+                             string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+        }
+    }
 
     for (uint32_t i = 0; i < create_info.attachmentCount; ++i) {
         const Location& attachment_loc = create_info_loc.dot(Field::pAttachments, i);
@@ -382,6 +478,58 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info
             skip |= LogError(vuid, device, create_info_loc.dot(Field::pSubpasses, i).dot(Field::inputAttachmentCount),
                              "(%" PRIu32 ") is greater than maxPerStageDescriptorInputAttachments (%" PRIu32 ").",
                              subpass_desc.inputAttachmentCount, phys_dev_props.limits.maxPerStageDescriptorInputAttachments);
+        }
+
+        if ((subpass_desc.flags & VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM) != 0) {
+            if (!rp_tile_shading_ci) {
+                std::stringstream conditional_ss{};
+                vuid = use_rp2 ? "VUID-VkSubpassDescription2-flags-10683" : "VUID-VkSubpassDescription-flags-10683";
+                conditional_ss << (use_rp2 ? "VkRenderPassCreateInfo2" : "VkRenderPassCreateInfo")
+                               << "::pNext chain doesn't include VkRenderPassTileShadingCreateInfoQCOM instance";
+                skip |= LogError(vuid, device,
+                                 create_info_loc.dot(Field::pSubpasses, i).dot(Field::flags),
+                                 "(%s) includes VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM bit, but %s.",
+                                 string_VkSubpassDescriptionFlags(subpass_desc.flags).c_str(),
+                                 conditional_ss.str().c_str());
+            }
+            else if (rp_tile_shading_ci->tileApronSize.width == 0 || rp_tile_shading_ci->tileApronSize.height == 0) {
+                vuid = use_rp2 ? "VUID-VkSubpassDescription2-flags-10683" : "VUID-VkSubpassDescription-flags-10683";
+                skip |= LogError(vuid, device,
+                                 create_info_loc.dot(Field::pSubpasses, i).dot(Field::flags),
+                                 "(%s) includes VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM bit, but "
+                                 "VkRenderPassTileShadingCreateInfoQCOM::tileApronSize are (%s).",
+                                 string_VkSubpassDescriptionFlags(subpass_desc.flags).c_str(),
+                                 string_VkExtent2D(rp_tile_shading_ci->tileApronSize).c_str());
+            }
+        }
+
+        if (!rp_tile_shading_ci || !(rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM)) {
+            continue;
+        }
+
+        for (uint32_t j = 0; j < subpass_desc.colorAttachmentCount; ++j) {
+            if (!subpass_desc.pResolveAttachments) {
+                continue;
+            }
+
+            auto const &attachment_ref = subpass_desc.pResolveAttachments[j];
+            if (attachment_ref.attachment == VK_ATTACHMENT_UNUSED ||
+                attachment_ref.attachment >= create_info.attachmentCount) {
+                continue;
+            }
+
+            const VkFormat attachment_format = create_info.pAttachments[attachment_ref.attachment].format;
+            if (attachment_format == VK_FORMAT_UNDEFINED) {
+                vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-pResolveAttachments-10650" :
+                                 "VUID-VkRenderPassCreateInfo-pResolveAttachments-10647";
+                skip |= LogError(vuid, device,
+                                 create_info_loc.dot(Field::pSubpasses, i).dot(Field::pResolveAttachments, j),
+                                 "references attachment description (%" PRIu32 ") with a format of VK_FORMAT_UNDEFINED, "
+                                 "while VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes "
+                                 "VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
+                                 attachment_ref.attachment,
+                                 string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+            }
         }
     }
 
@@ -830,6 +978,12 @@ bool Device::manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
             vku::FindStructInPNextChain<VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM>(pRenderingInfo->pNext)) {
         skip |= ValidateMultiviewPerViewRenderAreasRenderPassBeginInfo(commandBuffer, nullptr, pRenderingInfo,
                                                                        *multiview_per_view_info, rendering_info_loc);
+    }
+
+    if (const auto* rp_tile_shading_ci =
+            vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(pRenderingInfo->pNext)) {
+        const Location rp_tile_shading_loc = rendering_info_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM);
+        skip |= ValidateRenderPassTileShadingCreateInfo(*rp_tile_shading_ci, rp_tile_shading_loc);
     }
 
     skip |= ValidateRenderPassStripeBeginInfo(commandBuffer, pRenderingInfo->pNext, pRenderingInfo->renderArea, rendering_info_loc);

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2026 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +64,71 @@ bool Device::ValidateSubpassGraphicsFlags(const VkRenderPassCreateInfo2& create_
     return skip;
 }
 
+bool Device::ValidateRenderPassTileShadingCreateInfo(const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                     const Location& rp_tile_shading_loc) const {
+    bool skip = false;
+    const bool has_rp_enable_bit = ((rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0);
+    const bool has_rp_per_tile_exec_bit = ((rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0);
+    const bool disable_tile_shading_per_tile = (!enabled_features.tileShadingPerTileDispatch && !enabled_features.tileShadingPerTileDraw);
+    if (!enabled_features.tileShading && has_rp_enable_bit) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShading-10658", device,
+                         rp_tile_shading_loc.dot(Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, while "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShading feature is not enabled.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
+    }
+    if ((!enabled_features.tileShadingApron || !has_rp_enable_bit) &&
+        (rp_tile_shading_ci.tileApronSize.width != 0 || rp_tile_shading_ci.tileApronSize.height != 0)) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10659", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize),
+                         "are (%" PRIu32 ", %" PRIu32 "), while VkRenderPassTileShadingCreateInfoQCOM::flags is (%s) "
+                         "and VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingApron feature is (%s).",
+                         rp_tile_shading_ci.tileApronSize.width, rp_tile_shading_ci.tileApronSize.height,
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str(),
+                         string_VkBool32(enabled_features.tileShadingApron).c_str());
+    }
+    if ((disable_tile_shading_per_tile || !has_rp_enable_bit) && has_rp_per_tile_exec_bit) {
+        std::stringstream conditional_ss{};
+        if (disable_tile_shading_per_tile) {
+            conditional_ss << "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDispatch and "
+                              "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDraw features are not enabled";
+        }
+        if (has_rp_enable_bit) {
+            conditional_ss << (disable_tile_shading_per_tile ? ", and " : "")
+                           << "flags includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit";
+        }
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10660", device,
+                         rp_tile_shading_loc.dot(Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit, but %s.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str(),
+                         conditional_ss.str().c_str());
+    }
+    if (!enabled_features.tileShadingAnisotropicApron &&
+        (rp_tile_shading_ci.tileApronSize.width != rp_tile_shading_ci.tileApronSize.height)) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShadingAnisotropicApron-10661", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize),
+                         "are (%" PRIu32 ", %" PRIu32 "), width isn't equal to height, while"
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingAnisotropicApron feature is not enabled.",
+                         rp_tile_shading_ci.tileApronSize.width, rp_tile_shading_ci.tileApronSize.height);
+    }
+    if (rp_tile_shading_ci.tileApronSize.width > phys_dev_ext_props.tile_shading_props.maxApronSize) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10662", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize).dot(Field::width),
+                         "(%" PRIu32 ") is greater than "
+                         "VkPhysicalDeviceTileShadingPropertiesQCOM::maxApronSize (%" PRIu32 ").",
+                         rp_tile_shading_ci.tileApronSize.width, phys_dev_ext_props.tile_shading_props.maxApronSize);
+    }
+    if (rp_tile_shading_ci.tileApronSize.height > phys_dev_ext_props.tile_shading_props.maxApronSize) {
+        skip |= LogError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10663", device,
+                         rp_tile_shading_loc.dot(Field::tileApronSize).dot(Field::height),
+                         "(%" PRIu32 ") is greater than "
+                         "VkPhysicalDeviceTileShadingPropertiesQCOM::maxApronSize (%" PRIu32 ").",
+                         rp_tile_shading_ci.tileApronSize.height, phys_dev_ext_props.tile_shading_props.maxApronSize);
+    }
+
+    return skip;
+}
+
 bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info, const ErrorObject& error_obj) const {
     bool skip = false;
     const bool use_rp2 = error_obj.location.function != Func::vkCreateRenderPass;
@@ -73,6 +139,40 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     android_external_format_resolve_feature = enabled_features.externalFormatResolve;
 #endif
+
+    const auto* fragment_density_map_info =
+        vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
+    const auto* rp_tile_shading_ci =
+        vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(create_info.pNext);
+    const bool has_rp_enable_bit = rp_tile_shading_ci ? (rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0 :
+                                                        false;
+    const VkExtent2D tile_apron_size = rp_tile_shading_ci ? rp_tile_shading_ci->tileApronSize : VkExtent2D{0, 0};
+
+    if (rp_tile_shading_ci) {
+        const Location rp_tile_shading_loc = create_info_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM);
+        skip |= ValidateRenderPassTileShadingCreateInfo(*rp_tile_shading_ci, rp_tile_shading_loc);
+    }
+
+    if (rp_tile_shading_ci && (rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0) {
+        const char* vuid = use_rp2 ? "VUID-vkCreateRenderPass2-flags-10649" : "VUID-vkCreateRenderPass-flags-10646";
+        skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                         "(%s) includes VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+    }
+
+    if (fragment_density_map_info && fragment_density_map_info->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED &&
+        has_rp_enable_bit) {
+        const char* vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-fragmentDensityMapAttachment-10651" :
+                                     "VUID-VkRenderPassCreateInfo-fragmentDensityMapAttachment-10648";
+        const Location fragment_density_map_loc = create_info_loc.pNext(Struct::VkRenderPassFragmentDensityMapCreateInfoEXT,
+                                                                        Field::fragmentDensityMapAttachment);
+        const Location fragment_density_map_attachment_loc = fragment_density_map_loc.dot(Field::attachment);
+        skip |= LogError(vuid, device, fragment_density_map_attachment_loc,
+                         "is (%" PRIu32 "), but VkRenderPassTileShadingCreateInfoQCOM::flags (%s) "
+                         "includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
+                         fragment_density_map_info->fragmentDensityMapAttachment.attachment,
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+    }
 
     for (uint32_t i = 0; i < create_info.attachmentCount; ++i) {
         const Location& attachment_loc = create_info_loc.dot(Field::pAttachments, i);
@@ -382,6 +482,55 @@ bool Device::ValidateCreateRenderPass(const VkRenderPassCreateInfo2& create_info
             skip |= LogError(vuid, device, create_info_loc.dot(Field::pSubpasses, i).dot(Field::inputAttachmentCount),
                              "(%" PRIu32 ") is greater than maxPerStageDescriptorInputAttachments (%" PRIu32 ").",
                              subpass_desc.inputAttachmentCount, phys_dev_props.limits.maxPerStageDescriptorInputAttachments);
+        }
+
+        if ((subpass_desc.flags & VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM) != 0 &&
+            (tile_apron_size.width == 0 || tile_apron_size.height == 0)) {
+            std::stringstream conditional_ss{};
+            const char* vuid = use_rp2 ? "VUID-VkSubpassDescription2-flags-10683" : "VUID-VkSubpassDescription-flags-10683";
+            if (!rp_tile_shading_ci) {
+                conditional_ss << (use_rp2 ? "VkRenderPassCreateInfo2" : "VkRenderPassCreateInfo")
+                               << "::pNext chain doesn't include VkRenderPassTileShadingCreateInfoQCOM instance";
+            }
+            else {
+                conditional_ss << "VkRenderPassTileShadingCreateInfoQCOM::tileApronSize are ("
+                               << std::to_string(rp_tile_shading_ci->tileApronSize.width)
+                               << ", " << std::to_string(rp_tile_shading_ci->tileApronSize.height) << ")";
+            }
+            skip |= LogError(vuid, device,
+                             create_info_loc.dot(Field::pSubpasses, i).dot(Field::flags),
+                             "(%s) includes VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM bit, but %s.",
+                             string_VkSubpassDescriptionFlags(subpass_desc.flags).c_str(),
+                             conditional_ss.str().c_str());
+        }
+
+        if (!has_rp_enable_bit) {
+            continue;
+        }
+
+        for (uint32_t j = 0; j < subpass_desc.colorAttachmentCount; ++j) {
+            if (!subpass_desc.pResolveAttachments) {
+                continue;
+            }
+
+            auto const &attachment_ref = subpass_desc.pResolveAttachments[j];
+            if (attachment_ref.attachment == VK_ATTACHMENT_UNUSED ||
+                attachment_ref.attachment >= create_info.attachmentCount) {
+                continue;
+            }
+
+            const VkFormat attachment_format = create_info.pAttachments[attachment_ref.attachment].format;
+            if (attachment_format == VK_FORMAT_UNDEFINED) {
+                const char *vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-pResolveAttachments-10650" :
+                                             "VUID-VkRenderPassCreateInfo-pResolveAttachments-10647";
+                skip |= LogError(vuid, device,
+                                 create_info_loc.dot(Field::pSubpasses, i).dot(Field::pResolveAttachments, j),
+                                 "references attachment description (%" PRIu32 ") with a format of VK_FORMAT_UNDEFINED, "
+                                 "while VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes "
+                                 "VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
+                                 attachment_ref.attachment,
+                                 string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+            }
         }
     }
 
@@ -830,6 +979,12 @@ bool Device::manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
             vku::FindStructInPNextChain<VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM>(pRenderingInfo->pNext)) {
         skip |= ValidateMultiviewPerViewRenderAreasRenderPassBeginInfo(commandBuffer, nullptr, pRenderingInfo,
                                                                        *multiview_per_view_info, rendering_info_loc);
+    }
+
+    if (const auto* rp_tile_shading_ci =
+            vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(pRenderingInfo->pNext)) {
+        const Location rp_tile_shading_loc = rendering_info_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM);
+        skip |= ValidateRenderPassTileShadingCreateInfo(*rp_tile_shading_ci, rp_tile_shading_loc);
     }
 
     skip |= ValidateRenderPassStripeBeginInfo(commandBuffer, pRenderingInfo->pNext, pRenderingInfo->renderArea, rendering_info_loc);

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2025 Google Inc.
  * Copyright (C) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -484,6 +485,9 @@ class Device : public vvl::BaseDevice {
 
     bool ValidateSubpassGraphicsFlags(const VkRenderPassCreateInfo2 &create_info, uint32_t subpass, VkPipelineStageFlags2 stages,
                                       const char *vuid, const Location &loc) const;
+
+    bool ValidateRenderPassTileShadingCreateInfo(const VkRenderPassTileShadingCreateInfoQCOM &rp_tile_shading_ci,
+                                                 const Location &rp_tile_shading_loc) const;
 
     bool ValidateCreateRenderPass(const VkRenderPassCreateInfo2 &create_info, const ErrorObject &error_obj) const;
 

--- a/layers/utils/convert_utils.cpp
+++ b/layers/utils/convert_utils.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,43 +122,36 @@ static vku::safe_VkSubpassDependency2 ToV2KHR(const VkSubpassDependency& in_stru
 }
 
 vku::safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkRenderPassCreateInfo& create_info) {
+    const auto* multiview_info = vku::FindStructInPNextChain<VkRenderPassMultiviewCreateInfo>(create_info.pNext);
+    const auto* input_attachment_aspect_info = vku::FindStructInPNextChain<VkRenderPassInputAttachmentAspectCreateInfo>(create_info.pNext);
+
     vku::safe_VkRenderPassCreateInfo2 out_struct;
-    const auto multiview_info = vku::FindStructInPNextChain<VkRenderPassMultiviewCreateInfo>(create_info.pNext);
-    const auto* input_attachment_aspect_info =
-        vku::FindStructInPNextChain<VkRenderPassInputAttachmentAspectCreateInfo>(create_info.pNext);
-    const auto fragment_density_map_info =
-        vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
-    const auto tile_memory_size_info = vku::FindStructInPNextChain<VkTileMemorySizeInfoQCOM>(create_info.pNext);
-
     out_struct.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
-
-    // Fixup RPCI2 pNext chain.  Only FDM2 and Tile Mem Size is valid on both chains.
-    if (fragment_density_map_info || tile_memory_size_info) {
-        VkBaseOutStructure* last_base_out_struct = nullptr;
-        if (fragment_density_map_info) {
-            out_struct.pNext = vku::SafePnextCopy(fragment_density_map_info);
-            auto base_struct = reinterpret_cast<const VkBaseOutStructure*>(out_struct.pNext);
-            const_cast<VkBaseOutStructure*>(base_struct)->pNext = nullptr;
-            last_base_out_struct = const_cast<VkBaseOutStructure*>(base_struct);
-        }
-        if (tile_memory_size_info) {
-            if (!last_base_out_struct) {
-                out_struct.pNext = vku::SafePnextCopy(tile_memory_size_info);
-                auto base_struct = reinterpret_cast<const VkBaseOutStructure*>(out_struct.pNext);
-                const_cast<VkBaseOutStructure*>(base_struct)->pNext = nullptr;
-                last_base_out_struct = const_cast<VkBaseOutStructure*>(base_struct);
+    out_struct.pNext = vku::SafePnextCopy(create_info.pNext);
+    // VkRenderPassMultiviewCreateInfo and VkRenderPassInputAttachmentAspectCreateInfo extend
+    // VkRenderPassCreateInfo but are not valid in VkRenderPassCreateInfo2::pNext.
+    // Remove them from the copied chain.
+    {
+        const void* src = out_struct.pNext;
+        out_struct.pNext = nullptr;
+        VkBaseOutStructure* tail = nullptr;
+        while (src) {
+            auto* node = reinterpret_cast<VkBaseOutStructure*>(const_cast<void*>(src));
+            src = node->pNext;
+            node->pNext = nullptr;
+            if (node->sType == VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO ||
+                node->sType == VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO) {
+                vku::FreePnextChain(node);
             } else {
-                last_base_out_struct->pNext =
-                    reinterpret_cast<VkBaseOutStructure*>(const_cast<VkTileMemorySizeInfoQCOM*>(tile_memory_size_info));
-                auto base_struct = reinterpret_cast<const VkBaseOutStructure*>(last_base_out_struct->pNext);
-                const_cast<VkBaseOutStructure*>(base_struct)->pNext = nullptr;
-                last_base_out_struct = last_base_out_struct->pNext;
+                if (!tail) {
+                    out_struct.pNext = node;
+                } else {
+                    tail->pNext = node;
+                }
+                tail = node;
             }
         }
-    } else {
-        out_struct.pNext = nullptr;
     }
-
     out_struct.flags = create_info.flags;
     out_struct.attachmentCount = create_info.attachmentCount;
     out_struct.pAttachments = nullptr;  // to be filled

--- a/layers/utils/convert_utils.cpp
+++ b/layers/utils/convert_utils.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,41 +123,37 @@ static vku::safe_VkSubpassDependency2 ToV2KHR(const VkSubpassDependency& in_stru
 
 vku::safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkRenderPassCreateInfo& create_info) {
     vku::safe_VkRenderPassCreateInfo2 out_struct;
-    const auto multiview_info = vku::FindStructInPNextChain<VkRenderPassMultiviewCreateInfo>(create_info.pNext);
-    const auto* input_attachment_aspect_info =
-        vku::FindStructInPNextChain<VkRenderPassInputAttachmentAspectCreateInfo>(create_info.pNext);
-    const auto fragment_density_map_info =
-        vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
-    const auto tile_memory_size_info = vku::FindStructInPNextChain<VkTileMemorySizeInfoQCOM>(create_info.pNext);
+    const auto* multiview_info = vku::FindStructInPNextChain<VkRenderPassMultiviewCreateInfo>(create_info.pNext);
+    const auto* input_attachment_aspect_info = vku::FindStructInPNextChain<VkRenderPassInputAttachmentAspectCreateInfo>(create_info.pNext);
+    const auto* fragment_density_map_info = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(create_info.pNext);
+    const auto* tile_memory_size_info = vku::FindStructInPNextChain<VkTileMemorySizeInfoQCOM>(create_info.pNext);
+    const auto* rp_tile_shading_info = vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(create_info.pNext);
 
     out_struct.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
+    out_struct.pNext = nullptr;
 
     // Fixup RPCI2 pNext chain.  Only FDM2 and Tile Mem Size is valid on both chains.
-    if (fragment_density_map_info || tile_memory_size_info) {
-        VkBaseOutStructure* last_base_out_struct = nullptr;
-        if (fragment_density_map_info) {
-            out_struct.pNext = vku::SafePnextCopy(fragment_density_map_info);
-            auto base_struct = reinterpret_cast<const VkBaseOutStructure*>(out_struct.pNext);
-            const_cast<VkBaseOutStructure*>(base_struct)->pNext = nullptr;
-            last_base_out_struct = const_cast<VkBaseOutStructure*>(base_struct);
+    VkBaseOutStructure* last_base_out_struct = nullptr;
+    const auto append_copied_next_struct = [&out_struct, &last_base_out_struct] (const void* src_struct) {
+        if (!src_struct) return;
+
+        void* copied_struct = vku::SafePnextCopy(src_struct);
+        auto* base_struct = reinterpret_cast<VkBaseOutStructure*>(copied_struct);
+        base_struct->pNext = nullptr;
+
+        if (!last_base_out_struct) {
+            out_struct.pNext = copied_struct;
         }
-        if (tile_memory_size_info) {
-            if (!last_base_out_struct) {
-                out_struct.pNext = vku::SafePnextCopy(tile_memory_size_info);
-                auto base_struct = reinterpret_cast<const VkBaseOutStructure*>(out_struct.pNext);
-                const_cast<VkBaseOutStructure*>(base_struct)->pNext = nullptr;
-                last_base_out_struct = const_cast<VkBaseOutStructure*>(base_struct);
-            } else {
-                last_base_out_struct->pNext =
-                    reinterpret_cast<VkBaseOutStructure*>(const_cast<VkTileMemorySizeInfoQCOM*>(tile_memory_size_info));
-                auto base_struct = reinterpret_cast<const VkBaseOutStructure*>(last_base_out_struct->pNext);
-                const_cast<VkBaseOutStructure*>(base_struct)->pNext = nullptr;
-                last_base_out_struct = last_base_out_struct->pNext;
-            }
+        else {
+            last_base_out_struct->pNext = base_struct;
         }
-    } else {
-        out_struct.pNext = nullptr;
-    }
+
+        last_base_out_struct = base_struct;
+    };
+
+    append_copied_next_struct(fragment_density_map_info);
+    append_copied_next_struct(tile_memory_size_info);
+    append_copied_next_struct(rp_tile_shading_info);
 
     out_struct.flags = create_info.flags;
     out_struct.attachmentCount = create_info.attachmentCount;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,8 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/copy_buffer_image_positive.cpp
     unit/data_graph.cpp
     unit/data_graph_positive.cpp
+    unit/tile_shading.cpp
+    unit/tile_shading_positive.cpp
     unit/debug_extensions.cpp
     unit/debug_extensions_positive.cpp
     unit/debug_descriptor.cpp

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1787,6 +1787,18 @@
                     "queueSubmitBoundary": true,
                     "tileBufferTransfers": true
                 },
+                "VkPhysicalDeviceTileShadingPropertiesQCOM": {
+                    "maxApronSize": 8,
+                    "preferNonCoherent": true,
+                    "tileGranularity": {
+                        "width": 16,
+                        "height": 16
+                    },
+                    "maxTileShadingRate": {
+                        "width": 8,
+                        "height": 8
+                    }
+                },
                 "VkPhysicalDeviceMeshShaderPropertiesNV": {
                     "maxDrawMeshTasksCount": 65535,
                     "maxTaskWorkGroupInvocations": 32,

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -530,15 +530,15 @@ class CooperativeMatrixTest : public VkLayerTest {
 
 class TileShadingTest : public VkLayerTest {
   public:
-    struct TileShadingRenderTargetConfig {
+    struct Config {
         VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
         VkExtent2D rt_size = {64, 64};
         VkExtent2D tile_apron_size = {0, 0};
         bool use_render_pass2 = false;
-    };
+    } tile_shading_rp_config;
 
     void InitBasicTileShading();
-    void InitTileShadingRenderTarget(const TileShadingRenderTargetConfig& tile_shading_rp_config);
+    void InitTileShadingRenderTarget();
 
     vkt::RenderPass m_tile_shading_render_pass;
     vkt::Framebuffer m_tile_shading_framebuffer;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (c) 2015-2026 Google, Inc.
  * Copyright (C) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  * Modifications Copyright (C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -525,6 +526,24 @@ class WsiTest : public VkLayerTest {
 class CooperativeMatrixTest : public VkLayerTest {
   public:
     void InitCooperativeMatrixKHR();
+};
+
+class TileShadingTest : public VkLayerTest {
+  public:
+    struct TileShadingRenderTargetConfig {
+        VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+        VkExtent2D rt_size = {64, 64};
+        VkExtent2D tile_apron_size = {0, 0};
+        bool use_render_pass2 = false;
+    };
+
+    void InitBasicTileShading();
+    void InitTileShadingRenderTarget(const TileShadingRenderTargetConfig& tile_shading_rp_config);
+
+    vkt::RenderPass m_tile_shading_render_pass;
+    vkt::Framebuffer m_tile_shading_framebuffer;
+    vkt::Image m_color_image;
+    vkt::ImageView m_color_view;
 };
 
 class ParentTest : public VkLayerTest {

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -1335,4 +1335,93 @@ TEST_F(NegativeAndroidExternalResolve, RenderPassAndFramebuffer) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeAndroidExternalResolve, TileShadingDynamicRenderingWithExternalFormatDownsample) {
+    TEST_DESCRIPTION("Try to launch a dynamic rendering when tile-shading is enabled and external-format-downsample is used.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_FORMAT_RESOLVE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::externalFormatResolve);
+    AddRequiredFeature(vkt::Feature::samplerYcbcrConversion);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingColorAttachments);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceExternalFormatResolvePropertiesANDROID external_resolve_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&external_resolve_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    if (external_resolve_props.nullColorAttachmentWithExternalFormatResolve != VK_TRUE) {
+        GTEST_SKIP() << "nullColorAttachmentWithExternalFormatResolve is VK_FALSE, skipping test.";
+    }
+
+    vkt::AHB ahb(AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420, AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE, 64, 64);
+    if (!ahb.handle()) {
+        GTEST_SKIP() << "Failed to allocate AHB, skipping test.";
+    }
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+
+    VkAndroidHardwareBufferFormatResolvePropertiesANDROID format_resolve_prop = vku::InitStructHelper();
+    VkExternalFormatANDROID external_format = vku::InitStructHelper();
+    external_format.externalFormat = ahb.GetExternalFormat(*m_device, &format_resolve_prop);
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.pNext = &external_format;
+    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    image_ci.format = VK_FORMAT_UNDEFINED;
+    image_ci.extent = {image_width, image_height, 1};
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    vkt::Image resolve_image{*m_device, image_ci, vkt::set_layout};
+
+    VkSamplerYcbcrConversionCreateInfo syc_ci = vku::InitStructHelper(&external_format);
+    syc_ci.format = VK_FORMAT_UNDEFINED;
+    syc_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709;
+    syc_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
+    syc_ci.components = {VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO,
+                         VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO};
+
+    vkt::SamplerYcbcrConversion ycbcr_conv{*m_device, syc_ci};
+
+    VkSamplerYcbcrConversionInfo sy_ci = vku::InitStructHelper();
+    sy_ci.conversion = ycbcr_conv;
+
+    VkImageViewCreateInfo ivci = vku::InitStructHelper(&sy_ci);
+    ivci.image = resolve_image;
+    ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    ivci.format = VK_FORMAT_UNDEFINED;
+    ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view{*m_device, ivci};
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = VK_NULL_HANDLE;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID;
+    color_attachment.resolveImageView = resolve_view;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.layerCount = 1;
+    rendering_info.viewMask = 0;
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-resolveMode-10644");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
 #endif

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -1,0 +1,954 @@
+/*
+ * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "layer_validation_tests.h"
+#include "pipeline_helper.h"
+
+class NegativeTileShading : public TileShadingTest {};
+
+TEST_F(NegativeTileShading, EndPerTileExecutionWithNonTileShadingRenderPass) {
+    TEST_DESCRIPTION("End per-tile execution model in a non-tile-shading render pass.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdEndPerTileExecutionQCOM-None-10666");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdEndPerTileExecutionQCOM-None-10667");
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, BeginPerTileExecutionWithNonTileShadingRenderPass) {
+    TEST_DESCRIPTION("Begin per-tile execution model in a non-tile-shading render pass.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10664");
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, CreateTileShadingRenderPassButTileShadingFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass, but tileShading feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShading-10658");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+    vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+}
+
+TEST_F(NegativeTileShading, UseNonZeroTileApronSizeButTileShadingApronFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to use non-zero tile-apron size when creates a render pass, but "
+                     "tileShadingApron feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, tile_shading_props.maxApronSize};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10659");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+    vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+}
+
+TEST_F(NegativeTileShading, UseAnisotropicApronSizeButTileShadingAnisotropicApronFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to use anisotropic apron size when creates a render pass, but "
+                     "tileShadingAnisotropicApron feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingApron);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, std::max(tile_shading_props.maxApronSize - 1, 1U)};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShadingAnisotropicApron-10661");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+    vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+}
+
+TEST_F(NegativeTileShading, UseLargerTileApronSize) {
+    TEST_DESCRIPTION("Try to use tile apron size larger than maxApronSize when creates a render pass.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingApron);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize + 1, tile_shading_props.maxApronSize + 1};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10662");
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10663");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+    vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+}
+
+TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithPerTileExecutionBit) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass with per-tile-execution bit, but "
+                     "tileShadingPerTileDispatch and tileShadingPerTileDraw features are not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    RETURN_IF_SKIP(Init());
+
+    {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-vkCreateRenderPass-flags-10646");
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10660");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        VkAttachmentDescription2 attachment_desc2 = vku::InitStructHelper();
+        attachment_desc2.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc2.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc2.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc2.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc2.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref2 = vku::InitStructHelper();
+        color_ref2.attachment = 0;
+        color_ref2.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref2.aspectMask = 0;
+
+        VkSubpassDescription2 subpass_desc2 = vku::InitStructHelper();
+        subpass_desc2.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc2.viewMask = 0;
+        subpass_desc2.inputAttachmentCount = 0;
+        subpass_desc2.colorAttachmentCount = 1;
+        subpass_desc2.pColorAttachments = &color_ref2;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rpci2 = vku::InitStructHelper(&tile_shading_ci);
+        rpci2.flags = 0;
+        rpci2.attachmentCount = 1;
+        rpci2.pAttachments = &attachment_desc2;
+        rpci2.subpassCount = 1;
+        rpci2.pSubpasses = &subpass_desc2;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-vkCreateRenderPass2-flags-10649");
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10660");
+        vk::CreateRenderPass2(device(), &rpci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}
+
+TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingButTileShadingFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to launch a tile-shading dynamic rendering, but tileShading feature isn't enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t image_width = 64;
+    constexpr uint32_t image_height = 64;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShading-10658");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingWithApronSizeButRequiredFeaturesNotEnabled) {
+    TEST_DESCRIPTION("Try to launch a tile-shading dynamic rendering with specified anisotropic apron size, "
+                     "but tileShadingApron and tileShadingAnisotropicApron features aren't enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    constexpr uint32_t image_width = 64;
+    constexpr uint32_t image_height = 64;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, std::max(tile_shading_props.maxApronSize - 1, 1U)};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10659");
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShadingAnisotropicApron-10661");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithUndefinedFormatResolveAttachment) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides a undefined format resolve attachment.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        std::array<VkAttachmentDescription, 2> attachment_descs{};
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1].format = VK_FORMAT_UNDEFINED;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference resolve_ref{};
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = attachment_descs.size();
+        rp_ci.pAttachments = attachment_descs.data();
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkAttachmentDescription-format-06698");
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo-pResolveAttachments-10647");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        std::array<VkAttachmentDescription2, 2> attachment_descs{};
+        attachment_descs[0] = vku::InitStructHelper();
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1] = vku::InitStructHelper();
+        attachment_descs[1].format = VK_FORMAT_UNDEFINED;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 resolve_ref = vku::InitStructHelper();
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci2.attachmentCount = attachment_descs.size();
+        rp_ci2.pAttachments = attachment_descs.data();
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo2-pResolveAttachments-10650");
+        m_errorMonitor->SetDesiredError("VUID-VkAttachmentDescription2-format-09332");
+        vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}
+
+TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithFragmentDensityMapAttachment) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides an available fragment-density-map attachment.");
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        std::array<VkAttachmentDescription, 2> attachment_descs{};
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1].format = VK_FORMAT_R8G8_UNORM;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_ci = vku::InitStructHelper();
+        fdm_ci.fragmentDensityMapAttachment.attachment = 1;
+        fdm_ci.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper(&fdm_ci);
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = attachment_descs.size();
+        rp_ci.pAttachments = attachment_descs.data();
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo-fragmentDensityMapAttachment-10648");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        std::array<VkAttachmentDescription2, 2> attachment_descs{};
+        attachment_descs[0] = vku::InitStructHelper();
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1] = vku::InitStructHelper();
+        attachment_descs[1].format = VK_FORMAT_R8G8_UNORM;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_ci = vku::InitStructHelper();
+        fdm_ci.fragmentDensityMapAttachment.attachment = 1;
+        fdm_ci.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper(&fdm_ci);
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci2.attachmentCount = attachment_descs.size();
+        rp_ci2.pAttachments = attachment_descs.data();
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo2-fragmentDensityMapAttachment-10651");
+        vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}
+
+TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingInSimultaneousUseBitCommandBuffer) {
+    TEST_DESCRIPTION("Try to launch a dynamic rendering in a recorded command buffer "
+                     "with simultaneous-use-bit used.");
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRendering-flags-10641");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingWithPerTileExecutionBit) {
+    TEST_DESCRIPTION("Try to launch a tile-shading dynamic rendering but per-tile-execution bit is used.");
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRendering-flags-10642");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, EndTileShadingDynamicRenderingButPerTileExecutionModelEnabled) {
+    TEST_DESCRIPTION("Try to end a tile-shading dynamic rendering, but per-tile-execution model is still enabled.");
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    TileShadingRenderTargetConfig tile_shading_rp_config{};
+    InitTileShadingRenderTarget(tile_shading_rp_config);
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = m_color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.resolveImageView = VK_NULL_HANDLE;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    color_attachment.clearValue = clear_value;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, tile_shading_rp_config.rt_size};
+    rendering_info.layerCount = 1;
+    rendering_info.viewMask = 0;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdEndRendering-None-10645");
+    vk::CmdEndRendering(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, BeginTileShadingRenderPassWithSimultaneousUseBit) {
+    TEST_DESCRIPTION("Try to launch a tile-shading render pass in a recorded command buffer "
+                     "with simultaneous-use-bit used.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    TileShadingRenderTargetConfig tile_shading_rp_config{};
+    tile_shading_rp_config.use_render_pass2 = true;
+    InitTileShadingRenderTarget(tile_shading_rp_config);
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
+    subpass_begin_info.contents = VK_SUBPASS_CONTENTS_INLINE;
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRenderPass2-flags-10652");
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    vk::CmdBeginRenderPass2(m_command_buffer, &rp_begin_info, &subpass_begin_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, EndTileShadingRenderPassButPerTileExecutionModelEnabled) {
+    TEST_DESCRIPTION("Try to end a tile-shading render pass, but per-tile execution model is still enabled.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    TileShadingRenderTargetConfig tile_shading_rp_config{};
+    InitTileShadingRenderTarget(tile_shading_rp_config);
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdEndRenderPass-None-10653");
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, TileShadingDynamicRenderingWithFragmentDensityMapAttachment) {
+    TEST_DESCRIPTION("Try to launch a dynamic rendering when tile-shading is enabled and fragment-density-map attachment is provided.");
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMap);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMapNonSubsampledImages);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT };
+    vkt::ImageView color_view = color_image.CreateView();
+    vkt::Image fdm_image{*m_device, image_width, image_height, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT};
+    vkt::ImageView fdm_view = fdm_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fdm_attachment = vku::InitStructHelper();
+    fdm_attachment.imageView = fdm_view;
+    fdm_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper(&fdm_attachment);
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-10643");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, TileShadingSubpassDescriptionWithZeroApronSize) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides a tile-shading-apron subpass "
+                     "description with zero apron size.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.flags = 0;
+        attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.flags = VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM;
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.inputAttachmentCount = 0;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.flags = 0;
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription-flags-10683");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        VkAttachmentDescription2 attachment_desc2 = vku::InitStructHelper();
+        attachment_desc2.flags = 0;
+        attachment_desc2.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc2.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc2.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref2 = vku::InitStructHelper();
+        color_ref2.attachment = 0;
+        color_ref2.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref2.aspectMask = 0;
+
+        VkSubpassDescription2 subpass_desc2 = vku::InitStructHelper();
+        subpass_desc2.flags = VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM;
+        subpass_desc2.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc2.viewMask = 0;
+        subpass_desc2.inputAttachmentCount = 0;
+        subpass_desc2.colorAttachmentCount = 1;
+        subpass_desc2.pColorAttachments = &color_ref2;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rpci2 = vku::InitStructHelper(&tile_shading_ci);
+        rpci2.flags = 0;
+        rpci2.attachmentCount = 1;
+        rpci2.pAttachments = &attachment_desc2;
+        rpci2.subpassCount = 1;
+        rpci2.pSubpasses = &subpass_desc2;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-flags-10683");
+        vk::CreateRenderPass2(device(), &rpci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -1,0 +1,805 @@
+/*
+ * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "layer_validation_tests.h"
+#include "android_hardware_buffer.h"
+#include "pipeline_helper.h"
+
+class NegativeTileShading : public TileShadingTest {};
+
+TEST_F(NegativeTileShading, EndPerTileExecutionWithNonTileShadingRenderPass) {
+    TEST_DESCRIPTION("End per-tile execution model in a non-tile-shading render pass.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdEndPerTileExecutionQCOM-None-10666");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdEndPerTileExecutionQCOM-None-10667");
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, BeginPerTileExecutionWithNonTileShadingRenderPass) {
+    TEST_DESCRIPTION("Begin per-tile execution model in a non-tile-shading render pass.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10664");
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, BeginPerTileExecutionButTileShadingPerTileFeatureNotEnabled) {
+    TEST_DESCRIPTION("Begin per-tile execution model in a tile-shading render pass when tile-shading-per-tile-draw  "
+                     "or tile-shading-per-tile-dispatch feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    TileShadingRenderTargetConfig tile_shading_rp_config{};
+    InitTileShadingRenderTarget(tile_shading_rp_config);
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10665");
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, UseTileShadingEnableBitButTileShadingFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to use tile-shading enable bit when creates a render pass, but "
+                     "tileShading feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShading-10658");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, UseNonZeroTileApronSizeButTileShadingApronFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to use non-zero tile-apron size when creates a render pass, but "
+                     "tileShadingApron feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, tile_shading_props.maxApronSize};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10659");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, UseAnisotropicApronSizeButTileShadingAnisotropicApronFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to use anisotropic apron size when creates a render pass, but "
+                     "tileShadingAnisotropicApron feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingApron);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, std::max(tile_shading_props.maxApronSize - 1, 1U)};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShadingAnisotropicApron-10661");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, UseLargerTileApronSize) {
+    TEST_DESCRIPTION("Try to use tile apron size larger than maxApronSize when creates a render pass.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingApron);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize + 1, tile_shading_props.maxApronSize + 1};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+
+    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10662");
+    m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileApronSize-10663");
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithPerTileExecutionBit) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass with per-tile-execution bit, but "
+                     "tileShadingPerTileDispatch and tileShadingPerTileDraw features are not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    RETURN_IF_SKIP(Init());
+
+    {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-vkCreateRenderPass-flags-10646");
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10660");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        VkAttachmentDescription2 attachment_desc2 = vku::InitStructHelper();
+        attachment_desc2.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc2.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc2.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc2.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc2.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref2 = vku::InitStructHelper();
+        color_ref2.attachment = 0;
+        color_ref2.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref2.aspectMask = 0;
+
+        VkSubpassDescription2 subpass_desc2 = vku::InitStructHelper();
+        subpass_desc2.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc2.viewMask = 0;
+        subpass_desc2.inputAttachmentCount = 0;
+        subpass_desc2.colorAttachmentCount = 1;
+        subpass_desc2.pColorAttachments = &color_ref2;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rpci2 = vku::InitStructHelper(&tile_shading_ci);
+        rpci2.flags = 0;
+        rpci2.attachmentCount = 1;
+        rpci2.pAttachments = &attachment_desc2;
+        rpci2.subpassCount = 1;
+        rpci2.pSubpasses = &subpass_desc2;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-vkCreateRenderPass2-flags-10649");
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-flags-10660");
+        vk::CreateRenderPass2(device(), &rpci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithUndefinedFormatResolveAttachment) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides a undefined format resolve attachment.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        std::array<VkAttachmentDescription, 2> attachment_descs{};
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1].format = VK_FORMAT_UNDEFINED;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference resolve_ref{};
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = attachment_descs.size();
+        rp_ci.pAttachments = attachment_descs.data();
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkAttachmentDescription-format-06698");
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo-pResolveAttachments-10647");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        std::array<VkAttachmentDescription2, 2> attachment_descs{};
+        attachment_descs[0] = vku::InitStructHelper();
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1] = vku::InitStructHelper();
+        attachment_descs[1].format = VK_FORMAT_UNDEFINED;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 resolve_ref = vku::InitStructHelper();
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci2.attachmentCount = attachment_descs.size();
+        rp_ci2.pAttachments = attachment_descs.data();
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo2-pResolveAttachments-10650");
+        m_errorMonitor->SetDesiredError("VUID-VkAttachmentDescription2-format-09332");
+        vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithFragmentDensityMapAttachment) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides an available fragment-density-map attachment.");
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        std::array<VkAttachmentDescription, 2> attachment_descs{};
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1].format = VK_FORMAT_R8G8_UNORM;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_ci = vku::InitStructHelper();
+        fdm_ci.fragmentDensityMapAttachment.attachment = 1;
+        fdm_ci.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper(&fdm_ci);
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = attachment_descs.size();
+        rp_ci.pAttachments = attachment_descs.data();
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo-fragmentDensityMapAttachment-10648");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        std::array<VkAttachmentDescription2, 2> attachment_descs{};
+        attachment_descs[0] = vku::InitStructHelper();
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1] = vku::InitStructHelper();
+        attachment_descs[1].format = VK_FORMAT_R8G8_UNORM;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_ci = vku::InitStructHelper();
+        fdm_ci.fragmentDensityMapAttachment.attachment = 1;
+        fdm_ci.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper(&fdm_ci);
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci2.attachmentCount = attachment_descs.size();
+        rp_ci2.pAttachments = attachment_descs.data();
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo2-fragmentDensityMapAttachment-10651");
+        vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeTileShading, TileShadingDynamicRenderingWithFragmentDensityMapAttachment) {
+    TEST_DESCRIPTION("Try to launch a dynamic rendering when tile-shading is enabled and fragment-density-map attachment is provided.");
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMap);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMapNonSubsampledImages);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT };
+    vkt::ImageView color_view = color_image.CreateView();
+    vkt::Image fdm_image{*m_device, image_width, image_height, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT};
+    vkt::ImageView fdm_view = fdm_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fdm_attachment = vku::InitStructHelper();
+    fdm_attachment.imageView = fdm_view;
+    fdm_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper(&fdm_attachment);
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-10643");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+TEST_F(NegativeTileShading, TileShadingDynamicRenderingWithExternalFormatDownsample) {
+    TEST_DESCRIPTION("Try to launch a dynamic rendering when tile-shading is enabled and external-format-downsample is used.");
+    AddRequiredExtensions(VK_ANDROID_EXTERNAL_FORMAT_RESOLVE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::externalFormatResolve);
+    AddRequiredFeature(vkt::Feature::samplerYcbcrConversion);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceExternalFormatResolvePropertiesANDROID external_resolve_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&external_resolve_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    if (external_resolve_props.nullColorAttachmentWithExternalFormatResolve != VK_TRUE) {
+        GTEST_SKIP() << "nullColorAttachmentWithExternalFormatResolve is VK_FALSE, skipping test.";
+    }
+
+    vkt::AHB ahb(AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420, AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE, 64, 64);
+    if (!ahb.handle()) {
+        GTEST_SKIP() << "Failed to allocate AHB, skipping test.";
+    }
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+
+    VkAndroidHardwareBufferFormatResolvePropertiesANDROID format_resolve_prop = vku::InitStructHelper();
+    VkExternalFormatANDROID external_format = vku::InitStructHelper();
+    external_format.externalFormat = ahb.GetExternalFormat(*m_device, &format_resolve_prop);
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.pNext = &external_format;
+    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    image_ci.format = VK_FORMAT_UNDEFINED;
+    image_ci.extent = {image_width, image_height, 1};
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    vkt::Image resolve_image{*m_device, image_ci, vkt::set_layout};
+
+    VkSamplerYcbcrConversionCreateInfo syc_ci = vku::InitStructHelper(&external_format);
+    syc_ci.format = VK_FORMAT_UNDEFINED;
+    syc_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709;
+    syc_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_NARROW;
+    syc_ci.components = {VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO,
+                         VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ZERO};
+
+    vkt::SamplerYcbcrConversion ycbcr_conv{*m_device, syc_ci};
+
+    VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
+    syci.conversion = ycbcr_conv;
+
+    VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
+    ivci.image = resolve_image;
+    ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    ivci.format = VK_FORMAT_UNDEFINED;
+    ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view{*m_device, ivci};
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = VK_NULL_HANDLE;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID;
+    color_attachment.resolveImageView = resolve_view;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.layerCount = 1;
+    rendering_info.viewMask = 0;
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-resolveMode-10644");
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+#endif
+
+TEST_F(NegativeTileShading, TileShadingSubpassDescriptionWithZeroApronSize) {
+    TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides a tile-shading-apron subpass "
+                     "description with zero apron size.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.flags = 0;
+        attachment_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.flags = VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM;
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.inputAttachmentCount = 0;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.flags = 0;
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription-flags-10683");
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        VkAttachmentDescription2 attachment_desc2 = vku::InitStructHelper();
+        attachment_desc2.flags = 0;
+        attachment_desc2.format = VK_FORMAT_R8G8B8A8_UNORM;
+        attachment_desc2.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc2.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref2 = vku::InitStructHelper();
+        color_ref2.attachment = 0;
+        color_ref2.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref2.aspectMask = 0;
+
+        VkSubpassDescription2 subpass_desc2 = vku::InitStructHelper();
+        subpass_desc2.flags = VK_SUBPASS_DESCRIPTION_TILE_SHADING_APRON_BIT_QCOM;
+        subpass_desc2.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc2.viewMask = 0;
+        subpass_desc2.inputAttachmentCount = 0;
+        subpass_desc2.colorAttachmentCount = 1;
+        subpass_desc2.pColorAttachments = &color_ref2;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rpci2 = vku::InitStructHelper(&tile_shading_ci);
+        rpci2.flags = 0;
+        rpci2.attachmentCount = 1;
+        rpci2.pAttachments = &attachment_desc2;
+        rpci2.subpassCount = 1;
+        rpci2.pSubpasses = &subpass_desc2;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+
+        m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-flags-10683");
+        vk::CreateRenderPass2(device(), &rpci2, nullptr, &tile_shading_render_pass);
+        m_errorMonitor->VerifyFound();
+    }
+}
+

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
  * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -10,17 +12,11 @@
  */
 
 #include "layer_validation_tests.h"
-#include "pipeline_helper.h"
 
 class NegativeTileShading : public TileShadingTest {};
 
 TEST_F(NegativeTileShading, EndPerTileExecutionWithNonTileShadingRenderPass) {
-    TEST_DESCRIPTION("End per-tile execution model in a non-tile-shading render pass.");
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::tileShading);
-    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
     InitRenderTarget();
 
     VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
@@ -36,12 +32,7 @@ TEST_F(NegativeTileShading, EndPerTileExecutionWithNonTileShadingRenderPass) {
 }
 
 TEST_F(NegativeTileShading, BeginPerTileExecutionWithNonTileShadingRenderPass) {
-    TEST_DESCRIPTION("Begin per-tile execution model in a non-tile-shading render pass.");
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::tileShading);
-    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
     InitRenderTarget();
 
     VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
@@ -55,7 +46,7 @@ TEST_F(NegativeTileShading, BeginPerTileExecutionWithNonTileShadingRenderPass) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, CreateTileShadingRenderPassButTileShadingFeatureNotEnabled) {
+TEST_F(NegativeTileShading, RenderPassButTileShadingFeatureNotEnabled) {
     TEST_DESCRIPTION("Try to create a tile-shading render pass, but tileShading feature is not enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
@@ -90,15 +81,13 @@ TEST_F(NegativeTileShading, CreateTileShadingRenderPassButTileShadingFeatureNotE
     rp_ci.subpassCount = 1;
     rp_ci.pSubpasses = &subpass_desc;
 
-    VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
-
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassTileShadingCreateInfoQCOM-tileShading-10658");
-    vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+    VkRenderPass rp = VK_NULL_HANDLE;
+    vk::CreateRenderPass(device(), &rp_ci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
-    vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
 }
 
-TEST_F(NegativeTileShading, UseNonZeroTileApronSizeButTileShadingApronFeatureNotEnabled) {
+TEST_F(NegativeTileShading, NonZeroTileApronSizeButTileShadingApronFeatureNotEnabled) {
     TEST_DESCRIPTION("Try to use non-zero tile-apron size when creates a render pass, but "
                      "tileShadingApron feature is not enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -147,7 +136,7 @@ TEST_F(NegativeTileShading, UseNonZeroTileApronSizeButTileShadingApronFeatureNot
     vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
 }
 
-TEST_F(NegativeTileShading, UseAnisotropicApronSizeButTileShadingAnisotropicApronFeatureNotEnabled) {
+TEST_F(NegativeTileShading, AnisotropicApronSizeButTileShadingAnisotropicApronFeatureNotEnabled) {
     TEST_DESCRIPTION("Try to use anisotropic apron size when creates a render pass, but "
                      "tileShadingAnisotropicApron feature is not enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -197,13 +186,10 @@ TEST_F(NegativeTileShading, UseAnisotropicApronSizeButTileShadingAnisotropicApro
     vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
 }
 
-TEST_F(NegativeTileShading, UseLargerTileApronSize) {
+TEST_F(NegativeTileShading, LargerTileApronSize) {
     TEST_DESCRIPTION("Try to use tile apron size larger than maxApronSize when creates a render pass.");
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::tileShading);
     AddRequiredFeature(vkt::Feature::tileShadingApron);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
@@ -247,7 +233,7 @@ TEST_F(NegativeTileShading, UseLargerTileApronSize) {
     vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
 }
 
-TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithPerTileExecutionBit) {
+TEST_F(NegativeTileShading, RenderPassWithPerTileExecutionBit) {
     TEST_DESCRIPTION("Try to create a tile-shading render pass with per-tile-execution bit, but "
                      "tileShadingPerTileDispatch and tileShadingPerTileDraw features are not enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -337,7 +323,7 @@ TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithPerTileExecutionBit) 
     }
 }
 
-TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingButTileShadingFeatureNotEnabled) {
+TEST_F(NegativeTileShading, DynamicRenderingButTileShadingFeatureNotEnabled) {
     TEST_DESCRIPTION("Try to launch a tile-shading dynamic rendering, but tileShading feature isn't enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
@@ -373,7 +359,7 @@ TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingButTileShadingFeatur
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingWithApronSizeButRequiredFeaturesNotEnabled) {
+TEST_F(NegativeTileShading, DynamicRenderingWithApronSizeButRequiredFeaturesNotEnabled) {
     TEST_DESCRIPTION("Try to launch a tile-shading dynamic rendering with specified anisotropic apron size, "
                      "but tileShadingApron and tileShadingAnisotropicApron features aren't enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -416,10 +402,9 @@ TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingWithApronSizeButRequ
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithUndefinedFormatResolveAttachment) {
+TEST_F(NegativeTileShading, RenderPassWithUndefinedFormatResolveAttachment) {
     TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides a undefined format resolve attachment.");
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     {
         std::array<VkAttachmentDescription, 2> attachment_descs{};
@@ -527,11 +512,10 @@ TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithUndefinedFormatResolv
     }
 }
 
-TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithFragmentDensityMapAttachment) {
+TEST_F(NegativeTileShading, RenderPassWithFragmentDensityMapAttachment) {
     TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides an available fragment-density-map attachment.");
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     {
         std::array<VkAttachmentDescription, 2> attachment_descs{};
@@ -635,12 +619,11 @@ TEST_F(NegativeTileShading, CreateTileShadingRenderPassWithFragmentDensityMapAtt
     }
 }
 
-TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingInSimultaneousUseBitCommandBuffer) {
+TEST_F(NegativeTileShading, DynamicRenderingInSimultaneousUseBitCommandBuffer) {
     TEST_DESCRIPTION("Try to launch a dynamic rendering in a recorded command buffer "
                      "with simultaneous-use-bit used.");
     AddRequiredFeature(vkt::Feature::dynamicRendering);
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     constexpr uint32_t image_width = 32;
     constexpr uint32_t image_height = 32;
@@ -671,11 +654,10 @@ TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingInSimultaneousUseBit
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingWithPerTileExecutionBit) {
+TEST_F(NegativeTileShading, DynamicRenderingWithPerTileExecutionBit) {
     TEST_DESCRIPTION("Try to launch a tile-shading dynamic rendering but per-tile-execution bit is used.");
     AddRequiredFeature(vkt::Feature::dynamicRendering);
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     constexpr uint32_t image_width = 32;
     constexpr uint32_t image_height = 32;
@@ -706,14 +688,11 @@ TEST_F(NegativeTileShading, BeginTileShadingDynamicRenderingWithPerTileExecution
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, EndTileShadingDynamicRenderingButPerTileExecutionModelEnabled) {
+TEST_F(NegativeTileShading, DynamicRenderingButPerTileExecutionModelEnabled) {
     TEST_DESCRIPTION("Try to end a tile-shading dynamic rendering, but per-tile-execution model is still enabled.");
     AddRequiredFeature(vkt::Feature::dynamicRendering);
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
-
-    TileShadingRenderTargetConfig tile_shading_rp_config{};
-    InitTileShadingRenderTarget(tile_shading_rp_config);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
 
     VkClearValue clear_value{};
     clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
@@ -753,15 +732,13 @@ TEST_F(NegativeTileShading, EndTileShadingDynamicRenderingButPerTileExecutionMod
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, BeginTileShadingRenderPassWithSimultaneousUseBit) {
+TEST_F(NegativeTileShading, RenderPassWithSimultaneousUseBit) {
     TEST_DESCRIPTION("Try to launch a tile-shading render pass in a recorded command buffer "
                      "with simultaneous-use-bit used.");
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
-    TileShadingRenderTargetConfig tile_shading_rp_config{};
     tile_shading_rp_config.use_render_pass2 = true;
-    InitTileShadingRenderTarget(tile_shading_rp_config);
+    InitTileShadingRenderTarget();
 
     VkClearValue clear_value{};
     clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
@@ -784,13 +761,10 @@ TEST_F(NegativeTileShading, BeginTileShadingRenderPassWithSimultaneousUseBit) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, EndTileShadingRenderPassButPerTileExecutionModelEnabled) {
+TEST_F(NegativeTileShading, RenderPassButPerTileExecutionModelEnabled) {
     TEST_DESCRIPTION("Try to end a tile-shading render pass, but per-tile execution model is still enabled.");
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
-
-    TileShadingRenderTargetConfig tile_shading_rp_config{};
-    InitTileShadingRenderTarget(tile_shading_rp_config);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
 
     VkClearValue clear_value{};
     clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
@@ -817,20 +791,18 @@ TEST_F(NegativeTileShading, EndTileShadingRenderPassButPerTileExecutionModelEnab
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, TileShadingDynamicRenderingWithFragmentDensityMapAttachment) {
+TEST_F(NegativeTileShading, DynamicRenderingWithFragmentDensityMapAttachment) {
     TEST_DESCRIPTION("Try to launch a dynamic rendering when tile-shading is enabled and fragment-density-map attachment is provided.");
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     AddRequiredFeature(vkt::Feature::fragmentDensityMap);
     AddRequiredFeature(vkt::Feature::fragmentDensityMapNonSubsampledImages);
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
-    constexpr uint32_t image_width = 32;
-    constexpr uint32_t image_height = 32;
-    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT };
+    vkt::Image color_image{*m_device, 32, 32, m_render_target_fmt,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT};
     vkt::ImageView color_view = color_image.CreateView();
-    vkt::Image fdm_image{*m_device, image_width, image_height, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT};
+    vkt::Image fdm_image{*m_device, 32, 32, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT};
     vkt::ImageView fdm_view = fdm_image.CreateView();
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
@@ -849,7 +821,7 @@ TEST_F(NegativeTileShading, TileShadingDynamicRenderingWithFragmentDensityMapAtt
     tile_shading_ci.tileApronSize = {0, 0};
 
     VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
-    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.renderArea = {{0, 0}, {32, 32}};
     rendering_info.layerCount = 1;
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachments = &color_attachment;
@@ -861,11 +833,10 @@ TEST_F(NegativeTileShading, TileShadingDynamicRenderingWithFragmentDensityMapAtt
     m_command_buffer.End();
 }
 
-TEST_F(NegativeTileShading, TileShadingSubpassDescriptionWithZeroApronSize) {
+TEST_F(NegativeTileShading, SubpassDescriptionWithZeroApronSize) {
     TEST_DESCRIPTION("Try to create a tile-shading render pass, but provides a tile-shading-apron subpass "
                      "description with zero apron size.");
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     {
         VkAttachmentDescription attachment_desc{};
@@ -901,12 +872,10 @@ TEST_F(NegativeTileShading, TileShadingSubpassDescriptionWithZeroApronSize) {
         rp_ci.subpassCount = 1;
         rp_ci.pSubpasses = &subpass_desc;
 
-        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
-
+        VkRenderPass rp = VK_NULL_HANDLE;
         m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription-flags-10683");
-        vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass);
+        vk::CreateRenderPass(device(), &rp_ci, nullptr, &rp);
         m_errorMonitor->VerifyFound();
-        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
     }
     {
         VkAttachmentDescription2 attachment_desc2 = vku::InitStructHelper();
@@ -944,11 +913,9 @@ TEST_F(NegativeTileShading, TileShadingSubpassDescriptionWithZeroApronSize) {
         rpci2.subpassCount = 1;
         rpci2.pSubpasses = &subpass_desc2;
 
-        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
-
+        VkRenderPass rp = VK_NULL_HANDLE;
         m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-flags-10683");
-        vk::CreateRenderPass2(device(), &rpci2, nullptr, &tile_shading_render_pass);
+        vk::CreateRenderPass2(device(), &rpci2, nullptr, &rp);
         m_errorMonitor->VerifyFound();
-        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
     }
 }

--- a/tests/unit/tile_shading_positive.cpp
+++ b/tests/unit/tile_shading_positive.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
  * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -9,8 +11,8 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include "binding.h"
 #include "layer_validation_tests.h"
-#include "pipeline_helper.h"
 
 class PositiveTileShading : public TileShadingTest {};
 
@@ -24,9 +26,10 @@ void TileShadingTest::InitBasicTileShading() {
     AddRequiredFeature(vkt::Feature::tileShadingDepthAttachments);
     AddRequiredFeature(vkt::Feature::tileShadingStencilAttachments);
     AddRequiredFeature(vkt::Feature::tileShadingSampledAttachments);
+    RETURN_IF_SKIP(Init());
 }
 
-void TileShadingTest::InitTileShadingRenderTarget(const TileShadingRenderTargetConfig &tile_shading_rp_config) {
+void TileShadingTest::InitTileShadingRenderTarget() {
     m_color_image.Init(*m_device, tile_shading_rp_config.rt_size.width, tile_shading_rp_config.rt_size.height, 1,
                        tile_shading_rp_config.format,
                        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
@@ -138,11 +141,8 @@ void TileShadingTest::InitTileShadingRenderTarget(const TileShadingRenderTargetC
 
 TEST_F(PositiveTileShading, ExecutePerTileExecutionModel) {
     TEST_DESCRIPTION("Execute per-tile execution model for a secondary command buffer.");
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
-
-    TileShadingRenderTargetConfig tile_shading_rp_config{};
-    InitTileShadingRenderTarget(tile_shading_rp_config);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
 
     vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
 
@@ -158,6 +158,8 @@ TEST_F(PositiveTileShading, ExecutePerTileExecutionModel) {
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     begin_info.pInheritanceInfo = &inheritance_info;
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
 
     VkClearValue clear_value{};
     clear_value.color = {{0.f, 0.f, 0.f, 0.f}};
@@ -174,8 +176,6 @@ TEST_F(PositiveTileShading, ExecutePerTileExecutionModel) {
     VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
     VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
 
-    secondary_command.Begin(&begin_info);
-    secondary_command.End();
     m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer, &rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
@@ -185,10 +185,9 @@ TEST_F(PositiveTileShading, ExecutePerTileExecutionModel) {
     m_command_buffer.End();
 }
 
-TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithResolveAttachment) {
+TEST_F(PositiveTileShading, RenderPassWithResolveAttachment) {
     TEST_DESCRIPTION("Create a tile-shading render pass with a valid resolve attachment.");
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     {
         std::array<VkAttachmentDescription, 2> attachment_descs{};
@@ -244,9 +243,7 @@ TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithResolveAttachment) {
         rp_ci.dependencyCount = 1;
         rp_ci.pDependencies = &subpass_dependency;
 
-        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
-        ASSERT_EQ(vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass), VK_SUCCESS);
-        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+        vkt::RenderPass rp(*m_device, rp_ci);
     }
     {
         std::array<VkAttachmentDescription2, 2> attachment_descs{};
@@ -304,17 +301,14 @@ TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithResolveAttachment) {
         rp_ci2.dependencyCount = 1;
         rp_ci2.pDependencies = &subpass_dependency2;
 
-        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
-        ASSERT_EQ(vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass), VK_SUCCESS);
-        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+        vkt::RenderPass rp(*m_device, rp_ci2);
     }
 }
 
-TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithUnusedFragmentDensityMapAttachment) {
+TEST_F(PositiveTileShading, RenderPassWithUnusedFragmentDensityMapAttachment) {
     TEST_DESCRIPTION("Create a tile-shading render pass with an unused fragment-density-map attachment.");
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
     {
         VkAttachmentDescription attachment_desc{};
@@ -350,9 +344,7 @@ TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithUnusedFragmentDensity
         rp_ci.subpassCount = 1;
         rp_ci.pSubpasses = &subpass_desc;
 
-        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
-        ASSERT_EQ(vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass), VK_SUCCESS);
-        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+        vkt::RenderPass rp(*m_device, rp_ci);
     }
     {
         VkAttachmentDescription2 attachment_desc = vku::InitStructHelper();
@@ -388,21 +380,17 @@ TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithUnusedFragmentDensity
         rp_ci2.subpassCount = 1;
         rp_ci2.pSubpasses = &subpass_desc;
 
-        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
-        ASSERT_EQ(vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass), VK_SUCCESS);
-        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+        vkt::RenderPass rp(*m_device, rp_ci2);
     }
 }
 
-TEST_F(PositiveTileShading, TileShadingDynamicRendering) {
+TEST_F(PositiveTileShading, DynamicRendering) {
     TEST_DESCRIPTION("Launch a dynamic rendering when tile-shading is enabled.");
     AddRequiredFeature(vkt::Feature::dynamicRendering);
-    InitBasicTileShading();
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicTileShading());
 
-    constexpr uint32_t image_width = 32;
-    constexpr uint32_t image_height = 32;
-    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT };
+    vkt::Image color_image{*m_device, 32, 32, m_render_target_fmt,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT};
     vkt::ImageView color_view = color_image.CreateView();
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
@@ -418,17 +406,13 @@ TEST_F(PositiveTileShading, TileShadingDynamicRendering) {
     tile_info.tileApronSize = {0, 0};
 
     VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_info);
-    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.renderArea = {{0, 0}, {32, 32}};
     rendering_info.layerCount = 1;
-    rendering_info.viewMask = 0;
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachments = &color_attachment;
-    rendering_info.pDepthAttachment = nullptr;
-    rendering_info.pStencilAttachment = nullptr;
 
     m_command_buffer.Begin();
-    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
-    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.BeginRendering(rendering_info);
+    m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
-

--- a/tests/unit/tile_shading_positive.cpp
+++ b/tests/unit/tile_shading_positive.cpp
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (C) 2026 Qualcomm Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "layer_validation_tests.h"
+#include "pipeline_helper.h"
+
+class PositiveTileShading : public TileShadingTest {};
+
+void TileShadingTest::InitBasicTileShading() {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDispatch);
+    AddRequiredFeature(vkt::Feature::tileShadingColorAttachments);
+    AddRequiredFeature(vkt::Feature::tileShadingDepthAttachments);
+    AddRequiredFeature(vkt::Feature::tileShadingStencilAttachments);
+    AddRequiredFeature(vkt::Feature::tileShadingSampledAttachments);
+}
+
+void TileShadingTest::InitTileShadingRenderTarget(const TileShadingRenderTargetConfig &tile_shading_rp_config) {
+    m_color_image.Init(*m_device, tile_shading_rp_config.rt_size.width, tile_shading_rp_config.rt_size.height, 1,
+                       tile_shading_rp_config.format,
+                       VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                       VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
+    m_color_view = m_color_image.CreateView();
+
+    if (tile_shading_rp_config.use_render_pass2) {
+        VkAttachmentDescription2 attachment_desc2 = vku::InitStructHelper();
+        attachment_desc2.format = tile_shading_rp_config.format;
+        attachment_desc2.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc2.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc2.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc2.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref2 = vku::InitStructHelper();
+        color_ref2.attachment = 0;
+        color_ref2.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref2.aspectMask = 0;
+
+        VkSubpassDescription2 subpass_desc2 = vku::InitStructHelper();
+        subpass_desc2.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc2.viewMask = 0;
+        subpass_desc2.inputAttachmentCount = 0;
+        subpass_desc2.colorAttachmentCount = 1;
+        subpass_desc2.pColorAttachments = &color_ref2;
+
+        VkSubpassDependency2 subpass_dependency2 = vku::InitStructHelper();
+        subpass_dependency2.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency2.dstSubpass = 0;
+        subpass_dependency2.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.srcAccessMask = 0;
+        subpass_dependency2.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency2.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci2.flags = 0;
+        rp_ci2.attachmentCount = 1;
+        rp_ci2.pAttachments = &attachment_desc2;
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc2;
+        rp_ci2.dependencyCount = 1;
+        rp_ci2.pDependencies = &subpass_dependency2;
+
+        m_tile_shading_render_pass.Init(*m_device, rp_ci2);
+    }
+    else {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.format = tile_shading_rp_config.format;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkSubpassDependency subpass_dependency{};
+        subpass_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency.dstSubpass = 0;
+        subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.srcAccessMask = 0;
+        subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+        rp_ci.dependencyCount = 1;
+        rp_ci.pDependencies = &subpass_dependency;
+
+        m_tile_shading_render_pass.Init(*m_device, rp_ci);
+    }
+
+    const VkImageView color_view_handle = m_color_view.handle();
+    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
+    framebuffer_ci.renderPass = m_tile_shading_render_pass;
+    framebuffer_ci.attachmentCount = 1;
+    framebuffer_ci.pAttachments = &color_view_handle;
+    framebuffer_ci.width = tile_shading_rp_config.rt_size.width;
+    framebuffer_ci.height = tile_shading_rp_config.rt_size.height;
+    framebuffer_ci.layers = 1;
+
+    m_tile_shading_framebuffer.Init(*m_device, framebuffer_ci);
+}
+
+TEST_F(PositiveTileShading, ExecutePerTileExecutionModel) {
+    TEST_DESCRIPTION("Execute per-tile execution model for a secondary command buffer.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    TileShadingRenderTargetConfig tile_shading_rp_config{};
+    InitTileShadingRenderTarget(tile_shading_rp_config);
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.f, 0.f, 0.f, 0.f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkCommandBuffer secondary_handle = secondary_command.handle();
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdExecuteCommands(m_command_buffer, 1, &secondary_handle);
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithResolveAttachment) {
+    TEST_DESCRIPTION("Create a tile-shading render pass with a valid resolve attachment.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        std::array<VkAttachmentDescription, 2> attachment_descs{};
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1].format = m_render_target_fmt;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference resolve_ref{};
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkSubpassDependency subpass_dependency{};
+        subpass_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency.dstSubpass = 0;
+        subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.srcAccessMask = 0;
+        subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper();
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_info);
+        rp_ci.attachmentCount = attachment_descs.size();
+        rp_ci.pAttachments = attachment_descs.data();
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+        rp_ci.dependencyCount = 1;
+        rp_ci.pDependencies = &subpass_dependency;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        std::array<VkAttachmentDescription2, 2> attachment_descs{};
+        attachment_descs[0] = vku::InitStructHelper();
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1] = vku::InitStructHelper();
+        attachment_descs[1].format = m_render_target_fmt;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 resolve_ref = vku::InitStructHelper();
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkSubpassDependency2 subpass_dependency2 = vku::InitStructHelper();
+        subpass_dependency2.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency2.dstSubpass = 0;
+        subpass_dependency2.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.srcAccessMask = 0;
+        subpass_dependency2.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency2.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper();
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_info);
+        rp_ci2.attachmentCount = attachment_descs.size();
+        rp_ci2.pAttachments = attachment_descs.data();
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+        rp_ci2.dependencyCount = 1;
+        rp_ci2.pDependencies = &subpass_dependency2;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}
+
+TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithUnusedFragmentDensityMapAttachment) {
+    TEST_DESCRIPTION("Create a tile-shading render pass with an unused fragment-density-map attachment.");
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.format = m_render_target_fmt;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_info = vku::InitStructHelper();
+        fdm_info.fragmentDensityMapAttachment.attachment = VK_ATTACHMENT_UNUSED;
+        fdm_info.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper(&fdm_info);
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_info);
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        VkAttachmentDescription2 attachment_desc = vku::InitStructHelper();
+        attachment_desc.format = m_render_target_fmt;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_info = vku::InitStructHelper();
+        fdm_info.fragmentDensityMapAttachment.attachment = VK_ATTACHMENT_UNUSED;
+        fdm_info.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper(&fdm_info);
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_info);
+        rp_ci2.attachmentCount = 1;
+        rp_ci2.pAttachments = &attachment_desc;
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}
+
+TEST_F(PositiveTileShading, TileShadingDynamicRendering) {
+    TEST_DESCRIPTION("Launch a dynamic rendering when tile-shading is enabled.");
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT };
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.resolveImageView = VK_NULL_HANDLE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper();
+    tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_info.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_info);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.viewMask = 0;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+    rendering_info.pDepthAttachment = nullptr;
+    rendering_info.pStencilAttachment = nullptr;
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.End();
+}
+

--- a/tests/unit/tile_shading_positive.cpp
+++ b/tests/unit/tile_shading_positive.cpp
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "layer_validation_tests.h"
+#include "pipeline_helper.h"
+
+class PositiveTileShading : public TileShadingTest {};
+
+void TileShadingTest::InitBasicTileShading() {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDispatch);
+    AddRequiredFeature(vkt::Feature::tileShadingColorAttachments);
+    AddRequiredFeature(vkt::Feature::tileShadingDepthAttachments);
+    AddRequiredFeature(vkt::Feature::tileShadingStencilAttachments);
+    AddRequiredFeature(vkt::Feature::tileShadingSampledAttachments);
+}
+
+void TileShadingTest::InitTileShadingRenderTarget(const TileShadingRenderTargetConfig &tile_shading_rp_config) {
+    m_color_image.Init(*m_device, tile_shading_rp_config.rt_size.width, tile_shading_rp_config.rt_size.height, 1,
+                       tile_shading_rp_config.format,
+                       VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                       VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
+    m_color_view = m_color_image.CreateView();
+
+    if (tile_shading_rp_config.use_render_pass2) {
+        VkAttachmentDescription2 attachment_desc2 = vku::InitStructHelper();
+        attachment_desc2.format = tile_shading_rp_config.format;
+        attachment_desc2.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc2.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc2.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc2.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc2.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref2 = vku::InitStructHelper();
+        color_ref2.attachment = 0;
+        color_ref2.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref2.aspectMask = 0;
+
+        VkSubpassDescription2 subpass_desc2 = vku::InitStructHelper();
+        subpass_desc2.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc2.viewMask = 0;
+        subpass_desc2.inputAttachmentCount = 0;
+        subpass_desc2.colorAttachmentCount = 1;
+        subpass_desc2.pColorAttachments = &color_ref2;
+
+        VkSubpassDependency2 subpass_dependency2 = vku::InitStructHelper();
+        subpass_dependency2.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency2.dstSubpass = 0;
+        subpass_dependency2.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.srcAccessMask = 0;
+        subpass_dependency2.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency2.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci2.flags = 0;
+        rp_ci2.attachmentCount = 1;
+        rp_ci2.pAttachments = &attachment_desc2;
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc2;
+        rp_ci2.dependencyCount = 1;
+        rp_ci2.pDependencies = &subpass_dependency2;
+
+        m_tile_shading_render_pass.Init(*m_device, rp_ci2);
+    }
+    else {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.format = tile_shading_rp_config.format;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkSubpassDependency subpass_dependency{};
+        subpass_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency.dstSubpass = 0;
+        subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.srcAccessMask = 0;
+        subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+        tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+        rp_ci.dependencyCount = 1;
+        rp_ci.pDependencies = &subpass_dependency;
+
+        m_tile_shading_render_pass.Init(*m_device, rp_ci);
+    }
+
+    const VkImageView color_view_handle = m_color_view.handle();
+    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
+    framebuffer_ci.renderPass = m_tile_shading_render_pass;
+    framebuffer_ci.attachmentCount = 1;
+    framebuffer_ci.pAttachments = &color_view_handle;
+    framebuffer_ci.width = tile_shading_rp_config.rt_size.width;
+    framebuffer_ci.height = tile_shading_rp_config.rt_size.height;
+    framebuffer_ci.layers = 1;
+
+    m_tile_shading_framebuffer.Init(*m_device, framebuffer_ci);
+}
+
+TEST_F(PositiveTileShading, ExecutePerTileExecutionModel) {
+    TEST_DESCRIPTION("Execute per-tile execution model for a secondary command buffer.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    TileShadingRenderTargetConfig tile_shading_rp_config{};
+    InitTileShadingRenderTarget(tile_shading_rp_config);
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.f, 0.f, 0.f, 0.f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkCommandBuffer secondary_handle = secondary_command.handle();
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdExecuteCommands(m_command_buffer, 1, &secondary_handle);
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithResolveAttachment) {
+    TEST_DESCRIPTION("Create a tile-shading render pass with a valid resolve attachment.");
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        std::array<VkAttachmentDescription, 2> attachment_descs{};
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1].format = m_render_target_fmt;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference resolve_ref{};
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkSubpassDependency subpass_dependency{};
+        subpass_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency.dstSubpass = 0;
+        subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency.srcAccessMask = 0;
+        subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper();
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_info);
+        rp_ci.attachmentCount = attachment_descs.size();
+        rp_ci.pAttachments = attachment_descs.data();
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+        rp_ci.dependencyCount = 1;
+        rp_ci.pDependencies = &subpass_dependency;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        std::array<VkAttachmentDescription2, 2> attachment_descs{};
+        attachment_descs[0] = vku::InitStructHelper();
+        attachment_descs[0].format = m_render_target_fmt;
+        attachment_descs[0].samples = VK_SAMPLE_COUNT_4_BIT;
+        attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_descs[1] = vku::InitStructHelper();
+        attachment_descs[1].format = m_render_target_fmt;
+        attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 resolve_ref = vku::InitStructHelper();
+        resolve_ref.attachment = 1;
+        resolve_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+        subpass_desc.pResolveAttachments = &resolve_ref;
+
+        VkSubpassDependency2 subpass_dependency2 = vku::InitStructHelper();
+        subpass_dependency2.srcSubpass = VK_SUBPASS_EXTERNAL;
+        subpass_dependency2.dstSubpass = 0;
+        subpass_dependency2.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        subpass_dependency2.srcAccessMask = 0;
+        subpass_dependency2.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        subpass_dependency2.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper();
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_info);
+        rp_ci2.attachmentCount = attachment_descs.size();
+        rp_ci2.pAttachments = attachment_descs.data();
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+        rp_ci2.dependencyCount = 1;
+        rp_ci2.pDependencies = &subpass_dependency2;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}
+
+TEST_F(PositiveTileShading, CreateTileShadingRenderPassWithUnusedFragmentDensityMapAttachment) {
+    TEST_DESCRIPTION("Create a tile-shading render pass with an unused fragment-density-map attachment.");
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    {
+        VkAttachmentDescription attachment_desc{};
+        attachment_desc.format = m_render_target_fmt;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference color_ref{};
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription subpass_desc{};
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_info = vku::InitStructHelper();
+        fdm_info.fragmentDensityMapAttachment.attachment = VK_ATTACHMENT_UNUSED;
+        fdm_info.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper(&fdm_info);
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_info);
+        rp_ci.attachmentCount = 1;
+        rp_ci.pAttachments = &attachment_desc;
+        rp_ci.subpassCount = 1;
+        rp_ci.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass(device(), &rp_ci, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+    {
+        VkAttachmentDescription2 attachment_desc = vku::InitStructHelper();
+        attachment_desc.format = m_render_target_fmt;
+        attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkAttachmentReference2 color_ref = vku::InitStructHelper();
+        color_ref.attachment = 0;
+        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
+        subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_desc.colorAttachmentCount = 1;
+        subpass_desc.pColorAttachments = &color_ref;
+
+        VkRenderPassFragmentDensityMapCreateInfoEXT fdm_info = vku::InitStructHelper();
+        fdm_info.fragmentDensityMapAttachment.attachment = VK_ATTACHMENT_UNUSED;
+        fdm_info.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
+
+        VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper(&fdm_info);
+        tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+        tile_info.tileApronSize = {0, 0};
+
+        VkRenderPassCreateInfo2 rp_ci2 = vku::InitStructHelper(&tile_info);
+        rp_ci2.attachmentCount = 1;
+        rp_ci2.pAttachments = &attachment_desc;
+        rp_ci2.subpassCount = 1;
+        rp_ci2.pSubpasses = &subpass_desc;
+
+        VkRenderPass tile_shading_render_pass = VK_NULL_HANDLE;
+        ASSERT_EQ(vk::CreateRenderPass2(device(), &rp_ci2, nullptr, &tile_shading_render_pass), VK_SUCCESS);
+        vk::DestroyRenderPass(device(), tile_shading_render_pass, nullptr);
+    }
+}
+
+TEST_F(PositiveTileShading, TileShadingDynamicRendering) {
+    TEST_DESCRIPTION("Launch a dynamic rendering when tile-shading is enabled.");
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    InitBasicTileShading();
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t image_width = 32;
+    constexpr uint32_t image_height = 32;
+    vkt::Image color_image{*m_device, image_width, image_height, m_render_target_fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT };
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
+    color_attachment.resolveImageView = VK_NULL_HANDLE;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_info = vku::InitStructHelper();
+    tile_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_info.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_info);
+    rendering_info.renderArea = {{0, 0}, {image_width, image_height}};
+    rendering_info.layerCount = 1;
+    rendering_info.viewMask = 0;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+    rendering_info.pDepthAttachment = nullptr;
+    rendering_info.pStencilAttachment = nullptr;
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.End();
+}
+


### PR DESCRIPTION
1. **VK_QCOM_tile_shading VUID Part 1**: Add render pass creation, dynamic rendering, and per-tile execution VUIDs for VK_QCOM_tile_shading extension.

2. **VK_QCOM_tile_shading unit test Part 1**: Add render pass creation, dynamic rendering, and per-tile execution unit tests for VK_QCOM_tile_shading extension.
 
3. **Test result**: Passed or skipped on Qualcomm android device.