### PR TITLE
gpuav: Force robustness to set heaps/buffer to nullDescriptor

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -87,7 +87,9 @@ class Validator : public GpuShaderInstrumentor {
   private:
     void InitSettings(const Location& loc);
     void DestroySubstate();
-    void BindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize offset);
+    void BindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize offset, const Location& loc);
+    void SetMemoryWithNullDescriptor(const vvl::Buffer& buffer_state, VkDeviceMemory memory, VkDeviceSize offset,
+                                     const Location& loc);
 
     // gpuav_record.cpp
     // --------------
@@ -306,6 +308,9 @@ class Validator : public GpuShaderInstrumentor {
 
     // Make sure we call the right versions of any timeline semaphore functions.
     bool timeline_khr_ = false;
+
+    VkQueue internal_transfer_queue_handle_ = VK_NULL_HANDLE;
+    uint32_t internal_transfer_queue_family_index_ = 0;
 
   public:
     vko::GpuResourcesManager gpu_resources_manager_;

--- a/layers/gpuav/core/gpuav_features.cpp
+++ b/layers/gpuav/core/gpuav_features.cpp
@@ -387,7 +387,8 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
     }
 
     if (gpuav_settings.force_on_robustness &&
-        (supported_robustness2_feature.robustBufferAccess2 || supported_robustness2_feature.robustImageAccess2)) {
+        (supported_robustness2_feature.robustBufferAccess2 || supported_robustness2_feature.robustImageAccess2 ||
+         supported_robustness2_feature.nullDescriptor)) {
         const bool has_ext = IsExtensionAvailable(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME, available_extensions);
         const bool has_khr = IsExtensionAvailable(VK_KHR_ROBUSTNESS_2_EXTENSION_NAME, available_extensions);
         if (has_ext || has_khr) {
@@ -408,6 +409,10 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
                     adjustment_warnings += "\tForcing VkPhysicalDeviceRobustness2FeaturesKHR::robustImageAccess2 to VK_TRUE\n";
                     robust_buffer_2_feature->robustImageAccess2 = VK_TRUE;
                 }
+                if (!robust_buffer_2_feature->nullDescriptor && supported_robustness2_feature.nullDescriptor) {
+                    adjustment_warnings += "\tForcing VkPhysicalDeviceRobustness2FeaturesKHR::nullDescriptor to VK_TRUE\n";
+                    robust_buffer_2_feature->nullDescriptor = VK_TRUE;
+                }
             } else {
                 VkPhysicalDeviceRobustness2FeaturesKHR new_robust_buffer_2_feature = vku::InitStructHelper();
                 if (supported_robustness2_feature.robustBufferAccess2) {
@@ -419,6 +424,11 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
                     adjustment_warnings +=
                         "\tAdding a VkPhysicalDeviceRobustness2FeaturesKHR to pNext with robustImageAccess2 set to VK_TRUE\n";
                     new_robust_buffer_2_feature.robustImageAccess2 = VK_TRUE;
+                }
+                if (supported_robustness2_feature.nullDescriptor) {
+                    adjustment_warnings +=
+                        "\tAdding a VkPhysicalDeviceRobustness2FeaturesKHR to pNext with nullDescriptor set to VK_TRUE\n";
+                    new_robust_buffer_2_feature.nullDescriptor = VK_TRUE;
                 }
                 vku::AddToPnext(*modified_create_info, new_robust_buffer_2_feature);
             }

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
+#include <vulkan/vulkan_core.h>
 #include "chassis/chassis_modification_state.h"
+#include "generated/dispatch_functions.h"
 #include "gpuav/core/gpuav.h"
 #include "gpuav/core/gpuav_constants.h"
 #include "gpuav/debug_descriptor/debug_descriptor.h"
@@ -31,9 +33,12 @@
 #include "gpuav/validation_cmd/gpuav_dispatch.h"
 #include "gpuav/validation_cmd/gpuav_draw.h"
 #include "gpuav/validation_cmd/gpuav_ray_tracing.h"
+#include "state_tracker/device_memory_state.h"
+#include "utils/assert_utils.h"
 #include "utils/math_utils.h"
 
 #include <cstdint>
+#include <algorithm>
 #include <vulkan/utility/vk_safe_struct.hpp>
 
 namespace gpuav {
@@ -82,6 +87,18 @@ void Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateI
         chassis_state.modified_create_info.size = Align<VkDeviceSize>(chassis_state.modified_create_info.size, 4);
     }
 
