### PR TITLE
dump: Handle Reserved Ranges (and others)

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -43,6 +43,7 @@ namespace gpudump {
 // Return true if found warning
 bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const LastBound& last_bound) const {
     const vvl::CommandBuffer& cb_state = last_bound.cb_state;
+    bool found_warning = false;
     ss << "vkCmdBindDescriptorBuffersEXT last bound the following descriptor buffers:\n";
     for (uint32_t binding_i = 0; binding_i < cb_state.descriptor_buffer.binding_info.size(); binding_i++) {
         const VkDeviceAddress address = cb_state.descriptor_buffer.binding_info[binding_i].address;
@@ -53,6 +54,7 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
         }
         if (buffer_states.empty()) {
             ss << "    - No VkBuffer found at 0x" << std::hex << address << "\n";
+            found_warning = true;
         }
     }
 
@@ -148,10 +150,12 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
                 if (!dsl || dsl->Destroyed()) {
                     ss << "  - Set " << std::dec << var_set
                        << " VkDescriptorSetLayout was destroyed (TODO - Track more info in pipeline layout)";
+                    found_warning = true;
                     continue;
                 } else if ((dsl->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) == 0) {
                     ss << "  - Set " << std::dec << var_set
                        << " was not created with VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT";
+                    found_warning = true;
                     continue;
                 } else if (!descriptor_buffer_binding.has_value()) {
                     ss << "  - Set " << std::dec << var_set
@@ -160,6 +164,7 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
                         ss << " or because all bindings are using Immutable Samplers";
                     }
                     ss << ")\n";
+                    found_warning = true;
                     continue;
                 }
 
@@ -221,7 +226,7 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
             }
         }
     }
