### PR TITLE
layers: Add tile shading runtime SPIRV VUIDs (1/2)

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1673,7 +1673,9 @@ bool CoreChecks::ValidateActionState(const LastBound& last_bound_state, const Lo
         skip |= ValidateActionStateProtectedMemory(last_bound_state, bind_point, pipeline, loc);
     }
 
-    skip |= ValidateActionStateTileShading(last_bound_state, loc);
+    if (enabled_features.tileShading) {
+        skip |= ValidateActionStateTileShading(last_bound_state, loc);
+    }
 
     return skip;
 }
@@ -1681,13 +1683,14 @@ bool CoreChecks::ValidateActionState(const LastBound& last_bound_state, const Lo
 bool CoreChecks::ValidateActionStateTileShading(const LastBound& last_bound_state, const Location& loc) const {
     bool skip = false;
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
-    const vvl::Pipeline* pipeline = last_bound_state.pipeline_state;
     const VkPipelineBindPoint bind_point = last_bound_state.bind_point;
+    const LogObjectList objlist = cb_state.GetObjectList(bind_point);
+    const bool in_tile_shading_rp = cb_state.active_render_pass && cb_state.active_render_pass->has_tile_shading_enabled;
 
     if (cb_state.per_tile_execution_model_enabled) {
         if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS && !enabled_features.tileShadingPerTileDraw) {
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::PER_TILE_DRAW_ENABLED_10677),
-                             cb_state.GetObjectList(bind_point), loc,
+                             objlist, loc,
                              "the per-tile execution model is enabled in this command buffer, but "
                              "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingPerTileDraw feature isn't enabled.");
         } else if (bind_point == VK_PIPELINE_BIND_POINT_COMPUTE && !enabled_features.tileShadingPerTileDispatch) {
@@ -1698,25 +1701,39 @@ bool CoreChecks::ValidateActionStateTileShading(const LastBound& last_bound_stat
         }
     }
 
-    if (cb_state.active_render_pass && cb_state.active_render_pass->has_tile_shading_enabled) {
-        const VkShaderStageFlags allowed_shader_stages = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT |
-                                                         VK_SHADER_STAGE_COMPUTE_BIT;
-        VkShaderStageFlags active_stages = 0;
-        if (pipeline) {
-            active_stages = pipeline->active_shaders;
-        } else {
-            for (const auto& shader_object : last_bound_state.shader_object_states) {
-                if (shader_object) {
-                    active_stages |= shader_object->create_info.stage;
-                }
-            }
-        }
+    if (in_tile_shading_rp) {
+        constexpr VkShaderStageFlags allowed_shader_stages = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT |
+                                                             VK_SHADER_STAGE_COMPUTE_BIT;
+        const VkShaderStageFlags active_stages = last_bound_state.GetAllActiveBoundStages();
         if ((active_stages & ~allowed_shader_stages) != 0) {
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::TILE_SHADING_SHADER_STAGE_10678),
-                             cb_state.GetObjectList(bind_point), loc,
+                             objlist, loc,
                              "shader stages (%s) include stages not allowed "
                              "inside a tile shading render pass scope.",
                              string_VkShaderStageFlags(active_stages).c_str());
+        }
+    }
+
+    for (const auto* shader_stage : last_bound_state.GetStages()) {
+        if (!shader_stage->HasSpirv() ||
+            !shader_stage->spirv_state->HasCapability(spv::CapabilityTileShadingQCOM)) {
+            continue;
+        }
+
+        if (!in_tile_shading_rp) {
+            skip |= LogError("VUID-RuntimeSpirv-TileShadingQCOM-10700", objlist, loc,
+                             "shader %s has OpCapability TileShadingQCOM, but was invoked outside "
+                             "a tile shading render pass. "
+                             "(Can be enabled by using VkRenderPassTileShadingCreateInfoQCOM)",
+                             shader_stage->entrypoint->Describe().c_str());
+        }
+
+        if (!cb_state.per_tile_execution_model_enabled && shader_stage->GetStage() == VK_SHADER_STAGE_COMPUTE_BIT) {
+            skip |= LogError("VUID-RuntimeSpirv-TileShadingQCOM-10701", objlist, loc,
+                             "shader %s has OpCapability TileShadingQCOM, but the per-tile execution "
+                             "model is not enabled in the current render pass. "
+                             "(Did you forget to call vkCmdBeginPerTileExecutionQCOM)",
+                             shader_stage->entrypoint->Describe().c_str());
         }
     }
 

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -641,8 +641,11 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
 
     const uint32_t binding_index = resource_variable.decorations.binding;
     // Verify if attachments are used in DescriptorSet
