### PR TITLE
layers: Remove event submit callbacks. Part 1

### DIFF
--- a/layers/containers/container_utils.h
+++ b/layers/containers/container_utils.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,8 @@ namespace vvl {
 
 inline constexpr std::in_place_t in_place{};
 
-// Only use this if you aren't planning to use what you would have gotten from a find.
 template <typename Container, typename Key = typename Container::key_type>
-bool Contains(const Container &container, const Key &key) {
+bool Contains(const Container& container, const Key& key) {
     return container.find(key) != container.cend();
 }
 
@@ -45,6 +44,12 @@ bool Contains(const std::vector<T> &v, const T &value) {
 template <typename T>
 bool Contains(const std::vector<std::shared_ptr<const T>> &v, const std::shared_ptr<T> &value) {
     return std::find(v.cbegin(), v.cend(), value) != v.cend();
+}
+
+template <typename T, typename Pred>
+const T* FindIf(const std::vector<T>& v, Pred&& pred) {
+    auto it = std::find_if(v.begin(), v.end(), pred);
+    return (it != v.end()) ? &*it : nullptr;
 }
 
 //

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -75,10 +75,16 @@ struct CommandBufferSubmitState {
         }
 
         auto& cb_sub_state = core::SubState(cb_state);
+
+        for (const WaitEventSubmitInfo& submit_info : cb_sub_state.wait_event_submit_infos) {
+            skip |= submit_info.Validate(core, cb_state, local_event_signal_info, loc);
+        }
+
         for (auto& function : cb_sub_state.event_updates) {
             skip |= function(const_cast<vvl::CommandBuffer&>(cb_state), /*do_validate*/ true, local_event_signal_info,
                              queue_state.VkHandle(), loc);
         }
+
         VkQueryPool first_perf_query_pool = VK_NULL_HANDLE;
         for (auto& function : cb_sub_state.query_updates) {
             skip |= function(const_cast<vvl::CommandBuffer&>(cb_state), /*do_validate*/ true, first_perf_query_pool, perf_pass,

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -22,6 +22,7 @@
 #include <vulkan/vulkan_core.h>
 #include "core_validation.h"
 #include "cc_sync_vuid_maps.h"
+#include "containers/container_utils.h"
 #include "error_message/error_strings.h"
 #include "generated/error_location_helper.h"
 #include "state_tracker/buffer_state.h"
@@ -615,22 +616,51 @@ void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags
         });
 }
 
-void CommandBufferSubState::RecordWaitEvents(uint32_t eventCount, const VkEvent* pEvents, VkPipelineStageFlags2 src_stage_mask,
-                                             const VkDependencyInfo* dependency_info, const Location& loc) {
-    // vvl::CommandBuffer will add to the events vector. TODO this is now incorrect
-    auto first_event_index = base.events.size();
-    auto event_added_count = eventCount;
-
-    std::optional<vku::safe_VkDependencyInfo> safe_dependency_info;
-    if (dependency_info) {
-        safe_dependency_info.emplace(dependency_info);
+void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask,
+                                             const Location& loc) {
+    bool submit_validation = false;
+    std::vector<std::pair<VkEvent, EventSignalingState>> cb_signaling_state;
+    for (VkEvent event : events) {
+        if (const EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event)) {
+            cb_signaling_state.emplace_back(event, *signaling_state);
+        } else {
+            // Command buffer does not signal the waited event.
+            // The wait can be validated only during submit time
+            submit_validation = true;
+        }
     }
+    if (submit_validation) {
+        WaitEventSubmitInfo submit_info;
+        submit_info.wait_events.assign(events.begin(), events.end());
+        submit_info.wait_src_stage_mask = src_stage_mask;
+        submit_info.cb_signaling_state = std::move(cb_signaling_state);
+        wait_event_submit_infos.emplace_back(std::move(submit_info));
+    }
+
+    // TODO: this will be removed when submit validation callbacks are removed
+    auto first_event_index = base.events.size();
+    auto event_added_count = events.size();
+    std::optional<vku::safe_VkDependencyInfo> safe_dependency_info;
     event_updates.emplace_back(
-        [event_added_count, first_event_index, src_stage_mask, safe_dependency_info](
+        [event_added_count, first_event_index, safe_dependency_info](
             vvl::CommandBuffer& cb_state, bool do_validate, EventMap& local_event_signal_info, VkQueue queue, const Location& loc) {
             if (!do_validate) return false;
-            return CoreChecks::ValidateWaitEventsAtSubmit(cb_state, event_added_count, first_event_index, src_stage_mask,
-                                                          safe_dependency_info, local_event_signal_info, queue, loc);
+            return CoreChecks::ValidateWaitEventsAtSubmit(cb_state, event_added_count, first_event_index, safe_dependency_info,
+                                                          local_event_signal_info, queue, loc);
+        });
+}
+
+void CommandBufferSubState::RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
+    // TODO: this will be removed when submit validation callbacks are removed
+    auto first_event_index = base.events.size();
+    auto event_added_count = 1;
+    std::optional<vku::safe_VkDependencyInfo> safe_dependency_info(&dependency_info);
+    event_updates.emplace_back(
+        [event_added_count, first_event_index, safe_dependency_info](
+            vvl::CommandBuffer& cb_state, bool do_validate, EventMap& local_event_signal_info, VkQueue queue, const Location& loc) {
+            if (!do_validate) return false;
+            return CoreChecks::ValidateWaitEventsAtSubmit(cb_state, event_added_count, first_event_index, safe_dependency_info,
+                                                          local_event_signal_info, queue, loc);
         });
 }
 
@@ -1095,6 +1125,7 @@ void CommandBufferSubState::ResetCBState() {
     // Submit time validation
     queue_submit_functions.clear();
     event_updates.clear();
+    wait_event_submit_infos.clear();
     cmd_execute_commands_functions.clear();
     query_updates.clear();
 
@@ -1121,6 +1152,9 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
 
     for (auto& function : secondary_sub_state.event_updates) {
         event_updates.push_back(function);
+    }
+    for (auto& [event, event_signaling_state] : secondary_sub_state.event_signaling_states) {
+        event_signaling_states.insert_or_assign(event, event_signaling_state);
     }
 
     for (auto& function : secondary_sub_state.queue_submit_functions) {
@@ -1165,12 +1199,13 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
             function(base, /*do_validate*/ false, local_event_signal_info,
                      VK_NULL_HANDLE /* when do_validate is false then wait handler is inactive */, loc);
         }
-        for (const auto& [event, info] : local_event_signal_info) {
-            auto event_state = base.dev_data.Get<vvl::Event>(event);
-            event_state->signaled = info.signal;
-            event_state->dependency_info = info.dependency_info;
-            event_state->signal_src_stage_mask = info.src_stage_mask;
-            event_state->signaling_queue = queue_state.VkHandle();
+        for (const auto& [event, signaling_state] : event_signaling_states) {
+            if (auto event_state = base.dev_data.Get<vvl::Event>(event)) {
+                event_state->signaled = signaling_state.signaled;
+                event_state->signal_src_stage_mask = signaling_state.src_stage_mask;
+                event_state->dependency_info = signaling_state.dependency_info;
+                event_state->signaling_queue = queue_state.VkHandle();
+            }
         }
     }
 

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 #pragma once
+#include "core_checks/cc_synchronization.h"
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/queue_state.h"
@@ -98,8 +99,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     void RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stageMask, const VkDependencyInfo *dependency_info) final;
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask) final;
-    void RecordWaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags2 src_stage_mask,
-                          const VkDependencyInfo *dependency_info, const Location &loc) final;
+    void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) final;
+    void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) final;
     void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers, uint32_t image_barrier_count,
                         const VkImageMemoryBarrier *image_barriers, VkPipelineStageFlags src_stage_mask,
                         VkPipelineStageFlags dst_stage_mask, const Location &loc) final;
