### PR TITLE
layers: Validate event set-wait version mismatch

### DIFF
--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -634,7 +634,7 @@ void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags) 
     }
 }
 
-void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInfo&) {
+void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInfo&, const Location&) {
     if (auto* signaling_info = vvl::Find(event_signaling_state, event)) {
         signaling_info->signaled = true;
     } else {
@@ -642,7 +642,7 @@ void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInf
     }
 }
 
-void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags2) {
+void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags2, const Location&) {
     if (auto* signaling_info = vvl::Find(event_signaling_state, event)) {
         signaling_info->signaled = false;
     } else {

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -214,8 +214,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
                                 const VkClearRect* pRects, const Location& loc) final;
 
     void RecordSetEvent(VkEvent event, VkPipelineStageFlags stageMask) final;
-    void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) final;
-    void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask) final;
+    void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) final;
+    void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask, const Location& loc) final;
     void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
                         const VkImageMemoryBarrier* image_barriers, VkPipelineStageFlags src_stage_mask,
                         VkPipelineStageFlags dst_stage_mask, const Location& loc) final;

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1131,12 +1131,8 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer& 
 }
 
 // Return the signal stage mask when it can be identified from recorded state
-static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent event,
-                                                                        const EventSignalingStateMap& prior_signaling_states,
-                                                                        const EventSignalingStateMap& secondary_signaling_states) {
-    const EventSignalingState* prior_state = vvl::Find(prior_signaling_states, event);
-    const EventSignalingState* secondary_state = vvl::Find(secondary_signaling_states, event);
-
+static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent event, const EventSignalingState* prior_state,
+                                                                        const EventSignalingState* secondary_state) {
     if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
         if (secondary_state->signaled) {
             return secondary_state->signal_src_stage_mask;
@@ -1147,6 +1143,19 @@ static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent 
         return prior_state->signal_src_stage_mask;
     }
     return {};
+}
+
+// Return the last signaling command and does not take into acccount if it was ignored or not.
+// This is used for the set-wait version mismatch. The current validation logic considers
+// version mismtach to be an issue even if the command is ignored.
+static vvl::Func ResolveSignalingCommand(const EventSignalingState* prior_state, const EventSignalingState* secondary_state) {
+    if (secondary_state) {
+        return secondary_state->last_signaling_command;
+    }
+    if (prior_state) {
+        return prior_state->last_signaling_command;
+    }
+    return vvl::Func::Empty;
 }
 
 // Return true when recorded state proves the event is unsignaled at the wait
