### PR TITLE
Fix invalidating descriptor mode

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -276,6 +276,19 @@ void CommandBuffer::SetDescriptorMode(vvl::DescriptorMode new_mode, vvl::Func fu
     }
 }
 
+// Some functions like vkCmdPushConstant are valid in Classic/Buffer, but invalid in Heap
+// So calling it doesn't "set" a mode, but instead only "invalidates"
+void CommandBuffer::InvalidateDescriptorMode(vvl::DescriptorMode invalidate_mode, vvl::DescriptorMode new_mode,
+                                             vvl::Func function) {
+    for (uint32_t i = 0; i < vvl::BindPointCount; i++) {
+        const vvl::DescriptorMode current_mode = lastBound[i].GetDescriptorMode();
+        if (current_mode == invalidate_mode) {
+            SetDescriptorMode(new_mode, function);
+            break;
+        }
+    }
+}
+
 // Reset the command buffer state
 // Maintain the createInfo and set state to CB_NEW, but clear all other state
 void CommandBuffer::ResetCBState() {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -593,6 +593,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     } descriptor_heap;
 
     void SetDescriptorMode(vvl::DescriptorMode new_mode, vvl::Func function);
+    void InvalidateDescriptorMode(vvl::DescriptorMode invalidate_mode, vvl::DescriptorMode new_mode, vvl::Func function);
 
     mutable std::shared_mutex lock;
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3301,11 +3301,12 @@ void DeviceState::PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, 
     auto pipeline_layout_state = Get<PipelineLayout>(layout);
     ASSERT_AND_RETURN(cb_state && pipeline_layout_state);
 
-    const DescriptorMode descriptor_mode =
-        pipeline_layout_state->has_descriptor_buffer ? vvl::DescriptorModeBuffer : vvl::DescriptorModeClassic;
-    cb_state->SetDescriptorMode(descriptor_mode, record_obj.location.function);
     cb_state->RecordCommand(record_obj.location);
     cb_state->RecordPushConstants(*pipeline_layout_state, stageFlags, offset, size, pValues);
+
+    const DescriptorMode descriptor_mode =
+        pipeline_layout_state->has_descriptor_buffer ? vvl::DescriptorModeBuffer : vvl::DescriptorModeClassic;
+    cb_state->InvalidateDescriptorMode(vvl::DescriptorModeHeap, descriptor_mode, record_obj.location.function);
 }
 
 void DeviceState::PostCallRecordCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo* pPushConstantsInfo,

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -2245,3 +2245,43 @@ TEST_F(PositiveDescriptorBuffer, ImmutableSamplerIdenticallyDefinedMaintenance4)
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 }
+
+TEST_F(PositiveDescriptorBuffer, SetPushConstsWithDifferentLayout) {
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
+    InitRenderTarget();
+
+    vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
+
+    VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
+    buffer_binding_info.address = buffer.Address();
+    buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
+    const vkt::DescriptorSetLayout set_layout(*m_device, {binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+    const vkt::PipelineLayout pipeline_layout1(*m_device, {&set_layout});
+
+    VkPushConstantRange push_const_range;
+    push_const_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    push_const_range.offset = 0u;
+    push_const_range.size = sizeof(uint32_t);
+    const vkt::PipelineLayout pipeline_layout2(*m_device, {}, {push_const_range});
+
+    CreatePipelineHelper pipe(*this);
+    pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipe.gp_ci_.layout = pipeline_layout1;
+    pipe.CreateGraphicsPipeline();
+
+    const uint32_t index = 0;
+    const VkDeviceSize offset = 0;
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &buffer_binding_info);
+    vk::CmdPushConstants(m_command_buffer, pipeline_layout2, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(uint32_t), &index);
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout1, 0, 1, &index,
+                                         &offset);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
@spencer-lunarg I've realized that the change in #12136 could be wrong, do we agree that the test in this PR is valid?

Between vkCmdBindDescriptorBuffersEXT and vkCmdSetDescriptorBufferOffsetsEXT the tests calls vkCmdPushConstants with a different pipeline layout