-    return false;
+    return found_warning;
 }
 
 struct MappingInfo {
@@ -253,13 +258,16 @@ static const vvl::Buffer& GetLargestBuffer(const GpuDump& dev_data, uint64_t add
 bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, const MappingInfo& mapping_info) const {
     const VkDescriptorSetAndBindingMappingEXT& mapping = *mapping_info.mapping;
     const spirv::ResourceInterfaceVariable& resource_variable = *mapping_info.resource_variable;
-
-    // bool Print(const CommandBufferSubState& cb_sub_state, std::ostringstream& map_ss, const VkPhysicalDevice) {
+    vvl::CommandBuffer::DescriptorHeap& heap = base.descriptor_heap;
 
     ss << "    - Binding " << std::dec << resource_variable.decorations.binding << ", "
        << string_VkDescriptorMappingSourceEXT(mapping.source) << " (from pMappings[" << mapping_info.index << "])\n";
     const bool is_combined_image_sampler = resource_variable.is_combined_image_sampler;
-    const char* main_heap_type = resource_variable.is_sampler ? "Sampler" : "Resource";
+    const bool is_sampler = resource_variable.is_sampler;
+    const char* main_heap_type = is_sampler ? "Sampler" : "Resource";
+    const vvl::range<VkDeviceAddress>& heap_range = is_sampler ? heap.sampler_range : heap.resource_range;
+    const vvl::range<VkDeviceAddress>& heap_reserved = is_sampler ? heap.sampler_reserved : heap.resource_reserved;
+
     const bool is_array = resource_variable.IsArray();
     const bool is_runtime_array = resource_variable.IsRuntimeArray();
     uint32_t array_length = 0;
@@ -276,37 +284,61 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
     // attempts to catch obvious OOB offsets in mappings
     bool warn_oob = false;
     uint32_t warn_index_oob = 0;
+    uint32_t warn_reserved_range_start = vvl::kNoIndex32;
+    uint32_t warn_reserved_range_end = vvl::kNoIndex32;
     std::vector<uint32_t> warn_index_array;
+    std::vector<uint32_t> warn_reserved_range_index_array;
 
     ss << "      - ";
     const char* new_line = "\n        ";
 
-    vvl::CommandBuffer::DescriptorHeap& heap = base.descriptor_heap;
     if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
         const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping.sourceData.constantOffset;
 
         ss << "heapOffset: 0x" << std::hex << map_data.heapOffset << ", heapArrayStride: 0x" << map_data.heapArrayStride;
         VkDeviceSize index_zero_offset = map_data.heapOffset;
-        VkDeviceSize index_zero_address = heap.resource_range.begin + index_zero_offset;
+        VkDeviceSize index_zero_address = heap_range.begin + index_zero_offset;
         ss << new_line << main_heap_type << " Heap address: 0x" << index_zero_address;
         if (is_array) {
             ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
-            const VkDeviceSize available_space = (heap.resource_range.size() - index_zero_offset) - descriptor_size;
+            const VkDeviceSize available_space = (heap_range.size() - index_zero_offset) - descriptor_size;
             const uint32_t max_index = (uint32_t)(available_space / map_data.heapArrayStride);
             if (array_length != 0) {
                 const VkDeviceSize final_array_offset = (array_length - 1) * map_data.heapArrayStride;
                 ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                    << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
                    << (index_zero_address + final_array_offset + descriptor_size) << ")";
-                warn_index_oob = array_length > max_index ? max_index : 0;
+                warn_index_oob = array_length > (max_index+1) ? max_index : 0;
             } else if (is_runtime_array) {
                 const VkDeviceSize final_array_offset = (max_index * map_data.heapArrayStride);
                 ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                    << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
                    << (index_zero_address + final_array_offset + descriptor_size) << ")";
             }
+
+            if (!heap_reserved.empty()) {
+                const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
+                for (uint32_t i = 0; i < max_search_index; i++) {
+                    // TODO - be smart where to start searching if reserve range is at the end of huge buffer
+                    VkDeviceAddress next_index_address = index_zero_address + (i * map_data.heapArrayStride);
+                    vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                    if (next_index_range.intersects(heap_reserved)) {
+                        if (warn_reserved_range_start == vvl::kNoIndex32) {
+                            warn_reserved_range_start = i;
+                        }
+                        warn_reserved_range_end = i;
+                    } else if (warn_reserved_range_end != vvl::kNoIndex32) {
+                        break; // found end of reserved range
+                    }
+                }
+            }
+        } else if (!heap_reserved.empty()) {
+            vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+            if (index_zero_range.intersects(heap_reserved)) {
+                warn_reserved_range_start = 0;
+            }
         }
-        warn_oob |= (index_zero_offset + descriptor_size > heap.resource_range.size());
+        warn_oob |= (index_zero_offset + descriptor_size > heap_range.size());
 
         if (is_combined_image_sampler) {
             ss << new_line << "samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset << ", samplerHeapArrayStride: 0x"
@@ -323,13 +355,34 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                     ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                        << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
                        << (index_zero_address + final_array_offset + descriptor_size) << ")";
-                    warn_index_oob = array_length > max_index ? max_index : 0;
+                    warn_index_oob = array_length > (max_index+1)  ? max_index : 0;
                 } else if (is_runtime_array) {
                     const VkDeviceSize final_array_offset =
                         (map_data.samplerHeapOffset + (max_index * map_data.samplerHeapArrayStride));
                     ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                        << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
                        << (index_zero_address + final_array_offset + descriptor_size) << ")";
+                }
+
+                if (!heap.sampler_reserved.empty() && warn_reserved_range_start == vvl::kNoIndex32) {
+                    const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
+                    for (uint32_t i = 0; i < max_search_index; i++) {
+                        VkDeviceAddress next_index_address = index_zero_address + (i * map_data.samplerHeapArrayStride);
+                        vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                        if (next_index_range.intersects(heap.sampler_reserved)) {
+                            if (warn_reserved_range_start == vvl::kNoIndex32) {
+                                warn_reserved_range_start = i;
+                            }
+                            warn_reserved_range_end = i;
+                        } else if (warn_reserved_range_end != vvl::kNoIndex32) {
+                            break; // found end of reserved range
+                        }
+                    }
+                }
+            } else if (!heap.sampler_reserved.empty()) {
+                vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                if (index_zero_range.intersects(heap.sampler_reserved)) {
+                    warn_reserved_range_start = 0;
                 }
             }
             warn_oob |= (index_zero_offset + descriptor_size > heap.sampler_range.size());
@@ -344,27 +397,51 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         ss << new_line << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset << " + (0x"
            << push_index << " * 0x" << map_data.heapIndexStride << ")";
         VkDeviceSize index_zero_offset = map_data.heapOffset + (push_index * map_data.heapIndexStride);
-        VkDeviceSize index_zero_address = heap.resource_range.begin + index_zero_offset;
+        VkDeviceSize index_zero_address = heap_range.begin + index_zero_offset;
         if (is_array) {
             ss << " + (descriptor_index * 0x" << map_data.heapArrayStride << ")";
-            const VkDeviceSize available_space = (heap.resource_range.size() - index_zero_offset) - descriptor_size;
+            const VkDeviceSize available_space = (heap_range.size() - index_zero_offset) - descriptor_size;
             const uint32_t max_index = (uint32_t)(available_space / map_data.heapArrayStride);
             if (array_length != 0) {
                 const VkDeviceSize final_array_offset = (array_length - 1) * map_data.heapArrayStride;
                 ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                    << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
                    << (index_zero_address + final_array_offset + descriptor_size) << ")";
-                warn_index_oob = array_length > max_index ? max_index : 0;
+                warn_index_oob = array_length > (max_index+1)  ? max_index : 0;
             } else if (is_runtime_array) {
                 const VkDeviceSize final_array_offset = max_index * map_data.heapArrayStride;
                 ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                    << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
                    << (index_zero_address + final_array_offset + descriptor_size) << ")";
             }
+
+            if (!heap_reserved.empty()) {
+                const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
+                for (uint32_t i = 0; i < max_search_index; i++) {
+                    // TODO - be smart where to start searching if reserve range is at the end of huge buffer
+                    VkDeviceAddress next_index_address = index_zero_address + (i * map_data.heapArrayStride);
+                    vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                    if (next_index_range.intersects(heap_reserved)) {
+                        if (warn_reserved_range_start == vvl::kNoIndex32) {
+                            warn_reserved_range_start = i;
+                        }
+                        warn_reserved_range_end = i;
+                    } else if (warn_reserved_range_end != vvl::kNoIndex32) {
+                        break; // found end of reserved range
+                    }
+                }
+            }
         } else {
             ss << " [final address 0x" << index_zero_address << "]";
+
+            if (!heap_reserved.empty()) {
+                vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                if (index_zero_range.intersects(heap_reserved)) {
+                    warn_reserved_range_start = 0;
+                }
+            }
         }
-        warn_oob |= (index_zero_offset + descriptor_size > heap.resource_range.size());
+        warn_oob |= (index_zero_offset + descriptor_size > heap_range.size());
 
         if (is_combined_image_sampler) {
             ss << new_line << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", samplerHeapOffset: 0x"
@@ -384,15 +461,38 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                     ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                        << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
                        << (index_zero_address + final_array_offset + descriptor_size) << ")";
-                    warn_index_oob = array_length > max_index ? max_index : 0;
+                    warn_index_oob = array_length > (max_index+1)  ? max_index : 0;
                 } else if (is_runtime_array) {
                     const VkDeviceSize final_array_offset = max_index * map_data.samplerHeapArrayStride;
                     ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                        << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
                        << (index_zero_address + final_array_offset + descriptor_size) << ")";
                 }
+
+                if (!heap.sampler_reserved.empty() && warn_reserved_range_start == vvl::kNoIndex32) {
+                    const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
+                    for (uint32_t i = 0; i < max_search_index; i++) {
+                        VkDeviceAddress next_index_address = index_zero_address + (i * map_data.samplerHeapArrayStride);
+                        vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                        if (next_index_range.intersects(heap.sampler_reserved)) {
+                            if (warn_reserved_range_start == vvl::kNoIndex32) {
+                                warn_reserved_range_start = i;
+                            }
+                            warn_reserved_range_end = i;
+                        } else if (warn_reserved_range_end != vvl::kNoIndex32) {
+                            break; // found end of reserved range
+                        }
+                    }
+                }
             } else {
-                ss << " [final address 0x" << (heap.sampler_range.begin + index_zero_offset) << "]";
+                ss << " [final address 0x" << index_zero_address << "]";
+
+                if (!heap.sampler_reserved.empty()) {
+                    vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                    if (index_zero_range.intersects(heap.sampler_reserved)) {
+                        warn_reserved_range_start = 0;
+                    }
+                }
             }
             warn_oob |= (index_zero_offset + descriptor_size > heap.sampler_range.size());
         }
