### PR TITLE
layers: Add VK_QCOM_tile_shading cmd VUIDs and tests

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -365,6 +365,8 @@ bool CoreChecks::ValidateBeginCommandBufferInheritanceInfo(const vvl::CommandBuf
         }
     }
 
+    skip |= ValidateBeginCommandBufferRenderPassTileShadingCreateInfo(cb_state, info, begin_flags, inheritance_loc);
+
     return skip;
 }
 
@@ -466,6 +468,82 @@ bool CoreChecks::ValidateBeginCommandBufferRenderingInheritanceInfo(const vvl::C
                          "(0x%" PRIx32 ") most significant bit is greater or equal to maxMultiviewViewCount (%" PRIu32 ").",
                          rendering_info.viewMask, phys_dev_props_core11.maxMultiviewViewCount);
     }
+    return skip;
+}
+
+bool CoreChecks::ValidateBeginCommandBufferRenderPassTileShadingCreateInfo(const vvl::CommandBuffer& cb_state,
+                                                                           const VkCommandBufferInheritanceInfo& info,
+                                                                           const VkCommandBufferUsageFlags begin_flags,
+                                                                           const Location& inheritance_loc) const {
+    bool skip = false;
+    const bool has_rp_continue_bit = (begin_flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) != 0;
+    const auto* rp_tile_shading_ci = vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(info.pNext);
+    const bool has_rp_enable_bit = rp_tile_shading_ci ?
+                                   (rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0 : false;
+    const auto rp_state = Get<vvl::RenderPass>(info.renderPass);
+    const bool rp_enabled_tile_shading = rp_state ? rp_state->has_tile_shading_enabled : false;
+
+    if (has_rp_continue_bit && rp_enabled_tile_shading && !has_rp_enable_bit) {
+        std::stringstream conditional_ss{};
+        if (rp_tile_shading_ci) {
+            conditional_ss << "(" << string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags)
+                           << ")" << " doesn't contain VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, ";
+        }
+        else {
+            conditional_ss << "doesn't include VkRenderPassTileShadingCreateInfoQCOM instance, ";
+        }
+        conditional_ss << "but VkCommandBufferBeginInfo::flags (" << string_VkCommandBufferUsageFlags(begin_flags)
+                       << ") contains VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT bit and "
+                       << "VkCommandBufferInheritanceInfo::renderPass has been created with tile shading enabled.";
+
+        const LogObjectList objlist(cb_state.Handle(), rp_state->Handle());
+        if (rp_tile_shading_ci) {
+            skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-10617", objlist,
+                             inheritance_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                             "%s", conditional_ss.str().c_str());
+        }
+        else {
+            skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-10617", objlist,
+                             inheritance_loc.dot(Field::pNext),
+                             "%s", conditional_ss.str().c_str());
+        }
+    }
+
+    if (!has_rp_continue_bit && !rp_enabled_tile_shading && has_rp_enable_bit) {
+        std::stringstream conditional_ss{};
+        conditional_ss << "but VkCommandBufferBeginInfo::flags is ( " << string_VkCommandBufferUsageFlags(begin_flags) << ")";
+        if (!info.renderPass) {
+            conditional_ss << " and VkCommandBufferInheritanceInfo::renderPass is VK_NULL_HANDLE.";
+        }
+        else {
+            conditional_ss << " and VkCommandBufferInheritanceInfo::renderPass hasn't been created with tile shading enabled. "
+                              "(Can be enabled by using VkRenderPassTileShadingCreateInfoQCOM)";
+        }
+
+        skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-10618", cb_state.Handle(),
+                         inheritance_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                         "(%s) contains VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, %s",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str(),
+                         conditional_ss.str().c_str());
+    }
+
+    if (has_rp_enable_bit && rp_enabled_tile_shading) {
+        const auto* rp_tile_shading_ci_of_rp =
+                vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(rp_state->create_info.pNext);
+        if (rp_tile_shading_ci->tileApronSize.width != rp_tile_shading_ci_of_rp->tileApronSize.width ||
+            rp_tile_shading_ci->tileApronSize.height != rp_tile_shading_ci_of_rp->tileApronSize.height) {
+        const LogObjectList objlist(cb_state.Handle(), rp_state->Handle());
+        skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-10619", objlist,
+                         inheritance_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
+                         "(%s) contains VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, but "
+                         "tileApronSize (%s) aren't equal to that "
+                         "tileApronSize (%s) used to create VkCommandBufferInheritanceInfo::renderPass.",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str(),
+                         string_VkExtent2D(rp_tile_shading_ci->tileApronSize).c_str(),
+                         string_VkExtent2D(rp_tile_shading_ci_of_rp->tileApronSize).c_str());
+        }
+    }
+
     return skip;
 }
 
@@ -1318,6 +1396,18 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                  "the vkBeginCommandBuffer() was called.",
                                  FormatHandle(secondary_cb).c_str());
             }
+            if (secondary_cb_state.has_inheritance) {
+                const auto* rp_tile_shading_ci =
+                        vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(secondary_cb_state.inheritance_info.pNext);
+                if (rp_tile_shading_ci &&
+                    (rp_tile_shading_ci->tileApronSize.width != 0 || rp_tile_shading_ci->tileApronSize.height != 0)) {
+                    const LogObjectList objlist(commandBuffer, secondary_cb);
+                    skip |= LogError("VUID-vkCmdExecuteCommands-tileApronSize-10625", objlist, secondary_cb_loc,
+                                     "has been recorded with VkRenderPassTileShadingCreateInfoQCOM::tileApronSize "
+                                     "(%s) for non-render-pass scenario.",
+                                     string_VkExtent2D(rp_tile_shading_ci->tileApronSize).c_str());
+                }
+            }
         } else if (rp_state) {
             const vvl::RenderPass* secondary_rp_state = secondary_cb_state.active_render_pass.get();
             if (secondary_rp_state) {
@@ -1762,6 +1852,78 @@ bool CoreChecks::ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::Comm
         }
     }
 
