### PR TITLE
layers: Workaround thread sanitizer

### DIFF
--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -85,7 +85,7 @@ uint64_t vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission>&& submissions) 
         submission.BeginUse();
         for (SemaphoreInfo& wait : submission.wait_semaphores) {
             wait.semaphore->EnqueueWait(SubmissionReference(this, submission.seq), wait.payload);
-            timeline_wait_count_ += (wait.semaphore->type == VK_SEMAPHORE_TYPE_TIMELINE) ? 1 : 0;
+            timeline_wait_count_.fetch_add((wait.semaphore->type == VK_SEMAPHORE_TYPE_TIMELINE) ? 1 : 0);
         }
 
         for (SemaphoreInfo& signal : submission.signal_semaphores) {
@@ -173,7 +173,7 @@ std::optional<vvl::SemaphoreInfo> vvl::Queue::FindTimelineWaitWithoutResolvingSi
     small_vector<SemaphoreInfo, 8> timeline_waits;
     {
         auto guard = Lock();
-        for (auto it = submissions_.rbegin(); it != submissions_.rend() && processed_waits < timeline_wait_count_; ++it) {
+        for (auto it = submissions_.rbegin(); it != submissions_.rend() && processed_waits < timeline_wait_count_.load(); ++it) {
             const vvl::QueueSubmission& submission = *it;
             if (submission.seq <= until_seq) {
                 for (const auto& wait_info : submission.wait_semaphores) {
@@ -299,7 +299,7 @@ void vvl::Queue::Retire(QueueSubmission& submission) {
     submission.EndUse();
     for (auto& wait : submission.wait_semaphores) {
         wait.semaphore->RetireWait(this, wait.payload, submission.loc.Get(), true);
-        timeline_wait_count_ -= (wait.semaphore->type == VK_SEMAPHORE_TYPE_TIMELINE) ? 1 : 0;
+        timeline_wait_count_.fetch_sub((wait.semaphore->type == VK_SEMAPHORE_TYPE_TIMELINE) ? 1 : 0);
     }
 
     // When device is lost skip updating substates which might access destroyed/garbage objects.

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -205,7 +205,10 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
   private:
     DeviceState& device_state_;
     const VkQueueFamilyProperties queue_family_properties_;
-    uint32_t timeline_wait_count_ = 0;
+
+    // TODO: made this atomic to workaround thread sanitizer.
+    // Likely not a proper solution, need to investigate how this count should be used
+    std::atomic_uint32_t timeline_wait_count_ = 0;
 
     void ThreadFunc();
     QueueSubmission *NextSubmission();


### PR DESCRIPTION
If TS complained because of `Queue::timeline_wait_count_` then maybe this PR is a workaround.