@@ -413,7 +513,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         if (know_ubo) {
             ss << new_line << "indirectIndex: 0x" << indirect_index;
         }
-        ss << new_line << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset << " + (";
+        ss << new_line << main_heap_type << " Heap address: 0x" << heap_range.begin + map_data.heapOffset << " + (";
         if (know_ubo) {
             ss << "0x" << indirect_index;
         } else {
@@ -425,28 +525,54 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
             if (know_ubo) {
                 VkDeviceSize index_zero_offset = map_data.heapOffset + (indirect_index * map_data.heapIndexStride);
-                VkDeviceSize index_zero_address = heap.resource_range.begin + index_zero_offset;
-                VkDeviceSize available_space = (heap.resource_range.size() - index_zero_offset) - descriptor_size;
+                VkDeviceSize index_zero_address = heap_range.begin + index_zero_offset;
+                VkDeviceSize available_space = (heap_range.size() - index_zero_offset) - descriptor_size;
                 uint32_t max_index = (uint32_t)(available_space / map_data.heapArrayStride);
                 if (array_length != 0) {
                     const VkDeviceSize final_array_offset = (array_length - 1) * map_data.heapArrayStride;
                     ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                        << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
                        << (index_zero_address + final_array_offset + descriptor_size) << ")";
-                    warn_index_oob = array_length > max_index ? max_index : 0;
+                    warn_index_oob = array_length > (max_index+1)  ? max_index : 0;
                 } else if (is_runtime_array) {
                     const VkDeviceSize final_array_offset = max_index * map_data.heapArrayStride;
                     ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                        << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
                        << (index_zero_address + final_array_offset + descriptor_size) << ")";
                 }
+
+                if (!heap_reserved.empty()) {
+                    const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
+                    for (uint32_t i = 0; i < max_search_index; i++) {
+                        // TODO - be smart where to start searching if reserve range is at the end of huge buffer
+                        VkDeviceAddress next_index_address = index_zero_address + (i * map_data.heapArrayStride);
+                        vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                        if (next_index_range.intersects(heap_reserved)) {
+                            if (warn_reserved_range_start == vvl::kNoIndex32) {
+                                warn_reserved_range_start = i;
+                            }
+                            warn_reserved_range_end = i;
+                        } else if (warn_reserved_range_end != vvl::kNoIndex32) {
+                            break; // found end of reserved range
+                        }
+                    }
+                }
             }
         } else if (know_ubo) {
-            uint64_t final_offset = map_data.heapOffset + (indirect_index * map_data.heapIndexStride);
-            ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
-            warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
+            VkDeviceAddress final_offset = map_data.heapOffset + (indirect_index * map_data.heapIndexStride);
+            VkDeviceAddress index_zero_address = heap_range.begin + final_offset;
+            ss << " [final address 0x" << (heap_range.begin + final_offset) << "]";
+            warn_oob |= (final_offset + descriptor_size > heap_range.size());
+
+            if (!heap_reserved.empty()) {
+                vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                if (index_zero_range.intersects(heap_reserved)) {
+                    warn_reserved_range_start = 0;
+                }
+            }
         }