+    const auto* rp_tile_shading_ci = vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(inheritance_info.pNext);
+    const bool has_rp_enable_bit = (rp_tile_shading_ci) ?
+                                   (rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0 : false;
+    const bool has_rp_per_tile_exec_bit = (rp_tile_shading_ci) ?
+                                          (rp_tile_shading_ci->flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0 : false;
+    if (rp_state.has_tile_shading_enabled) {
+        if (!has_rp_enable_bit) {
+            std::stringstream conditional_ss{};
+            if (rp_tile_shading_ci) {
+                conditional_ss << "has been recorded with VkRenderPassTileShadingCreateInfoQCOM::flags ("
+                               << string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags)
+                               << ") doesn't include VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, ";
+            } else {
+                conditional_ss << "hasn't been recorded with VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit since "
+                               << "VkCommandBufferInheritanceInfo::pNext doesn't include "
+                               << "VkRenderPassTileShadingCreateInfoQCOM instance, ";
+            }
+            conditional_ss << "but the render pass has tile shading enabled.";
+            const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), rp_state.Handle());
+            skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-10620", objlist, secondary_cb_loc,
+                             "%s", conditional_ss.str().c_str());
+        }
+
+        const auto *rp_tile_shading_ci_of_rp =
+                vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(rp_state.create_info.pNext);
+        if (rp_tile_shading_ci &&
+            (rp_tile_shading_ci_of_rp->tileApronSize.width != rp_tile_shading_ci->tileApronSize.width ||
+             rp_tile_shading_ci_of_rp->tileApronSize.height != rp_tile_shading_ci->tileApronSize.height)) {
+            const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), rp_state.Handle());
+            skip |= LogError("VUID-vkCmdExecuteCommands-tileApronSize-10622", objlist, secondary_cb_loc,
+                             "has been recorded with VkRenderPassTileShadingCreateInfoQCOM::tileApronSize "
+                             "(%s) that isn't equal to that tileApronSize (%s) used to create the render pass.",
+                             string_VkExtent2D(rp_tile_shading_ci->tileApronSize).c_str(),
+                             string_VkExtent2D(rp_tile_shading_ci_of_rp->tileApronSize).c_str());
+        }
+    }
+
+    if (has_rp_enable_bit && !rp_state.has_tile_shading_enabled) {
+        const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), rp_state.Handle());
+        skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-10623", objlist, secondary_cb_loc,
+                         "has been recorded with VkRenderPassTileShadingCreateInfoQCOM::flags (%s) "
+                         "that includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit, but "
+                         "the render pass doesn't have tile shading enabled. "
+                         "(Can be enabled by using VkRenderPassTileShadingCreateInfoQCOM)",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+    }
+
+    if (cb_state.per_tile_execution_model_enabled && !has_rp_per_tile_exec_bit) {
+        std::stringstream conditional_ss{};
+        if (rp_tile_shading_ci) {
+            conditional_ss << "has been recorded with VkRenderPassTileShadingCreateInfoQCOM::flags ("
+                           << string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags)
+                           << ") doesn't include VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit, ";
+        } else {
+            conditional_ss << "hasn't been recorded with VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM "
+                           << "bit since VkCommandBufferInheritanceInfo::pNext doesn't include "
+                           << "VkRenderPassTileShadingCreateInfoQCOM instance, ";
+        }
+        conditional_ss << "but the per-tile execution model is enabled in the command buffer.";
+        const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), rp_state.Handle());
+        skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-10621", objlist, secondary_cb_loc,
+                         "%s", conditional_ss.str().c_str());
+    } else if (!cb_state.per_tile_execution_model_enabled && has_rp_per_tile_exec_bit) {
+        const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), rp_state.Handle());
+        skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-10624", objlist, secondary_cb_loc,
+                         "has been recorded with VkRenderPassTileShadingCreateInfoQCOM::flags (%s) "
+                         "includes VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM bit, but "
+                         "the per-tile execution model isn't enabled in the command buffer. "
+                         "(Can be enabled by calling vkCmdBeginPerTileExecutionQCOM)",
+                         string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci->flags).c_str());
+    }
+
     return skip;
 }
 
@@ -2113,12 +2275,28 @@ bool CoreChecks::PreCallValidateCmdEndPerTileExecutionQCOM(VkCommandBuffer comma
 bool CoreChecks::PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer, const VkDebugMarkerMarkerInfoEXT* pMarkerInfo,
                                                        const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    return ValidateCmd(*cb_state, error_obj.location);
+    bool skip = ValidateCmd(*cb_state, error_obj.location);
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdDebugMarkerBeginEXT-None-10614", commandBuffer, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdDebugMarkerBeginEXT)");
+    }
+
+    return skip;
 }
 
 bool CoreChecks::PreCallValidateCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    return ValidateCmd(*cb_state, error_obj.location);
+    bool skip = ValidateCmd(*cb_state, error_obj.location);
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdDebugMarkerEndEXT-None-10615", commandBuffer, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdDebugMarkerEndEXT)");
+    }
+
+    return skip;
 }
 
 bool CoreChecks::PreCallValidateCmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer,
@@ -2358,6 +2536,12 @@ bool CoreChecks::PreCallValidateCmdBeginTransformFeedbackEXT(VkCommandBuffer com
         }
     }
 
+    if (cb_state->per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdBeginTransformFeedbackEXT-None-10656", commandBuffer, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdBeginTransformFeedbackEXT)");
+    }
+
     return skip;
 }
 
@@ -2436,6 +2620,12 @@ bool CoreChecks::PreCallValidateCmdEndTransformFeedbackEXT(VkCommandBuffer comma
                                  string_VkBufferUsageFlags2(buffer_state->usage).c_str());
             }
         }
+    }
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdEndTransformFeedbackEXT-None-10657", commandBuffer, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdEndTransformFeedbackEXT)");
     }
 
     return skip;

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -365,7 +365,9 @@ bool CoreChecks::ValidateBeginCommandBufferInheritanceInfo(const vvl::CommandBuf
         }
     }
 
-    skip |= ValidateBeginCommandBufferRenderPassTileShadingCreateInfo(cb_state, info, begin_flags, inheritance_loc);
+    if (enabled_features.tileShading) {
+        skip |= ValidateBeginCommandBufferRenderPassTileShadingCreateInfo(cb_state, info, begin_flags, inheritance_loc);
+    }
 
     return skip;
 }
@@ -497,16 +499,10 @@ bool CoreChecks::ValidateBeginCommandBufferRenderPassTileShadingCreateInfo(const
                        << "VkCommandBufferInheritanceInfo::renderPass has been created with tile shading enabled.";
 
         const LogObjectList objlist(cb_state.Handle(), rp_state->Handle());
-        if (rp_tile_shading_ci) {
-            skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-10617", objlist,
-                             inheritance_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags),
-                             "%s", conditional_ss.str().c_str());
-        }
-        else {
-            skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-10617", objlist,
-                             inheritance_loc.dot(Field::pNext),
-                             "%s", conditional_ss.str().c_str());
-        }
+        const Location error_loc = rp_tile_shading_ci ?
+                inheritance_loc.pNext(Struct::VkRenderPassTileShadingCreateInfoQCOM, Field::flags) : inheritance_loc.dot(Field::pNext);
+        skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-10617", objlist, error_loc,
+                         "%s", conditional_ss.str().c_str());
     }
 
     if (!has_rp_continue_bit && !rp_enabled_tile_shading && has_rp_enable_bit) {

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1343,6 +1343,13 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
             }
         }
     }