@@ -1167,23 +1176,33 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
     bool skip = false;
     for (const WaitEventSubmitInfo& secondary_wait : secondary_cb_sub_state.wait_event_submit_infos) {
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
-        bool can_validate = true;
+        bool can_validate_stage_mask = true;
         bool found_known_signals = false;
 
         for (VkEvent event : secondary_wait.wait_events) {
-            if (auto stage_mask = ResolveKnownSignalStageMask(event, local_signaling_states, secondary_wait.signaling_states)) {
+            const EventSignalingState* local_state = vvl::Find(local_signaling_states, event);
+            const EventSignalingState* secondary_state = vvl::Find(secondary_wait.signaling_states, event);
+
+            // Validate set-wait version mismatch
+            const vvl::Func signal_command = ResolveSignalingCommand(local_state, secondary_state);
+            if (IsValueIn(signal_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                skip |=
+                    LogError("VUID-vkCmdWaitEvents-pEvents-03847", event, secondary_cb_loc, "%s: %s was set by %s.",
+                             vvl::String(secondary_wait.wait_command), FormatHandle(event).c_str(), vvl::String(signal_command));
+            }
+
+            // Determine if stage mask validation is possible during execution time
+            if (auto stage_mask = ResolveKnownSignalStageMask(event, local_state, secondary_state)) {
                 signals_src_stage_mask |= *stage_mask;
                 found_known_signals = true;
-                continue;
+            } else if (IsKnownUnsignaled(event, local_signaling_states, secondary_wait.signaling_states)) {
+                // Contribute 0 (nothing) to signals_src_stage_mask
+            } else {
+                can_validate_stage_mask = false;
             }
-            if (IsKnownUnsignaled(event, local_signaling_states, secondary_wait.signaling_states)) {
-                // Contribute 0 to signals_src_stage_mask
-                continue;
-            }
-            can_validate = false;
-            break;
         }
-        if (can_validate && secondary_wait.wait_src_stage_mask != signals_src_stage_mask) {
+        // Validate state mask
+        if (can_validate_stage_mask && secondary_wait.wait_src_stage_mask != signals_src_stage_mask) {
             const LogObjectList objlist(secondary_cb_sub_state.Handle());
             if (found_known_signals) {
                 std::ostringstream ss;
@@ -1200,6 +1219,21 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
                       "vkCmdSetEvent signal.";
                 skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, secondary_cb_loc, "%s", ss.str().c_str());
             }
+        }
+    }
+    for (const WaitEvent2SubmitInfo& secondary_wait : secondary_cb_sub_state.wait_event2_submit_infos) {
+        // Set-wait version mismatch is always reported. Do not try to determine whether signal is ignored
+        vvl::Func signaling_command = vvl::Func::Empty;
+        if (secondary_wait.signaling_state.has_value() && secondary_wait.signaling_state->signaled) {
+            signaling_command = secondary_wait.signaling_state->last_signaling_command;
+        } else if (const EventSignalingState* local_state = vvl::Find(local_signaling_states, secondary_wait.wait_event);
+                   local_state && local_state->signaled) {
+            signaling_command = local_state->last_signaling_command;
+        }
+        if (signaling_command == vvl::Func::vkCmdSetEvent) {
+            skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03837", secondary_wait.wait_event, secondary_cb_loc,
+                             "%s: %s was set by %s.", vvl::String(secondary_wait.wait_command),
+                             FormatHandle(secondary_wait.wait_event).c_str(), vvl::String(signaling_command));
         }
     }
     UpdateEventSignalingStates(local_signaling_states, secondary_cb_sub_state.event_signaling_states);

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -591,35 +591,40 @@ void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags s
         if (!state->signaled) {
             state->signaled = true;
             state->signal_src_stage_mask = stage_mask;
+            state->last_signaling_command = vvl::Func::vkCmdSetEvent;
             // Keep was_reset unchanged
         }
     } else {
         EventSignalingState new_state;
         new_state.signaled = true;
         new_state.signal_src_stage_mask = stage_mask;
+        new_state.last_signaling_command = vvl::Func::vkCmdSetEvent;
         event_signaling_states.insert(std::make_pair(event, std::move(new_state)));
     }
 }
 
-void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) {
+void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
     if (EventSignalingState* state = vvl::Find(event_signaling_states, event)) {
         if (!state->signaled) {
             state->signaled = true;
             state->signal_dependency_info.emplace(&dependency_info);
+            state->last_signaling_command = loc.function;
             // Keep was_reset unchanged
         }
     } else {
         EventSignalingState new_state;
         new_state.signaled = true;
         new_state.signal_dependency_info.emplace(&dependency_info);
+        new_state.last_signaling_command = loc.function;
         event_signaling_states.insert(std::make_pair(event, std::move(new_state)));
     }
 }
 
-void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags2) {
+void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags2, const Location& loc) {
     EventSignalingState& signaling_state = event_signaling_states[event];
     signaling_state = {};
     signaling_state.was_reset = true;
+    signaling_state.last_signaling_command = loc.function;
 }
 
 void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask,
@@ -627,7 +632,7 @@ void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, Vk
     bool submit_validation = false;
     EventSignalingStateMap signaling_states;
     for (VkEvent event : events) {
-        const EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
+        EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
         if (signaling_state) {
             signaling_states.emplace(event, *signaling_state);
         }
@@ -642,12 +647,13 @@ void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, Vk
         submit_info.wait_events.assign(events.begin(), events.end());
         submit_info.wait_src_stage_mask = src_stage_mask;
         submit_info.signaling_states = std::move(signaling_states);
+        submit_info.wait_command = loc.function;
         wait_event_submit_infos.emplace_back(std::move(submit_info));
     }
 }
 
 void CommandBufferSubState::RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
-    const EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
+    EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
     const bool already_validated = signaling_state && signaling_state->was_reset;
     const bool submit_validation = !already_validated;
     if (submit_validation) {
@@ -657,6 +663,7 @@ void CommandBufferSubState::RecordWaitEvent2(VkEvent event, const VkDependencyIn
         if (signaling_state) {
             submit_info.signaling_state = *signaling_state;
         }
+        submit_info.wait_command = loc.function;
         wait_event2_submit_infos.emplace_back(std::move(submit_info));
     }
 }