-        warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+
+        warn_oob |= (map_data.heapOffset + descriptor_size > heap_range.size());
 
         if (is_combined_image_sampler) {
             push_indirect_address = *((VkDeviceAddress*)&push_data_value[map_data.samplerPushOffset]);
@@ -486,19 +612,44 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                         ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                            << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
                            << (index_zero_address + final_array_offset + descriptor_size) << ")";
-                        warn_index_oob = array_length > max_index ? max_index : 0;
+                        warn_index_oob = array_length > (max_index+1)  ? max_index : 0;
                     } else if (is_runtime_array) {
                         const VkDeviceSize final_array_offset = max_index * map_data.samplerHeapArrayStride;
                         ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                            << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
                            << (index_zero_address + final_array_offset + descriptor_size) << ")";
                     }
+
+                    if (!heap.sampler_reserved.empty() && warn_reserved_range_start == vvl::kNoIndex32) {
+                        const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
+                        for (uint32_t i = 0; i < max_search_index; i++) {
+                            VkDeviceAddress next_index_address = index_zero_address + (i * map_data.samplerHeapArrayStride);
+                            vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                            if (next_index_range.intersects(heap.sampler_reserved)) {
+                                if (warn_reserved_range_start == vvl::kNoIndex32) {
+                                    warn_reserved_range_start = i;
+                                }
+                                warn_reserved_range_end = i;
+                            } else if (warn_reserved_range_end != vvl::kNoIndex32) {
+                                break; // found end of reserved range
+                            }
+                        }
+                    }
                 }
             } else if (know_ubo) {
-                uint64_t final_offset = map_data.samplerHeapOffset + (indirect_index * map_data.samplerHeapIndexStride);
-                ss << " [final address 0x" << (heap.sampler_range.begin + final_offset) << "]";
+                VkDeviceAddress final_offset = map_data.samplerHeapOffset + (indirect_index * map_data.samplerHeapIndexStride);
+                VkDeviceAddress index_zero_address = heap.sampler_range.begin + final_offset;
+                ss << " [final address 0x" << (index_zero_address) << "]";
                 warn_oob |= (final_offset + descriptor_size > heap.sampler_range.size());
+
+                if (!heap.sampler_range.empty()) {
+                    vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                    if (index_zero_range.intersects(heap.sampler_range)) {
+                        warn_reserved_range_start = 0;
+                    }
+                }
             }
+
             warn_oob |= (map_data.samplerHeapOffset + descriptor_size > heap.sampler_range.size());
         }
     } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
@@ -511,7 +662,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         ss << new_line << "indirectAddress: 0x" << final_indirect_address << " (0x" << push_indirect_address << " + 0x"
            << map_data.addressOffset << ")";
 
-        ss << new_line << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset
+        ss << new_line << main_heap_type << " Heap address: 0x" << heap_range.begin + map_data.heapOffset
            << " + (indirectIndex * 0x" << map_data.heapIndexStride << ")";
 
         const vvl::Buffer& buffer_state = GetLargestBuffer(dev_data, final_indirect_address);
@@ -541,23 +692,33 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
             if (!is_array) {
                 uint32_t indirect_index = indirect_index_words[0];
                 uint64_t final_offset = map_data.heapOffset + (indirect_index * map_data.heapIndexStride);
-                ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
-                warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
+                ss << " [final address 0x" << (heap_range.begin + final_offset) << " where indirectIndex is 0x" << indirect_index << "]";
+                warn_oob |= (final_offset + descriptor_size > heap_range.size());
             } else if (!is_runtime_array) {
+                // Runtime arrays are unbounded and not idea where to stop looking,
+                // can add if people find valuable.
                 ss << new_line << "indirectIndex values from buffer: [";
                 for (uint32_t i = 0; i < search_slots; i++) {
                     const uint32_t current_index_value = indirect_index_words[i];
-                    uint64_t final_offset = map_data.heapOffset + (current_index_value * map_data.heapIndexStride);
-                    if (final_offset + descriptor_size > heap.resource_range.size()) {
+                    VkDeviceAddress final_offset = map_data.heapOffset + (current_index_value * map_data.heapIndexStride);
+                    if (final_offset + descriptor_size > heap_range.size()) {
                         warn_index_array.emplace_back(i);
                     }
                     if (i != 0) ss << ", ";
                     ss << "0x" << current_index_value;
+
+                    if (!heap_reserved.empty()) {
+                        VkDeviceAddress next_index_address = heap_range.begin + final_offset;
+                        vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                        if (next_index_range.intersects(heap_reserved)) {
+                            warn_reserved_range_index_array.emplace_back(i);
+                        }
+                    }
                 }
                 ss << "]";
             }
         }
