### PR TITLE
layers: Rework event validation to ignore repeated signals

### DIFF
--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -626,7 +626,15 @@ void CommandBufferSubState::RecordActionCommand(LastBound& last_bound, const Loc
     validator.UpdateBoundDescriptorSets(*this, last_bound, loc);
 }
 
-void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags2, const VkDependencyInfo*) {
+void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags) {
+    if (auto* signaling_info = vvl::Find(event_signaling_state, event)) {
+        signaling_info->signaled = true;
+    } else {
+        event_signaling_state.emplace(event, bp_state::CommandBufferSubState::SignalingInfo(true));
+    }
+}
+
+void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInfo&) {
     if (auto* signaling_info = vvl::Find(event_signaling_state, event)) {
         signaling_info->signaled = true;
     } else {

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -213,7 +213,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment* pAttachments, uint32_t rect_count,
                                 const VkClearRect* pRects, const Location& loc) final;
 
-    void RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stageMask, const VkDependencyInfo* dependency_info) final;
+    void RecordSetEvent(VkEvent event, VkPipelineStageFlags stageMask) final;
+    void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) final;
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask) final;
     void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
                         const VkImageMemoryBarrier* image_barriers, VkPipelineStageFlags src_stage_mask,

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1129,35 +1129,79 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer& 
     return skip;
 }
 
+// Return the signal stage mask when it can be identified from recorded state
+static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent event,
+                                                                        const EventSignalingStateMap& prior_signaling_states,
+                                                                        const EventSignalingStateMap& secondary_signaling_states) {
+    const EventSignalingState* prior_state = vvl::Find(prior_signaling_states, event);
+    const EventSignalingState* secondary_state = vvl::Find(secondary_signaling_states, event);
+
+    if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
+        if (secondary_state->signaled) {
+            return secondary_state->signal_src_stage_mask;
+        }
+        return {};
+    }
+    if (prior_state && prior_state->HasKnownEffect() && prior_state->signaled) {
+        return prior_state->signal_src_stage_mask;
+    }
+    return {};
+}
+
+// Return true when recorded state proves the event is unsignaled at the wait
+static bool IsKnownUnsignaled(VkEvent event, const EventSignalingStateMap& prior_signaling_states,
+                              const EventSignalingStateMap& secondary_signaling_states) {
+    const EventSignalingState* prior_state = vvl::Find(prior_signaling_states, event);
+    const EventSignalingState* secondary_state = vvl::Find(secondary_signaling_states, event);
+
+    if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
+        return !secondary_state->signaled;
+    }
+    return prior_state && prior_state->HasKnownEffect() && !prior_state->signaled;
+}
+
 bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBufferSubState& secondary_cb_sub_state,
                                                           const Location& secondary_cb_loc,
                                                           EventSignalingStateMap& local_signaling_states) const {
     bool skip = false;
     for (const WaitEventSubmitInfo& secondary_wait : secondary_cb_sub_state.wait_event_submit_infos) {
-        auto signaling_states = secondary_wait.signaling_states;
-        AddWaitEventSignalingStates(secondary_wait.wait_events, local_signaling_states, signaling_states);
+        VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
+        bool can_validate = true;
+        bool found_known_signals = false;
 
-        // Do validation if all signaling states are found. Otherwise, validate during submit-time
-        const bool found_all_signaling_states = signaling_states.size() == secondary_wait.wait_events.size();
-        if (found_all_signaling_states) {
-            VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
-            for (const auto& [event, signaling_state] : signaling_states) {
-                signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signaling_state.src_stage_mask);
+        for (VkEvent event : secondary_wait.wait_events) {
+            if (auto stage_mask = ResolveKnownSignalStageMask(event, local_signaling_states, secondary_wait.signaling_states)) {
+                signals_src_stage_mask |= *stage_mask;
+                found_known_signals = true;
+                continue;
             }
-            if (secondary_wait.wait_src_stage_mask != signals_src_stage_mask) {
-                const LogObjectList objlist(secondary_cb_sub_state.Handle());
+            if (IsKnownUnsignaled(event, local_signaling_states, secondary_wait.signaling_states)) {
+                // Contribute 0 to signals_src_stage_mask
+                continue;
+            }
+            can_validate = false;
+            break;
+        }
+        if (can_validate && secondary_wait.wait_src_stage_mask != signals_src_stage_mask) {
+            const LogObjectList objlist(secondary_cb_sub_state.Handle());
+            if (found_known_signals) {
                 std::ostringstream ss;
                 ss << "(" << FormatHandle(secondary_cb_sub_state.Handle()) << ") contains a vkCmdWaitEvents call with srcStageMask "
                    << string_VkPipelineStageFlags(secondary_wait.wait_src_stage_mask)
                    << ", but the bitwise OR of stageMask values from the most recent vkCmdSetEvent calls is "
                    << string_VkPipelineStageFlags(signals_src_stage_mask);
                 skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, secondary_cb_loc, "%s", ss.str().c_str());
+            } else {
+                std::ostringstream ss;
+                ss << "(" << FormatHandle(secondary_cb_sub_state.Handle()) << ") contains a vkCmdWaitEvents call with srcStageMask "
+                   << string_VkPipelineStageFlags(secondary_wait.wait_src_stage_mask)
+                   << ", but the waited events are known to be unsignaled at this point. The wait does not have a corresponding "
+                      "vkCmdSetEvent signal.";
+                skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, secondary_cb_loc, "%s", ss.str().c_str());
             }
         }
     }
-    for (const auto& [event, signaling_state] : secondary_cb_sub_state.event_signaling_states) {
-        local_signaling_states.insert_or_assign(event, signaling_state);
-    }
+    UpdateEventSignalingStates(local_signaling_states, secondary_cb_sub_state.event_signaling_states);
     return skip;
 }
 

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -586,32 +586,66 @@ void CommandBufferSubState::RecordClearAttachments(uint32_t attachment_count, co
     }
 }
 
