### PR TITLE
layers: Fix VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR

### DIFF
--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -698,7 +698,7 @@ bool CoreChecks::ValidateDrawShaderObjectFlags(const LastBound& last_bound_state
             continue;
         }
 
-        if (shader->safe_create_info.flags & VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR) {
+        if (shader->is_independent_set) {
             shader_with_independent_sets = shader;
         } else {
             shader_without_independent_sets = shader;
@@ -749,7 +749,7 @@ bool CoreChecks::ValidateDrawShaderObjectFlags(const LastBound& last_bound_state
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::INDEPENDENT_SETS_13362), objlist, loc,
                              "Shader object bound at stage %s has flag VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR but the "
                              "VkPipelineLayout (bound with %s) "
-                             "was created without the INDEPENDENT_SETS flag\nCreate flags: %s.",
+                             "was created without the VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT flag\nCreate flags: %s.",
                              string_VkShaderStageFlagBits(shader_with_independent_sets->safe_create_info.stage),
                              vvl::String(last_bound_state.GetDescriptorModeFunc()),
                              string_VkPipelineLayoutCreateFlags(last_bound_state.desc_set_pipeline_layout->create_flags).c_str());
@@ -960,7 +960,10 @@ bool CoreChecks::ValidateDrawShaderObjectPushConstantAndLayout(const LastBound& 
             }
         }
 
-        if (first->create_info.setLayoutCount != shader_state->create_info.setLayoutCount) {
+        // 13361 ensure both shader objects have INDEPENDENT_SETS
+        const bool has_independent_sets = first->is_independent_set;
+
+        if (first->create_info.setLayoutCount != shader_state->create_info.setLayoutCount && !has_independent_sets) {
             const LogObjectList objlist(cb_state.Handle(), first->Handle(), shader_state->Handle());
             skip |=
                 LogError(CreateActionVuid(loc.function, vvl::ActionVUID::SHADERS_DESCRIPTOR_LAYOUTS_08879), objlist, loc,
@@ -973,15 +976,21 @@ bool CoreChecks::ValidateDrawShaderObjectPushConstantAndLayout(const LastBound& 
                 const auto first_layout = Get<vvl::DescriptorSetLayout>(first->create_info.pSetLayouts[i]);
                 const auto current_layout = Get<vvl::DescriptorSetLayout>(shader_state->create_info.pSetLayouts[i]);
                 if (!first_layout || !current_layout) {
-                    continue;  // Error will be caught in VUID-VkShaderCreateInfoEXT-pSetLayouts-parameter
+                    // Can be NULL if using VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR
+                    // Otherwise will be caught in 13359/13360
+                    continue;
                 }
                 if (std::string err_msg; !VerifyDescriptorSetLayoutIsCompatibile(*first_layout, *current_layout, err_msg)) {
                     const LogObjectList objlist(cb_state.Handle(), first_layout->Handle(), current_layout->Handle());
+                    const char* hint =
+                        "\nHint: If using VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR make sure to use VK_NULL_HANDLE for the "
+                        "VkShaderCreateInfoEXT::pSetLayouts not being used by the stage.";
                     skip |= LogError(
                         CreateActionVuid(loc.function, vvl::ActionVUID::SHADERS_DESCRIPTOR_LAYOUTS_08879), objlist, loc,
-                        "The bound %s and %s shader are incompatible due to differently defined VkDescriptorSetLayouts.\n%s",
+                        "The bound %s and %s shader are incompatible due to differently defined VkDescriptorSetLayouts.\n%s%s",
                         string_VkShaderStageFlagBits(first->create_info.stage),
-                        string_VkShaderStageFlagBits(shader_state->create_info.stage), err_msg.c_str());
+                        string_VkShaderStageFlagBits(shader_state->create_info.stage), err_msg.c_str(),
+                        has_independent_sets ? hint : "");
                     break;
                 }
             }

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -954,6 +954,7 @@ bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::PipelineLayout& pi
     if ((set >= ds_slots.size()) || (set >= pipeline_layout.set_compat_ids.size())) {
         return false;
     }
+    // (because I always forget) Checked in PipelineLayoutCompatDef::operator==
     return (*(ds_slots[set].compat_id_for_set) == *(pipeline_layout.set_compat_ids[set]));
 }
 
@@ -961,6 +962,7 @@ bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::ShaderObject& shad
     if ((set >= ds_slots.size()) || (set >= shader_object_state.set_compat_ids.size())) {
         return false;
     }
+    // (because I always forget) Checked in PipelineLayoutCompatDef::operator==
     return (*(ds_slots[set].compat_id_for_set) == *(shader_object_state.set_compat_ids[set]));
 };
 