@@ -211,6 +212,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
                                              VkQueue waiting_queue, const Location& loc)>;
     std::vector<EventCallback> event_updates;
     vvl::unordered_map<VkEvent, EventSignalingState> event_signaling_states;
+    std::vector<WaitEventSubmitInfo> wait_event_submit_infos;
 
     // Validation functions run when secondary CB is executed in primary
     std::vector<

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -24,7 +24,6 @@
 
 #include <vulkan/vk_enum_string_helper.h>
 #include <vulkan/utility/vk_format_utils.h>
-#include <vulkan/vulkan_core.h>
 #include "core_checks/cc_sync_vuid_maps.h"
 #include "core_checks/cc_synchronization.h"
 #include "core_checks/cc_state_tracker.h"
@@ -389,6 +388,46 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location& signal_semaph
     } else {
         assert(semaphore_state.type == VK_SEMAPHORE_TYPE_TIMELINE);
         skip |= ValidateTimelineSignal(signal_semaphore_loc, semaphore_state, value);
+    }
+    return skip;
+}
+
+bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::CommandBuffer& cb_state, EventMap& submit_signaling_state,
+                                   const Location& loc) const {
+    bool skip = false;
+    VkPipelineStageFlags signals_src_stage_mask = 0;
+    for (VkEvent event : wait_events) {
+        auto has_event = [event](const auto& e) { return e.first == event; };
+        // NOTE: if signaling state is "unsignaled" then src stage mask is NONE
+        if (const auto* cb_signaling = vvl::FindIf(cb_signaling_state, has_event)) {
+            // a) signal from the same command buffer
+            signals_src_stage_mask |= cb_signaling->second.src_stage_mask;
+        } else if (const auto* submit_signaling = vvl::Find(submit_signaling_state, event)) {
+            // b) signals from the previous command buffers of the same submit command
+            signals_src_stage_mask |= submit_signaling->src_stage_mask;
+        } else if (auto event_state = core.Get<vvl::Event>(event)) {
+            // c) global event state
+            signals_src_stage_mask |= event_state->signal_src_stage_mask;
+        }
+    }
+    if (wait_src_stage_mask != signals_src_stage_mask) {
+        std::ostringstream ss;
+        ss << "(" << core.FormatHandle(cb_state.Handle()) << ") contains a vkCmdWaitEvents call with srcStageMask "
+           << string_VkPipelineStageFlags(wait_src_stage_mask)
+           << ", but the bitwise OR of stageMask values from the most recent vkCmdSetEvent calls is "
+           << string_VkPipelineStageFlags(signals_src_stage_mask & ~VK_PIPELINE_STAGE_HOST_BIT);
+
+        if (wait_src_stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
+            if (!(signals_src_stage_mask & VK_PIPELINE_STAGE_HOST_BIT)) {
+                ss << " and none of the waited events were set by vkSetEvent";
+            }
+        } else {
+            if (signals_src_stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
+                ss << " and at least one waited event was set by vkSetEvent, so srcStageMask must also include "
+                      "VK_PIPELINE_STAGE_HOST_BIT";
+            }
+        }
+        skip |= core.LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", cb_state.Handle(), loc, "%s", ss.str().c_str());
     }
     return skip;
 }