-void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask,
-                                           const VkDependencyInfo* dependency_info) {
-    EventSignalingState signaling_state(true, stage_mask);
-    if (dependency_info) {
-        signaling_state.dependency_info.emplace(dependency_info);
+void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags stage_mask) {
+    if (EventSignalingState* state = vvl::Find(event_signaling_states, event)) {
+        if (!state->signaled) {
+            state->signaled = true;
+            state->signal_src_stage_mask = stage_mask;
+            // Keep was_reset unchanged
+        }
+    } else {
+        EventSignalingState new_state;
+        new_state.signaled = true;
+        new_state.signal_src_stage_mask = stage_mask;
+        event_signaling_states.insert(std::make_pair(event, std::move(new_state)));
     }
-    event_signaling_states.insert_or_assign(event, signaling_state);
+    // TODO: this part will be removed soon because event_updates are going to disappear
+    event_updates.emplace_back([event, stage_mask](vvl::CommandBuffer&, bool do_validate, EventMap& local_event_signal_info,
+                                                   VkQueue, const Location& loc) {
+        EventInfo& info = local_event_signal_info[event];
+        if (!info.signal) {
+            info.signal = true;
+            info.src_stage_mask = stage_mask;
+        }
+        return false;  // skip
+    });
+}
 
+void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) {
+    if (EventSignalingState* state = vvl::Find(event_signaling_states, event)) {
+        if (!state->signaled) {
+            state->signaled = true;
+            state->signal_dependency_info.emplace(&dependency_info);
+            // Keep was_reset unchanged
+        }
+    } else {
+        EventSignalingState new_state;
+        new_state.signaled = true;
+        new_state.signal_dependency_info.emplace(&dependency_info);
+        event_signaling_states.insert(std::make_pair(event, std::move(new_state)));
+    }
     // TODO: this part will be removed soon because event_updates are going to disappear
     std::optional<vku::safe_VkDependencyInfo> safe_dependency_info;
-    if (dependency_info) {
-        safe_dependency_info.emplace(dependency_info);
-    }
-    event_updates.emplace_back([event, stage_mask, safe_dependency_info](vvl::CommandBuffer&, bool do_validate,
-                                                                         EventMap& local_event_signal_info, VkQueue,
-                                                                         const Location& loc) {
-        local_event_signal_info[event] = EventInfo{stage_mask, true, safe_dependency_info};
+    safe_dependency_info.emplace(&dependency_info);
+    event_updates.emplace_back([event, safe_dependency_info](vvl::CommandBuffer&, bool do_validate,
+                                                             EventMap& local_event_signal_info, VkQueue, const Location& loc) {
+        EventInfo& info = local_event_signal_info[event];
+        if (!info.signal) {
+            info.signal = true;
+            info.dependency_info = safe_dependency_info;
+        }
         return false;  // skip
     });
 }
 
 void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags2) {
-    event_signaling_states.insert_or_assign(event, EventSignalingState(false));
+    EventSignalingState& signaling_state = event_signaling_states[event];
+    signaling_state = {};
+    signaling_state.was_reset = true;
+
     event_updates.emplace_back(
         [event](vvl::CommandBuffer&, bool do_validate, EventMap& local_event_signal_info, VkQueue, const Location& loc) {
-            local_event_signal_info[event] = EventInfo{VK_PIPELINE_STAGE_2_NONE, false, {}};
+            local_event_signal_info[event] = EventInfo{VK_PIPELINE_STAGE_2_NONE, false, {}, true};
             return false;  // skip
         });
 }
@@ -619,13 +653,15 @@ void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags
 void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask,
                                              const Location& loc) {
     bool submit_validation = false;
-    EventSignalingStateMap cb_signaling_states;
+    EventSignalingStateMap signaling_states;
     for (VkEvent event : events) {
-        if (const EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event)) {
-            cb_signaling_states.emplace(event, *signaling_state);
-        } else {
-            // Command buffer does not signal the waited event.
-            // The wait can be validated only during submit time
+        const EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
+        if (signaling_state) {
+            signaling_states.emplace(event, *signaling_state);
+        }
+        // NOTE: the same logic is used by the validation phase
+        const bool already_validated = signaling_state && signaling_state->HasKnownEffect();
+        if (!already_validated) {
             submit_validation = true;
         }
     }
@@ -633,7 +669,7 @@ void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, Vk
         WaitEventSubmitInfo submit_info;
         submit_info.wait_events.assign(events.begin(), events.end());
         submit_info.wait_src_stage_mask = src_stage_mask;
-        submit_info.signaling_states = std::move(cb_signaling_states);
+        submit_info.signaling_states = std::move(signaling_states);
         wait_event_submit_infos.emplace_back(std::move(submit_info));
     }
 
