### PR TITLE
layers: Add VK_QCOM_queue_perf_hint VUIDs

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -371,6 +371,7 @@ vvl_sources = [
   "layers/stateless/sl_image.cpp",
   "layers/stateless/sl_instance_device.cpp",
   "layers/stateless/sl_pipeline.cpp",
+  "layers/stateless/sl_queue.cpp",
   "layers/stateless/sl_ray_tracing.cpp",
   "layers/stateless/sl_ray_tracing_micromap.cpp",
   "layers/stateless/sl_ray_tracing_nv.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -453,6 +453,7 @@ target_sources(vvl PRIVATE
     stateless/sl_image.cpp
     stateless/sl_instance_device.cpp
     stateless/sl_pipeline.cpp
+    stateless/sl_queue.cpp
     stateless/sl_ray_tracing.cpp
     stateless/sl_ray_tracing_micromap.cpp
     stateless/sl_ray_tracing_nv.cpp

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -26,6 +26,7 @@
 #include "cc_synchronization.h"
 #include "core_validation.h"
 #include "core_checks/cc_state_tracker.h"
+#include "generated/dispatch_functions.h"
 #include "state_tracker/queue_state.h"
 #include "state_tracker/semaphore_state.h"
 #include "state_tracker/image_state.h"
@@ -841,5 +842,24 @@ bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
             }
         }
     }
+    return skip;
+}
+
+bool CoreChecks::PreCallValidateQueueSetPerfHintQCOM(VkQueue queue, const VkPerfHintInfoQCOM* pPerfHintInfo,
+                                                     const ErrorObject& error_obj) const {
+    bool skip = false;
+    const auto queue_state = Get<vvl::Queue>(queue);
+
+    // Query here as should not be a common call to need to save in state tracker
+    VkPhysicalDeviceQueuePerfHintPropertiesQCOM queue_perf_hint_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&queue_perf_hint_props);
+    DispatchGetPhysicalDeviceProperties2Helper(api_version, physical_device, &props2);
+
+    if ((queue_state->GetQueueFlags() & queue_perf_hint_props.supportedQueues) == 0) {
+        skip |= LogError("VUID-vkQueueSetPerfHintQCOM-queue-12388", queue, error_obj.location,
+                         "the queue with flags (%s) doesn't support queue performance hints.",
+                         string_VkQueueFlags(queue_state->GetQueueFlags()).c_str());
+    }
+
     return skip;
 }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -3037,6 +3037,9 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateBoundTileMemory(const vvl::Bindable& bindable, const vvl::CommandBuffer& cb_state,
                                  const Location& loc) const override;
 
+    bool PreCallValidateQueueSetPerfHintQCOM(VkQueue queue, const VkPerfHintInfoQCOM* pPerfHintInfo,
+                                             const ErrorObject& error_obj) const override;
+
     void Created(vvl::CommandBuffer& cb) override;
     void Created(vvl::Queue& queue) override;
 

--- a/layers/stateless/sl_queue.cpp
+++ b/layers/stateless/sl_queue.cpp
@@ -1,0 +1,50 @@
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2026 Qualcomm Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stateless/stateless_validation.h"
+
+namespace stateless {
+
+bool Device::manual_PreCallValidateQueueSetPerfHintQCOM(VkQueue queue, const VkPerfHintInfoQCOM *pPerfHintInfo,
+                                                        const Context &context) const {
+    bool skip = false;
+
+    if (!enabled_features.queuePerfHint) {
+        skip |= LogError("VUID-vkQueueSetPerfHintQCOM-queuePerfHint-12387", queue, context.error_obj.location,
+                         "VkPhysicalDeviceQueuePerfHintFeaturesQCOM::queuePerfHint feature isn't enabled.");
+    }
+
+    if (pPerfHintInfo) {
+        if (pPerfHintInfo->type != VK_PERF_HINT_TYPE_FREQUENCY_SCALED_QCOM && pPerfHintInfo->scale != 0) {
+            const Location perf_hint_scale_loc = context.error_obj.location.pNext(Struct::VkPerfHintInfoQCOM, Field::scale);
+            skip |= LogError("VUID-VkPerfHintInfoQCOM-type-12389", queue, perf_hint_scale_loc,
+                             "(%" PRIu32 ") is non zero, but VkPerfHintInfoQCOM::type is %s.",
+                             pPerfHintInfo->scale, string_VkPerfHintTypeQCOM(pPerfHintInfo->type));
+        }
+        if (pPerfHintInfo->scale > 100) {
+            const Location perf_hint_scale_loc = context.error_obj.location.pNext(Struct::VkPerfHintInfoQCOM, Field::scale);
+            skip |= LogError("VUID-VkPerfHintInfoQCOM-scale-12390", queue, perf_hint_scale_loc,
+                             "(%" PRIu32 ") is greater than 100.",
+                             pPerfHintInfo->scale);
+        }
+    }
+
+    return skip;
+}
+
+}  // namespace stateless

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1379,6 +1379,8 @@ class Device : public vvl::BaseDevice {
                                                             const Context &context) const;
     bool manual_PreCallValidateCmdDispatchTileQCOM(VkCommandBuffer commandBuffer, const VkDispatchTileInfoQCOM* pDispatchTileInfo,
                                                    const Context& context) const;
