### PR TITLE
layers: Better reservedRangeOffset error message

### DIFF
--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -1512,18 +1512,19 @@ bool Device::manual_PreCallValidateCmdBindResourceHeapEXT(VkCommandBuffer comman
                          phys_dev_ext_props.descriptor_heap_props.resourceHeapAlignment);
     }
 
-    if (!IsPointerAligned(pBindInfo->reservedRangeOffset, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment)) {
-        skip |= LogError("VUID-vkCmdBindResourceHeapEXT-pBindInfo-11435", commandBuffer,
-                         error_obj.location.dot(Field::pBindInfo).dot(Field::reservedRangeOffset),
-                         "(0x%" PRIx64 ") must be aligned with bufferDescriptorAlignment (%" PRIu64 ").",
-                         pBindInfo->reservedRangeOffset, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment);
-    }
-
-    if (!IsPointerAligned(pBindInfo->reservedRangeOffset, phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment)) {
-        skip |= LogError("VUID-vkCmdBindResourceHeapEXT-pBindInfo-11436", commandBuffer,
-                         error_obj.location.dot(Field::pBindInfo).dot(Field::reservedRangeOffset),
-                         "(0x%" PRIx64 ") must be aligned with imageDescriptorAlignment (%" PRIu64 ").",
-                         pBindInfo->reservedRangeOffset, phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment);
+    // While these are 2 VUs, they really should be one as you want to know both together
+    const bool buffer_misaligned =
+        !IsPointerAligned(pBindInfo->reservedRangeOffset, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment);
+    const bool image_misaligned =
+        !IsPointerAligned(pBindInfo->reservedRangeOffset, phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment);
+    if (buffer_misaligned || image_misaligned) {
+        const char* vuid =
+            buffer_misaligned ? "VUID-vkCmdBindResourceHeapEXT-pBindInfo-11435" : "VUID-vkCmdBindResourceHeapEXT-pBindInfo-11436";
+        skip |= LogError(vuid, commandBuffer, error_obj.location.dot(Field::pBindInfo).dot(Field::reservedRangeOffset),
+                         "(0x%" PRIx64 ") must be aligned with both bufferDescriptorAlignment (0x%" PRIx64
+                         ") and imageDescriptorAlignment (0x%" PRIx64 ").",
+                         pBindInfo->reservedRangeOffset, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment,
+                         phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment);
     }
     return skip;
 }

--- a/tests/unit/descriptor_heap.cpp
+++ b/tests/unit/descriptor_heap.cpp
@@ -1483,7 +1483,7 @@ TEST_F(NegativeDescriptorHeap, CmdBindResourceHeapReservedRangeAlign) {
 
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindResourceHeapEXT-pBindInfo-11435");
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBindResourceHeapEXT-pBindInfo-11436");
+    // could also be VUID-vkCmdBindResourceHeapEXT-pBindInfo-11436
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();


### PR DESCRIPTION
provides a better error message

```
Validation Error: [ VUID-vkCmdBindResourceHeapEXT-pBindInfo-11435 ] | MessageID = 0x2dca0d2c
vkCmdBindResourceHeapEXT(): pBindInfo->reservedRangeOffset (0x1) must be aligned with both bufferDescriptorAlignment (0x100) and imageDescriptorAlignment (0x100).
```

otherwise, if they are different you will hit one, and then just hit the other, so just report together