-        warn_oob |= (map_data.heapOffset + descriptor_size > heap.resource_range.size());
+        warn_oob |= (map_data.heapOffset + descriptor_size > heap_range.size());
 
         if (is_combined_image_sampler) {
             push_indirect_address = *((VkDeviceAddress*)&push_data_value[map_data.samplerPushOffset]);
@@ -602,13 +763,21 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                     ss << new_line << "indirectIndex values from buffer: [";
                     for (uint32_t i = 0; i < search_slots; i++) {
                         const uint32_t current_index_value = indirect_index_words[i];
-                        uint64_t final_offset =
+                        VkDeviceAddress final_offset =
                             map_data.samplerHeapOffset + (current_index_value * map_data.samplerHeapIndexStride);
                         if (final_offset + descriptor_size > heap.sampler_range.size()) {
                             warn_index_array.emplace_back(i);
                         }
                         if (i != 0) ss << ", ";
                         ss << "0x" << current_index_value;
+
+                        if (!heap.sampler_reserved.empty()) {
+                            VkDeviceAddress next_index_address = heap.sampler_range.begin + final_offset;
+                            vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                            if (next_index_range.intersects(heap.sampler_reserved)) {
+                                warn_reserved_range_index_array.emplace_back(i);
+                            }
+                        }
                     }
                     ss << "]";
                 }
@@ -621,11 +790,20 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
         ss << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", heapOffset: 0x" << map_data.heapOffset;
         ss << new_line << "Push data at 0x" << std::hex << map_data.pushOffset << ": 0x" << push_data;
-        ss << new_line << main_heap_type << " Heap address: 0x" << heap.resource_range.begin + map_data.heapOffset << " + 0x"
+        ss << new_line << main_heap_type << " Heap address: 0x" << heap_range.begin + map_data.heapOffset << " + 0x"
            << push_data;
-        uint64_t final_offset = map_data.heapOffset + push_data;
-        ss << " [final address 0x" << (heap.resource_range.begin + final_offset) << "]";
-        warn_oob |= (final_offset + descriptor_size > heap.resource_range.size());
+        VkDeviceAddress final_offset = map_data.heapOffset + push_data;
+        VkDeviceAddress final_address = heap_range.begin + final_offset;
+        ss << " [final address 0x" << final_address << "]";
+        warn_oob |= (final_offset + descriptor_size > heap_range.size());
+
+        if (!heap_reserved.empty()) {
+            vvl::range<VkDeviceAddress> index_zero_range{final_address, final_address + descriptor_size};
+            if (index_zero_range.intersects(heap_reserved)) {
+                warn_reserved_range_start = 0;
+            }
+        }
+
     } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT) {
         ss << "pushDataOffset: 0x" << std::hex << mapping.sourceData.pushDataOffset;
     } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT) {
@@ -667,8 +845,19 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         ss << new_line << "Descriptor size: 0x" << descriptor_size << " (" << string_VkDescriptorType(descriptor_type) << ")";
     }
 
+    bool report_warning = false;
     if (warn_oob) {
         ss << new_line << "[WARNING] OUT OF BOUNDS - any access to this descriptor will be invalid";
+        report_warning = true;
+    } else if (warn_reserved_range_start != vvl::kNoIndex32) {
+        if (warn_reserved_range_start == warn_reserved_range_end) {
+            ss << new_line << "[WARNING] OUT OF BOUNDS - descriptor index at [" << std::dec << warn_reserved_range_start << std::hex << "] will overlap with the reserved range and the access will be invalid";
+        } else if (warn_reserved_range_end != vvl::kNoIndex32) {
+            ss << new_line << "[WARNING] OUT OF BOUNDS - descriptor index starting at [" << std::dec << warn_reserved_range_start << "] to [" << warn_reserved_range_end << std::hex << "] will overlap with the reserved range and the access will be invalid";
+        } else {
+            ss << new_line << "[WARNING] OUT OF BOUNDS - this descriptor overlaps with the reserved range is any access will be invalid";
+        }
+        report_warning = true;
     } else if (!warn_index_array.empty()) {
         ss << new_line << "[WARNING] OUT OF BOUNDS - descriptors indexes at [" << std::dec;
         for (uint32_t i = 0; i < warn_index_array.size(); i++) {
@@ -676,24 +865,35 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
             ss << warn_index_array[i];
         }
         ss << std::hex << "] will be invalid if accessed";
+        report_warning = true;
+    } else if (!warn_reserved_range_index_array.empty()) {
+        ss << new_line << "[WARNING] OUT OF BOUNDS - descriptors indexes at [" << std::dec;
+        for (uint32_t i = 0; i < warn_reserved_range_index_array.size(); i++) {
+            if (i != 0) ss << ", ";
+            ss << warn_reserved_range_index_array[i];
+        }
+        ss << std::hex << "] will overlap with the reserved range is any access will be invalid";
+        report_warning = true;
     } else if (warn_index_oob != 0) {
         ss << new_line << "[WARNING] OUT OF BOUNDS - descriptor has an array length of [" << std::dec << array_length
            << "] but any element accessed starting at [" << warn_index_oob + 1 << std::hex << "] will be invalid if accessed";
+        report_warning = true;
     }
 
     ss << '\n';
 
