### PR TITLE
layers: State track PushData like PushConstant

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -2116,16 +2116,18 @@ bool CoreChecks::ValidateActionStatePushConstantDescriptorHeap(const vvl::Comman
 
     const auto& pc_variable = *entry_point->push_constant_variable;
     if (pc_variable.size > 0) {
+        const auto& cb_sub_state = core::SubState(cb_state);
+
         const uint32_t begin = pc_variable.offset;
         const uint32_t end = begin + pc_variable.size - 1;
 
-        if (!cb_state.descriptor_heap.push_data.empty()) {
-            const uint32_t size = static_cast<uint32_t>(cb_state.descriptor_heap.push_data.size());
+        if (!cb_sub_state.push_data_mask.empty()) {
+            const uint32_t size = static_cast<uint32_t>(cb_sub_state.push_data_mask.size());
             // Find the first range of bytes which were not set
             uint32_t unset_start = size;
             uint32_t unset_end = end;
             for (uint32_t i = begin; i <= end; i++) {
-                if (i >= size || !cb_state.descriptor_heap.push_data[i]) {
+                if (i >= size || !cb_sub_state.push_data_mask[i]) {
                     if (unset_start == size) {
                         unset_start = i;
                     }

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -244,6 +244,19 @@ void CommandBufferSubState::RecordSetPrimitiveRestartIndex(uint32_t primitive_re
     custom_primitive_restart_index = primitive_restart_index;
 }
 
+void CommandBufferSubState::RecordPushData(const VkPushDataInfoEXT& push_data_info) {
+    if (push_data_info.data.size > 0) {
+        const size_t begin = push_data_info.offset;
+        const size_t end = push_data_info.offset + push_data_info.data.size;
+        if (push_data_mask.size() < end) {
+            push_data_mask.resize(end);
+        }
+        memset(push_data_mask.data() + begin, 1, end - begin);
+    }
+}
+
+void CommandBufferSubState::ClearPushData() { push_data_mask.clear(); }
+
 void CommandBufferSubState::RecordNextSubpass(const VkSubpassBeginInfo&, const VkSubpassEndInfo*, const Location&) {
     ASSERT_AND_RETURN(base.active_render_pass);
     validator.TransitionSubpassLayouts(base, *base.active_render_pass, base.GetActiveSubpass());
@@ -1074,6 +1087,8 @@ void CommandBufferSubState::ResetCBState() {
     custom_resolve.stencil_format = VK_FORMAT_UNDEFINED;
 
     custom_primitive_restart_index = 0;
+
+    push_data_mask.clear();
 
     // Submit time validation
     queue_submit_functions.clear();

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -48,6 +48,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordBindIndexbuffer() final;
     void RecordSetPrimitiveRestartIndex(uint32_t primitive_restart_index) final;
 
+    void RecordPushData(const VkPushDataInfoEXT& push_data_info) final;
+    void ClearPushData() final;
+
     void RecordBeginRendering(const VkRenderingInfo &rendering_info, const Location &loc) final;
     void RecordBeginRenderPass(const VkRenderPassBeginInfo &render_pass_begin, const VkSubpassBeginInfo &subpass_begin_info,
                                const Location &loc) final;
@@ -180,6 +183,10 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     // VK_EXT_primitive_restart_index
     uint32_t custom_primitive_restart_index;
+
+    // VK_EXT_descriptor_heap
+    // Mark which ranges vkCmdPushDataKHR has set (will be 0 or 1)
+    std::vector<uint8_t> push_data_mask{};
 
     uint32_t used_viewport_scissor_count;
 

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -306,8 +306,7 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             return resource_variable->decorations.binding < other.resource_variable->decorations.binding;
         }
 
-        void Print(std::ostringstream& map_ss, const VkPhysicalDevice physical_device,
-                   const vvl::CommandBuffer::DescriptorHeap& heap) {
+        void Print(const CommandBufferSubState& cb_sub_state, std::ostringstream& map_ss, const VkPhysicalDevice physical_device) {
             map_ss << "    - Binding " << std::dec << resource_variable->decorations.binding << ", "
                    << string_VkDescriptorMappingSourceEXT(mapping->source) << " (from pMappings[" << mapping_index << "])\n";
             const bool is_sampler =
@@ -329,6 +328,8 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             bool warn_index_oob = false;
 
             map_ss << "      - ";
+
+            vvl::CommandBuffer::DescriptorHeap& heap = cb_sub_state.base.descriptor_heap;
             if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
                 const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping->sourceData.constantOffset;
                 if (is_sampler) {
@@ -342,7 +343,7 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                                                descriptor_size) > heap.sampler_range.size());
                         }
                     }
-                    warn_oob = (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
+                    warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
                 } else {
                     map_ss << "heapOffset: 0x" << std::hex << map_data.heapOffset << ", heapArrayStride: 0x"
                            << map_data.heapArrayStride;
@@ -354,45 +355,60 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                                                descriptor_size) > heap.resource_range.size());
                         }
                     }
-                    warn_oob = (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
                 const VkDescriptorMappingSourcePushIndexEXT& map_data = mapping->sourceData.pushIndex;
+                uint32_t push_index = *((uint32_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
+
                 if (is_sampler) {
                     map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", samplerHeapOffset: 0x"
                            << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride
                            << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
-                    map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
-                           << " + (pushIndex * 0x" << map_data.samplerHeapIndexStride << ")";
+                    map_ss << "\n        pushIndex: 0x" << push_index;
+                    map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset << " + (0x"
+                           << push_index << " * 0x" << map_data.samplerHeapIndexStride << ")";
                     if (is_array) {
                         map_ss << " + (descriptor_index * 0x" << map_data.samplerHeapArrayStride << ")";
                         if (array_length != 0) {
                             warn_index_oob = ((map_data.samplerHeapOffset + ((array_length - 1) * map_data.samplerHeapArrayStride) +
                                                descriptor_size) > heap.sampler_range.size());
                         }
+                    } else {
+                        uint64_t final_offset = map_data.samplerHeapOffset + (push_index * map_data.samplerHeapIndexStride);
+                        map_ss << " [final address 0x" << (heap.sampler_range.begin + final_offset) << "]";
+                        warn_oob |= (final_offset + descriptor_size > heap.sampler_range.size());
                     }
-                    warn_oob = (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
+                    warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
                 } else {
                     map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", heapOffset: 0x" << map_data.heapOffset
                            << ", heapIndexStride: 0x" << map_data.heapIndexStride << ", heapArrayStride: 0x"
                            << map_data.heapArrayStride;
-                    map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
-                           << " + (pushIndex * 0x" << map_data.heapIndexStride << ")";
+                    map_ss << "\n        pushIndex: 0x" << push_index;
+                    map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset << " + (0x"
+                           << push_index << " * 0x" << map_data.heapIndexStride << ")";
                     if (is_array) {
                         map_ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
                         if (array_length != 0) {
                             warn_index_oob = ((map_data.heapOffset + ((array_length - 1) * map_data.heapArrayStride) +
                                                descriptor_size) > heap.resource_range.size());
                         }
+                    } else {
+                        uint64_t final_offset = map_data.heapOffset + (push_index * map_data.heapIndexStride);
+                        map_ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
+                        warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
                     }
-                    warn_oob = (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
                 const VkDescriptorMappingSourceIndirectIndexEXT& map_data = mapping->sourceData.indirectIndex;
+                uint64_t indirect_address = *((uint64_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
+
                 if (is_sampler) {
                     map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
                            << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x"
                            << map_data.samplerHeapIndexStride << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
+                    map_ss << "\n        indirectAddress: 0x" << indirect_address;
                     map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
                            << " + (indirectIndex * 0x" << map_data.samplerHeapIndexStride << ")";
                     if (is_array) {
@@ -402,11 +418,12 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                                                descriptor_size) > heap.sampler_range.size());
                         }
                     }
-                    warn_oob = (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
+                    warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
                 } else {
                     map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
                            << ", heapOffset: 0x" << map_data.heapOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride
                            << ", heapArrayStride: 0x" << map_data.heapArrayStride;
+                    map_ss << "\n        indirectAddress: 0x" << indirect_address;
                     map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
                            << " + (indirectIndex * 0x" << map_data.heapIndexStride << ")";
                     if (is_array) {
@@ -416,36 +433,49 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                                                descriptor_size) > heap.resource_range.size());
                         }
                     }
-                    warn_oob = (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
                 const VkDescriptorMappingSourceIndirectIndexArrayEXT& map_data = mapping->sourceData.indirectIndexArray;
+                uint64_t indirect_address = *((uint64_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
+
                 if (is_sampler) {
                     map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
                            << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x"
                            << map_data.samplerHeapIndexStride;
+                    map_ss << "\n        indirectAddress: 0x" << indirect_address;
                     map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
                            << " + (indirectIndex * 0x" << map_data.samplerHeapIndexStride << ")";
-                    warn_oob = (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
+                    warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
                 } else {
                     map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
                            << ", heapOffset: 0x" << map_data.heapOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride;
+                    map_ss << "\n        indirectAddress: 0x" << indirect_address;
                     map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
                            << " + (indirectIndex * 0x" << map_data.heapIndexStride << ")";
-                    warn_oob = (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT) {
                 const VkDescriptorMappingSourceHeapDataEXT& map_data = mapping->sourceData.heapData;
+                uint32_t push_data = *((uint32_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
+
                 map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", heapOffset: 0x" << map_data.heapOffset;
-                map_ss << "\n        Resource Heap base address: 0x" << heap.resource_range.begin + map_data.heapOffset
-                       << " + value_at_push_offset(0x" << map_data.pushOffset << ")";
+                map_ss << "\n        Push data at 0x" << std::hex << map_data.pushOffset << ": 0x" << push_data;
+                map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset << " + 0x" << push_data;
+                uint64_t final_offset = map_data.heapOffset + push_data;
+                map_ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
+                warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT) {
                 map_ss << "pushDataOffset: 0x" << std::hex << mapping->sourceData.pushDataOffset;
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT) {
+                uint64_t indirect_address = *((uint64_t*)&cb_sub_state.push_data_value[mapping->sourceData.pushAddressOffset]);
                 map_ss << "pushAddressOffset: 0x" << std::hex << mapping->sourceData.pushAddressOffset;
+                map_ss << "\n        Indirect Adresss 0x" << indirect_address;
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT) {
                 const VkDescriptorMappingSourceIndirectAddressEXT& map_data = mapping->sourceData.indirectAddress;
+                uint64_t indirect_address = *((uint64_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
                 map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset;
+                map_ss << "\n        Indirect Adresss 0x" << indirect_address;
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT) {
                 // TODO - Add address for RTX
                 const VkDescriptorMappingSourceShaderRecordIndexEXT& map_data = mapping->sourceData.shaderRecordIndex;
@@ -523,7 +553,7 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             ss << "  - Set " << set_index << ":\n";
             std::sort(mapping_info_list.begin(), mapping_info_list.end());
             for (MappingInfo& set_info : mapping_info_list) {
-                set_info.Print(ss, dev_data.physical_device, cb_state.descriptor_heap);
+                set_info.Print(*this, ss, dev_data.physical_device);
             }
         }
     }

--- a/layers/gpu_dump/gpu_dump_state.cpp
+++ b/layers/gpu_dump/gpu_dump_state.cpp
@@ -31,6 +31,16 @@ void CommandBufferSubState::RecordActionCommand(LastBound& last_bound, const Loc
     }
 }
 
+void CommandBufferSubState::RecordPushData(const VkPushDataInfoEXT& push_data_info) {
+    if (push_data_value.empty()) {
+        push_data_value.resize((size_t)base.dev_data.phys_dev_ext_props.descriptor_heap_props.maxPushDataSize);
+    }
+
+    memcpy(push_data_value.data() + push_data_info.offset, push_data_info.data.address, push_data_info.data.size);
+}
+
+void CommandBufferSubState::ClearPushData() { push_data_value.clear(); }
+
 void CommandBufferSubState::RecordExecuteGeneratedCommands(const VkGeneratedCommandsInfoEXT& info, VkPipelineBindPoint bind_point,
                                                            const Location& loc) {
     if (dev_data.gpu_dump_settings.device_generated_commands) {

--- a/layers/gpu_dump/gpu_dump_state.h
+++ b/layers/gpu_dump/gpu_dump_state.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <cstdint>
 #include "chassis/layer_object_id.h"
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/cmd_buffer_state.h"
@@ -27,6 +28,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     GpuDump& dev_data;
 
     void RecordActionCommand(LastBound& last_bound, const Location& loc) final;
+
+    void RecordPushData(const VkPushDataInfoEXT& push_data_info) final;
+    void ClearPushData() final;
 
     void RecordExecuteGeneratedCommands(const VkGeneratedCommandsInfoEXT& info, VkPipelineBindPoint bind_point,
                                         const Location& loc) final;
@@ -46,6 +50,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     void DumpDeviceGeneratedCommands(const VkGeneratedCommandsInfoEXT& info, VkPipelineBindPoint bind_point,
                                      const Location& loc) const;
+
+    std::vector<uint8_t> push_data_value;
 };
 
 static inline CommandBufferSubState& SubState(vvl::CommandBuffer& cb) {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -2279,18 +2279,16 @@ void CommandBuffer::RecordPushConstants(const vvl::PipelineLayout& pipeline_layo
 
     for (auto& item : sub_states_) {
         item.second->RecordPushConstants(pipeline_layout_state.VkHandle(), stage_flags, offset, size, values);
+        item.second->ClearPushData();  // vkspec.html#descriptorheaps-invalidate-sets
     }
 }
 
-void CommandBuffer::RecordCmdPushDataEXT(const VkPushDataInfoEXT& push_data_info, const Location& loc) {
+void CommandBuffer::RecordPushData(const VkPushDataInfoEXT& push_data_info, const Location& loc) {
     RecordCommand(loc);
-    if (push_data_info.data.size > 0) {
-        const size_t begin = push_data_info.offset;
-        const size_t end = push_data_info.offset + push_data_info.data.size;
-        if (descriptor_heap.push_data.size() < end) {
-            descriptor_heap.push_data.resize(end);
-        }
-        memset(descriptor_heap.push_data.data() + begin, 1, end - begin);
+
+    for (auto& item : sub_states_) {
+        item.second->RecordPushData(push_data_info);
+        item.second->ClearPushConstants();  // vkspec.html#descriptorheaps-invalidate-sets
     }
 }
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -581,8 +581,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
         bool resource_bound;
         vvl::range<VkDeviceAddress> resource_range;
         vvl::range<VkDeviceAddress> resource_reserved;
-        // Heap buffer push data assigned with vkCmdPushDataKHR ranges
-        std::vector<uint8_t> push_data{};
 
         void Reset() {
             sampler_bound = false;
@@ -591,7 +589,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
             resource_bound = false;
             resource_reserved = {};
             resource_range = {};
-            push_data.clear();
         }
     } descriptor_heap;
 
@@ -766,7 +763,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
                           const VkDependencyInfo *dependency_info, const Location &loc);
     void RecordPushConstants(const vvl::PipelineLayout &pipeline_layout_state, VkShaderStageFlags stage_flags, uint32_t offset,
                              uint32_t size, const void *values);
-    void RecordCmdPushDataEXT(const VkPushDataInfoEXT& push_data_info, const Location& loc);
+    void RecordPushData(const VkPushDataInfoEXT& push_data_info, const Location& loc);
 
     void RecordBeginConditionalRendering(const Location &loc);
     void RecordEndConditionalRendering(const Location &loc);
@@ -945,6 +942,10 @@ class CommandBufferSubState {
 
     virtual void RecordPushConstants(VkPipelineLayout layout, VkShaderStageFlags stage_flags, uint32_t offset, uint32_t size,
                                      const void *values) {}
+    virtual void RecordPushData(const VkPushDataInfoEXT& push_data_info) {}
+
+    virtual void ClearPushConstants() {}
+    virtual void ClearPushData() {}
 
     virtual void RecordBeginRendering(const VkRenderingInfo &rendering_info, const Location &loc) {}
     virtual void RecordBeginRenderPass(const VkRenderPassBeginInfo &render_pass_begin, const VkSubpassBeginInfo &subpass_begin_info,
@@ -978,7 +979,6 @@ class CommandBufferSubState {
     virtual void RecordDecodeVideo(vvl::VideoSession &vs_state, const VkVideoDecodeInfoKHR &decode_info, const Location &loc) {}
     virtual void RecordEncodeVideo(vvl::VideoSession &vs_state, const VkVideoEncodeInfoKHR &encode_info, const Location &loc) {}
 
-    virtual void ClearPushConstants() {}
     virtual void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {}
 
     virtual void Submit(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc) {}

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -6837,7 +6837,7 @@ void DeviceState::PostCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBu
 void DeviceState::PostCallRecordCmdPushDataEXT(VkCommandBuffer commandBuffer, const VkPushDataInfoEXT* pPushDataInfo,
                                                const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
-    cb_state->RecordCmdPushDataEXT(*pPushDataInfo, record_obj.location);
+    cb_state->RecordPushData(*pPushDataInfo, record_obj.location);
 
     cb_state->SetDescriptorMode(DescriptorModeHeap, record_obj.location.function);
 }


### PR DESCRIPTION
This mimics PushData to be like PushConstant

For `CoreValidation` we don't need the value of the push data/constant, we just track "if they have been set" so we do that in the `cc_state_tracker.cpp` substate (`CommandBufferSubState`)

Then for things like GPU-AV (or I tested with GPU Dump) where we want to store the real data, it can