### PR TITLE
layers: Add VU 12427

### DIFF
--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -886,11 +886,11 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
             }
         }
 
+        const auto rendering_struct = vku::FindStructInPNextChain<VkPipelineRenderingCreateInfo>(create_info.pNext);
         if (!create_info.renderPass) {
             // Pipeline has fragment output state
             if ((flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0 ||
                 (create_info.pColorBlendState && create_info.pMultisampleState)) {
-                const auto rendering_struct = vku::FindStructInPNextChain<VkPipelineRenderingCreateInfo>(create_info.pNext);
                 if (rendering_struct) {
                     skip |= ValidatePipelineRenderingCreateInfo(context, *rendering_struct, create_info_loc);
                 }
@@ -907,6 +907,13 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                     }
                 }
             }
+        } else if (rendering_struct) {
+            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pNext-12427", device, create_info_loc.dot(Field::renderPass),
+                             "(%s) is not VK_NULL_HANDLE, but the pNext chain includes VkPipelineRenderingCreateInfo. It is "
+                             "invalid to mix legacy RenderPass wit Dynamic Rendering as its ambiguous for an implementation to use "
+                             "the legacy RenderPass or the VkPipelineRenderingCreateInfo struct, so only one can be set.\n%s",
+                             FormatHandle(create_info.renderPass).c_str(),
+                             PrintPNextChain(Struct::VkGraphicsPipelineCreateInfo, create_info.pNext).c_str());
         }
 
         if (!IsExtEnabled(extensions.vk_ext_graphics_pipeline_library)) {

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -3072,7 +3072,7 @@ TEST_F(NegativeDynamicRendering, LibraryRenderPass) {
 
     CreatePipelineHelper lib(*this);
     lib.cb_ci_ = color_blend_state_create_info;
-    lib.InitFragmentOutputLibInfo(&pipeline_rendering_info);
+    lib.InitFragmentOutputLibInfo();
     lib.CreateGraphicsPipeline();
 
     VkPipelineLibraryCreateInfoKHR library_create_info = vku::InitStructHelper(&pipeline_rendering_info);

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -483,42 +483,6 @@ TEST_F(PositiveDynamicRendering, ResumeThenActionCommandSecondary) {
     m_command_buffer.End();
 }
 
-TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
-    TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled");
-    RETURN_IF_SKIP(InitBasicDynamicRendering());
-
-    const char* fsSource = R"glsl(
-        #version 450
-        layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
-        layout(location=0) out vec4 color;
-        void main() {
-           color = subpassLoad(x);
-        }
-    )glsl";
-
-    VkShaderObj fs(*m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    const vkt::DescriptorSetLayout dsl(*m_device,
-                                       {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr});
-    const vkt::PipelineLayout pl(*m_device, {&dsl});
-
-    VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkPipelineRenderingCreateInfo rendering_info = vku::InitStructHelper();
-    rendering_info.colorAttachmentCount = 1;
-    rendering_info.pColorAttachmentFormats = &color_format;
-
-    RenderPassSingleSubpass rp(*this);
-    rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_PREINITIALIZED);
-    rp.AddInputAttachment(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.CreateRenderPass();
-
-    CreatePipelineHelper pipe(*this, &rendering_info);
-    pipe.shader_stages_[1] = fs.GetStageCreateInfo();
-    pipe.gp_ci_.layout = pl;
-    pipe.gp_ci_.renderPass = rp;
-    pipe.CreateGraphicsPipeline();
-}
-
 TEST_F(PositiveDynamicRendering, CreateGraphicsPipelineNoInfo) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled but no rendering info struct.");
     RETURN_IF_SKIP(InitBasicDynamicRendering());

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -1974,11 +1974,7 @@ TEST_F(PositivePipeline, SampleLocations) {
     multi_sample_state.sampleShadingEnable = VK_FALSE;
     multi_sample_state.minSampleShading = 1.0f;
 
-    VkPipelineRenderingCreateInfo pipeline_rendering_ci = vku::InitStructHelper();
-    pipeline_rendering_ci.colorAttachmentCount = 1u;
-    pipeline_rendering_ci.pColorAttachmentFormats = &image_ci.format;
-
-    CreatePipelineHelper pipe(*this, &pipeline_rendering_ci);
+    CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.pMultisampleState = &multi_sample_state;
     pipe.gp_ci_.renderPass = render_pass;
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -5092,3 +5092,19 @@ TEST_F(NegativeRenderPass, MaxPerStageDescriptorInputAttachments) {
     vkt::RenderPass rp(*m_device, rpci);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeRenderPass, DynamicAndLegacy) {
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    VkPipelineRenderingCreateInfo rendering_info = vku::InitStructHelper();
+    RenderPassSingleSubpass rp(*this);
+    rp.CreateRenderPass();
+
+    CreatePipelineHelper pipe(*this, &rendering_info);
+    pipe.gp_ci_.renderPass = rp;
+    m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pNext-12427");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -7951,7 +7951,7 @@ TEST_F(NegativeShaderObject, MissingHeapBind) {
 TEST_F(NegativeShaderObject, ResetShaderObjectBinding) {
     TEST_DESCRIPTION("Bind a pipeline after shader objects to invalidate the shader object bindings.");
     RETURN_IF_SKIP(InitBasicShaderObject());
-    InitRenderTarget();
+    InitDynamicRenderTarget();
 
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
     const auto vert_spv = GLSLToSPV(stages[0], kVertexMinimalGlsl);
@@ -7964,9 +7964,10 @@ TEST_F(NegativeShaderObject, ResetShaderObjectBinding) {
     const vkt::Shader vert_shader(*m_device, create_infos[0]);
     const vkt::Shader frag_shader(*m_device, create_infos[1]);
 
+    VkFormat color_format = GetRenderTargetFormat();
     VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1u;
-    pipeline_rendering_info.pColorAttachmentFormats = &m_render_target_fmt;
+    pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.CreateGraphicsPipeline();
 


### PR DESCRIPTION
Adds `VUID-VkGraphicsPipelineCreateInfo-pNext-12427`

basically found some drivers go

```c++
if  (create_info.renderPass != null) {
    // legacy render pass
} else {
   // dynamic rendering
    findPNext<VkPipelineRenderingCreateInfo>();
}
```

and some go


```
if  (findPNext<VkPipelineRenderingCreateInfo>() {
   // dynamic rendering
} else {
     // legacy render pass
}
```

so providing both is going to lead to ambiguity, so we banned it