+
+    if (cb_state.per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdClearAttachments-None-10616", commandBuffer, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdClearAttachments)");
+    }
+
     return skip;
 }
 

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -766,6 +766,14 @@ bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
     QueryObject query_obj = {queryPool, slot};
     skip |= ValidateBeginQuery(*cb_state, query_obj, flags, 0, error_obj.location);
     skip |= ValidateCmd(*cb_state, error_obj.location);
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        const LogObjectList objlist(commandBuffer, queryPool);
+        skip |= LogError("VUID-vkCmdBeginQuery-None-10681", objlist, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdBeginQuery)");
+    }
+
     return skip;
 }
 
@@ -962,6 +970,14 @@ bool CoreChecks::PreCallValidateCmdEndQuery(VkCommandBuffer commandBuffer, VkQue
         skip |= ValidateCmdEndQuery(*cb_state, queryPool, slot, 0, error_obj.location);
         skip |= ValidateCmd(*cb_state, error_obj.location);
     }
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        const LogObjectList objlist(commandBuffer, queryPool);
+        skip |= LogError("VUID-vkCmdEndQuery-None-10682", objlist, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdEndQuery)");
+    }
+
     return skip;
 }
 
@@ -1293,6 +1309,14 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp(VkCommandBuffer commandBuffer,
 
     const Location stage_loc = error_obj.location.dot(Field::pipelineStage);
     skip |= ValidatePipelineStage(LogObjectList(commandBuffer), stage_loc, cb_state->GetQueueFlags(), pipelineStage);
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        const LogObjectList objlist(commandBuffer, queryPool);
+        skip |= LogError("VUID-vkCmdWriteTimestamp-None-10640", objlist, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdWriteTimestamp)");
+    }
+
     return skip;
 }
 
@@ -1314,6 +1338,14 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp2(VkCommandBuffer commandBuffer
                          "(%s) must only set a single pipeline stage.", string_VkPipelineStageFlags2(stage).c_str());
     }
     skip |= ValidatePipelineStage(LogObjectList(commandBuffer), stage_loc, cb_state->GetQueueFlags(), stage);
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        const LogObjectList objlist(commandBuffer, queryPool);
+        skip |= LogError("VUID-vkCmdWriteTimestamp2-None-10639", objlist, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdWriteTimestamp2)");
+    }
+
     return skip;
 }
 

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1449,6 +1449,13 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
         skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-07308", objlist, error_obj.location.dot(Field::srcStageMask), "is %s.",
                          sync_utils::StringPipelineStageFlags(srcStageMask).c_str());
     }
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdWaitEvents-None-10655", objlist, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdWaitEvents)");
+    }
+
     return skip;
 }
 
@@ -1491,6 +1498,13 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
         skip |= ValidateDependencyInfo(objlist, dep_info_loc, *cb_state, pDependencyInfos[i]);
     }
     skip |= ValidateCmd(*cb_state, error_obj.location);
+
+    if (cb_state->per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdWaitEvents2-None-10654", commandBuffer, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdWaitEvents2)");
+    }
+
     return skip;
 }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1699,6 +1699,10 @@ class CoreChecks : public vvl::DeviceProxy {
                                                             const VkCommandBufferInheritanceInfo& info,
                                                             const VkCommandBufferInheritanceRenderingInfo& rendering_info,
                                                             const Location& inheritance_loc) const;
+    bool ValidateBeginCommandBufferRenderPassTileShadingCreateInfo(const vvl::CommandBuffer& cb_state,
+                                                                   const VkCommandBufferInheritanceInfo& info,
+                                                                   const VkCommandBufferUsageFlags begin_flags,
+                                                                   const Location& inheritance_loc) const;
     bool ValidateRenderingInfoAttachmentDeviceGroup(const vvl::Image& image_state, const VkRenderingInfo& rendering_info,
                                                     const LogObjectList& objlist, const Location& loc) const;
     bool ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -1497,4 +1497,19 @@ bool Device::manual_PreCallValidateCmdConvertCooperativeVectorMatrixNV(VkCommand
     return skip;
 }
 
+bool Device::manual_PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                                const VkPerTileBeginInfoQCOM *pPerTileBeginInfo,
+                                                                const Context &context) const {
+    bool skip = false;
+
+    if (!enabled_features.tileShadingPerTileDispatch && !enabled_features.tileShadingPerTileDraw) {
+        skip |= LogError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10665",
+                         commandBuffer, context.error_obj.location,
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDispatch and "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDraw features are not enabled.");
+    }
+
+    return skip;
+}
+
 }  // namespace stateless

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1374,6 +1374,9 @@ class Device : public vvl::BaseDevice {
                                                                      VkTilePropertiesQCOM* pProperties,
                                                                      const Context &context) const;
     bool ValidateTileMemorySizeInfo(const VkTileMemorySizeInfoQCOM& create_info, const Location& loc) const;
+    bool manual_PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer commandBuffer,
+                                                            const VkPerTileBeginInfoQCOM *pPerTileBeginInfo,
+                                                            const Context &context) const;
 
 #include "generated/stateless_device_methods.h"
 };

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -24501,6 +24501,7 @@ bool Device::PreCallValidateCmdBeginPerTileExecutionQCOM(VkCommandBuffer command
             context.ValidateStructPnext(pPerTileBeginInfo_loc, pPerTileBeginInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
                                         "VUID-VkPerTileBeginInfoQCOM-pNext-pNext", kVUIDUndefined, true);
     }
+    if (!skip) skip |= manual_PreCallValidateCmdBeginPerTileExecutionQCOM(commandBuffer, pPerTileBeginInfo, context);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -28,6 +28,11 @@ from base_generator import BaseGenerator
 from dataclasses import dataclass
 from string import Template
 
+@dataclass
+class ExtendedFlag:
+    struct: str
+    member: Member
+
 # The way we generate this code is "clever" (aka not fun to debug)
 #
 # We create each struct's code inject string templates (like "${funcName}") and when we loop
@@ -280,6 +285,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkCmdBindIndexBuffer3KHR',
             'vkCreateAccelerationStructure2KHR',
             'vkCmdBeginTransformFeedback2EXT',
+            'vkCmdBeginPerTileExecutionQCOM',
         ]
 
         # Commands to ignore