@@ -651,7 +687,9 @@ void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, Vk
 }
 
 void CommandBufferSubState::RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
-    const bool submit_validation = !vvl::Contains(event_signaling_states, event);
+    const EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
+    const bool already_validated = signaling_state && signaling_state->was_reset;
+    const bool submit_validation = !already_validated;
     if (submit_validation) {
         WaitEvent2SubmitInfo submit_info;
         submit_info.wait_event = event;
@@ -1153,6 +1191,36 @@ void CommandBufferSubState::ResetCBState() {
     scissor.used_dynamic_count = false;
 }
 
+static std::optional<WaitEventSubmitInfo> BuildSubmitTimeWaitInfo(const WaitEventSubmitInfo& secondary_wait,
+                                                                  const EventSignalingStateMap& primary_states) {
+    EventSignalingStateMap wait_signaling_states;
+    bool all_signaling_states_known = true;
+    for (VkEvent event : secondary_wait.wait_events) {
+        const EventSignalingState* primary_state = vvl::Find(primary_states, event);
+        const EventSignalingState* secondary_state = vvl::Find(secondary_wait.signaling_states, event);
+
+        const bool primary_state_known = primary_state && primary_state->HasKnownEffect();
+        const bool secondary_state_known = secondary_state && secondary_state->HasKnownEffect(primary_state);
+        if (secondary_state_known || (!primary_state && secondary_state)) {
+            wait_signaling_states[event] = *secondary_state;
+        } else if (primary_state) {
+            wait_signaling_states[event] = *primary_state;
+        }
+
+        const bool state_known = primary_state_known || secondary_state_known;
+        if (!state_known) {
+            all_signaling_states_known = false;
+        }
+    }
+    if (all_signaling_states_known) {
+        // Record-time validation already had enough information, no need to schedule submit-time validation
+        return {};
+    }
+    WaitEventSubmitInfo wait = secondary_wait;
+    wait.signaling_states = std::move(wait_signaling_states);
+    return wait;
+}
+
 void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_command_buffer, uint32_t, const Location&) {
     auto& secondary_sub_state = SubState(secondary_command_buffer);
     if (secondary_command_buffer.IsSecondary()) {
@@ -1164,16 +1232,8 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
     }
 
     for (const WaitEventSubmitInfo& secondary_wait : secondary_sub_state.wait_event_submit_infos) {
-        auto signaling_states = secondary_wait.signaling_states;
-        AddWaitEventSignalingStates(secondary_wait.wait_events, event_signaling_states, signaling_states);
-
-        // Do nothing if all signaling states are found: validation has already run during vkCmdExecuteCommands.
-        // Otherwise, schedule submit-time validation
-        const bool found_all_signaling_states = signaling_states.size() == secondary_wait.wait_events.size();
-        if (!found_all_signaling_states) {
-            WaitEventSubmitInfo wait = secondary_wait;
-            wait.signaling_states = std::move(signaling_states);
-            wait_event_submit_infos.emplace_back(wait);
+        if (auto wait = BuildSubmitTimeWaitInfo(secondary_wait, event_signaling_states)) {
+            wait_event_submit_infos.emplace_back(std::move(*wait));
         }
     }
     for (const WaitEvent2SubmitInfo& secondary_wait : secondary_sub_state.wait_event2_submit_infos) {
@@ -1182,10 +1242,7 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
             wait_event2_submit_infos.emplace_back(secondary_wait);
         }
     }
-
-    for (auto& [event, event_signaling_state] : secondary_sub_state.event_signaling_states) {
-        event_signaling_states.insert_or_assign(event, event_signaling_state);
-    }
+    UpdateEventSignalingStates(event_signaling_states, secondary_sub_state.event_signaling_states);
 
     for (auto& function : secondary_sub_state.queue_submit_functions) {
         queue_submit_functions.push_back(function);
@@ -1224,10 +1281,20 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
     // Update global vvl:Event state with signaling state at the end of the command buffer
     for (const auto& [event, signaling_state] : event_signaling_states) {
         if (auto event_state = base.dev_data.Get<vvl::Event>(event)) {
-            event_state->signaled = signaling_state.signaled;
-            event_state->signal_src_stage_mask = signaling_state.src_stage_mask;
-            event_state->dependency_info = signaling_state.dependency_info;
-            event_state->signaling_queue = queue_state.VkHandle();
+            if (signaling_state.signaled) {
+                const bool can_signal = !event_state->signaled || signaling_state.was_reset;
+                if (can_signal) {
+                    event_state->signaled = true;
+                    event_state->signal_src_stage_mask = signaling_state.signal_src_stage_mask;
+                    event_state->dependency_info = signaling_state.signal_dependency_info;
+                    event_state->signaling_queue = queue_state.VkHandle();
+                }
+            } else {
+                event_state->signaled = false;
+                event_state->signal_src_stage_mask = VK_PIPELINE_STAGE_NONE;
+                event_state->dependency_info.reset();
+                event_state->signaling_queue = VK_NULL_HANDLE;
+            }
         }
     }
 

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -97,7 +97,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment *pAttachments, uint32_t rect_count,
                                 const VkClearRect *pRects, const Location &loc) final;
 
-    void RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stageMask, const VkDependencyInfo *dependency_info) final;
+    void RecordSetEvent(VkEvent event, VkPipelineStageFlags stageMask) final;
+    void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) final;
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask) final;
     void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) final;
     void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) final;

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -419,20 +419,29 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
 
     VkPipelineStageFlags signals_src_stage_mask = 0;
     for (VkEvent event : wait_events) {
-        auto event_state = core.Get<vvl::Event>(event);
-        if (event_state && !vvl::Contains(signaling_states, event)) {
-            skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signaling_states, loc);
-        }
-        // NOTE: if signaling state is "unsignaled" then src stage mask is NONE
-        if (const auto* cb_signaling = vvl::Find(signaling_states, event)) {
-            // a) signal from the same command buffer
-            signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(cb_signaling->src_stage_mask);
-        } else if (const auto* submit_signaling = vvl::Find(submit_signaling_states, event)) {
-            // b) signals from the previous command buffers of the same submit command
-            signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(submit_signaling->src_stage_mask);
-        } else if (event_state) {
-            // c) global event state
-            signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(event_state->signal_src_stage_mask);
+        if (auto event_state = core.Get<vvl::Event>(event)) {
+            if (!vvl::Contains(signaling_states, event)) {
+                skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signaling_states, loc);
+            }
+            // NOTE: for unsignaled events the signal_src_stage_mask is NONE
+            VkPipelineStageFlags2 stage_mask = 0;
+            bool last_signal = false;
+            if (event_state->signaled) {
+                stage_mask = event_state->signal_src_stage_mask;
+                last_signal = event_state->signaled;
+            }
+            if (const auto* submit_signaling = vvl::Find(submit_signaling_states, event)) {
+                if (!last_signal || submit_signaling->was_reset) {
+                    stage_mask = submit_signaling->src_stage_mask;
+                }
+                last_signal = submit_signaling->signal;
+            }
+            if (const auto* cb_signaling = vvl::Find(signaling_states, event)) {
+                if (!last_signal || cb_signaling->HasKnownEffect()) {
+                    stage_mask = cb_signaling->signal_src_stage_mask;
+                }
+            }
+            signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(stage_mask);
         }
     }
     // Validate src stage mask mismatch