@@ -1326,16 +1365,13 @@ bool CoreChecks::ValidateAccessMask(const LogObjectList& objlist, const Location
 }
 
 bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer& cb_state, size_t eventCount, size_t firstEventIndex,
-                                            VkPipelineStageFlags2 wait_src_stage_mask,
                                             const std::optional<vku::safe_VkDependencyInfo>& dependency_info_opt,
                                             const EventMap& local_event_signal_info, VkQueue waiting_queue, const Location& loc) {
     bool skip = false;
     const vvl::DeviceState& state_data = cb_state.dev_data;
-    VkPipelineStageFlags2KHR combined_set_stage_mask = 0;
     const auto max_event = std::min((firstEventIndex + eventCount), cb_state.events.size());
     const bool wait_is_event2 = dependency_info_opt.has_value();
 
-    bool any_event2 = wait_is_event2;
     for (size_t event_index = firstEventIndex; event_index < max_event; ++event_index) {
         auto event = cb_state.events[event_index];
 
@@ -1348,13 +1384,11 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer& cb_state, 
         // the last src_stage from that submission).
         std::optional<vku::safe_VkDependencyInfo> set_dependency_info;
         if (const auto* event_info = vvl::Find(local_event_signal_info, event)) {
-            combined_set_stage_mask |= event_info->src_stage_mask;
             set_dependency_info = event_info->dependency_info;
             // The "set event" is found in the current submission (the same queue); there can't be inter-queue usage errors
         } else {
             auto event_state = state_data.Get<vvl::Event>(event);
             if (!event_state) continue;
-            combined_set_stage_mask |= event_state->signal_src_stage_mask;
             set_dependency_info = event_state->dependency_info;
 
             if (event_state->signaling_queue != VK_NULL_HANDLE && event_state->signaling_queue != waiting_queue) {
@@ -1367,7 +1401,6 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer& cb_state, 
         }
 
         bool set_is_event2 = set_dependency_info.has_value();
-        any_event2 |= set_is_event2;
 
         if (!set_is_event2 || !wait_is_event2) {
             continue;  // the following code is only for event2
@@ -1414,25 +1447,6 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(const vvl::CommandBuffer& cb_state, 
                 }
             }
         }
-    }
-    if (!any_event2 && wait_src_stage_mask != combined_set_stage_mask) {
-        std::ostringstream ss;
-        ss << "(" << state_data.FormatHandle(cb_state.Handle()) << ") contains a vkCmdWaitEvents call with srcStageMask "
-           << string_VkPipelineStageFlags2(wait_src_stage_mask)
-           << ", but the bitwise OR of stageMask values from the most recent vkCmdSetEvent calls is "
-           << string_VkPipelineStageFlags2(combined_set_stage_mask & ~VK_PIPELINE_STAGE_HOST_BIT);
-
-        if (wait_src_stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
-            if (!(combined_set_stage_mask & VK_PIPELINE_STAGE_HOST_BIT)) {
-                ss << " and none of the waited events were set by vkSetEvent";
-            }
-        } else {
-            if (combined_set_stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
-                ss << " and at least one waited event was set by vkSetEvent, so srcStageMask must also include "
-                      "VK_PIPELINE_STAGE_HOST_BIT";
-            }
-        }
-        skip |= state_data.LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", cb_state.Handle(), loc, "%s", ss.str().c_str());
     }
     return skip;
 }
