### PR TITLE
Refactor ResourceInterfaceVariable tracking of descriptor type 

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -222,198 +222,6 @@ bool CoreChecks::ValidatePushConstantUsage(const spirv::Module& module_state, co
     return skip;
 }
 
-struct ShaderResourceType {
-    // All possible VkDescriptorSet
-    vvl::unordered_set<uint32_t> descriptor_type_set;
-    // Way to print out extra useful information
-    bool is_buffer_block{false};
-
-    bool HasType(VkDescriptorType type) { return descriptor_type_set.find(type) != descriptor_type_set.end(); }
-
-    std::string Describe(bool hints) {
-        std::ostringstream ss;
-        for (auto it = descriptor_type_set.begin(); it != descriptor_type_set.end(); ++it) {
-            if (ss.tellp()) ss << " or ";
-            ss << string_VkDescriptorType(VkDescriptorType(*it));
-        }
-
-        // Currently this is used for 2 checks
-        // - When there is no binding found at all
-        // - When it is found, but the mismatch, here we want to help give hints
-        if (hints) {
-            ss << "\nInfo on SPIR-V mapping for each type:";
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_SAMPLER)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_SAMPLER is an OpTypeSampler with UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER is an OpTypeSampledImage that consumes both a OpTypeSampler "
-                      "and OpTypeImage in UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE is an OpTypeImage, with Sampled = 1, in UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_STORAGE_IMAGE is an OpTypeImage, with Sampled = 2, in UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER is an OpTypeImage, with Sampled = 1 and Dim = Buffer, in "
-                      "UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER is an OpTypeImage, with Sampled = 2 and Dim = Buffer, in "
-                      "UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER/VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK is an OpTypeStruct as "
-                      "Uniform";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_STORAGE_BUFFER is an OpTypeStruct as ";
-                if (is_buffer_block) {
-                    ss << "Uniform, with BufferBlock (Vulkan 1.0 didn't have a dedicated StorageBuffer storage class, more info at "
-                          "https://docs.vulkan.org/guide/latest/extensions/"
-                          "shader_features.html#VK_KHR_storage_buffer_storage_class)";
-                } else {
-                    ss << "StorageBuffer";
-                }
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT is an OpTypeImage, with Sampled = 2 and Dim = SubpassData, in "
-                      "UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR is an OpTypeAccelerationStructureKHR in UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV is an OpTypeAccelerationStructureKHR in "
-                      "UniformConstant";
-            }
-            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_TENSOR_ARM)) {
-                ss << "\n - VK_DESCRIPTOR_TYPE_TENSOR_ARM is an OpTypeTensorARM in UniformConstant";
-            }
-            ss << "\nFull list of mappings can be found at "
-                  "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-storage-class-correspondence";
-        }
-        return ss.str();
-    }
-};
-
-// This function is matching the VkDescriptorType to the SPIR-V.
-// We return back a set, because things like a Uniform in SPIR-V could be one of many possible matching VkDescriptorType.
-// https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-storage-class-correspondence
-static void TypeToDescriptorTypeSet(const spirv::Module& module_state, uint32_t type_id, uint32_t data_type_id,
-                                    ShaderResourceType& out_data) {
-    const spirv::Instruction* type = module_state.FindDef(type_id);
-    assert(type->Opcode() == spv::OpTypePointer || type->Opcode() == spv::OpTypeUntypedPointerKHR);
-    bool is_storage_buffer = type->StorageClass() == spv::StorageClassStorageBuffer;
-
-    if (data_type_id != 0) {
-        type = module_state.FindDef(data_type_id);
-    }
-
-    // Strip off any array or ptrs. Where we remove array levels, adjust the  descriptor count for each dimension.
-    while (type->IsArray() || type->Opcode() == spv::OpTypePointer) {
-        if (type->Opcode() == spv::OpTypeRuntimeArray) {
-            type = module_state.FindDef(type->Word(2));
-        } else if (type->Opcode() == spv::OpTypeArray) {
-            type = module_state.FindDef(type->Word(2));
-        } else {
-            if (type->StorageClass() == spv::StorageClassStorageBuffer) {
-                is_storage_buffer = true;
-            }
-            type = module_state.FindDef(type->Word(3));
-        }
-    }
-
-    switch (type->Opcode()) {
-        case spv::OpTypeStruct: {
-            for (const spirv::Instruction* insn : module_state.static_data_.decoration_inst) {
-                if (insn->Word(1) == type->ResultId()) {
-                    if (insn->Word(2) == spv::DecorationBlock) {
-                        if (is_storage_buffer) {
-                            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-                            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);
-                        } else {
-                            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
-                            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
-                            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK);
-                        }
-                    } else if (insn->Word(2) == spv::DecorationBufferBlock) {
-                        out_data.is_buffer_block = true;
-                        out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-                        out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);
-                    }
-                    break;
-                }
-            }
-            return;
-        }
-
-        case spv::OpTypeSampler:
-            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_SAMPLER);
-            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-            return;
-
-        case spv::OpTypeSampledImage: {
-            // Slight relaxation for some GLSL historical madness: samplerBuffer doesn't really have a sampler, and a texel
-            // buffer descriptor doesn't really provide one. Allow this slight mismatch.
-            const spirv::Instruction* image_type = module_state.FindDef(type->Word(2));
-            auto dim = image_type->Word(3);
-            auto sampled = image_type->Word(7);
-            if (dim == spv::DimBuffer && sampled == 1) {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
-            } else {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-            }
-            return;
-        }
-        case spv::OpTypeImage: {
-            // Many descriptor types backing image types-- depends on dimension and whether the image will be used with a sampler.
-            // SPIRV for Vulkan requires that sampled be 1 or 2 -- leaving the decision to runtime is unacceptable.
-            auto dim = type->Word(3);
-            auto sampled = type->Word(7);
-
-            if (dim == spv::DimSubpassData) {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
-            } else if (dim == spv::DimBuffer) {
-                if (sampled == 1) {
-                    out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
-                } else {
-                    out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
-                }
-            } else if (sampled == 1) {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
-            } else {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
-            }
-            return;
-        }
-
-        // The OpType are alias, but the Descriptor Types are different
-        case spv::OpTypeAccelerationStructureKHR:
-            // Only KHR or NV base acceleration structure is selected
-            if (module_state.HasCapability(spv::CapabilityRayTracingNV)) {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV);
-            } else {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
-            }
-            // Additionally allow PTLAS if shader uses cluster acceleration structure features
-            if (module_state.HasCapability(spv::CapabilityRayTracingClusterAccelerationStructureNV)) {
-                out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV);
-            }
-            return;
-        case spv::OpTypeTensorARM: {
-            out_data.descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_TENSOR_ARM);
-            return;
-        }
-
-        default:
-            // We shouldn't really see any other junk types -- but if we do, they're a mismatch.
-            return;  // Matches nothing
-    }
-}
-
 // Map SPIR-V type to VK_COMPONENT_TYPE enum
 VkComponentTypeKHR GetComponentType(const spirv::Instruction* insn, bool is_signed_int) {
     if (insn->Opcode() == spv::OpTypeInt) {
@@ -1620,27 +1428,14 @@ bool CoreChecks::ValidateShaderInterfaceVariable(const spirv::Module& module_sta
         // If the variable is a struct, all members must contain NonWritable
         if (!variable.type_struct_info ||
             !variable.type_struct_info->decorations.AllMemberHave(spirv::DecorationSet::nonwritable_bit)) {
-            auto print_type = [variable]() {
-                if (variable.is_storage_image) {
-                    return "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE";
-                } else if (variable.is_storage_texel_buffer) {
-                    return "VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER";
-                } else if (variable.is_storage_buffer) {
-                    return "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER";
-                } else if (variable.is_storage_tensor) {
-                    return "VK_DESCRIPTOR_TYPE_TENSOR_ARM";
-                } else {
-                    return "Unknown VkDescriptorType";
-                }
-            };
-
             switch (variable.stage) {
                 case VK_SHADER_STAGE_FRAGMENT_BIT:
                     if (!enabled_features.fragmentStoresAndAtomics) {
                         skip |= LogError("VUID-RuntimeSpirv-NonWritable-06340", module_state.handle(), loc,
                                          "shader %s uses descriptor %s (type %s) which is not "
                                          "marked with NonWritable, but fragmentStoresAndAtomics was not enabled.",
-                                         entrypoint.Describe().c_str(), variable.DescribeDescriptor().c_str(), print_type());
+                                         entrypoint.Describe().c_str(), variable.DescribeDescriptor().c_str(),
+                                         string_VkDescriptorType(variable.GetPotentialDescriptorType()));
                     }
                     break;
                 case VK_SHADER_STAGE_VERTEX_BIT:
@@ -1651,7 +1446,8 @@ bool CoreChecks::ValidateShaderInterfaceVariable(const spirv::Module& module_sta
                         skip |= LogError("VUID-RuntimeSpirv-NonWritable-06341", module_state.handle(), loc,
                                          "shader %s uses descriptor %s (type %s) which is not marked with NonWritable, but "
                                          "vertexPipelineStoresAndAtomics was not enabled.",
-                                         entrypoint.Describe().c_str(), variable.DescribeDescriptor().c_str(), print_type());
+                                         entrypoint.Describe().c_str(), variable.DescribeDescriptor().c_str(),
+                                         string_VkDescriptorType(variable.GetPotentialDescriptorType()));
                     }
                     break;
                 default:
@@ -1687,6 +1483,83 @@ bool CoreChecks::ValidateShaderInterfaceVariable(const spirv::Module& module_sta
     return skip;
 }
 
+struct ShaderResourceType {
+    const spirv::ResourceInterfaceVariable& resource_variable;
+    const vvl::unordered_set<VkDescriptorType> descriptor_type_set;
+
+    explicit ShaderResourceType(const spirv::ResourceInterfaceVariable& variable)
+        : resource_variable(variable), descriptor_type_set(variable.GetAllDescriptorTypes()) {}
+
+    bool HasType(VkDescriptorType type) { return descriptor_type_set.find(type) != descriptor_type_set.end(); }
+
+    std::string Describe(bool hints) {
+        std::ostringstream ss;
+        for (auto it = descriptor_type_set.begin(); it != descriptor_type_set.end(); ++it) {
+            if (ss.tellp()) ss << " or ";
+            ss << string_VkDescriptorType(VkDescriptorType(*it));
+        }
+
+        // Currently this is used for 2 checks
+        // - When there is no binding found at all
+        // - When it is found, but the mismatch, here we want to help give hints
+        if (hints) {
+            ss << "\nInfo on SPIR-V mapping for each type:";
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_SAMPLER)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_SAMPLER is an OpTypeSampler with UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER is an OpTypeSampledImage that consumes both a OpTypeSampler "
+                      "and OpTypeImage in UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE is an OpTypeImage, with Sampled = 1, in UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_STORAGE_IMAGE is an OpTypeImage, with Sampled = 2, in UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER is an OpTypeImage, with Sampled = 1 and Dim = Buffer, in "
+                      "UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER is an OpTypeImage, with Sampled = 2 and Dim = Buffer, in "
+                      "UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER/VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK is an OpTypeStruct as "
+                      "Uniform";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_STORAGE_BUFFER is an OpTypeStruct as ";
+                if (resource_variable.is_buffer_block) {
+                    ss << "Uniform, with BufferBlock (Vulkan 1.0 didn't have a dedicated StorageBuffer storage class, more info at "
+                          "https://docs.vulkan.org/guide/latest/extensions/"
+                          "shader_features.html#VK_KHR_storage_buffer_storage_class)";
+                } else {
+                    ss << "StorageBuffer";
+                }
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT is an OpTypeImage, with Sampled = 2 and Dim = SubpassData, in "
+                      "UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR is an OpTypeAccelerationStructureKHR in UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV is an OpTypeAccelerationStructureKHR in "
+                      "UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_TENSOR_ARM)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_TENSOR_ARM is an OpTypeTensorARM in UniformConstant";
+            }
+            ss << "\nFull list of mappings can be found at "
+                  "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-storage-class-correspondence";
+        }
+        return ss.str();
+    }
+};
+
 bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                                     const ShaderStageState& stage_state,
                                                     const spirv::ResourceInterfaceVariable& variable, const Location& loc) const {
@@ -1717,9 +1590,7 @@ bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module& module_
         return ss.str();
     };
 