@@ -1526,27 +1535,24 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
 
     if (pEvents) {
         auto& cb_sub_state = core::SubState(*cb_state);
-
-        // Record time validation of VUID 01158 is possible only if all relevant
-        // CmdSetEvent commands are recorded in the same command buffer
-        bool found_all_set_commands = true;
-
-        VkPipelineStageFlags set_event_src_stages = VK_PIPELINE_STAGE_NONE;
+        bool can_validate = true;
+        VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
         for (uint32_t i = 0; i < eventCount; i++) {
             const EventSignalingState* signaling_state = vvl::Find(cb_sub_state.event_signaling_states, pEvents[i]);
-            if (!signaling_state) {
-                found_all_set_commands = false;
+            // NOTE: the same logic is used by the record phase
+            if (!signaling_state || !signaling_state->HasKnownEffect()) {
+                can_validate = false;
                 break;
             }
-            set_event_src_stages |= static_cast<VkPipelineStageFlags>(signaling_state->src_stage_mask);
+            signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signaling_state->signal_src_stage_mask);
         }
-        if (found_all_set_commands) {
-            if (srcStageMask != set_event_src_stages) {
+        if (can_validate) {
+            if (srcStageMask != signals_src_stage_mask) {
                 skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, error_obj.location.dot(Field::srcStageMask),
                                  "is %s, but the bitwise OR of stageMask values from the most recent vkCmdSetEvent call for each "
                                  "waited event is %s.",
                                  string_VkPipelineStageFlags(srcStageMask).c_str(),
-                                 string_VkPipelineStageFlags(set_event_src_stages).c_str());
+                                 string_VkPipelineStageFlags(signals_src_stage_mask).c_str());
             }
         }
     }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -2174,13 +2174,24 @@ void CommandBuffer::RecordUpdateMemory(VkDeviceAddressRangeKHR range, const Loca
     (void)range;
 }
 
-void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const VkDependencyInfo* dependency_info,
-                                   const Location& loc) {
+void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags stage_mask, const Location& loc) {
     RecordCommand(loc);
     for (auto& item : sub_states_) {
-        item.second->RecordSetEvent(event, stage_mask, dependency_info);
+        item.second->RecordSetEvent(event, stage_mask);
     }
+    if (!dev_data.disabled[command_buffer_state]) {
+        if (auto event_state = dev_data.Get<vvl::Event>(event)) {
+            AddChild(event_state);
+        }
+    }
+    events.push_back(event);
+}
 
