### PR TITLE
layers: Temp remove 13073/06209

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -2969,20 +2969,6 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound& last_bound, const Lo
             const auto attr_index = location.second.index;
             const auto& attr_desc = location.second.desc;
 
-            if (last_bound.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE)) {
-                const VkDeviceSize attribute_binding_extent = attr_desc.offset + GetVertexInputFormatSize(attr_desc.format);
-                if (vertex_buffer_binding->stride != 0 && vertex_buffer_binding->stride < attribute_binding_extent) {
-                    const char* vuid_str = cb_state.bind_vertex_buffer_3_used ? "VUID-vkCmdBindVertexBuffers3KHR-addressRange-13073"
-                                                                              : "VUID-vkCmdBindVertexBuffers2-pStrides-06209";
-                    skip |= LogError(vuid_str, last_bound.cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), loc,
-                                     "(attribute binding %" PRIu32 ", attribute location %" PRIu32 ") The pStrides value (%" PRIu64
-                                     ") parameter in the last call to %s is not 0 "
-                                     "and is less than the extent of the binding for the attribute (%" PRIu64 ").",
-                                     attr_desc.binding, attr_desc.location, vertex_buffer_binding->stride, String(loc.function),
-                                     attribute_binding_extent);
-                }
-            }
-
             // TODO - Handle https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/45
             if (!enabled_features.robustBufferAccess && !robust_pipeline && vertex_buffer_binding->Buffer() != VK_NULL_HANDLE) {
                 const VkDeviceSize vertex_buffer_offset = vertex_buffer_binding->BufferOffset();

--- a/tests/unit/device_address_commands.cpp
+++ b/tests/unit/device_address_commands.cpp
@@ -1365,7 +1365,8 @@ TEST_F(NegativeDeviceAddressCommands, VertexBufferBindingSizeZero) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeDeviceAddressCommands, VertexBufferBindingStride) {
+// VU being reworked in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8276
+TEST_F(NegativeDeviceAddressCommands, DISABLED_VertexBufferBindingStride) {
     RETURN_IF_SKIP(InitBasicDeviceAddressCommands());
     InitRenderTarget();
 

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -814,7 +814,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
 
     VkDeviceSize strides[] = {1};
     vk::CmdBindVertexBuffers2EXT(m_command_buffer, 0, 1, buffers.data(), offsets.data(), 0, strides);
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers2-pStrides-06209");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-02721");
     vk::CmdDraw(m_command_buffer, 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -7437,7 +7437,8 @@ TEST_F(NegativeShaderObject, InvalidVertexBuffer) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeShaderObject, VertexStride) {
+// VU being reworked in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8276
+TEST_F(NegativeShaderObject, DISABLED_VertexStride) {
     TEST_DESCRIPTION("Draw with vertex format components not matching vertex input format components.");
 
     AddRequiredFeature(vkt::Feature::shaderInt64);


### PR DESCRIPTION
VUs are being reworked in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8276 and these are just currently wrong (and misleading)

Going to just remove until they get merged in a near-future header (so people don't get false positives)