-    return warn_oob || (warn_index_oob != 0) || !warn_index_array.empty();
+    return report_warning;
 }
 
 // Return true if warning found
 bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const LastBound& last_bound) const {
+    bool found_warning = false;
     const vvl::CommandBuffer& cb_state = last_bound.cb_state;
     if (!cb_state.descriptor_heap.resource_range.empty()) {
         ss << "vkCmdBindResourceHeapEXT last bound the resource heap to "
            << string_range_hex(cb_state.descriptor_heap.resource_range);
         if (!cb_state.descriptor_heap.resource_reserved.empty()) {
-            ss << " (reserved range " << string_range_hex(cb_state.descriptor_heap.resource_reserved) << ")";
+            ss << " (reserved range " << std::dec << cb_state.descriptor_heap.resource_reserved.size() << " bytes at " << string_range_hex(cb_state.descriptor_heap.resource_reserved) << ")";
         } else {
             ss << " (no reserved range)";
         }
@@ -704,12 +904,14 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         }
         if (buffer_states.empty()) {
             ss << "  - No VkBuffer found at 0x" << std::hex << cb_state.descriptor_heap.resource_range.begin << "\n";
+            found_warning = true;
         }
     }
     if (!cb_state.descriptor_heap.sampler_range.empty()) {
         ss << "vkCmdBindSamplerHeapEXT last bound the sampler heap to " << string_range_hex(cb_state.descriptor_heap.sampler_range);
         if (!cb_state.descriptor_heap.sampler_reserved.empty()) {
-            ss << " (reserved range " << string_range_hex(cb_state.descriptor_heap.sampler_reserved) << ")";
+            ss << " (reserved range " << std::dec << cb_state.descriptor_heap.sampler_reserved.size() << " bytes at "
+               << string_range_hex(cb_state.descriptor_heap.sampler_reserved) << ")";
         } else {
             ss << " (no reserved range)";
         }
@@ -720,6 +922,7 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         }
         if (buffer_states.empty()) {
             ss << "  - No VkBuffer found at 0x" << std::hex << cb_state.descriptor_heap.sampler_range.begin << "\n";
+            found_warning = true;
         }
     }
 
@@ -737,7 +940,6 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         }
     }
 