+void CommandBuffer::RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
+    RecordCommand(loc);
+    for (auto& item : sub_states_) {
+        item.second->RecordSetEvent2(event, dependency_info);
+    }
     if (!dev_data.disabled[command_buffer_state]) {
         if (auto event_state = dev_data.Get<vvl::Event>(event)) {
             AddChild(event_state);

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -760,12 +760,12 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordFillMemory(VkDeviceAddressRangeKHR range, const Location& loc);
     void RecordUpdateMemory(VkDeviceAddressRangeKHR range, const Location& loc);
 
-    void RecordSetEvent(VkEvent event, VkPipelineStageFlags2KHR stageMask, const VkDependencyInfo *dependency_info,
-                        const Location &loc);
+    void RecordSetEvent(VkEvent event, VkPipelineStageFlags stageMask, const Location& loc);
+    void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc);
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2KHR stageMask, const Location &loc);
     void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc);
     void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& dep_info_loc);
-    void RecordPushConstants(const vvl::PipelineLayout &pipeline_layout_state, VkShaderStageFlags stage_flags, uint32_t offset,
+    void RecordPushConstants(const vvl::PipelineLayout& pipeline_layout_state, VkShaderStageFlags stage_flags, uint32_t offset,
                              uint32_t size, const void *values);
     void RecordPushData(const VkPushDataInfoEXT& push_data_info, const Location& loc);
 
@@ -929,7 +929,8 @@ class CommandBufferSubState {
     virtual void RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {}
     virtual void RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {}
 
-    virtual void RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const VkDependencyInfo *dependency_info) {}
+    virtual void RecordSetEvent(VkEvent event, VkPipelineStageFlags stage_mask) {}
+    virtual void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) {}
     virtual void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask) {}
     virtual void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) {}
     virtual void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {}

--- a/layers/state_tracker/event_map.h
+++ b/layers/state_tracker/event_map.h
@@ -32,6 +32,7 @@ struct EventInfo {
     VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_NONE;
     bool signal = false;  // signal (SetEvent) or unsignal (ResetEvent)
     std::optional<vku::safe_VkDependencyInfo> dependency_info;
+    bool was_reset = false;
 };
 using EventMap = vvl::unordered_map<VkEvent, EventInfo>;
 
@@ -40,28 +41,49 @@ struct EventSignalingState {
     // When recording is finished, this is the event state at the end of the command buffer
     bool signaled = false;
 
-    // If signaled is true, this is the stage mask specified by the CmdSetEvent command.
-    // If signaled is false, this is NONE
-    VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_NONE;
+    // If this event was unsignaled at least once during command buffer recording
+    bool was_reset = false;
 
-    // If signaled is true and the event was set by CmdSetEvent2, this is the dependency info from that command
-    std::optional<vku::safe_VkDependencyInfo> dependency_info;
+    // Stage mask from CmdSetEvent.
+    // It is NONE for CmdSetEvent2, or if the event is unsignaled
+    VkPipelineStageFlags2 signal_src_stage_mask = VK_PIPELINE_STAGE_2_NONE;
 
-    EventSignalingState(bool signaled, VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_NONE)
-        : signaled(signaled), src_stage_mask(src_stage_mask) {}
+    // The dependency info from CmdSetEvent2.
+    // It is no value for CmdSetEvent, or if the event is unsignaled
+    std::optional<vku::safe_VkDependencyInfo> signal_dependency_info;
+
+    // Return true if this state's effect on the event is known.
+    // Without a reset or known prior state, we cannot tell whether a signal
+    // in this state is a repeated signal, which the spec says is ignored
+    //
+    // NOTE: this implementation does not try to handle repeated unsignals, which
+    // are also ignored. We do not currently keep data associated with unsignals,
+    // (and for signals we store stage mask/dependency info). Update this if we
+    // need to track associated unsignal data.
+    bool HasKnownEffect(const EventSignalingState* prior_state = nullptr) const {
+        // After a reset, later signal/reset commands define the event state
+        if (was_reset) {
+            return true;
+        }
+        // If the prior state ended unsignaled, this state cannot be a repeated
+        // signal and defines the event state
+        const bool is_prior_unsignaled = prior_state && !prior_state->signaled;
+        return is_prior_unsignaled;
+    }
 };
 using EventSignalingStateMap = vvl::unordered_map<VkEvent, EventSignalingState>;
 
