### PR TITLE
sync: Decrease event logic dependence on IsIgnoredByWait

### DIFF
--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -435,8 +435,8 @@ void SyncOpPipelineBarrier::ApplySingleImageBarrier(CommandExecutionContext& exe
                                                  image_barrier.layout_transition, image_barrier.handle_index, exec_tag);
 
     const auto& sub_state = SubState(*image_barrier.image);
-    const bool can_transition_depth_slices =
-        CanTransitionDepthSlices(exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+    const bool can_transition_depth_slices = CanTransitionDepthSlices(exec_context.GetSyncState().extensions,
+                                                                      sub_state.base.GetImageType(), sub_state.base.create_flags);
     auto range_gen = sub_state.MakeImageRangeGen(image_barrier.subresource_range, can_transition_depth_slices);
 
     access_context->UpdateMemoryAccessState(apply_barrier, range_gen);
@@ -473,8 +473,8 @@ void SyncOpPipelineBarrier::ApplyMultipleBarriers(CommandExecutionContext& exec_
     }
     for (const SyncImageBarrier& barrier : barrier_set_.image_barriers) {
         const auto& sub_state = SubState(*barrier.image);
-        const bool can_transition_depth_slices = CanTransitionDepthSlices(exec_context.GetSyncState().extensions,
-                                                                          sub_state.base.GetImageType(), sub_state.base.create_flags);
+        const bool can_transition_depth_slices = CanTransitionDepthSlices(
+            exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
         auto range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
         // TODO: check if we need: barrier.layout_transition && (queue_id == kQueueIdInvalid)
         ApplyMarkupFunctor markup_action(barrier.layout_transition);
@@ -668,13 +668,15 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext& exec_context, c
     for (const auto& event : events_) {
         const auto* sync_event = events_context->Get(event.get());
         const auto& barrier_set = barrier_sets_[barrier_set_index];
-        if (!sync_event) {
+        if (!sync_event || !sync_event->first_scope) {
             barrier_set_index += barrier_set_incr;
             continue;  // Core, Lifetimes, or Param check needs to catch invalid events.
         }
 
         // For replay calls, don't revalidate "same command buffer" events
-        if (sync_event->last_command_tag >= base_tag) continue;
+        if (sync_event->last_command_tag >= base_tag) {
+            continue;
+        }
 
         const VkEvent event_handle = sync_event->event->VkHandle();
         // TODO add "destroyed" checks
@@ -727,7 +729,8 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext& exec_context, c
                 default:
                     assert(ignore_reason == SyncEventState::NotIgnored);
             }
-        } else if (barrier_set.image_barriers.size()) {
+        }
+        if (barrier_set.image_barriers.size()) {
             const auto& image_memory_barriers = barrier_set.image_barriers;
             const auto* context = exec_context.GetCurrentAccessContext();
             assert(context);
@@ -800,36 +803,39 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext& exec_context, Resou
     size_t barrier_set_index = 0;
     size_t barrier_set_incr = (barrier_sets_.size() == 1) ? 0 : 1;
     for (auto& event_shared : events_) {
-        if (!event_shared.get()) continue;
+        if (!event_shared) {
+            continue;
+        }
         auto* sync_event = events_context->GetFromShared(event_shared);
+        if (!sync_event->first_scope) {
+            continue;  // [core validation check]
+        }
 
         sync_event->last_command = command_;
         sync_event->last_command_tag = exec_tag;
 
         const auto& barrier_set = barrier_sets_[barrier_set_index];
-        if (!sync_event->IsIgnoredByWait(command_, barrier_set.src_exec_scope.mask_param)) {
-            for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
-                if (SimpleBinding(*barrier.buffer)) {
-                    const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
-                    const AccessRange range = barrier.range + base_address;
-                    EventSimpleRangeGenerator filtered_range_gen(sync_event->FirstScope(), range);
-                    ApplyMarkupFunctor markup_action(false);
-                    access_context->UpdateMemoryAccessState(markup_action, filtered_range_gen);
-                }
-            }
-            for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
-                const auto& sub_state = SubState(*barrier.image);
-                const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                    exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
-                ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
-                EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
-                ApplyMarkupFunctor markup_action(barrier.layout_transition);
+        for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
+            if (SimpleBinding(*barrier.buffer)) {
+                const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
+                const AccessRange range = barrier.range + base_address;
+                EventSimpleRangeGenerator filtered_range_gen(sync_event->FirstScope(), range);
+                ApplyMarkupFunctor markup_action(false);
                 access_context->UpdateMemoryAccessState(markup_action, filtered_range_gen);
             }
-            auto global_barriers_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
-            ApplyMarkupFunctor markup_action(false);
-            access_context->UpdateMemoryAccessState(markup_action, global_barriers_range_gen);
         }
+        for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
+            const auto& sub_state = SubState(*barrier.image);
+            const bool can_transition_depth_slices = CanTransitionDepthSlices(
+                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
+            EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
+            ApplyMarkupFunctor markup_action(barrier.layout_transition);
+            access_context->UpdateMemoryAccessState(markup_action, filtered_range_gen);
+        }
+        auto global_barriers_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
+        ApplyMarkupFunctor markup_action(false);
+        access_context->UpdateMemoryAccessState(markup_action, global_barriers_range_gen);
         barrier_set_index += barrier_set_incr;
     }
 
@@ -838,66 +844,73 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext& exec_context, Resou
     barrier_set_index = 0;
     barrier_set_incr = (barrier_sets_.size() == 1) ? 0 : 1;
     for (auto& event_shared : events_) {
-        if (!event_shared.get()) continue;
+        if (!event_shared.get()) {
+            continue;
+        }
         auto* sync_event = events_context->GetFromShared(event_shared);
+        if (!sync_event->first_scope) {
+            continue;  // [core validation check]
+        }
 
         const auto& barrier_set = barrier_sets_[barrier_set_index];
         const auto& dst = barrier_set.dst_exec_scope;
-        if (!sync_event->IsIgnoredByWait(command_, barrier_set.src_exec_scope.mask_param)) {
-            // These apply barriers one at a time as the are restricted to the resource ranges specified per each barrier,
-            // but do not update the dependency chain information (but set the "pending" state) // s.t. the order independence
-            // of the barriers is maintained.
 
-            for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
-                if (SimpleBinding(*barrier.buffer)) {
-                    const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
-                    const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
-                    CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
-                                                            pending_barriers);
+        // These apply barriers one at a time as the are restricted to the resource ranges specified per each barrier,
+        // but do not update the dependency chain information (but set the "pending" state) // s.t. the order independence
+        // of the barriers is maintained.
 
-                    const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
-                    const AccessRange range = barrier.range + base_address;
-                    EventSimpleRangeGenerator range_gen(sync_event->FirstScope(), range);
-
-                    access_context->UpdateMemoryAccessState(collect_barriers, range_gen);
-                }
-            }
-            for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
+        for (const SyncBufferBarrier& barrier : barrier_set.buffer_barriers) {
+            if (SimpleBinding(*barrier.buffer)) {
                 const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
-                const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
-                CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, event_barrier, barrier.layout_transition,
-                                                        barrier.handle_index, pending_barriers);
-
-                const auto& sub_state = SubState(*barrier.image);
-                const bool can_transition_depth_slices = CanTransitionDepthSlices(
-                    exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
-                ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
-                EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
-
-                access_context->UpdateMemoryAccessState(collect_barriers, filtered_range_gen);
-            }
-            // TODO: because each iteration applies functor to the same range, investigate if it is
-            // beneficial for the functor to support multiple barriers, so we traverse access map once.
-            auto global_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
-            for (const auto& barrier : barrier_set.memory_barriers) {
-                const SyncBarrier event_barrier = RestrictToEvent(barrier, *sync_event);
                 const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
                 CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
                                                         pending_barriers);
 
-                auto range_gen = global_range_gen;  // intentional copy
+                const VkDeviceSize base_address = ResourceBaseAddress(*barrier.buffer);
+                const AccessRange range = barrier.range + base_address;
+                EventSimpleRangeGenerator range_gen(sync_event->FirstScope(), range);
+
                 access_context->UpdateMemoryAccessState(collect_barriers, range_gen);
             }
+        }
+        for (const SyncImageBarrier& barrier : barrier_set.image_barriers) {
+            const SyncBarrier event_barrier = RestrictToEvent(barrier.barrier, *sync_event);
+            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+            CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, event_barrier, barrier.layout_transition,
+                                                    barrier.handle_index, pending_barriers);
 
-            // Apply the global barrier to the event itself (for race condition tracking)
-            // Events don't happen at a stage, so we need to store the unexpanded ALL_COMMANDS if set for inter-event-calls
-            sync_event->barriers = dst.mask_param & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-            sync_event->barriers |= dst.exec_scope;
-        } else {
+            const auto& sub_state = SubState(*barrier.image);
+            const bool can_transition_depth_slices = CanTransitionDepthSlices(
+                exec_context.GetSyncState().extensions, sub_state.base.GetImageType(), sub_state.base.create_flags);
+            ImageRangeGen range_gen = sub_state.MakeImageRangeGen(barrier.subresource_range, can_transition_depth_slices);
+            EventImageRangeGenerator filtered_range_gen(sync_event->FirstScope(), range_gen);
+
+            access_context->UpdateMemoryAccessState(collect_barriers, filtered_range_gen);
+        }
+        // TODO: because each iteration applies functor to the same range, investigate if it is
+        // beneficial for the functor to support multiple barriers, so we traverse access map once.
+        auto global_range_gen = EventSimpleRangeGenerator(sync_event->FirstScope(), kFullRange);
+        for (const auto& barrier : barrier_set.memory_barriers) {
+            const SyncBarrier event_barrier = RestrictToEvent(barrier, *sync_event);
+            const BarrierScope barrier_scope(event_barrier, queue_id, sync_event->first_scope_tag);
+            CollectBarriersFunctor collect_barriers(*access_context, barrier_scope, event_barrier, false, vvl::kNoIndex32,
+                                                    pending_barriers);
+
+            auto range_gen = global_range_gen;  // intentional copy
+            access_context->UpdateMemoryAccessState(collect_barriers, range_gen);
+        }
+
+        // Apply the global barrier to the event itself (for race condition tracking)
+        // Events don't happen at a stage, so we need to store the unexpanded ALL_COMMANDS if set for inter-event-calls
+        sync_event->barriers = dst.mask_param & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+        sync_event->barriers |= dst.exec_scope;
+
+        barrier_set_index += barrier_set_incr;
+
+        if (sync_event->IsIgnoredByWait(command_, barrier_set.src_exec_scope.mask_param)) {
             // We ignored this wait, so we don't have any effective synchronization barriers for it.
             sync_event->barriers = 0U;
         }
-        barrier_set_index += barrier_set_incr;
     }
 
     // Update access states with collected barriers


### PR DESCRIPTION
Most of the error conditions detected by IsIgnoredByWait will end up in the core checks. This change moves the code in a typical direction that if something is a core validation error then the goal of syncval is not to crash but otherwise don't try to handle it and it's also possible to have false positives. Core sync errors must be fixed first, synval relies on it.