@@ -982,9 +984,8 @@ std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::Pipelin
 std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderObject& shader_object_state) const {
     std::ostringstream ss;
     if (set >= ds_slots.size()) {
-        ss << "The set (" << set << ") is out of bounds for the number of sets bound (" << ds_slots.size()
-           << ")\nHint: Make sure the previous calls to " << String(desc_set_bound_command)
-           << " has all sets bound that are needed.";
+        ss << "The bound shader VkShaderCreateInfoEXT::pSetLayouts[" << set << "] is out of bounds for the number of sets bound ("
+           << ds_slots.size() << ") in the previous call to " << String(desc_set_bound_command);
     } else if (set >= shader_object_state.set_compat_ids.size()) {
         ss << "The set (" << set << ") is out of bounds for the number of sets in the non-compatible VkDescriptorSetLayout ("
            << shader_object_state.set_compat_ids.size() << ")\n";

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -71,15 +71,25 @@ bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef& other) c
     assert(set < other_ds_layouts.size());
     for (uint32_t i = 0; i <= set; i++) {
         if (descriptor_set_layouts[i] != other_ds_layouts[i]) {
+            if (other.is_independent_sets && other.from_shader_object) {
+                // This is hit because the vvl::ShaderObject can have NULL, independent layouts.
+                // This never happens with pipelines because we get |merged_graphics_layout| that occurs during the final linking of
+                // the pipeline which is creating a unified version for us.
+                continue;
+            }
             return false;
         }
     }
     return true;
 }
 
+// When comparing from draw time the |other| value is
+//  - when using pipelines, the `vkCmdBindPipeline` layout
+//  - when using shaderObject, the "fake" wrapper around VkShaderCreateInfoEXT::pSetLayouts
 std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutCompatDef& other) const {
     std::ostringstream ss;
     if (set != other.set) {
+        assert(!other.from_shader_object);
         ss << "The set " << set << " is different from the non-compatible VkPipelineLayout (" << other.set << ")\n";
     } else if (push_constant_ranges != other.push_constant_ranges) {
         ss << "The VkPipelineLayout bound with last call to vkCmdBindDescriptorSets has following push constant ranges:\n";
@@ -90,7 +100,11 @@ std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutComp
                 ss << "VkPushConstantRange[" << pcr_i << "]: " << string_VkPushConstantRange(pcr) << '\n';
             }
         }