-// TODO: later this file will be renamed to event_state.h/cpp and this function will go into cpp
-static inline void AddWaitEventSignalingStates(const std::vector<VkEvent>& wait_events,
-                                               const EventSignalingStateMap& new_signaling_states,
-                                               EventSignalingStateMap& current_signaling_states) {
-    for (const auto& signaling_state : new_signaling_states) {
-        const VkEvent event = signaling_state.first;
-        const bool is_waited = vvl::Contains(wait_events, event);
-        const bool is_signaled = vvl::Contains(current_signaling_states, event);
-        if (is_waited && !is_signaled) {
-            current_signaling_states.insert(signaling_state);
+inline void UpdateEventSignalingStates(EventSignalingStateMap& accumulated_states, const EventSignalingStateMap& recorded_states) {
+    for (const auto& [event, recorded_state] : recorded_states) {
+        EventSignalingState& accumulated_state = accumulated_states[event];
+
+        const bool keep_accumulated_state = accumulated_state.signaled && !recorded_state.was_reset;
+        if (keep_accumulated_state) {
+            continue;
         }
+
+        const bool was_reset = accumulated_state.was_reset;
+        accumulated_state = recorded_state;
+        accumulated_state.was_reset |= was_reset;
     }
 }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3497,7 +3497,7 @@ void DeviceState::PostCallRecordCmdUpdateMemoryKHR(VkCommandBuffer commandBuffer
 void DeviceState::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
-    cb_state->RecordSetEvent(event, stageMask, nullptr, record_obj.location);
+    cb_state->RecordSetEvent(event, stageMask, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
@@ -3508,9 +3508,7 @@ void DeviceState::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, V
 void DeviceState::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
                                              const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
-    auto exec_scopes = sync_utils::GetExecScopes(*pDependencyInfo);
-
-    cb_state->RecordSetEvent(event, exec_scopes.src, pDependencyInfo, record_obj.location);
+    cb_state->RecordSetEvent2(event, *pDependencyInfo, record_obj.location);
     cb_state->RecordBarrierObjects(*pDependencyInfo, record_obj.location.dot(vvl::Field::pDependencyInfo));
 }
 

--- a/tests/unit/event.cpp
+++ b/tests/unit/event.cpp
@@ -114,36 +114,6 @@ TEST_F(NegativeEvent, WaitEvent2HostStage) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeEvent, EventStageMask) {
-    RETURN_IF_SKIP(Init());
-    vkt::Event event(*m_device);
-
-    m_command_buffer.Begin();
-    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
-
-    // Source stage mask does not match CmdSetEvent's stage mask
-    m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
-    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-    m_errorMonitor->VerifyFound();
-
-    m_command_buffer.End();
-}
-
-TEST_F(NegativeEvent, EventStageMask2) {
-    RETURN_IF_SKIP(Init());
-    vkt::Event event(*m_device);
-
-    m_command_buffer.Begin();
-    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
-
-    // Source stage mask does not match CmdSetEvent's stage mask
-    m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
-    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-    m_errorMonitor->VerifyFound();
-
-    m_command_buffer.End();
-}
-
 TEST_F(NegativeEvent, StageMaskResetEvent) {
     RETURN_IF_SKIP(Init());
     vkt::Event event(*m_device);
@@ -151,6 +121,23 @@ TEST_F(NegativeEvent, StageMaskResetEvent) {
     m_command_buffer.ResetEvent(event);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
     m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, StageMaskResetEventSecondary) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_command_buffer.ExecuteCommands(secondary);
     monitor_.VerifyFound();
     m_command_buffer.End();
 }
@@ -223,6 +210,11 @@ TEST_F(NegativeEvent, SecondaryWaitIncludesHostStage) {
     secondary.End();
 
     m_command_buffer.Begin();
+
+    // Record-time validation is only possible if we know there was reset,
+    // otherwise we don't know if CmdSetEvent is ignored because it is a duplicate
+    m_command_buffer.ResetEvent(event);
+
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
     m_command_buffer.ExecuteCommands(secondary);
@@ -285,19 +277,6 @@ TEST_F(NegativeEvent, EventStageMaskHost2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeEvent, EventStageMaskHost3) {
-    RETURN_IF_SKIP(Init());
-    vkt::Event event(*m_device);
-
-    m_command_buffer.Begin();
-    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
-    m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
-    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_HOST_BIT,
-                               VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-    m_errorMonitor->VerifyFound();
-    m_command_buffer.End();
-}
-
 TEST_F(NegativeEvent, StageMaskPrimarySetSecondaryWait) {
     RETURN_IF_SKIP(Init());
     vkt::Event event(*m_device);
@@ -308,6 +287,11 @@ TEST_F(NegativeEvent, StageMaskPrimarySetSecondaryWait) {
     secondary.End();
 
     m_command_buffer.Begin();
+
+    // Record-time validation is only possible if we know there was reset,
+    // otherwise we don't know if CmdSetEvent is ignored because it is a duplicate
+    m_command_buffer.ResetEvent(event);
+
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
     m_command_buffer.ExecuteCommands(secondary);
@@ -340,12 +324,68 @@ TEST_F(NegativeEvent, StageMaskPrimarySetSecondaryWaitSubmit) {
     monitor_.VerifyFound();
 }
 
+TEST_F(NegativeEvent, StageMaskPrimarySetSecondaryResetAndWait) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    vkt::Event event2(*m_device);
+    const VkEvent events[2] = {event, event2};
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    // Reset the first event so its signal's stage mask is not taken into account during Wait call
+    secondary.ResetEvent(event);
+
+    vk::CmdWaitEvents(secondary, 2, events, VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_command_buffer.ResetEvent(event2);
+    m_command_buffer.SetEvent(event2, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_command_buffer.ExecuteCommands(secondary);
+    monitor_.VerifyFound();
+
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeEvent, StageMaskSecondarySetSecondaryWait) {
     RETURN_IF_SKIP(Init());
     vkt::Event event(*m_device);
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     secondary.Begin();
+    secondary.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    secondary.End();
+
+    vkt::CommandBuffer secondary2(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary2.Begin();
+    secondary2.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    secondary2.End();
+
+    m_command_buffer.Begin();
+    // Make sure WaitEvents is validated at record-time.
+    // Without Reset the validation can't prove CmdSetEvent is not ignored
+    m_command_buffer.ResetEvent(event);
+
+    m_command_buffer.ExecuteCommands(secondary);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_command_buffer.ExecuteCommands(secondary2);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, StageMaskSecondarySetSecondaryWait2) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.ResetEvent(event);  // Make sure this is validated at record-time
     secondary.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
     secondary.End();
 
@@ -379,8 +419,42 @@ TEST_F(NegativeEvent, StageMaskTwoSecondariesSameCommand) {
     const VkCommandBuffer secondaries[2] = {secondary, secondary2};
 
     m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
     vk::CmdExecuteCommands(m_command_buffer, 2, secondaries);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, StageMaskPrimaryResetSecondarySetAndWait) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    secondary.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_command_buffer.ExecuteCommands(secondary);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, RepeatedSetEvent) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-01158");
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
     monitor_.VerifyFound();
     m_command_buffer.End();
 }

--- a/tests/unit/event_positive.cpp
+++ b/tests/unit/event_positive.cpp
@@ -49,9 +49,8 @@ TEST_F(PositiveEvent, EventStageMaskTwoSubmits) {
     m_default_queue->Wait();
 }
 
-TEST_F(PositiveEvent, EventStageMaskTwoBatches) {
+TEST_F(PositiveEvent, TwoCommandBuffers) {
     RETURN_IF_SKIP(Init());
-
     vkt::Event event(*m_device);
 
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
@@ -73,7 +72,47 @@ TEST_F(PositiveEvent, EventStageMaskTwoBatches) {
     m_default_queue->Wait();
 }
 
-TEST_F(PositiveEvent, StageMaskTwoEventsTwoSubmits) {
+TEST_F(PositiveEvent, TwoBatches) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.ResetEvent(event);
+    command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    command_buffer.End();
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    // This signal goes after the signal from another command buffer and is ignored
+    command_buffer2.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
+
+    command_buffer2.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    command_buffer2.End();
+
+    // Need to use semaphore to guarantee ordering of CmdSetEvents
+    vkt::Semaphore semaphore(*m_device);
+
+    VkSubmitInfo submit_infos[2];
+    submit_infos[0] = vku::InitStructHelper();
+    submit_infos[0].commandBufferCount = 1;
+    submit_infos[0].pCommandBuffers = &command_buffer.handle();
+    submit_infos[0].signalSemaphoreCount = 1;
+    submit_infos[0].pSignalSemaphores = &semaphore.handle();
+
+    const VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    submit_infos[1] = vku::InitStructHelper();
+    submit_infos[1].waitSemaphoreCount = 1;
+    submit_infos[1].pWaitSemaphores = &semaphore.handle();
+    submit_infos[1].pWaitDstStageMask = &wait_stage;
+    submit_infos[1].commandBufferCount = 1;
+    submit_infos[1].pCommandBuffers = &command_buffer2.handle();
+
+    vk::QueueSubmit(*m_default_queue, 2, submit_infos, VK_NULL_HANDLE);
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveEvent, TwoEventsTwoSubmits) {
     RETURN_IF_SKIP(Init());
 
     vkt::Event event(*m_device);
@@ -96,6 +135,34 @@ TEST_F(PositiveEvent, StageMaskTwoEventsTwoSubmits) {
     m_default_queue->SubmitAndWait(command_buffer2);
 }
 
+TEST_F(PositiveEvent, StageMaskTwoEventsTwoSubmits2) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    vkt::Event event2(*m_device);
+    const VkEvent events[2] = {event, event2};
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    command_buffer.End();
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.SetEvent(event2, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    command_buffer2.End();
+
+    vkt::CommandBuffer command_buffer3(*m_device, m_command_pool);
+    command_buffer3.Begin();
+    vk::CmdWaitEvents(command_buffer3, 2, events, VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                      VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
+    command_buffer3.End();
+
+    m_default_queue->SubmitAndWait(command_buffer);
+    m_default_queue->SubmitAndWait(command_buffer2);
+    m_default_queue->SubmitAndWait(command_buffer3);
+}
+
 TEST_F(PositiveEvent, EventStageMaskHostSubmit) {
     RETURN_IF_SKIP(Init());
     vkt::Event event(*m_device);
@@ -105,6 +172,58 @@ TEST_F(PositiveEvent, EventStageMaskHostSubmit) {
     m_command_buffer.End();
 
     event.Set();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveEvent, PrimarySetSecondaryWaitCantDetectMismatch) {
+    TEST_DESCRIPTION("CmdSetEvent is not possible to validate during record time without preceding CmdResetEvent");
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    // We don't know if signal is ignored or not (there could be earlier signal which takes priority),
+    // that's why we can't check for signal/wait source stage mismatch
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, SecondarySetAndWaitMismatch) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    secondary.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    // For the secondary command buffer we can't validate signal/wait stage mismatch
+    // at record-time. The signal can be ignored if it is preceded by another one
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, SecondarySetAndWaitSubmit) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    secondary.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
@@ -146,6 +265,24 @@ TEST_F(PositiveEvent, PrimarySetSecondaryWait) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
+TEST_F(PositiveEvent, PrimaryResetSecondarySetAndWait) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    secondary.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
 TEST_F(PositiveEvent, SecondaryWaitTwoEvents) {
     RETURN_IF_SKIP(Init());
     vkt::Event event(*m_device);
@@ -180,14 +317,12 @@ TEST_F(PositiveEvent, BasicSetAndWaitEvent) {
 
     const vkt::Event event(*m_device);
 
-    // Record time validation
     m_command_buffer.Begin();
     vk::CmdSetEvent(m_command_buffer, event, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
     vk::CmdWaitEvents(m_command_buffer, 1, &event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                       0, nullptr, 0, nullptr, 0, nullptr);
     m_command_buffer.End();
 
-    // Also submit to the queue to test submit time validation
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -314,80 +449,4 @@ TEST_F(PositiveEvent, AsymmetricEventNoMemorySubmit) {
 
     // Check that missing memory barrier does not confuse submit validation
     m_default_queue->SubmitAndWait(m_command_buffer);
-}
-
-TEST_F(PositiveEvent, InterQueueEventUsage) {
-    all_queue_count_ = true;
-    RETURN_IF_SKIP(Init());
-
-    if ((m_second_queue_caps & VK_QUEUE_GRAPHICS_BIT) == 0) {
-        GTEST_SKIP() << "2 graphics queues are needed";
-    }
-    const vkt::Event event(*m_device);
-
-    vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.Begin();
-    cb1.SetEvent(event);
-    cb1.End();
-
-    vkt::CommandPool pool2(*m_device, m_second_queue->family_index);
-    vkt::CommandBuffer cb2(*m_device, pool2);
-    cb2.Begin();
-    cb2.SetEvent(event);
-    cb2.End();
-    vkt::CommandBuffer cb3(*m_device, pool2);
-    cb3.Begin();
-    cb3.WaitEvent(event);
-    cb3.End();
-
-    const VkCommandBuffer queue2_cbs[2] = {cb2, cb3};
-    VkSubmitInfo queue2_submit_info = vku::InitStructHelper();
-    queue2_submit_info.commandBufferCount = 2;
-    queue2_submit_info.pCommandBuffers = queue2_cbs;
-
-    m_default_queue->SubmitAndWait(cb1);
-
-    // Check that event wait on the second queue can find the signal on the same queue.
-    // If due to regression the signal from the first queue is used then it will trigger
-    // cross queue event usage error
-    vk::QueueSubmit(*m_second_queue, 1, &queue2_submit_info, VK_NULL_HANDLE);
-    m_second_queue->Wait();
-}
-
-TEST_F(PositiveEvent, InterQueueEventUsage2) {
-    all_queue_count_ = true;
-    RETURN_IF_SKIP(Init());
-
-    if ((m_second_queue_caps & VK_QUEUE_GRAPHICS_BIT) == 0) {
-        GTEST_SKIP() << "2 graphics queues are needed";
-    }
-    const vkt::Event event(*m_device);
-    const vkt::Event event2(*m_device);
-    const VkEvent events[2] = {event, event2};
-
-    vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.Begin();
-    cb1.SetEvent(event2);
-    cb1.End();
-
-    vkt::CommandPool pool2(*m_device, m_second_queue->family_index);
-    vkt::CommandBuffer cb2(*m_device, pool2);
-    cb2.Begin();
-    cb2.SetEvent(event);
-    cb2.End();
-    vkt::CommandBuffer cb3(*m_device, pool2);
-    cb3.Begin();
-    cb3.SetEvent(event2);
-    vk::CmdWaitEvents(cb3, 2, events, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, nullptr, 0,
-                      nullptr, 0, nullptr);
-    cb3.End();
-
-    const VkCommandBuffer queue2_cbs[2] = {cb2, cb3};
-    VkSubmitInfo queue2_submit_info = vku::InitStructHelper();
-    queue2_submit_info.commandBufferCount = 2;
-    queue2_submit_info.pCommandBuffers = queue2_cbs;
-
-    m_default_queue->SubmitAndWait(cb1);
-    vk::QueueSubmit(*m_second_queue, 1, &queue2_submit_info, VK_NULL_HANDLE);
-    m_second_queue->Wait();
 }


### PR DESCRIPTION
Implement the rule that repeated event signals are ignored. This affects a lot of event state logic, especially on the various boundaries (primary/secondary, inside batch, submit-time).

This also affects the amount of record-time validation that can be done. CmdSetEvent can only participate in record-time validation if we can prove it is not ignored.

The current implementation does not really ignore duplicated unsignals because we don't track additional information associated with unsignal. If that changes, the implementation may need to be extended to detect the effective unsignal.

This work was initiated by this question: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4830. It was clear that duplicated signals are ignored but it was less clear how this rule interacts with VUID 01158. The answers is that VUID 01158 uses the same rule and ignores stage masks of ignored signals.