### PR TITLE
layers: Fix VK_HOST_IMAGE_COPY_MEMCPY_BIT VU

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -2705,20 +2705,19 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
             if (region.imageOffset.x != 0 || region.imageOffset.y != 0 || region.imageOffset.z != 0) {
                 const char* vuid = from_image ? "VUID-VkCopyImageToMemoryInfo-imageOffset-09114"
                                               : "VUID-VkCopyMemoryToImageInfo-imageOffset-09114";
-                skip |= LogError(vuid, objlist, loc.dot(info_type).dot(Field::flags),
-                                 "contains VK_HOST_IMAGE_COPY_MEMCPY which "
-                                 "means that pRegions[%" PRIu32 "].imageOffset (%s) must all be zero",
-                                 i, string_VkOffset3D(region.imageOffset).c_str());
+                skip |= LogError(vuid, objlist, region_loc.dot(Field::imageOffset),
+                                 "(%s) must all be zero if %s->flags contains VK_HOST_IMAGE_COPY_MEMCPY",
+                                 string_VkOffset3D(region.imageOffset).c_str(), String(info_type));
             }
-            const VkExtent3D subresource_extent = image_state->GetEffectiveSubresourceExtent(region.imageSubresource);
+            const VkExtent3D subresource_extent = image_state->GetEffectiveSubresourceLayerExtent(region.imageSubresource);
             if (!IsExtentEqual(region.imageExtent, subresource_extent)) {
                 const char* vuid =
                     from_image ? "VUID-VkCopyImageToMemoryInfo-srcImage-09115" : "VUID-VkCopyMemoryToImageInfo-dstImage-09115";
-                skip |= LogError(
-                    vuid, objlist, region_loc.dot(Field::imageExtent),
-                    "(%s) must match the imageSubresource extents (%s) because %s->flags contains VK_HOST_IMAGE_COPY_MEMCPY\n%s",
-                    string_VkExtent3D(region.imageExtent).c_str(), string_VkExtent3D(subresource_extent).c_str(), String(info_type),
-                    image_state->DescribeSubresourceLayers(region.imageSubresource).c_str());
+                skip |= LogError(vuid, objlist, region_loc.dot(Field::imageExtent),
+                                 "(%s) must match the imageSubresource extents (%s) for a single array layer because %s->flags "
+                                 "contains VK_HOST_IMAGE_COPY_MEMCPY\n%s",
+                                 string_VkExtent3D(region.imageExtent).c_str(), string_VkExtent3D(subresource_extent).c_str(),
+                                 String(info_type), image_state->DescribeSubresourceLayers(region.imageSubresource).c_str());
             }
             if ((region.memoryRowLength != 0) || (region.memoryImageHeight != 0)) {
                 const char* vuid =
@@ -2866,11 +2865,14 @@ bool CoreChecks::ValidateMemcpyExtents(const ImageCopyRegion& region, const Loca
         skip |= LogError("VUID-VkCopyImageToImageInfo-srcOffset-09114", region.objlist, region_loc.dot(Field::srcOffset),
                          "is (%s) but flags contains VK_HOST_IMAGE_COPY_MEMCPY.", string_VkOffset3D(region.src_offset).c_str());
     }
-    if (!IsExtentEqual(region.extent, region.src_subresource_extent)) {
+
+    VkExtent3D subresource_extent = region.src_state.GetEffectiveSubresourceLayerExtent(region.src_subresource);
+    if (!IsExtentEqual(region.extent, subresource_extent)) {
         skip |= LogError("VUID-VkCopyImageToImageInfo-srcImage-09115", region.objlist, region_loc.dot(Field::imageExtent),
-                         "(%s) must match the image's srcSubresource.extents (%s) when VkCopyImageToImageInfo->flags contains "
+                         "(%s) must match the image's srcSubresource.extents (%s) for a single array layer when "
+                         "VkCopyImageToImageInfo->flags contains "
                          "VK_HOST_IMAGE_COPY_MEMCPY\n%s",
-                         string_VkExtent3D(region.extent).c_str(), string_VkExtent3D(region.src_subresource_extent).c_str(),
+                         string_VkExtent3D(region.extent).c_str(), string_VkExtent3D(subresource_extent).c_str(),
                          region.src_state.DescribeSubresourceLayers(region.src_subresource).c_str());
     }
 
@@ -2878,11 +2880,14 @@ bool CoreChecks::ValidateMemcpyExtents(const ImageCopyRegion& region, const Loca
         skip |= LogError("VUID-VkCopyImageToImageInfo-dstOffset-09114", region.objlist, region_loc.dot(Field::dstOffset),
                          "is (%s) but flags contains VK_HOST_IMAGE_COPY_MEMCPY.", string_VkOffset3D(region.dst_offset).c_str());
     }
-    if (!IsExtentEqual(region.extent, region.dst_subresource_extent)) {
+
+    subresource_extent = region.dst_state.GetEffectiveSubresourceLayerExtent(region.dst_subresource);
+    if (!IsExtentEqual(region.extent, subresource_extent)) {
         skip |= LogError("VUID-VkCopyImageToImageInfo-dstImage-09115", region.objlist, region_loc.dot(Field::imageExtent),
-                         "(%s) must match the image's dstSubresource.extents (%s) when VkCopyImageToImageInfo->flags contains "
+                         "(%s) must match the image's dstSubresource.extents (%s) for a single array layer when "
+                         "VkCopyImageToImageInfo->flags contains "
                          "VK_HOST_IMAGE_COPY_MEMCPY\n%s",
-                         string_VkExtent3D(region.extent).c_str(), string_VkExtent3D(region.dst_subresource_extent).c_str(),
+                         string_VkExtent3D(region.extent).c_str(), string_VkExtent3D(subresource_extent).c_str(),
                          region.dst_state.DescribeSubresourceLayers(region.dst_subresource).c_str());
     }
     return skip;

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -343,9 +343,8 @@ bool Image::IsCreateInfoDedicatedAllocationImageAliasingCompatible(const Image& 
 }
 
 VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageAspectFlags aspect_mask, const uint32_t mip_level) const {
-    return GetEffectiveExtent(GetMipLevels(), GetExtent(), GetFormat(),
-                              create_flags, GetImageType(), GetArrayLayers(), aspect_mask,
-                              mip_level);
+    return GetEffectiveExtent(GetMipLevels(), GetExtent(), GetFormat(), create_flags, GetImageType(), GetArrayLayers(), aspect_mask,
+                              mip_level, false);
 }
 
 bool Image::IsCompatibleAliasing(const Image* other_image_state) const {
@@ -387,6 +386,11 @@ VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresource& sub) c
 
 VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceRange& range) const {
     return GetEffectiveSubresourceExtent(range.aspectMask, range.baseMipLevel);
+}
+
+VkExtent3D Image::GetEffectiveSubresourceLayerExtent(const VkImageSubresourceLayers& sub) const {
+    return GetEffectiveExtent(GetMipLevels(), GetExtent(), GetFormat(), create_flags, GetImageType(), GetArrayLayers(),
+                              sub.aspectMask, sub.mipLevel, true);
 }
 
 std::string Image::DescribeSubresourceLayers(const VkImageSubresourceLayers& subresource) const {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -218,6 +218,8 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceLayers &sub) const;
     VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresource &sub) const;
     VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceRange &range) const;
