### PR TITLE
gpuav: Relax HOST_CACHED_BIT requirement for descriptor state buffer allocation

### DIFF
--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -65,8 +65,11 @@ void DescriptorSetSubState::CreateDescriptorEncodingBuffer() {
 
     // The descriptor state buffer can be very large (4mb+ in some games). Allocating it as HOST_CACHED
     // and manually flushing it at the end of the state updates is faster than using HOST_COHERENT.
+    // HOST_CACHED is preferred rather than required so we fall back to HOST_COHERENT on implementations
+    // that don't expose a HOST_CACHED memory type.
     VmaAllocationCreateInfo alloc_info{};
-    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+    alloc_info.preferredFlags = VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
     const VkResult result = descriptor_encodings_.Create(&buffer_info, &alloc_info);
     if (result != VK_SUCCESS) {
         return;


### PR DESCRIPTION
Currently, the allocator strictly requires `VK_MEMORY_PROPERTY_HOST_CACHED_BIT` along with `HOST_VISIBLE_BIT`. Since the Vulkan spec only guarantees a memory type with `HOST_VISIBLE` and `HOST_COHERENT`, this strict requirement causes allocation failures on hardware that doesn't expose a cached memory type.

This PR moves `HOST_CACHED_BIT` to preferredFlags. This allows VMA to still use it for the performance optimization where available, but safely fall back to the guaranteed coherent memory type via process of elimination when it's not.