@@ -1493,7 +1507,7 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
         VkPipelineStageFlags2 set_event_src_stages = VK_PIPELINE_STAGE_2_NONE;
         for (uint32_t i = 0; i < eventCount; i++) {
             const EventSignalingState* signaling_state = vvl::Find(cb_sub_state.event_signaling_states, pEvents[i]);
-            if (!signaling_state || !signaling_state->signaled) {
+            if (!signaling_state) {
                 found_all_set_commands = false;
                 break;
             }

--- a/layers/core_checks/cc_synchronization.h
+++ b/layers/core_checks/cc_synchronization.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024-2025 The Khronos Group Inc.
- * Copyright (c) 2024-2025 Valve Corporation
- * Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 The Khronos Group Inc.
+ * Copyright (c) 2024-2026 Valve Corporation
+ * Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,21 @@
 
 #pragma once
 
-#include "state_tracker/semaphore_state.h"
 #include "containers/custom_containers.h"
+#include <vulkan/vulkan_core.h>
+#include <optional>
+
+// TODO: temporary use EventMap, but it will be removed
+#include "state_tracker/event_map.h"
 
 class CoreChecks;
+struct Location;
+
+namespace vvl {
+class CommandBuffer;
+class Semaphore;
+enum class Func;
+}  // namespace vvl
 
 // Tracks semaphore state changes during the validation phase of QueueSubmit commands.
 // Semaphore state object (vvl::Semaphore) is updated later in the record phase.
@@ -59,4 +70,15 @@ struct SemaphoreSubmitState {
     bool ValidateBinarySignal(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state);
     bool ValidateTimelineSignal(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
     bool ValidateSignalSemaphore(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
+};
+
+struct WaitEventSubmitInfo {
+    std::vector<VkEvent> wait_events;
+    VkPipelineStageFlags wait_src_stage_mask = VK_PIPELINE_STAGE_NONE;
+
+    // Waited events that were signaled in the same command buffer and corresponding signal stage masks
+    std::vector<std::pair<VkEvent, EventSignalingState>> cb_signaling_state;
+
+    bool Validate(const CoreChecks& core, const vvl::CommandBuffer& cb_state, EventMap& submit_signaling_state,
+                  const Location& loc) const;
 };

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -765,7 +765,6 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateActionStateProtectedMemory(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
                                             const vvl::Pipeline* pipeline, const Location& loc) const;
     static bool ValidateWaitEventsAtSubmit(const vvl::CommandBuffer& cb_state, size_t eventCount, size_t firstEventIndex,
-                                           VkPipelineStageFlags2 wait_src_stage_mask,
                                            const std::optional<vku::safe_VkDependencyInfo>& dependency_info_opt,
                                            const EventMap& local_event_signal_info, VkQueue waiting_queue, const Location& loc);
     bool ValidateQueueFamilyIndices(const Location& loc, const vvl::CommandBuffer& cb_state, const vvl::Queue& queue_state) const;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -341,9 +341,7 @@ void CommandBuffer::ResetCBState() {
     active_subpass_contents = VK_SUBPASS_CONTENTS_INLINE;
     SetActiveSubpass(0);
     rendering_attachments.Reset();
-    waited_events.clear();
     events.clear();
-    write_events_before_wait.clear();
     active_queries.clear();
     started_queries.clear();
     render_pass_queries.clear();
@@ -2189,9 +2187,6 @@ void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_ma
         }
     }
     events.push_back(event);
-    if (!waited_events.count(event)) {
-        write_events_before_wait.push_back(event);
-    }
 }
 
 void CommandBuffer::RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const Location& loc) {
@@ -2206,26 +2201,32 @@ void CommandBuffer::RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_
         }
     }
     events.push_back(event);
