### PR TITLE
sync: Fix multiview does not check for null imageView

### DIFF
--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -1074,16 +1074,21 @@ DynamicRenderingInfo::Attachment::Attachment(const SyncValidator& state, const v
 }
 
 ImageRangeGen DynamicRenderingInfo::Attachment::GetRangeGen(uint32_t view_mask) const {
+    // VkRenderingAttachmentInfo::imageView is allowed to be VK_NULL_HANDLE
+    if (!view) {
+        return {};
+    }
+    // Multiview is disabled: return precomputed range gen
     if (view_mask == 0) {
-        return view_gen;  // precomputed range gen when multivie is disabled
+        return view_gen;
+    }
+    // Initialize range gen based on view mask
+    if (type == AttachmentType::kColor) {
+        return MakeImageRangeGen(*view, view_mask);
+    } else if (type == AttachmentType::kDepth) {
+        return MakeImageRangeGen(*view, view_mask, VK_IMAGE_ASPECT_DEPTH_BIT);
     } else {
-        if (type == AttachmentType::kColor) {
-            return MakeImageRangeGen(*view, view_mask);
-        } else if (type == AttachmentType::kDepth) {
-            return MakeImageRangeGen(*view, view_mask, VK_IMAGE_ASPECT_DEPTH_BIT);
-        } else {
-            return MakeImageRangeGen(*view, view_mask, VK_IMAGE_ASPECT_STENCIL_BIT);
-        }
+        return MakeImageRangeGen(*view, view_mask, VK_IMAGE_ASPECT_STENCIL_BIT);
     }
 }
 

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -4545,6 +4545,41 @@ TEST_F(PositiveSyncVal, Multiview2) {
     m_command_buffer.End();
 }
 
+TEST_F(PositiveSyncVal, MultiviewNullView) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12257");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
+    const VkImageCreateInfo image_ci =
+        vkt::Image::ImageCreateInfo2D(128, 128, 1, 2 /* layers*/, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2, VK_IMAGE_ASPECT_DEPTH_BIT);
+
+    VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
+    depth_attachment.imageView = image_view;
+    depth_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    depth_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    depth_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+
+    // It is allowed to specify VK_NULL_HANDLE image view
+    VkRenderingAttachmentInfo stencil_attachment = vku::InitStructHelper();
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {128, 128};
+    rendering_info.layerCount = 2;
+    rendering_info.viewMask = 0x3;  // view 0 + view 1
+    rendering_info.pDepthAttachment = &depth_attachment;
+    rendering_info.pStencilAttachment = &stencil_attachment;
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
 TEST_F(PositiveSyncVal, ClearAttachmentSecondaryCb) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12217");
     SetTargetApiVersion(VK_API_VERSION_1_3);


### PR DESCRIPTION
It is allowed to specify VK_NULL_HANDLE for imageView in dynamic rendering.
The original code worked properly, but when I added multiview support (somewhere after 1.4.341.1) I assumed not null imageView.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12257