@@ -394,13 +400,6 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             * limitations under the License.
             ****************************************************************************/\n''')
         self.write('// NOLINTBEGIN') # Wrap for clang-tidy to ignore
-
-        # Todo: move to vulkan object
-        from dataclasses import dataclass
-        @dataclass
-        class ExtendedFlag:
-            struct: str
-            member: Member
 
         for member in (m for s in self.vk.structs.values() for m in s.members):
                 member.extendedFlag = None

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -28,6 +28,7 @@ from base_generator import BaseGenerator
 from dataclasses import dataclass
 from string import Template
 
+# Todo: move to vulkan object
 @dataclass
 class ExtendedFlag:
     struct: str

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "layer_validation_tests.h"
+#include "pipeline_helper.h"
 
 class NegativeTileShading : public TileShadingTest {};
 
@@ -40,6 +41,38 @@ TEST_F(NegativeTileShading, BeginPerTileExecutionWithNonTileShadingRenderPass) {
     m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer, &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10664");
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, BeginPerTileExecutionButTileShadingPerTileFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to launch per-tile execution model in a tile-shading render pass scope, "
+                     "but tileShadingPerTileDispatch or tileShadingPerTileDraw feature is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    RETURN_IF_SKIP(Init());
+
+    InitTileShadingRenderTarget();
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginPerTileExecutionQCOM-None-10665");
     vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
     m_errorMonitor->VerifyFound();
     vk::CmdEndRenderPass(m_command_buffer);
@@ -917,5 +950,780 @@ TEST_F(NegativeTileShading, SubpassDescriptionWithZeroApronSize) {
         m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-flags-10683");
         vk::CreateRenderPass2(device(), &rpci2, nullptr, &rp);
         m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeTileShading, BeginNonTileShadingCommandBufferWithTileShadingRenderPass) {
+    TEST_DESCRIPTION("Begin a command buffer without tile-shading-enable bit, but a tile-shading render pass "
+                     "is included in the inheritance information.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+    tile_shading_ci.flags = 0;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    m_errorMonitor->SetDesiredError("VUID-VkCommandBufferBeginInfo-flags-10617");
+    vk::BeginCommandBuffer(secondary_command, &begin_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, BeginTileShadingCommandBufferWithNonTileShadingRenderPass) {
+    TEST_DESCRIPTION("Begin a command buffer with tile-shading-enable bit, but the inheritance information "
+                     "includes a non-tile-shading render pass.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitRenderTarget();
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = {0, 0};
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = RenderPass();
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = Framebuffer();
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = 0;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    m_errorMonitor->SetDesiredError("VUID-VkCommandBufferBeginInfo-flags-10618");
+     vk::BeginCommandBuffer(secondary_command, &begin_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, BeginTileShadingCommandBufferButHasInconsistentApronSize) {
+    TEST_DESCRIPTION("Begin a command buffer with tile-shading-enable bit, but the inheritance information "
+                     "has tileApronSize that isn't equal to that tileApronSize used to create render pass.");
+    AddRequiredFeature(vkt::Feature::tileShadingApron);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, tile_shading_props.maxApronSize};
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    m_errorMonitor->SetDesiredError("VUID-VkCommandBufferBeginInfo-flags-10619");
+     vk::BeginCommandBuffer(secondary_command, &begin_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, ExecuteTileShadingCommandWithoutTileShadingEnableBit) {
+    TEST_DESCRIPTION("Execute a secondary command inside a tile-shading render pass scope, but that secondary "
+                     "command hasn't been recorded with tile-shading-enable bit.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+    tile_shading_ci.flags = 0;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkCommandBufferBeginInfo-flags-10617");
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-10620");
+    m_command_buffer.ExecuteCommands(secondary_command);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, ExecuteTileShadingCommandInPerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Execute a secondary command inside the per-tile execution model scope, but that secondary "
+                     "command only has been recorded with tile-shading-enable bit.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-10621");
+    m_command_buffer.ExecuteCommands(secondary_command);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, ExecuteTileShadingCommandWithInconsistentTileApronSize) {
+    TEST_DESCRIPTION("Execute a secondary command inside a tile-shading render pass scope, but that secondary "
+                     "command has been recorded with a tile-apron size inconsistent with that of the render pass.");
+    AddRequiredFeature(vkt::Feature::tileShadingApron);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, tile_shading_props.maxApronSize};
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-tileApronSize-10622");
+    m_command_buffer.ExecuteCommands(secondary_command);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, ExecuteTileShadingCommandInNonTileShadingRenderPass) {
+    TEST_DESCRIPTION("Execute a secondary command inside a non-tile-shading render pass scope, but that secondary "
+                     "command has been recorded with tile-shading-enable bit.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitRenderTarget();
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = {0, 0};
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = RenderPass();
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = Framebuffer();
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = RenderPass();
+    rp_begin_info.framebuffer = Framebuffer();
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = {m_width, m_height};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-10623");
+    m_command_buffer.ExecuteCommands(secondary_command);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, ExecutePerTileExecutionCommandButPerTileExecutionModelNotEnabled) {
+    TEST_DESCRIPTION("Execute a secondary command that has been recorded with per-tile-execution bit, "
+                     "but the per-tile execution model isn't enabled.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = tile_shading_rp_config.tile_apron_size;
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM | VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = m_tile_shading_render_pass;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = m_tile_shading_framebuffer;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-10624");
+    m_command_buffer.ExecuteCommands(secondary_command);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, ExecuteNonZeroTileSizeCommand) {
+    TEST_DESCRIPTION("Execute a secondary command without a render pass, but that secondary "
+                     "command has been recorded with a non-zero tile-apron size.");
+    AddRequiredFeature(vkt::Feature::tileShadingApron);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.tileApronSize = {tile_shading_props.maxApronSize, tile_shading_props.maxApronSize};
+    tile_shading_ci.flags = 0;
+
+    VkCommandBufferInheritanceInfo inheritance_info = vku::InitStructHelper(&tile_shading_ci);
+    inheritance_info.renderPass = nullptr;
+    inheritance_info.subpass = 0;
+    inheritance_info.framebuffer = nullptr;
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = 0;
+    begin_info.pInheritanceInfo = &inheritance_info;
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    secondary_command.Begin(&begin_info);
+    secondary_command.End();
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-tileApronSize-10625");
+    m_command_buffer.ExecuteCommands(secondary_command);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, LaunchTileAttachmentMemoryBarrierButUseWrongStageMask) {
+    TEST_DESCRIPTION("Try to launch tile attachment memory barrier but provides a wrong stage mask.");
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    m_command_buffer.Begin();
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_READ_BIT_QCOM;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_MEMORY_WRITE_BIT;
+
+        m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-srcAccessMask-10670");
+        m_command_buffer.Barrier(barrier2);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_WRITE_BIT_QCOM;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT;
+
+        m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-srcAccessMask-10671");
+        m_command_buffer.Barrier(barrier2);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_READ_BIT_QCOM;
+
+        m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-dstAccessMask-10670");
+        m_command_buffer.Barrier(barrier2);
+        m_errorMonitor->VerifyFound();
+    }
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_WRITE_BIT_QCOM;
+
+        m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-dstAccessMask-10671");
+        m_command_buffer.Barrier(barrier2);
+        m_errorMonitor->VerifyFound();
+    }
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, DebugMarkerInsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Try to begin or end debug marker inside the per-tile execution model scope.");
+    AddRequiredExtensions(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    VkDebugMarkerMarkerInfoEXT marker_info = vku::InitStructHelper();
+    marker_info.pMarkerName = "tile-shading-marker";
+    marker_info.color[0] = 1.0f;
+    marker_info.color[1] = 0.0f;
+    marker_info.color[2] = 0.0f;
+    marker_info.color[3] = 1.0f;
+
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdDebugMarkerBeginEXT-None-10614");
+        vk::CmdDebugMarkerBeginEXT(m_command_buffer, &marker_info);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+        m_command_buffer.Reset();
+    }
+    {
+        m_command_buffer.Begin();
+        vk::CmdDebugMarkerBeginEXT(m_command_buffer, &marker_info);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdDebugMarkerEndEXT-None-10615");
+        vk::CmdDebugMarkerEndEXT(m_command_buffer);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        vk::CmdDebugMarkerEndEXT(m_command_buffer);
+        m_command_buffer.End();
+    }
+}
+
+TEST_F(NegativeTileShading, ClearAttachmentInsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Try to clear attachment inside the per-tile execution model scope.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkClearAttachment clear_attachment{};
+    clear_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    clear_attachment.colorAttachment = 0;
+    clear_attachment.clearValue = clear_value;
+
+    VkClearRect clear_rect{};
+    clear_rect.rect.offset = {0, 0};
+    clear_rect.rect.extent = tile_shading_rp_config.rt_size;
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-None-10616");
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, WriteTimestampInsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Try to write timestamp inside the per-tile execution model scope.");
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::QueryPool query_pool{*m_device, VK_QUERY_TYPE_TIMESTAMP, 1};
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    {
+        m_command_buffer.Begin();
+        vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-None-10640");
+        vk::CmdWriteTimestamp(m_command_buffer,
+                              VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                              query_pool, 0);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+        m_command_buffer.Reset();
+    }
+    {
+        m_command_buffer.Begin();
+        vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp2-None-10639");
+        vk::CmdWriteTimestamp2(m_command_buffer,
+                               VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
+                               query_pool, 0);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+    }
+}
+
+TEST_F(NegativeTileShading, WaitEventsInsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Try to wait events inside the per-tile execution model scope.");
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::Event event{*m_device};
+    const VkEvent event_handle = event.handle();
+
+    VkClearValue clear_value = {};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-None-10655");
+        vk::CmdWaitEvents(m_command_buffer,
+                          1, &event_handle,
+                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                          0, nullptr,
+                          0, nullptr,
+                          0, nullptr);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+        m_command_buffer.Reset();
+    }
+    {
+        VkMemoryBarrier2 mem_barrier2 = vku::InitStructHelper();
+        mem_barrier2.srcStageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+        mem_barrier2.srcAccessMask = 0;
+        mem_barrier2.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+        mem_barrier2.dstAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_READ_BIT_QCOM;
+
+        VkDependencyInfo dependency_info = vku::InitStructHelper();
+        dependency_info.memoryBarrierCount = 1;
+        dependency_info.pMemoryBarriers = &mem_barrier2;
+
+        m_command_buffer.Begin();
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents2-None-10654");
+        vk::CmdWaitEvents2(m_command_buffer, 1, &event_handle, &dependency_info);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+    }
+}
+
+TEST_F(NegativeTileShading, TransformFeedbackInsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Try to begin or end transform feedback inside the per-tile execution model scope.");
+    AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::transformFeedback);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    const char *vs_source = R"glsl(
+        #version 460
+
+        layout(xfb_buffer = 0, xfb_stride = 16) out;
+        layout(location = 0, xfb_offset = 0) out vec4 xfb_out;
+
+        vec2 positions[3] = vec2[3](
+            vec2( 0.0, -0.5),
+            vec2( 0.5,  0.5),
+            vec2(-0.5,  0.5)
+        );
+
+        void main() {
+            vec4 out_position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+            xfb_out = out_position;
+            gl_Position = out_position;
+        }
+    )glsl";
+    const char *fs_source = R"glsl(
+        #version 460
+
+        layout(location = 0) out vec4 out_color;
+
+        void main() {
+            out_color = vec4(1.0);
+        }
+    )glsl";
+
+    VkShaderObj vs{*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_3};
+    VkShaderObj fs{*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3};
+
+    CreatePipelineHelper xfb_pipe{*this};
+    xfb_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    xfb_pipe.gp_ci_.renderPass = m_tile_shading_render_pass;
+    xfb_pipe.CreateGraphicsPipeline();
+
+    constexpr VkDeviceSize xfb_offset = 0;
+    constexpr VkDeviceSize xfb_size = 4096;
+    vkt::Buffer xfb_buffer{*m_device, xfb_size,
+                           VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT,
+                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT};
+    VkBuffer xfb_handle = xfb_buffer.handle();
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, xfb_pipe);
+        vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer,
+                                               0, 1, &xfb_handle, &xfb_offset, &xfb_size);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBeginTransformFeedbackEXT-None-10656");
+        vk::CmdBeginTransformFeedbackEXT(m_command_buffer,
+                                         0,
+                                         0,
+                                         nullptr,
+                                         nullptr);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+        m_command_buffer.Reset();
+    }
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, xfb_pipe);
+        vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer,
+                                               0, 1, &xfb_handle, &xfb_offset, &xfb_size);
+        vk::CmdBeginTransformFeedbackEXT(m_command_buffer,
+                                         0,
+                                         0,
+                                         nullptr,
+                                         nullptr);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdEndTransformFeedbackEXT-None-10657");
+        vk::CmdEndTransformFeedbackEXT(m_command_buffer,
+                                       0,
+                                       0,
+                                       nullptr,
+                                       nullptr);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        vk::CmdEndTransformFeedbackEXT(m_command_buffer,
+                                       0,
+                                       0,
+                                       nullptr,
+                                       nullptr);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+    }
+}
+
+TEST_F(NegativeTileShading, QueryInsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Try to begin or end query inside the per-tile execution model scope.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::QueryPool query_pool{*m_device, VK_QUERY_TYPE_OCCLUSION, 1};
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    {
+        m_command_buffer.Begin();
+        vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-None-10681");
+        vk::CmdBeginQuery(m_command_buffer, query_pool, 0, 0);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+        m_command_buffer.Reset();
+    }
+    {
+        m_command_buffer.Begin();
+        vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
+        vk::CmdBeginQuery(m_command_buffer, query_pool, 0, 0);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdEndQuery-None-07007");
+        m_errorMonitor->SetDesiredError("VUID-vkCmdEndQuery-None-10682");
+        vk::CmdEndQuery(m_command_buffer, query_pool, 0);
+        m_errorMonitor->VerifyFound();
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        vk::CmdEndQuery(m_command_buffer, query_pool, 0);
+        m_command_buffer.End();
     }
 }

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -1001,7 +1001,7 @@ TEST_F(NegativeTileShading, BeginTileShadingCommandBufferWithNonTileShadingRende
     begin_info.pInheritanceInfo = &inheritance_info;
 
     m_errorMonitor->SetDesiredError("VUID-VkCommandBufferBeginInfo-flags-10618");
-     vk::BeginCommandBuffer(secondary_command, &begin_info);
+    vk::BeginCommandBuffer(secondary_command, &begin_info);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1032,7 +1032,7 @@ TEST_F(NegativeTileShading, BeginTileShadingCommandBufferButHasInconsistentApron
     begin_info.pInheritanceInfo = &inheritance_info;
 
     m_errorMonitor->SetDesiredError("VUID-VkCommandBufferBeginInfo-flags-10619");
-     vk::BeginCommandBuffer(secondary_command, &begin_info);
+    vk::BeginCommandBuffer(secondary_command, &begin_info);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1133,11 +1133,55 @@ TEST_F(NegativeTileShading, ExecuteTileShadingCommandWithInconsistentTileApronSi
                      "command has been recorded with a tile-apron size inconsistent with that of the render pass.");
     AddRequiredFeature(vkt::Feature::tileShadingApron);
     RETURN_IF_SKIP(InitBasicTileShading());
-    InitTileShadingRenderTarget();
 
     VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&tile_shading_props);
     vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
+
+    tile_shading_rp_config.tile_apron_size = {tile_shading_props.maxApronSize, tile_shading_props.maxApronSize};
+    InitTileShadingRenderTarget();
+
+    VkAttachmentDescription attachment_desc{};
+    attachment_desc.format = tile_shading_rp_config.format;
+    attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+
+    VkSubpassDependency subpass_dependency{};
+    subpass_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dependency.dstSubpass = 0;
+    subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependency.srcAccessMask = 0;
+    subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    subpass_dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci_primary = vku::InitStructHelper();
+    tile_shading_ci_primary.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci_primary.tileApronSize = {0, 0};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci_primary);
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_desc;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+    rp_ci.dependencyCount = 1;
+    rp_ci.pDependencies = &subpass_dependency;
+
+    vkt::RenderPass zero_apron_rp{*m_device, rp_ci};
 
     vkt::CommandBuffer secondary_command{*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY};
 
@@ -1158,7 +1202,7 @@ TEST_F(NegativeTileShading, ExecuteTileShadingCommandWithInconsistentTileApronSi
     clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
 
     VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
-    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.renderPass = zero_apron_rp;
     rp_begin_info.framebuffer = m_tile_shading_framebuffer;
     rp_begin_info.renderArea.offset = {0, 0};
     rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
@@ -1475,9 +1519,7 @@ TEST_F(NegativeTileShading, WriteTimestampInsidePerTileExecutionModelScope) {
         m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
         m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-None-10640");
-        vk::CmdWriteTimestamp(m_command_buffer,
-                              VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                              query_pool, 0);
+        vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool, 0);
         m_errorMonitor->VerifyFound();
         vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
         m_command_buffer.EndRenderPass();
@@ -1490,9 +1532,7 @@ TEST_F(NegativeTileShading, WriteTimestampInsidePerTileExecutionModelScope) {
         m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
         m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp2-None-10639");
-        vk::CmdWriteTimestamp2(m_command_buffer,
-                               VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
-                               query_pool, 0);
+        vk::CmdWriteTimestamp2(m_command_buffer, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT, query_pool, 0);
         m_errorMonitor->VerifyFound();
         vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
         m_command_buffer.EndRenderPass();
@@ -1632,15 +1672,10 @@ TEST_F(NegativeTileShading, TransformFeedbackInsidePerTileExecutionModelScope) {
         m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, xfb_pipe);
-        vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer,
-                                               0, 1, &xfb_handle, &xfb_offset, &xfb_size);
+        vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer, 0, 1, &xfb_handle, &xfb_offset, &xfb_size);
         vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
         m_errorMonitor->SetDesiredError("VUID-vkCmdBeginTransformFeedbackEXT-None-10656");
-        vk::CmdBeginTransformFeedbackEXT(m_command_buffer,
-                                         0,
-                                         0,
-                                         nullptr,
-                                         nullptr);
+        vk::CmdBeginTransformFeedbackEXT(m_command_buffer, 0, 0, nullptr, nullptr);
         m_errorMonitor->VerifyFound();
         vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
         m_command_buffer.EndRenderPass();
@@ -1651,27 +1686,14 @@ TEST_F(NegativeTileShading, TransformFeedbackInsidePerTileExecutionModelScope) {
         m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, xfb_pipe);
-        vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer,
-                                               0, 1, &xfb_handle, &xfb_offset, &xfb_size);
-        vk::CmdBeginTransformFeedbackEXT(m_command_buffer,
-                                         0,
-                                         0,
-                                         nullptr,
-                                         nullptr);
+        vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer, 0, 1, &xfb_handle, &xfb_offset, &xfb_size);
+        vk::CmdBeginTransformFeedbackEXT(m_command_buffer, 0, 0, nullptr, nullptr);
         vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
         m_errorMonitor->SetDesiredError("VUID-vkCmdEndTransformFeedbackEXT-None-10657");
-        vk::CmdEndTransformFeedbackEXT(m_command_buffer,
-                                       0,
-                                       0,
-                                       nullptr,
-                                       nullptr);
+        vk::CmdEndTransformFeedbackEXT(m_command_buffer, 0, 0, nullptr, nullptr);
         m_errorMonitor->VerifyFound();
         vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
-        vk::CmdEndTransformFeedbackEXT(m_command_buffer,
-                                       0,
-                                       0,
-                                       nullptr,
-                                       nullptr);
+        vk::CmdEndTransformFeedbackEXT(m_command_buffer, 0, 0, nullptr, nullptr);
         m_command_buffer.EndRenderPass();
         m_command_buffer.End();
     }

--- a/tests/unit/tile_shading_positive.cpp
+++ b/tests/unit/tile_shading_positive.cpp
@@ -569,9 +569,7 @@ TEST_F(PositiveTileShading, WriteTimestampOutsidePerTileExecutionModelScope) {
     {
         m_command_buffer.Begin();
         vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
-        vk::CmdWriteTimestamp(m_command_buffer,
-                              VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                              query_pool, 0);
+        vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool, 0);
         m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
         vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
@@ -582,9 +580,7 @@ TEST_F(PositiveTileShading, WriteTimestampOutsidePerTileExecutionModelScope) {
     {
         m_command_buffer.Begin();
         vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
-        vk::CmdWriteTimestamp2(m_command_buffer,
-                               VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
-                               query_pool, 0);
+        vk::CmdWriteTimestamp2(m_command_buffer, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT, query_pool, 0);
         m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
         vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
         vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
@@ -660,20 +656,11 @@ TEST_F(PositiveTileShading, LaunchTransformFeedbackOutsidePerTileExecutionModelS
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, xfb_pipe);
-    vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer,
-                                            0, 1, &xfb_handle, &xfb_offset, &xfb_size);
-    vk::CmdBeginTransformFeedbackEXT(m_command_buffer,
-                                        0,
-                                        0,
-                                        nullptr,
-                                        nullptr);
+    vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer, 0, 1, &xfb_handle, &xfb_offset, &xfb_size);
+    vk::CmdBeginTransformFeedbackEXT(m_command_buffer, 0, 0, nullptr, nullptr);
     vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
     vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
-    vk::CmdEndTransformFeedbackEXT(m_command_buffer,
-                                    0,
-                                    0,
-                                    nullptr,
-                                    nullptr);
+    vk::CmdEndTransformFeedbackEXT(m_command_buffer, 0, 0, nullptr, nullptr);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }

--- a/tests/unit/tile_shading_positive.cpp
+++ b/tests/unit/tile_shading_positive.cpp
@@ -13,6 +13,7 @@
 
 #include "binding.h"
 #include "layer_validation_tests.h"
+#include "pipeline_helper.h"
 
 class PositiveTileShading : public TileShadingTest {};
 
@@ -172,16 +173,15 @@ TEST_F(PositiveTileShading, ExecutePerTileExecutionModel) {
     rp_begin_info.clearValueCount = 1;
     rp_begin_info.pClearValues = &clear_value;
 
-    VkCommandBuffer secondary_handle = secondary_command.handle();
     VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
     VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
 
     m_command_buffer.Begin();
-    vk::CmdBeginRenderPass(m_command_buffer, &rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
-    vk::CmdExecuteCommands(m_command_buffer, 1, &secondary_handle);
+    m_command_buffer.ExecuteCommands(secondary_command);
     vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
-    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }
 
@@ -414,5 +414,342 @@ TEST_F(PositiveTileShading, DynamicRendering) {
     m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
     m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, LaunchTileAttachmentMemoryBarrier) {
+    TEST_DESCRIPTION("Launch correct tile attachment memory barrier.");
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    m_command_buffer.Begin();
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_READ_BIT_QCOM;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_MEMORY_WRITE_BIT;
+        m_command_buffer.Barrier(barrier2);
+    }
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_WRITE_BIT_QCOM;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT;
+        m_command_buffer.Barrier(barrier2);
+    }
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_READ_BIT_QCOM;
+        m_command_buffer.Barrier(barrier2);
+    }
+    {
+        VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+        barrier2.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+        barrier2.srcAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT;
+        barrier2.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+        barrier2.dstAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_WRITE_BIT_QCOM;
+        m_command_buffer.Barrier(barrier2);
+    }
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, LaunchQueryOutsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Launch query outside the per-tile execution model scope.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::QueryPool query_pool{*m_device, VK_QUERY_TYPE_OCCLUSION, 1};
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginQuery(m_command_buffer, query_pool, 0, 0);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    vk::CmdEndQuery(m_command_buffer, query_pool, 0);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, WaitEventsOutsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Wait events outside the per-tile execution model scope.");
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::Event event{*m_device};
+    const VkEvent event_handle = event.handle();
+
+    VkClearValue clear_value = {};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.WaitEvents(1, &event_handle, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                                    0, nullptr, 0, nullptr, 0, nullptr);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+        m_command_buffer.Reset();
+    }
+    {
+        VkMemoryBarrier2 mem_barrier2 = vku::InitStructHelper();
+        mem_barrier2.srcStageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+        mem_barrier2.srcAccessMask = 0;
+        mem_barrier2.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
+        mem_barrier2.dstAccessMask = VK_ACCESS_2_SHADER_TILE_ATTACHMENT_READ_BIT_QCOM;
+
+        VkDependencyInfo dependency_info = vku::InitStructHelper();
+        dependency_info.memoryBarrierCount = 1;
+        dependency_info.pMemoryBarriers = &mem_barrier2;
+
+        m_command_buffer.Begin();
+        vk::CmdWaitEvents2(m_command_buffer, 1, &event_handle, &dependency_info);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+    }
+}
+
+TEST_F(PositiveTileShading, WriteTimestampOutsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Write timestamp outside the per-tile execution model scope.");
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    vkt::QueryPool query_pool{*m_device, VK_QUERY_TYPE_TIMESTAMP, 1};
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    {
+        m_command_buffer.Begin();
+        vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
+        vk::CmdWriteTimestamp(m_command_buffer,
+                              VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                              query_pool, 0);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+        m_command_buffer.Reset();
+    }
+    {
+        m_command_buffer.Begin();
+        vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
+        vk::CmdWriteTimestamp2(m_command_buffer,
+                               VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
+                               query_pool, 0);
+        m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+        vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+        m_command_buffer.EndRenderPass();
+        m_command_buffer.End();
+    }
+}
+
+TEST_F(PositiveTileShading, LaunchTransformFeedbackOutsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Launch transform feedback outside the per-tile execution model scope.");
+    AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::transformFeedback);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    const char *vs_source = R"glsl(
+        #version 460
+
+        layout(xfb_buffer = 0, xfb_stride = 16) out;
+        layout(location = 0, xfb_offset = 0) out vec4 xfb_out;
+
+        vec2 positions[3] = vec2[3](
+            vec2( 0.0, -0.5),
+            vec2( 0.5,  0.5),
+            vec2(-0.5,  0.5)
+        );
+
+        void main() {
+            vec4 out_position = vec4(positions[gl_VertexIndex], 0.0, 1.0);
+            xfb_out = out_position;
+            gl_Position = out_position;
+        }
+    )glsl";
+    const char *fs_source = R"glsl(
+        #version 460
+
+        layout(location = 0) out vec4 out_color;
+
+        void main() {
+            out_color = vec4(1.0);
+        }
+    )glsl";
+
+    VkShaderObj vs{*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_3};
+    VkShaderObj fs{*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3};
+
+    CreatePipelineHelper xfb_pipe{*this};
+    xfb_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    xfb_pipe.gp_ci_.renderPass = m_tile_shading_render_pass;
+    xfb_pipe.CreateGraphicsPipeline();
+
+    constexpr VkDeviceSize xfb_offset = 0;
+    constexpr VkDeviceSize xfb_size = 4096;
+    vkt::Buffer xfb_buffer{*m_device, xfb_size,
+                           VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT,
+                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT};
+    VkBuffer xfb_handle = xfb_buffer.handle();
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, xfb_pipe);
+    vk::CmdBindTransformFeedbackBuffersEXT(m_command_buffer,
+                                            0, 1, &xfb_handle, &xfb_offset, &xfb_size);
+    vk::CmdBeginTransformFeedbackEXT(m_command_buffer,
+                                        0,
+                                        0,
+                                        nullptr,
+                                        nullptr);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    vk::CmdEndTransformFeedbackEXT(m_command_buffer,
+                                    0,
+                                    0,
+                                    nullptr,
+                                    nullptr);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, ClearAttachmentOutsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Clear attachment outside the per-tile execution model scope.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkClearAttachment clear_attachment{};
+    clear_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    clear_attachment.colorAttachment = 0;
+    clear_attachment.clearValue = clear_value;
+
+    VkClearRect clear_rect{};
+    clear_rect.rect.offset = {0, 0};
+    clear_rect.rect.extent = tile_shading_rp_config.rt_size;
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, LaunchDebugMarkerOutsidePerTileExecutionModelScope) {
+    TEST_DESCRIPTION("Launch debug marker outside the per-tile execution model scope.");
+    AddRequiredExtensions(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    VkClearValue clear_value{};
+    clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea.offset = {0, 0};
+    rp_begin_info.renderArea.extent = tile_shading_rp_config.rt_size;
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_value;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    VkDebugMarkerMarkerInfoEXT marker_info = vku::InitStructHelper();
+    marker_info.pMarkerName = "tile-shading-marker";
+    marker_info.color[0] = 1.0f;
+    marker_info.color[1] = 0.0f;
+    marker_info.color[2] = 0.0f;
+    marker_info.color[3] = 1.0f;
+
+    m_command_buffer.Begin();
+    vk::CmdDebugMarkerBeginEXT(m_command_buffer, &marker_info);
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    vk::CmdDebugMarkerEndEXT(m_command_buffer);
     m_command_buffer.End();
 }


### PR DESCRIPTION
# Introduction
VK_QCOM_tile_shading command buffer VUIDs and unit tests. 21 VUIDs totally.

# VUID coverage
| Test | VUID |
|------|------|
| `BeginPerTileExecutionButTileShadingPerTileFeatureNotEnabled` | `VUID-vkCmdBeginPerTileExecutionQCOM-None-10665` |
| `BeginNonTileShadingCommandBufferWithTileShadingRenderPass` | `VUID-VkCommandBufferBeginInfo-flags-10617` |
| `BeginTileShadingCommandBufferWithNonTileShadingRenderPass` | `VUID-VkCommandBufferBeginInfo-flags-10618` |
| `BeginTileShadingCommandBufferButHasInconsistentApronSize` | `VUID-VkCommandBufferBeginInfo-flags-10619` |
| `ExecuteTileShadingCommandWithoutTileShadingEnableBit` | `VUID-vkCmdExecuteCommands-pCommandBuffers-10620` |
| `ExecuteTileShadingCommandInPerTileExecutionModelScope` | `VUID-vkCmdExecuteCommands-pCommandBuffers-10621` |
| `ExecuteTileShadingCommandWithInconsistentTileApronSize` | `VUID-vkCmdExecuteCommands-tileApronSize-10622` |
| `ExecuteTileShadingCommandInNonTileShadingRenderPass` | `VUID-vkCmdExecuteCommands-pCommandBuffers-10623` |
| `ExecutePerTileExecutionCommandButPerTileExecutionModelNotEnabled` | `VUID-vkCmdExecuteCommands-pCommandBuffers-10624` |
| `ExecuteNonZeroTileSizeCommand` | `VUID-vkCmdExecuteCommands-tileApronSize-10625` |
| `LaunchTileAttachmentMemoryBarrierButUseWrongStageMask` | `VUID-VkMemoryBarrier2-srcAccessMask-10670` |
| `LaunchTileAttachmentMemoryBarrierButUseWrongStageMask` | `VUID-VkMemoryBarrier2-srcAccessMask-10671` |
| `LaunchTileAttachmentMemoryBarrierButUseWrongStageMask` | `VUID-VkMemoryBarrier2-dstAccessMask-10670` |
| `LaunchTileAttachmentMemoryBarrierButUseWrongStageMask` | `VUID-VkMemoryBarrier2-dstAccessMask-10671` |
| `DebugMarkerInsidePerTileExecutionModelScope` | `VUID-vkCmdDebugMarkerBeginEXT-None-10614` |
| `DebugMarkerInsidePerTileExecutionModelScope` | `VUID-vkCmdDebugMarkerEndEXT-None-10615` |
| `ClearAttachmentInsidePerTileExecutionModelScope` | `VUID-vkCmdClearAttachments-None-10616` |
| `WriteTimestampInsidePerTileExecutionModelScope` | `VUID-vkCmdWriteTimestamp-None-10640` |
| `WriteTimestampInsidePerTileExecutionModelScope` | `VUID-vkCmdWriteTimestamp2-None-10639` |
| `WaitEventsInsidePerTileExecutionModelScope` | `VUID-vkCmdWaitEvents-None-10655` |
| `WaitEventsInsidePerTileExecutionModelScope` | `VUID-vkCmdWaitEvents2-None-10654` |
| `TransformFeedbackInsidePerTileExecutionModelScope` | `VUID-vkCmdBeginTransformFeedbackEXT-None-10656` |
| `TransformFeedbackInsidePerTileExecutionModelScope` | `VUID-vkCmdEndTransformFeedbackEXT-None-10657` |
| `QueryInsidePerTileExecutionModelScope` | `VUID-vkCmdBeginQuery-None-10681` |
| `QueryInsidePerTileExecutionModelScope` | `VUID-vkCmdEndQuery-None-10682` |

`VUID-VkMemoryBarrier2-srcAccessMask-10670` and `VUID-VkMemoryBarrier2-srcAccessMask-10671` and `VUID-VkMemoryBarrier2-dstAccessMask-10670` and `VUID-VkMemoryBarrier2-dstAccessMask-10671` have already supported by another contributor.
 