+    // For cases where we just want the extent of a single
+    VkExtent3D GetEffectiveSubresourceLayerExtent(const VkImageSubresourceLayers& sub) const;
 
     std::string DescribeSubresourceLayers(const VkImageSubresourceLayers &subresource) const;
 

--- a/layers/utils/image_utils.cpp
+++ b/layers/utils/image_utils.cpp
@@ -54,7 +54,8 @@ uint32_t GetEffectiveLayerCount(const VkImageSubresourceRange& subresource_range
 
 // Returns the effective extent of an image subresource, adjusted for mip level and array depth.
 VkExtent3D GetEffectiveExtent(uint32_t mip_levels, VkExtent3D extent, VkFormat format, VkImageCreateFlags flags,
-                              VkImageType image_type, uint32_t array_layers, VkImageAspectFlags aspect_mask, uint32_t mip_level) {
+                              VkImageType image_type, uint32_t array_layers, VkImageAspectFlags aspect_mask, uint32_t mip_level,
+                              bool layer_only) {
     // Return zero extent if mip level doesn't exist
     if (mip_level >= mip_levels) {
         return VkExtent3D{0, 0, 0};
@@ -88,15 +89,18 @@ VkExtent3D GetEffectiveExtent(uint32_t mip_levels, VkExtent3D extent, VkFormat f
     }
 
     // Image arrays have an effective z extent that isn't diminished by mip level
-    if (VK_IMAGE_TYPE_3D != image_type) {
+    // Some cases (https://gitlab.khronos.org/vulkan/vulkan/-/issues/4819) we want only 1 layer's extent
+    if (VK_IMAGE_TYPE_3D != image_type && !layer_only) {
         extent.depth = array_layers;
     }
 
     return extent;
 }
 
+// Currently only used by the testing framework
 VkExtent3D GetEffectiveExtent(const VkImageCreateInfo& ci, const VkImageAspectFlags aspect_mask, const uint32_t mip_level) {
-    return GetEffectiveExtent(ci.mipLevels, ci.extent, ci.format, ci.flags, ci.imageType, ci.arrayLayers, aspect_mask, mip_level);
+    return GetEffectiveExtent(ci.mipLevels, ci.extent, ci.format, ci.flags, ci.imageType, ci.arrayLayers, aspect_mask, mip_level,
+                              false);
 }
 
 std::optional<VkImageUsageFlags> GetImageStencilUsageFlags(const void* pNext) {

--- a/layers/utils/image_utils.h
+++ b/layers/utils/image_utils.h
@@ -29,7 +29,8 @@ uint32_t GetEffectiveLevelCount(const VkImageSubresourceRange &subresource_range
 uint32_t GetEffectiveLayerCount(const VkImageSubresourceRange &subresource_range, uint32_t total_layer_count);
 
 VkExtent3D GetEffectiveExtent(uint32_t mip_levels, VkExtent3D extent, VkFormat format, VkImageCreateFlags flags,
-                              VkImageType image_type, uint32_t array_layers, VkImageAspectFlags aspect_mask, uint32_t mip_level);
+                              VkImageType image_type, uint32_t array_layers, VkImageAspectFlags aspect_mask, uint32_t mip_level,
+                              bool layer_only);
 VkExtent3D GetEffectiveExtent(const VkImageCreateInfo& ci, const VkImageAspectFlags aspect_mask, const uint32_t mip_level);
 
 std::optional<VkImageUsageFlags> GetImageStencilUsageFlags(const void *pNext);

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -155,35 +155,6 @@ TEST_F(NegativeHostImageCopy, ImageOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeHostImageCopy, ImageOffsetArrayLayer) {
-    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11627");
-    RETURN_IF_SKIP(InitHostImageCopyTest());
-
-    VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    image_ci.arrayLayers = 2;
-    vkt::Image image(*m_device, image_ci);
-    image.SetLayout(layout);
-
-    uint8_t garbage = 0;  // should never be dereferenced
-
-    VkMemoryToImageCopy region_to_image = vku::InitStructHelper();
-    region_to_image.pHostPointer = &garbage;
-    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-    region_to_image.imageOffset = {0, 0, 0};
-    region_to_image.imageExtent = {width, height, 1};
-
-    VkCopyMemoryToImageInfo copy_to_image = vku::InitStructHelper();
-    copy_to_image.dstImage = image;
-    copy_to_image.dstImageLayout = layout;
-    copy_to_image.regionCount = 1;
-    copy_to_image.pRegions = &region_to_image;
-
-    copy_to_image.flags = VK_HOST_IMAGE_COPY_MEMCPY;
-    m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-dstImage-09115");
-    vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
-    m_errorMonitor->VerifyFound();
-}
-
 TEST_F(NegativeHostImageCopy, AspectMask) {
     RETURN_IF_SKIP(InitHostImageCopyTest());
 
@@ -2534,5 +2505,42 @@ TEST_F(NegativeHostImageCopy, TransitionImageLayoutStencilWrongAspect) {
     transition_info.subresourceRange = range;
     m_errorMonitor->SetDesiredError("VUID-VkHostImageLayoutTransitionInfo-image-10750");
     vk::TransitionImageLayoutEXT(*m_device, 1, &transition_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeHostImageCopy, CopyImageToMemoryLayers) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12212");
+    RETURN_IF_SKIP(InitHostImageCopyTest());
+
+    image_ci.mipLevels = 2;
+    vkt::Image image(*m_device, image_ci);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
+    const uint32_t buffer_size = width * height * 4u;
+    std::vector<uint8_t> data(buffer_size);
+
+    VkImageToMemoryCopy region = vku::InitStructHelper();
+    region.pHostPointer = data.data();
+    region.memoryRowLength = 0u;
+    region.memoryImageHeight = 0u;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 1u, 0u, 1u};
+    region.imageOffset = {0u, 0u, 0u};
+    region.imageExtent = {8u, 8u, 1u};  // only copying half of mip 2 (16x16)
+
+    VkCopyImageToMemoryInfo copy_to_image_memory = vku::InitStructHelper();
+    copy_to_image_memory.flags = VK_HOST_IMAGE_COPY_MEMCPY;
+    copy_to_image_memory.srcImage = image;
+    copy_to_image_memory.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    copy_to_image_memory.regionCount = 1u;
+    copy_to_image_memory.pRegions = &region;
+
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-09115");
+    vk::CopyImageToMemoryEXT(*m_device, &copy_to_image_memory);
+    m_errorMonitor->VerifyFound();
+
+    region.imageSubresource.mipLevel = 0;
+    region.imageExtent = {16u, 16u, 1u};
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-09115");
+    vk::CopyImageToMemoryEXT(*m_device, &copy_to_image_memory);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -11,6 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
 #include <algorithm>
 
@@ -429,4 +430,59 @@ TEST_F(PositiveHostImageCopy, CopyImageToImageMemcpyUsesSubresourceExtent) {
     copy.pRegions = &region;
 
     vk::CopyImageToImageEXT(*m_device, &copy);
+}
+
+TEST_F(PositiveHostImageCopy, CopyImageToMemoryLayers) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12212");
+    RETURN_IF_SKIP(InitHostImageCopyTest());
+
+    image_ci.arrayLayers = 2;
+    vkt::Image image(*m_device, image_ci);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
+    const uint32_t buffer_size = width * height * 4u * image_ci.arrayLayers;
+    std::vector<uint8_t> data(buffer_size);
+
+    VkImageToMemoryCopy region = vku::InitStructHelper();
+    region.pHostPointer = data.data();
+    region.memoryRowLength = 0u;
+    region.memoryImageHeight = 0u;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 2u};
+    region.imageOffset = {0u, 0u, 0u};
+    region.imageExtent = {32u, 32u, 1u};
+
+    VkCopyImageToMemoryInfo copy_to_image_memory = vku::InitStructHelper();
+    copy_to_image_memory.flags = VK_HOST_IMAGE_COPY_MEMCPY;
+    copy_to_image_memory.srcImage = image;
+    copy_to_image_memory.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    copy_to_image_memory.regionCount = 1u;
+    copy_to_image_memory.pRegions = &region;
+
+    vk::CopyImageToMemoryEXT(*m_device, &copy_to_image_memory);
+}
+
+TEST_F(PositiveHostImageCopy, CopyImageToImageLayers) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12212");
+    RETURN_IF_SKIP(InitHostImageCopyTest());
+
+    image_ci.arrayLayers = 2;
+    vkt::Image src_image(*m_device, image_ci);
+    src_image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+    vkt::Image dst_image(*m_device, image_ci);
+    dst_image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
+    VkImageCopy2 image_copy_2 = vku::InitStructHelper();
+    image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 2u};
+    image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 2u};
+    image_copy_2.extent = {width, height, 1};
+    VkCopyImageToImageInfo copy_image_to_image = vku::InitStructHelper();
+    copy_image_to_image.flags = VK_HOST_IMAGE_COPY_MEMCPY;
+    copy_image_to_image.regionCount = 1;
+    copy_image_to_image.pRegions = &image_copy_2;
+    copy_image_to_image.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    copy_image_to_image.dstImageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    copy_image_to_image.srcImage = src_image;
+    copy_image_to_image.dstImage = dst_image;
+
+    vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12212

`VK_HOST_IMAGE_COPY_MEMCPY_BIT` is just a special case where we don't want to apply the layerCount as a depth since VUs like `VUID-VkCopyImageToImageInfo-srcImage-09069` prevent you from doing a 2D Array to 3D copy anyway