-    if (!cb_state.active_attachments.empty() && !cb_state.active_subpasses.empty() &&
+    if (!cb_state.active_attachments.empty() &&
         (descriptor_type != VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
+        const bool use_tile_attachment = cb_state.active_render_pass &&
+                                         cb_state.active_render_pass->has_tile_shading_enabled &&
+                                         resource_variable.storage_class == spv::StorageClassTileAttachmentQCOM;
         for (uint32_t att_index = 0; att_index < cb_state.active_attachments.size(); ++att_index) {
             const auto& attachment_info = cb_state.active_attachments[att_index];
             const auto* view_state = attachment_info.image_view;
@@ -656,62 +659,117 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
             }
 
             bool descriptor_written_to = false;
-            const auto pipeline = cb_state.GetLastBoundGraphics().pipeline_state;
-            for (const ShaderStageState& stage : pipeline->stage_states) {
-                if (!stage.HasSpirv()) {
-                    continue;
-                }
-                for (const auto& interface_variable : stage.entrypoint->resource_interface_variables) {
-                    if (interface_variable.decorations.set == set_index &&
-                        interface_variable.decorations.binding == binding_index) {
-                        descriptor_written_to |= interface_variable.IsWrittenTo();
-                        break;  // only one set/binding will match
+
+            // Note: In a tile-shading render pass, compute dispatch can run without a bound graphics pipeline.
+            if (const auto pipeline = cb_state.GetLastBoundGraphics().pipeline_state) {
+                for (const ShaderStageState& stage : pipeline->stage_states) {
+                    if (!stage.HasSpirv()) {
+                        continue;
+                    }
+                    for (const auto& interface_variable : stage.entrypoint->resource_interface_variables) {
+                        if (interface_variable.decorations.set == set_index &&
+                            interface_variable.decorations.binding == binding_index) {
+                            descriptor_written_to |= interface_variable.IsWrittenTo();
+                            break;  // only one set/binding will match
+                        }
                     }
                 }
             }
 
-            const SubpassInfo& subpass = cb_state.active_subpasses[att_index];
-            const bool layout_read_only = IsImageLayoutReadOnly(attachment_info.layout);
-            const bool read_attachment = (subpass.usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) != 0;
-            if (read_attachment && descriptor_written_to) {
-                const vvl::ActionVUID vuid = attachment_info.IsDepth()     ? vvl::ActionVUID::SUBRESOURCE_SUBPASS_12339
-                                             : attachment_info.IsStencil() ? vvl::ActionVUID::SUBRESOURCE_SUBPASS_12340
-                                                                           : vvl::ActionVUID::SUBRESOURCE_SUBPASS_12338;
-                if (same_view) {
-                    const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer);
-                    skip |= LogError(CreateActionVuid(loc.Get().function, vuid), objlist, loc.Get(),
-                                     "the %s has %s which will be read from as %s attachment %" PRIu32 ".%s",
-                                     DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
-                                     FormatHandle(image_view).c_str(), FormatHandle(framebuffer).c_str(), att_index,
-                                     DescribeInstruction().c_str());
-                } else if (overlapping_view) {
-                    const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer,
-                                                view_state->Handle());
-                    skip |= LogError(CreateActionVuid(loc.Get().function, vuid), objlist, loc.Get(),
-                                     "the %s has %s which will be overlap read from as %s in %s attachment %" PRIu32 " overlap.%s",
-                                     DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
-                                     FormatHandle(image_view).c_str(), FormatHandle(view_state->Handle()).c_str(),
-                                     FormatHandle(framebuffer).c_str(), att_index, DescribeInstruction().c_str());
+            if (!cb_state.active_subpasses.empty()) {
+                const SubpassInfo& subpass = cb_state.active_subpasses[att_index];
+                const bool layout_read_only = IsImageLayoutReadOnly(attachment_info.layout);
+                const bool read_attachment = (subpass.usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) != 0;
+                if (read_attachment && descriptor_written_to) {
+                    const vvl::ActionVUID vuid = attachment_info.IsDepth()     ? vvl::ActionVUID::SUBRESOURCE_SUBPASS_12339
+                                                 : attachment_info.IsStencil() ? vvl::ActionVUID::SUBRESOURCE_SUBPASS_12340
+                                                                               : vvl::ActionVUID::SUBRESOURCE_SUBPASS_12338;
+                    if (same_view) {
+                        const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer);
+                        skip |= LogError(CreateActionVuid(loc.Get().function, vuid), objlist, loc.Get(),
+                                         "the %s has %s which will be read from as %s attachment %" PRIu32 ".%s",
+                                         DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
+                                         FormatHandle(image_view).c_str(), FormatHandle(framebuffer).c_str(), att_index,
+                                         DescribeInstruction().c_str());
+                    } else if (overlapping_view) {
+                        const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer,
+                                                    view_state->Handle());
+                        skip |= LogError(CreateActionVuid(loc.Get().function, vuid), objlist, loc.Get(),
+                                         "the %s has %s which will be overlap read from as %s in %s attachment %" PRIu32
+                                         " overlap.%s",
+                                         DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
+                                         FormatHandle(image_view).c_str(), FormatHandle(view_state->Handle()).c_str(),
+                                         FormatHandle(framebuffer).c_str(), att_index, DescribeInstruction().c_str());
+                    }
+                }
+
+                if (descriptor_written_to && !layout_read_only) {
+                    if (same_view) {
+                        const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer);
+                        skip |= LogError(CreateActionVuid(loc.Get().function, ActionVUID::SUBRESOURCE_RP_WRTIE_06537), objlist,
+                                         loc.Get(),
+                                         "the %s has %s which is written to but is also %s attachment %" PRIu32 ".%s",
+                                         DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
+                                         FormatHandle(image_view).c_str(), FormatHandle(framebuffer).c_str(), att_index,
+                                         DescribeInstruction().c_str());
+                    } else if (overlapping_view) {
+                        const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer,
+                                                    view_state->Handle());
+                        skip |= LogError(CreateActionVuid(loc.Get().function, ActionVUID::SUBRESOURCE_RP_WRTIE_06537), objlist,
+                                         loc.Get(),
+                                         "the %s has %s which overlaps writes to %s but is also %s attachment %" PRIu32 ".%s",
+                                         DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
+                                         FormatHandle(image_view).c_str(), FormatHandle(view_state->Handle()).c_str(),
+                                         FormatHandle(framebuffer).c_str(), att_index, DescribeInstruction().c_str());
+                    }
                 }
             }
 
-            if (descriptor_written_to && !layout_read_only) {
+            if (!use_tile_attachment) {
+                continue;
+            }
+
+            const uint32_t base_type_opcode = resource_variable.base_type.Opcode();
+            struct TileShadingRuntimeSpirvInfo {
+                const char* vuid = nullptr;
+                vvl::Field feature_field = vvl::Field::Empty;
+            } ts_spirv_info;
+            if (!dev_proxy.enabled_features.tileShadingColorAttachments &&
+                attachment_info.IsColor() && base_type_opcode == spv::OpTypeImage) {
+                ts_spirv_info = {"VUID-RuntimeSpirv-OpTypeImage-10707", vvl::Field::tileShadingColorAttachments};
+            } else if (!dev_proxy.enabled_features.tileShadingDepthAttachments &&
+                       attachment_info.IsDepth() && base_type_opcode == spv::OpTypeImage) {
+                ts_spirv_info = {"VUID-RuntimeSpirv-OpTypeImage-10708", vvl::Field::tileShadingDepthAttachments};
+            } else if (!dev_proxy.enabled_features.tileShadingStencilAttachments &&
+                       attachment_info.IsStencil() && base_type_opcode == spv::OpTypeImage) {
+                ts_spirv_info = {"VUID-RuntimeSpirv-OpTypeImage-10709", vvl::Field::tileShadingStencilAttachments};
+            } else if (!dev_proxy.enabled_features.tileShadingInputAttachments &&
+                       attachment_info.IsInput() && base_type_opcode == spv::OpTypeImage) {
+                ts_spirv_info = {"VUID-RuntimeSpirv-OpTypeImage-10710", vvl::Field::tileShadingInputAttachments};
+            } else if (!dev_proxy.enabled_features.tileShadingSampledAttachments &&
+                       base_type_opcode == spv::OpTypeSampledImage) {
+                ts_spirv_info = {"VUID-RuntimeSpirv-OpTypeSampledImage-10711", vvl::Field::tileShadingSampledAttachments};
+            }
+            if (ts_spirv_info.vuid) {
+                const uint32_t attachment_desc_index =
+                    (cb_state.attachment_source == AttachmentSource::DynamicRendering) ? attachment_info.type_index : att_index;
+                const std::string attachment_desc = attachment_info.Describe(cb_state, attachment_desc_index);
                 if (same_view) {
-                    const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer);
-                    skip |= LogError(CreateActionVuid(loc.Get().function, ActionVUID::SUBRESOURCE_RP_WRTIE_06537), objlist,
-                                     loc.Get(), "the %s has %s which is written to but is also %s attachment %" PRIu32 ".%s",
+                    const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view);
+                    skip |= LogError(ts_spirv_info.vuid, objlist, loc.Get(),
+                                     "the %s is TileAttachmentQCOM storage class, it is backed by %s which is "
+                                     "bound as %s, but VkPhysicalDeviceTileShadingFeaturesQCOM::%s isn't enabled.%s",
                                      DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
-                                     FormatHandle(image_view).c_str(), FormatHandle(framebuffer).c_str(), att_index,
-                                     DescribeInstruction().c_str());
+                                     FormatHandle(image_view).c_str(), attachment_desc.c_str(),
+                                     String(ts_spirv_info.feature_field), DescribeInstruction().c_str());
                 } else if (overlapping_view) {
-                    const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, framebuffer,
-                                                view_state->Handle());
-                    skip |=
-                        LogError(CreateActionVuid(loc.Get().function, ActionVUID::SUBRESOURCE_RP_WRTIE_06537), objlist, loc.Get(),
-                                 "the %s has %s which overlaps writes to %s but is also %s attachment %" PRIu32 ".%s",
-                                 DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
-                                 FormatHandle(image_view).c_str(), FormatHandle(view_state->Handle()).c_str(),
-                                 FormatHandle(framebuffer).c_str(), att_index, DescribeInstruction().c_str());
+                    const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view, view_state->Handle());
+                    skip |= LogError(ts_spirv_info.vuid, objlist, loc.Get(),
+                                     "the %s is TileAttachmentQCOM storage class, it is backed by %s which "
+                                     "overlaps %s that is bound as %s, but VkPhysicalDeviceTileShadingFeaturesQCOM::%s isn't enabled.%s",
+                                     DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
+                                     FormatHandle(image_view).c_str(), FormatHandle(view_state->Handle()).c_str(),
+                                     attachment_desc.c_str(), String(ts_spirv_info.feature_field), DescribeInstruction().c_str());
                 }
             }
         }

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1,5 +1,6 @@
 ﻿/* Copyright (c) 2021-2026 The Khronos Group Inc.
  * Copyright (c) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -232,6 +233,12 @@ void ExecutionModeSet::Add(const Instruction& insn) {
             break;
         case spv::ExecutionModeLocalSize:
             flags |= local_size_bit;
+            local_size.x = insn.Word(3);
+            local_size.y = insn.Word(4);
+            local_size.z = insn.Word(5);
+            break;
+        case spv::ExecutionModeTileShadingRateQCOM:
+            flags |= tile_shading_rate_bit;
             local_size.x = insn.Word(3);
             local_size.y = insn.Word(4);
             local_size.z = insn.Word(5);

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -1,5 +1,6 @@
 /* Copyright (c) 2021-2026 The Khronos Group Inc.
  * Copyright (c) 2025 Arm Limited.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,12 +175,14 @@ struct ExecutionModeSet {
         geometry_input_triangle_adjacency_bit = 1ull << 42,
 
         shader_64bit_indexing = 1ull << 43,
+
+        tile_shading_rate_bit = 1ull << 44,
     };
 
     // bits to know if things have been set or not by a Decoration
     uint64_t flags = 0;
 
-    // SPIR-V spec says only LocalSize or LocalSizeId can be used, so can share
+    // SPIR-V spec says only LocalSize or LocalSizeId or TileShadingRateQCOM can be used, so can share
     LocalSize local_size = {kInvalidValue, kInvalidValue, kInvalidValue};
 
     uint32_t output_vertices = kInvalidValue;

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -119,6 +119,7 @@ bool SpirvValidator::Validate(const spirv::Module& module_state, const spirv::St
         skip |= ValidateConservativeRasterization(module_state, entry_point, stateless_data, loc);
         skip |= ValidateTransformFeedbackEmitStreams(module_state, entry_point, stateless_data, loc);
         skip |= ValidateShaderTensor(module_state, entry_point, stateless_data, loc);
+        skip |= ValidateTileShadingCapability(module_state, entry_point, stateless_data, loc);
     }
 
     return skip;
@@ -1626,6 +1627,48 @@ bool SpirvValidator::ValidateShaderTensor(const spirv::Module& module_state, con
                                  instruction->Describe().c_str(), copy_object_type_bytes,
                                  phys_dev_ext_props.tensor_properties.maxTensorShaderAccessSize);
             }
+        }
+    }
+
+    return skip;
+}
+
+bool SpirvValidator::ValidateTileShadingCapability(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                   const spirv::StatelessData& stateless_data, const Location& loc) const {
+    bool skip = false;
+    const bool has_tile_shading_capability = module_state.HasCapability(spv::CapabilityTileShadingQCOM);
+
+    if (!enabled_features.tileShading && entrypoint.stage == VK_SHADER_STAGE_COMPUTE_BIT && has_tile_shading_capability) {
+        skip |= LogError("VUID-RuntimeSpirv-TileShadingQCOM-10698", module_state.handle(), loc,
+                         "shader %s declares OpCapability TileShadingQCOM, but "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShading isn't enabled.",
+                         entrypoint.Describe().c_str());
+    }
+
+    if (!enabled_features.tileShadingFragmentStage && entrypoint.stage == VK_SHADER_STAGE_FRAGMENT_BIT && has_tile_shading_capability) {
+        skip |= LogError("VUID-RuntimeSpirv-TileShadingQCOM-10699", module_state.handle(), loc,
+                         "shader %s declares OpCapability TileShadingQCOM, but "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingFragmentStage isn't enabled.",
+                         entrypoint.Describe().c_str());
+    }
+
+    if (entrypoint.stage == VK_SHADER_STAGE_COMPUTE_BIT && has_tile_shading_capability &&
+        entrypoint.execution_mode.Has(spirv::ExecutionModeSet::tile_shading_rate_bit)) {
+        if (entrypoint.execution_mode.local_size.x > phys_dev_ext_props.tile_shading_props.maxTileShadingRate.width) {
+            skip |= LogError("VUID-RuntimeSpirv-x-10702", module_state.handle(), loc,
+                             "shader %s has OpExecutionMode TileShadingRateQCOM with x = %" PRIu32
+                             ", but exceeds VkPhysicalDeviceTileShadingPropertiesQCOM::maxTileShadingRate.width (%" PRIu32 ").",
+                             entrypoint.Describe().c_str(),
+                             entrypoint.execution_mode.local_size.x,
+                             phys_dev_ext_props.tile_shading_props.maxTileShadingRate.width);
+        }
+        if (entrypoint.execution_mode.local_size.y > phys_dev_ext_props.tile_shading_props.maxTileShadingRate.height) {
+            skip |= LogError("VUID-RuntimeSpirv-y-10703", module_state.handle(), loc,
+                             "shader %s has OpExecutionMode TileShadingRateQCOM with y = %" PRIu32
+                             ", but exceeds VkPhysicalDeviceTileShadingPropertiesQCOM::maxTileShadingRate.height (%" PRIu32 ").",
+                             entrypoint.Describe().c_str(),
+                             entrypoint.execution_mode.local_size.y,
+                             phys_dev_ext_props.tile_shading_props.maxTileShadingRate.height);
         }
     }
 

--- a/layers/stateless/sl_spirv.h
+++ b/layers/stateless/sl_spirv.h
@@ -95,6 +95,8 @@ class SpirvValidator : public Logger {
     bool ValidateConservativeRasterization(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                            const spirv::StatelessData& stateless_data, const Location& loc) const;
     bool ValidateShaderTensor(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint, const spirv::StatelessData &stateless_data, const Location& loc) const;
+    bool ValidateTileShadingCapability(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
+                                       const spirv::StatelessData &stateless_data, const Location &loc) const;
 
     // Auto-generated helper functions
     bool ValidateShaderCapabilitiesAndExtensions(const spirv::Module& module_state, const spirv::Instruction& insn,

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -2205,3 +2205,781 @@ TEST_F(NegativeTileShading, ImageDescriptorMismatchTileMemory) {
     m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
+
+TEST_F(NegativeTileShading, CapabilityInComputeShaderFeatureNotEnabled) {
+    TEST_DESCRIPTION("Create compute shader module with TileShadingQCOM capability, but the tileShading feature isn't enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    const char* cs_source = R"asm(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main TileShadingRateQCOM 1 1 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )asm";
+
+    m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740");
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10698");
+    VkShaderObj cs{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, CapabilityInFragmentShaderFeatureNotEnabled) {
+    TEST_DESCRIPTION("Create fragment shader module with TileShadingQCOM capability, but the tileShadingFragmentStage feature isn't enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    const char* fs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint Fragment %main "main" %out_color
+                OpExecutionMode %main OriginUpperLeft
+                OpDecorate %out_color Location 0
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+       %float = OpTypeFloat 32
+     %v4float = OpTypeVector %float 4
+ %ptr_out_v4f = OpTypePointer Output %v4float
+   %out_color = OpVariable %ptr_out_v4f Output
+     %float_1 = OpConstant %float 1
+     %float_0 = OpConstant %float 0
+    %vec4_red = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpStore %out_color %vec4_red
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740");
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10699");
+    VkShaderObj fs{*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, CapabilityInComputeShaderOutsideTileShadingRenderPass) {
+    TEST_DESCRIPTION("Invoke a tile shading compute shader kernel outside a tile shading render pass.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const char* cs_source = R"asm(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %storage_image
+               OpExecutionMode %main TileShadingRateQCOM 1 1 1
+               OpDecorate %storage_image NonWritable
+               OpDecorate %storage_image Binding 0
+               OpDecorate %storage_image DescriptorSet 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+          %8 = OpTypeImage %float 2D 0 0 0 2 Rgba8
+%_ptr_TileAttachmentQCOM_8 = OpTypePointer TileAttachmentQCOM %8
+%storage_image = OpVariable %_ptr_TileAttachmentQCOM_8 TileAttachmentQCOM
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )asm";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    compute_pipe.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10700");
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10701");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, CapabilityInComputeShaderObjectOutsideTileShadingRenderPass) {
+    TEST_DESCRIPTION("Invoke a tile shading compute shader object outside a tile shading render pass.");
+    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderObject);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const char* cs_source = R"asm(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main TileShadingRateQCOM 1 1 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )asm";
+
+    std::vector<uint32_t> cs_spv{};
+    ASMtoSPV(SPV_ENV_VULKAN_1_3, 0, cs_source, cs_spv);
+    vkt::Shader cs{*m_device, ShaderCreateInfo(cs_spv, VK_SHADER_STAGE_COMPUTE_BIT)};
+
+    m_command_buffer.Begin();
+    m_command_buffer.BindCompShader(cs);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10700");
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10701");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, CapabilityInFragmentShaderOutsideTileShadingRenderPass) {
+    TEST_DESCRIPTION("Invoke a tile shading fragment shader kernel outside a tile shading render pass.");
+    AddRequiredFeature(vkt::Feature::tileShadingFragmentStage);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitRenderTarget();
+
+    const char* vs_source = R"asm(
+                OpCapability Shader
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint Vertex %main "main" %out_pos
+                OpDecorate %out_pos BuiltIn Position
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+       %float = OpTypeFloat 32
+     %v4float = OpTypeVector %float 4
+ %ptr_out_v4f = OpTypePointer Output %v4float
+     %out_pos = OpVariable %ptr_out_v4f Output
+     %float_0 = OpConstant %float 0
+     %float_1 = OpConstant %float 1
+    %vec4_pos = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_1
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpStore %out_pos %vec4_pos
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    const char* fs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint Fragment %main "main" %out_color
+                OpExecutionMode %main OriginUpperLeft
+                OpDecorate %out_color Location 0
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+       %float = OpTypeFloat 32
+     %v4float = OpTypeVector %float 4
+ %ptr_out_v4f = OpTypePointer Output %v4float
+   %out_color = OpVariable %ptr_out_v4f Output
+     %float_1 = OpConstant %float 1
+     %float_0 = OpConstant %float 0
+    %vec4_red = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpStore %out_color %vec4_red
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    VkShaderObj vs{*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    VkShaderObj fs{*m_device, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+
+    CreatePipelineHelper graphics_pipe{*this};
+    graphics_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    graphics_pipe.CreateGraphicsPipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBeginRenderPass(m_command_buffer, &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, graphics_pipe);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10700");
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndRenderPass(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, CapabilityInFragmentShaderObjectOutsideTileShadingRenderPass) {
+    TEST_DESCRIPTION("Invoke a tile shading fragment shader object outside a tile shading render pass.");
+    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderObject);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::tileShadingFragmentStage);
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitDynamicRenderTarget();
+
+    const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
+
+    const char* fs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint Fragment %main "main" %out_color
+                OpExecutionMode %main OriginUpperLeft
+                OpDecorate %out_color Location 0
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+       %float = OpTypeFloat 32
+     %v4float = OpTypeVector %float 4
+ %ptr_out_v4f = OpTypePointer Output %v4float
+   %out_color = OpVariable %ptr_out_v4f Output
+     %float_1 = OpConstant %float 1
+     %float_0 = OpConstant %float 0
+    %vec4_red = OpConstantComposite %v4float %float_1 %float_0 %float_0 %float_1
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpStore %out_color %vec4_red
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    std::vector<uint32_t> fs_spv{};
+    ASMtoSPV(SPV_ENV_VULKAN_1_3, 0, fs_source, fs_spv);
+
+    vkt::Shader vs{*m_device, ShaderCreateInfo(vs_spv, VK_SHADER_STAGE_VERTEX_BIT)};
+    vkt::Shader fs{*m_device, ShaderCreateInfoNoNextStage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT)};
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    SetDefaultDynamicStatesExclude();
+    m_command_buffer.BindShaders(vs, fs);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-TileShadingQCOM-10700");
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, MaxTileShadingRateWidth) {
+    TEST_DESCRIPTION("Create a compute shader module with TileShadingRateQCOM.x exceeding "
+                     "VkPhysicalDeviceTileShadingPropertiesQCOM::maxTileShadingRate::width.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(tile_shading_props);
+    uint32_t invalid_width = 1;
+    while (invalid_width <= tile_shading_props.maxTileShadingRate.width) {
+        invalid_width <<= 1;
+    }
+
+    std::string cs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main"
+                OpExecutionMode %main TileShadingRateQCOM )asm" + std::to_string(invalid_width) + " 1 1\n" +
+                R"asm(
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-x-10702");
+    VkShaderObj cs{*m_device, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, MaxTileShadingRateHeight) {
+    TEST_DESCRIPTION("Create a compute shader module with TileShadingRateQCOM.y exceeding "
+                     "VkPhysicalDeviceTileShadingPropertiesQCOM::maxTileShadingRate::height.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    VkPhysicalDeviceTileShadingPropertiesQCOM tile_shading_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(tile_shading_props);
+    uint32_t invalid_height = 1;
+    while (invalid_height <= tile_shading_props.maxTileShadingRate.height) {
+        invalid_height <<= 1;
+    }
+
+    std::string cs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main"
+                OpExecutionMode %main TileShadingRateQCOM 1 )asm" + std::to_string(invalid_height) + " 1\n" +
+                R"asm(
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-y-10703");
+    VkShaderObj cs{*m_device, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, TileShadingColorAttachmentsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Launch a compute pass that reads a TileAttachmentQCOM image backed by the "
+                     "color attachment of the current subpass, but tileShadingColorAttachments is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDispatch);
+    RETURN_IF_SKIP(Init());
+    InitTileShadingRenderTarget();
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM, rgba8) uniform readonly image2D tile_img;
+
+        void main() {
+            uvec2 pixel_loc = gl_TileOffsetQCOM + uvec2(gl_GlobalInvocationID.xy);
+            vec4 color = imageLoad(tile_img, ivec2(pixel_loc));
+            if (color.x > 0.5) {}
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3};
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, nullptr, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                          VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0, 0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpTypeImage-10707");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, TileShadingDepthAttachmentsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Launch a compute pass that reads a TileAttachmentQCOM image backed by the "
+                     "depth aspect of the depth attachment, but tileShadingDepthAttachments is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDispatch);
+    AddRequiredFeature(vkt::Feature::tileShadingColorAttachments);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t width = 64;
+    constexpr uint32_t height = 64;
+    constexpr VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
+    constexpr VkFormat ds_format = VK_FORMAT_D32_SFLOAT;
+
+    vkt::Image color_image{*m_device, width, height, color_format,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT};
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkImageCreateInfo ds_ci = vku::InitStructHelper();
+    ds_ci.imageType = VK_IMAGE_TYPE_2D;
+    ds_ci.format = ds_format;
+    ds_ci.extent = {width, height, 1};
+    ds_ci.mipLevels = 1;
+    ds_ci.arrayLayers = 1;
+    ds_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    ds_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ds_ci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+    ds_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    vkt::Image ds_image{*m_device, ds_ci, vkt::set_layout};
+    vkt::ImageView ds_view = ds_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM, r32f) uniform readonly image2D tile_img;
+
+        void main() {
+            uvec2 pixel_loc = gl_TileOffsetQCOM + uvec2(gl_GlobalInvocationID.xy);
+            vec4 depth = imageLoad(tile_img, ivec2(pixel_loc));
+            if (depth.x > 0.5) {}
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3};
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, ds_view, nullptr, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                          VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
+    depth_attachment.imageView = ds_view;
+    depth_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {width, height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+    rendering_info.pDepthAttachment = &depth_attachment;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpTypeImage-10708");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, TileShadingStencilAttachmentsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Launch a compute pass that reads a TileAttachmentQCOM image backed by the "
+                     "stencil aspect of the depth/stencil attachment, but tileShadingStencilAttachments is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDispatch);
+    AddRequiredFeature(vkt::Feature::tileShadingColorAttachments);
+    AddRequiredFeature(vkt::Feature::tileShadingDepthAttachments);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t width = 64;
+    constexpr uint32_t height = 64;
+    constexpr VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
+
+    VkFormat ds_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : {VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT}) {
+        if (FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL,
+                                       VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+            ds_format = format;
+            break;
+        }
+    }
+    if (ds_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "No depth/stencil format supports combined DEPTH_STENCIL_ATTACHMENT and STORAGE usage, skipping test.";
+    }
+
+    vkt::Image color_image{*m_device, width, height, color_format,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT};
+    vkt::ImageView color_view = color_image.CreateView();
+
+    VkImageCreateInfo ds_ci = vku::InitStructHelper();
+    ds_ci.imageType = VK_IMAGE_TYPE_2D;
+    ds_ci.format = ds_format;
+    ds_ci.extent = {width, height, 1};
+    ds_ci.mipLevels = 1;
+    ds_ci.arrayLayers = 1;
+    ds_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    ds_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ds_ci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+    ds_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    vkt::Image ds_image{*m_device, ds_ci, vkt::set_layout};
+    vkt::ImageView stencil_view = ds_image.CreateView(VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM, r8ui) uniform readonly uimage2D tile_img;
+
+        void main() {
+            uvec2 pixel_loc = gl_TileOffsetQCOM + uvec2(gl_GlobalInvocationID.xy);
+            uvec4 stencil = imageLoad(tile_img, ivec2(pixel_loc));
+            if (stencil.x > 0u) {}
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3};
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, stencil_view, nullptr, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                          VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderingAttachmentInfo stencil_attachment = vku::InitStructHelper();
+    stencil_attachment.imageView = stencil_view;
+    stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, {width, height}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+    rendering_info.pStencilAttachment = &stencil_attachment;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpTypeImage-10709");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, TileShadingInputAttachmentsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Launch a compute pass that reads a TileAttachmentQCOM image backed by the "
+                     "input attachment of the current subpass, but tileShadingInputAttachments is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDispatch);
+    AddRequiredFeature(vkt::Feature::tileShadingColorAttachments);
+    RETURN_IF_SKIP(Init());
+
+    constexpr uint32_t width = 64;
+    constexpr uint32_t height = 64;
+    constexpr VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
+
+    vkt::Image color_image{*m_device, width, height, color_format,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT};
+    vkt::ImageView color_view = color_image.CreateView();
+
+    vkt::Image input_image{*m_device, width, height, color_format,
+                           VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT};
+    vkt::ImageView input_view = input_image.CreateView();
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM, rgba8) uniform readonly image2D tile_img;
+
+        void main() {
+            uvec2 pixel_loc = gl_TileOffsetQCOM + uvec2(gl_GlobalInvocationID.xy);
+            vec4 color = imageLoad(tile_img, ivec2(pixel_loc));
+            if (color.x > 0.5) {}
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3};
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, input_view, nullptr, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                          VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    std::array<VkAttachmentDescription, 2> attachment_descs{};
+    attachment_descs[0].format = color_format;
+    attachment_descs[0].samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_descs[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    attachment_descs[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment_descs[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_descs[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_descs[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    attachment_descs[0].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment_descs[1].format = color_format;
+    attachment_descs[1].samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_descs[1].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attachment_descs[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_descs[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_descs[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    attachment_descs[1].initialLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    attachment_descs[1].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkAttachmentReference color_ref{0, VK_IMAGE_LAYOUT_GENERAL};
+    VkAttachmentReference input_ref{1, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpass_desc{};
+    subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_desc.colorAttachmentCount = 1;
+    subpass_desc.pColorAttachments = &color_ref;
+    subpass_desc.inputAttachmentCount = 1;
+    subpass_desc.pInputAttachments = &input_ref;
+
+    VkSubpassDependency dependency{};
+    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dependency.dstSubpass = 0;
+    dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.srcAccessMask = 0;
+    dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&tile_shading_ci);
+    rp_ci.attachmentCount = attachment_descs.size();
+    rp_ci.pAttachments = attachment_descs.data();
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass_desc;
+    rp_ci.dependencyCount = 1;
+    rp_ci.pDependencies = &dependency;
+    vkt::RenderPass tile_shading_render_pass{*m_device, rp_ci};
+
+    VkImageView fb_attachments[2]{color_view.handle(), input_view.handle()};
+    vkt::Framebuffer tile_shading_framebuffer{*m_device, tile_shading_render_pass, 2, fb_attachments, width, height};
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = tile_shading_render_pass;
+    rp_begin_info.framebuffer = tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0, 0}, {width, height}};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpTypeImage-10710");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, TileShadingSampledAttachmentsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Launch a compute pass that samples a TileAttachmentQCOM image backed by an attachment "
+                     "of the current subpass, but tileShadingSampledAttachments is not enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDraw);
+    AddRequiredFeature(vkt::Feature::tileShadingPerTileDispatch);
+    AddRequiredFeature(vkt::Feature::tileShadingColorAttachments);
+    RETURN_IF_SKIP(Init());
+    InitTileShadingRenderTarget();
+
+    vkt::Sampler sampler{*m_device, SafeSaneSamplerCreateInfo()};
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM) uniform sampler2D sampled_tex;
+
+        void main() {
+            uvec2 pixel_loc = gl_TileOffsetQCOM + uvec2(gl_GlobalInvocationID.xy);
+            vec4 color = texture(sampled_tex, vec2(pixel_loc) / vec2(64.0, 64.0));
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
+    compute_pipe.dsl_bindings_ = {
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+    };
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                                          VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0, 0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpTypeSampledImage-10711");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}

--- a/tests/unit/tile_shading_positive.cpp
+++ b/tests/unit/tile_shading_positive.cpp
@@ -46,11 +46,11 @@ void TileShadingTest::InitTileShadingRenderTarget() {
         attachment_desc2.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         attachment_desc2.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
         attachment_desc2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_desc2.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         VkAttachmentReference2 color_ref2 = vku::InitStructHelper();
         color_ref2.attachment = 0;
-        color_ref2.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref2.layout = VK_IMAGE_LAYOUT_GENERAL;
         color_ref2.aspectMask = 0;
 
         VkSubpassDescription2 subpass_desc2 = vku::InitStructHelper();
@@ -93,11 +93,11 @@ void TileShadingTest::InitTileShadingRenderTarget() {
         attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         attachment_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
         attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachment_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         VkAttachmentReference color_ref{};
         color_ref.attachment = 0;
-        color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_ref.layout = VK_IMAGE_LAYOUT_GENERAL;
 
         VkSubpassDescription subpass_desc{};
         subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
@@ -765,6 +765,71 @@ TEST_F(PositiveTileShading, DispatchInsidePerTileExecutionModelAndTileShadingRen
     m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveTileShading, DispatchReadImageBackingOfTileAttachmentAfterDrawWrite) {
+    TEST_DESCRIPTION("Launch a dispatch read via tile attachment api after a tile-shading draw write "
+                     "the memory backing image subresource in the same subpass.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+    InitTileShadingRenderTarget();
+
+    VkShaderObj vs{*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_3};
+    VkShaderObj fs{*m_device, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_3};
+
+    CreatePipelineHelper tile_shading_graphics_pipe{*this};
+    tile_shading_graphics_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    tile_shading_graphics_pipe.gp_ci_.renderPass = m_tile_shading_render_pass;
+    tile_shading_graphics_pipe.CreateGraphicsPipeline();
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM, rgba8) uniform readonly image2D tile_img;
+
+        void main() {
+            uvec2 pixel_loc = gl_TileOffsetQCOM + uvec2(gl_GlobalInvocationID.xy);
+            vec4 color = imageLoad(tile_img, ivec2(pixel_loc));
+            vec4 out_color = vec4(1.0) - color;
+            if (out_color.x > 0.5) {}
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3};
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, nullptr, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0,0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, tile_shading_graphics_pipe);
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
     m_command_buffer.EndRenderPass();


### PR DESCRIPTION
# Overview
Adds SPIRV validation for `VK_QCOM_tile_shading` (1/2):
- `VUID-RuntimeSpirv-TileShadingQCOM-10698`
- `VUID-RuntimeSpirv-TileShadingQCOM-10699`
- `VUID-RuntimeSpirv-TileShadingQCOM-10700`
- `VUID-RuntimeSpirv-TileShadingQCOM-10701`
- `VUID-RuntimeSpirv-x-10702`
- `VUID-RuntimeSpirv-y-10703`
- `VUID-RuntimeSpirv-OpTypeImage-10707`
- `VUID-RuntimeSpirv-OpTypeImage-10709`
- `VUID-RuntimeSpirv-OpTypeImage-10710`
- `VUID-RuntimeSpirv-OpTypeSampledImage-10711`

# Unit Tests

| Test | VUID & Description |
|------|------|
| `CapabilityInComputeShaderFeatureNotEnabled` | 10698 |
| `CapabilityInFragmentShaderFeatureNotEnabled` | 10699 |
| `CapabilityInComputeShaderOutsideTileShadingRenderPass` | 10700, 10701 |
| `CapabilityInComputeShaderObjectOutsideTileShadingRenderPass` | 10700, 10701, `ShaderObject` |
| `CapabilityInFragmentShaderOutsideTileShadingRenderPass` | 10700 |
| `CapabilityInFragmentShaderObjectOutsideTileShadingRenderPass` | 10700, `ShaderObject` |
| `MaxTileShadingRateWidth` | 10702 |
| `MaxTileShadingRateHeight` | 10703 |
| `TileShadingColorAttachmentsFeatureNotEnabled` | 10707 |
| `TileShadingDepthAttachmentsFeatureNotEnabled` | 10708, `DynamicRendering` |
| `TileShadingStencilAttachmentsFeatureNotEnabled` | 10709, `DynamicRendering` |
| `TileShadingInputAttachmentsFeatureNotEnabled` | 10710 |
| `TileShadingSampledAttachmentsFeatureNotEnabled` | 10711 |
| `DispatchReadImageBackingOfTileAttachmentAfterDrawWrite` | Positive |