### PR TITLE
layers: Fix 13357 using Image not ImageView

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2007,19 +2007,21 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create
         }
     }
 
+    if (image_flags & VK_IMAGE_CREATE_ALIAS_SINGLE_LAYER_DESCRIPTOR_BIT_KHR) {
+        if (vkuFormatIsMultiplane(view_format)) {
+            skip |= LogError("VUID-VkImageViewCreateInfo-image-13357", create_info.image, create_info_loc.dot(Field::format),
+                             "(%s) is a multiplane format, but the image was created with flag "
+                             "VK_IMAGE_CREATE_ALIAS_SINGLE_LAYER_DESCRIPTOR_BIT_KHR. (image flags: %s).",
+                             string_VkFormat(view_format), string_VkImageCreateFlags(image_flags).c_str());
+        }
+    }
+
     const bool multiplane_image = vkuFormatIsMultiplane(image_format);
     if (multiplane_image) {
         if (IsMultiplePlaneAspect(aspect_mask)) {
             skip |= LogError("VUID-VkImageViewCreateInfo-subresourceRange-07818", create_info.image,
                              create_info_loc.dot(Field::subresourceRange).dot(Field::aspectMask), "(%s) is invalid for %s.",
                              string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_format));
-        }
-
-        if (image_flags & VK_IMAGE_CREATE_ALIAS_SINGLE_LAYER_DESCRIPTOR_BIT_KHR) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-image-13357", create_info.image, create_info_loc.dot(Field::format),
-                             "(%s) is a multiplane format, but the image was created with flag "
-                             "VK_IMAGE_CREATE_ALIAS_SINGLE_LAYER_DESCRIPTOR_BIT_KHR. (image flags: %s).",
-                             string_VkFormat(view_format), string_VkImageCreateFlags(image_flags).c_str());
         }
     }
 
@@ -2065,10 +2067,11 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo& create
             }
         }
     } else if (image_format != view_format) {
-        skip |= LogError("VUID-VkImageViewCreateInfo-image-12397", create_info.image, create_info_loc.dot(Field::format),
-                         "%s is different from %s format (%s). Formats must be identical unless VK_IMAGE_CREATE_MUTABLE_FORMAT was "
-                         "set on image creation.",
-                         string_VkFormat(view_format), FormatHandle(create_info.image).c_str(), string_VkFormat(image_format));
+        skip |=
+            LogError("VUID-VkImageViewCreateInfo-image-12397", create_info.image, create_info_loc.dot(Field::format),
+                     "%s is different from %s format (%s). Formats must be identical unless VK_IMAGE_CREATE_MUTABLE_FORMAT)BIT was "
+                     "set on image creation.",
+                     string_VkFormat(view_format), FormatHandle(create_info.image).c_str(), string_VkFormat(image_format));
     }
 
     if (image_state.GetSamples() != VK_SAMPLE_COUNT_1_BIT && view_type != VK_IMAGE_VIEW_TYPE_2D &&

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -945,3 +945,22 @@ TEST_F(PositiveImage, BlockTexelViewLayerCount) {
     // Test that VK_REMAINING_ARRAY_LAYERS evaluates to 1
     vkt::ImageView view(*m_device, image_view_ci);
 }
+
+TEST_F(PositiveImage, ImageSingleLayerDescriptorFlagButMultiplanarImageView) {
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_11_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance11);
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    RETURN_IF_SKIP(Init());
+
+    auto image_ci =
+        vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image_ci.flags |= VK_IMAGE_CREATE_ALIAS_SINGLE_LAYER_DESCRIPTOR_BIT_KHR | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
+
+    vkt::Image image(*m_device, image_ci);
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
+    image_view_ci.image = image;
+    image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    image_view_ci.format = VK_FORMAT_R8_UNORM;
+    image_view_ci.subresourceRange = {VK_IMAGE_ASPECT_PLANE_0_BIT, 0u, 1u, 0u, VK_REMAINING_ARRAY_LAYERS};
+    vkt::ImageView view(*m_device, image_view_ci);
+}


### PR DESCRIPTION
This was printing

```
Validation Error: [ VUID-VkImageViewCreateInfo-image-13357 ] | MessageID = 0xd425e585
vkCreateImageView(): pCreateInfo->format (VK_FORMAT_R8_UNORM) is a multiplane format, but the image was created with flag VK_IMAGE_CREATE_ALIAS_SINGLE_LAYER_DESCRIPTOR_BIT_KHR. (image flags: VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT|VK_IMAGE_CREATE_ALIAS_SINGLE_LAYER_DESCRIPTOR_BIT_KHR).
```

because we were using `image_format`, not `image_view_format`