-    if (!waited_events.count(event)) {
-        write_events_before_wait.push_back(event);
-    }
 }
 
-void CommandBuffer::RecordWaitEvents(uint32_t eventCount, const VkEvent* pEvents, VkPipelineStageFlags2 src_stage_mask,
-                                     const VkDependencyInfo* dependency_info, const Location& loc) {
+void CommandBuffer::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) {
     for (auto& item : sub_states_) {
-        item.second->RecordWaitEvents(eventCount, pEvents, src_stage_mask, dependency_info, loc);
+        item.second->RecordWaitEvents(events, src_stage_mask, loc);
     }
-    for (uint32_t i = 0; i < eventCount; ++i) {
-        const VkEvent event_hanle = pEvents[i];
+    for (const VkEvent event : events) {
         if (!dev_data.disabled[command_buffer_state]) {
-            if (auto event_state = dev_data.Get<vvl::Event>(event_hanle)) {
+            if (auto event_state = dev_data.Get<vvl::Event>(event)) {
                 AddChild(event_state);
             }
         }
-        waited_events.insert(event_hanle);
-        events.push_back(event_hanle);
+        this->events.push_back(event);
     }
+}
+
+void CommandBuffer::RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& dep_info_loc) {
+    for (auto& item : sub_states_) {
+        item.second->RecordWaitEvent2(event, dependency_info, dep_info_loc);
+    }
+    if (!dev_data.disabled[command_buffer_state]) {
+        if (auto event_state = dev_data.Get<vvl::Event>(event)) {
+            AddChild(event_state);
+        }
+    }
+    events.push_back(event);
 }
 
 void CommandBuffer::RecordBarrierObjects(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier* buffer_barriers,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -147,11 +147,12 @@ class Event : public StateObject {
     // Signaling state.
     // Gets updated at queue submission granularity or when signaled from the host.
     bool signaled = false;
-    std::optional<vku::safe_VkDependencyInfo> dependency_info;
 
     // Source stage specified by the "set event" command.
     // Gets updated at queue submission granularity.
     VkPipelineStageFlags2 signal_src_stage_mask = VK_PIPELINE_STAGE_2_NONE;
+
+    std::optional<vku::safe_VkDependencyInfo> dependency_info;
 
     // Queue that signaled this event. It's null if event was signaled from the host.
     VkQueue signaling_queue = VK_NULL_HANDLE;
@@ -515,8 +516,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
         }
     } rendering_attachments;
 
-    vvl::unordered_set<VkEvent> waited_events;
-    std::vector<VkEvent> write_events_before_wait;
     std::vector<VkEvent> events;
     vvl::unordered_set<QueryObject> active_queries;
     vvl::unordered_set<QueryObject> started_queries;
@@ -764,8 +763,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordSetEvent(VkEvent event, VkPipelineStageFlags2KHR stageMask, const VkDependencyInfo *dependency_info,
                         const Location &loc);
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2KHR stageMask, const Location &loc);
-    void RecordWaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags2KHR src_stage_mask,
-                          const VkDependencyInfo *dependency_info, const Location &loc);
+    void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc);
+    void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& dep_info_loc);
     void RecordPushConstants(const vvl::PipelineLayout &pipeline_layout_state, VkShaderStageFlags stage_flags, uint32_t offset,
                              uint32_t size, const void *values);
     void RecordPushData(const VkPushDataInfoEXT& push_data_info, const Location& loc);
