### PR TITLE
tests: Consistent naming scheme

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -20,9 +20,9 @@ There is nothing worse than debugging why your layers are not reporting the VUID
 
 ## Google Test Overview
 
-The tests take advantage of the Google Test (gtest) Framework which breaks each test into a `TEST_F(VkLayerTest, TestName)` "Test Fixture". This just means that for every test there will be a class that holds many useful member variables.
+The tests take advantage of the Google Test (gtest) Framework which breaks each test into a `TEST_F(NegativeOther, TestName)` "Test Fixture". This just means that for every test there will be a class that holds many useful member variables.
 
-To run a test labeled `TEST_F(VkLayerTest, Foo)` is as simple as going `--gtest_filter=VkLayerTest.Foo`
+To run a test labeled `TEST_F(NegativeOther, Foo)` is as simple as going `--gtest_filter=NegativeOther.Foo`
 
 ## VkRenderFramework
 

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -114,7 +114,7 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
     }
 
     // We have a few speical VUID we never actually want to suppress.
-    // If a new VUID is added here, make sure to add it in VkLayerTest.VuidHashStability test as well.
+    // If a new VUID is added here, make sure to add it in NegativeOther.VuidHashStability test as well.
     const bool skip_checking_limit =
         // We want to print DebugPrintf message forever, otherwise user will mistake duplicate limit for things not printing
         (vuid_hash == 0x4fe1fef9) ||

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,15 +29,16 @@ else()
     add_executable(vk_layer_validation_tests)
 endif()
 target_sources(vk_layer_validation_tests PRIVATE
-    unit/amd_best_practices.cpp
     unit/android_hardware_buffer.cpp
     unit/android_hardware_buffer_positive.cpp
     unit/android_external_resolve.cpp
     unit/android_external_resolve_positive.cpp
-    unit/arm_best_practices.cpp
     unit/atomics.cpp
     unit/atomics_positive.cpp
     unit/best_practices.cpp
+    unit/best_practices_amd.cpp
+    unit/best_practices_arm.cpp
+    unit/best_practices_nvidia.cpp
     unit/best_practices_positive.cpp
     unit/buffer.cpp
     unit/buffer_positive.cpp
@@ -164,7 +165,6 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/mesh_positive.cpp
     unit/multiview.cpp
     unit/multiview_positive.cpp
-    unit/nvidia_best_practices.cpp
     unit/object_lifetime.cpp
     unit/object_lifetime_positive.cpp
     unit/other_positive.cpp

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -20,25 +20,9 @@
 #include "../framework/sync_helper.h"
 #include "../framework/thread_helper.h"
 
-void VkBestPracticesLayerTest::InitBestPracticesFramework(const char* vendor_checks_to_enable) {
-    const VkLayerSettingEXT settings = {OBJECT_LAYER_NAME, vendor_checks_to_enable, VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    const VkLayerSettingsCreateInfoEXT layer_settings_create_info{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
-                                                                  &settings};
+class NegativeBestPractices : public VkBestPracticesLayerTest {};
 
-    if (vendor_checks_to_enable) {
-        features_.pNext = &layer_settings_create_info;
-    }
-
-    AddRequiredExtensions(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
-    InitFramework(&features_);
-}
-
-void VkBestPracticesLayerTest::InitBestPractices(const char* vendor_checks_to_enable) {
-    RETURN_IF_SKIP(InitBestPracticesFramework(vendor_checks_to_enable));
-    RETURN_IF_SKIP(InitState());
-}
-
-TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
+TEST_F(NegativeBestPractices, ReturnCodes) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
     AddSurfaceExtension();
@@ -82,7 +66,7 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, SpecialUseExtensionsInstance) {
+TEST_F(NegativeBestPractices, SpecialUseExtensionsInstance) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     if (!InstanceExtensionSupported(VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
         GTEST_SKIP() << "Did not find required instance extension";
@@ -105,7 +89,7 @@ TEST_F(VkBestPracticesLayerTest, SpecialUseExtensionsInstance) {
     Monitor().VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, SpecialUseExtensionsDevice) {
+TEST_F(NegativeBestPractices, SpecialUseExtensionsDevice) {
     AddRequiredExtensions(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework());
 
@@ -128,7 +112,7 @@ TEST_F(VkBestPracticesLayerTest, SpecialUseExtensionsDevice) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
+TEST_F(NegativeBestPractices, CmdClearAttachmentTest) {
     TEST_DESCRIPTION("Test for validating usage of vkCmdClearAttachments");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -157,7 +141,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
+TEST_F(NegativeBestPractices, CmdClearAttachmentTestSecondary) {
     TEST_DESCRIPTION("Test for validating usage of vkCmdClearAttachments with secondary command buffers");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -224,7 +208,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
     m_command_buffer.EndRenderPass();
 }
 
-TEST_F(VkBestPracticesLayerTest, ZeroSizeBlitRegion) {
+TEST_F(NegativeBestPractices, ZeroSizeBlitRegion) {
     TEST_DESCRIPTION("vkCmdBlitImage with a zero area region");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -250,7 +234,7 @@ TEST_F(VkBestPracticesLayerTest, ZeroSizeBlitRegion) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, SecondaryCommandBuffer) {
+TEST_F(NegativeBestPractices, SecondaryCommandBuffer) {
     TEST_DESCRIPTION("Test for validating usage of vkCreateCommandPool with VK_COMMAND_BUFFER_LEVEL_SECONDARY");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -293,7 +277,7 @@ TEST_F(VkBestPracticesLayerTest, SecondaryCommandBuffer) {
     vk::FreeCommandBuffers(device(), command_pool, 1, &command_buffer);
 }
 
-TEST_F(VkBestPracticesLayerTest, SmallDedicatedAllocation) {
+TEST_F(NegativeBestPractices, SmallDedicatedAllocation) {
     TEST_DESCRIPTION("Test for small dedicated memory allocations");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -313,7 +297,7 @@ TEST_F(VkBestPracticesLayerTest, SmallDedicatedAllocation) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, MSImageRequiresMemory) {
+TEST_F(NegativeBestPractices, MSImageRequiresMemory) {
     TEST_DESCRIPTION("Test for MS image that requires memory");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -343,7 +327,7 @@ TEST_F(VkBestPracticesLayerTest, MSImageRequiresMemory) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
+TEST_F(NegativeBestPractices, AttachmentShouldNotBeTransient) {
     TEST_DESCRIPTION("Test for non-lazy multisampled images");
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
@@ -376,7 +360,7 @@ TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, TooManyInstancedVertexBuffers) {
+TEST_F(NegativeBestPractices, TooManyInstancedVertexBuffers) {
     TEST_DESCRIPTION("Test for too many instanced vertex buffers");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -425,7 +409,7 @@ TEST_F(VkBestPracticesLayerTest, TooManyInstancedVertexBuffers) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
+TEST_F(NegativeBestPractices, ClearAttachmentsAfterLoad) {
     TEST_DESCRIPTION("Test for clearing attachments after load");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -467,7 +451,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
+TEST_F(NegativeBestPractices, ClearAttachmentsAfterLoadSecondary) {
     TEST_DESCRIPTION("Test for clearing attachments after load with secondary command buffers");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -603,7 +587,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     m_command_buffer.EndRenderPass();
 }
 
-TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
+TEST_F(NegativeBestPractices, TripleBufferingTest) {
     TEST_DESCRIPTION("Test for usage of triple buffering");
 
     AddSurfaceExtension();
@@ -660,7 +644,7 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     m_swapchain.Init(*m_device, swapchain_create_info);
 }
 
-TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
+TEST_F(NegativeBestPractices, SwapchainCreationTest) {
     TEST_DESCRIPTION("Test for correct swapchain creation");
 
     AddSurfaceExtension();
@@ -724,7 +708,7 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     m_swapchain.Init(*m_device, swapchain_create_info);
 }
 
-TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
+TEST_F(NegativeBestPractices, ExpectedQueryDetails) {
     TEST_DESCRIPTION("Check that GetPhysicalDeviceQueueFamilyProperties is working as expected");
 
     // Vulkan 1.1 required to test vkGetPhysicalDeviceQueueFamilyProperties2
@@ -762,7 +746,7 @@ TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
     vkt::Device device(phys_device_obj, m_device_extension_names);
 }
 
-TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
+TEST_F(NegativeBestPractices, MissingQueryDetails) {
     TEST_DESCRIPTION("Check that GetPhysicalDeviceQueueFamilyProperties generates appropriate query warning");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -810,7 +794,7 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
+TEST_F(NegativeBestPractices, CreatePipelineVsFsTypeMismatchArraySize) {
     TEST_DESCRIPTION("Test that an error is produced for mismatched array sizes across the vertex->fragment shader interface");
 
     RETURN_IF_SKIP(Init());
@@ -842,7 +826,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "WARNING-Shader-OutputNotConsumed");
 }
 
-TEST_F(VkBestPracticesLayerTest, WorkgroupSizeDeprecated) {
+TEST_F(NegativeBestPractices, WorkgroupSizeDeprecated) {
     TEST_DESCRIPTION("SPIR-V 1.6 deprecated WorkgroupSize build-in.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -877,7 +861,7 @@ TEST_F(VkBestPracticesLayerTest, WorkgroupSizeDeprecated) {
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "BestPractices-SpirvDeprecated_WorkgroupSize");
 }
 
-TEST_F(VkBestPracticesLayerTest, ImageExtendedUsageWithoutMutableFormat) {
+TEST_F(NegativeBestPractices, ImageExtendedUsageWithoutMutableFormat) {
     TEST_DESCRIPTION("Create image with extended usage bit but not mutable format bit.");
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -892,7 +876,7 @@ TEST_F(VkBestPracticesLayerTest, ImageExtendedUsageWithoutMutableFormat) {
 }
 
 #if GTEST_IS_THREADSAFE
-TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
+TEST_F(NegativeBestPractices, ThreadUpdateDescriptorUpdateAfterBindNoCollision) {
     TEST_DESCRIPTION("Two threads updating the same UAB descriptor set, expected not to generate a threading error");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -937,7 +921,7 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
 }
 #endif  // GTEST_IS_THREADSAFE
 
-TEST_F(VkBestPracticesLayerTest, TransitionFromUndefinedToReadOnly) {
+TEST_F(NegativeBestPractices, TransitionFromUndefinedToReadOnly) {
     TEST_DESCRIPTION("Transition image layout from undefined to read only");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -975,7 +959,7 @@ TEST_F(VkBestPracticesLayerTest, TransitionFromUndefinedToReadOnly) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
+TEST_F(NegativeBestPractices, OverAllocateFromDescriptorPool) {
     TEST_DESCRIPTION("Attempt to allocate more sets and descriptors than descriptor pool has available.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -1005,7 +989,7 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, OverAllocateTypeFromDescriptorPool) {
+TEST_F(NegativeBestPractices, OverAllocateTypeFromDescriptorPool) {
     TEST_DESCRIPTION("Attempt to allocate more sets and descriptors than descriptor pool has available.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -1036,7 +1020,7 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateTypeFromDescriptorPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, RenderPassClearWithoutLoadOpClear) {
+TEST_F(NegativeBestPractices, RenderPassClearWithoutLoadOpClear) {
     TEST_DESCRIPTION("Test for clearing a RenderPass with non-zero clearValueCount without any VK_ATTACHMENT_LOAD_OP_CLEAR");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -1099,7 +1083,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearWithoutLoadOpClear) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, RenderPassClearValueCountHigherThanAttachmentCount) {
+TEST_F(NegativeBestPractices, RenderPassClearValueCountHigherThanAttachmentCount) {
     TEST_DESCRIPTION(
         "Test for beginning a RenderPass with VkRenderPassBeginInfo.clearValueCount > VkRenderPassCreateInfo.attachmentCount");
 
@@ -1170,7 +1154,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearValueCountHigherThanAttachmentCo
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
+TEST_F(NegativeBestPractices, DontCareThenLoad) {
     TEST_DESCRIPTION("Test for storing an attachment with STORE_OP_DONT_CARE then loading with LOAD_OP_LOAD");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -1246,7 +1230,7 @@ TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
     m_default_queue->Wait();
 }
 
-TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
+TEST_F(NegativeBestPractices, ExclusiveImageMultiQueueUsage) {
     TEST_DESCRIPTION("Test for using a queue exclusive image on multiple queues");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -1430,7 +1414,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     m_errorMonitor->Finish();
 }
 
-TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
+TEST_F(NegativeBestPractices, ImageMemoryBarrierAccessLayoutCombinations) {
     TEST_DESCRIPTION("Transition image layout from undefined to read only");
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
@@ -1523,7 +1507,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
     }
 }
 
-TEST_F(VkBestPracticesLayerTest, NonSimultaneousSecondaryMarksPrimary) {
+TEST_F(NegativeBestPractices, NonSimultaneousSecondaryMarksPrimary) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
@@ -1546,7 +1530,7 @@ TEST_F(VkBestPracticesLayerTest, NonSimultaneousSecondaryMarksPrimary) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, NoCreateSwapchainPresentModes) {
+TEST_F(NegativeBestPractices, NoCreateSwapchainPresentModes) {
     TEST_DESCRIPTION("With swapchain maintenance 1, CreateSwapchain with VkPresentModesCreateInfoEXT");
 
     AddSurfaceExtension();
@@ -1562,7 +1546,7 @@ TEST_F(VkBestPracticesLayerTest, NoCreateSwapchainPresentModes) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, PipelineWithoutRenderPassOrRenderingInfo) {
+TEST_F(NegativeBestPractices, PipelineWithoutRenderPassOrRenderingInfo) {
     TEST_DESCRIPTION("Create pipeline with VK_NULL_HANDLE render pass and no VkPipelineRenderingCreateInfo in pNext chain");
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
@@ -1579,7 +1563,7 @@ TEST_F(VkBestPracticesLayerTest, PipelineWithoutRenderPassOrRenderingInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, GetQueryPoolResultsWithoutBegin) {
+TEST_F(NegativeBestPractices, GetQueryPoolResultsWithoutBegin) {
     TEST_DESCRIPTION("Get query pool results without ever beginning the query");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -1599,7 +1583,7 @@ TEST_F(VkBestPracticesLayerTest, GetQueryPoolResultsWithoutBegin) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, NonOptimalResolveFormat) {
+TEST_F(NegativeBestPractices, NonOptimalResolveFormat) {
     TEST_DESCRIPTION("Create a render pass with a resolve attachment that is not optimal");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1658,7 +1642,7 @@ TEST_F(VkBestPracticesLayerTest, NonOptimalResolveFormat) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEnd) {
+TEST_F(NegativeBestPractices, PartialPushConstantSetEnd) {
     TEST_DESCRIPTION("Set only a part of push constants at end of a struct");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -1701,7 +1685,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEnd) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
+TEST_F(NegativeBestPractices, PartialPushConstantSetMiddle) {
     TEST_DESCRIPTION("Set only a part of push constants in middle of as struct");
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
@@ -1746,7 +1730,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7495
-TEST_F(VkBestPracticesLayerTest, IgnoreResolveImageView) {
+TEST_F(NegativeBestPractices, IgnoreResolveImageView) {
     TEST_DESCRIPTION("Help warn user when they might have resolveMode set to NONE by accident");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
@@ -1791,7 +1775,7 @@ TEST_F(VkBestPracticesLayerTest, IgnoreResolveImageView) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetSignaledEvent) {
+TEST_F(NegativeBestPractices, SetSignaledEvent) {
     TEST_DESCRIPTION("Signal event two times");
     RETURN_IF_SKIP(InitBestPractices());
 
@@ -1805,7 +1789,7 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEvent) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetSignaledEvent2) {
+TEST_F(NegativeBestPractices, SetSignaledEvent2) {
     TEST_DESCRIPTION("Signal event two times using CmdSetEvent2 api");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -1826,7 +1810,7 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEvent2) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetEventSignaledByHost) {
+TEST_F(NegativeBestPractices, SetEventSignaledByHost) {
     TEST_DESCRIPTION("Set event that was previously set be the host");
     RETURN_IF_SKIP(InitBestPractices());
 
@@ -1841,7 +1825,7 @@ TEST_F(VkBestPracticesLayerTest, SetEventSignaledByHost) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetSignaledEventMultipleSubmits) {
+TEST_F(NegativeBestPractices, SetSignaledEventMultipleSubmits) {
     TEST_DESCRIPTION("Set event from different submits");
     RETURN_IF_SKIP(InitBestPractices());
 
@@ -1862,7 +1846,7 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventMultipleSubmits) {
     m_device->Wait();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetSignaledEventMultipleSubmits2) {
+TEST_F(NegativeBestPractices, SetSignaledEventMultipleSubmits2) {
     TEST_DESCRIPTION("Set event from multiple submits using QueueSubmit2 api");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -1885,7 +1869,7 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventMultipleSubmits2) {
     m_device->Wait();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary) {
+TEST_F(NegativeBestPractices, SetSignaledEventSecondary) {
     TEST_DESCRIPTION("Set event in the primary command buffer and then one more time in the secondary");
     RETURN_IF_SKIP(InitBestPractices());
 
@@ -1904,7 +1888,7 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary2) {
+TEST_F(NegativeBestPractices, SetSignaledEventSecondary2) {
     TEST_DESCRIPTION("Set event in different secondary command buffers");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -1929,7 +1913,7 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary2) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary3) {
+TEST_F(NegativeBestPractices, SetSignaledEventSecondary3) {
     TEST_DESCRIPTION("Set event in the secondary command buffer and in the primary from different submissions");
     RETURN_IF_SKIP(InitBestPractices());
 
@@ -1955,7 +1939,7 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary3) {
     m_device->Wait();
 }
 
-TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEndCompute) {
+TEST_F(NegativeBestPractices, PartialPushConstantSetEndCompute) {
     TEST_DESCRIPTION("Set only a part of push constants at end of a struct");
 
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -2003,7 +1987,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEndCompute) {
     m_command_buffer.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, UnneededQueueFamilyOwnershipTransfer) {
+TEST_F(NegativeBestPractices, UnneededQueueFamilyOwnershipTransfer) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_9_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -2056,7 +2040,7 @@ TEST_F(VkBestPracticesLayerTest, UnneededQueueFamilyOwnershipTransfer) {
     transfer_cb.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, UnneededQueueFamilyOwnershipTransferImage) {
+TEST_F(NegativeBestPractices, UnneededQueueFamilyOwnershipTransferImage) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_9_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -2106,7 +2090,7 @@ TEST_F(VkBestPracticesLayerTest, UnneededQueueFamilyOwnershipTransferImage) {
     transfer_cb.End();
 }
 
-TEST_F(VkBestPracticesLayerTest, BadDestroy) {
+TEST_F(NegativeBestPractices, BadDestroy) {
     TEST_DESCRIPTION(
         "In PreCallRecordDestroyDevice, make sure CommandBufferSubState is destroyed before destroying device state and validation "
         "does not crash");
@@ -2154,7 +2138,7 @@ TEST_F(VkBestPracticesLayerTest, BadDestroy) {
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyInstance-instance-00629");
 }
 
-TEST_F(VkBestPracticesLayerTest, MutableDescriptors) {
+TEST_F(NegativeBestPractices, MutableDescriptors) {
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::mutableDescriptorType);
     RETURN_IF_SKIP(InitBestPractices());
@@ -2177,7 +2161,7 @@ TEST_F(VkBestPracticesLayerTest, MutableDescriptors) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkBestPracticesLayerTest, MaxPreferredWorkGroupInvocations) {
+TEST_F(NegativeBestPractices, MaxPreferredWorkGroupInvocations) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::meshShader);

--- a/tests/unit/best_practices_amd.cpp
+++ b/tests/unit/best_practices_amd.cpp
@@ -18,12 +18,12 @@
 // Tests for AMD-specific best practices
 const char* kEnableAMDValidation = "validate_best_practices_amd";
 
-class VkAmdBestPracticesLayerTest : public VkBestPracticesLayerTest {};
+class NegativeBestPracticesAMD : public VkBestPracticesLayerTest {};
 
 // this is a very long test (~10 minutes)
 // disabled for now
 #ifdef AMD_LONG_RUNNING_TEST
-TEST_F(VkAmdBestPracticesLayerTest, TooManyPipelines) {
+TEST_F(NegativeBestPracticesAMD, TooManyPipelines) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -55,7 +55,7 @@ TEST_F(VkAmdBestPracticesLayerTest, TooManyPipelines) {
 }
 #endif
 
-TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
+TEST_F(NegativeBestPracticesAMD, UseMutableRT) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -86,7 +86,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
+TEST_F(NegativeBestPracticesAMD, UsageConcurentRT) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -117,7 +117,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
     }
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, UsageStorageRT) {
+TEST_F(NegativeBestPracticesAMD, UsageStorageRT) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -129,7 +129,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageStorageRT) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, PrimitiveRestart) {
+TEST_F(NegativeBestPracticesAMD, PrimitiveRestart) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
@@ -143,7 +143,7 @@ TEST_F(VkAmdBestPracticesLayerTest, PrimitiveRestart) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, NumDynamicStates) {
+TEST_F(NegativeBestPracticesAMD, NumDynamicStates) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
@@ -166,7 +166,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumDynamicStates) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, KeepLayoutSmall) {
+TEST_F(NegativeBestPracticesAMD, KeepLayoutSmall) {
     // TODO: add dynamic buffer check as well
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
@@ -192,7 +192,7 @@ TEST_F(VkAmdBestPracticesLayerTest, KeepLayoutSmall) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, CopyingDescriptors) {
+TEST_F(NegativeBestPracticesAMD, CopyingDescriptors) {
     // TODO: add dynamic buffer check as well
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
@@ -230,7 +230,7 @@ TEST_F(VkAmdBestPracticesLayerTest, CopyingDescriptors) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
+TEST_F(NegativeBestPracticesAMD, ClearImage) {
     TEST_DESCRIPTION("Test for validating usage of vkCmdClearAttachments");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
@@ -288,7 +288,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
     }
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, ImageToImageCopy) {
+TEST_F(NegativeBestPracticesAMD, ImageToImageCopy) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -319,7 +319,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ImageToImageCopy) {
     m_command_buffer.End();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, GeneralLayout) {
+TEST_F(NegativeBestPracticesAMD, GeneralLayout) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -331,7 +331,7 @@ TEST_F(VkAmdBestPracticesLayerTest, GeneralLayout) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, RobustAccessOn) {
+TEST_F(NegativeBestPracticesAMD, RobustAccessOn) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -355,7 +355,7 @@ TEST_F(VkAmdBestPracticesLayerTest, RobustAccessOn) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, Barriers) {
+TEST_F(NegativeBestPracticesAMD, Barriers) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -389,7 +389,7 @@ TEST_F(VkAmdBestPracticesLayerTest, Barriers) {
     m_command_buffer.End();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
+TEST_F(NegativeBestPracticesAMD, NumberOfSubmissions) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
@@ -417,7 +417,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
+TEST_F(NegativeBestPracticesAMD, NumSyncPrimitives) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -441,7 +441,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
+TEST_F(NegativeBestPracticesAMD, SecondaryCmdBuffer) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -501,7 +501,7 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSize) {
+TEST_F(NegativeBestPracticesAMD, ComputeWorkgroupSize) {
     TEST_DESCRIPTION("On AMD make the workgroup size a multiple of 64 to obtain best performance across all GPU generations.");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
@@ -549,7 +549,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSize) {
     }
 }
 
-TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSizeMaintenance5) {
+TEST_F(NegativeBestPracticesAMD, ComputeWorkgroupSizeMaintenance5) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::maintenance5);

--- a/tests/unit/best_practices_arm.cpp
+++ b/tests/unit/best_practices_arm.cpp
@@ -20,7 +20,7 @@
 
 const char* kEnableArmValidation = "validate_best_practices_arm";
 
-class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {};
+class NegativeBestPracticesARM : public VkBestPracticesLayerTest {};
 
 class VkConstantBufferObj : public vkt::Buffer {
   public:
@@ -36,7 +36,7 @@ class VkConstantBufferObj : public vkt::Buffer {
 
 // Tests for Arm-specific best practices
 
-TEST_F(VkArmBestPracticesLayerTest, TooManySamples) {
+TEST_F(NegativeBestPracticesARM, TooManySamples) {
     TEST_DESCRIPTION("Test for multisampled images with too many samples");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
@@ -61,7 +61,7 @@ TEST_F(VkArmBestPracticesLayerTest, TooManySamples) {
     }
 }
 
-TEST_F(VkArmBestPracticesLayerTest, NonTransientMSImage) {
+TEST_F(NegativeBestPracticesARM, NonTransientMSImage) {
     TEST_DESCRIPTION("Test for non-transient multisampled images");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
@@ -77,7 +77,7 @@ TEST_F(VkArmBestPracticesLayerTest, NonTransientMSImage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, SamplerCreation) {
+TEST_F(NegativeBestPracticesARM, SamplerCreation) {
     TEST_DESCRIPTION("Test for various checks during sampler creation");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
@@ -105,7 +105,7 @@ TEST_F(VkArmBestPracticesLayerTest, SamplerCreation) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, MultisampledBlending) {
+TEST_F(NegativeBestPracticesARM, MultisampledBlending) {
     TEST_DESCRIPTION("Test for multisampled blending");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
@@ -157,7 +157,7 @@ TEST_F(VkArmBestPracticesLayerTest, MultisampledBlending) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, AttachmentNeedsReadback) {
+TEST_F(NegativeBestPracticesARM, AttachmentNeedsReadback) {
     TEST_DESCRIPTION("Test for attachments that need readback");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
@@ -183,7 +183,7 @@ TEST_F(VkArmBestPracticesLayerTest, AttachmentNeedsReadback) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
+TEST_F(NegativeBestPracticesARM, ManySmallIndexedDrawcalls) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdDrawIndexed-many-small-indexed-drawcalls");
@@ -221,7 +221,7 @@ TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
     m_command_buffer.End();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, SuboptimalDescriptorReuseTest) {
+TEST_F(NegativeBestPracticesARM, SuboptimalDescriptorReuseTest) {
     TEST_DESCRIPTION("Test for validation warnings of potentially suboptimal re-use of descriptor set allocations");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
@@ -278,7 +278,7 @@ TEST_F(VkArmBestPracticesLayerTest, SuboptimalDescriptorReuseTest) {
     // this should create no validation warnings
 }
 
-TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
+TEST_F(NegativeBestPracticesARM, SparseIndexBufferTest) {
     TEST_DESCRIPTION(
         "Test for appropriate warnings to be thrown when recording an indexed draw call with sparse/non-sparse index buffers.");
 
@@ -382,7 +382,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
     test_pipelines(sparse_ibo, sparse_indices.size(), true);
 }
 
-TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest) {
+TEST_F(NegativeBestPracticesARM, PostTransformVertexCacheThrashingIndicesTest) {
     TEST_DESCRIPTION(
         "Test for appropriate warnings to be thrown when recording an indexed draw call where the indices thrash the "
         "post-transform vertex cache.");
@@ -446,7 +446,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     best_ibo.Memory().Unmap();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
+TEST_F(NegativeBestPracticesARM, PresentModeTest) {
     TEST_DESCRIPTION("Test for usage of Presentation Modes");
 
     AddSurfaceExtension();
@@ -503,7 +503,7 @@ TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
     ASSERT_TRUE(m_swapchain.initialized());
 }
 
-TEST_F(VkArmBestPracticesLayerTest, PipelineDepthBiasZeroTest) {
+TEST_F(NegativeBestPracticesARM, PipelineDepthBiasZeroTest) {
     TEST_DESCRIPTION("Test for unnecessary rasterization due to using 0 for depthBiasConstantFactor and depthBiasSlopeFactor");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
@@ -523,7 +523,7 @@ TEST_F(VkArmBestPracticesLayerTest, PipelineDepthBiasZeroTest) {
     pipe.CreateGraphicsPipeline();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, RobustBufferAccessTest) {
+TEST_F(NegativeBestPracticesARM, RobustBufferAccessTest) {
     TEST_DESCRIPTION("Test for appropriate warnings to be thrown when robustBufferAccess is enabled.");
 
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
@@ -556,7 +556,7 @@ TEST_F(VkArmBestPracticesLayerTest, RobustBufferAccessTest) {
     }
 }
 
-TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
+TEST_F(NegativeBestPracticesARM, DepthPrePassUsage) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -636,7 +636,7 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest) {
+TEST_F(NegativeBestPracticesARM, ComputeShaderBadWorkGroupThreadAlignmentTest) {
     TEST_DESCRIPTION(
         "Testing for cases where compute shaders will be dispatched in an inefficient way, due to work group dispatch counts on "
         "Arm Mali architectures.");
@@ -690,7 +690,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest
     }
 }
 
-TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadCountTest) {
+TEST_F(NegativeBestPracticesARM, ComputeShaderBadWorkGroupThreadCountTest) {
     TEST_DESCRIPTION(
         "Testing for cases where the number of work groups spawned is greater than advised for Arm Mali architectures.");
 
@@ -740,7 +740,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadCountTest) {
     }
 }
 
-TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocality) {
+TEST_F(NegativeBestPracticesARM, ComputeShaderBadSpatialLocality) {
     TEST_DESCRIPTION(
         "Testing for cases where a compute shader's configuration makes poor use of spatial locality, on Arm Mali architectures, "
         "for one or more of its resources.");
@@ -803,7 +803,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocality) {
     }
 }
 
-TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocalityMultiEntrypoint) {
+TEST_F(NegativeBestPracticesARM, ComputeShaderBadSpatialLocalityMultiEntrypoint) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10035");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
@@ -868,7 +868,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocalityMultiEntrypoi
     pipe.CreateComputePipeline();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
+TEST_F(NegativeBestPracticesARM, RedundantRenderPassStore) {
     TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant store is used.");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
@@ -929,7 +929,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     render_pass_begin_info.pClearValues = clear_values;
     render_pass_begin_info.renderArea.extent = {32, 32};
 
-    const auto execute_work = [&](const std::function<void(vkt::CommandBuffer & command_buffer)>& work) {
+    const auto execute_work = [&](const std::function<void(vkt::CommandBuffer& command_buffer)>& work) {
         vk::ResetCommandPool(device(), m_command_pool, 0);
         m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
@@ -978,7 +978,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassClear) {
+TEST_F(NegativeBestPracticesARM, RedundantRenderPassClear) {
     TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant clear is used.");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
@@ -1041,7 +1041,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassClear) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, InefficientRenderPassClear) {
+TEST_F(NegativeBestPracticesARM, InefficientRenderPassClear) {
     TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant clear is used on a LOAD_OP_LOAD attachment.");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
@@ -1125,7 +1125,7 @@ TEST_F(VkArmBestPracticesLayerTest, InefficientRenderPassClear) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, DescriptorTracking) {
+TEST_F(NegativeBestPracticesARM, DescriptorTracking) {
     TEST_DESCRIPTION("Tests that we track descriptors, which means we should not trigger warnings.");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
@@ -1263,7 +1263,7 @@ TEST_F(VkArmBestPracticesLayerTest, DescriptorTracking) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
-TEST_F(VkArmBestPracticesLayerTest, BlitImageLoadOpLoad) {
+TEST_F(NegativeBestPracticesARM, BlitImageLoadOpLoad) {
     TEST_DESCRIPTION("Test for vkBlitImage followed by a LoadOpLoad renderpass");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
@@ -1377,7 +1377,7 @@ TEST_F(VkArmBestPracticesLayerTest, BlitImageLoadOpLoad) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
+TEST_F(NegativeBestPracticesARM, RedundantAttachment) {
     TEST_DESCRIPTION("Test for redundant renderpasses which consume bandwidth");
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());

--- a/tests/unit/best_practices_nvidia.cpp
+++ b/tests/unit/best_practices_nvidia.cpp
@@ -24,9 +24,9 @@ const char* kEnableNVIDIAValidation = "validate_best_practices_nvidia";
 
 static constexpr float defaultQueuePriority = 0.0f;
 
-class VkNvidiaBestPracticesLayerTest : public VkBestPracticesLayerTest {};
+class NegativeBestPracticesNV : public VkBestPracticesLayerTest {};
 
-TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
+TEST_F(NegativeBestPracticesNV, PageableDeviceLocalMemory) {
     AddRequiredExtensions(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
 
@@ -63,7 +63,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, TilingLinear) {
+TEST_F(NegativeBestPracticesNV, TilingLinear) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -92,7 +92,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, TilingLinear) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
+TEST_F(NegativeBestPracticesNV, Depth32Format) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -124,7 +124,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
+TEST_F(NegativeBestPracticesNV, QueueBindSparse_NotAsync) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -235,7 +235,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
+TEST_F(NegativeBestPracticesNV, AccelerationStructure_NotAsync) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
@@ -289,7 +289,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_SetPriority) {
+TEST_F(NegativeBestPracticesNV, AllocateMemory_SetPriority) {
     AddRequiredExtensions(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
@@ -315,7 +315,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_SetPriority) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_ReuseAllocations) {
+TEST_F(NegativeBestPracticesNV, AllocateMemory_ReuseAllocations) {
     AddRequiredExtensions(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
@@ -349,7 +349,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_ReuseAllocations) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
+TEST_F(NegativeBestPracticesNV, BindMemory_NoPriority) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
@@ -412,7 +412,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_StaticPriority) {
+TEST_F(NegativeBestPracticesNV, BindMemory_StaticPriority) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
@@ -468,7 +468,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_StaticPriority) {
     m_errorMonitor->Finish();
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_SeparateSampler) {
+TEST_F(NegativeBestPracticesNV, CreatePipelineLayout_SeparateSampler) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
 
@@ -510,7 +510,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_SeparateSampler) {
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_LargePipelineLayout) {
+TEST_F(NegativeBestPracticesNV, CreatePipelineLayout_LargePipelineLayout) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
     if (m_device->Physical().limits_.maxPerStageDescriptorStorageBuffers < 16) {
@@ -558,7 +558,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_LargePipelineLayout)
     }
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineSwitchTessGeometryMesh) {
+TEST_F(NegativeBestPracticesNV, BindPipelineSwitchTessGeometryMesh) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
@@ -618,7 +618,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineSwitchTessGeometryMesh) {
 }
 
 // TODO - This test needs to move the positive checks to new test because currently they will trigger many other errors
-TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineZcullDirection) {
+TEST_F(NegativeBestPracticesNV, BindPipelineZcullDirection) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -791,7 +791,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineZcullDirection) {
     m_command_buffer.End();
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineZcullDirectionDepth) {
+TEST_F(NegativeBestPracticesNV, BindPipelineZcullDirectionDepth) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -975,7 +975,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineZcullDirectionDepth) {
     m_command_buffer.End();
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineZcullDirectionSubresource) {
+TEST_F(NegativeBestPracticesNV, BindPipelineZcullDirectionSubresource) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -1122,7 +1122,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipelineZcullDirectionSubresource) {
     m_command_buffer.End();
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, ClearColorNotCompressed) {
+TEST_F(NegativeBestPracticesNV, ClearColorNotCompressed) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
@@ -1216,7 +1216,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColorNotCompressed) {
     m_command_buffer.End();
 }
 
-TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
+TEST_F(NegativeBestPracticesNV, BeginCommandBuffer_OneTimeSubmit) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
 

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -16,9 +16,27 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
-class VkPositiveBestPracticesLayerTest : public VkBestPracticesLayerTest {};
+void VkBestPracticesLayerTest::InitBestPracticesFramework(const char* vendor_checks_to_enable) {
+    const VkLayerSettingEXT settings = {OBJECT_LAYER_NAME, vendor_checks_to_enable, VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
+    const VkLayerSettingsCreateInfoEXT layer_settings_create_info{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                                  &settings};
 
-TEST_F(VkPositiveBestPracticesLayerTest, TestDestroyFreeNullHandles) {
+    if (vendor_checks_to_enable) {
+        features_.pNext = &layer_settings_create_info;
+    }
+
+    AddRequiredExtensions(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+    InitFramework(&features_);
+}
+
+void VkBestPracticesLayerTest::InitBestPractices(const char* vendor_checks_to_enable) {
+    RETURN_IF_SKIP(InitBestPracticesFramework(vendor_checks_to_enable));
+    RETURN_IF_SKIP(InitState());
+}
+
+class PositiveBestPractices : public VkBestPracticesLayerTest {};
+
+TEST_F(PositiveBestPractices, TestDestroyFreeNullHandles) {
     VkResult err;
 
     TEST_DESCRIPTION("Call all applicable destroy and free routines with NULL handles, expecting no validation errors");
@@ -87,7 +105,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, TestDestroyFreeNullHandles) {
     vk::FreeMemory(device(), VK_NULL_HANDLE, NULL);
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, DrawingWithUnboundUnusedSet) {
+TEST_F(PositiveBestPractices, DrawingWithUnboundUnusedSet) {
     TEST_DESCRIPTION(
         "Test issuing draw command with pipeline layout that has 2 descriptor sets with first descriptor set begin unused and "
         "unbound. Its purpose is to catch regression of this bug: "
@@ -121,7 +139,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, DrawingWithUnboundUnusedSet) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, DynStateIgnoreAttachments) {
+TEST_F(PositiveBestPractices, DynStateIgnoreAttachments) {
     TEST_DESCRIPTION("Make sure pAttachments is ignored if dynamic state is enabled");
 
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
@@ -155,7 +173,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, DynStateIgnoreAttachments) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, PipelineLibraryNoRendering) {
+TEST_F(PositiveBestPractices, PipelineLibraryNoRendering) {
     TEST_DESCRIPTION("Create a pipeline library without a render pass or rendering info");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -176,7 +194,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, PipelineLibraryNoRendering) {
     pre_raster_lib.CreateGraphicsPipeline();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, PushConstantSet) {
+TEST_F(PositiveBestPractices, PushConstantSet) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
@@ -224,7 +242,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, PushConstantSet) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, VertexBufferNotForAllDraws) {
+TEST_F(PositiveBestPractices, VertexBufferNotForAllDraws) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7636");
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::nullDescriptor);
@@ -265,7 +283,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, VertexBufferNotForAllDraws) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, SetDifferentEvents) {
+TEST_F(PositiveBestPractices, SetDifferentEvents) {
     TEST_DESCRIPTION("Signal different events");
     RETURN_IF_SKIP(InitBestPractices());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);  // TODO: should be part of BP config
@@ -279,7 +297,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, SetDifferentEvents) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSet) {
+TEST_F(PositiveBestPractices, ResetEventBeforeSet) {
     TEST_DESCRIPTION("Set event two times with reset in between");
     RETURN_IF_SKIP(InitBestPractices());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);  // TODO: should be part of BP config
@@ -293,7 +311,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSet) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSetMultipleSubmits) {
+TEST_F(PositiveBestPractices, ResetEventBeforeSetMultipleSubmits) {
     TEST_DESCRIPTION("Set event two times with reset in between from multiple submits");
     RETURN_IF_SKIP(InitBestPractices());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);  // TODO: should be part of BP config
@@ -314,7 +332,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSetMultipleSubmits) {
     m_default_queue->Wait();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSetMultipleSubmits2) {
+TEST_F(PositiveBestPractices, ResetEventBeforeSetMultipleSubmits2) {
     TEST_DESCRIPTION("Set event two times with reset in between using single submit with two batches");
     RETURN_IF_SKIP(InitBestPractices());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);  // TODO: should be part of BP config
@@ -343,7 +361,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSetMultipleSubmits2) {
     m_default_queue->Wait();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, ResetEventFromSecondary) {
+TEST_F(PositiveBestPractices, ResetEventFromSecondary) {
     TEST_DESCRIPTION("Set event two times with reset in between executed from a secondary command buffer");
     RETURN_IF_SKIP(InitBestPractices());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);  // TODO: should be part of BP config
@@ -362,7 +380,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventFromSecondary) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, DestroyEventThenUseAnotherEvent) {
+TEST_F(PositiveBestPractices, DestroyEventThenUseAnotherEvent) {
     TEST_DESCRIPTION("Destroy event that was set in a command buffer");
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
@@ -383,7 +401,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, DestroyEventThenUseAnotherEvent) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, CreateFifoRelaxedSwapchain) {
+TEST_F(PositiveBestPractices, CreateFifoRelaxedSwapchain) {
     TEST_DESCRIPTION("Test creating fifo relaxed swapchain");
 
     AddSurfaceExtension();
@@ -432,7 +450,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, CreateFifoRelaxedSwapchain) {
     m_swapchain.Init(*m_device, swapchain_create_info);
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, ShaderObjectDraw) {
+TEST_F(PositiveBestPractices, ShaderObjectDraw) {
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
@@ -482,7 +500,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, ShaderObjectDraw) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveBestPracticesLayerTest, CreateDeviceWithFeatures) {
+TEST_F(PositiveBestPractices, CreateDeviceWithFeatures) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     const vkt::PhysicalDevice phys_device_obj(gpu_);
 

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -14,9 +14,9 @@
 #include "../framework/layer_validation_tests.h"
 #include <cstdlib>
 
-class VkPositiveLayerTest : public VkLayerTest {};
+class PositiveOther : public VkLayerTest {};
 
-TEST_F(VkPositiveLayerTest, StatelessValidationDisable) {
+TEST_F(PositiveOther, StatelessValidationDisable) {
     TEST_DESCRIPTION("Specify a non-zero value for a reserved parameter with stateless validation disabled");
 
     VkValidationFeatureDisableEXT disables[] = {VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT};
@@ -33,7 +33,7 @@ TEST_F(VkPositiveLayerTest, StatelessValidationDisable) {
     vkt::Event event(*m_device, event_info);
 }
 
-TEST_F(VkPositiveLayerTest, Maintenance1Tests) {
+TEST_F(PositiveOther, Maintenance1Tests) {
     TEST_DESCRIPTION("Validate various special cases for the Maintenance1_KHR extension");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -46,7 +46,7 @@ TEST_F(VkPositiveLayerTest, Maintenance1Tests) {
     cmd_buf.End();
 }
 
-TEST_F(VkPositiveLayerTest, ValidStructPNext) {
+TEST_F(PositiveOther, ValidStructPNext) {
     TEST_DESCRIPTION("Verify that a valid pNext value is handled correctly");
 
     // Positive test to check parameter_validation and unique_objects support for NV_dedicated_allocation
@@ -78,7 +78,7 @@ TEST_F(VkPositiveLayerTest, ValidStructPNext) {
     vk::BindBufferMemory(device(), buffer, buffer_memory, 0);
 }
 
-TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
+TEST_F(PositiveOther, DeviceIDPropertiesExtensions) {
     TEST_DESCRIPTION("VkPhysicalDeviceIDProperties can be enabled from 1 of 3 extensions");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -95,7 +95,7 @@ TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
     vk::GetPhysicalDeviceProperties2KHR(Gpu(), &props2);
 }
 
-TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {
+TEST_F(PositiveOther, ParameterLayerFeatures2Capture) {
     TEST_DESCRIPTION("Ensure parameter_validation_layer correctly captures physical device features");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
@@ -164,13 +164,13 @@ TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {
     vk::DestroyDevice(device, nullptr);
 }
 
-TEST_F(VkPositiveLayerTest, ApiVersionZero) {
+TEST_F(PositiveOther, ApiVersionZero) {
     TEST_DESCRIPTION("Check that apiVersion = 0 is valid.");
     app_info_.apiVersion = 0U;
     RETURN_IF_SKIP(InitFramework());
 }
 
-TEST_F(VkPositiveLayerTest, ModifyPnext) {
+TEST_F(PositiveOther, ModifyPnext) {
     TEST_DESCRIPTION("Make sure invalid values in pNext structures are ignored at query time");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -185,7 +185,7 @@ TEST_F(VkPositiveLayerTest, ModifyPnext) {
     vk::GetPhysicalDeviceProperties2(Gpu(), &props);
 }
 
-TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
+TEST_F(PositiveOther, UseFirstQueueUnqueried) {
     TEST_DESCRIPTION("Use first queue family and one queue without first querying with vkGetPhysicalDeviceQueueFamilyProperties");
 
     RETURN_IF_SKIP(InitFramework());
@@ -208,7 +208,7 @@ TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
 
 // Android loader returns an error in this case
 #if !defined(VK_USE_PLATFORM_ANDROID_KHR)
-TEST_F(VkPositiveLayerTest, GetDevProcAddrNullPtr) {
+TEST_F(PositiveOther, GetDevProcAddrNullPtr) {
     TEST_DESCRIPTION("Call GetDeviceProcAddr on an enabled instance extension expecting nullptr");
     AddRequiredExtensions(VK_KHR_SURFACE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
@@ -219,7 +219,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrNullPtr) {
     }
 }
 
-TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
+TEST_F(PositiveOther, GetDevProcAddrExtensions) {
     TEST_DESCRIPTION("Call GetDeviceProcAddr with and without extension enabled");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
@@ -250,7 +250,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
 }
 #endif
 
-TEST_F(VkPositiveLayerTest, Vulkan12FeaturesBufferDeviceAddress) {
+TEST_F(PositiveOther, Vulkan12FeaturesBufferDeviceAddress) {
     TEST_DESCRIPTION("Enable bufferDeviceAddress feature via Vulkan12features struct");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
@@ -277,7 +277,7 @@ TEST_F(VkPositiveLayerTest, Vulkan12FeaturesBufferDeviceAddress) {
     if (nullptr != vkGetBufferDeviceAddressKHR) m_errorMonitor->SetError("Didn't receive expected null pointer");
 }
 
-TEST_F(VkPositiveLayerTest, EnumeratePhysicalDeviceGroups) {
+TEST_F(PositiveOther, EnumeratePhysicalDeviceGroups) {
     TEST_DESCRIPTION("Test using VkPhysicalDevice handles obtained with vkEnumeratePhysicalDeviceGroups");
 
 #ifdef __linux__
@@ -325,7 +325,7 @@ TEST_F(VkPositiveLayerTest, EnumeratePhysicalDeviceGroups) {
     vk::DestroyInstance(test_instance, nullptr);
 }
 
-TEST_F(VkPositiveLayerTest, ExtensionXmlDependsLogic) {
+TEST_F(PositiveOther, ExtensionXmlDependsLogic) {
     TEST_DESCRIPTION("Make sure the OR in 'depends' from XML is observed correctly");
     // VK_KHR_buffer_device_address requires
     // (VK_KHR_get_physical_device_properties2 AND VK_KHR_device_group) OR VK_VERSION_1_1
@@ -349,7 +349,7 @@ TEST_F(VkPositiveLayerTest, ExtensionXmlDependsLogic) {
     RETURN_IF_SKIP(InitState());
 }
 
-TEST_F(VkPositiveLayerTest, FormatProperties3FromProfiles) {
+TEST_F(PositiveOther, FormatProperties3FromProfiles) {
     // https://github.com/KhronosGroup/Vulkan-Profiles/pull/392
     TEST_DESCRIPTION("Make sure VkFormatProperties3 is overwritten correctly in Profiles layer");
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -361,7 +361,7 @@ TEST_F(VkPositiveLayerTest, FormatProperties3FromProfiles) {
     vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 }
 
-TEST_F(VkPositiveLayerTest, GDPAWithMultiCmdExt) {
+TEST_F(PositiveOther, GDPAWithMultiCmdExt) {
     TEST_DESCRIPTION("Use GetDeviceProcAddr on a function which is provided by multiple extensions");
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
@@ -369,7 +369,7 @@ TEST_F(VkPositiveLayerTest, GDPAWithMultiCmdExt) {
     ASSERT_NE(vkCmdSetColorBlendAdvancedEXT, nullptr);
 }
 
-TEST_F(VkPositiveLayerTest, UseInteractionApi1) {
+TEST_F(PositiveOther, UseInteractionApi1) {
     TEST_DESCRIPTION("Use an API that is provided by multiple extensions (part 1)");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
@@ -385,7 +385,7 @@ TEST_F(VkPositiveLayerTest, UseInteractionApi1) {
     vk::GetDeviceGroupPresentCapabilitiesKHR(device(), &device_group_present_caps);
 }
 
-TEST_F(VkPositiveLayerTest, UseInteractionApi2) {
+TEST_F(PositiveOther, UseInteractionApi2) {
     TEST_DESCRIPTION("Use an API that is provided by multiple extensions (part 2)");
     SetTargetApiVersion(VK_API_VERSION_1_0);
     AddRequiredExtensions(VK_KHR_SURFACE_EXTENSION_NAME);
@@ -402,7 +402,7 @@ TEST_F(VkPositiveLayerTest, UseInteractionApi2) {
     vk::GetDeviceGroupPresentCapabilitiesKHR(device(), &device_group_present_caps);
 }
 
-TEST_F(VkPositiveLayerTest, ExtensionExpressions) {
+TEST_F(PositiveOther, ExtensionExpressions) {
     TEST_DESCRIPTION(
         "Enable an extension (e.g., VK_KHR_fragment_shading_rate) that depends on multiple core versions _or_ regular extensions");
 
@@ -420,7 +420,7 @@ TEST_F(VkPositiveLayerTest, ExtensionExpressions) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveLayerTest, AllowedDuplicateStype) {
+TEST_F(PositiveOther, AllowedDuplicateStype) {
     TEST_DESCRIPTION("Pass duplicate structs to whose vk.xml definition contains allowduplicate=true");
 
     VkInstance instance;
@@ -438,7 +438,7 @@ TEST_F(VkPositiveLayerTest, AllowedDuplicateStype) {
     ASSERT_NO_FATAL_FAILURE(vk::DestroyInstance(instance, nullptr));
 }
 
-TEST_F(VkPositiveLayerTest, ExtensionsInCreateInstance) {
+TEST_F(PositiveOther, ExtensionsInCreateInstance) {
     TEST_DESCRIPTION("Test to see if instance extensions are called during CreateInstance.");
     // See https://github.com/KhronosGroup/Vulkan-Loader/issues/537 for more details.
     // This is specifically meant to ensure a crash encountered in profiles does not occur, but also to
@@ -459,7 +459,7 @@ TEST_F(VkPositiveLayerTest, ExtensionsInCreateInstance) {
     RETURN_IF_SKIP(InitFramework());
 }
 
-TEST_F(VkPositiveLayerTest, ExclusiveScissorVersionCount) {
+TEST_F(PositiveOther, ExclusiveScissorVersionCount) {
     TEST_DESCRIPTION("Test using vkCmdSetExclusiveScissorEnableNV.");
 
     AddRequiredExtensions(VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME);
@@ -488,7 +488,7 @@ TEST_F(VkPositiveLayerTest, ExclusiveScissorVersionCount) {
     m_command_buffer.End();
 }
 
-TEST_F(VkPositiveLayerTest, GetCalibratedTimestamps) {
+TEST_F(PositiveOther, GetCalibratedTimestamps) {
     TEST_DESCRIPTION("Basic usage of vkGetCalibratedTimestampsEXT.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
@@ -513,7 +513,7 @@ TEST_F(VkPositiveLayerTest, GetCalibratedTimestamps) {
     vk::GetCalibratedTimestampsEXT(device(), 2, timestamp_infos, timestamps, &max_deviation);
 }
 
-TEST_F(VkPositiveLayerTest, GetCalibratedTimestampsKHR) {
+TEST_F(PositiveOther, GetCalibratedTimestampsKHR) {
     TEST_DESCRIPTION("Basic usage of vkGetCalibratedTimestampsKHR.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
@@ -538,7 +538,7 @@ TEST_F(VkPositiveLayerTest, GetCalibratedTimestampsKHR) {
     vk::GetCalibratedTimestampsKHR(device(), 2, timestamp_infos, timestamps, &max_deviation);
 }
 
-TEST_F(VkPositiveLayerTest, ExtensionPhysicalDeviceFeatureEXT) {
+TEST_F(PositiveOther, ExtensionPhysicalDeviceFeatureEXT) {
     TEST_DESCRIPTION("VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR has an EXT and KHR extension that can enable it");
     AddRequiredExtensions(VK_EXT_GLOBAL_PRIORITY_QUERY_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
@@ -547,7 +547,7 @@ TEST_F(VkPositiveLayerTest, ExtensionPhysicalDeviceFeatureEXT) {
     RETURN_IF_SKIP(InitState(nullptr, &query_feature));
 }
 
-TEST_F(VkPositiveLayerTest, ExtensionPhysicalDeviceFeatureKHR) {
+TEST_F(PositiveOther, ExtensionPhysicalDeviceFeatureKHR) {
     TEST_DESCRIPTION("VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR has an EXT and KHR extension that can enable it");
     AddRequiredExtensions(VK_KHR_GLOBAL_PRIORITY_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
@@ -556,7 +556,7 @@ TEST_F(VkPositiveLayerTest, ExtensionPhysicalDeviceFeatureKHR) {
     RETURN_IF_SKIP(InitState(nullptr, &query_feature));
 }
 
-TEST_F(VkPositiveLayerTest, NoExtensionFromInstanceFunction) {
+TEST_F(PositiveOther, NoExtensionFromInstanceFunction) {
     TEST_DESCRIPTION("Valid because we instance functions don't know which device it needs");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     // Required to pass in various memory flags without querying for corresponding extensions.
@@ -567,7 +567,7 @@ TEST_F(VkPositiveLayerTest, NoExtensionFromInstanceFunction) {
     vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_B16G16R16G16_422_UNORM, &format_properties);
 }
 
-TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct0) {
+TEST_F(PositiveOther, InstanceExtensionsCallingDeviceStruct0) {
     TEST_DESCRIPTION(
         "Use VkImageFormatListCreateInfo with VkPhysicalDeviceImageFormatInfo2 if VK_KHR_image_format_list is available");
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -594,7 +594,7 @@ TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct0) {
     vk::GetPhysicalDeviceImageFormatProperties2KHR(Gpu(), &image_format_info, &image_format_properties);
 }
 
-TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct1) {
+TEST_F(PositiveOther, InstanceExtensionsCallingDeviceStruct1) {
     TEST_DESCRIPTION(
         "Use VkBufferUsageFlags2CreateInfo with VkPhysicalDeviceExternalBufferInfo if VK_KHR_maintenance5 is available");
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -621,7 +621,7 @@ TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct1) {
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10208
-TEST_F(VkPositiveLayerTest, TimelineSemaphoreWithVulkan11) {
+TEST_F(PositiveOther, TimelineSemaphoreWithVulkan11) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8308");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_NV_LOW_LATENCY_2_EXTENSION_NAME);
@@ -630,7 +630,7 @@ TEST_F(VkPositiveLayerTest, TimelineSemaphoreWithVulkan11) {
     RETURN_IF_SKIP(Init());
 }
 
-TEST_F(VkPositiveLayerTest, UnrecognizedEnumOutOfRange) {
+TEST_F(PositiveOther, UnrecognizedEnumOutOfRange) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     RETURN_IF_SKIP(Init());
     if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
@@ -641,7 +641,7 @@ TEST_F(VkPositiveLayerTest, UnrecognizedEnumOutOfRange) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkPositiveLayerTest, UnrecognizedEnumOutOfRange2) {
+TEST_F(PositiveOther, UnrecognizedEnumOutOfRange2) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
@@ -652,7 +652,7 @@ TEST_F(VkPositiveLayerTest, UnrecognizedEnumOutOfRange2) {
     vk::GetPhysicalDeviceFormatProperties2(Gpu(), static_cast<VkFormat>(8000), &format_properties);
 }
 
-TEST_F(VkPositiveLayerTest, UnrecognizedFlagOutOfRange) {
+TEST_F(PositiveOther, UnrecognizedFlagOutOfRange) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     RETURN_IF_SKIP(Init());
     if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
@@ -664,7 +664,7 @@ TEST_F(VkPositiveLayerTest, UnrecognizedFlagOutOfRange) {
                                                static_cast<VkImageUsageFlags>(0xffffffff), 0, &format_properties);
 }
 
-TEST_F(VkPositiveLayerTest, UnrecognizedFlagOutOfRange2) {
+TEST_F(PositiveOther, UnrecognizedFlagOutOfRange2) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
@@ -682,7 +682,7 @@ TEST_F(VkPositiveLayerTest, UnrecognizedFlagOutOfRange2) {
     vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &format_info, &format_properties);
 }
 
-TEST_F(VkPositiveLayerTest, PhysicalDeviceLayeredApiVulkanProperties) {
+TEST_F(PositiveOther, PhysicalDeviceLayeredApiVulkanProperties) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     // Don't enable maintenance7 because we are doing this at an instance level
@@ -701,7 +701,7 @@ TEST_F(VkPositiveLayerTest, PhysicalDeviceLayeredApiVulkanProperties) {
     vk::GetPhysicalDeviceProperties2(Gpu(), &phys_dev_props_2);
 }
 
-TEST_F(VkPositiveLayerTest, HeapWithoutUntypedPointers) {
+TEST_F(PositiveOther, HeapWithoutUntypedPointers) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
@@ -710,7 +710,7 @@ TEST_F(VkPositiveLayerTest, HeapWithoutUntypedPointers) {
     InitState();
 }
 
-TEST_F(VkPositiveLayerTest, GetDeviceFaultReportsWithoutTimeout) {
+TEST_F(PositiveOther, GetDeviceFaultReportsWithoutTimeout) {
     AddRequiredExtensions(VK_KHR_DEVICE_FAULT_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::deviceFault);
     RETURN_IF_SKIP(Init());
@@ -720,7 +720,7 @@ TEST_F(VkPositiveLayerTest, GetDeviceFaultReportsWithoutTimeout) {
     ASSERT_EQ(fault_counts, 0);
 }
 
-TEST_F(VkPositiveLayerTest, GetDeviceFaultReportsWithTimeout) {
+TEST_F(PositiveOther, GetDeviceFaultReportsWithTimeout) {
     AddRequiredExtensions(VK_KHR_DEVICE_FAULT_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::deviceFault);
     RETURN_IF_SKIP(Init());

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -20,7 +20,9 @@
 #include "utils/hash_util.h"
 #include "generated/vk_validation_error_messages.h"
 
-TEST_F(VkLayerTest, VersionCheckPromotedAPIs) {
+class NegativeOther : public VkLayerTest {};
+
+TEST_F(NegativeOther, VersionCheckPromotedAPIs) {
     TEST_DESCRIPTION("Validate that promoted APIs are not valid in old versions.");
     SetTargetApiVersion(VK_API_VERSION_1_0);
 
@@ -46,7 +48,7 @@ TEST_F(VkLayerTest, VersionCheckPromotedAPIs) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnsupportedPnextApiVersion) {
+TEST_F(NegativeOther, UnsupportedPnextApiVersion) {
     TEST_DESCRIPTION("Validate that newer pnext structs are not valid for old Vulkan versions.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -66,7 +68,7 @@ TEST_F(VkLayerTest, UnsupportedPnextApiVersion) {
     }
 }
 
-TEST_F(VkLayerTest, VuidCheckForHashCollisions) {
+TEST_F(NegativeOther, VuidCheckForHashCollisions) {
     TEST_DESCRIPTION("Ensure there are no VUID hash collisions");
 
     std::vector<uint32_t> hashes;
@@ -80,7 +82,7 @@ TEST_F(VkLayerTest, VuidCheckForHashCollisions) {
     ASSERT_TRUE(it == hashes.end());
 }
 
-TEST_F(VkLayerTest, VuidHashStability) {
+TEST_F(NegativeOther, VuidHashStability) {
     TEST_DESCRIPTION("Ensure stability of VUID hashes clients rely on for filtering");
     ASSERT_TRUE(hash_util::VuidHash("VUID-VkRenderPassCreateInfo-pNext-01963") == 0xa19880e3);
     ASSERT_TRUE(hash_util::VuidHash("VUID-BaryCoordKHR-BaryCoordKHR-04154") == 0xcc72e520);
@@ -91,7 +93,7 @@ TEST_F(VkLayerTest, VuidHashStability) {
     ASSERT_TRUE(hash_util::VuidHash("WARNING-Setting-Limit-Adjusted") == 0x86fe6721);
 }
 
-TEST_F(VkLayerTest, RequiredParameter) {
+TEST_F(NegativeOther, RequiredParameter) {
     TEST_DESCRIPTION("Specify VK_NULL_HANDLE, NULL, and 0 for required handle, pointer, array, and array count parameters");
 
     RETURN_IF_SKIP(Init());
@@ -181,7 +183,7 @@ TEST_F(VkLayerTest, RequiredParameter) {
 }
 
 #ifdef ANNOTATED_SPEC_LINK
-TEST_F(VkLayerTest, SpecLinksImplicit) {
+TEST_F(NegativeOther, SpecLinksImplicit) {
     TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
     RETURN_IF_SKIP(Init());
 
@@ -194,7 +196,7 @@ TEST_F(VkLayerTest, SpecLinksImplicit) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SpecLinksExplicit) {
+TEST_F(NegativeOther, SpecLinksExplicit) {
     TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
     RETURN_IF_SKIP(Init());
 
@@ -211,7 +213,7 @@ TEST_F(VkLayerTest, SpecLinksExplicit) {
 
 #else   // ANNOTATED_SPEC_LINK
 
-TEST_F(VkLayerTest, SpecLinksImplicit) {
+TEST_F(NegativeOther, SpecLinksImplicit) {
     TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
     RETURN_IF_SKIP(Init());
 
@@ -224,7 +226,7 @@ TEST_F(VkLayerTest, SpecLinksImplicit) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SpecLinksExplicit) {
+TEST_F(NegativeOther, SpecLinksExplicit) {
     TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
     RETURN_IF_SKIP(Init());
 
@@ -241,7 +243,7 @@ TEST_F(VkLayerTest, SpecLinksExplicit) {
 }
 #endif  // ANNOTATED_SPEC_LINK
 
-TEST_F(VkLayerTest, PnextOnlyStructValidation) {
+TEST_F(NegativeOther, PnextOnlyStructValidation) {
     TEST_DESCRIPTION("See if checks occur on structs ONLY used in pnext chains.");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -278,7 +280,7 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ReservedParameter) {
+TEST_F(NegativeOther, ReservedParameter) {
     TEST_DESCRIPTION("Specify a non-zero value for a reserved parameter");
 
     RETURN_IF_SKIP(Init());
@@ -294,7 +296,7 @@ TEST_F(VkLayerTest, ReservedParameter) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidStructSType) {
+TEST_F(NegativeOther, InvalidStructSType) {
     TEST_DESCRIPTION("Specify an invalid VkStructureType for a Vulkan structure's sType field");
 
     RETURN_IF_SKIP(Init());
@@ -319,7 +321,7 @@ TEST_F(VkLayerTest, InvalidStructSType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidStructPNext) {
+TEST_F(NegativeOther, InvalidStructPNext) {
     TEST_DESCRIPTION("Specify an invalid value for a Vulkan structure's pNext field");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -355,7 +357,7 @@ TEST_F(VkLayerTest, InvalidStructPNext) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnrecognizedEnumOutOfRange) {
+TEST_F(NegativeOther, UnrecognizedEnumOutOfRange) {
     RETURN_IF_SKIP(Init());
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
@@ -370,7 +372,7 @@ TEST_F(VkLayerTest, UnrecognizedEnumOutOfRange) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnrecognizedEnumOutOfRange2) {
+TEST_F(NegativeOther, UnrecognizedEnumOutOfRange2) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
@@ -383,7 +385,7 @@ TEST_F(VkLayerTest, UnrecognizedEnumOutOfRange2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange) {
+TEST_F(NegativeOther, UnrecognizedFlagOutOfRange) {
     RETURN_IF_SKIP(Init());
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
@@ -396,7 +398,7 @@ TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange2) {
+TEST_F(NegativeOther, UnrecognizedFlagOutOfRange2) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
@@ -415,7 +417,7 @@ TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnrecognizedValueBadMask) {
+TEST_F(NegativeOther, UnrecognizedValueBadMask) {
     RETURN_IF_SKIP(Init());
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
@@ -430,7 +432,7 @@ TEST_F(VkLayerTest, UnrecognizedValueBadMask) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnrecognizedValueBadFlag) {
+TEST_F(NegativeOther, UnrecognizedValueBadFlag) {
     RETURN_IF_SKIP(Init());
 
     m_errorMonitor->SetDesiredError("VUID-VkSubmitInfo-pWaitDstStageMask-parameter");
@@ -450,7 +452,7 @@ TEST_F(VkLayerTest, UnrecognizedValueBadFlag) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnrecognizedValueBadBool) {
+TEST_F(NegativeOther, UnrecognizedValueBadBool) {
     // Make sure using VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE doesn't trigger a false positive.
     AddRequiredExtensions(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
@@ -465,7 +467,7 @@ TEST_F(VkLayerTest, UnrecognizedValueBadBool) {
     CreateSamplerTest(sampler_info, "UNASSIGNED-GeneralParameterError-UnrecognizedBool32");
 }
 
-TEST_F(VkLayerTest, UnrecognizedValueMaxEnum) {
+TEST_F(NegativeOther, UnrecognizedValueMaxEnum) {
     RETURN_IF_SKIP(Init());
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
@@ -478,7 +480,7 @@ TEST_F(VkLayerTest, UnrecognizedValueMaxEnum) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
+TEST_F(NegativeOther, UseObjectWithWrongDevice) {
     TEST_DESCRIPTION(
         "Try to destroy a render pass object using a device other than the one it was created on. This should generate a distinct "
         "error from the invalid handle error.");
@@ -513,7 +515,7 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     vk::DestroyDevice(second_device, nullptr);
 }
 
-TEST_F(VkLayerTest, InvalidAllocationCallbacks) {
+TEST_F(NegativeOther, InvalidAllocationCallbacks) {
     TEST_DESCRIPTION("Test with invalid VkAllocationCallbacks");
 
     RETURN_IF_SKIP(Init());
@@ -571,7 +573,7 @@ TEST_F(VkLayerTest, InvalidAllocationCallbacks) {
     }
 }
 
-TEST_F(VkLayerTest, ValidationCacheTestBadMerge) {
+TEST_F(NegativeOther, ValidationCacheTestBadMerge) {
     AddRequiredExtensions(VK_EXT_VALIDATION_CACHE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkValidationCacheCreateInfoEXT validationCacheCreateInfo = vku::InitStructHelper();
@@ -589,7 +591,7 @@ TEST_F(VkLayerTest, ValidationCacheTestBadMerge) {
     vk::DestroyValidationCacheEXT(device(), validationCache, nullptr);
 }
 
-TEST_F(VkLayerTest, UnclosedAndDuplicateQueries) {
+TEST_F(NegativeOther, UnclosedAndDuplicateQueries) {
     TEST_DESCRIPTION("End a command buffer with a query still in progress, create nested queries.");
 
     RETURN_IF_SKIP(Init());
@@ -614,7 +616,7 @@ TEST_F(VkLayerTest, UnclosedAndDuplicateQueries) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExecuteUnrecordedCB) {
+TEST_F(NegativeOther, ExecuteUnrecordedCB) {
     TEST_DESCRIPTION("Attempt vkQueueSubmit with a CB in the initial state");
 
     RETURN_IF_SKIP(Init());
@@ -635,7 +637,7 @@ TEST_F(VkLayerTest, ExecuteUnrecordedCB) {
     // m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ValidateArrayLength) {
+TEST_F(NegativeOther, ValidateArrayLength) {
     TEST_DESCRIPTION("Validate arraylength VUs");
 
     RETURN_IF_SKIP(Init());
@@ -711,7 +713,7 @@ TEST_F(VkLayerTest, ValidateArrayLength) {
     command_buffer.End();
 }
 
-TEST_F(VkLayerTest, DuplicatePhysicalDevices) {
+TEST_F(NegativeOther, DuplicatePhysicalDevices) {
     TEST_DESCRIPTION("Duplicated physical devices in DeviceGroupDeviceCreateInfo.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
@@ -750,7 +752,7 @@ TEST_F(VkLayerTest, DuplicatePhysicalDevices) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidImageCreateFlagWithPhysicalDeviceCount) {
+TEST_F(NegativeOther, InvalidImageCreateFlagWithPhysicalDeviceCount) {
     TEST_DESCRIPTION("Test for invalid imageCreate flags bit with physicalDeviceCount.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -792,7 +794,7 @@ TEST_F(VkLayerTest, InvalidImageCreateFlagWithPhysicalDeviceCount) {
     CreateImageTest(ici, "VUID-VkImageCreateInfo-physicalDeviceCount-01421");
 }
 
-TEST_F(VkLayerTest, ZeroBitmask) {
+TEST_F(NegativeOther, ZeroBitmask) {
     TEST_DESCRIPTION("Test a reserved flags field set to a non-zero value");
 
     RETURN_IF_SKIP(Init());
@@ -805,7 +807,7 @@ TEST_F(VkLayerTest, ZeroBitmask) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidExtEnum) {
+TEST_F(NegativeOther, InvalidExtEnum) {
     TEST_DESCRIPTION("Use an enum from an extension that is not enabled.");
     RETURN_IF_SKIP(Init());
 
@@ -816,7 +818,7 @@ TEST_F(VkLayerTest, InvalidExtEnum) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExtensionNotEnabledYCbCr) {
+TEST_F(NegativeOther, ExtensionNotEnabledYCbCr) {
     TEST_DESCRIPTION("Validate that using an API from an unenabled extension returns an error");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -843,7 +845,7 @@ TEST_F(VkLayerTest, ExtensionNotEnabledYCbCr) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DuplicateValidPNextStructures) {
+TEST_F(NegativeOther, DuplicateValidPNextStructures) {
     TEST_DESCRIPTION("Create a pNext chain containing valid structures, but with a duplicate structure type");
 
     // VK_KHR_get_physical_device_properties2 promoted to 1.1
@@ -865,7 +867,7 @@ TEST_F(VkLayerTest, DuplicateValidPNextStructures) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, GetPhysicalDeviceImageFormatPropertiesFlags) {
+TEST_F(NegativeOther, GetPhysicalDeviceImageFormatPropertiesFlags) {
     RETURN_IF_SKIP(Init());
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
@@ -883,7 +885,7 @@ TEST_F(VkLayerTest, GetPhysicalDeviceImageFormatPropertiesFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, GetCalibratedTimestampsDuplicate) {
+TEST_F(NegativeOther, GetCalibratedTimestampsDuplicate) {
     TEST_DESCRIPTION("vkGetCalibratedTimestampsEXT with duplicated timeDomain.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
@@ -907,7 +909,7 @@ TEST_F(VkLayerTest, GetCalibratedTimestampsDuplicate) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, GetCalibratedTimestampsDuplicateKHR) {
+TEST_F(NegativeOther, GetCalibratedTimestampsDuplicateKHR) {
     TEST_DESCRIPTION("vkGetCalibratedTimestampsKHR with duplicated timeDomain.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
@@ -931,7 +933,7 @@ TEST_F(VkLayerTest, GetCalibratedTimestampsDuplicateKHR) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, GetCalibratedTimestampsQuery) {
+TEST_F(NegativeOther, GetCalibratedTimestampsQuery) {
     TEST_DESCRIPTION("vkGetCalibratedTimestampsEXT with invalid timeDomain.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
@@ -957,7 +959,7 @@ TEST_F(VkLayerTest, GetCalibratedTimestampsQuery) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExtensionXmlDependsLogic) {
+TEST_F(NegativeOther, ExtensionXmlDependsLogic) {
     TEST_DESCRIPTION("Make sure the OR in 'depends' from XML is observed correctly");
     // VK_KHR_buffer_device_address requires
     // (VK_KHR_get_physical_device_properties2 AND VK_KHR_device_group) OR VK_VERSION_1_1
@@ -999,7 +1001,7 @@ TEST_F(VkLayerTest, ExtensionXmlDependsLogic) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExtensionXmlDependsLogic2) {
+TEST_F(NegativeOther, ExtensionXmlDependsLogic2) {
     // VK_KHR_shared_presentable_image requires
     // VK_KHR_swapchain
     //    and
@@ -1045,7 +1047,7 @@ TEST_F(VkLayerTest, ExtensionXmlDependsLogic2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExtensionXmlDependsLogic3) {
+TEST_F(NegativeOther, ExtensionXmlDependsLogic3) {
     // VK_KHR_shared_presentable_image requires
     // VK_KHR_swapchain
     //    and
@@ -1091,7 +1093,7 @@ TEST_F(VkLayerTest, ExtensionXmlDependsLogic3) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidGetExternalBufferPropertiesUsage) {
+TEST_F(NegativeOther, InvalidGetExternalBufferPropertiesUsage) {
     TEST_DESCRIPTION("Call vkGetPhysicalDeviceExternalBufferProperties with invalid usage");
 
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
@@ -1121,7 +1123,7 @@ TEST_F(VkLayerTest, InvalidGetExternalBufferPropertiesUsage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorBufferNoExtension) {
+TEST_F(NegativeOther, DescriptorBufferNoExtension) {
     TEST_DESCRIPTION("Create VkBuffer without the extension.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
@@ -1134,7 +1136,7 @@ TEST_F(VkLayerTest, DescriptorBufferNoExtension) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MissingCreateInfo) {
+TEST_F(NegativeOther, MissingCreateInfo) {
     RETURN_IF_SKIP(Init());
 
     VkBuffer buffer;
@@ -1250,7 +1252,7 @@ TEST_F(VkLayerTest, MissingCreateInfo) {
 
 // Android loader returns an error in this case, so never makes it to the VVL
 #if !defined(VK_USE_PLATFORM_ANDROID_KHR)
-TEST_F(VkLayerTest, GetDeviceProcAddrInstance) {
+TEST_F(NegativeOther, GetDeviceProcAddrInstance) {
     TEST_DESCRIPTION("Call GetDeviceProcAddr on an instance function");
     RETURN_IF_SKIP(Init());
     m_errorMonitor->SetDesiredWarning("WARNING-vkGetDeviceProcAddr-device");
@@ -1261,7 +1263,7 @@ TEST_F(VkLayerTest, GetDeviceProcAddrInstance) {
 
 // TODO - Can reproduce locally when setting VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME
 // but need to unset variable and make sure works on Android before having CI run this
-TEST_F(VkLayerTest, DISABLED_DisplayApplicationName) {
+TEST_F(NegativeOther, DISABLED_DisplayApplicationName) {
     TEST_DESCRIPTION("Test message_format_display_application_name");
     const char* name_0 = "first instance";
     app_info_.pApplicationName = name_0;
@@ -1297,7 +1299,7 @@ TEST_F(VkLayerTest, DISABLED_DisplayApplicationName) {
     ASSERT_NO_FATAL_FAILURE(vk::DestroyInstance(instance2, nullptr));
 }
 
-TEST_F(VkLayerTest, GetDeviceFaultInfoEXT) {
+TEST_F(NegativeOther, GetDeviceFaultInfoEXT) {
     AddRequiredExtensions(VK_EXT_DEVICE_FAULT_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFaultFeaturesEXT ext_features = vku::InitStructHelper();
@@ -1310,7 +1312,7 @@ TEST_F(VkLayerTest, GetDeviceFaultInfoEXT) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, GetDeviceFaultDebugInfo) {
+TEST_F(NegativeOther, GetDeviceFaultDebugInfo) {
     AddRequiredExtensions(VK_KHR_DEVICE_FAULT_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::deviceFault);
     RETURN_IF_SKIP(Init());
@@ -1320,7 +1322,7 @@ TEST_F(VkLayerTest, GetDeviceFaultDebugInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PhysicalDeviceLayeredApiVulkanPropertiesKHR) {
+TEST_F(NegativeOther, PhysicalDeviceLayeredApiVulkanPropertiesKHR) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_7_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::maintenance7);
@@ -1347,7 +1349,7 @@ TEST_F(VkLayerTest, PhysicalDeviceLayeredApiVulkanPropertiesKHR) {
 
 // stype-check off
 // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9185
-TEST_F(VkLayerTest, DISABLED_PhysicalDeviceLayeredApiVulkanPropertiesPNext) {
+TEST_F(NegativeOther, DISABLED_PhysicalDeviceLayeredApiVulkanPropertiesPNext) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_7_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::maintenance7);
@@ -1370,14 +1372,14 @@ TEST_F(VkLayerTest, DISABLED_PhysicalDeviceLayeredApiVulkanPropertiesPNext) {
 }
 // stype-check on
 
-TEST_F(VkLayerTest, UnrecognizedEnumExtension) {
+TEST_F(NegativeOther, UnrecognizedEnumExtension) {
     RETURN_IF_SKIP(Init());
     m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-format-parameter");
     vkt::Image image(*m_device, 4, 4, VK_FORMAT_A4B4G4R4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT);
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MissingExtensionBufferUsageFlags2CreateInfo) {
+TEST_F(NegativeOther, MissingExtensionBufferUsageFlags2CreateInfo) {
     TEST_DESCRIPTION("Use VkBufferUsageFlags2CreateInfo without the extension");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
@@ -1406,7 +1408,7 @@ TEST_F(VkLayerTest, MissingExtensionBufferUsageFlags2CreateInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MissingExtensionPipelineCreateFlags2) {
+TEST_F(NegativeOther, MissingExtensionPipelineCreateFlags2) {
     TEST_DESCRIPTION("Use VkPipelineCreateFlags2 without the extension");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
@@ -1421,7 +1423,7 @@ TEST_F(VkLayerTest, MissingExtensionPipelineCreateFlags2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, OverridePipelineCreateFlags2) {
+TEST_F(NegativeOther, OverridePipelineCreateFlags2) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredFeature(vkt::Feature::maintenance5);
     RETURN_IF_SKIP(Init());
@@ -1436,7 +1438,7 @@ TEST_F(VkLayerTest, OverridePipelineCreateFlags2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UnkonwnStructType) {
+TEST_F(NegativeOther, UnkonwnStructType) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkBaseOutStructure bogus_struct{};
@@ -1449,7 +1451,7 @@ TEST_F(VkLayerTest, UnkonwnStructType) {
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10208
-TEST_F(VkLayerTest, DISABLED_MultipleExtensionOrDependency) {
+TEST_F(NegativeOther, DISABLED_MultipleExtensionOrDependency) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_NV_LOW_LATENCY_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -1459,7 +1461,7 @@ TEST_F(VkLayerTest, DISABLED_MultipleExtensionOrDependency) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CooperativeMatrixProps) {
+TEST_F(NegativeOther, CooperativeMatrixProps) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-Docs/issues/2613");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
@@ -1484,7 +1486,7 @@ TEST_F(VkLayerTest, CooperativeMatrixProps) {
     }
 }
 
-TEST_F(VkLayerTest, FeatureNotPresentNoCoreFeatures) {
+TEST_F(NegativeOther, FeatureNotPresentNoCoreFeatures) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11390");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(InitFramework());

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -27,6 +27,7 @@
 class NegativeRenderPass : public VkLayerTest {
   public:
     void TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR& create_info, const std::vector<const char*>& vuids);
+    void TestPotentialFormatFeatures(bool const useLinearColorAttachment);
 };
 
 void NegativeRenderPass::TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR& create_info,
@@ -1994,12 +1995,7 @@ TEST_F(NegativeRenderPass, MissingAttachment) {
     m_command_buffer.End();
 }
 
-class RenderPassCreatePotentialFormatFeaturesTest : public NegativeRenderPass {
-  public:
-    void Test(bool const useLinearColorAttachment);
-};
-
-void RenderPassCreatePotentialFormatFeaturesTest::Test(bool const useLinearColorAttachment) {
+void NegativeRenderPass::TestPotentialFormatFeatures(bool const useLinearColorAttachment) {
     // Check for VK_KHR_get_physical_device_properties2
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     if (useLinearColorAttachment) {
@@ -2132,14 +2128,14 @@ void RenderPassCreatePotentialFormatFeaturesTest::Test(bool const useLinearColor
     }
 }
 
-TEST_F(RenderPassCreatePotentialFormatFeaturesTest, Core) {
+TEST_F(NegativeRenderPass, PotentialFormatFeaturesCore) {
     TEST_DESCRIPTION("Validate PotentialFormatFeatures in renderpass create");
-    Test(false);
+    TestPotentialFormatFeatures(false);
 }
 
-TEST_F(RenderPassCreatePotentialFormatFeaturesTest, LinearColorAttachment) {
+TEST_F(NegativeRenderPass, PotentialFormatFeaturesLinearColorAttachment) {
     TEST_DESCRIPTION("Validate PotentialFormatFeatures in renderpass create with linearColorAttachment");
-    Test(true);
+    TestPotentialFormatFeatures(true);
 }
 
 TEST_F(NegativeRenderPass, DepthStencilResolveMode) {

--- a/tests/vvl_utils/pnext_chain_extraction.cpp
+++ b/tests/vvl_utils/pnext_chain_extraction.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ bool FindSTypes(void* chain, const std::vector<VkStructureType>& sTypes_list) {
 }
 
 // Extract all structs from a pNext chain
-TEST(PnextChainExtract, Extract1) {
+TEST(UtilsPnextChainExtract, Extract1) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
     VkImageCompressionControlEXT s1 = vku::InitStructHelper();
     VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);
@@ -43,7 +43,7 @@ TEST(PnextChainExtract, Extract1) {
 }
 
 // Extract all structs mentioned in tuple vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 and found in input pNext chain
-TEST(PnextChainExtract, Extract2) {
+TEST(UtilsPnextChainExtract, Extract2) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
     VkImageCompressionControlEXT s1 = vku::InitStructHelper();
     VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);
@@ -66,7 +66,7 @@ TEST(PnextChainExtract, Extract2) {
 
 // Test that no struct is extracted when no struct from a pNext chain extends the reference struct, here
 // VkPhysicalDeviceImageFormatInfo2
-TEST(PnextChainExtract, Extract3) {
+TEST(UtilsPnextChainExtract, Extract3) {
     // Those structs do not extend VkPhysicalDeviceImageFormatInfo2
     VkExternalMemoryImageCreateInfo wrong1 = vku::InitStructHelper();
     VkImageDrmFormatModifierListCreateInfoEXT wrong2 = vku::InitStructHelper(&wrong1);
@@ -79,7 +79,7 @@ TEST(PnextChainExtract, Extract3) {
 }
 
 // Extract all structs from a pNext chain, add a new element, then remove it
-TEST(PnextChainExtract, ExtractAddRemove1) {
+TEST(UtilsPnextChainExtract, ExtractAddRemove1) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
     VkImageCompressionControlEXT s1 = vku::InitStructHelper();
     VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);
@@ -104,7 +104,7 @@ TEST(PnextChainExtract, ExtractAddRemove1) {
 }
 
 // Extract all structs from a pNext chain, add two new elements, in a nested fashion, then remove them
-TEST(PnextChainExtract, ExtractAddRemove2) {
+TEST(UtilsPnextChainExtract, ExtractAddRemove2) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
     VkImageCompressionControlEXT s1 = vku::InitStructHelper();
     VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);

--- a/tests/vvl_utils/small_vector.cpp
+++ b/tests/vvl_utils/small_vector.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ bool HaveSameElements(const T& l1, const U& l2) {
     return l1.size() == l2.size() && HaveSameElementsUpTo(l1, l2, l1.size());
 }
 
-TEST(CustomContainer, SmallVectorIntResize) {
+TEST(UtilsCustomContainer, SmallVectorIntResize) {
     // Resize int small vector, moving to small store
     // ---
     {
@@ -139,7 +139,7 @@ struct NoDefaultCons {
 
 bool operator!=(const NoDefaultCons& lhs, const NoDefaultCons& rhs) { return lhs.x != rhs.x; }
 
-TEST(CustomContainer, SmallVectorNotDefaultInsertable) {
+TEST(UtilsCustomContainer, SmallVectorNotDefaultInsertable) {
     // Resize NoDefault small vector, moving to small store
     // ---
     {
@@ -217,7 +217,7 @@ TEST(CustomContainer, SmallVectorNotDefaultInsertable) {
     }
 }
 
-TEST(CustomContainer, SmallVectorNotDefaultInsertableDefaultValue) {
+TEST(UtilsCustomContainer, SmallVectorNotDefaultInsertableDefaultValue) {
     // Resize NoDefault small vector, moving to small store
     // ---
     {
@@ -293,7 +293,7 @@ TEST(CustomContainer, SmallVectorNotDefaultInsertableDefaultValue) {
         ASSERT_TRUE(HaveSameElements(v9, ref));
     }
 }
-TEST(CustomContainer, SmallVectorConstruct) {
+TEST(UtilsCustomContainer, SmallVectorConstruct) {
     using SmallVector = small_vector<std::string, 5, size_t>;
     const SmallVector ref_small = {"one", "two", "three", "four"};
     SmallVector ref_large = {"one", "two", "three", "four", "five", "six"};
@@ -335,7 +335,7 @@ TEST(CustomContainer, SmallVectorConstruct) {
     ASSERT_TRUE(HaveSameElements(ref_large, v_large_move_dst));
 }
 
-TEST(CustomContainer, SmallVectorAssign) {
+TEST(UtilsCustomContainer, SmallVectorAssign) {
     using SmallVector = small_vector<std::string, 5, size_t>;
     const SmallVector ref_xxs = {"one", "two"};
     const SmallVector ref_xs = {"one", "two", "three"};
@@ -425,7 +425,7 @@ TEST(CustomContainer, SmallVectorAssign) {
     ASSERT_TRUE(HaveSameElements(ref_xxl, v_dst));
 }
 
-TEST(CustomContainer, Enumerate) {
+TEST(UtilsCustomContainer, Enumerate) {
     small_vector<int, 2, size_t> sv = {1, 2, 3, 4};
     std::array ref_elements = {1, 2, 3, 4};
     size_t indices_i = 0;
@@ -436,7 +436,7 @@ TEST(CustomContainer, Enumerate) {
     }
 }
 
-TEST(CustomContainer, EnumerateConst) {
+TEST(UtilsCustomContainer, EnumerateConst) {
     const std::vector<int> sv{1, 2, 3, 4};
     std::array ref_elements = {1, 2, 3, 4};
     size_t indices_i = 0;


### PR DESCRIPTION
For future improvement in internal CI, want to just have a single naming scheme

- `Positive*`
- `Negative*`
- `Utils*`

While here, rename the Best Practice test files to match and make them grouped together