-        ss << "But the VkPipelineLayout layout of last vkCmdBindPipeline/vkCmdBindShader has following push constant ranges:\n";
+        if (other.from_shader_object) {
+            ss << "But the VkShaderCreateInfoEXT::pPushConstantRanges was created with the following push constant ranges:\n";
+        } else {
+            ss << "But the VkPipelineLayout layout of last vkCmdBindPipeline has following push constant ranges:\n";
+        }
         if (other.push_constant_ranges->empty()) {
             ss << "Empty\n";
         } else {
@@ -99,14 +113,22 @@ std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutComp
             }
         }
     } else if (is_independent_sets != other.is_independent_sets) {
-        ss << "The VkPipelineLayout used to bind set " << set;
-        if (is_independent_sets) {
-            ss << " was created with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT when the VkPipelineLayout of last bound "
-                  "pipeline was not.";
+        ss << "The VkPipelineLayout used to bind set " << set << " was created " << ((is_independent_sets) ? "with" : "without")
+           << " VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT when the ";
+
+        if (other.from_shader_object) {
+            ss << "VkShaderCreateInfoEXT::flags was";
+            if (is_independent_sets) {
+                ss << " not ";
+            }
+            ss << "created with VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR";
         } else {
-            ss << " was created without VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT when the VkPipelineLayout of last bound "
-                  "pipeline was.";
+            ss << "VkPipelineLayout of last bound pipeline was";
+            if (is_independent_sets) {
+                ss << " not";
+            }
         }
+
     } else {
         const auto& descriptor_set_layouts = *set_layouts_id.get();
         const auto& other_ds_layouts = *other.set_layouts_id.get();
@@ -124,8 +146,10 @@ std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutComp
 }
 
 static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId& pcr_id,
-                                             const PipelineLayoutSetLayoutsId& set_layouts_id, bool is_independent_sets) {
-    return pipeline_layout_compat_dict.LookUp(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id, is_independent_sets));
+                                             const PipelineLayoutSetLayoutsId& set_layouts_id, bool is_independent_sets,
+                                             bool from_shader_object) {
+    return pipeline_layout_compat_dict.LookUp(
+        PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id, is_independent_sets, from_shader_object));
 }
 
 // For repeatable sorting, not very useful for "memory in range" search
@@ -178,8 +202,8 @@ static PushConstantRangesId GetPushConstantRangesFromLayouts(const vvl::span<con
 }
 
 std::vector<PipelineLayoutCompatId> GetCompatForSet(const vvl::DescriptorSetLayoutList& set_layouts,
-                                                    const PushConstantRangesId& push_constant_ranges,
-                                                    VkPipelineLayoutCreateFlags pipeline_layout_create_flags) {
+                                                    const PushConstantRangesId& push_constant_ranges, bool is_independent_sets,
+                                                    bool from_shader_object) {
     PipelineLayoutSetLayoutsDef set_layout_ids(set_layouts.list.size());
     for (size_t i = 0; i < set_layouts.list.size(); i++) {
         if (set_layouts.list[i]) {
@@ -191,11 +215,9 @@ std::vector<PipelineLayoutCompatId> GetCompatForSet(const vvl::DescriptorSetLayo
     std::vector<PipelineLayoutCompatId> set_compat_ids;
     set_compat_ids.reserve(set_layouts.list.size());
 
-    // Only current flag to effect pipeline layout compatibility
-    bool is_independent_sets = (pipeline_layout_create_flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) != 0;
-
     for (uint32_t i = 0; i < set_layouts.list.size(); i++) {
-        set_compat_ids.emplace_back(GetCanonicalId(i, push_constant_ranges, set_layouts_id, is_independent_sets));
+        set_compat_ids.emplace_back(
+            GetCanonicalId(i, push_constant_ranges, set_layouts_id, is_independent_sets, from_shader_object));
     }
     return set_compat_ids;
 }
@@ -276,17 +298,19 @@ PipelineLayout::PipelineLayout(DeviceState& dev_data, VkPipelineLayout handle, c
       set_layouts(GetSetLayouts(dev_data, pCreateInfo)),
       push_constant_ranges_layout(GetCanonicalId(pCreateInfo->pushConstantRangeCount, pCreateInfo->pPushConstantRanges)),
       create_flags(pCreateInfo->flags),
-      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges_layout, create_flags)),
+      is_independent_set((create_flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) != 0),
       has_descriptor_buffer(HasDescriptorBuffer(set_layouts)),
-      has_immutable_samplers(HasImmutableSamplers(set_layouts)) {}
+      has_immutable_samplers(HasImmutableSamplers(set_layouts)),
+      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges_layout, is_independent_set, false)) {}
 
 PipelineLayout::PipelineLayout(const vvl::span<const PipelineLayout* const>& layouts)
     : StateObject(static_cast<VkPipelineLayout>(VK_NULL_HANDLE), kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(layouts)),
       push_constant_ranges_layout(GetPushConstantRangesFromLayouts(layouts)),  // TODO is this correct?
       create_flags(GetCreateFlags(layouts)),