@@ -932,8 +931,8 @@ class CommandBufferSubState {
 
     virtual void RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const VkDependencyInfo *dependency_info) {}
     virtual void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask) {}
-    virtual void RecordWaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags2 src_stage_mask,
-                                  const VkDependencyInfo *dependency_info, const Location &loc) {}
+    virtual void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) {}
+    virtual void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {}
     virtual void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers,
                                 uint32_t image_barrier_count, const VkImageMemoryBarrier *image_barriers,
                                 VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask, const Location &loc) {}

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3475,16 +3475,16 @@ void DeviceState::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, Vk
 }
 
 void DeviceState::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
-                                              VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
+                                              VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
                                               uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
                                               uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                               uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
-    cb_state->RecordWaitEvents(eventCount, pEvents, sourceStageMask, nullptr, record_obj.location);
+    cb_state->RecordWaitEvents(vvl::make_span(pEvents, eventCount), srcStageMask, record_obj.location);
     cb_state->RecordBarrierObjects(bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers,
-                                   sourceStageMask, dstStageMask, record_obj.location);
+                                   srcStageMask, dstStageMask, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
@@ -3498,9 +3498,8 @@ void DeviceState::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
     cb_state->RecordCommand(record_obj.location);
     for (uint32_t i = 0; i < eventCount; i++) {
         const auto& dep_info = pDependencyInfos[i];
-        auto exec_scopes = sync_utils::GetExecScopes(dep_info);
         const Location& dep_info_loc = record_obj.location.dot(vvl::Field::pDependencyInfos, i);
-        cb_state->RecordWaitEvents(1, &pEvents[i], exec_scopes.src, &pDependencyInfos[i], dep_info_loc);
+        cb_state->RecordWaitEvent2(pEvents[i], pDependencyInfos[i], dep_info_loc);
         cb_state->RecordBarrierObjects(dep_info, dep_info_loc);
     }
 }

