### PR TITLE
dump: Fix CombineImageSampler

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -287,6 +287,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
     const vvl::range<VkDeviceAddress>& heap_reserved = is_sampler ? heap.sampler_reserved : heap.resource_reserved;
 
     const char* new_line = "\n        ";
+    const char* new_bullet_line = "\n      - ";
 
     const bool is_array = resource_variable.IsArray();
     const bool is_runtime_array = resource_variable.IsRuntimeArray();
@@ -295,11 +296,19 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         array_length = resource_variable.array_length;
     }
 
-    const VkDescriptorType descriptor_type = resource_variable.GetPotentialDescriptorType();
-    // TODO - Cache these once on device creation
-    VkDeviceSize descriptor_size = descriptor_type == VK_DESCRIPTOR_TYPE_MAX_ENUM
-                                       ? 0
-                                       : DispatchGetPhysicalDeviceDescriptorSizeEXT(dev_data.physical_device, descriptor_type);
+    VkDescriptorType descriptor_type = resource_variable.GetPotentialDescriptorType();
+
+    VkDeviceSize descriptor_size = 0;
+    VkDeviceSize sampler_descriptor_size = dev_data.phys_dev_ext_props.descriptor_heap_props.samplerDescriptorSize;
+    if (descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) {
+        assert(is_combined_image_sampler);
+        // not valid to query this type, we just want the "resource" portion as the sampler is handled itself later
+        descriptor_type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        descriptor_size = dev_data.phys_dev_ext_props.descriptor_heap_props.imageDescriptorSize;
+    } else if (descriptor_type != VK_DESCRIPTOR_TYPE_MAX_ENUM) {
+        // TODO - Cache these once on device creation
+        descriptor_size = DispatchGetPhysicalDeviceDescriptorSizeEXT(dev_data.physical_device, descriptor_type);
+    }
 
     // TODO - Make common util if others need it
     VkDeviceSize required_alignment = 0;
