### PR TITLE
gpuav: Rename DescriptorHeap with DescriptorIdPool

### DIFF
--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -47,40 +47,40 @@ void Validator::Created(vvl::CommandBuffer& cb_state) {
 void Validator::Created(vvl::Queue& queue) { queue.SetSubState(container_type, std::make_unique<QueueSubState>(*this, queue)); }
 
 void Validator::Created(vvl::Image& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<ImageSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<ImageSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::ImageView& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<ImageViewSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<ImageViewSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::Buffer& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<BufferSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<BufferSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::BufferView& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<BufferViewSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<BufferViewSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::Sampler& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<SamplerSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<SamplerSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::AccelerationStructureNV& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<AccelerationStructureNVSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<AccelerationStructureNVSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::AccelerationStructureKHR& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<AccelerationStructureKHRSubState>(*this, obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<AccelerationStructureKHRSubState>(*this, obj, desc_id_pool));
 }
 void Validator::Created(vvl::Tensor& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<TensorSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<TensorSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::TensorView& obj) {
-    DescriptorHeap& desc_heap = shared_resources_cache.Get<DescriptorHeap>();
-    obj.SetSubState(container_type, std::make_unique<TensorViewSubState>(obj, desc_heap));
+    DescriptorIdPool& desc_id_pool = shared_resources_cache.Get<DescriptorIdPool>();
+    obj.SetSubState(container_type, std::make_unique<TensorViewSubState>(obj, desc_id_pool));
 }
 void Validator::Created(vvl::ShaderObject& obj) { obj.SetSubState(container_type, std::make_unique<ShaderObjectSubState>(obj)); }
 
@@ -547,9 +547,9 @@ bool Validator::IsAllDeviceLocalMappable() const {
     return true;
 }
 
-// Things like DescriptorHeap are singleton class that lives in GPU-AV, but are used when state tracking adds/destroy new resources
-// we need to track. One issue is on vkDestroyDevice we need to teardown the GPU-AV class, then after we try and destroy leaked
-// state objects (ex. user forgot to call vkDestroySampler).
+// Things like DescriptorIdPool are singleton class that lives in GPU-AV, but are used when state tracking adds/destroy new
+// resources we need to track. One issue is on vkDestroyDevice we need to teardown the GPU-AV class, then after we try and destroy
+// leaked state objects (ex. user forgot to call vkDestroySampler).
 void Validator::DestroySubstate() {
     if (!dispatch_device_ || aborted_) {
         return;

--- a/layers/gpuav/instrumentation/descriptor_checks.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks.cpp
@@ -29,7 +29,7 @@ static uint32_t BitBufferSize(uint32_t num_bits) {
     return (((num_bits + (kBitsPerWord - 1)) & ~(kBitsPerWord - 1)) / kBitsPerWord) * sizeof(uint32_t);
 }
 
-DescriptorHeap::DescriptorHeap(Validator& gpuav, uint32_t max_descriptors) : max_descriptors_(max_descriptors), buffer_(gpuav) {
+DescriptorIdPool::DescriptorIdPool(Validator& gpuav, uint32_t max_descriptors) : max_descriptors_(max_descriptors), buffer_(gpuav) {
     // If max_descriptors_ is 0, GPU-AV aborted during vkCreateDevice(). We still need to
     // support calls into this class as no-ops if this happens.
     if (max_descriptors_ == 0) {
@@ -47,18 +47,18 @@ DescriptorHeap::DescriptorHeap(Validator& gpuav, uint32_t max_descriptors) : max
         return;
     }
 
-    gpu_heap_state_ = (uint32_t*)buffer_.GetMappedPtr();
-    memset(gpu_heap_state_, 0, static_cast<size_t>(buffer_info.size));
+    gpu_id_pool_state_ = (uint32_t*)buffer_.GetMappedPtr();
+    memset(gpu_id_pool_state_, 0, static_cast<size_t>(buffer_info.size));
 }
 
-DescriptorHeap::~DescriptorHeap() {
+DescriptorIdPool::~DescriptorIdPool() {
     if (max_descriptors_ > 0) {
         buffer_.Destroy();
-        gpu_heap_state_ = nullptr;
+        gpu_id_pool_state_ = nullptr;
     }
 }
 
-DescriptorId DescriptorHeap::NextId(const VulkanTypedHandle& handle) {
+DescriptorId DescriptorIdPool::NextId(const VulkanTypedHandle& handle) {
     if (max_descriptors_ == 0) {
         return 0;
     }
@@ -77,15 +77,15 @@ DescriptorId DescriptorHeap::NextId(const VulkanTypedHandle& handle) {
         }
     } while (alloc_map_.count(result) > 0);
     alloc_map_[result] = handle;
-    gpu_heap_state_[result / 32] |= 1u << (result & 31);
+    gpu_id_pool_state_[result / 32] |= 1u << (result & 31);
     return result;
 }
 
-void DescriptorHeap::DeleteId(DescriptorId id) {
+void DescriptorIdPool::DeleteId(DescriptorId id) {
     if (max_descriptors_ > 0) {
         std::lock_guard guard(lock_);
         // Note: We don't mess with next_id_ here because ids should be assigned in LRU order.
-        gpu_heap_state_[id / 32] &= ~(1u << (id & 31));
+        gpu_id_pool_state_[id / 32] &= ~(1u << (id & 31));
         alloc_map_.erase(id);
     }
 }
@@ -96,7 +96,7 @@ struct DescriptorChecksCbState {
 
 void DescriptorChecksOnFinishDeviceSetup(Validator& gpuav) {
     if (!gpuav.gpuav_settings.shader_instrumentation.descriptor_checks) {
-        gpuav.shared_resources_cache.GetOrCreate<DescriptorHeap>(gpuav, 0);
+        gpuav.shared_resources_cache.GetOrCreate<DescriptorIdPool>(gpuav, 0);
         return;
     }
 
@@ -109,7 +109,7 @@ void DescriptorChecksOnFinishDeviceSetup(Validator& gpuav) {
         num_descs = glsl::kDebugInputBindlessMaxDescriptors;
     }
 
-    gpuav.shared_resources_cache.GetOrCreate<DescriptorHeap>(gpuav, num_descs);
+    gpuav.shared_resources_cache.GetOrCreate<DescriptorIdPool>(gpuav, num_descs);
 }
 
 void RegisterDescriptorChecksValidation(Validator& gpuav, CommandBufferSubState& cb) {
@@ -347,7 +347,7 @@ void RegisterDescriptorChecksValidation(Validator& gpuav, CommandBufferSubState&
             dc_cb_state.last_bound_desc_sets_ssbo.Clear();
             auto desc_sets_ssbo =
                 static_cast<glsl::BoundDescriptorSetsSSBO*>(dc_cb_state.last_bound_desc_sets_ssbo.offset_mapped_ptr);
-            desc_sets_ssbo->descriptor_init_status = gpuav.shared_resources_cache.Get<DescriptorHeap>().GetDeviceAddress();
+            desc_sets_ssbo->descriptor_init_status = gpuav.shared_resources_cache.Get<DescriptorIdPool>().GetDeviceAddress();
 
             for (size_t bound_ds_i = 0; bound_ds_i < desc_binding_cmd.bound_descriptor_sets.size(); ++bound_ds_i) {
                 auto& bound_ds = desc_binding_cmd.bound_descriptor_sets[bound_ds_i];

--- a/layers/gpuav/instrumentation/descriptor_checks.h
+++ b/layers/gpuav/instrumentation/descriptor_checks.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ class Validator;
 class CommandBufferSubState;
 
 using DescriptorId = uint32_t;
-class DescriptorHeap {
+class DescriptorIdPool {
   public:
-    DescriptorHeap(Validator &gpuav, uint32_t max_descriptors);
-    ~DescriptorHeap();
+    DescriptorIdPool(Validator& gpuav, uint32_t max_descriptors);
+    ~DescriptorIdPool();
 
     DescriptorId NextId(const VulkanTypedHandle &handle);
     void DeleteId(DescriptorId id);
@@ -43,7 +43,7 @@ class DescriptorHeap {
     vvl::unordered_map<DescriptorId, VulkanTypedHandle> alloc_map_;
 
     vko::Buffer buffer_;
-    uint32_t *gpu_heap_state_{nullptr};
+    uint32_t* gpu_id_pool_state_{nullptr};
 };
 
 // Descriptor Ids are used on the GPU to identify if a given descriptor is valid.
@@ -52,14 +52,14 @@ class DescriptorHeap {
 // so that the instrumentation can decide if a descriptor is actually valid when it is used in a shader.
 class DescriptorIdTracker {
   public:
-    DescriptorIdTracker(DescriptorHeap &heap_, VulkanTypedHandle handle) : heap(heap_), id(heap_.NextId(handle)) {}
+    DescriptorIdTracker(DescriptorIdPool& id_pool_, VulkanTypedHandle handle) : id_pool(id_pool_), id(id_pool_.NextId(handle)) {}
 
     DescriptorIdTracker(const DescriptorIdTracker &) = delete;
     DescriptorIdTracker &operator=(const DescriptorIdTracker &) = delete;
 
-    ~DescriptorIdTracker() { heap.DeleteId(id); }
+    ~DescriptorIdTracker() { id_pool.DeleteId(id); }
 
-    DescriptorHeap &heap;
+    DescriptorIdPool& id_pool;
     const DescriptorId id{};
 };
 

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -592,43 +592,43 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
     }
 }
 
-ImageSubState::ImageSubState(vvl::Image& obj, DescriptorHeap& heap)
-    : vvl::ImageSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+ImageSubState::ImageSubState(vvl::Image& obj, DescriptorIdPool& id_pool)
+    : vvl::ImageSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void ImageSubState::Destroy() { id_tracker.reset(); }
 
 void ImageSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-ImageViewSubState::ImageViewSubState(vvl::ImageView& obj, DescriptorHeap& heap)
-    : vvl::ImageViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+ImageViewSubState::ImageViewSubState(vvl::ImageView& obj, DescriptorIdPool& id_pool)
+    : vvl::ImageViewSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void ImageViewSubState::Destroy() { id_tracker.reset(); }
 
 void ImageViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-BufferSubState::BufferSubState(vvl::Buffer& obj, DescriptorHeap& heap)
-    : vvl::BufferSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+BufferSubState::BufferSubState(vvl::Buffer& obj, DescriptorIdPool& id_pool)
+    : vvl::BufferSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void BufferSubState::Destroy() { id_tracker.reset(); }
 
 void BufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-BufferViewSubState::BufferViewSubState(vvl::BufferView& obj, DescriptorHeap& heap)
-    : vvl::BufferViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+BufferViewSubState::BufferViewSubState(vvl::BufferView& obj, DescriptorIdPool& id_pool)
+    : vvl::BufferViewSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void BufferViewSubState::Destroy() { id_tracker.reset(); }
 
 void BufferViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-SamplerSubState::SamplerSubState(vvl::Sampler& obj, DescriptorHeap& heap)
-    : vvl::SamplerSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+SamplerSubState::SamplerSubState(vvl::Sampler& obj, DescriptorIdPool& id_pool)
+    : vvl::SamplerSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void SamplerSubState::Destroy() { id_tracker.reset(); }
 
 void SamplerSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-AccelerationStructureNVSubState::AccelerationStructureNVSubState(vvl::AccelerationStructureNV& obj, DescriptorHeap& heap)
-    : vvl::AccelerationStructureNVSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+AccelerationStructureNVSubState::AccelerationStructureNVSubState(vvl::AccelerationStructureNV& obj, DescriptorIdPool& id_pool)
+    : vvl::AccelerationStructureNVSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void AccelerationStructureNVSubState::Destroy() { id_tracker.reset(); }
 
@@ -637,8 +637,8 @@ void AccelerationStructureNVSubState::NotifyInvalidate(const vvl::StateObject::N
 }
 
 AccelerationStructureKHRSubState::AccelerationStructureKHRSubState(Validator& validator, vvl::AccelerationStructureKHR& obj,
-                                                                   DescriptorHeap& heap)
-    : vvl::AccelerationStructureKHRSubState(obj), id_tracker(std::in_place, heap, obj.Handle()), validator(validator) {
+                                                                   DescriptorIdPool& id_pool)
+    : vvl::AccelerationStructureKHRSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()), validator(validator) {
     gpu_state = validator.gpu_resources_manager_.GetHostCoherentBufferRange(sizeof(uint32_t));
     gpu_state.Clear();
 }
@@ -652,15 +652,15 @@ void AccelerationStructureKHRSubState::NotifyInvalidate(const vvl::StateObject::
     id_tracker.reset();
 }
 
-TensorSubState::TensorSubState(vvl::Tensor& obj, DescriptorHeap& heap)
-    : vvl::TensorSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+TensorSubState::TensorSubState(vvl::Tensor& obj, DescriptorIdPool& id_pool)
+    : vvl::TensorSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void TensorSubState::Destroy() { id_tracker.reset(); }
 
 void TensorSubState::NotifyInvalidate(const vvl::StateObject::NodeList& invalid_nodes, bool unlink) { id_tracker.reset(); }
 
-TensorViewSubState::TensorViewSubState(vvl::TensorView& obj, DescriptorHeap& heap)
-    : vvl::TensorViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+TensorViewSubState::TensorViewSubState(vvl::TensorView& obj, DescriptorIdPool& id_pool)
+    : vvl::TensorViewSubState(obj), id_tracker(std::in_place, id_pool, obj.Handle()) {}
 
 void TensorViewSubState::Destroy() { id_tracker.reset(); }
 

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -222,7 +222,7 @@ class QueueSubState : public vvl::QueueSubState {
 
 class ImageSubState : public vvl::ImageSubState {
   public:
-    ImageSubState(vvl::Image &obj, DescriptorHeap &heap);
+    ImageSubState(vvl::Image& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -238,7 +238,7 @@ static inline const ImageSubState &SubState(const vvl::Image &obj) {
 
 class ImageViewSubState : public vvl::ImageViewSubState {
   public:
-    ImageViewSubState(vvl::ImageView &obj, DescriptorHeap &heap);
+    ImageViewSubState(vvl::ImageView& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -254,7 +254,7 @@ static inline const ImageViewSubState &SubState(const vvl::ImageView &obj) {
 
 class BufferSubState : public vvl::BufferSubState {
   public:
-    BufferSubState(vvl::Buffer &obj, DescriptorHeap &heap);
+    BufferSubState(vvl::Buffer& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -270,7 +270,7 @@ static inline const BufferSubState &SubState(const vvl::Buffer &obj) {
 
 class BufferViewSubState : public vvl::BufferViewSubState {
   public:
-    BufferViewSubState(vvl::BufferView &obj, DescriptorHeap &heap);
+    BufferViewSubState(vvl::BufferView& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -286,7 +286,7 @@ static inline const BufferViewSubState &SubState(const vvl::BufferView &obj) {
 
 class SamplerSubState : public vvl::SamplerSubState {
   public:
-    SamplerSubState(vvl::Sampler &obj, DescriptorHeap &heap);
+    SamplerSubState(vvl::Sampler& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -302,7 +302,7 @@ static inline const SamplerSubState &SubState(const vvl::Sampler &obj) {
 
 class AccelerationStructureNVSubState : public vvl::AccelerationStructureNVSubState {
   public:
-    AccelerationStructureNVSubState(vvl::AccelerationStructureNV &obj, DescriptorHeap &heap);
+    AccelerationStructureNVSubState(vvl::AccelerationStructureNV& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -317,7 +317,7 @@ static inline const AccelerationStructureNVSubState &SubState(const vvl::Acceler
 }
 class AccelerationStructureKHRSubState : public vvl::AccelerationStructureKHRSubState {
   public:
-    AccelerationStructureKHRSubState(Validator& validator, vvl::AccelerationStructureKHR& obj, DescriptorHeap& heap);
+    AccelerationStructureKHRSubState(Validator& validator, vvl::AccelerationStructureKHR& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -344,7 +344,7 @@ static inline const AccelerationStructureKHRSubState &SubState(const vvl::Accele
 
 class TensorSubState : public vvl::TensorSubState {
   public:
-    TensorSubState(vvl::Tensor &obj, DescriptorHeap &heap);
+    TensorSubState(vvl::Tensor& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
@@ -360,7 +360,7 @@ static inline const TensorSubState &SubState(const vvl::Tensor &obj) {
 
 class TensorViewSubState : public vvl::TensorViewSubState {
   public:
-    TensorViewSubState(vvl::TensorView &obj, DescriptorHeap &heap);
+    TensorViewSubState(vvl::TensorView& obj, DescriptorIdPool& id_pool);
     void Destroy() override;
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 

--- a/layers/gpuav/shaders/instrumentation/descriptor_indexing_oob.comp
+++ b/layers/gpuav/shaders/instrumentation/descriptor_indexing_oob.comp
@@ -27,7 +27,7 @@ layout(buffer_reference, buffer_reference_align = 8, scalar) buffer DescriptorEn
 };
 
 layout(buffer_reference, buffer_reference_align = 8, scalar) buffer InitializedStatus {
-    // Maps to DescriptorHeap and used to detect if descriptor is still valid on CPU
+    // Maps to DescriptorIdPool and used to detect if descriptor is still valid on CPU
     uint data[];
 };
 


### PR DESCRIPTION
`DescriptorHeap` turned out to be a bad name while adding `VK_EXT_descriptor_heap` support