+    // Might need to call vkCmdFillBuffer to set the memory
+    if (set_null_descriptors_) {
+        if ((in_usage & (VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT |
+                         VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT)) != 0) {
+            if (flags2) {
+                const_cast<VkBufferUsageFlags2CreateInfo*>(flags2)->usage |= VK_BUFFER_USAGE_2_TRANSFER_DST_BIT;
+            } else {
+                chassis_state.modified_create_info.usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+            }
+        }
+    }
+
     chassis_state.create_info_copy = chassis_state.modified_create_info.ptr();
 }
 
@@ -108,21 +125,98 @@ void Validator::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, 
     }
 }
 
-void Validator::BindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize offset) {
+void Validator::SetMemoryWithNullDescriptor(const vvl::Buffer& buffer_state, VkDeviceMemory memory, VkDeviceSize offset,
+                                            const Location& loc) {
+    auto device_memory_state = Get<vvl::DeviceMemory>(memory);
+    ASSERT_AND_RETURN(device_memory_state);
+
+    // Printing out the nullDescriptor (and confirm with driver dev) both NVIDIA and AMD use zero as a null descriptor
+    uint32_t null_dword = 0;
+    if (phys_dev_props.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU && phys_dev_props.vendorID == 0x8086) {
+        // For Intel Integrated GPUs (from Metorlake+ which support heaps) they have a special null descriptor
+        null_dword = 0xe0000000;
+
+        // Note: For Lavapipe, it has a special 64-byte sequence that will be different from each descriptor type
+        // For now not going to support it unless desired, but this debugging feature was never ment for Lavapipe
+    }
+
+    const VkDeviceSize bound_size = buffer_state.GetSize();
+    if (device_memory_state->mappable) {
+        uint32_t* data_ptr = (uint32_t*)device_memory_state->p_driver_data;
+
+        if (!device_memory_state->p_driver_data) {
+            DispatchMapMemory(device, memory, offset, bound_size, 0, (void**)&data_ptr);
+        }
+
+        const VkDeviceSize dword_count = bound_size / sizeof(uint32_t);
+        std::fill(data_ptr, data_ptr + dword_count, null_dword);
+
+        if (!device_memory_state->p_driver_data) {
+            // Flush regardless to not need to check if coherent (safe to flush regardless)
+            VkMappedMemoryRange memory_range = vku::InitStructHelper();
+            memory_range.memory = memory;
+            memory_range.offset = offset;
+            memory_range.size = bound_size;
+            DispatchFlushMappedMemoryRanges(device, 1, &memory_range);
+
+            DispatchUnmapMemory(device, memory);
+        }
+    } else if (internal_transfer_queue_handle_ != VK_NULL_HANDLE) {
+        vko::CommandPool& cb_pool =
+            shared_resources_cache.GetOrCreate<vko::CommandPool>(*this, internal_transfer_queue_family_index_, loc);
+        auto [cb_handle, fence_handle] = cb_pool.GetCommandBuffer();
+        assert(cb_handle != VK_NULL_HANDLE);
+
+        DispatchResetCommandBuffer(cb_handle, 0);
+        VkCommandBufferBeginInfo cb_bi = vku::InitStructHelper();
+        cb_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+        DispatchBeginCommandBuffer(cb_handle, &cb_bi);
+        DispatchCmdFillBuffer(cb_handle, buffer_state.VkHandle(), 0, VK_WHOLE_SIZE, null_dword);
+        DispatchEndCommandBuffer(cb_handle);
+
+        // Need to wait until all work is done
+        // This **should** be ok since we are only doing this when allocating descriptor memory, which should not be something done
+        // once at the start of the app (or at least not a common operation)
+        DispatchQueueWaitIdle(internal_transfer_queue_handle_);
+
+        VkSubmitInfo submit_info = vku::InitStructHelper();
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &cb_handle;
+        DispatchQueueSubmit(internal_transfer_queue_handle_, 1, &submit_info, fence_handle);
+        DispatchWaitForFences(device, 1, &fence_handle, VK_TRUE, UINT64_MAX);
+        DispatchResetFences(device, 1, &fence_handle);
+    } else {
+        InternalWarning(buffer_state.VkHandle(), loc, "Unable to set memory with null descriptor");
+    }
+}
+
+void Validator::BindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize offset, const Location& loc) {
     if (descriptor_buffer.resource_handles_.find(buffer) != descriptor_buffer.resource_handles_.end()) {
         descriptor_buffer.resource_memory_handles_.emplace(memory);
+    }
+
+    // This is where we will try and "memset" the Descriptor Heap/Buffer to be a "safe" value by default
+    // Only want to do the buffer state lookup when actually needed
+    if (set_null_descriptors_) {
+        if (auto buffer_state = Get<vvl::Buffer>(buffer)) {
+            if ((buffer_state->usage &
+                 (VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
+                  VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT)) != 0) {
+                SetMemoryWithNullDescriptor(*buffer_state, memory, offset, loc);
+            }
+        }
     }
 }
 
 void Validator::PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                                const RecordObject& record_obj) {
-    BindBufferMemory(buffer, memory, memoryOffset);
+    BindBufferMemory(buffer, memory, memoryOffset, record_obj.location);
 }
 
 void Validator::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos,
                                                 const RecordObject& record_obj) {
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        BindBufferMemory(pBindInfos->buffer, pBindInfos->memory, pBindInfos->memoryOffset);
+        BindBufferMemory(pBindInfos->buffer, pBindInfos->memory, pBindInfos->memoryOffset, record_obj.location);
     }
 }
 

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -304,6 +304,20 @@ void Validator::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const L
             indices_ptr[offset] = i;
         }
     }
