### PR TITLE
gpuav: Add AccessPath helper

### DIFF
--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -212,13 +212,14 @@ bool BufferDeviceAddressPass::Instrument() {
                     if (!meta.pointer_inst->IsAccessChain()) {
                         continue;
                     }
-                    // OpAccesschain -> OpLoad/OpBitcast -> OpTypePointer (PSB) -> OpTypeStruct
+                    // OpTypeStruct -> OpTypePointer (PSB) -> OpLoad/OpBitcast -> OpAccesschain
                     std::vector<const Instruction*> access_chain_insts;
 
                     const Instruction* next_inst = meta.pointer_inst;
                     // First walk back to the outer most access chain
                     while (next_inst && next_inst->IsAccessChain()) {
-                        access_chain_insts.push_back(next_inst);
+                        access_chain_insts.insert(access_chain_insts.begin(), next_inst);
+
                         const uint32_t access_chain_base_id = next_inst->Operand(0);
                         next_inst = function.FindInstruction(access_chain_base_id);
                     }
@@ -235,7 +236,7 @@ bool BufferDeviceAddressPass::Instrument() {
 
                             // GLSL/HLSL will only ever a struct, but for Slang, we might have the first access be the pointer and
                             // we actually need that outer struct, which "looks" an OpTypePointer with an ArrayStride attached to it
-                            const Instruction* last_access = access_chain_insts.back();
+                            const Instruction* last_access = access_chain_insts.front();
                             if (!last_access->IsNonPtrAccessChain() && last_access->TypeId() == load_type_pointer->Id()) {
                                 root_struct_id = load_type_pointer->Id();
                             }

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -17,13 +17,13 @@
 #include "generated/device_features.h"
 #include "generated/spirv_grammar_helper.h"
 #include "containers/container_utils.h"
-#include "state_tracker/shader_instruction.h"
 #include "module.h"
 #include <spirv/unified1/spirv.hpp>
 #include <iostream>
 
 #include "generated/gpuav_offline_spirv.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
+#include "type_manager.h"
 
 namespace gpuav {
 namespace spirv {
@@ -53,12 +53,12 @@ uint32_t DescriptorClassGeneralBufferPass::GetLinkFunctionId(bool is_coop_mat) {
 }
 
 void DescriptorClassGeneralBufferPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta) {
-    assert(!meta.access_chain_insts.empty());
+    assert(!meta.access_path.ac_list.empty());
     const Constant& desc_set_constant = type_manager_.GetConstantUInt32(meta.descriptor_set);
     const uint32_t desc_index_id = CastToUint32(meta.descriptor_index_id, block, inst_it);  // might be int32
 
     const uint32_t descriptor_offset_id =
-        GetLastByte(*meta.descriptor_type, meta.access_chain_insts, meta.coop_mat_access, block, inst_it);
+        GetLastByte(*meta.descriptor_type, meta.access_path.ac_list, meta.coop_mat_access, block, inst_it);
 
     const auto& layout_lut = module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut;
     BindingLayout binding_layout = layout_lut[meta.descriptor_set][meta.descriptor_binding];
@@ -95,32 +95,18 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
         return false;
     }
 
-    const Instruction* next_access_chain = function.FindInstruction(inst.Operand(0));
-    if (!next_access_chain || !next_access_chain->IsNonPtrAccessChain()) {
+    meta.access_path = type_manager_.BuildAccessPath(function, inst);
+    if (!meta.access_path.IsValid()) {
         return false;
     }
+    const Variable& access_variable = *meta.access_path.variable;
 
-    const Variable* variable = nullptr;
-    // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-    while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
-        meta.access_chain_insts.push_back(next_access_chain);
-        const uint32_t access_chain_base_id = next_access_chain->Operand(0);
-        variable = type_manager_.FindVariableById(access_chain_base_id);
-        if (variable) {
-            break;  // found
-        }
-        next_access_chain = function.FindInstruction(access_chain_base_id);
-    }
-    if (!variable) {
-        return false;
-    }
-
-    uint32_t storage_class = variable->StorageClass();
+    uint32_t storage_class = access_variable.StorageClass();
     if (storage_class != spv::StorageClassUniform && storage_class != spv::StorageClassStorageBuffer) {
         return false;
     }
 
-    meta.descriptor_type = variable->PointerType(type_manager_);
+    meta.descriptor_type = access_variable.PointerType(type_manager_);
     if (!meta.descriptor_type || meta.descriptor_type->spv_type_ == SpvType::kRuntimeArray) {
         return false;  // TODO - Currently we mark these as "bindless"
     }
@@ -142,20 +128,20 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
     }
 
     // Grab front() as it will be the "final" type we access
-    const Type* value_type = type_manager_.FindValueTypeById(meta.access_chain_insts.front()->TypeId());
+    const Type* value_type = type_manager_.FindValueTypeById(meta.access_path.FinalAccessedType());
     if (!value_type) {
         return false;
     }
 
     if (is_descriptor_array) {
         // Because you can't have 2D array of descriptors, the first index of the last accessChain is the descriptor index
-        meta.descriptor_index_id = meta.access_chain_insts.back()->Operand(1);
+        meta.descriptor_index_id = meta.access_path.DescriptorIndexId();
     } else {
         // There is no array of this descriptor, so we essentially have an array of 1
         meta.descriptor_index_id = type_manager_.GetConstantZeroUint32().Id();
     }
 
-    GetDescriptorSetAndBinding(variable->Id(), meta.descriptor_set, meta.descriptor_binding);
+    GetDescriptorSetAndBinding(access_variable.Id(), meta.descriptor_set, meta.descriptor_binding);
 
     if (meta.descriptor_set >= glsl::kDebugInputBindlessMaxDescSets) {
         module_.InternalWarning(Name(), "Tried to use a descriptor slot over the current max limit");
@@ -169,7 +155,7 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
 
     if (!module_.settings_.safe_mode) {
         meta.access_offset =
-            FindOffsetInStruct(meta.descriptor_id, &meta.coop_mat_access, is_descriptor_array, meta.access_chain_insts);
+            FindOffsetInStruct(meta.descriptor_id, &meta.coop_mat_access, is_descriptor_array, meta.access_path.ac_list);
     }
 
     // Save information to be used to make the Function

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 #include <cstdint>
+#include "type_manager.h"
 #include "pass.h"
 
 namespace gpuav {
@@ -45,11 +46,7 @@ class DescriptorClassGeneralBufferPass : public Pass {
         // Id to the descriptor, will have array stripped if descriptor indexing
         uint32_t descriptor_id = 0;
 
-        // List of OpAccessChains fom the Store/Load down to the OpVariable
-        // The front() will be closet to the exact spot accesssed
-        // The back() will be closest to the OpVariable
-        // (note GLSL will try to always create a single large OpAccessChain)
-        std::vector<const Instruction*> access_chain_insts;
+        AccessPath access_path;
 
         // Capture the upper bound offset into the struct the instruction accesses
         // Will be zero if we can't determine it (or in Safe Mode)

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -177,24 +177,13 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
                AtomicOperation(opcode)) {
         // Buffer and Buffer Atomics and Storage Images
 
-        const Variable* variable = nullptr;
-        const Instruction* access_chain_inst = function.FindInstruction(inst.Operand(0));
-        // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-        while (access_chain_inst && access_chain_inst->IsNonPtrAccessChain()) {
-            const uint32_t access_chain_base_id = access_chain_inst->Operand(0);
-            variable = type_manager_.FindVariableById(access_chain_base_id);
-            if (variable) {
-                break;  // found
-            }
-            access_chain_inst = function.FindInstruction(access_chain_base_id);
-        }
-        if (!variable) {
+        const AccessPath access_path = type_manager_.BuildAccessPath(function, inst);
+        if (!access_path.IsValid()) {
             return false;
         }
+        meta.var_inst = &access_path.variable->inst_;
 
-        meta.var_inst = &variable->inst_;
-
-        const uint32_t storage_class = variable->StorageClass();
+        const uint32_t storage_class = access_path.variable->StorageClass();
         if (storage_class == spv::StorageClassUniformConstant) {
             // TODO - Need to add Storage Image support
             return false;
@@ -203,7 +192,7 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
             return false;  // Prevents things like Push Constants
         }
 
-        const Type* pointer_type = variable->PointerType(type_manager_);
+        const Type* pointer_type = access_path.variable->PointerType(type_manager_);
         if (!pointer_type) {
             module_.InternalError(Name(), "Pointer type not found");
             return false;
@@ -211,7 +200,7 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
 
         if (pointer_type->IsArray()) {
             array_found = true;
-            meta.descriptor_index_id = access_chain_inst->Operand(1);
+            meta.descriptor_index_id = access_path.DescriptorIndexId();
         } else {
             // There is no array of this descriptor, so we essentially have an array of 1
             meta.descriptor_index_id = type_manager_.GetConstantZeroUint32().Id();

--- a/layers/gpuav/spirv/mesh_shading_pass.cpp
+++ b/layers/gpuav/spirv/mesh_shading_pass.cpp
@@ -22,6 +22,7 @@
 #include <iostream>
 
 #include "generated/gpuav_offline_spirv.h"
+#include "type_manager.h"
 
 namespace gpuav {
 namespace spirv {
@@ -71,24 +72,10 @@ bool MeshShading::RequiresInstrumentation(const Function& function, const Instru
         meta.function_id = SET_MESH_OUTPUT;
         return true;
     } else if (guard_all_task_payloads_ && (IsValueIn(opcode, {spv::OpLoad, spv::OpStore}) || AtomicOperation(opcode))) {
-        // |Operand 0| works for both Store/Load
-        const uint32_t ptr_id = inst.Operand(0);
-
-        // Unlike descriptors, TaskPayload can be a scalar that does a direct variable access, not using an access chain
-        const Variable* variable = type_manager_.FindVariableById(ptr_id);
-        const Instruction* next_access_chain = function.FindInstruction(inst.Operand(0));
-        // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-        while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
-            const uint32_t access_chain_base_id = next_access_chain->Operand(0);
-            variable = type_manager_.FindVariableById(access_chain_base_id);
-            if (variable) {
-                break;  // found
-            }
-            next_access_chain = function.FindInstruction(access_chain_base_id);
-        }
-        if (!variable) {
+        const AccessPath access_path = type_manager_.BuildAccessPath(function, inst);
+        if (!access_path.IsValid()) {
             return false;
-        } else if (variable->StorageClass() != spv::StorageClassTaskPayloadWorkgroupEXT) {
+        } else if (access_path.variable->StorageClass() != spv::StorageClassTaskPayloadWorkgroupEXT) {
             return false;
         }
 

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -382,7 +382,7 @@ uint32_t Pass::GetLastByte(const Type& descriptor_type, const std::vector<const 
     // }
     //
     // it will get us to 20 bytes
-    auto access_chain_iter = access_chain_insts.rbegin();
+    auto access_chain_iter = access_chain_insts.begin();
 
     // This occurs in things like Slang where they have a single OpAccessChain for the descriptor
     // (GLSL/HLSL will combine 2 indexes into the last OpAccessChain)
@@ -391,7 +391,7 @@ uint32_t Pass::GetLastByte(const Type& descriptor_type, const std::vector<const 
         ac_word_index = reset_ac_word;
     }
 
-    while (access_chain_iter != access_chain_insts.rend()) {
+    while (access_chain_iter != access_chain_insts.end()) {
         const uint32_t ac_index_id = (*access_chain_iter)->Word(ac_word_index);
         uint32_t current_offset_id = 0;
 
@@ -580,7 +580,7 @@ uint32_t Pass::FindOffsetInStruct(uint32_t struct_id, const CooperativeMatrixAcc
     bool col_major = false;
     bool in_matrix = false;
 
-    auto access_chain_iter = access_chain_insts.rbegin();
+    auto access_chain_iter = access_chain_insts.begin();
 
     // This occurs in things like Slang where they have a single OpAccessChain for the descriptor
     // (GLSL/HLSL will combine 2 indexes into the last OpAccessChain)
@@ -591,7 +591,7 @@ uint32_t Pass::FindOffsetInStruct(uint32_t struct_id, const CooperativeMatrixAcc
 
     uint32_t current_type_id = struct_id;
     // Walk down access chains to build up the offset
-    while (access_chain_iter != access_chain_insts.rend()) {
+    while (access_chain_iter != access_chain_insts.end()) {
         const uint32_t ac_index_id = (*access_chain_iter)->Word(ac_word_index);
         const Constant* index_constant = type_manager_.FindConstantById(ac_index_id);
         if (!index_constant || index_constant->inst_.Opcode() != spv::OpConstant) {

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -68,30 +68,21 @@ bool PostProcessDescriptorIndexingPass::RequiresInstrumentation(const Function& 
 
     const Instruction* var_inst = nullptr;
     if (IsValueIn(opcode, {spv::OpLoad, spv::OpStore, spv::OpCooperativeMatrixLoadKHR, spv::OpCooperativeMatrixStoreKHR})) {
-        const Variable* variable = nullptr;
-        const Instruction* access_chain_inst = function.FindInstruction(inst.Operand(0));
-        // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-        while (access_chain_inst && access_chain_inst->IsNonPtrAccessChain()) {
-            const uint32_t access_chain_base_id = access_chain_inst->Operand(0);
-            variable = type_manager_.FindVariableById(access_chain_base_id);
-            if (variable) {
-                break;  // found
-            }
-            access_chain_inst = function.FindInstruction(access_chain_base_id);
-        }
-        if (!variable) {
+        const AccessPath access_path = type_manager_.BuildAccessPath(function, inst);
+        if (!access_path.IsValid()) {
             return false;
         }
-        var_inst = &variable->inst_;
 
-        const uint32_t storage_class = variable->StorageClass();
+        var_inst = &access_path.variable->inst_;
+
+        const uint32_t storage_class = access_path.variable->StorageClass();
         if (storage_class != spv::StorageClassUniform && storage_class != spv::StorageClassStorageBuffer) {
             return false;
         }
 
-        const Type* pointer_type = variable->PointerType(type_manager_);
+        const Type* pointer_type = access_path.variable->PointerType(type_manager_);
         if (pointer_type->IsArray()) {
-            meta.descriptor_index_id = access_chain_inst->Operand(1);
+            meta.descriptor_index_id = access_path.DescriptorIndexId();
         } else {
             // There is no array of this descriptor, so we essentially have an array of 1
             meta.descriptor_index_id = type_manager_.GetConstantZeroUint32().Id();

--- a/layers/gpuav/spirv/shared_memory_data_race_pass.cpp
+++ b/layers/gpuav/spirv/shared_memory_data_race_pass.cpp
@@ -192,25 +192,10 @@ bool SharedMemoryDataRacePass::RequiresInstrumentation(const Function& function,
         return true;
     }
 
-    const uint32_t ptr_id = inst.Operand(0);  // works with both store and loads
-
-    std::vector<const Instruction*> access_chains;
-    const Variable* variable = type_manager_.FindVariableById(ptr_id);
-    const Instruction* access_chain_inst = FindInstructionGlobal(function, ptr_id);
-    // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-    while (access_chain_inst && access_chain_inst->IsNonPtrAccessChain()) {
-        // inserting in front allows us to walk over the loop from the front
-        access_chains.insert(access_chains.begin(), access_chain_inst);
-        const uint32_t access_chain_base_id = access_chain_inst->Operand(0);
-        variable = type_manager_.FindVariableById(access_chain_base_id);
-        if (variable) {
-            break;  // found
-        }
-        access_chain_inst = FindInstructionGlobal(function, access_chain_base_id);
-    }
-    if (!variable) {
+    const AccessPath access_path = type_manager_.BuildAccessPath(function, inst);
+    if (!access_path.IsValid()) {
         return false;
-    } else if (variable->StorageClass() != spv::StorageClassWorkgroup) {
+    } else if (access_path.variable->StorageClass() != spv::StorageClassWorkgroup) {
         return false;
     }
 
@@ -219,8 +204,8 @@ bool SharedMemoryDataRacePass::RequiresInstrumentation(const Function& function,
 
     // ptr_elem_type will point to the portion of the variable being accessed. Initialize it
     // to the variable's pointee type in case of no access chains.
-    const Type* ptr_elem_type = type_manager_.FindChildType(*type_manager_.FindTypeById(variable->inst_.Word(1)), 0);
-    for (auto ac : access_chains) {
+    const Type* ptr_elem_type = type_manager_.FindChildType(*type_manager_.FindTypeById(access_path.variable->inst_.Word(1)), 0);
+    for (auto ac : access_path.ac_list) {
         auto ptr = FindInstructionGlobal(function, ac->Word(3));
         const Type* base_ptr_type = type_manager_.FindTypeById(ptr->Word(1));
 
@@ -246,8 +231,8 @@ bool SharedMemoryDataRacePass::RequiresInstrumentation(const Function& function,
                     uint32_t idx_u32 = idx_c->GetValueUint32();
 
                     uint32_t scalar_offset = 0;
-                    for (uint32_t i = 0; i < idx_u32; ++i) {
-                        scalar_offset += type_manager_.GetScalarElementCount(*type_manager_.FindChildType(*ptr_elem_type, i));
+                    for (uint32_t idx_m = 0; idx_m < idx_u32; idx_m++) {
+                        scalar_offset += type_manager_.GetScalarElementCount(*type_manager_.FindChildType(*ptr_elem_type, idx_m));
                     }
 
                     uint32_t new_id = module_.TakeNextId();
@@ -276,9 +261,9 @@ bool SharedMemoryDataRacePass::RequiresInstrumentation(const Function& function,
     }
 
     meta.access_chain_idx_id = offset_id;
-    meta.start = slot_start_[variable->Id()];
+    meta.start = slot_start_[access_path.variable->Id()];
     meta.element_count = type_manager_.GetScalarElementCount(*ptr_elem_type);
-    meta.variable_idx = variable->Id();
+    meta.variable_idx = access_path.variable->Id();
 
     switch (opcode) {
         case spv::OpLoad:

--- a/layers/gpuav/spirv/shared_memory_data_race_pass.cpp
+++ b/layers/gpuav/spirv/shared_memory_data_race_pass.cpp
@@ -67,7 +67,7 @@ void SharedMemoryDataRacePass::CreateFunctionCall(const Function& function, Basi
 
     if (meta.function_idx == INIT_SHADOW) {
         const uint32_t function_result = module_.TakeNextId();
-        const uint32_t length_id = type_manager_.GetConstantUInt32(num_slots_).Id();
+        const uint32_t length_id = type_manager_.GetConstantUInt32(slot_count_).Id();
         block.CreateInstruction(spv::OpFunctionCall, {void_type, function_result, function_def, length_id, work_group_size_id_},
                                 inst_it);
     } else {
@@ -80,7 +80,7 @@ void SharedMemoryDataRacePass::CreateFunctionCall(const Function& function, Basi
         const uint32_t inst_position_id = type_manager_.GetConstantUInt32(inst_position).Id();
 
         const uint32_t variable_idx_id = type_manager_.GetConstantUInt32(meta.variable_idx).Id();
-        for (uint32_t i = 0; i < meta.num_elements; ++i) {
+        for (uint32_t i = 0; i < meta.element_count; ++i) {
             const uint32_t function_result = module_.TakeNextId();
             uint32_t start = type_manager_.GetConstantUInt32(meta.start + i).Id();
 
@@ -108,14 +108,13 @@ void SharedMemoryDataRacePass::CreateFunctionCall(const Function& function, Basi
                 // get type of pointee
                 auto ptr_inst = FindInstructionGlobal(function, ptr_id);
                 const Type* ptr_type = type_manager_.FindTypeById(ptr_inst->TypeId());
-                const Type* ptr_elem_type = type_manager_.FindChildType(*ptr_type, 0);
-                const Type* scalar_elem_type = ptr_elem_type;
+                const Type* scalar_elem_type = type_manager_.FindChildType(*ptr_type, 0);
 
                 const Type& uint32_type = type_manager_.GetTypeInt(32, false);
 
                 // if the pointer is to a vector type, scale stride_id by the vector size
-                if (ptr_elem_type->VectorSize()) {
-                    uint32_t vec_size = ptr_elem_type->VectorSize();
+                if (scalar_elem_type->VectorSize() > 0) {
+                    uint32_t vec_size = scalar_elem_type->VectorSize();
 
                     uint32_t next_id = module_.TakeNextId();
                     block.CreateInstruction(spv::OpIMul,
@@ -123,7 +122,7 @@ void SharedMemoryDataRacePass::CreateFunctionCall(const Function& function, Basi
                                             inst_it);
                     stride_id = next_id;
 
-                    scalar_elem_type = type_manager_.FindChildType(*ptr_elem_type, 0);
+                    scalar_elem_type = type_manager_.FindChildType(*scalar_elem_type, 0);
                 }
 
                 // If the size of the scalar element type doesn't match the component size,
@@ -245,16 +244,22 @@ bool SharedMemoryDataRacePass::RequiresInstrumentation(const Function& function,
                     // offset_id += offsetof(struct member idx)
                     auto idx_c = type_manager_.FindConstantById(idx_id);
                     uint32_t idx_u32 = idx_c->GetValueUint32();
-                    uint32_t off = type_manager_.GetNumScalarElementsBeforeCompositeMember(*ptr_elem_type, idx_u32);
+
+                    uint32_t scalar_offset = 0;
+                    for (uint32_t i = 0; i < idx_u32; ++i) {
+                        scalar_offset += type_manager_.GetScalarElementCount(*type_manager_.FindChildType(*ptr_elem_type, i));
+                    }
+
                     uint32_t new_id = module_.TakeNextId();
                     block.CreateInstruction(
-                        spv::OpIAdd, {uint32_type.Id(), new_id, offset_id, type_manager_.GetConstantUInt32(off).Id()}, &inst_it);
+                        spv::OpIAdd, {uint32_type.Id(), new_id, offset_id, type_manager_.GetConstantUInt32(scalar_offset).Id()},
+                        &inst_it);
                     offset_id = new_id;
                     ptr_elem_type = type_manager_.FindChildType(*ptr_elem_type, idx_u32);
                 } break;
                 default: {
                     // offset_id += (stride of first member) * idx
-                    uint32_t stride = type_manager_.GetNumScalarElementsBeforeCompositeMember(*ptr_elem_type, 1);
+                    uint32_t stride = type_manager_.GetScalarElementCount(*type_manager_.FindChildType(*ptr_elem_type, 0));
 
                     uint32_t stride_times_idx_id = module_.TakeNextId();
                     block.CreateInstruction(
@@ -272,7 +277,7 @@ bool SharedMemoryDataRacePass::RequiresInstrumentation(const Function& function,
 
     meta.access_chain_idx_id = offset_id;
     meta.start = slot_start_[variable->Id()];
-    meta.num_elements = type_manager_.GetNumScalarElements(*ptr_elem_type);
+    meta.element_count = type_manager_.GetScalarElementCount(*ptr_elem_type);
     meta.variable_idx = variable->Id();
 
     switch (opcode) {
@@ -284,11 +289,11 @@ bool SharedMemoryDataRacePass::RequiresInstrumentation(const Function& function,
             break;
         case spv::OpCooperativeMatrixLoadKHR:
             meta.function_idx = DO_COOPMAT_LOAD;
-            meta.num_elements = 1;
+            meta.element_count = 1;
             break;
         case spv::OpCooperativeMatrixStoreKHR:
             meta.function_idx = DO_COOPMAT_STORE;
-            meta.num_elements = 1;
+            meta.element_count = 1;
             break;
         default:
             meta.function_idx = DO_ATOMIC;
@@ -361,21 +366,21 @@ bool SharedMemoryDataRacePass::Instrument() {
     // Compute how much shared memory is needed.
     for (const Variable* v : shmem_vars) {
         const uint32_t v_id = v->Id();
-        slot_start_[v_id] = num_slots_;
+        slot_start_[v_id] = slot_count_;
         const Type* pointee_type = v->PointerType(type_manager_);
-        uint32_t num_scalar_elements = type_manager_.GetNumScalarElements(*pointee_type);
-        assert(num_scalar_elements != 0);
-        num_slots_ += num_scalar_elements;
+        uint32_t scalar_elements = type_manager_.GetScalarElementCount(*pointee_type);
+        assert(scalar_elements != 0);
+        slot_count_ += scalar_elements;
 
         shared_memory_size += type_manager_.GetTypeBytesSize(*pointee_type);
     }
 
-    if (num_slots_ == 0) {
+    if (slot_count_ == 0) {
         return false;  // no shared memory being used
     }
 
     // Bail if we would overflow the limit
-    if (shared_memory_size + (num_slots_ * sizeof(uint32_t)) > module_.settings_.max_compute_shared_memory_size) {
+    if (shared_memory_size + (slot_count_ * sizeof(uint32_t)) > module_.settings_.max_compute_shared_memory_size) {
         return false;
     }
 
@@ -441,7 +446,7 @@ bool SharedMemoryDataRacePass::Instrument() {
     // Need to actutally add the shadow array variable type into the module
     if (instrumentations_count_ != 0) {
         const Type& uint32_type = type_manager_.GetTypeInt(32, false);
-        const Constant& array_size = type_manager_.GetConstantUInt32(num_slots_);
+        const Constant& array_size = type_manager_.GetConstantUInt32(slot_count_);
         const Type& uint32_arr_type = type_manager_.GetTypeArray(uint32_type, array_size);
         const Type& uint32_arr_ptr_type = type_manager_.GetTypePointer(spv::StorageClassWorkgroup, uint32_arr_type);
 

--- a/layers/gpuav/spirv/shared_memory_data_race_pass.h
+++ b/layers/gpuav/spirv/shared_memory_data_race_pass.h
@@ -40,7 +40,7 @@ class SharedMemoryDataRacePass : public Pass {
         // start of this variable in the shadow memory
         uint32_t start;
         // number of scalar elements touched by this access
-        uint32_t num_elements;
+        uint32_t element_count;
         // The OpVariable ID of the memory being accessed
         uint32_t variable_idx;
     };
@@ -74,7 +74,7 @@ class SharedMemoryDataRacePass : public Pass {
     // < variable ID, starting slot >
     vvl::unordered_map<uint32_t, uint32_t> slot_start_;
     // number of slots in shadow memory
-    uint32_t num_slots_ = 0;
+    uint32_t slot_count_ = 0;
     // Constant ID of known total workgroup size (X * Y * Z)
     uint32_t work_group_size_id_ = 0;
 };

--- a/layers/gpuav/spirv/trace_ray_pass.cpp
+++ b/layers/gpuav/spirv/trace_ray_pass.cpp
@@ -58,40 +58,25 @@ std::vector<uint32_t> TraceRayPass::GetTlasValidationFunctionCallInstructions(co
         return {};
     }
 
-    // AS descriptors use UniformConstant storage class (unlike buffers which use Uniform/StorageBuffer),
-    // so a non-array AS can be loaded directly from its variable with no access chain in between.
-    // Pre-initialize variable for that case; the loop below handles the access-chain case.
-    const Variable* variable = type_manager_.FindVariableById(as_op_load_inst->Operand(0));
-    std::vector<const Instruction*> access_chain_insts;
-    const Instruction* next_access_chain = function.FindInstruction(as_op_load_inst->Operand(0));
-    // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-    while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
-        access_chain_insts.push_back(next_access_chain);
-        const uint32_t access_chain_base_id = next_access_chain->Operand(0);
-        variable = type_manager_.FindVariableById(access_chain_base_id);
-        if (variable) {
-            break;  // found
-        }
-        next_access_chain = function.FindInstruction(access_chain_base_id);
-    }
-    if (!variable) {
+    const AccessPath access_path = type_manager_.BuildAccessPath(function, *as_op_load_inst);
+    if (!access_path.IsValid()) {
         return {};
     }
 
-    const Type* descriptor_type = variable->PointerType(type_manager_);
+    const Type* descriptor_type = access_path.variable->PointerType(type_manager_);
     if (!descriptor_type || descriptor_type->spv_type_ == SpvType::kRuntimeArray) {
         return {};  // TODO - Currently we mark these as "bindless"
     }
 
     const bool is_descriptor_array = descriptor_type->IsArray();
-    if (is_descriptor_array && access_chain_insts.empty()) {
+    if (is_descriptor_array && access_path.ac_list.empty()) {
         return {};  // array descriptor without an access chain is invalid SPIR-V
     }
 
     uint32_t descriptor_index_id = 0;
     if (is_descriptor_array) {
         // Because you can't have 2D array of descriptors, the first index of the last accessChain is the descriptor index
-        descriptor_index_id = access_chain_insts.back()->Operand(1);
+        descriptor_index_id = access_path.DescriptorIndexId();
     } else {
         // There is no array of this descriptor, so we essentially have an array of 1
         descriptor_index_id = type_manager_.GetConstantZeroUint32().Id();
@@ -100,7 +85,7 @@ std::vector<uint32_t> TraceRayPass::GetTlasValidationFunctionCallInstructions(co
     uint32_t descriptor_set = 0;
     uint32_t descriptor_binding = 0;
     for (const auto& annotation : module_.annotations_) {
-        if (annotation->Opcode() == spv::OpDecorate && annotation->Word(1) == variable->Id()) {
+        if (annotation->Opcode() == spv::OpDecorate && annotation->Word(1) == access_path.variable->Id()) {
             if (annotation->Word(2) == spv::DecorationDescriptorSet) {
                 descriptor_set = annotation->Word(3);
             } else if (annotation->Word(2) == spv::DecorationBinding) {

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -794,19 +794,26 @@ bool Type::Is64Bit() const {
     return false;
 }
 
-uint32_t TypeManager::GetNumScalarElements(const Type& type) const {
+// Current use for SharedMemoryDataRace where each scalar is a slot and we need to know where inside a data type the slot index is.
+uint32_t TypeManager::GetScalarElementCount(const Type& type) const {
     switch (type.spv_type_) {
-        case SpvType::kStruct:
-            return GetNumScalarElementsBeforeCompositeMember(type, type.inst_.Length() - 2);
+        case SpvType::kStruct: {
+            uint32_t count = 0;
+            uint32_t members = type.inst_.Length() - 2;
+            for (uint32_t i = 0; i < members; ++i) {
+                count += GetScalarElementCount(*FindChildType(type, i));
+            }
+            return count;
+        }
         case SpvType::kArray: {
             const Type* element_type = FindTypeById(type.inst_.Word(2));
-            return type.meta_.array.length * GetNumScalarElements(*element_type);
+            return type.meta_.array.length * GetScalarElementCount(*element_type);
         }
         case SpvType::kVectorIdEXT:
         case SpvType::kVector:
             return type.meta_.vector.component_count;
         case SpvType::kMatrix:
-            return type.meta_.matrix.component_count * GetNumScalarElements(*FindTypeById(type.inst_.Word(2)));
+            return type.meta_.matrix.component_count * GetScalarElementCount(*FindTypeById(type.inst_.Word(2)));
         case SpvType::kInt:
         case SpvType::kFloat:
         case SpvType::kBool:
@@ -848,6 +855,7 @@ void TypeManager::AddUndef(std::unique_ptr<Instruction> new_inst) {
 
 bool TypeManager::IsUndef(uint32_t id) const { return undef_ids_.find(id) != undef_ids_.end(); }
 
+// Not ideal to use, the caller really should already know which type it wants
 const Type* TypeManager::FindChildType(const Type& type, uint32_t idx) const {
     switch (type.spv_type_) {
         case SpvType::kPointer:
@@ -871,14 +879,6 @@ const Type* TypeManager::FindChildType(const Type& type, uint32_t idx) const {
             assert(0);
             return nullptr;
     }
-}
-
-uint32_t TypeManager::GetNumScalarElementsBeforeCompositeMember(const Type& type, uint32_t idx) const {
-    uint32_t count = 0;
-    for (uint32_t i = 0; i < idx; ++i) {
-        count += GetNumScalarElements(*FindChildType(type, i));
-    }
-    return count;
 }
 
 // This stems from the fact even if you have two OpTypeStruct that are the EXACT SAME, it is not valid to mix and match them

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -712,6 +712,37 @@ const Constant& TypeManager::GetConstantNull(const Type& type) {
     return AddConstant(std::move(new_inst), type);
 }
 
+const AccessPath TypeManager::BuildAccessPath(const Function& function, const Instruction& inst) const {
+    AccessPath path;
+
+    // |Operand 0| works for both Store/Load
+    const uint32_t ptr_id = inst.Operand(0);
+
+    // Buffer/Image Descriptor will always have an access chains, but some cases can have direct access.
+    // TaskPayload can be a scalar that does a direct variable access
+    // An non-array AccelerationStructure (which uses UniformConstant storage class)
+    path.variable = FindVariableById(ptr_id);
+    if (path.variable) {
+        return path;
+    }
+
+    const Instruction* next_access_chain = function.FindInstruction(ptr_id);
+    // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
+    while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
+        // inserting in front allows us to walk over the loop from the front
+        path.ac_list.insert(path.ac_list.begin(), next_access_chain);
+
+        const uint32_t access_chain_base_id = next_access_chain->Operand(0);
+        path.variable = FindVariableById(access_chain_base_id);
+        if (path.variable) {
+            break;  // found
+        }
+        next_access_chain = function.FindInstruction(access_chain_base_id);
+    }
+
+    return path;
+}
+
 const Variable& TypeManager::AddVariable(std::unique_ptr<Instruction> new_inst, const Type& type) {
     const auto& inst = module_.types_values_constants_.emplace_back(std::move(new_inst));
 

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -27,6 +27,7 @@ using Instruction = ::spirv::Instruction;
 
 class Module;
 class TypeManager;
+struct Function;
 
 // These are the constant operations that we plan to handle in for shader instrumentation
 static constexpr bool ConstantOperation(uint32_t opcode) {
@@ -132,6 +133,29 @@ struct Variable {
     const Instruction& inst_;
 };
 
+// We often want to walk the SSA from an "access" (load, store, atomic, etc) to the Variable it is referencing. There can be a
+// single OpAccessChain or multiple, and this struct holds this information.
+// Background info: https://github.com/KhronosGroup/SPIRV-Guide/blob/main/chapters/access_chains.md
+struct AccessPath {
+    // The variable at the end of the access chain
+    const Variable* variable = nullptr;
+
+    bool IsValid() const { return variable != nullptr; }
+
+    // List of OpAccessChains from the variable to the "access"
+    // - The front() will be closest to the OpVariable
+    // - The back() will be closest to the exact spot accesssed
+    // This is on purpose as we really will want to loop the OpAccessChain in reserve SSA order
+    //
+    // Note: GLSL will try to always create a single large OpAccessChain
+    std::vector<const Instruction*> ac_list;
+
+    // When dealing with an array of descriptors, the access closest to the variable will have it
+    uint32_t DescriptorIndexId() const { return ac_list.front()->Operand(1); }
+
+    uint32_t FinalAccessedType() const { return ac_list.back()->TypeId(); }
+};
+
 // In charge of tracking all Types, Constants, and Variable in the module.
 // Since both Variable and Constant both rely on Types, the Types are the core thing we track
 //
@@ -189,6 +213,8 @@ class TypeManager {
     const Constant& GetConstantZeroUvec4();
     const Constant& GetConstantZeroVector(const Type& vector_type);
     const Constant& GetConstantNull(const Type& type);
+
+    const AccessPath BuildAccessPath(const Function& function, const Instruction& inst) const;
 
     const Variable& AddVariable(std::unique_ptr<Instruction> new_inst, const Type& type);
     const Variable* FindVariableById(uint32_t id) const;

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -198,8 +198,7 @@ class TypeManager {
 
     const Type* FindChildType(const Type& type, uint32_t idx) const;
 
-    uint32_t GetNumScalarElements(const Type& type) const;
-    uint32_t GetNumScalarElementsBeforeCompositeMember(const Type& type, uint32_t idx) const;
+    uint32_t GetScalarElementCount(const Type& type) const;
 
     void AddUndef(std::unique_ptr<Instruction> new_inst);
     bool IsUndef(uint32_t id) const;


### PR DESCRIPTION
This creates a single way to do the whole "walk the access (OpLoad) to the OpVariable" logic as we keep repeating it and doing it slightly different for no good reason