-      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges_layout, create_flags)),
+      is_independent_set((create_flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) != 0),
       has_descriptor_buffer(HasDescriptorBuffer(set_layouts)),
-      has_immutable_samplers(HasImmutableSamplers(set_layouts)) {}
+      has_immutable_samplers(HasImmutableSamplers(set_layouts)),
+      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges_layout, is_independent_set, false)) {}
 
 }  // namespace vvl

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -54,10 +54,20 @@ struct PipelineLayoutCompatDef {
     uint32_t set;
     PushConstantRangesId push_constant_ranges;
     PipelineLayoutSetLayoutsId set_layouts_id;
-    bool is_independent_sets;  // VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT
+    // VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT or VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR
+    bool is_independent_sets;
+    // When report mismatch errors, it is confusing for ShaderObject because there is no 'vkCmdBindPipeline' and the PipelineLayout
+    // we are comparing is just a "fake" wrapper our the VkShaderCreateInfoEXT::pSetLayouts to make the pipeline and shaderObject
+    // logic the same
+    bool from_shader_object;
+
     PipelineLayoutCompatDef(const uint32_t set_index, const PushConstantRangesId pcr_id, const PipelineLayoutSetLayoutsId sl_id,
-                            bool is_independent_sets)
-        : set(set_index), push_constant_ranges(pcr_id), set_layouts_id(sl_id), is_independent_sets(is_independent_sets) {}
+                            bool is_independent_sets, bool from_shader_object)
+        : set(set_index),
+          push_constant_ranges(pcr_id),
+          set_layouts_id(sl_id),
+          is_independent_sets(is_independent_sets),
+          from_shader_object(from_shader_object) {}
     size_t hash() const;
 
     bool operator==(const PipelineLayoutCompatDef &other) const;