+
+    if (set_null_descriptors_) {
+        // Find the first possible queue to do internal transfer on
+        for (uint32_t i = 0; i < physical_device_state->queue_family_properties.size(); i++) {
+            const VkQueueFamilyProperties& props = physical_device_state->queue_family_properties[i];
+            if (props.queueFlags & VK_QUEUE_TRANSFER_BIT) {
+                internal_transfer_queue_family_index_ = i;
+                DispatchGetDeviceQueue(device, i, 0, &internal_transfer_queue_handle_);
+                if (internal_transfer_queue_handle_ != VK_NULL_HANDLE) {
+                    break;
+                }
+            }
+        }
+    }
 }
 
 vko::Buffer& Validator::GetGlobalDescriptorBuffer() {

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -265,6 +265,9 @@ void GpuShaderInstrumentor::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateI
         return;
     }
 
+    set_null_descriptors_ = gpuav_settings.force_on_robustness && modified_features.nullDescriptor &&
+                            (enabled_features.descriptorBuffer || enabled_features.descriptorHeap);
+
     SetupClassicDescriptor(loc);
     SetupDescriptorBuffers(loc);
     SetupDescriptorHeap(loc);

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -245,6 +245,9 @@ class GpuShaderInstrumentor : public vvl::DeviceProxy {
     DeviceExtensions modified_extensions;
     DeviceFeatures modified_features;
 
+    // If we should be setting null descriptors for the app (for Descriptor Buffer/Heap)
+    bool set_null_descriptors_ = false;
+
   private:
     bool IsPipelineSelectedForInstrumentation(VkPipeline pipeline, const Location &loc);
     bool IsShaderSelectedForInstrumentation(vku::safe_VkShaderModuleCreateInfo *modified_shader_module_ci,

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -295,7 +295,7 @@ class GpuAVRayQueryTest : public GpuAVTest {
 
 class GpuAVDescriptorHeap : public GpuAVTest {
   public:
-    void InitGpuAVDescriptorHeap(bool safe_mode = true);
+    void InitGpuAVDescriptorHeap(std::vector<VkLayerSettingEXT> layer_settings = {}, bool safe_mode = true);
 
     void CreateResourceHeap(VkDeviceSize app_size);
     void CreateSamplerHeap(VkDeviceSize app_size, bool use_embedded_samplers = false);

--- a/tests/unit/gpu_av_descriptor_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer.cpp
@@ -12,7 +12,6 @@
 #include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/buffer_helper.h"
 #include "test_framework.h"
 #include "utils/math_utils.h"
 

--- a/tests/unit/gpu_av_descriptor_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer_positive.cpp
@@ -490,3 +490,87 @@ TEST_F(PositiveGpuAVDescriptorBuffer, MultipleAccessChainsBDA) {
 
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
+
+// Note - will crash on Lavapipe, not planning to support currently
+TEST_F(PositiveGpuAVDescriptorBuffer, ForceNullDescriptor) {
+    TEST_DESCRIPTION(
+        "Never set anything in the descriptor buffer, turn on gpuav_force_on_robustness, then pray hard that GPU-AV will prevent "
+        "crashing");
+    std::vector<VkLayerSettingEXT> layer_settings = {
+        {OBJECT_LAYER_NAME, "gpuav_force_on_robustness", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+    };
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer(layer_settings, false));
+
+    std::vector<VkDescriptorSetLayoutBinding> bindings = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                          {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                          {2, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                          {3, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    vkt::DescriptorSetLayout ds_layout(*m_device, bindings, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+    vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout});
+
+    vkt::Buffer descriptor_buffer_host(
+        *m_device, 65536, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT,
+        vkt::device_address);
+
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+    buffer_ci.size = 65536;
+    buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
+                      VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    vkt::Buffer descriptor_buffer_device(*m_device, buffer_ci, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
+
+    // Few extra allocation to stress our internal way to call vkCmdFillBuffer
+    {
+        buffer_ci.size = 1024;
+        vkt::Buffer dummy_buffer_1(*m_device, buffer_ci, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
+        vkt::Buffer dummy_buffer_2(*m_device, buffer_ci, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
+    }
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(local_size_x = 1) in;
+        layout(set = 0, binding = 0) uniform A { vec4 a; };
+        layout(set = 0, binding = 1) buffer B { vec4 b; };
+        layout(set = 0, binding = 2) uniform texture2D t;
+        layout(set = 0, binding = 3) uniform sampler s;
+        void main() {
+            b = texture(sampler2D(t, s), vec2(0.5f)) * a;
+        }
+    )glsl";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    pipe.cp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipe.cp_ci_.layout = pipeline_layout;
+    pipe.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+
+    VkDescriptorBufferBindingInfoEXT descriptor_buffer_binding_info[2];
+    descriptor_buffer_binding_info[0] = vku::InitStructHelper();
+    descriptor_buffer_binding_info[0].address = descriptor_buffer_host.Address();
+    descriptor_buffer_binding_info[0].usage =
+        VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
+    descriptor_buffer_binding_info[1] = vku::InitStructHelper();
+    descriptor_buffer_binding_info[1].address = descriptor_buffer_device.Address();
+    descriptor_buffer_binding_info[1].usage =
+        VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
+    vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 2, descriptor_buffer_binding_info);
+
+    uint32_t buffer_index = 0;
+    VkDeviceSize buffer_offset = 0;
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1, &buffer_index,
+                                         &buffer_offset);
+    vk::CmdDispatch(m_command_buffer, 4, 1, 4);
+
+    buffer_index = 1;
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1, &buffer_index,
+                                         &buffer_offset);
+    vk::CmdDispatch(m_command_buffer, 2, 8, 1);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -16,15 +16,6 @@
 #include "../framework/buffer_helper.h"
 #include "../utils/math_utils.h"
 
-void GpuAVDescriptorHeap::InitGpuAVDescriptorHeap(bool safe_mode) {
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::descriptorHeap);
-    RETURN_IF_SKIP(InitGpuAvFramework({}, safe_mode));
-    RETURN_IF_SKIP(InitState());
-    GetPhysicalDeviceProperties2(heap_props);
-}
-
 void GpuAVDescriptorHeap::CreateResourceHeap(VkDeviceSize app_size) {
     const VkDeviceSize heap_size = AlignResource(app_size) + heap_props.minResourceHeapReservedRange;
     VkBufferUsageFlags2CreateInfo buffer_usage = vku::InitStructHelper();
@@ -53,8 +44,7 @@ void GpuAVDescriptorHeap::CreateSamplerHeap(VkDeviceSize app_size, bool use_embe
 
 void GpuAVDescriptorHeap::BindResourceHeap() {
     VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
-    bind_resource_info.heapRange.address = resource_heap_.Address();
-    bind_resource_info.heapRange.size = resource_heap_.CreateInfo().size;
+    bind_resource_info.heapRange = resource_heap_.AddressRange();
     bind_resource_info.reservedRangeOffset = resource_heap_.CreateInfo().size - heap_props.minResourceHeapReservedRange;
     bind_resource_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
@@ -64,8 +54,7 @@ void GpuAVDescriptorHeap::BindSamplerHeap() {
     const VkDeviceSize min_reserved_range =
         embedded_samplers ? heap_props.minSamplerHeapReservedRangeWithEmbedded : heap_props.minSamplerHeapReservedRange;
     VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
-    bind_resource_info.heapRange.address = sampler_heap_.Address();
-    bind_resource_info.heapRange.size = sampler_heap_.CreateInfo().size;
+    bind_resource_info.heapRange = sampler_heap_.AddressRange();
     bind_resource_info.reservedRangeOffset = sampler_heap_.CreateInfo().size - min_reserved_range;
     bind_resource_info.reservedRangeSize = min_reserved_range;
     vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_resource_info);
@@ -243,7 +232,6 @@ TEST_F(NegativeGpuAVDescriptorHeap, NoHeapBound) {
 
 TEST_F(NegativeGpuAVDescriptorHeap, HeapBoundBeforePipeline) {
     TEST_DESCRIPTION("Validate illegal index buffer values when descriptor heap is bound before the pipeline");
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
 
@@ -318,7 +306,6 @@ TEST_F(NegativeGpuAVDescriptorHeap, HeapBoundBeforePipeline) {
 
 TEST_F(NegativeGpuAVDescriptorHeap, HeapBoundAfterPipeline) {
     TEST_DESCRIPTION("Validate illegal index buffer values when descriptor heap is bound after pipeline");
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
 
@@ -393,7 +380,6 @@ TEST_F(NegativeGpuAVDescriptorHeap, HeapBoundAfterPipeline) {
 
 TEST_F(NegativeGpuAVDescriptorHeap, SamplerHeapBound) {
     TEST_DESCRIPTION("Validate illegal index buffer values when sampler heap is bound");
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
 
@@ -467,7 +453,6 @@ TEST_F(NegativeGpuAVDescriptorHeap, SamplerHeapBound) {
 
 TEST_F(NegativeGpuAVDescriptorHeap, MappingsUsed) {
     TEST_DESCRIPTION("Validate illegal index buffer values when custom mappings are used");
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
@@ -690,7 +675,6 @@ TEST_F(NegativeGpuAVDescriptorHeap, DispatchWorkgroupSize) {
 }
 
 TEST_F(NegativeGpuAVDescriptorHeap, HeapRebound) {
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
 
@@ -770,7 +754,6 @@ TEST_F(NegativeGpuAVDescriptorHeap, HeapRebound) {
 TEST_F(NegativeGpuAVDescriptorHeap, ShaderObjects) {
     TEST_DESCRIPTION("Validate illegal index buffer values with shader objects");
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::shaderObject);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());

--- a/tests/unit/gpu_av_descriptor_heap_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_heap_positive.cpp
@@ -13,14 +13,23 @@
 #include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/buffer_helper.h"
 #include "../utils/math_utils.h"
+#include "test_framework.h"
 
 class PositiveGpuAVDescriptorHeap : public GpuAVDescriptorHeap {};
 
+void GpuAVDescriptorHeap::InitGpuAVDescriptorHeap(std::vector<VkLayerSettingEXT> layer_settings, bool safe_mode) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    RETURN_IF_SKIP(InitGpuAvFramework(layer_settings, safe_mode));
+    RETURN_IF_SKIP(InitState());
+    GetPhysicalDeviceProperties2(heap_props);
+}
+
 TEST_F(PositiveGpuAVDescriptorHeap, BufferPointerOffset) {
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
@@ -73,7 +82,6 @@ TEST_F(PositiveGpuAVDescriptorHeap, BufferPointerOffset) {
 TEST_F(PositiveGpuAVDescriptorHeap, SamplerPointerOffset) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
@@ -186,7 +194,6 @@ TEST_F(PositiveGpuAVDescriptorHeap, SamplerPointerOffset) {
 
 TEST_F(PositiveGpuAVDescriptorHeap, HeapBoundInMultimpleCmdBuffers) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
 
@@ -211,7 +218,6 @@ TEST_F(PositiveGpuAVDescriptorHeap, HeapBoundInMultimpleCmdBuffers) {
 }
 
 TEST_F(PositiveGpuAVDescriptorHeap, PushAddress) {
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
@@ -318,7 +324,6 @@ TEST_F(PositiveGpuAVDescriptorHeap, PushAddress) {
 TEST_F(PositiveGpuAVDescriptorHeap, ResourceHeapImage) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     InitRenderTarget();
@@ -412,6 +417,106 @@ TEST_F(PositiveGpuAVDescriptorHeap, ResourceHeapImage) {
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     BindResourceHeap();
     vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+// Note - will crash on Lavapipe, not planning to support currently
+TEST_F(PositiveGpuAVDescriptorHeap, ForceNullDescriptor) {
+    TEST_DESCRIPTION(
+        "Never set anything in the heap, turn on gpuav_force_on_robustness, then pray hard that GPU-AV will prevent crashing");
+    std::vector<VkLayerSettingEXT> layer_settings = {
+        {OBJECT_LAYER_NAME, "gpuav_force_on_robustness", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+    };
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap(layer_settings, false));
+    uint32_t random_size = 16384;
+    CreateResourceHeap(random_size * 4);
+    CreateSamplerHeap(random_size * 2);
+
+    VkBufferUsageFlags2CreateInfo buffer_usage = vku::InitStructHelper();
+    buffer_usage.usage = VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT | VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT;
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage);
+    buffer_ci.size = random_size + heap_props.minResourceHeapReservedRange + heap_props.minSamplerHeapReservedRange;
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    // Using as both the resource and sampler... because why not
+    vkt::Buffer descriptor_heap_device(*m_device, buffer_ci, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
+
+    // Few extra allocation to stress our internal way to call vkCmdFillBuffer
+    {
+        buffer_ci.size = 1024;
+        vkt::Buffer dummy_buffer_1(*m_device, buffer_ci, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
+        vkt::Buffer dummy_buffer_2(*m_device, buffer_ci, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
+    }
+
+    VkDescriptorSetAndBindingMappingEXT mappings[4];
+    mappings[0] = MakeSetAndBindingMapping(0, 1);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = (uint32_t)heap_props.bufferDescriptorSize;
+    mappings[1] = MakeSetAndBindingMapping(0, 2);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
+    mappings[1].sourceData.pushIndex.heapOffset = (uint32_t)heap_props.imageDescriptorSize * 2;
+    mappings[1].sourceData.pushIndex.heapIndexStride = 1;
+    mappings[1].sourceData.pushIndex.pushOffset = 8;
+    mappings[2] = MakeSetAndBindingMapping(0, 0);
+    mappings[2].source = VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT;
+    mappings[2].sourceData.heapData.heapOffset = (uint32_t)heap_props.bufferDescriptorSize * 4;
+    mappings[2].sourceData.heapData.pushOffset = 8;
+    mappings[3] = MakeSetAndBindingMapping(0, 3);
+    mappings[3].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[3].sourceData.constantOffset.heapOffset = (uint32_t)heap_props.samplerDescriptorSize * 3;
+    mappings[3].sourceData.constantOffset.heapArrayStride = 0;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 4;
+    mapping_info.pMappings = mappings;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(local_size_x = 1) in;
+        layout(set = 0, binding = 0) uniform A { vec4 a; };
+        layout(set = 0, binding = 1) buffer B { vec4 b; };
+        layout(set = 0, binding = 2) uniform texture2D t;
+        layout(set = 0, binding = 3) uniform sampler s;
+        void main() {
+            b = texture(sampler2D(t, s), vec2(0.5f)) * a;
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.CreateComputePipeline(false);
+
+    m_command_buffer.Begin();
+    BindResourceHeap();
+    BindSamplerHeap();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+
+    uint32_t push_offset = 0;
+    VkPushDataInfoEXT push_data = vku::InitStructHelper();
+    push_data.offset = 8;
+    push_data.data.address = &push_offset;
+    push_data.data.size = sizeof(uint32_t);
+    vk::CmdPushDataEXT(m_command_buffer, &push_data);
+
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = descriptor_heap_device.AddressRange();
+    bind_resource_info.reservedRangeOffset = random_size;
+    bind_resource_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    bind_resource_info.reservedRangeOffset = random_size + heap_props.minResourceHeapReservedRange;
+    bind_resource_info.reservedRangeSize = heap_props.minSamplerHeapReservedRange;
+    vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_resource_info);
+
+    vk::CmdDispatch(m_command_buffer, 8, 8, 2);
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 }


### PR DESCRIPTION
Basic idea if the user sets `gpuav_force_on_robustness` GPU-AV will try to "`memset`" the descriptor buffer/heap with a the "magic nullDescriptor" value such that if the user has not set anything in their buffer/heap, it will safely get through without crashing