### PR TITLE
sync: Fix external semaphore validation

### DIFF
--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -73,13 +73,6 @@ bool SignalsUpdate::OnTimelineSignal(const vvl::Semaphore& semaphore_state, cons
         return false;  // [core validation check]: strictly increasing signal values
     }
 
-    // Do not register signal for external semaphore - external wait-before-signals are skipped
-    // since there is no guarantee we can track the signal. Because of that it's possible that
-    // signals have no way to be released (resolving waits can be wait-before-signals and are skipped)
-    if (semaphore_state.Scope() != vvl::Semaphore::Scope::kInternal) {
-        return false;
-    }
-
     // Register signal
     const VkQueueFlags queue_flags = batch->GetQueueFlags();
     const auto exec_scope = SyncExecScope::MakeSrc(queue_flags, submit_signal.stageMask, VK_PIPELINE_STAGE_2_HOST_BIT);
@@ -710,9 +703,6 @@ std::vector<BatchContextPtr> QueueBatchContext::ResolveSubmitWaits(vvl::span<con
                 } else {
                     // Do not register wait-before-signal for external semaphore.
                     // We might not be able to track the signal. Just assume that wait is satified.
-                    // TODO: current support for external semaphores ensures resources are not
-                    // leaked. It is still possible to get false-positives. Improve how to silence
-                    // validation when signal cannot be tracked properly.
                     continue;
                 }
             }

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -654,6 +654,70 @@ TEST_F(PositiveSyncValTimelineSemaphore, ExternalSemaphoreWaitBeforeSignal) {
         m_device->Wait();
     }
 }
+
+TEST_F(PositiveSyncValTimelineSemaphore, ExternalSemaphoreWaitAfterSignal) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12218");
+    AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitTimelineSemaphore());
+
+    constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
+        GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
+    }
+
+    VkSemaphoreTypeCreateInfo semaphore_type_ci = vku::InitStructHelper();
+    semaphore_type_ci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+
+    VkExportSemaphoreCreateInfo export_semaphore_ci = vku::InitStructHelper(&semaphore_type_ci);
+    export_semaphore_ci.handleTypes = handle_type;
+
+    const VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper(&export_semaphore_ci);
+    vkt::Semaphore semaphore(*m_device, semaphore_ci);
+
+    HANDLE win32_handle = NULL;
+    semaphore.ExportHandle(win32_handle, handle_type);
+
+    vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    vk::CmdFillBuffer(m_command_buffer, buffer, 0, 4, 0x42);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer, vkt::TimelineSignal(semaphore, 1));
+    m_default_queue->Submit(m_command_buffer, vkt::TimelineWait(semaphore, 1));
+    m_default_queue->Wait();
+}
+
+// TODO: create PositiveSyncValSemaphore for binary semaphores
+TEST_F(PositiveSyncValTimelineSemaphore, ExternalBinarySemaphoreWaitAfterSignal) {
+    AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitTimelineSemaphore());
+
+    constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_BINARY, handle_type)) {
+        GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
+    }
+
+    VkExportSemaphoreCreateInfo export_semaphore_ci = vku::InitStructHelper();
+    export_semaphore_ci.handleTypes = handle_type;
+
+    const VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper(&export_semaphore_ci);
+    vkt::Semaphore semaphore(*m_device, semaphore_ci);
+
+    HANDLE win32_handle = NULL;
+    semaphore.ExportHandle(win32_handle, handle_type);
+
+    vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    vk::CmdFillBuffer(m_command_buffer, buffer, 0, 4, 0x42);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer, vkt::Signal(semaphore));
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(semaphore));
+    m_default_queue->Wait();
+}
+
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 TEST_F(PositiveSyncValTimelineSemaphore, QueueWaitIdleRemovesSignals) {


### PR DESCRIPTION
In the initial timeline semaphore implementation syncval did not register external semaphore signals due to resource leaking problem.

Missing semaphore signals can lead to false positives because waiting on the semaphore has no effect and does not protect accesses (as reported in this issue).

The resource leak was later fixed in a general way: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8606 https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8613

After those fixes, syncval no longer needs to skip registration of external semaphore signals

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12218
