### PR TITLE
tests: Null check xcb_connection

### DIFF
--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -3119,7 +3119,10 @@ TEST_F(NegativeWsi, CreatingXcbSurface) {
     RETURN_IF_SKIP(Init());
 
     xcb_connection_t* xcb_connection = xcb_connect(nullptr, nullptr);
-    ASSERT_TRUE(xcb_connection);
+    if (!xcb_connection) {
+        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12276
+        GTEST_SKIP() << "xcb_connection failed";
+    }
 
     // NOTE: This is technically an invalid window! (There is no width/height)
     // But there is no robust way to check for a valid window without crashing the app.

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -115,7 +115,10 @@ TEST_F(PositiveWsi, CreateXcbSurface) {
     RETURN_IF_SKIP(Init());
 
     xcb_connection_t* xcb_connection = xcb_connect(nullptr, nullptr);
-    ASSERT_TRUE(xcb_connection);
+    if (!xcb_connection) {
+        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12276
+        GTEST_SKIP() << "xcb_connection failed";
+    }
 
     // NOTE: This is technically an invalid window! (There is no width/height)
     // But there is no robust way to check for a valid window without crashing the app.


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12276