@@ -313,7 +322,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         required_alignment = dev_data.phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment;
         alignment_name = vvl::Field::samplerDescriptorAlignment;
     } else if (IsValueIn(descriptor_type, {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
-                                           VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER})) {
+                                           VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE})) {
         required_alignment = dev_data.phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment;
         alignment_name = vvl::Field::imageDescriptorAlignment;
     } else if (IsValueIn(descriptor_type, {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
@@ -332,12 +341,12 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         if (from_sampler) {
             if (offset > heap.sampler_range.size()) {
                 warn_ss
-                    << new_line
+                    << new_bullet_line
                     << "[WARNING] OUT OF BOUNDS - descriptor not in sampler heap and any access to this descriptor will be invalid";
             }
         } else {
             if (offset > heap_range.size()) {
-                warn_ss << new_line
+                warn_ss << new_bullet_line
                         << "[WARNING] OUT OF BOUNDS - descriptor not in resource heap and any access to this descriptor will be "
                            "invalid";
             }
@@ -346,7 +355,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto warn_alignment_scalar_indirect = [&](VkDeviceAddress address, VkDeviceSize alignment) {
         if (!IsPointerAligned(address, alignment)) {
-            warn_ss << new_line << "[WARNING] MISALIGNED - the indirect address is not aligned to ";
+            warn_ss << new_bullet_line << "[WARNING] MISALIGNED - the indirect address is not aligned to ";
             if (alignment == 4) {
                 warn_ss << "4 (scalar alignment for a uint32_t)";
             } else if (alignment == 8) {
@@ -370,7 +379,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         }
 
         if (!IsPointerAligned(address, alignment)) {
-            warn_ss << new_line << "[WARNING] MISALIGNED - the ";
+            warn_ss << new_bullet_line << "[WARNING] MISALIGNED - the ";
             if (from_resource) {
                 warn_ss << "resource";
             } else {
@@ -393,7 +402,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto warn_alignment_descriptor = [&](VkDeviceAddress address) {
         if (!IsPointerAligned(address, required_alignment)) {
-            warn_ss << new_line << "[WARNING] MISALIGNED - the final address";
+            warn_ss << new_bullet_line << "[WARNING] MISALIGNED - the final address";
             if (resource_variable.IsArray()) {
                 warn_ss << ", to the first element of the array,";
             }
@@ -407,7 +416,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto warn_alignment_sampler = [&](VkDeviceAddress address) {
         if (!IsPointerAligned(address, dev_data.phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment)) {
-            warn_ss << new_line << "[WARNING] MISALIGNED - the final address";
+            warn_ss << new_bullet_line << "[WARNING] MISALIGNED - the final address";
             if (resource_variable.IsArray()) {
                 warn_ss << ", to the first element of the array,";
             }
@@ -419,14 +428,15 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto warn_index_oob = [&](uint32_t max_index) {
         if (array_length > (max_index + 1)) {
-            warn_ss << new_line << "[WARNING] OUT OF BOUNDS - descriptor has an array length of [" << std::dec << array_length
-                    << "] but any element accessed starting at [" << max_index + 1 << std::hex << "] will be invalid if accessed";
+            warn_ss << new_bullet_line << "[WARNING] OUT OF BOUNDS - descriptor has an array length of [" << std::dec
+                    << array_length << "] but any element accessed starting at [" << max_index + 1 << std::hex
+                    << "] will be invalid if accessed";
         }
     };
 
     auto warn_index_array = [&](std::vector<uint32_t>& bad_indexes) {
         if (!bad_indexes.empty()) {
-            warn_ss << new_line << "[WARNING] OUT OF BOUNDS - descriptors indexes at [" << std::dec;
+            warn_ss << new_bullet_line << "[WARNING] OUT OF BOUNDS - descriptors indexes at [" << std::dec;
             for (uint32_t i = 0; i < bad_indexes.size(); i++) {
                 if (i != 0) warn_ss << ", ";
                 warn_ss << bad_indexes[i];
@@ -437,7 +447,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto warn_alignment_index_array = [&](std::vector<uint32_t>& bad_indexes) {
         if (!bad_indexes.empty()) {
-            warn_ss << new_line << "[WARNING] MISALIGNED - descriptors indexes at [" << std::dec;
+            warn_ss << new_bullet_line << "[WARNING] MISALIGNED - descriptors indexes at [" << std::dec;
             for (uint32_t i = 0; i < bad_indexes.size(); i++) {
                 if (i != 0) warn_ss << ", ";
                 warn_ss << bad_indexes[i];
@@ -452,7 +462,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto warn_reserved_range_index_array = [&](std::vector<uint32_t>& bad_indexes) {
         if (!bad_indexes.empty()) {
-            warn_ss << new_line << "[WARNING] RESERVED RANGE - descriptors indexes at [" << std::dec;
+            warn_ss << new_bullet_line << "[WARNING] RESERVED RANGE - descriptors indexes at [" << std::dec;
             for (uint32_t i = 0; i < bad_indexes.size(); i++) {
                 if (i != 0) warn_ss << ", ";
                 warn_ss << bad_indexes[i];
@@ -463,7 +473,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto warn_alignment_index_array_sampler = [&](std::vector<uint32_t>& bad_indexes) {
         if (!bad_indexes.empty()) {
-            warn_ss << new_line << "[WARNING] MISALIGNED - descriptors indexes at [" << std::dec;
+            warn_ss << new_bullet_line << "[WARNING] MISALIGNED - descriptors indexes at [" << std::dec;
             for (uint32_t i = 0; i < bad_indexes.size(); i++) {
                 if (i != 0) warn_ss << ", ";
                 warn_ss << bad_indexes[i];
@@ -525,34 +535,35 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         warn_oob(index_zero_offset + descriptor_size, false);
 
         if (is_combined_image_sampler) {
-            ss << new_line << "samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset << ", samplerHeapArrayStride: 0x"
-               << map_data.samplerHeapArrayStride;
+            ss << new_bullet_line << "samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset
+               << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
             index_zero_offset = map_data.samplerHeapOffset;
             index_zero_address = heap.sampler_range.begin + index_zero_offset;
             ss << new_line << "Sampler Heap address: 0x" << index_zero_address;
             if (is_array) {
                 ss << " + (descriptor_index * 0x" << map_data.samplerHeapArrayStride << ")";
-                const VkDeviceSize available_space = (heap.sampler_range.size() - index_zero_offset) - descriptor_size;
+                const VkDeviceSize available_space = (heap.sampler_range.size() - index_zero_offset) - sampler_descriptor_size;
                 const uint32_t max_index = (uint32_t)(available_space / map_data.samplerHeapArrayStride);
                 if (array_length != 0) {
                     const VkDeviceSize final_array_offset = (array_length - 1) * map_data.samplerHeapArrayStride;
                     ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                        << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
-                       << (index_zero_address + final_array_offset + descriptor_size) << ")";
+                       << (index_zero_address + final_array_offset + sampler_descriptor_size) << ")";
                     warn_index_oob(max_index);
                 } else if (is_runtime_array) {
                     const VkDeviceSize final_array_offset =
                         (map_data.samplerHeapOffset + (max_index * map_data.samplerHeapArrayStride));
                     ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                        << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
-                       << (index_zero_address + final_array_offset + descriptor_size) << ")";
+                       << (index_zero_address + final_array_offset + sampler_descriptor_size) << ")";
                 }
 
                 if (!heap.sampler_reserved.empty() && warn_reserved_range_start == vvl::kNoIndex32) {
                     const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
                     for (uint32_t i = 0; i < max_search_index; i++) {
                         VkDeviceAddress next_index_address = index_zero_address + (i * map_data.samplerHeapArrayStride);
-                        vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                        vvl::range<VkDeviceAddress> next_index_range{next_index_address,
+                                                                     next_index_address + sampler_descriptor_size};
                         if (next_index_range.intersects(heap.sampler_reserved)) {
                             if (warn_reserved_range_start == vvl::kNoIndex32) {
                                 warn_reserved_range_start = i;
@@ -564,12 +575,12 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                     }
                 }
             } else if (!heap.sampler_reserved.empty()) {
-                vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + sampler_descriptor_size};
                 if (index_zero_range.intersects(heap.sampler_reserved)) {
                     warn_reserved_range_start = 0;
                 }
             }
-            warn_oob(index_zero_offset + descriptor_size, true);
+            warn_oob(index_zero_offset + sampler_descriptor_size, true);
         }
     } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
         const VkDescriptorMappingSourcePushIndexEXT& map_data = mapping.sourceData.pushIndex;
@@ -631,7 +642,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         warn_oob(index_zero_offset + descriptor_size, false);
 
         if (is_combined_image_sampler) {
-            ss << new_line << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", samplerHeapOffset: 0x"
+            ss << new_bullet_line << "pushOffset: 0x" << std::hex << map_data.pushOffset << ", samplerHeapOffset: 0x"
                << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride
                << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
             ss << new_line << "pushIndex: 0x" << push_index;
@@ -644,26 +655,27 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
             if (is_array) {
                 ss << " + (descriptor_index * 0x" << map_data.samplerHeapArrayStride << ")";
-                const VkDeviceSize available_space = (heap.sampler_range.size() - index_zero_offset) - descriptor_size;
+                const VkDeviceSize available_space = (heap.sampler_range.size() - index_zero_offset) - sampler_descriptor_size;
                 const uint32_t max_index = (uint32_t)(available_space / map_data.samplerHeapArrayStride);
                 if (array_length != 0) {
                     const VkDeviceSize final_array_offset = (array_length - 1) * map_data.samplerHeapArrayStride;
                     ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                        << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
-                       << (index_zero_address + final_array_offset + descriptor_size) << ")";
+                       << (index_zero_address + final_array_offset + sampler_descriptor_size) << ")";
                     warn_index_oob(max_index);
                 } else if (is_runtime_array) {
                     const VkDeviceSize final_array_offset = max_index * map_data.samplerHeapArrayStride;
                     ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                        << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
-                       << (index_zero_address + final_array_offset + descriptor_size) << ")";
+                       << (index_zero_address + final_array_offset + sampler_descriptor_size) << ")";
                 }
 
                 if (!heap.sampler_reserved.empty() && warn_reserved_range_start == vvl::kNoIndex32) {
                     const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
                     for (uint32_t i = 0; i < max_search_index; i++) {
                         VkDeviceAddress next_index_address = index_zero_address + (i * map_data.samplerHeapArrayStride);
-                        vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                        vvl::range<VkDeviceAddress> next_index_range{next_index_address,
+                                                                     next_index_address + sampler_descriptor_size};
                         if (next_index_range.intersects(heap.sampler_reserved)) {
                             if (warn_reserved_range_start == vvl::kNoIndex32) {
                                 warn_reserved_range_start = i;
@@ -678,7 +690,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                 ss << " [final address 0x" << index_zero_address << "]";
 
                 if (!heap.sampler_reserved.empty()) {
-                    vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                    vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + sampler_descriptor_size};
                     if (index_zero_range.intersects(heap.sampler_reserved)) {
                         warn_reserved_range_start = 0;
                     }
@@ -784,10 +796,10 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
             know_ubo = !indirect_index_data.empty();
             indirect_index = know_ubo ? *((uint32_t*)indirect_index_data.data()) : 0;
 
-            ss << new_line << "samplerPushOffset: 0x" << std::hex << map_data.samplerPushOffset << ", samplerAddressOffset: 0x"
-               << map_data.samplerAddressOffset << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset
-               << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride << ", samplerHeapArrayStride: 0x"
-               << map_data.samplerHeapArrayStride;
+            ss << new_bullet_line << "samplerPushOffset: 0x" << std::hex << map_data.samplerPushOffset
+               << ", samplerAddressOffset: 0x" << map_data.samplerAddressOffset << ", samplerHeapOffset: 0x"
+               << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride
+               << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
             ss << new_line << "indirectAddress: 0x" << final_indirect_address << " (0x" << push_indirect_address << " + 0x"
                << map_data.samplerAddressOffset << ")";
 
@@ -812,26 +824,27 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                     VkDeviceAddress index_zero_address = heap.sampler_range.begin + index_zero_offset;
                     warn_alignment_sampler(index_zero_address);
 
-                    VkDeviceSize available_space = (heap.sampler_range.size() - index_zero_offset) - descriptor_size;
+                    VkDeviceSize available_space = (heap.sampler_range.size() - index_zero_offset) - sampler_descriptor_size;
                     uint32_t max_index = (uint32_t)(available_space / map_data.samplerHeapArrayStride);
                     if (array_length != 0) {
                         const VkDeviceSize final_array_offset = (array_length - 1) * map_data.samplerHeapArrayStride;
                         ss << new_line << "    The final descriptor index at [" << std::dec << array_length << std::hex
                            << "] will access [0x" << (index_zero_address + final_array_offset) << ", 0x"
-                           << (index_zero_address + final_array_offset + descriptor_size) << ")";
+                           << (index_zero_address + final_array_offset + sampler_descriptor_size) << ")";
                         warn_index_oob(max_index);
                     } else if (is_runtime_array) {
                         const VkDeviceSize final_array_offset = max_index * map_data.samplerHeapArrayStride;
                         ss << new_line << "    The final descriptor index in bounds is [" << std::dec << max_index << std::hex
                            << "] which would be accessed at [0x" << (index_zero_address + final_array_offset) << ", 0x"
-                           << (index_zero_address + final_array_offset + descriptor_size) << ")";
+                           << (index_zero_address + final_array_offset + sampler_descriptor_size) << ")";
                     }
 
                     if (!heap.sampler_reserved.empty() && warn_reserved_range_start == vvl::kNoIndex32) {
                         const uint32_t max_search_index = array_length != 0 ? array_length : max_index + 1;
                         for (uint32_t i = 0; i < max_search_index; i++) {
                             VkDeviceAddress next_index_address = index_zero_address + (i * map_data.samplerHeapArrayStride);
-                            vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                            vvl::range<VkDeviceAddress> next_index_range{next_index_address,
+                                                                         next_index_address + sampler_descriptor_size};
                             if (next_index_range.intersects(heap.sampler_reserved)) {
                                 if (warn_reserved_range_start == vvl::kNoIndex32) {
                                     warn_reserved_range_start = i;
@@ -849,17 +862,17 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                 warn_alignment_sampler(index_zero_address);
 
                 ss << " [final address 0x" << (index_zero_address) << "]";
-                warn_oob(final_offset + descriptor_size, true);
+                warn_oob(final_offset + sampler_descriptor_size, true);
 
                 if (!heap.sampler_range.empty()) {
-                    vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + descriptor_size};
+                    vvl::range<VkDeviceAddress> index_zero_range{index_zero_address, index_zero_address + sampler_descriptor_size};
                     if (index_zero_range.intersects(heap.sampler_range)) {
                         warn_reserved_range_start = 0;
                     }
                 }
             }
 
-            warn_oob(map_data.samplerHeapOffset + descriptor_size, true);
+            warn_oob(map_data.samplerHeapOffset + sampler_descriptor_size, true);
         }
     } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
         const VkDescriptorMappingSourceIndirectIndexArrayEXT& map_data = mapping.sourceData.indirectIndexArray;
@@ -952,9 +965,9 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
             warn_alignment_scalar_indirect(final_indirect_address, 4);
 
-            ss << new_line << "samplerPushOffset: 0x" << std::hex << map_data.samplerPushOffset << ", samplerAddressOffset: 0x"
-               << map_data.samplerAddressOffset << ", samplerHeapOffset: 0x" << map_data.samplerHeapOffset
-               << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride;
+            ss << new_bullet_line << "samplerPushOffset: 0x" << std::hex << map_data.samplerPushOffset
+               << ", samplerAddressOffset: 0x" << map_data.samplerAddressOffset << ", samplerHeapOffset: 0x"
+               << map_data.samplerHeapOffset << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride;
             ss << new_line << "indirectAddress: 0x" << final_indirect_address << " (0x" << push_indirect_address << " + 0x"
                << map_data.samplerAddressOffset << ")";
 
@@ -992,7 +1005,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                     warn_alignment_sampler(final_address);
 
                     ss << " [final address 0x" << final_address << "]";
-                    warn_oob(final_offset + descriptor_size, true);
+                    warn_oob(final_offset + sampler_descriptor_size, true);
                 } else if (!is_runtime_array) {
                     ss << new_line << "indirectIndex values from buffer: [";
                     std::vector<uint32_t> bad_array_indexes;
@@ -1002,7 +1015,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                         const uint32_t current_index_value = indirect_index_words[i];
                         VkDeviceSize final_offset =
                             map_data.samplerHeapOffset + (current_index_value * map_data.samplerHeapIndexStride);
-                        if (final_offset + descriptor_size > heap.sampler_range.size()) {
+                        if (final_offset + sampler_descriptor_size > heap.sampler_range.size()) {
                             bad_array_indexes.emplace_back(i);
                         }
                         if (i != 0) ss << ", ";
@@ -1015,7 +1028,8 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                         }
 
                         if (!heap.sampler_reserved.empty()) {
-                            vvl::range<VkDeviceAddress> next_index_range{next_index_address, next_index_address + descriptor_size};
+                            vvl::range<VkDeviceAddress> next_index_range{next_index_address,
+                                                                         next_index_address + sampler_descriptor_size};
                             if (next_index_range.intersects(heap.sampler_reserved)) {
                                 bad_reserve_indexes.emplace_back(i);
                             }
@@ -1027,7 +1041,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
                     ss << "]";
                 }
             }
-            warn_oob(map_data.samplerHeapOffset + descriptor_size, true);
+            warn_oob(map_data.samplerHeapOffset + sampler_descriptor_size, true);
         }
     } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT) {
         const VkDescriptorMappingSourceHeapDataEXT& map_data = mapping.sourceData.heapData;
@@ -1086,9 +1100,9 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         ss << "heapOffset: 0x" << std::hex << map_data.heapOffset << ", shaderRecordOffset: 0x" << map_data.shaderRecordOffset
            << ", heapIndexStride: 0x" << map_data.heapIndexStride << ", heapArrayStride: 0x" << map_data.heapArrayStride;
         if (is_combined_image_sampler) {
-            ss << new_line << "samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset << ", samplerShaderRecordOffset: 0x"
-               << map_data.samplerShaderRecordOffset << ", samplerHeapIndexStride: 0x" << map_data.samplerHeapIndexStride
-               << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
+            ss << new_bullet_line << "samplerHeapOffset: 0x" << std::hex << map_data.samplerHeapOffset
+               << ", samplerShaderRecordOffset: 0x" << map_data.samplerShaderRecordOffset << ", samplerHeapIndexStride: 0x"
+               << map_data.samplerHeapIndexStride << ", samplerHeapArrayStride: 0x" << map_data.samplerHeapArrayStride;
         }
     } else if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_DATA_EXT) {
         // TODO - Add more info probably
@@ -1099,8 +1113,13 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
     }
 
     if (descriptor_type != VK_DESCRIPTOR_TYPE_MAX_ENUM) {
-        ss << new_line << "Descriptor size: 0x" << std::hex << descriptor_size << " (" << string_VkDescriptorType(descriptor_type)
-           << ")";
+        if (is_combined_image_sampler) {
+            ss << new_bullet_line << "Descriptor size: 0x" << std::hex << descriptor_size << " (imageDescriptorSize) and 0x"
+               << sampler_descriptor_size << " (samplerDescriptorAlignment)";
+        } else {
+            ss << new_bullet_line << "Descriptor size: 0x" << std::hex << descriptor_size << " ("
+               << string_VkDescriptorType(descriptor_type) << ")";
+        }
     }
 
     if (warn_reserved_range_start != vvl::kNoIndex32) {
@@ -1132,7 +1151,7 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
     bool found_warning = false;
     const vvl::CommandBuffer& cb_state = last_bound.cb_state;
     if (!cb_state.descriptor_heap.resource_range.empty()) {
-        ss << "vkCmdBindResourceHeapEXT last bound the resource heap to "
+        ss << "- vkCmdBindResourceHeapEXT last bound the resource heap to "
            << string_range_hex(cb_state.descriptor_heap.resource_range);
         if (!cb_state.descriptor_heap.resource_reserved.empty()) {
             ss << " (reserved range " << std::dec << cb_state.descriptor_heap.resource_reserved.size() << " bytes at " << string_range_hex(cb_state.descriptor_heap.resource_reserved) << ")";
@@ -1143,7 +1162,8 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         found_warning |= dev_data.ListBuffers(ss, cb_state.descriptor_heap.resource_range.begin, 1);
     }
     if (!cb_state.descriptor_heap.sampler_range.empty()) {
-        ss << "vkCmdBindSamplerHeapEXT last bound the sampler heap to " << string_range_hex(cb_state.descriptor_heap.sampler_range);
+        ss << "- vkCmdBindSamplerHeapEXT last bound the sampler heap to "
+           << string_range_hex(cb_state.descriptor_heap.sampler_range);
         if (!cb_state.descriptor_heap.sampler_reserved.empty()) {
             ss << " (reserved range " << std::dec << cb_state.descriptor_heap.sampler_reserved.size() << " bytes at "
                << string_range_hex(cb_state.descriptor_heap.sampler_reserved) << ")";
@@ -1154,13 +1174,12 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         found_warning |= dev_data.ListBuffers(ss, cb_state.descriptor_heap.sampler_range.begin, 1);
     }
 
-    ss << '\n';
     if (last_bound.pipeline_state) {
-        ss << "Last bound pipeline:\n    " << dev_data.FormatHandle(last_bound.pipeline_state->VkHandle())
-           << " (bind point: " << string_VkPipelineBindPoint(last_bound.pipeline_state->pipeline_type) << ")\n";
+        ss << "- Last bound pipeline: " << dev_data.FormatHandle(last_bound.pipeline_state->VkHandle()) << " ("
+           << string_VkPipelineBindPoint(last_bound.pipeline_state->pipeline_type) << ")\n";
     }
 
-    ss << "\nShader descriptors:\n";
+    ss << "- Shader descriptors:\n";
     small_vector<const ShaderStageState*, 3> stages = last_bound.GetStages();
     for (const ShaderStageState* stage : stages) {
         if (!stage->HasSpirv()) {
@@ -1169,7 +1188,12 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             continue;
         }
         const spirv::EntryPoint& entry_point = *stage->entrypoint;
-        ss << entry_point.Describe() << "\n";
+        ss << "  " << entry_point.Describe();
+        // TODO - add util in ShaderStageState to get ShaderObject handle here
+        if (stage->module_state && stage->module_state->VkHandle() != VK_NULL_HANDLE) {
+            ss << " " << dev_data.FormatHandle(stage->module_state->VkHandle());
+        }
+        ss << "\n";
 
         const auto* mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(stage->GetPNext());
 
@@ -1195,7 +1219,7 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         }
 
         if (mapping_info_map.empty()) {
-            ss << "  No VkDescriptorSetAndBindingMappingEXT were found for this shader\n";
+            ss << "    - No VkDescriptorSetAndBindingMappingEXT were found for this shader\n";
             continue;
         }
 
@@ -1204,7 +1228,6 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             std::sort(mapping_info_list.begin(), mapping_info_list.end());
             for (const MappingInfo& set_info : mapping_info_list) {
                 found_warning |= DumpDescriptorHeapMapping(ss, set_info);
-                ss << '\n';
             }
         }
     }

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -1325,3 +1325,55 @@ TEST_F(NegativeGpuDump, DescriptorHeapIndirectIndexNoBuffer) {
 
     m_command_buffer.End();
 }
+
+TEST_F(NegativeGpuDump, DescriptorHeapCombinedImageSampler) {
+    RETURN_IF_SKIP(InitDescriptorHeap());
+    InitRenderTarget();
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.imageDescriptorSize;
+    const VkDeviceSize sampler_stride = heap_props.samplerDescriptorSize;
+    vkt::Buffer resource_heap(*m_device, resource_stride, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+    vkt::Buffer sampler_heap(*m_device, sampler_stride, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform sampler2D tex;
+        void main() {
+            vec4 data = texture(tex, vec2(0.5f));
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset = {};
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    mapping.sourceData.constantOffset.samplerHeapOffset = 0;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.CreateComputePipeline(false);
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = resource_heap.AddressRange();
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+    bind_resource_info.heapRange = sampler_heap.AddressRange();
+    vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_resource_info);
+    vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+}


### PR DESCRIPTION
was calling `DispatchGetPhysicalDeviceDescriptorSizeEXT` with `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER`

also improves the `-` lines used and print some handles for the `VkShaderModule` if used