@@ -79,12 +89,16 @@ class PipelineLayout : public StateObject {
     // canonical form IDs for the "compatible for set" contents
     const PushConstantRangesId push_constant_ranges_layout;
     VkPipelineLayoutCreateFlags create_flags;
-    // table of "compatible for set N" canonical forms for trivial accept validation
-    const std::vector<PipelineLayoutCompatId> set_compat_ids;
+
+    // To match the shader object variation
+    bool is_independent_set;
     // When the sets are using VK_EXT_descriptor_buffer
     bool has_descriptor_buffer;
     // Way to quick prevent searching if we know there are no immutable samplers
     bool has_immutable_samplers;
+
+    // table of "compatible for set N" canonical forms for trivial accept validation
+    const std::vector<PipelineLayoutCompatId> set_compat_ids;
 
     PipelineLayout(DeviceState &dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
@@ -100,6 +114,6 @@ class PipelineLayout : public StateObject {
 
 }  // namespace vvl
 
-std::vector<PipelineLayoutCompatId> GetCompatForSet(const vvl::DescriptorSetLayoutList &set_layouts,
-                                                    const PushConstantRangesId &push_constant_ranges,
-                                                    VkPipelineLayoutCreateFlags pipeline_layout_create_flags);
+std::vector<PipelineLayoutCompatId> GetCompatForSet(const vvl::DescriptorSetLayoutList& set_layouts,
+                                                    const PushConstantRangesId& push_constant_ranges, bool is_independent_sets,
+                                                    bool from_shader_object);

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -19,7 +19,6 @@
 #include <vulkan/vulkan_core.h>
 #include "shader_module.h"
 #include "state_tracker/state_tracker.h"
-#include "utils/shader_utils.h"
 
 namespace vvl {
 static DescriptorSetLayoutList GetSetLayouts(DeviceState& dev_data, const VkShaderCreateInfoEXT& pCreateInfo) {
@@ -35,11 +34,12 @@ ShaderObject::ShaderObject(DeviceState& dev_data, const VkShaderCreateInfoEXT& c
     : StateObject(handle, kVulkanObjectTypeShaderEXT),
       safe_create_info(&create_info_i),
       create_info(*safe_create_info.ptr()),
-      set_layouts(GetSetLayouts(dev_data, create_info)),
-      push_constant_ranges(GetCanonicalId(create_info.pushConstantRangeCount, create_info.pPushConstantRanges)),
-      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges, 0)),
+      is_independent_set((create_info_i.flags & VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR) != 0),
       descriptor_heap_mode((create_info_i.flags & VK_SHADER_CREATE_DESCRIPTOR_HEAP_BIT_EXT) != 0),
       descriptor_heap_embedded_samplers_count(descriptor_heap_mode ? CountDescriptorHeapEmbeddedSamplers(create_info_i.pNext) : 0),
+      set_layouts(GetSetLayouts(dev_data, create_info)),
+      push_constant_ranges(GetCanonicalId(create_info.pushConstantRangeCount, create_info.pPushConstantRanges)),
+      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges, is_independent_set, true)),
       stage(nullptr, &safe_create_info, &set_layouts, nullptr, spirv_module, VK_NULL_HANDLE, descriptor_heap_mode),
       active_slots(GetActiveSlots(stage.entrypoint)),
       max_active_slot(GetMaxActiveSlot(active_slots)) {

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -37,12 +37,13 @@ struct ShaderObject : public StateObject, public SubStateManager<ShaderObjectSub
     const vku::safe_VkShaderCreateInfoEXT safe_create_info;
     const VkShaderCreateInfoEXT &create_info;
 
+    const bool is_independent_set;  // to match Pipeline version
+    const bool descriptor_heap_mode;
+    const uint32_t descriptor_heap_embedded_samplers_count;
+
     const DescriptorSetLayoutList set_layouts;
     const PushConstantRangesId push_constant_ranges;
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
-
-    const bool descriptor_heap_mode;
-    const uint32_t descriptor_heap_embedded_samplers_count;
 
     // We use this to make things more unified with Pipelines, which need a list of these for each stage
     // Basically the rule is:

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -15,6 +15,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
+#include "test_framework.h"
 
 void GraphicsLibraryTest::InitBasicGraphicsLibrary() {
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -216,9 +217,9 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
     const std::array<VkDescriptorSet, 3> desc_sets = {ds.set_, VK_NULL_HANDLE, VK_NULL_HANDLE};
 
     vkt::Buffer uniform_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
-    ds.WriteDescriptorBufferInfo(0, uniform_buffer, 0, 1024);
+    ds.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     ds.UpdateDescriptorSets();
-    ds2.WriteDescriptorBufferInfo(0, uniform_buffer, 0, 1024);
+    ds2.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     ds2.UpdateDescriptorSets();
 
     CreatePipelineHelper vertex_input_lib(*this);
@@ -276,6 +277,113 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_null, 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveGraphicsLibrary, MultipleIndependentSetsUsed) {
+    TEST_DESCRIPTION("Main issues with other variations is they are not statically using the sets in the shader");
+    RETURN_IF_SKIP(InitBasicGraphicsLibrary());
+    InitRenderTarget();
+
+    OneOffDescriptorSet ds_v(m_device, {
+                                           {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+                                       });
+    OneOffDescriptorSet ds_f(m_device, {
+                                           {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                       });
+    OneOffDescriptorSet ds_extra_v(m_device, {
+                                                 {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+                                             });
+    OneOffDescriptorSet ds_extra_f(m_device, {
+                                                 {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                             });
+
+    vkt::PipelineLayout pipeline_layout_vs(*m_device, {nullptr, &ds_v.layout_}, {},
+                                           VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+    vkt::PipelineLayout pipeline_layout_fs(*m_device, {&ds_f.layout_}, {}, VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+    vkt::PipelineLayout pipeline_layout_null(*m_device, {nullptr, nullptr}, {}, VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+    vkt::PipelineLayout pipeline_layout_link(*m_device, {&ds_extra_f.layout_, &ds_extra_v.layout_}, {},
+                                             VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+
+    vkt::Buffer uniform_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    ds_v.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
+    ds_v.UpdateDescriptorSets();
+    ds_f.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
+    ds_f.UpdateDescriptorSets();
+    ds_extra_v.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
+    ds_extra_v.UpdateDescriptorSets();
+    ds_extra_f.WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
+    ds_extra_f.UpdateDescriptorSets();
+
+    CreatePipelineHelper vertex_input_lib(*this);
+    vertex_input_lib.InitVertexInputLibInfo();
+    vertex_input_lib.CreateGraphicsPipeline(false);
+
+    CreatePipelineHelper pre_raster_lib(*this);
+    {
+        const char* vs_src = R"glsl(
+            #version 450
+            layout(set=1, binding=0) uniform foo { vec4 x; };
+            void main() {
+                gl_Position = x;
+            }
+        )glsl";
+        const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_src);
+        vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
+        pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
+        pre_raster_lib.gp_ci_.layout = pipeline_layout_vs;
+        pre_raster_lib.CreateGraphicsPipeline(false);
+    }
+
+    CreatePipelineHelper frag_shader_lib(*this);
+    {
+        const char* fs_src = R"glsl(
+            #version 450
+            layout(set = 0, binding = 0) uniform UBO {
+                vec4 data;
+            };
+            layout(location = 0) out vec4 uFragColor;
+            void main(){
+                uFragColor = data;
+            }
+        )glsl";
+        const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fs_src);
+        vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
+        frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
+        frag_shader_lib.gp_ci_.layout = pipeline_layout_fs;
+        frag_shader_lib.CreateGraphicsPipeline(false);
+    }
+
+    CreatePipelineHelper frag_out_lib(*this);
+    frag_out_lib.InitFragmentOutputLibInfo();
+    frag_out_lib.CreateGraphicsPipeline(false);
+
+    VkPipeline libraries[4] = {
+        vertex_input_lib,
+        pre_raster_lib,
+        frag_shader_lib,
+        frag_out_lib,
+    };
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
+    link_info.libraryCount = size32(libraries);
+    link_info.pLibraries = libraries;
+
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
+    exe_pipe_ci.layout = pipeline_layout_null;
+    vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
+    ASSERT_TRUE(exe_pipe.initialized());
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+
+    // Draw with pipeline created with null set
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe);
+    const VkDescriptorSet set_handles[2] = {ds_extra_f.set_, ds_v.set_};
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_link, 0, 2, set_handles, 0,
+                              nullptr);
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -8267,3 +8267,81 @@ TEST_F(NegativeShaderObject, NoIndependentSetFlagAndInvalidSetLayout) {
     const vkt::Shader vert_shader(*m_device, create_info);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeShaderObject, IndependentSetsNotNull) {
+    AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_11_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance11);
+    RETURN_IF_SKIP(InitBasicShaderObject());
+    InitDynamicRenderTarget();
+
+    const char* vert_src = R"glsl(
+        #version 460
+        layout(set = 0, binding = 0) uniform UBO {
+            vec4 data;
+        };
+        void main() {
+            gl_Position = data;
+        }
+    )glsl";
+
+    const char* frag_src = R"glsl(
+        #version 460
+        layout(set = 1, binding = 0) uniform UBO {
+            vec4 data;
+        };
+        layout(location = 0) out vec4 uFragColor;
+        void main(){
+           uFragColor = data;
+        }
+    )glsl";
+
+    OneOffDescriptorSet ds_v(m_device, {
+                                           {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+                                       });
+    OneOffDescriptorSet ds_f(m_device, {
+                                           {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                       });
+
+    // This is not used by the shader
+    OneOffDescriptorSet ds_f_bad(m_device, {
+                                               {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                           });
+
+    vkt::Buffer ubo(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    ds_v.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_v.UpdateDescriptorSets();
+    ds_f.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_f.UpdateDescriptorSets();
+
+    // Should be NULL, as won't match up later
+    VkDescriptorSetLayout dsl_handles_v[2] = {ds_v.layout_, ds_f_bad.layout_};
+    VkDescriptorSetLayout dsl_handles_f[2] = {VK_NULL_HANDLE, ds_f.layout_};
+
+    const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vert_src);
+    VkShaderCreateInfoEXT create_info = ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT, 2, dsl_handles_v);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader vert_shader(*m_device, create_info);
+
+    const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src);
+    create_info = ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT, 2, dsl_handles_f);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader frag_shader(*m_device, create_info);
+
+    vkt::PipelineLayout pipeline_layout(*m_device, {&ds_v.layout_, &ds_f.layout_}, {},
+                                        VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    SetDefaultDynamicStatesExclude();
+    const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
+    VkShaderEXT shaders[] = {vert_shader, frag_shader};
+    vk::CmdBindShadersEXT(m_command_buffer, 2u, stages, shaders);
+    const VkDescriptorSet set_handles[2] = {ds_v.set_, ds_f.set_};
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0u, 2u, set_handles, 0u, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08879");
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -14,6 +14,7 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/shader_helper.h"
 #include "../framework/shader_templates.h"
+#include "test_framework.h"
 #include "utils/math_utils.h"
 
 void ShaderObjectTest::InitBasicShaderObject(void* instance_pnext) {
@@ -1932,6 +1933,165 @@ TEST_F(PositiveShaderObject, IdenticallyDefinedLayouts) {
                               nullptr);
     vk::CmdDraw(m_command_buffer, 4, 1, 0, 0);
 
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveShaderObject, IndependentSets) {
+    AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_11_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance11);
+    RETURN_IF_SKIP(InitBasicShaderObject());
+    InitDynamicRenderTarget();
+
+    const char* vert_src = R"glsl(
+        #version 460
+        layout(set = 0, binding = 0) uniform UBO {
+            vec4 data;
+        };
+        void main() {
+            gl_Position = data;
+        }
+    )glsl";
+
+    const char* frag_src = R"glsl(
+        #version 460
+        layout(set = 1, binding = 0) uniform UBO {
+            vec4 data;
+        };
+        layout(location = 0) out vec4 uFragColor;
+        void main(){
+           uFragColor = data;
+        }
+    )glsl";
+
+    OneOffDescriptorSet ds_v(m_device, {
+                                           {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+                                       });
+    OneOffDescriptorSet ds_f(m_device, {
+                                           {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                       });
+
+    vkt::Buffer ubo(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    ds_v.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_v.UpdateDescriptorSets();
+    ds_f.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_f.UpdateDescriptorSets();
+
+    VkDescriptorSetLayout dsl_handles_v[2] = {ds_v.layout_, VK_NULL_HANDLE};
+    VkDescriptorSetLayout dsl_handles_f[2] = {VK_NULL_HANDLE, ds_f.layout_};
+
+    const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vert_src);
+    VkShaderCreateInfoEXT create_info = ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT, 2, dsl_handles_v);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader vert_shader(*m_device, create_info);
+
+    const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src);
+    create_info = ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT, 2, dsl_handles_f);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader frag_shader(*m_device, create_info);
+
+    vkt::PipelineLayout pipeline_layout(*m_device, {&ds_v.layout_, &ds_f.layout_}, {},
+                                        VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    SetDefaultDynamicStatesExclude();
+    const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
+    VkShaderEXT shaders[] = {vert_shader, frag_shader};
+    vk::CmdBindShadersEXT(m_command_buffer, 2u, stages, shaders);
+    const VkDescriptorSet set_handles[2] = {ds_v.set_, ds_f.set_};
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0u, 2u, set_handles, 0u, nullptr);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveShaderObject, IndependentSetsDifferentSetLayoutCount) {
+    TEST_DESCRIPTION("https://gitlab.khronos.org/vulkan/vulkan/-/issues/4812");
+    AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_11_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance11);
+    RETURN_IF_SKIP(InitBasicShaderObject());
+    InitDynamicRenderTarget();
+
+    const char* vert_src = R"glsl(
+        #version 460
+        layout(set = 0, binding = 0) uniform UBO_0 {
+            vec4 data;
+        };
+        layout(set = 2, binding = 0) uniform UBO {
+            vec4 foo;
+        };
+        void main() {
+            gl_Position = data + foo;
+        }
+    )glsl";
+
+    const char* frag_src = R"glsl(
+        #version 460
+        layout(set = 0, binding = 0) uniform UBO_0 {
+            vec4 data;
+        };
+        layout(set = 1, binding = 0) uniform UBO {
+            vec4 foo;
+        };
+        layout(location = 0) out vec4 uFragColor;
+        void main(){
+           uFragColor = data + foo;
+        }
+    )glsl";
+
+    OneOffDescriptorSet ds_v0(
+        m_device, {
+                      {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                  });
+    OneOffDescriptorSet ds_v2(m_device, {
+                                            {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+                                        });
+    OneOffDescriptorSet ds_f0(
+        m_device, {
+                      {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                  });
+    OneOffDescriptorSet ds_f1(m_device, {
+                                            {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                        });
+
+    vkt::Buffer ubo(*m_device, 64, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    ds_v0.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_v0.UpdateDescriptorSets();
+    ds_v2.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_v2.UpdateDescriptorSets();
+    ds_f0.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_f0.UpdateDescriptorSets();
+    ds_f1.WriteDescriptorBufferInfo(0, ubo, 0, VK_WHOLE_SIZE);
+    ds_f1.UpdateDescriptorSets();
+
+    VkDescriptorSetLayout dsl_handles_v[4] = {ds_v0.layout_, VK_NULL_HANDLE, ds_v2.layout_, VK_NULL_HANDLE};
+    VkDescriptorSetLayout dsl_handles_f[2] = {ds_f0.layout_, ds_f1.layout_};
+
+    const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vert_src);
+    VkShaderCreateInfoEXT create_info = ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT, 4, dsl_handles_v);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader vert_shader(*m_device, create_info);
+
+    const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src);
+    create_info = ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT, 2, dsl_handles_f);
+    create_info.flags = VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR;
+    const vkt::Shader frag_shader(*m_device, create_info);
+
+    vkt::PipelineLayout pipeline_layout(*m_device, {&ds_v0.layout_, &ds_f1.layout_, &ds_v2.layout_}, {},
+                                        VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    SetDefaultDynamicStatesExclude();
+    const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
+    VkShaderEXT shaders[] = {vert_shader, frag_shader};
+    vk::CmdBindShadersEXT(m_command_buffer, 2u, stages, shaders);
+    const VkDescriptorSet set_handles[3] = {ds_f0.set_, ds_f1.set_, ds_v2.set_};
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0u, 3u, set_handles, 0u, nullptr);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRendering();
     m_command_buffer.End();
 }


### PR DESCRIPTION
fixes false positives when using `VK_SHADER_CREATE_INDEPENDENT_SETS_BIT_KHR` due to GPL :hankey: now being part of shader objects

also fixed many misleading error messages around "shader objects having a VkPipelineLayout"