@@ -1243,6 +1250,7 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
                 event_state->signal_dependency_info.reset();
                 event_state->signaling_queue = VK_NULL_HANDLE;
             }
+            event_state->last_signaling_command = signaling_state.last_signaling_command;
         }
     }
 

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -98,8 +98,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
                                 const VkClearRect *pRects, const Location &loc) final;
 
     void RecordSetEvent(VkEvent event, VkPipelineStageFlags stageMask) final;
-    void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) final;
-    void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask) final;
+    void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) final;
+    void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask, const Location& loc) final;
     void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) final;
     void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) final;
     void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers, uint32_t image_barrier_count,

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -426,6 +426,7 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
     bool skip = false;
 
     VkPipelineStageFlags signals_src_stage_mask = 0;
+    bool set_wait_version_mismatch = false;  // if version mismatch is detected some other validations make no sense
     for (VkEvent event : wait_events) {
         if (auto event_state = core.Get<vvl::Event>(event)) {
             if (!vvl::Contains(signaling_states, event)) {
@@ -433,27 +434,40 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
             }
             // NOTE: for unsignaled events the signal_src_stage_mask is NONE
             VkPipelineStageFlags2 stage_mask = 0;
+            vvl::Func signal_command = vvl::Func::Empty;
             bool last_signal = false;
             if (event_state->signaled) {
                 stage_mask = event_state->signal_src_stage_mask;
                 last_signal = event_state->signaled;
+                signal_command = event_state->last_signaling_command;
             }
             if (const auto* submit_signaling = vvl::Find(submit_signaling_states, event)) {
                 if (!last_signal || submit_signaling->HasKnownEffect()) {
                     stage_mask = submit_signaling->signal_src_stage_mask;
                 }
                 last_signal = submit_signaling->signal_src_stage_mask;
+                signal_command = submit_signaling->last_signaling_command;
             }
             if (const auto* cb_signaling = vvl::Find(signaling_states, event)) {
                 if (!last_signal || cb_signaling->HasKnownEffect()) {
                     stage_mask = cb_signaling->signal_src_stage_mask;
                 }
+                signal_command = cb_signaling->last_signaling_command;
             }
             signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(stage_mask);
+
+            // Validate set-wait mismatch
+            if (IsValueIn(signal_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                set_wait_version_mismatch = true;
+                const LogObjectList objlist(cb_state.Handle(), event_state->Handle());
+                skip |= core.LogError("VUID-vkCmdWaitEvents-pEvents-03847", objlist, loc, "%s: %s was set by %s.",
+                                      vvl::String(wait_command), core.FormatHandle(event).c_str(), vvl::String(signal_command));
+            }
         }
     }
-    // Validate src stage mask mismatch
-    if (wait_src_stage_mask != signals_src_stage_mask) {
+
+    // Validate src stage mask
+    if (!set_wait_version_mismatch && wait_src_stage_mask != signals_src_stage_mask) {
         std::ostringstream ss;
         ss << "(" << core.FormatHandle(cb_state.Handle()) << ") contains a vkCmdWaitEvents call with srcStageMask "
            << string_VkPipelineStageFlags(wait_src_stage_mask)
@@ -487,15 +501,24 @@ bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& qu
     skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signaling_states, loc);
 
     std::optional<vku::safe_VkDependencyInfo> signal_dependency_info;
+    vvl::Func signal_command = vvl::Func::Empty;
     if (signaling_state.has_value()) {
-        assert(signaling_state->signal_dependency_info.has_value());
         signal_dependency_info = signaling_state->signal_dependency_info;
+        signal_command = signaling_state->last_signaling_command;
     } else if (const auto* submit_signaling_state = vvl::Find(submit_signaling_states, wait_event)) {
         signal_dependency_info = submit_signaling_state->signal_dependency_info;
-    } else if (event_state->signal_dependency_info.has_value()) {
-        signal_dependency_info = *event_state->signal_dependency_info;
+        signal_command = submit_signaling_state->last_signaling_command;
+    } else {
+        signal_dependency_info = event_state->signal_dependency_info;
+        signal_command = event_state->last_signaling_command;
     }
 
+    if (signal_command == vvl::Func::vkCmdSetEvent) {
+        const LogObjectList objlist(cb_state.Handle(), event_state->Handle());
+        skip |=
+            core.LogError("VUID-vkCmdWaitEvents2-pEvents-03837", objlist, loc, "%s: %s was set by %s.", vvl::String(wait_command),
+                          core.FormatHandle(event_state->Handle()).c_str(), vvl::String(signal_command));
+    }
     if (signal_dependency_info.has_value()) {
         const bool signal_has_asymmetric = (signal_dependency_info->dependencyFlags & VK_DEPENDENCY_ASYMMETRIC_EVENT_BIT_KHR) != 0;
         const bool wait_has_asymmetric = (wait_dependency_info.dependencyFlags & VK_DEPENDENCY_ASYMMETRIC_EVENT_BIT_KHR) != 0;
@@ -1516,18 +1539,27 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
 
     if (pEvents) {
         auto& cb_sub_state = core::SubState(*cb_state);
-        bool can_validate = true;
+        bool can_validate_stage_mask = true;
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
         for (uint32_t i = 0; i < eventCount; i++) {
             const EventSignalingState* signaling_state = vvl::Find(cb_sub_state.event_signaling_states, pEvents[i]);
-            // NOTE: the same logic is used by the record phase
+
+            // Record phase also uses this logic to determine stage mask validation status
             if (!signaling_state || !signaling_state->HasKnownEffect()) {
-                can_validate = false;
-                break;
+                can_validate_stage_mask = false;
+            } else {
+                signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signaling_state->signal_src_stage_mask);
             }
-            signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signaling_state->signal_src_stage_mask);
+
+            // Set-wait version mismatch is always reported.
+            // Do not try to determine whether signal is ignored
+            if (signaling_state &&
+                IsValueIn(signaling_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                skip |= LogError("VUID-vkCmdWaitEvents-pEvents-03847", pEvents[i], error_obj.location, "%s was set by %s.",
+                                 FormatHandle(pEvents[i]).c_str(), vvl::String(signaling_state->last_signaling_command));
+            }
         }
-        if (can_validate) {
+        if (can_validate_stage_mask) {
             if (srcStageMask != signals_src_stage_mask) {
                 skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, error_obj.location.dot(Field::srcStageMask),
                                  "is %s, but the bitwise OR of stageMask values from the most recent vkCmdSetEvent call for each "
@@ -1537,20 +1569,26 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
             }
         }
     }
-
     return skip;
 }
 
 bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                const VkDependencyInfo* pDependencyInfos, const ErrorObject& error_obj) const {
-    auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-
     bool skip = false;
+    auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
+    auto& cb_sub_state = core::SubState(*cb_state);
+
+    skip |= ValidateCmd(*cb_state, error_obj.location);
     if (!enabled_features.synchronization2) {
         skip |= LogError("VUID-vkCmdWaitEvents2-synchronization2-03836", commandBuffer, error_obj.location,
                          "the synchronization2 feature was not enabled.");
     }
-    for (uint32_t i = 0; (i < eventCount) && !skip; i++) {
+    if (cb_state->per_tile_execution_model_enabled) {
+        skip |= LogError("VUID-vkCmdWaitEvents2-None-10654", commandBuffer, error_obj.location,
+                         "the per-tile execution model has been enabled in this command buffer. "
+                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdWaitEvents2)");
+    }
+    for (uint32_t i = 0; i < eventCount && !skip; i++) {
         const LogObjectList objlist(commandBuffer, pEvents[i]);
         const Location dep_info_loc = error_obj.location.dot(Field::pDependencyInfos, i);
 
@@ -1578,15 +1616,16 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
                              "is (%s).", string_VkDependencyFlags(pDependencyInfos[i].dependencyFlags).c_str());
         }
         skip |= ValidateDependencyInfo(objlist, dep_info_loc, *cb_state, pDependencyInfos[i]);
-    }
-    skip |= ValidateCmd(*cb_state, error_obj.location);
 
-    if (cb_state->per_tile_execution_model_enabled) {
-        skip |= LogError("VUID-vkCmdWaitEvents2-None-10654", commandBuffer, error_obj.location,
-                         "the per-tile execution model has been enabled in this command buffer. "
-                         "(Don't call vkCmdBeginPerTileExecutionQCOM before vkCmdWaitEvents2)");
+        if (const EventSignalingState* signaling_state = vvl::Find(cb_sub_state.event_signaling_states, pEvents[i])) {
+            // Set-wait version mismatch is always reported.
+            // Do not try to determine whether signal is ignored
+            if (signaling_state->last_signaling_command == vvl::Func::vkCmdSetEvent) {
+                skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03837", pEvents[i], error_obj.location, "%s was set by %s.",
+                                 FormatHandle(pEvents[i]).c_str(), vvl::String(signaling_state->last_signaling_command));
+            }
+        }
     }