+    bool manual_PreCallValidateQueueSetPerfHintQCOM(VkQueue queue, const VkPerfHintInfoQCOM *pPerfHintInfo,
+                                                    const Context &context) const;
 
 #include "generated/stateless_device_methods.h"
 };

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -24766,6 +24766,7 @@ bool Device::PreCallValidateQueueSetPerfHintQCOM(VkQueue queue, const VkPerfHint
         skip |= context.ValidateRangedEnum(pPerfHintInfo_loc.dot(Field::type), vvl::Enum::VkPerfHintTypeQCOM, pPerfHintInfo->type,
                                            "VUID-VkPerfHintInfoQCOM-type-parameter");
     }
+    if (!skip) skip |= manual_PreCallValidateQueueSetPerfHintQCOM(queue, pPerfHintInfo, context);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -288,6 +288,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkCmdBeginTransformFeedback2EXT',
             'vkCmdBeginPerTileExecutionQCOM',
             'vkCmdDispatchTileQCOM',
+            'vkQueueSetPerfHintQCOM',
         ]
 
         # Commands to ignore

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1815,6 +1815,12 @@
                 "VkPhysicalDeviceShaderMultipleWaitQueuesPropertiesQCOM": {
                     "maxShaderWaitQueues": 2
                 },
+                "VkPhysicalDeviceQueuePerfHintPropertiesQCOM": {
+                    "supportedQueues": [
+                        "VK_QUEUE_GRAPHICS_BIT",
+                        "VK_QUEUE_COMPUTE_BIT"
+                    ]
+                },
                 "VkPhysicalDeviceTileMemoryHeapPropertiesQCOM": {
                     "queueSubmitBoundary": true,
                     "tileBufferTransfers": true

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -604,3 +604,141 @@ TEST_F(NegativeDeviceQueue, MissingInternallySynchronizedQueuesFeature) {
     vk::CreateDevice(Gpu(), &device_ci, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeDeviceQueue, QueuePerfHintFeatureNotEnabled) {
+    TEST_DESCRIPTION("Try to invoke vkQueueSetPerfHintQCOM API, but queuePerfHint feature isn't enabled.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_QUEUE_PERF_HINT_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkPerfHintInfoQCOM perf_hint_info = vku::InitStructHelper();
+    perf_hint_info.type = VK_PERF_HINT_TYPE_DEFAULT_QCOM;
+    perf_hint_info.scale = 0;
+
+    m_errorMonitor->SetDesiredError("VUID-vkQueueSetPerfHintQCOM-queuePerfHint-12387");
+    vk::QueueSetPerfHintQCOM(m_default_queue->handle(), &perf_hint_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDeviceQueue, QueueNotInPerfHintSupportedQueues) {
+    TEST_DESCRIPTION("Try to invoke vkQueueSetPerfHintQCOM API, but the queue isn't in the perf-hint supported queues.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_QUEUE_PERF_HINT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::queuePerfHint);
+    RETURN_IF_SKIP(InitFramework());
+
+    VkPhysicalDeviceQueuePerfHintPropertiesQCOM perf_hint_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(perf_hint_props);
+    const VkQueueFlags supported_queues = perf_hint_props.supportedQueues;
+
+    uint32_t queue_family_count = 0;
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> queue_family_props(queue_family_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_family_props.data());
+
+    uint32_t bad_queue_family_index = std::numeric_limits<uint32_t>::max();
+    for (uint32_t index = 0; index < queue_family_count; ++index) {
+        if ((queue_family_props[index].queueFlags & supported_queues) == 0) {
+            bad_queue_family_index = index;
+            break;
+        }
+    }
+    if (bad_queue_family_index == std::numeric_limits<uint32_t>::max()) {
+        GTEST_SKIP() << "Failed to find the queue family that doesn't support queue perf-hint property, skipping test.";
+    }
+
+    RETURN_IF_SKIP(InitState());
+
+    VkQueue bad_queue = VK_NULL_HANDLE;
+    vk::GetDeviceQueue(device(), bad_queue_family_index, 0, &bad_queue);
+
+    VkPerfHintInfoQCOM perf_hint_info = vku::InitStructHelper();
+    perf_hint_info.type = VK_PERF_HINT_TYPE_DEFAULT_QCOM;
+    perf_hint_info.scale = 0;
+
+    m_errorMonitor->SetDesiredError("VUID-vkQueueSetPerfHintQCOM-queue-12388");
+    vk::QueueSetPerfHintQCOM(bad_queue, &perf_hint_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDeviceQueue, MaxFrequencyPerfHintButNotZeroScale) {
+    TEST_DESCRIPTION("Try to invoke vkQueueSetPerfHintQCOM API with maximum frequency perf-hint, but the scale isn't zero.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_QUEUE_PERF_HINT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::queuePerfHint);
+    RETURN_IF_SKIP(InitFramework());
+
+    VkPhysicalDeviceQueuePerfHintPropertiesQCOM perf_hint_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(perf_hint_props);
+    const VkQueueFlags supported_queues = perf_hint_props.supportedQueues;
+
+    uint32_t queue_family_count = 0;
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> queue_family_props(queue_family_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_family_props.data());
+
+    uint32_t expected_queue_family_index = std::numeric_limits<uint32_t>::max();
+    for (uint32_t index = 0; index < queue_family_count; ++index) {
+        if ((queue_family_props[index].queueFlags & supported_queues) != 0) {
+            expected_queue_family_index = index;
+            break;
+        }
+    }
+    if (expected_queue_family_index == std::numeric_limits<uint32_t>::max()) {
+        GTEST_SKIP() << "Failed to find the queue family that supports queue perf-hint property, skipping test.";
+    }
+
+    RETURN_IF_SKIP(InitState());
+
+    VkQueue perf_hint_queue = VK_NULL_HANDLE;
+    vk::GetDeviceQueue(device(), expected_queue_family_index, 0, &perf_hint_queue);
+
+    VkPerfHintInfoQCOM perf_hint_info = vku::InitStructHelper();
+    perf_hint_info.type = VK_PERF_HINT_TYPE_FREQUENCY_MAX_QCOM;
+    perf_hint_info.scale = 100;
+
+    m_errorMonitor->SetDesiredError("VUID-VkPerfHintInfoQCOM-type-12389");
+    vk::QueueSetPerfHintQCOM(perf_hint_queue, &perf_hint_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDeviceQueue, ScaledFrequencyPerfHintButInvalidScale) {
+    TEST_DESCRIPTION("Try to invoke vkQueueSetPerfHintQCOM API with scaled frequency perf-hint, but the scale is greater than 100.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_QUEUE_PERF_HINT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::queuePerfHint);
+    RETURN_IF_SKIP(InitFramework());
+
+    VkPhysicalDeviceQueuePerfHintPropertiesQCOM perf_hint_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(perf_hint_props);
+    const VkQueueFlags supported_queues = perf_hint_props.supportedQueues;
+
+    uint32_t queue_family_count = 0;
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> queue_family_props(queue_family_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_family_props.data());
+
+    uint32_t expected_queue_family_index = std::numeric_limits<uint32_t>::max();
+    for (uint32_t index = 0; index < queue_family_count; ++index) {
+        if ((queue_family_props[index].queueFlags & supported_queues) != 0) {
+            expected_queue_family_index = index;
+            break;
+        }
+    }
+    if (expected_queue_family_index == std::numeric_limits<uint32_t>::max()) {
+        GTEST_SKIP() << "Failed to find the queue family that supports queue perf-hint property, skipping test.";
+    }
+
+    RETURN_IF_SKIP(InitState());
+
+    VkQueue perf_hint_queue = VK_NULL_HANDLE;
+    vk::GetDeviceQueue(device(), expected_queue_family_index, 0, &perf_hint_queue);
+
+    VkPerfHintInfoQCOM perf_hint_info = vku::InitStructHelper();
+    perf_hint_info.type = VK_PERF_HINT_TYPE_FREQUENCY_SCALED_QCOM;
+    perf_hint_info.scale = 120;
+
+    m_errorMonitor->SetDesiredError("VUID-VkPerfHintInfoQCOM-scale-12390");
+    vk::QueueSetPerfHintQCOM(perf_hint_queue, &perf_hint_info);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/device_queue_positive.cpp
+++ b/tests/unit/device_queue_positive.cpp
@@ -93,3 +93,57 @@ TEST_F(PositiveDeviceQueue, QueueFamilyIndexDifferentCreateFlags) {
     vk::CreateDevice(Gpu(), &device_ci, nullptr, &test_device);
     vk::DestroyDevice(test_device, nullptr);
 }
+
+TEST_F(PositiveDeviceQueue, MultipleQueuePerfHint) {
+    TEST_DESCRIPTION("Test vkQueueSetPerfHintQCOM on all supported queues.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_QUEUE_PERF_HINT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::queuePerfHint);
+    RETURN_IF_SKIP(InitFramework());
+
+    VkPhysicalDeviceQueuePerfHintPropertiesQCOM perf_hint_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(perf_hint_props);
+    const VkQueueFlags supported_queues = perf_hint_props.supportedQueues;
+
+    uint32_t queue_family_count = 0;
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
+    std::vector<VkQueueFamilyProperties> queue_family_props(queue_family_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_family_props.data());
+
+    std::vector<uint32_t> supported_queue_ids{};
+    for (uint32_t index = 0; index < queue_family_count; ++index) {
+        if ((queue_family_props[index].queueFlags & supported_queues) != 0) {
+            supported_queue_ids.push_back(index);
+        }
+    }
+    if (supported_queue_ids.empty()) {
+        GTEST_SKIP() << "Failed to find the queue family that supports queue perf-hint property, skipping test.";
+    }
+
+    RETURN_IF_SKIP(InitState());
+
+    constexpr std::array<VkPerfHintTypeQCOM, 3> hint_types{
+        VK_PERF_HINT_TYPE_FREQUENCY_SCALED_QCOM,
+        VK_PERF_HINT_TYPE_DEFAULT_QCOM,
+        VK_PERF_HINT_TYPE_FREQUENCY_MIN_QCOM,
+    };
+
+    uint32_t index = 0;
+    for (const uint32_t family_id : supported_queue_ids) {
+        VkQueue queue = VK_NULL_HANDLE;
+        vk::GetDeviceQueue(device(), family_id, 0, &queue);
+
+        VkPerfHintInfoQCOM perf_hint_info = vku::InitStructHelper();
+        perf_hint_info.type = hint_types[index];
+        perf_hint_info.scale = 0;
+
+        if (hint_types[index] == VK_PERF_HINT_TYPE_FREQUENCY_SCALED_QCOM) {
+            perf_hint_info.scale = 65;
+        }
+
+        vk::QueueSetPerfHintQCOM(queue, &perf_hint_info);
+
+        ++index;
+        index = index % hint_types.size();
+    }
+}


### PR DESCRIPTION
 # Overview
Adds validation and unit tests for `VK_QCOM_queue_perf_hint`:
- `VUID-vkQueueSetPerfHintQCOM-queuePerfHint-12387`
- `VUID-vkQueueSetPerfHintQCOM-queue-12388`
- `VUID-VkPerfHintInfoQCOM-type-12389`
- `VUID-VkPerfHintInfoQCOM-scale-12390`

This also tracks `VkPhysicalDeviceQueuePerfHintPropertiesQCOM::supportedQueues`
in queue state and updates `max_profile.json`.

# Unit Tests
| Unit test | VUID & Description |
|------|------|
| `QueuePerfHintFeatureNotEnabled` | 12387 |
| `QueueNotInPerfHintSupportedQueues` | 12388 |
| `MaxFrequencyPerfHintButNotZeroScale` | 12389 |
| `ScaledFrequencyPerfHintButInvalidScale` | 12390 |
| `MultipleQueuePerfHint` | `Positive` |

Related to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11339