-    bool found_warning = false;
     for (const ShaderStageState* stage : stages) {
         if (!stage->HasSpirv()) {
             ss << "[No SPIR-V found for " << string_VkShaderStageFlagBits(stage->GetStage())

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -197,8 +197,12 @@ TEST_F(NegativeGpuDump, DescriptorHeapDescriptorIndexing) {
     VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(heap_props);
 
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
-    const VkDeviceSize heap_size = Align((resource_stride * 4) + heap_props.minResourceHeapReservedRange, resource_stride);
+    const VkDeviceSize heap_size = Align((resource_stride * 4), resource_stride);
 
     vkt::Buffer descriptor_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
@@ -239,8 +243,8 @@ TEST_F(NegativeGpuDump, DescriptorHeapDescriptorIndexing) {
 
     VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
     bind_resource_info.heapRange = descriptor_heap.AddressRange();
-    bind_resource_info.reservedRangeOffset = descriptor_heap.CreateInfo().size - heap_props.minResourceHeapReservedRange;
-    bind_resource_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
+    bind_resource_info.reservedRangeOffset = 0;
+    bind_resource_info.reservedRangeSize = 0;
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
 
     VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
@@ -364,6 +368,366 @@ TEST_F(NegativeGpuDump, DescriptorHeapDescriptorIndexing) {
     pipe8.CreateComputePipeline(false);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe8);
     m_errorMonitor->SetDesiredInfo("GPU-DUMP");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, DescriptorHeapReservedRangeNonArray) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    RETURN_IF_SKIP(InitFramework(&kAllDumpSettingCi));
+    RETURN_IF_SKIP(InitState());
+
+    VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(heap_props);
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    const VkDeviceSize heap_size = Align((resource_stride * 4), resource_stride);
+    vkt::Buffer descriptor_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    const char* cs_source = R"glsl(
+        #version 450
+        layout (set = 0, binding = 0) buffer SSBO_0 {
+            uint data;
+        };
+
+        void main() {
+            data = 0;
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    m_command_buffer.Begin();
+
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = descriptor_heap.AddressRange();
+    bind_resource_info.reservedRangeOffset = 0;
+    bind_resource_info.reservedRangeSize = 256;
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    mapping.sourceData.constantOffset.heapArrayStride = (uint32_t)resource_stride;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.CreateComputePipeline(false);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredWarning("GPU-DUMP");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, DescriptorHeapReservedRangeArray) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    RETURN_IF_SKIP(InitFramework(&kAllDumpSettingCi));
+    RETURN_IF_SKIP(InitState());
+
+    VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(heap_props);
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    const VkDeviceSize heap_size = Align((resource_stride * 4), resource_stride);
+    vkt::Buffer descriptor_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    const char* cs_source = R"glsl(
+        #version 450
+        layout (set = 0, binding = 0) buffer SSBO_0 {
+            uint data;
+        } x[4];
+
+        void main() {
+            x[0].data = 0;
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    m_command_buffer.Begin();
+
+    VkDeviceSize max_descriptor_alignement = std::max(heap_props.bufferDescriptorAlignment, heap_props.imageDescriptorAlignment);
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = descriptor_heap.AddressRange();
+    bind_resource_info.reservedRangeOffset = (uint32_t)max_descriptor_alignement;
+    bind_resource_info.reservedRangeSize = (uint32_t)resource_stride * 2;
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    mapping.sourceData.constantOffset.heapArrayStride = (uint32_t)resource_stride;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.CreateComputePipeline(false);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredWarning("GPU-DUMP");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, DescriptorHeapReservedRangeArrayIndexed) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    RETURN_IF_SKIP(InitFramework(&kAllDumpSettingCi));
+    RETURN_IF_SKIP(InitState());
+
+    VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(heap_props);
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    const VkDeviceSize heap_size = Align((resource_stride * 4), resource_stride);
+    vkt::Buffer descriptor_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    const char* cs_source = R"glsl(
+        #version 450
+        layout (set = 0, binding = 0) buffer SSBO_0 {
+            uint data;
+        } x[4];
+
+        void main() {
+            x[0].data = 0;
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    m_command_buffer.Begin();
+
+    vkt::Buffer ubo_buffer(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
+    uint32_t* ubo_data = (uint32_t*)ubo_buffer.Memory().Map();
+    memset((void*)ubo_data, 0, 64);
+    ubo_data[0] = 0;
+    ubo_data[1] = (uint32_t)resource_stride;
+    ubo_data[2] = (uint32_t)resource_stride * 2;
+    ubo_data[3] = (uint32_t)resource_stride * 3;
+
+    VkDeviceSize max_descriptor_alignement = std::max(heap_props.bufferDescriptorAlignment, heap_props.imageDescriptorAlignment);
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = descriptor_heap.AddressRange();
+    bind_resource_info.reservedRangeOffset = (uint32_t)max_descriptor_alignement;
+    bind_resource_info.reservedRangeSize = (uint32_t)resource_stride * 2;
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    VkDeviceAddress indirect_ubo_address = ubo_buffer.Address();
+    VkPushDataInfoEXT push_data_info = vku::InitStructHelper();
+    push_data_info.data.size = 8;
+    push_data_info.data.address = &indirect_ubo_address;
+    vk::CmdPushDataEXT(m_command_buffer, &push_data_info);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT;
+    mapping.sourceData.indirectIndex.heapIndexStride = 1;
+    mapping.sourceData.indirectIndex.heapArrayStride = (uint32_t)resource_stride;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.CreateComputePipeline(false);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredWarning("GPU-DUMP");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, DescriptorHeapReservedRangeIndirectArray) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    RETURN_IF_SKIP(InitFramework(&kAllDumpSettingCi));
+    RETURN_IF_SKIP(InitState());
+
+    VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(heap_props);
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    const VkDeviceSize heap_size = Align((resource_stride * 4), resource_stride);
+    vkt::Buffer descriptor_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    const char* cs_source = R"glsl(
+        #version 450
+        layout (set = 0, binding = 0) buffer SSBO_0 {
+            uint data;
+        } x[4];
+
+        void main() {
+            x[0].data = 0;
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    m_command_buffer.Begin();
+
+    vkt::Buffer ubo_buffer(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
+    uint32_t* ubo_data = (uint32_t*)ubo_buffer.Memory().Map();
+    memset((void*)ubo_data, 0, 64);
+    ubo_data[0] = (uint32_t)resource_stride * 2;
+    ubo_data[1] = (uint32_t)resource_stride * 3;
+    ubo_data[2] = 0;
+    ubo_data[3] = (uint32_t)resource_stride;
+
+    VkDeviceAddress indirect_ubo_address = ubo_buffer.Address();
+    VkPushDataInfoEXT push_data_info = vku::InitStructHelper();
+    push_data_info.data.size = 8;
+    push_data_info.data.address = &indirect_ubo_address;
+    vk::CmdPushDataEXT(m_command_buffer, &push_data_info);
+
+    VkDeviceSize max_descriptor_alignement = std::max(heap_props.bufferDescriptorAlignment, heap_props.imageDescriptorAlignment);
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = descriptor_heap.AddressRange();
+    bind_resource_info.reservedRangeOffset = (uint32_t)max_descriptor_alignement;
+    bind_resource_info.reservedRangeSize = (uint32_t)resource_stride * 2;
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT;
+    mapping.sourceData.indirectIndexArray.heapIndexStride = 1;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    // CONSTANT_DATA Static array, can detect OOB
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.CreateComputePipeline(false);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredWarning("GPU-DUMP");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, DescriptorHeapSampler) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    RETURN_IF_SKIP(InitFramework(&kAllDumpSettingCi));
+    RETURN_IF_SKIP(InitState());
+
+    VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(heap_props);
+
+    if (heap_props.minResourceHeapReservedRange != 0 || heap_props.minSamplerHeapReservedRange != 0) {
+        GTEST_SKIP() << "heapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.samplerDescriptorSize;
+    const VkDeviceSize heap_size = Align((resource_stride * 2), resource_stride);
+    vkt::Buffer descriptor_heap_r(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+    vkt::Buffer descriptor_heap_s(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    const char* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform texture2D t;
+        layout(set = 0, binding = 1) uniform sampler s[64];
+        void main() {
+	        vec4 data = texture(sampler2D(t, s[2]), vec2(0.5f));
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    m_command_buffer.Begin();
+
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = descriptor_heap_r.AddressRange();
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    bind_resource_info.heapRange = descriptor_heap_s.AddressRange();
+    vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_resource_info);
+
+    VkDescriptorSetAndBindingMappingEXT mappings[2];
+    mappings[0] = MakeSetAndBindingMapping(0, 0);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[0].sourceData.constantOffset.heapArrayStride = 0;
+    mappings[1] = MakeSetAndBindingMapping(0, 1);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset.heapOffset = 0;
+    mappings[1].sourceData.constantOffset.heapArrayStride = (uint32_t)resource_stride;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 2u;
+    mapping_info.pMappings = mappings;
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.CreateComputePipeline(false);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredWarning("GPU-DUMP");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
cc @ziga-lunarg 

now will give things like

```
Validation Warning: [ GPU-DUMP ] | MessageID = 0xe5c5edc1
vkCmdDispatch(): [Dump Descriptor] (VkCommandBuffer 0x581b1a9664d0, VkPipeline 0xa000000000a)
vkCmdBindResourceHeapEXT last bound the resource heap to [0x300000000, 0x300000100) (reserved range 256 bytes at [0x300000000, 0x300000100))
  - VkBuffer 0x30000000003, size: 256 bytes, range: [0x300000000, 0x300000100)
[VK_SHADER_STAGE_COMPUTE_BIT]
  - Set 0:
    - Binding 0, VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT (from pMappings[0])
      - pushOffset: 0x0, addressOffset: 0x0, heapOffset: 0x0, heapIndexStride: 0x1
        indirectAddress: 0x440000000 (0x440000000 + 0x0)
        Resource Heap address: 0x300000000 + (indirectIndex * 0x1)
        indirectIndex values from buffer: [0x80, 0xc0, 0x0, 0x40]
        Descriptor size: 0x40 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
        [WARNING] OUT OF BOUNDS - descriptors indexes at [0, 1, 2, 3] will overlap with the reserved range is any access will be invalid

Validation Warning: [ GPU-DUMP ] | MessageID = 0xe5c5edc1
vkCmdDispatch(): [Dump Descriptor] (VkCommandBuffer 0x63de1446d4d0, VkPipeline 0xa000000000a)
vkCmdBindResourceHeapEXT last bound the resource heap to [0x300000000, 0x300000100) (reserved range 128 bytes at [0x300000040, 0x3000000c0))
  - VkBuffer 0x30000000003, size: 256 bytes, range: [0x300000000, 0x300000100)
[VK_SHADER_STAGE_COMPUTE_BIT]
  - Set 0:
    - Binding 0, VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT (from pMappings[0])
      - pushOffset: 0x0, addressOffset: 0x0, heapOffset: 0x0, heapIndexStride: 0x1
        indirectAddress: 0x440000000 (0x440000000 + 0x0)
        Resource Heap address: 0x300000000 + (indirectIndex * 0x1)
        indirectIndex values from buffer: [0x80, 0xc0, 0x0, 0x40]
        Descriptor size: 0x40 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
        [WARNING] OUT OF BOUNDS - descriptors indexes at [0, 3] will overlap with the reserved range is any access will be invalid
```