### PR TITLE
layers: Remove unnecessary host state special case

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1513,11 +1513,7 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
             set_event_src_stages |= static_cast<VkPipelineStageFlags>(signaling_state->src_stage_mask);
         }
         if (found_all_set_commands) {
-            // Do not try to validate HOST stage during record time.
-            // vkSetEvent can be tracked only during submit time (it can be called after command buffer recording)
-            VkPipelineStageFlags src_stage_mask_without_host = srcStageMask & ~VK_PIPELINE_STAGE_HOST_BIT;
-
-            if (src_stage_mask_without_host != set_event_src_stages) {
+            if (srcStageMask != set_event_src_stages) {
                 skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, error_obj.location.dot(Field::srcStageMask),
                                  "is %s, but the bitwise OR of stageMask values from the most recent vkCmdSetEvent call for each "
                                  "waited event is %s.",

--- a/tests/unit/event.cpp
+++ b/tests/unit/event.cpp
@@ -285,6 +285,19 @@ TEST_F(NegativeEvent, EventStageMaskHost2) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeEvent, EventStageMaskHost3) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT,
+                               VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeEvent, StageMaskPrimarySetSecondaryWait) {
     RETURN_IF_SKIP(Init());
     vkt::Event event(*m_device);

--- a/tests/unit/event_positive.cpp
+++ b/tests/unit/event_positive.cpp
@@ -96,17 +96,6 @@ TEST_F(PositiveEvent, StageMaskTwoEventsTwoSubmits) {
     m_default_queue->SubmitAndWait(command_buffer2);
 }
 
-TEST_F(PositiveEvent, EventStageMaskHost) {
-    RETURN_IF_SKIP(Init());
-    vkt::Event event(*m_device);
-
-    m_command_buffer.Begin();
-    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
-    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT,
-                               VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-    m_command_buffer.End();
-}
-
 TEST_F(PositiveEvent, EventStageMaskHostSubmit) {
     RETURN_IF_SKIP(Init());
     vkt::Event event(*m_device);


### PR DESCRIPTION
Fixes some wrong reasoning in the recent changes.

The `found_all_set_commands` condition during command buffer recording means that all events were found in the same command buffer (signals or unsignals before CmdWaitEvents). This provides all information needed to validate stage masks.

Any prior host signals become irrelevant because they are overwritten by command buffer signals/unsignals.