### PR TITLE
tests: Disable assert message boxes on Windows

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -821,10 +821,23 @@ int main(int argc, char** argv) {
         }
     }
     if (!break_on_failure) {
+        // Make general CRT and Windows failure reporting noninteractive
+        _set_error_mode(_OUT_TO_STDERR);
+        _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+        SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+
         // Disable message box for: "Errors, unrecoverable problems, and issues that require immediate attention."
-        // This does not include asserts. GTest does similar configuration for asserts.
         _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
         _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+
+        // gtest suppresses assert message boxes on Windows when gtest_catch_exceptions=1.
+        // Because our internal CI configuration uses gtest_catch_exceptions=0, the corresponding
+        // gtest functionality is disabled, so we need to suppress assert message boxes manually.
+        // Allow assert message boxes if running under debugger.
+        if (!IsDebuggerPresent()) {
+            _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+            _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+        }
     }
 #endif
 


### PR DESCRIPTION
This brings back most of functionality that was removed in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7009/changes/dd03f4d63e5410d15ec8049f07141f9b9c0f8136, except `_CRT_WARN` which does not raise message boxes. This change allows message boxes if running under debugger.

I tested this directly on CI machine by using old version of `NegativeDescriptorHeap.SamplerAllocationCount` that does out of bounds access. Not sure if we can provide  a test as part of VVL to trigger such assert. I tried simple and **safe** assert(false) but this does not show message boxes even before this fix. So far I found only one way to show message boxes is out-of-bounds access detected by msvc. Maybe that can be a separate faulty program run by CI as a separate step. It's not clear if this is useful in case of regression, which means we have opened message boxes.