### PR TITLE
layers: Ignore host stage during record time validation

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1481,7 +1481,11 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
             set_event_src_stages |= signaling_state->src_stage_mask;
         }
         if (found_all_set_commands) {
-            if (srcStageMask != set_event_src_stages) {
+            // Do not try to validate HOST stage during record time.
+            // vkSetEvent can be tracked only during submit time (it can be called after command buffer recording)
+            VkPipelineStageFlags src_stage_mask_without_host = srcStageMask & ~VK_PIPELINE_STAGE_HOST_BIT;
+
+            if (src_stage_mask_without_host != set_event_src_stages) {
                 skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, error_obj.location.dot(Field::srcStageMask),
                                  "is %s, but the bitwise OR of stageMask values from the most recent vkCmdSetEvent call for each "
                                  "waited event is %s.",

--- a/tests/unit/event_positive.cpp
+++ b/tests/unit/event_positive.cpp
@@ -49,6 +49,17 @@ TEST_F(PositiveEvent, EventStageMaskTwoSubmits) {
     m_default_queue->Wait();
 }
 
+TEST_F(PositiveEvent, EventStageMaskHost) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT,
+                               VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    m_command_buffer.End();
+}
+
 TEST_F(PositiveEvent, BasicSetAndWaitEvent) {
     TEST_DESCRIPTION("Sets event and then wait for it using CmdSetEvent/CmdWaitEvents");
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
Follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12220. It is now safe for SDK.