--- a/tests/unit/event.cpp
+++ b/tests/unit/event.cpp
@@ -144,6 +144,17 @@ TEST_F(NegativeEvent, EventStageMask2) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeEvent, StageMaskResetEvent) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+    m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeEvent, EventStageMaskSubmit) {
     RETURN_IF_SKIP(Init());
 
@@ -166,6 +177,47 @@ TEST_F(NegativeEvent, EventStageMaskSubmit) {
     m_errorMonitor->VerifyFound();
 
     m_default_queue->Wait();
+}
+
+TEST_F(NegativeEvent, StageMaskWaitBeforeSetSubmit) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+
+    // Test that during submit validation this Set can't resolve previous wait
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    m_command_buffer.End();
+
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    monitor_.VerifyFound();
+}
+
+TEST_F(NegativeEvent, StageMaskTwoEventsTwoSubmits) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    vkt::Event event2(*m_device);
+    const VkEvent events[2] = {event, event2};
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT);
+    command_buffer.End();
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.SetEvent(event2, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    vk::CmdWaitEvents(command_buffer2, 2, events, VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
+    command_buffer2.End();
+
+    m_default_queue->Submit(command_buffer);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_default_queue->SubmitAndWait(command_buffer2);
+    monitor_.VerifyFound();
 }
 
 TEST_F(NegativeEvent, EventStageMaskHost) {

--- a/tests/unit/event_positive.cpp
+++ b/tests/unit/event_positive.cpp
@@ -41,12 +41,59 @@ TEST_F(PositiveEvent, EventStageMaskTwoSubmits) {
     m_default_queue->Submit(commandBuffer1);
 
     commandBuffer2.Begin();
-    vk::CmdWaitEvents(commandBuffer2, 1, &event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                      VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
+    vk::CmdWaitEvents(commandBuffer2, 1, &event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                      0, nullptr, 0, nullptr, 0, nullptr);
     commandBuffer2.End();
     m_default_queue->Submit(commandBuffer2);
 
     m_default_queue->Wait();
+}
+
+TEST_F(PositiveEvent, EventStageMaskTwoBatches) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent(event, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    command_buffer.End();
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.WaitEvent(event, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    command_buffer2.End();
+
+    const VkCommandBuffer command_buffers[2] = {command_buffer, command_buffer2};
+
+    VkSubmitInfo submit_info = vku::InitStructHelper();
+    submit_info.commandBufferCount = 2;
+    submit_info.pCommandBuffers = command_buffers;
+    vk::QueueSubmit(*m_default_queue, 1, &submit_info, VK_NULL_HANDLE);
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveEvent, StageMaskTwoEventsTwoSubmits) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    vkt::Event event2(*m_device);
+    const VkEvent events[2] = {event, event2};
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    command_buffer.End();
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.SetEvent(event2, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    vk::CmdWaitEvents(command_buffer2, 2, events, VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
+    command_buffer2.End();
+
+    m_default_queue->Submit(command_buffer);
+    m_default_queue->SubmitAndWait(command_buffer2);
 }
 
 TEST_F(PositiveEvent, EventStageMaskHost) {
@@ -56,7 +103,7 @@ TEST_F(PositiveEvent, EventStageMaskHost) {
     m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
     m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT,
-                               VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+                               VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
     m_command_buffer.End();
 }
 
@@ -65,10 +112,28 @@ TEST_F(PositiveEvent, EventStageMaskHostSubmit) {
     vkt::Event event(*m_device);
 
     m_command_buffer.Begin();
-    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
     m_command_buffer.End();
 
     event.Set();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveEvent, SecondaryCb) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.SetEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    m_command_buffer.End();
+
+    // If due to regression ExecuteCommands has no effect then submit validation will report an error
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -4015,18 +4015,9 @@ TEST_F(NegativeSyncVal, EventsCopyImageHazards) {
 
 TEST_F(NegativeSyncVal, EventsCommandHazards) {
     TEST_DESCRIPTION("Check Set/Reset/Wait command hazard checking");
-    RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitSyncVal());
 
     vkt::Event event(*m_device);
-
-    m_command_buffer.Begin();
-    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
-
-    m_errorMonitor->SetDesiredError("VUID-vkCmdResetEvent-event-03834");
-    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
-    m_errorMonitor->VerifyFound();
-    m_command_buffer.End();
 
     m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
@@ -4874,21 +4865,20 @@ TEST_F(NegativeSyncVal, QSBufferEvents) {
     vkt::Event event(*m_device);
 
     reset.Begin();
-    vk::CmdResetEvent(reset, event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    reset.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
     reset.End();
 
     // Command Buffer A reads froms buffer A and writes to buffer B
     cb0.Begin();
     cb0.Copy(buffer_a, buffer_b);
-    vk::CmdSetEvent(cb0, event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    cb0.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
     cb0.End();
 
     // cb1 reads froms buffer C and writes to buffer A, but has a wait to protect
     // the write to A when executed on the same queue
     cb1.Begin();
     barrier_war.buffer = buffer_a;
-    vk::CmdWaitEvents(cb1, 1, &event.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, nullptr, 1,
-                      &barrier_war, 0, nullptr);
+    cb1.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, barrier_war);
     cb1.Copy(buffer_c, buffer_a);
     cb1.End();
 
@@ -4897,10 +4887,9 @@ TEST_F(NegativeSyncVal, QSBufferEvents) {
     //    reads froms buffer C and writes to buffer A, but has a barrier to protect the write to A when
     cb2.Begin();
     cb2.Copy(buffer_a, buffer_b);
-    vk::CmdSetEvent(cb2, event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    cb2.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
     barrier_war.buffer = buffer_a;
-    vk::CmdWaitEvents(cb2, 1, &event.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, nullptr, 1,
-                      &barrier_war, 0, nullptr);
+    cb2.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, barrier_war);
     cb2.Copy(buffer_c, buffer_a);
     cb2.End();
 
@@ -4945,10 +4934,9 @@ TEST_F(NegativeSyncVal, QSBufferEvents) {
     cb0.End();
 
     cb1.Begin();
-    vk::CmdSetEvent(cb1, event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    cb1.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
     barrier_war.buffer = buffer_a;
-    vk::CmdWaitEvents(cb1, 1, &event.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, nullptr, 1,
-                      &barrier_war, 0, nullptr);
+    cb1.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, barrier_war);
     cb1.Copy(buffer_c, buffer_a);
     cb1.End();
 


### PR DESCRIPTION
Start using regular state tracking for event submit-time validation instead of replaying state through callbacks.

The callbacks are still here, but VUID 01158 now uses dedicated validation logic instead of a callback.

Additional Event v1 vs v2 cleanup.