### PR TITLE
tests: Reduce iteration count

### DIFF
--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -303,7 +303,7 @@ TEST_F(PositiveCommand, ThreadedCommandBuffersWithLabels) {
         VkDebugUtilsLabelEXT label = vku::InitStructHelper();
         label.pLabelName = "Test label";
 
-        constexpr int iteration_count = 1000;
+        constexpr int iteration_count = 250; /* Initially 1000 */
         for (int frame = 0; frame < iteration_count; frame++) {
             std::array<VkCommandBuffer, command_buffers_per_pool> command_buffers;
             ASSERT_EQ(VK_SUCCESS, vk::AllocateCommandBuffers(device(), &commands_allocate_info, command_buffers.data()));

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1252,7 +1252,7 @@ struct FenceSemRaceData {
     std::atomic<bool>* bailout{nullptr};
     uint64_t wait_value{0};
     uint64_t timeout{kWaitTimeout};
-    uint32_t iterations{100000};
+    uint32_t iterations{5000};  // Initially 100000 for higher repro rate
 };
 
 void WaitTimelineSem(FenceSemRaceData* data) {
@@ -1365,7 +1365,7 @@ struct SemBufferRaceData {
     vkt::Semaphore sem;
     uint64_t start_wait_value{0};
     uint64_t timeout_ns{kWaitTimeout};
-    uint32_t iterations{10000};
+    uint32_t iterations{500};  // Initially 10000 for higher repro rate
     std::atomic<bool> bailout{false};
 
     std::unique_ptr<vkt::Buffer> thread_buffer;
@@ -2291,7 +2291,7 @@ TEST_F(PositiveSyncObject, KhronosTimelineSemaphoreExample) {
         GTEST_SKIP() << "Two queues are needed";
     }
 
-    int N = 1000;
+    int N = 250; /* Initially 1000 */
 
     for (int i = 0; i < N; i++) {
         vkt::Semaphore timeline(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -149,7 +149,7 @@ TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
         GTEST_SKIP() << "Failed to pre-transition swapchain images";
     }
 
-    constexpr int N = 1'000;
+    constexpr int N = 100;  // Initially 1000 for higher repro rate
     std::mutex queue_mutex;
 
     // Worker thread submits accesses and waits on the fence.
@@ -1086,7 +1086,7 @@ TEST_F(PositiveSyncValWsi, ConcurrentPresentAndSubmit) {
     }
 
     const auto swapchain_images = m_swapchain.GetImages();
-    const int N = 500;
+    const int N = 100;  // Initially 500 for higher repro rate
 
     std::atomic<bool> bailout{false};
     monitor_.SetBailout(&bailout);
@@ -1140,9 +1140,9 @@ TEST_F(PositiveSyncValWsi, ConcurrentPresentMultipleSwapchains) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(InitSyncVal());
 
-    const uint32_t num_threads = 8;
+    const uint32_t num_threads = 6; /* Initially 8 */
     const uint32_t num_frames_in_flight = 2;
-    const uint32_t N = 200;
+    const uint32_t N = 100; /* Initially 200 */
 
     std::mutex queue_mutex;
 

--- a/tests/unit/threading.cpp
+++ b/tests/unit/threading.cpp
@@ -54,7 +54,7 @@ TEST_F(NegativeThreading, CommandBufferCollision) {
     // Add many entries to command buffer from another thread.
     std::thread thread1(AddToCommandBuffer, &data);
     // Make non-conflicting calls from this thread at the same time.
-    for (int i = 0; i < 80000; i++) {
+    for (int i = 0; i < 1000 /* Initially 80000 to make machine miserable */; i++) {
         uint32_t count;
         vk::EnumeratePhysicalDevices(instance(), &count, NULL);
     }

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -339,7 +339,7 @@ TEST_F(PositiveThreading, GetPhysicalDeviceFeatures) {
     VkInstanceCreateInfo instance_ci = GetInstanceCreateInfo();
 
     // mimics --gtest_repeat=100 which is needed to reproduce constantly
-    for (uint32_t repeat = 0; repeat < 100; repeat++) {
+    for (uint32_t repeat = 0; repeat < 20 /* Initially 100 */; repeat++) {
         VkInstance instance;
         vk::CreateInstance(&instance_ci, nullptr, &instance);
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -1380,8 +1380,7 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
     };
     std::vector<Frame> frames;
 
-    // TODO: iteration count can be reduced (100?) if queue simulation is done in more deterministic way
-    for (uint32_t i = 0; i < 500; i++) {
+    for (uint32_t i = 0; i < 100 /* initially 1000 for higher repro rate*/; i++) {
         // Remove completed frames
         for (auto it = frames.begin(); it != frames.end();) {
             if (it->present_finished_fence.GetStatus() == VK_SUCCESS) {


### PR DESCRIPTION
This targets the most visible outliers https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12334 (not everything). We can iterate later too.

These tests used larger iterations count for a long time and correspoding functionality is stable. Reduce iteration count to speed up CI.

Still iteration count should be descent enough, sometimes it's hard to reproduce with too small iteration count since it takes time for the thread to start, potentially other OS effects.