-    // Pass as reference to not copy the unordered_set on a return
-    ShaderResourceType resource_type;
-    TypeToDescriptorTypeSet(module_state, variable.type_id, variable.data_type_id, resource_type);
+    ShaderResourceType resource_type(variable);
 
     // If no binding nothing left to validate
     if (!binding) {

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -3237,8 +3237,6 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT,
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT})) {
                 const uint32_t base_opcode = resource_variable.base_type.Opcode();
-                // TODO - Seem we are missing the image portion of combined image samplers
-                const bool is_sampler = resource_variable.is_combined_image_sampler;
 
                 struct MappingSourceInfo {
                     uint32_t offset = 0;
@@ -3248,10 +3246,12 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                     Field align_field = Field::Empty;
                 } info;
 
-                if (is_sampler) {
-                    info.vuid = "VUID-VkDescriptorSetAndBindingMappingEXT-source-11254";
-                    info.align = phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment;
-                    info.align_field = Field::samplerDescriptorAlignment;
+                if (base_opcode == spv::OpTypeSampledImage) {
+                    // VUID being added in
+                    // https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8242
+                    info.vuid = "UNASSIGNED-VkDescriptorSetAndBindingMappingEXT-combined-image";
+                    info.align = phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment;
+                    info.align_field = Field::imageDescriptorAlignment;
                 } else if (base_opcode == spv::OpTypeImage) {
                     info.vuid = "VUID-VkDescriptorSetAndBindingMappingEXT-source-11251";
                     info.align = phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment;
@@ -3274,44 +3274,85 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
 
                 if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
                     const auto& source_data = mapping.sourceData.constantOffset;
-                    info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
-                    info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
+                    info.offset = source_data.heapOffset;
+                    info.array_stride = source_data.heapArrayStride;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
                     const auto& source_data = mapping.sourceData.pushIndex;
-                    info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
-                    info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
+                    info.offset = source_data.heapOffset;
+                    info.array_stride = source_data.heapArrayStride;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
                     const auto& source_data = mapping.sourceData.indirectIndex;
-                    info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
-                    info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
+                    info.offset = source_data.heapOffset;
+                    info.array_stride = source_data.heapArrayStride;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
                     const auto& source_data = mapping.sourceData.indirectIndexArray;
-                    info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
+                    info.offset = source_data.heapOffset;
                 } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT) {
                     const auto& source_data = mapping.sourceData.shaderRecordIndex;
-                    info.offset = is_sampler ? source_data.samplerHeapOffset : source_data.heapOffset;
-                    info.array_stride = is_sampler ? source_data.samplerHeapArrayStride : source_data.heapArrayStride;
+                    info.offset = source_data.heapOffset;
+                    info.array_stride = source_data.heapArrayStride;
                 }
 
                 if (!IsIntegerMultipleOf(info.offset, info.align) || !IsIntegerMultipleOf(info.array_stride, info.align)) {
                     const Field source_field = vvl::Field_VkDescriptorMappingSourceDataEXT(mapping.source);
-                    const Field offset_field = is_sampler ? Field::samplerHeapOffset : Field::heapOffset;
-                    const Field stride_field = is_sampler ? Field::samplerHeapArrayStride : Field::heapArrayStride;
 
                     std::stringstream ss;
                     ss << "(" << string_VkDescriptorMappingSourceEXT(mapping.source) << ") is used to map descriptor "
                        << resource_variable.DescribeDescriptor() << " in " << entrypoint.Describe() << " but it is unaligned.\n"
-                       << String(source_field) << "." << String(offset_field) << " (" << info.offset << ") ";
+                       << String(source_field) << ".heapOffset (" << info.offset << ") ";
                     if (mapping.source != VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
-                        ss << "and " << String(source_field) << "." << String(stride_field) << " (" << info.array_stride
-                           << ") both ";
+                        ss << "and " << String(source_field) << ".heapArrayStride (" << info.array_stride << ") both ";
                     }
-                    ss << "must be aligned with " << String(info.align_field) << " (" << info.align << ")";
+                    ss << "must be zero or aligned with " << String(info.align_field) << " (" << info.align << ")";
 
                     skip |= LogError(
                         info.vuid, module_state.handle(),
                         loc.pNext(Struct::VkShaderDescriptorSetAndBindingMappingInfoEXT, Field::pMappings, i).dot(Field::source),
                         "%s", ss.str().c_str());
+                }
+
+                // Combined Image Sampler is only spot we need to check twice
+                if (base_opcode == spv::OpTypeSampledImage) {
+                    if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
+                        const auto& source_data = mapping.sourceData.constantOffset;
+                        info.offset = source_data.samplerHeapOffset;
+                        info.array_stride = source_data.samplerHeapArrayStride;
+                    } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
+                        const auto& source_data = mapping.sourceData.pushIndex;
+                        info.offset = source_data.samplerHeapOffset;
+                        info.array_stride = source_data.samplerHeapArrayStride;
+                    } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
+                        const auto& source_data = mapping.sourceData.indirectIndex;
+                        info.offset = source_data.samplerHeapOffset;
+                        info.array_stride = source_data.samplerHeapArrayStride;
+                    } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
+                        const auto& source_data = mapping.sourceData.indirectIndexArray;
+                        info.offset = source_data.samplerHeapOffset;
+                    } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT) {
+                        const auto& source_data = mapping.sourceData.shaderRecordIndex;
+                        info.offset = source_data.samplerHeapOffset;
+                        info.array_stride = source_data.samplerHeapArrayStride;
+                    }
+
+                    info.align = phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment;
+
+                    if (!IsIntegerMultipleOf(info.offset, info.align) || !IsIntegerMultipleOf(info.array_stride, info.align)) {
+                        const Field source_field = vvl::Field_VkDescriptorMappingSourceDataEXT(mapping.source);
+
+                        std::stringstream ss;
+                        ss << "(" << string_VkDescriptorMappingSourceEXT(mapping.source) << ") is used to map descriptor "
+                           << resource_variable.DescribeDescriptor() << " in " << entrypoint.Describe() << " but it is unaligned.\n"
+                           << String(source_field) << ".samplerHeapOffset (" << info.offset << ") ";
+                        if (mapping.source != VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
+                            ss << "and " << String(source_field) << ".samplerHeapArrayStride (" << info.array_stride << ") both ";
+                        }
+                        ss << "must be zero or aligned with samplerDescriptorAlignment (" << info.align << ")";
+
+                        skip |= LogError("VUID-VkDescriptorSetAndBindingMappingEXT-source-11254", module_state.handle(),
+                                         loc.pNext(Struct::VkShaderDescriptorSetAndBindingMappingInfoEXT, Field::pMappings, i)
+                                             .dot(Field::source),
+                                         "%s", ss.str().c_str());
+                    }
                 }
             } else if (IsValueIn(mapping.source,
                                  {VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT, VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_DATA_EXT,

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1801,7 +1801,7 @@ bool CoreChecks::ValidateShaderYcbcrSampler(const spirv::Module& module_state, c
     }
 
     // YCbCr is only allowed for Combined Image Samplers (error is caught before)
-    if (!variable.is_type_sampled_image) {
+    if (!variable.is_combined_image_sampler) {
         return skip;
     }
 
@@ -3365,9 +3365,9 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT,
                                            VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT})) {
-                const spirv::Instruction& base_type = resource_variable.base_type;
-                const uint32_t base_opcode = base_type.Opcode();
-                const bool is_sampler = (base_opcode == spv::OpTypeSampledImage) || resource_variable.is_type_sampled_image;
+                const uint32_t base_opcode = resource_variable.base_type.Opcode();
+                // TODO - Seem we are missing the image portion of combined image samplers
+                const bool is_sampler = resource_variable.is_combined_image_sampler;
 
                 struct MappingSourceInfo {
                     uint32_t offset = 0;

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -309,8 +309,8 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         void Print(const CommandBufferSubState& cb_sub_state, std::ostringstream& map_ss, const VkPhysicalDevice physical_device) {
             map_ss << "    - Binding " << std::dec << resource_variable->decorations.binding << ", "
                    << string_VkDescriptorMappingSourceEXT(mapping->source) << " (from pMappings[" << mapping_index << "])\n";
-            const bool is_sampler =
-                (resource_variable->base_type.Opcode() == spv::OpTypeSampledImage) || resource_variable->is_type_sampled_image;
+            // TODO - should print both here
+            const bool is_sampler = resource_variable->is_combined_image_sampler;
             const bool is_array = resource_variable->IsArray();
             uint32_t array_length = 0;
             if (is_array && !resource_variable->IsRuntimeArray() && resource_variable->array_length != spirv::kSpecConstant) {

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -285,8 +285,8 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         void Print(const CommandBufferSubState& cb_sub_state, std::ostringstream& map_ss, const VkPhysicalDevice physical_device) {
             map_ss << "    - Binding " << std::dec << resource_variable->decorations.binding << ", "
                    << string_VkDescriptorMappingSourceEXT(mapping->source) << " (from pMappings[" << mapping_index << "])\n";
-            // TODO - should print both here
-            const bool is_sampler = resource_variable->is_combined_image_sampler;
+            const bool is_combined_image_sampler = resource_variable->is_combined_image_sampler;
+            const char* main_heap_type = resource_variable->is_sampler ? "Sampler" : "Resource";
             const bool is_array = resource_variable->IsArray();
             uint32_t array_length = 0;
             if (is_array && !resource_variable->IsRuntimeArray() && resource_variable->array_length != spirv::kSpecConstant) {
@@ -308,10 +308,23 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             vvl::CommandBuffer::DescriptorHeap& heap = cb_sub_state.base.descriptor_heap;
             if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
                 const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping->sourceData.constantOffset;
-                if (is_sampler) {
-                    map_ss << "samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset << ", samplerHeapArrayStride: 0x"
-                           << map_data.samplerHeapArrayStride;
-                    map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset;
+
+                map_ss << "heapOffset: 0x" << std::hex << map_data.heapOffset << ", heapArrayStride: 0x"
+                       << map_data.heapArrayStride;
+                map_ss << "\n        " << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset;
+                if (is_array) {
+                    map_ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
+                    if (array_length != 0) {
+                        warn_index_oob = ((map_data.heapOffset + ((array_length - 1) * map_data.heapArrayStride) +
+                                           descriptor_size) > heap.resource_range.size());
+                    }
+                }
+                warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+
+                if (is_combined_image_sampler) {
+                    map_ss << "\n        samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset
+                           << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
+                    map_ss << "\n        Sampler Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset;
                     if (is_array) {
                         map_ss << " + (descriptor_index * 0x" << map_data.samplerHeapArrayStride << ")";
                         if (array_length != 0) {
@@ -320,30 +333,37 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                         }
                     }
                     warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
-                } else {
-                    map_ss << "heapOffset: 0x" << std::hex << map_data.heapOffset << ", heapArrayStride: 0x"
-                           << map_data.heapArrayStride;
-                    map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset;
-                    if (is_array) {
-                        map_ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
-                        if (array_length != 0) {
-                            warn_index_oob = ((map_data.heapOffset + ((array_length - 1) * map_data.heapArrayStride) +
-                                               descriptor_size) > heap.resource_range.size());
-                        }
-                    }
-                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
                 const VkDescriptorMappingSourcePushIndexEXT& map_data = mapping->sourceData.pushIndex;
                 uint32_t push_index = *((uint32_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
 
-                if (is_sampler) {
-                    map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", samplerHeapOffset: 0x"
+                map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", heapOffset: 0x" << map_data.heapOffset
+                       << ", heapIndexStride: 0x" << map_data.heapIndexStride << ", heapArrayStride: 0x"
+                       << map_data.heapArrayStride;
+                map_ss << "\n        pushIndex: 0x" << push_index;
+                map_ss << "\n        " << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
+                       << " + (0x" << push_index << " * 0x" << map_data.heapIndexStride << ")";
+                if (is_array) {
+                    map_ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
+                    if (array_length != 0) {
+                        warn_index_oob = ((map_data.heapOffset + ((array_length - 1) * map_data.heapArrayStride) +
+                                           descriptor_size) > heap.resource_range.size());
+                    }
+                } else {
+                    uint64_t final_offset = map_data.heapOffset + (push_index * map_data.heapIndexStride);
+                    map_ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
+                    warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
+                }
+                warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+
+                if (is_combined_image_sampler) {
+                    map_ss << "\n        pushOffset: 0x" << std::hex << map_data.pushOffset << ", samplerHeapOffset: 0x"
                            << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride
                            << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
                     map_ss << "\n        pushIndex: 0x" << push_index;
-                    map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset << " + (0x"
-                           << push_index << " * 0x" << map_data.samplerHeapIndexStride << ")";
+                    map_ss << "\n        Sampler Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
+                           << " + (0x" << push_index << " * 0x" << map_data.samplerHeapIndexStride << ")";
                     if (is_array) {
                         map_ss << " + (descriptor_index * 0x" << map_data.samplerHeapArrayStride << ")";
                         if (array_length != 0) {
@@ -356,36 +376,33 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                         warn_oob |= (final_offset + descriptor_size > heap.sampler_range.size());
                     }
                     warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
-                } else {
-                    map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", heapOffset: 0x" << map_data.heapOffset
-                           << ", heapIndexStride: 0x" << map_data.heapIndexStride << ", heapArrayStride: 0x"
-                           << map_data.heapArrayStride;
-                    map_ss << "\n        pushIndex: 0x" << push_index;
-                    map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset << " + (0x"
-                           << push_index << " * 0x" << map_data.heapIndexStride << ")";
-                    if (is_array) {
-                        map_ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
-                        if (array_length != 0) {
-                            warn_index_oob = ((map_data.heapOffset + ((array_length - 1) * map_data.heapArrayStride) +
-                                               descriptor_size) > heap.resource_range.size());
-                        }
-                    } else {
-                        uint64_t final_offset = map_data.heapOffset + (push_index * map_data.heapIndexStride);
-                        map_ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
-                        warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
-                    }
-                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
                 const VkDescriptorMappingSourceIndirectIndexEXT& map_data = mapping->sourceData.indirectIndex;
                 uint64_t indirect_address = *((uint64_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
 
-                if (is_sampler) {
-                    map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
-                           << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x"
-                           << map_data.samplerHeapIndexStride << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
+                map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
+                       << ", heapOffset: 0x" << map_data.heapOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride
+                       << ", heapArrayStride: 0x" << map_data.heapArrayStride;
+                map_ss << "\n        indirectAddress: 0x" << indirect_address;
+                map_ss << "\n        " << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
+                       << " + (indirectIndex * 0x" << map_data.heapIndexStride << ")";
+                if (is_array) {
+                    map_ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
+                    if (array_length != 0) {
+                        warn_index_oob = ((map_data.heapOffset + ((array_length - 1) * map_data.heapArrayStride) +
+                                           descriptor_size) > heap.resource_range.size());
+                    }
+                }
+                warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+
+                if (is_combined_image_sampler) {
+                    map_ss << "\n        pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x"
+                           << map_data.addressOffset << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset
+                           << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride << ", samplerHeapArrayStride: 0x"
+                           << map_data.samplerHeapArrayStride;
                     map_ss << "\n        indirectAddress: 0x" << indirect_address;
-                    map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
+                    map_ss << "\n        Sampler Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
                            << " + (indirectIndex * 0x" << map_data.samplerHeapIndexStride << ")";
                     if (is_array) {
                         map_ss << " + (descriptor_index * 0x" << map_data.samplerHeapArrayStride << ")";
@@ -395,41 +412,26 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                         }
                     }
                     warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
-                } else {
-                    map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
-                           << ", heapOffset: 0x" << map_data.heapOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride
-                           << ", heapArrayStride: 0x" << map_data.heapArrayStride;
-                    map_ss << "\n        indirectAddress: 0x" << indirect_address;
-                    map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
-                           << " + (indirectIndex * 0x" << map_data.heapIndexStride << ")";
-                    if (is_array) {
-                        map_ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
-                        if (array_length != 0) {
-                            warn_index_oob = ((map_data.heapOffset + ((array_length - 1) * map_data.heapArrayStride) +
-                                               descriptor_size) > heap.resource_range.size());
-                        }
-                    }
-                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
                 const VkDescriptorMappingSourceIndirectIndexArrayEXT& map_data = mapping->sourceData.indirectIndexArray;
                 uint64_t indirect_address = *((uint64_t*)&cb_sub_state.push_data_value[map_data.pushOffset]);
 
-                if (is_sampler) {
-                    map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
-                           << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x"
-                           << map_data.samplerHeapIndexStride;
+                map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
+                       << ", heapOffset: 0x" << map_data.heapOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride;
+                map_ss << "\n        indirectAddress: 0x" << indirect_address;
+                map_ss << "\n        " << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
+                       << " + (indirectIndex * 0x" << map_data.heapIndexStride << ")";
+                warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+
+                if (is_combined_image_sampler) {
+                    map_ss << "\n        pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x"
+                           << map_data.addressOffset << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset
+                           << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride;
                     map_ss << "\n        indirectAddress: 0x" << indirect_address;
-                    map_ss << "\n        Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
+                    map_ss << "\n        Sampler Heap address: 0x" << heap.sampler_range.begin + map_data.samplerHeapOffset
                            << " + (indirectIndex * 0x" << map_data.samplerHeapIndexStride << ")";
                     warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
-                } else {
-                    map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", addressOffset: 0x" << map_data.addressOffset
-                           << ", heapOffset: 0x" << map_data.heapOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride;
-                    map_ss << "\n        indirectAddress: 0x" << indirect_address;
-                    map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
-                           << " + (indirectIndex * 0x" << map_data.heapIndexStride << ")";
-                    warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT) {
                 const VkDescriptorMappingSourceHeapDataEXT& map_data = mapping->sourceData.heapData;
@@ -437,7 +439,8 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
 
                 map_ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", heapOffset: 0x" << map_data.heapOffset;
                 map_ss << "\n        Push data at 0x" << std::hex << map_data.pushOffset << ": 0x" << push_data;
-                map_ss << "\n        Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset << " + 0x" << push_data;
+                map_ss << "\n        " << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
+                       << " + 0x" << push_data;
                 uint64_t final_offset = map_data.heapOffset + push_data;
                 map_ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
                 warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
@@ -455,14 +458,14 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT) {
                 // TODO - Add address for RTX
                 const VkDescriptorMappingSourceShaderRecordIndexEXT& map_data = mapping->sourceData.shaderRecordIndex;
-                if (is_sampler) {
-                    map_ss << "samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset << ", samplerShaderRecordOffset: 0x"
-                           << map_data.samplerShaderRecordOffset << ", samplerHeapIndexStride: 0x"
-                           << map_data.samplerHeapIndexStride << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
-                } else {
-                    map_ss << "heapOffset: 0x" << std::hex << map_data.heapOffset << ", shaderRecordOffset: 0x"
-                           << map_data.shaderRecordOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride
-                           << ", heapArrayStride: 0x" << map_data.heapArrayStride;
+                map_ss << "heapOffset: 0x" << std::hex << map_data.heapOffset << ", shaderRecordOffset: 0x"
+                       << map_data.shaderRecordOffset << ", heapIndexStride: 0x" << map_data.heapIndexStride
+                       << ", heapArrayStride: 0x" << map_data.heapArrayStride;
+                if (is_combined_image_sampler) {
+                    map_ss << "\n        samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset
+                           << ", samplerShaderRecordOffset: 0x" << map_data.samplerShaderRecordOffset
+                           << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride << ", samplerHeapArrayStride: 0x"
+                           << map_data.samplerHeapArrayStride;
                 }
             } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_DATA_EXT) {
                 // TODO - Add more info probably

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -221,30 +221,6 @@ void CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
     }
 }
 
-// TODO - Make a helper in ResourceInterfaceVariable
-static VkDescriptorType GetResourceInterfaceVariableType(const spirv::ResourceInterfaceVariable& resource_variable) {
-    if (resource_variable.is_storage_image) {
-        return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    } else if (resource_variable.is_storage_texel_buffer) {
-        return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-    } else if (resource_variable.is_storage_buffer) {
-        return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    } else if (resource_variable.is_uniform_buffer) {
-        return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    } else if (resource_variable.is_input_attachment) {
-        return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-    } else if (resource_variable.is_storage_tensor) {
-        return VK_DESCRIPTOR_TYPE_TENSOR_ARM;
-    } else if (resource_variable.is_sampler) {
-        return VK_DESCRIPTOR_TYPE_SAMPLER;
-    }
-    // TODO - Add support in ResourceInterfaceVariable to detect
-    // - VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
-    // - VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
-    // - VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR
-    return VK_DESCRIPTOR_TYPE_MAX_ENUM;
-}
-
 void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const LastBound& last_bound) const {
     const vvl::CommandBuffer& cb_state = last_bound.cb_state;
     if (!cb_state.descriptor_heap.resource_range.empty()) {
@@ -317,7 +293,7 @@ void CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
                 array_length = resource_variable->array_length;
             }
 
-            const VkDescriptorType descriptor_type = GetResourceInterfaceVariableType(*resource_variable);
+            const VkDescriptorType descriptor_type = resource_variable->GetPotentialDescriptorType();
             // TODO - Cache these once on device creation
             VkDeviceSize descriptor_size = descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM
                                                ? 0

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -930,8 +930,11 @@ bool vvl::DescriptorSet::ValidateBindingOnGPU(const DescriptorBinding& binding,
     } else if (IsBindless(binding.binding_flags)) {
         // If flags allow descriptor to be "bindless" (can be invalid up until submit time)
         return true;
-    } else if (variable.is_runtime_descriptor_array) {
+    } else if (variable.array_length == spirv::kRuntimeArray) {
         // We don't know where OOB is on the CPU
+        //
+        // True if the Resource variable itself is runtime descriptor array
+        // Online example to showcase various arrays we do/don't care about here https://godbolt.org/z/h9jhsKaPn
         return true;
     }
     return false;

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -205,15 +205,6 @@ bool Instruction::IsAccessChain() const {
            opcode == spv::OpInBoundsPtrAccessChain;
 }
 
-spv::Dim Instruction::FindImageDim() const { return (Opcode() == spv::OpTypeImage) ? (spv::Dim(Word(3))) : spv::DimMax; }
-
-bool Instruction::IsImageArray() const { return (Opcode() == spv::OpTypeImage) && (Word(5) != 0); }
-
-bool Instruction::IsImageMultisampled() const {
-    // spirv-val makes sure that the MS operand is only non-zero when possible to be Multisampled
-    return (Opcode() == spv::OpTypeImage) && (Word(6) != 0);
-}
-
 bool Instruction::IsTensor() const { return (Opcode() == spv::OpTypeTensorARM); }
 
 // Returns "any" constant

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -80,9 +80,6 @@ class Instruction {
     bool IsNonPtrAccessChain() const;
     bool IsAccessChain() const;
     // Helpers for OpTypeImage
-    spv::Dim FindImageDim() const;
-    bool IsImageArray() const;
-    bool IsImageMultisampled() const;
     bool IsTensor() const;
     bool IsConstant() const;
     bool IsSpecConstant() const;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2436,8 +2436,12 @@ vvl::unordered_set<VkDescriptorType> ResourceInterfaceVariable::GetAllDescriptor
         types.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     } else if (is_sampler) {
         types.insert(VK_DESCRIPTOR_TYPE_SAMPLER);
+        // See PositivePipeline.CombinedImageSamplerConsumedAsSampler
+        types.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     } else if (is_sampled_image) {
         types.insert(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+        // See PositivePipeline.CombinedImageSamplerConsumedAsImage
+        types.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     } else if (is_storage_buffer) {
         types.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
         types.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);
@@ -2455,8 +2459,13 @@ vvl::unordered_set<VkDescriptorType> ResourceInterfaceVariable::GetAllDescriptor
         types.insert(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
     } else if (is_storage_tensor) {
         types.insert(VK_DESCRIPTOR_TYPE_TENSOR_ARM);
-    } else if (is_acceleration_structure || is_acceleration_structure_nv) {
+    } else if (is_acceleration_structure) {
         types.insert(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
+        if (is_partitioned_acceleration_structure) {
+            types.insert(VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV);
+        }
+    } else if (is_acceleration_structure_nv) {
+        types.insert(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV);
         if (is_partitioned_acceleration_structure) {
             types.insert(VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV);
         }

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2398,6 +2398,74 @@ const Instruction& ResourceInterfaceVariable::FindBaseType(ResourceInterfaceVari
     return *type;
 }
 
+// Used for things that just want to report the error message with "some" type
+// should NOT be used for checking the shader interface (use GetAllDescriptorTypes instead)
+VkDescriptorType ResourceInterfaceVariable::GetPotentialDescriptorType() const {
+    if (is_storage_image) {
+        return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    } else if (is_storage_texel_buffer) {
+        return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+    } else if (is_uniform_texel_buffer) {
+        return VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    } else if (is_storage_buffer) {
+        return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    } else if (is_uniform_buffer) {
+        return VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    } else if (is_input_attachment) {
+        return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+    } else if (is_storage_tensor) {
+        return VK_DESCRIPTOR_TYPE_TENSOR_ARM;
+    } else if (is_sampler) {
+        return VK_DESCRIPTOR_TYPE_SAMPLER;
+    } else if (is_sampled_image) {
+        return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    } else if (is_combined_image_sampler) {
+        return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    } else if (is_storage_tensor) {
+        return VK_DESCRIPTOR_TYPE_TENSOR_ARM;
+    } else if (is_acceleration_structure || is_acceleration_structure_nv) {
+        return VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
+    }
+    return VK_DESCRIPTOR_TYPE_MAX_ENUM;
+}
+
+vvl::unordered_set<VkDescriptorType> ResourceInterfaceVariable::GetAllDescriptorTypes() const {
+    vvl::unordered_set<VkDescriptorType> types;
+
+    if (is_combined_image_sampler) {
+        types.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+    } else if (is_sampler) {
+        types.insert(VK_DESCRIPTOR_TYPE_SAMPLER);
+    } else if (is_sampled_image) {
+        types.insert(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    } else if (is_storage_buffer) {
+        types.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        types.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);
+    } else if (is_uniform_buffer) {
+        types.insert(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+        types.insert(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
+        types.insert(VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK);
+    } else if (is_storage_image) {
+        types.insert(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+    } else if (is_storage_texel_buffer) {
+        types.insert(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+    } else if (is_uniform_texel_buffer) {
+        types.insert(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    } else if (is_input_attachment) {
+        types.insert(VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
+    } else if (is_storage_tensor) {
+        types.insert(VK_DESCRIPTOR_TYPE_TENSOR_ARM);
+    } else if (is_acceleration_structure || is_acceleration_structure_nv) {
+        types.insert(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
+        if (is_partitioned_acceleration_structure) {
+            types.insert(VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV);
+        }
+    }
+
+    assert(!types.empty() || IsHeap());
+    return types;
+}
+
 ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state, const EntryPoint& entrypoint,
                                                      const Instruction& insn, const ParsedInfo& parsed)
     : VariableBase(module_state, insn, entrypoint.stage, parsed), base_type(FindBaseType(*this, module_state)) {

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1937,21 +1937,6 @@ VkFormat Module::GetTensorFormat(const spirv::Instruction& type_inst) const {
     return VK_FORMAT_UNDEFINED;
 }
 
-bool Module::HasRuntimeArray(uint32_t type_id) const {
-    const Instruction* type = FindDef(type_id);
-    if (!type) {
-        return false;
-    }
-    while (type->IsArray() || type->Opcode() == spv::OpTypePointer || type->Opcode() == spv::OpTypeSampledImage) {
-        if (type->Opcode() == spv::OpTypeRuntimeArray) {
-            return true;
-        }
-        const uint32_t next_word = (type->Opcode() == spv::OpTypePointer) ? 3 : 2;
-        type = FindDef(type->Word(next_word));
-    }
-    return false;
-}
-
 std::string InterfaceSlot::Describe() const {
     std::ostringstream msg;
     msg << "Location = " << Location() << " | Component = " << Component() << " | Type = " << string_SpvOpcode(type) << " "
@@ -2391,21 +2376,20 @@ const Instruction& ResourceInterfaceVariable::FindBaseType(ResourceInterfaceVari
     // Takes a OpVariable and looks at the the descriptor type it uses. This will find things such as if the variable is writable,
     // image atomic operation, matching images to samplers, etc
     const Instruction* type = module_state.FindDef(variable.type_id);
+    assert(type->Opcode() == spv::OpTypePointer || type->Opcode() == spv::OpTypeUntypedPointerKHR);
+
+    if (variable.data_type_id != 0) {
+        type = module_state.FindDef(variable.data_type_id);
+    }
 
     // Strip off any array or ptrs. Where we remove array levels, adjust the  descriptor count for each dimension.
-    while (type->IsArray() || type->Opcode() == spv::OpTypePointer || type->Opcode() == spv::OpTypeSampledImage) {
-        if (type->IsArray() || type->Opcode() == spv::OpTypeSampledImage) {
-            // currently just tracks 1D arrays
-            if (type->Opcode() == spv::OpTypeArray && variable.array_length == 0) {
-                variable.array_length = module_state.GetConstantValueById(type->Word(3));
-            } else if (type->Opcode() == spv::OpTypeRuntimeArray) {
-                variable.array_length = spirv::kRuntimeArray;
-            }
-
-            if (type->Opcode() == spv::OpTypeSampledImage) {
-                variable.is_type_sampled_image = true;
-            }
-
+    while (type->IsArray() || type->Opcode() == spv::OpTypePointer) {
+        // currently just tracks 1D arrays
+        if (type->Opcode() == spv::OpTypeArray && variable.array_length == 0) {
+            variable.array_length = module_state.GetConstantValueById(type->Word(3));
+            type = module_state.FindDef(type->Word(2));  // Element type
+        } else if (type->Opcode() == spv::OpTypeRuntimeArray) {
+            variable.array_length = spirv::kRuntimeArray;
             type = module_state.FindDef(type->Word(2));  // Element type
         } else {
             type = module_state.FindDef(type->Word(3));  // Pointer type
@@ -2414,54 +2398,64 @@ const Instruction& ResourceInterfaceVariable::FindBaseType(ResourceInterfaceVari
     return *type;
 }
 
-bool ResourceInterfaceVariable::IsStorageBuffer(const ResourceInterfaceVariable& variable) {
-    // before VK_KHR_storage_buffer_storage_class Storage Buffer were a Uniform storage class
-    const bool physical_storage_buffer = variable.storage_class == spv::StorageClassPhysicalStorageBuffer;
-    const bool storage_buffer = variable.storage_class == spv::StorageClassStorageBuffer;
-    const bool uniform = variable.storage_class == spv::StorageClassUniform;
-    // Block decorations are always on the struct of the variable
-    const bool buffer_block =
-        variable.type_struct_info && variable.type_struct_info->decorations.Has(DecorationSet::buffer_block_bit);
-    const bool block = variable.type_struct_info && variable.type_struct_info->decorations.Has(DecorationSet::block_bit);
-    return ((uniform && buffer_block) || ((storage_buffer || physical_storage_buffer) && block));
-}
-
-bool ResourceInterfaceVariable::IsUniformBuffer(const ResourceInterfaceVariable& variable) {
-    const bool uniform = variable.storage_class == spv::StorageClassUniform;
-    const bool block = variable.type_struct_info && variable.type_struct_info->decorations.Has(DecorationSet::block_bit);
-    return (uniform && block);
-}
-
 ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state, const EntryPoint& entrypoint,
                                                      const Instruction& insn, const ParsedInfo& parsed)
-    : VariableBase(module_state, insn, entrypoint.stage, parsed),
-      is_type_sampled_image(false),
-      base_type(FindBaseType(*this, module_state)),
-      is_runtime_descriptor_array(module_state.HasRuntimeArray(type_id)),
-      is_storage_buffer(IsStorageBuffer(*this)),
-      is_uniform_buffer(IsUniformBuffer(*this)) {
+    : VariableBase(module_state, insn, entrypoint.stage, parsed), base_type(FindBaseType(*this, module_state)) {
     // to make sure no padding in-between the struct produce noise and force same data to become a different hash
     info = {};  // will be cleared with c++11 initialization
-    info.image_dim = base_type.FindImageDim();
-    info.is_image_array = base_type.IsImageArray();
-    info.is_multisampled = base_type.IsImageMultisampled();
 
-    // Handle anything specific to the base type
-    if (base_type.Opcode() == spv::OpTypeImage) {
-        const spirv::Instruction& element_type_instr = *module_state.FindDef(base_type.Word(2));
+    const uint32_t base_type_opcode = base_type.Opcode();
+    if (base_type_opcode == spv::OpTypeStruct) {
+        assert(type_struct_info);
+        // Block/BufferBlock are always on the OpTypeStruct
+        if (type_struct_info->decorations.Has(DecorationSet::block_bit)) {
+            if (storage_class == spv::StorageClassStorageBuffer) {
+                is_storage_buffer = true;
+            } else {
+                is_uniform_buffer = true;
+            }
+        } else if (type_struct_info->decorations.Has(DecorationSet::buffer_block_bit)) {
+            is_buffer_block = true;
+            is_storage_buffer = true;
+        }
+    } else if (base_type_opcode == spv::OpTypeImage || base_type_opcode == spv::OpTypeSampledImage) {
+        // OpTypeSamplerImage == CombinedImageSampler, so we want the image information from it still
+        const spirv::Instruction& image_type =
+            (base_type_opcode == spv::OpTypeImage) ? base_type : *module_state.FindDef(base_type.Word(2));
+
+        const spirv::Instruction& element_type_instr = *module_state.FindDef(image_type.Word(2));
         info.numeric_type = module_state.GetNumericType(element_type_instr);
         info.bit_width = static_cast<uint8_t>(element_type_instr.GetBitWidth());
-        info.vk_format = CompatibleSpirvImageFormat(base_type.Word(8));
+        info.vk_format = CompatibleSpirvImageFormat(image_type.Word(8));
+        info.image_dim = spv::Dim(image_type.Word(3));
+        info.is_image_array = image_type.Word(5) != 0;
+        // spirv-val makes sure that the MS operand is only non-zero when possible to be Multisampled
+        info.is_multisampled = image_type.Word(6) != 0;
+        const bool is_sampled_without_sampler = image_type.Word(7) == 2;  // Word(7) == Sampled
 
-        // Things marked regardless of the image being accessed or not
-        const bool is_sampled_without_sampler = base_type.Word(7) == 2;  // Word(7) == Sampled
-        if (is_sampled_without_sampler) {
-            if (info.image_dim == spv::DimSubpassData) {
-                is_input_attachment = true;
-            } else if (info.image_dim == spv::DimBuffer) {
-                is_storage_texel_buffer = true;
+        if (base_type_opcode == spv::OpTypeSampledImage) {
+            // Slight relaxation for some GLSL historical madness: samplerBuffer doesn't really have a sampler, and a texel
+            // buffer descriptor doesn't really provide one. Allow this slight mismatch.
+            const uint32_t dim = image_type.Word(3);
+            const uint32_t sampled = image_type.Word(7);
+            if (dim == spv::DimBuffer && sampled == 1) {
+                is_uniform_texel_buffer = true;
             } else {
-                is_storage_image = true;
+                is_combined_image_sampler = true;
+            }
+        } else if (base_type_opcode == spv::OpTypeImage) {
+            if (is_sampled_without_sampler) {
+                if (info.image_dim == spv::DimSubpassData) {
+                    is_input_attachment = true;
+                } else if (info.image_dim == spv::DimBuffer) {
+                    is_storage_texel_buffer = true;
+                } else {
+                    is_storage_image = true;
+                }
+            } else if (info.image_dim == spv::DimBuffer) {
+                is_uniform_texel_buffer = true;
+            } else {
+                is_sampled_image = true;
             }
         }
 
@@ -2483,7 +2477,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
                 access_mask |= image_access.access_mask;
 
                 const bool is_image_without_format =
-                    ((is_sampled_without_sampler) && (base_type.Word(8) == spv::ImageFormatUnknown));
+                    ((is_sampled_without_sampler) && (image_type.Word(8) == spv::ImageFormatUnknown));
                 if (image_access.access_mask & AccessBit::image_write) {
                     if (is_image_without_format) {
                         info.is_write_without_format |= true;
@@ -2517,7 +2511,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
                 }
 
                 // if not CombinedImageSampler, need to find all Samplers that were accessed with the image
-                if (!image_access.variable_sampler_insn.empty() && !is_type_sampled_image) {
+                if (!image_access.variable_sampler_insn.empty() && !is_combined_image_sampler) {
                     // if no AccessChain, it is same conceptually as being zero
                     // TODO - Handle Spec Constants
                     const uint32_t image_index = (image_access.image_access_chain_index != kInvalidValue &&
@@ -2543,15 +2537,29 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
                 }
             }
         }
-    } else if (base_type.Opcode() == spv::OpTypeTensorARM) {
+    } else if (base_type_opcode == spv::OpTypeTensorARM) {
         is_storage_tensor = true;
         const spirv::Instruction& element_type_instr = *module_state.FindDef(base_type.Word(2));
         info.numeric_type = module_state.GetNumericType(element_type_instr);
         info.bit_width = static_cast<uint8_t>(element_type_instr.GetBitWidth());
         info.vk_format = module_state.GetTensorFormat(element_type_instr);
         info.tensor_rank = module_state.GetConstantValueById(base_type.Word(3));
-    } else if (base_type.Opcode() == spv::OpTypeSampler) {
+    } else if (base_type_opcode == spv::OpTypeSampler) {
         is_sampler = true;
+    } else if (base_type_opcode == spv::OpTypeAccelerationStructureKHR) {
+        // The SPIR-V OpType* are alias, but the Descriptor Types are different
+
+        // Only KHR or NV base acceleration structure is selected
+        if (module_state.HasCapability(spv::CapabilityRayTracingNV)) {
+            is_acceleration_structure_nv = true;
+        } else {
+            is_acceleration_structure = true;
+        }
+
+        // Additionally allow PTLAS if shader uses cluster acceleration structure features
+        if (module_state.HasCapability(spv::CapabilityRayTracingClusterAccelerationStructureNV)) {
+            is_partitioned_acceleration_structure = true;
+        }
     }
 
     for (const auto& accessible_id : entrypoint.accessible_ids) {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -431,9 +431,6 @@ struct ResourceInterfaceVariable : public VariableBase {
     bool IsRuntimeArray() const { return array_length == kRuntimeArray; }
     bool IsArray() const { return array_length != 0; }
 
-    // OpTypeSampledImage (used for combined image samplers)
-    bool is_type_sampled_image;
-
     // The index of vector is index of image. (TODO - this doesn't work for GPU-AV)
     std::vector<vvl::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
 
@@ -445,12 +442,8 @@ struct ResourceInterfaceVariable : public VariableBase {
     vvl::unordered_set<uint32_t> input_attachment_index_read;
 
     // Type once array/pointer are stripped
-    // most likely will be OpTypeImage, OpTypeStruct, OpTypeSampler, or OpTypeAccelerationStructureKHR
+    // most likely will be OpTypeImage, OpTypeStruct, OpTypeSampler, OpTypeSampledImage, or OpTypeAccelerationStructureKHR
     const Instruction &base_type;
-
-    // True if the Resource variable itself is runtime descriptor array
-    // Online example to showcase various arrays we do/don't care about here https://godbolt.org/z/h9jhsKaPn
-    bool is_runtime_descriptor_array;
 
     // "constant integral expressions" is fancy spec language to mean "you are not doing dynamic descriptor indexing into an array"
     // NOTE - This just checks if there is ANY non-costant access
@@ -475,7 +468,7 @@ struct ResourceInterfaceVariable : public VariableBase {
         // the width in bits of the 'Type' operand of OpTypeImage/OpTypeTensorARM (64 is the largest bit width in SPIR-V)
         uint8_t bit_width{0};
 
-        spv::Dim image_dim;
+        spv::Dim image_dim{spv::DimMax};
         bool is_image_array{false};
         bool is_multisampled{false};
 
@@ -494,19 +487,29 @@ struct ResourceInterfaceVariable : public VariableBase {
     // For non descriptor indexing usages, this hash allows use to skip re-validating because a different VkImageView bound will
     // result in the same outcome
     uint64_t descriptor_hash = 0;
-    bool IsImage() const { return base_type.Opcode() == spv::OpTypeImage; }
+    bool IsImage() const { return base_type.Opcode() == spv::OpTypeImage || base_type.Opcode() == spv::OpTypeSampledImage; }
 
     bool IsHeap() const;
     std::string DescribeDescriptor() const;
 
     // Type of resource type (vkspec.html#interfaces-resources-storage-class-correspondence)
+    // A resource variable is not a 1:1 mapping to a VkDescriptorType, it can be many different possible types. We capture all
+    // possible options and provide helper functions to get the information out depending what is actually needed
+    bool is_storage_buffer{false};
+    bool is_uniform_buffer{false};
     bool is_storage_image{false};
+    bool is_uniform_texel_buffer{false};
     bool is_storage_texel_buffer{false};
-    const bool is_storage_buffer;
-    const bool is_uniform_buffer;
     bool is_input_attachment{false};
-    bool is_storage_tensor{false};
     bool is_sampler{false};
+    bool is_sampled_image{false};
+    bool is_combined_image_sampler{false};
+    bool is_acceleration_structure{false};
+    bool is_acceleration_structure_nv{false};
+    bool is_partitioned_acceleration_structure{false};
+    bool is_storage_tensor{false};
+    // Way to print out extra useful information
+    bool is_buffer_block{false};
 
     bool is_resource_heap{false};
     bool is_sampler_heap{false};
@@ -515,9 +518,7 @@ struct ResourceInterfaceVariable : public VariableBase {
                               const ParsedInfo &parsed);
 
   protected:
-    static const Instruction &FindBaseType(ResourceInterfaceVariable &variable, const Module &module_state);
-    static bool IsStorageBuffer(const ResourceInterfaceVariable &variable);
-    static bool IsUniformBuffer(const ResourceInterfaceVariable &variable);
+    static const Instruction& FindBaseType(ResourceInterfaceVariable& variable, const Module& module_state);
 };
 
 // Used to help detect if different variable is being used
@@ -820,8 +821,6 @@ struct Module {
     NumericType GetNumericType(const Instruction &insn) const;
     bool IsTensorFormatCompatible(VkFormat format, const spirv::Instruction& type_inst) const;
     VkFormat GetTensorFormat(const spirv::Instruction& type_inst) const;
-
-    bool HasRuntimeArray(uint32_t type_id) const;
 
     // Instruction helpers that need the knowledge of the whole SPIR-V module
     uint32_t GetNumComponentsInBaseType(const Instruction *insn) const;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -495,6 +495,8 @@ struct ResourceInterfaceVariable : public VariableBase {
     // Type of resource type (vkspec.html#interfaces-resources-storage-class-correspondence)
     // A resource variable is not a 1:1 mapping to a VkDescriptorType, it can be many different possible types. We capture all
     // possible options and provide helper functions to get the information out depending what is actually needed
+    VkDescriptorType GetPotentialDescriptorType() const;
+    vvl::unordered_set<VkDescriptorType> GetAllDescriptorTypes() const;
     bool is_storage_buffer{false};
     bool is_uniform_buffer{false};
     bool is_storage_image{false};

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -195,7 +195,8 @@ bool ResourceTypeMatchesBinding(VkSpirvResourceTypeFlagsEXT resource_type,
             return true;
         }
     }
-    if ((resource_type & VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT) != 0 && resource_variable.is_type_sampled_image) {
+    if ((resource_type & VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT) != 0 &&
+        resource_variable.is_combined_image_sampler) {
         return true;
     }
     if ((resource_type & VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT) != 0 && resource_variable.is_uniform_buffer) {
@@ -255,7 +256,8 @@ std::string DescribeResourceTypeMismatch(VkSpirvResourceTypeFlagsEXT resource_ty
             return "is decorated with NonWritable";
         }
     }
-    if ((resource_type & VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT) != 0 && !resource_variable.is_type_sampled_image) {
+    if ((resource_type & VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT) != 0 &&
+        !resource_variable.is_combined_image_sampler) {
         return "is not OpTypeSampledImage";
     }
     if ((resource_type & VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT) != 0 && !resource_variable.is_uniform_buffer) {

--- a/tests/unit/descriptor_heap.cpp
+++ b/tests/unit/descriptor_heap.cpp
@@ -3453,8 +3453,7 @@ TEST_F(NegativeDescriptorHeap, OpTypeSampler) {
     }
 }
 
-TEST_F(NegativeDescriptorHeap, OpTypeSampledImage) {
-    TEST_DESCRIPTION("Validate that mapping is aligned for OpTypeSampledImage");
+TEST_F(NegativeDescriptorHeap, OpTypeSampledImageAlignedSampler) {
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(InitBasicDescriptorHeap());
     RETURN_IF_SKIP(CheckSlangSupport());
@@ -3518,6 +3517,55 @@ TEST_F(NegativeDescriptorHeap, OpTypeSampledImage) {
         pipe.CreateComputePipeline(false);
         m_errorMonitor->VerifyFound();
     }
+}
+
+TEST_F(NegativeDescriptorHeap, OpTypeSampledImageAlignedImage) {
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitBasicDescriptorHeap());
+
+    if (heap_props.imageDescriptorAlignment < 2) {
+        GTEST_SKIP() << "Cannot be unaligned with imageDescriptorAlignment less than 2";
+    }
+
+    VkDescriptorSetAndBindingMappingEXT mappings[2];
+    mappings[0] = MakeSetAndBindingMapping(0, 0);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[0].sourceData.constantOffset.heapArrayStride = 0;
+
+    mappings[1] = MakeSetAndBindingMapping(0, 1);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 2;
+    mapping_info.pMappings = mappings;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(local_size_x = 1) in;
+        layout(set = 0, binding = 0) buffer Output { int result[]; };
+        layout(set = 0, binding = 1) uniform sampler2D tex;
+        void main() {
+            vec4 color = textureLod(tex, vec2(gl_GlobalInvocationID.xy), 0);
+            result[gl_LocalInvocationIndex] = int(color.r);
+        }
+    )glsl";
+
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    VkPipelineCreateFlags2CreateInfo pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+
+    mappings[1].sourceData.constantOffset.heapOffset = 1;
+    mappings[1].sourceData.constantOffset.heapArrayStride = 0;
+
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkDescriptorSetAndBindingMappingEXT-combined-image");
+    pipe.CreateComputePipeline(false);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, NoMappingStruct) {


### PR DESCRIPTION
This moves the logic of "which VkDescriptorType` into `ResourceInterfaceVariable` 

1. This removes redundent work being done in `ValidateShaderInterfaceVariableDSL` each time
2. Allows easy API for other people to use
3. Caught this missing VU along the way because it was not obvious before using the old way https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8242