-
     return skip;
 }
 

--- a/layers/core_checks/cc_synchronization.h
+++ b/layers/core_checks/cc_synchronization.h
@@ -78,6 +78,8 @@ struct WaitEventSubmitInfo {
     // Subset of waited events with known signaling state
     EventSignalingStateMap signaling_states;
 
+    vvl::Func wait_command = vvl::Func::Empty;
+
     bool Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
                   EventSignalingStateMap& submit_signaling_states, const Location& loc) const;
 };
@@ -86,6 +88,7 @@ struct WaitEvent2SubmitInfo {
     VkEvent wait_event = VK_NULL_HANDLE;
     vku::safe_VkDependencyInfo wait_dependency_info;
     std::optional<EventSignalingState> signaling_state;
+    vvl::Func wait_command = vvl::Func::Empty;
 
     bool Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
                   EventSignalingStateMap& submit_signaling_states, const Location& loc) const;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -2167,7 +2167,7 @@ void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags stage_mas
 void CommandBuffer::RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
     RecordCommand(loc);
     for (auto& item : sub_states_) {
-        item.second->RecordSetEvent2(event, dependency_info);
+        item.second->RecordSetEvent2(event, dependency_info, loc);
     }
     if (!dev_data.disabled[command_buffer_state]) {
         if (auto event_state = dev_data.Get<vvl::Event>(event)) {
@@ -2180,9 +2180,8 @@ void CommandBuffer::RecordSetEvent2(VkEvent event, const VkDependencyInfo& depen
 void CommandBuffer::RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const Location& loc) {
     RecordCommand(loc);
     for (auto& item : sub_states_) {
-        item.second->RecordResetEvent(event, stage_mask);
+        item.second->RecordResetEvent(event, stage_mask, loc);
     }
-
     if (!dev_data.disabled[command_buffer_state]) {
         if (auto event_state = dev_data.Get<vvl::Event>(event)) {
             AddChild(event_state);

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -905,8 +905,8 @@ class CommandBufferSubState {
     virtual void RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {}
 
     virtual void RecordSetEvent(VkEvent event, VkPipelineStageFlags stage_mask) {}
-    virtual void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info) {}
-    virtual void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask) {}
+    virtual void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {}
+    virtual void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const Location& loc) {}
     virtual void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) {}
     virtual void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {}
     virtual void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers,

--- a/layers/state_tracker/event_state.h
+++ b/layers/state_tracker/event_state.h
@@ -21,6 +21,7 @@
 
 #include "state_tracker/state_object.h"
 #include "containers/custom_containers.h"
+#include "generated/error_location_helper.h"
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <optional>
 
@@ -39,6 +40,9 @@ struct EventSignalingState {
     // The dependency info from CmdSetEvent2.
     // It is no value for CmdSetEvent, or if the event is unsignaled
     std::optional<vku::safe_VkDependencyInfo> signal_dependency_info;
+
+    // Last command that changed the event signal state: Set/Set2/Reset/Reset2
+    vvl::Func last_signaling_command = vvl::Func::Empty;
 
     // Return true if this state's effect on the event is known.
     // Without a reset or known prior state, we cannot tell whether a signal
@@ -80,6 +84,9 @@ class Event : public StateObject {
 
     // Queue that signaled this event. It's null if event was signaled from the host.
     VkQueue signaling_queue = VK_NULL_HANDLE;
+
+    // Last command that changed the event signal state: Set/Set2/Reset/Reset2
+    vvl::Func last_signaling_command = vvl::Func::Empty;
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4146,6 +4146,7 @@ void DeviceState::PostCallRecordSetEvent(VkDevice device, VkEvent event, const R
         event_state->signal_dependency_info.reset();
         event_state->signal_src_stage_mask = VK_PIPELINE_STAGE_HOST_BIT;
         event_state->signaling_queue = VK_NULL_HANDLE;
+        event_state->last_signaling_command = vvl::Func::vkSetEvent;
     }
 }
 

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -2181,6 +2181,20 @@ void CommandBuffer::WaitEvent(const Event& event, VkPipelineStageFlags src_stage
     vk::CmdWaitEvents(handle(), 1, &event.handle(), src_stage_mask, dst_stage_mask, 0, nullptr, 0, nullptr, 1, &image_barrier);
 }
 
+void CommandBuffer::SetEvent2(const Event& event, const VkMemoryBarrier2& memory_barrier) {
+    VkDependencyInfo dep_info = vku::InitStructHelper();
+    dep_info.memoryBarrierCount = 1;
+    dep_info.pMemoryBarriers = &memory_barrier;
+    vk::CmdSetEvent2(handle(), event, &dep_info);
+}
+
+void CommandBuffer::WaitEvent2(const Event& event, const VkMemoryBarrier2& memory_barrier) {
+    VkDependencyInfo dep_info = vku::InitStructHelper();
+    dep_info.memoryBarrierCount = 1;
+    dep_info.pMemoryBarriers = &memory_barrier;
+    vk::CmdWaitEvents2(handle(), 1, &event.handle(), &dep_info);
+}
+
 void CommandBuffer::Copy(const Buffer& src, const Buffer& dst) {
     assert(src.CreateInfo().size == dst.CreateInfo().size);
     const VkBufferCopy region = {0, 0, src.CreateInfo().size};

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1137,6 +1137,9 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void WaitEvent(const Event& event, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
                    const VkImageMemoryBarrier& image_barrier);
 
+    void SetEvent2(const Event& event, const VkMemoryBarrier2& memory_barrier);
+    void WaitEvent2(const Event& event, const VkMemoryBarrier2& memory_barrier);
+
     void Copy(const Buffer &src, const Buffer &dst);
     void ExecuteCommands(const CommandBuffer &secondary);
 

--- a/tests/unit/event.cpp
+++ b/tests/unit/event.cpp
@@ -1045,3 +1045,199 @@ TEST_F(NegativeEvent, StageMaskHost) {
 
     m_default_queue->Wait();
 }
+
+TEST_F(NegativeEvent, SetWait2VersionMismatch) {
+    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents2");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents2-pEvents-03837");
+    m_command_buffer.WaitEvent2(event, barrier);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, SetWait2VersionMismatchSecondary) {
+    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents2");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.WaitEvent2(event, barrier);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents2-pEvents-03837");
+    m_command_buffer.ExecuteCommands(secondary);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, SetWait2VersionMismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents2");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent(event);
+    command_buffer.End();
+    m_default_queue->Submit(command_buffer);
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.WaitEvent2(event, barrier);
+    command_buffer2.End();
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents2-pEvents-03837");
+    m_default_queue->Submit(command_buffer2);
+    monitor_.VerifyFound();
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeEvent, SetWaitThenWait2VersionMismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents, then CmdWaitEvents2");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent(event);
+    command_buffer.WaitEvent(event);
+    command_buffer.End();
+    m_default_queue->Submit(command_buffer);
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.WaitEvent2(event, barrier);
+    command_buffer2.End();
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents2-pEvents-03837");
+    m_default_queue->Submit(command_buffer2);
+    monitor_.VerifyFound();
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeEvent, Set2WaitVersionMismatch) {
+    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, barrier);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
+    m_command_buffer.WaitEvent(event);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, Set2WaitVersionMismatchSecondary) {
+    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.WaitEvent(event);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, barrier);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
+    m_command_buffer.ExecuteCommands(secondary);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, Set2WaitVersionMismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent2(event, barrier);
+    command_buffer.End();
+    m_default_queue->Submit(command_buffer);
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.WaitEvent(event);
+    command_buffer2.End();
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
+    m_default_queue->Submit(command_buffer2);
+    monitor_.VerifyFound();
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeEvent, Set2Wait2ThenWaitVersionMismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents2, then CmdWaitEvents");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent2(event, barrier);
+    command_buffer.WaitEvent2(event, barrier);
+    command_buffer.End();
+    m_default_queue->Submit(command_buffer);
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.WaitEvent(event);
+    command_buffer2.End();
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
+    m_default_queue->Submit(command_buffer2);
+    monitor_.VerifyFound();
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Adds VUID 03837/03847 that checks sync1 vs sync2 version mismatch between CmdSetEvent(2) and CmdWaitEvents(2).

Syncval has incomplete validation of 03837 (and without testing) - it will be removed.

Also part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11386
