### PR TITLE
layers: Validate event reset after wait execution dependency

### DIFF
--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -625,13 +625,43 @@ void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags
     signaling_state = {};
     signaling_state.was_reset = true;
     signaling_state.last_signaling_command = loc.function;
+    event_wait_states.erase(event);
+}
+
+// Return the second synchronization scope in canonical form (meta stage expansion and logically later stages)
+static VkPipelineStageFlags2 MakeEventBarriers(VkPipelineStageFlags2 dst_stage_mask, VkQueueFlags queue_flags) {
+    VkPipelineStageFlags2 barriers = sync_utils::ExpandPipelineStages(dst_stage_mask, queue_flags);
+    barriers = sync_utils::AddLaterPipelineStages(barriers);
+
+    // Add ALL_COMMANDS if it was present in the original mask (expansion removes it)
+    barriers |= (dst_stage_mask & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
+
+    return barriers;
+}
+
+// Return event barrier added by src/dst dependency.
+// Return NONE if it does not chain with current_event_barriers
+static VkPipelineStageFlags2 GetNewEventBarriersFromDependency(VkPipelineStageFlags2 current_event_barriers,
+                                                               VkPipelineStageFlags2 src_stage_mask,
+                                                               VkPipelineStageFlags2 dst_stage_mask, VkQueueFlags queue_flags) {
+    const bool all_commands_bit = (src_stage_mask & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) != 0;
+    const VkPipelineStageFlags2 expanded_src_stage_mask = sync_utils::ExpandPipelineStages(src_stage_mask, queue_flags);
+    if (all_commands_bit || (current_event_barriers & expanded_src_stage_mask) != 0) {
+        return MakeEventBarriers(dst_stage_mask, queue_flags);
+    }
+    return VK_PIPELINE_STAGE_2_NONE;
 }
 
 void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask,
-                                             const Location& loc) {
+                                             VkPipelineStageFlags dst_stage_mask, const Location& loc) {
     bool submit_validation = false;
     EventSignalingStateMap signaling_states;
+
+    const VkPipelineStageFlags2 barriers = MakeEventBarriers(dst_stage_mask, base.GetQueueFlags());
+
     for (VkEvent event : events) {
+        event_wait_states[event] = EventWaitState{barriers, loc.function};
+
         EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
         if (signaling_state) {
             signaling_states.emplace(event, *signaling_state);
@@ -653,6 +683,10 @@ void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, Vk
 }
 
 void CommandBufferSubState::RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
+    const VkPipelineStageFlags2 dst_stage_mask = sync_utils::GetExecScopes(dependency_info).dst;
+    const VkPipelineStageFlags2 barriers = MakeEventBarriers(dst_stage_mask, base.GetQueueFlags());
+    event_wait_states[event] = EventWaitState{barriers, loc.function};
+
     EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
     const bool already_validated = signaling_state && signaling_state->was_reset;
     const bool submit_validation = !already_validated;
@@ -665,6 +699,40 @@ void CommandBufferSubState::RecordWaitEvent2(VkEvent event, const VkDependencyIn
         }
         submit_info.wait_command = loc.function;
         wait_event2_submit_infos.emplace_back(std::move(submit_info));
+    }
+}
+
+void CommandBufferSubState::UpdateEventWaitBarriers(VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask) {
+    for (auto& [event, state] : event_wait_states) {
+        state.barriers |= GetNewEventBarriersFromDependency(state.barriers, src_stage_mask, dst_stage_mask, base.GetQueueFlags());
+    }
+}
+
+void CommandBufferSubState::UpdateEventWaitBarriers(const VkDependencyInfo& dep_info) {
+    for (auto& [event, state] : event_wait_states) {
+        VkPipelineStageFlags2 new_barriers = VK_PIPELINE_STAGE_2_NONE;
+        if (dep_info.pMemoryBarriers) {
+            for (uint32_t i = 0; i < dep_info.memoryBarrierCount; i++) {
+                const auto& barrier = dep_info.pMemoryBarriers[i];
+                new_barriers |= GetNewEventBarriersFromDependency(state.barriers, barrier.srcStageMask, barrier.dstStageMask,
+                                                                  base.GetQueueFlags());
+            }
+        }
+        if (dep_info.pBufferMemoryBarriers) {
+            for (uint32_t i = 0; i < dep_info.bufferMemoryBarrierCount; i++) {
+                const auto& barrier = dep_info.pBufferMemoryBarriers[i];
+                new_barriers |= GetNewEventBarriersFromDependency(state.barriers, barrier.srcStageMask, barrier.dstStageMask,
+                                                                  base.GetQueueFlags());
+            }
+        }
+        if (dep_info.pImageMemoryBarriers) {
+            for (uint32_t i = 0; i < dep_info.imageMemoryBarrierCount; i++) {
+                const auto& barrier = dep_info.pImageMemoryBarriers[i];
+                new_barriers |= GetNewEventBarriersFromDependency(state.barriers, barrier.srcStageMask, barrier.dstStageMask,
+                                                                  base.GetQueueFlags());
+            }
+        }
+        state.barriers |= new_barriers;
     }
 }
 
@@ -686,6 +754,14 @@ void CommandBufferSubState::RecordBarriers(uint32_t buffer_barrier_count, const 
         validator.RecordBarrierValidationInfo(barrier_loc, base, img_barrier, *image_state, qfo_transfer_image_barriers);
         validator.RecordTransitionImageLayout(base, img_barrier, *image_state);
         validator.EnqueueValidateImageBarrierAttachment(barrier_loc, *this, img_barrier);
+    }
+
+    // Update event's execution dependency chain for pipeline barrier commands.
+    // RecordBarriers is also used by WaitEvents so we need to check for specific commands.
+    const bool is_pipeline_barrier = IsValueIn(
+        loc.function, {vvl::Func::vkCmdPipelineBarrier, vvl::Func::vkCmdPipelineBarrier2, vvl::Func::vkCmdPipelineBarrier2KHR});
+    if (is_pipeline_barrier) {
+        UpdateEventWaitBarriers(src_stage_mask, dst_stage_mask);
     }
 }
 
@@ -711,6 +787,14 @@ void CommandBufferSubState::RecordBarriers2(const VkDependencyInfo& dep_info, co
             const TensorBarrier barrier(tensor_barrier_dep_info->pTensorMemoryBarriers[i]);
             base.tensor_barriers.emplace_back(barrier);
         }
+    }
+
+    // Update event's execution dependency chain for pipeline barrier commands.
+    // RecordBarriers2 is also used by WaitEvents2 so we need to check for specific commands.
+    const bool is_pipeline_barrier = IsValueIn(
+        loc.function, {vvl::Func::vkCmdPipelineBarrier, vvl::Func::vkCmdPipelineBarrier2, vvl::Func::vkCmdPipelineBarrier2KHR});
+    if (is_pipeline_barrier) {
+        UpdateEventWaitBarriers(dep_info);
     }
 }
 
@@ -1127,6 +1211,7 @@ void CommandBufferSubState::ResetCBState() {
 
     push_data_mask.clear();
     event_signaling_states.clear();
+    event_wait_states.clear();
 
     // Submit time validation
     queue_submit_functions.clear();
@@ -1198,6 +1283,15 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
         }
     }
     UpdateEventSignalingStates(event_signaling_states, secondary_sub_state.event_signaling_states);
+
+    // We don't currently merge secondary wait state precisely. Use a simplified model
+    // that clears the current wait state and keeps only the secondary's final wait state.
+    // To validate more primary/secondary interactions, this can be extended to replay
+    // secondary wait/barrier/reset commands.
+    event_wait_states.clear();
+    for (const auto& [event, wait_state] : secondary_sub_state.event_wait_states) {
+        event_wait_states[event] = wait_state;
+    }
 
     for (auto& function : secondary_sub_state.queue_submit_functions) {
         queue_submit_functions.push_back(function);

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -100,7 +100,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordSetEvent(VkEvent event, VkPipelineStageFlags stageMask) final;
     void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) final;
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stageMask, const Location& loc) final;
-    void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) final;
+    void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
+                          const Location& loc) final;
     void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) final;
     void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers, uint32_t image_barrier_count,
                         const VkImageMemoryBarrier *image_barriers, VkPipelineStageFlags src_stage_mask,
@@ -205,13 +206,15 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     // currently need to hold in Command buffer because it can be a suspended renderpass
     std::vector<VkOffset2D> fragment_density_offsets;
 
+    // Event state tracking
+    EventSignalingStateMap event_signaling_states;
+    EventWaitStateMap event_wait_states;
+    std::vector<WaitEventSubmitInfo> wait_event_submit_infos;
+    std::vector<WaitEvent2SubmitInfo> wait_event2_submit_infos;
+
     // Validation functions run at primary CB queue submit time
     using QueueCallback = std::function<bool(const class vvl::Queue &queue_state, const vvl::CommandBuffer &cb_state)>;
     std::vector<QueueCallback> queue_submit_functions;
-
-    EventSignalingStateMap event_signaling_states;
-    std::vector<WaitEventSubmitInfo> wait_event_submit_infos;
-    std::vector<WaitEvent2SubmitInfo> wait_event2_submit_infos;
 
     // Validation functions run when secondary CB is executed in primary
     std::vector<
@@ -228,6 +231,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void UpdateActionShaderObjectState(LastBound &last_bound);
     void UpdateActiveSlotsState(LastBound &last_bound, const ActiveSlotMap &active_slots);
     void UpdateCustomResolve(LastBound &last_bound);
+    void UpdateEventWaitBarriers(VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask);
+    void UpdateEventWaitBarriers(const VkDependencyInfo& dep_info);
 
     // Funnel because Image/Buffer copies have 2 variations for the regions
     template <typename RegionType>

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1054,6 +1054,7 @@ bool CoreChecks::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkE
     skip |= ValidateCmd(*cb_state, error_obj.location);
     skip |= ValidatePipelineStage(objlist, stage_mask_loc, cb_state->GetQueueFlags(), stageMask);
     skip |= ValidateStageMaskHost(objlist, stage_mask_loc, stageMask);
+    skip |= ValidateResetVsWaitRace(*cb_state, event, stageMask, error_obj.location);
     return skip;
 }
 
@@ -1071,12 +1072,36 @@ bool CoreChecks::PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, Vk
     skip |= ValidateCmd(*cb_state, error_obj.location);
     skip |= ValidatePipelineStage(objlist, stage_mask_loc, cb_state->GetQueueFlags(), stageMask);
     skip |= ValidateStageMaskHost(objlist, stage_mask_loc, stageMask);
+    skip |= ValidateResetVsWaitRace(*cb_state, event, stageMask, error_obj.location);
     return skip;
 }
 
 bool CoreChecks::PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
                                                   const ErrorObject& error_obj) const {
     return PreCallValidateCmdResetEvent2(commandBuffer, event, stageMask, error_obj);
+}
+
+bool CoreChecks::ValidateResetVsWaitRace(const vvl::CommandBuffer& cb_state, VkEvent event, VkPipelineStageFlags2 reset_stage_mask,
+                                         const Location& loc) const {
+    bool skip = false;
+    const auto& cb_sub_state = core::SubState(cb_state);
+    if (const EventWaitState* state = vvl::Find(cb_sub_state.event_wait_states, event)) {
+        VkPipelineStageFlags2 reset_exec_scope = sync_utils::ExpandPipelineStages(reset_stage_mask, cb_state.GetQueueFlags());
+        reset_exec_scope = sync_utils::AddEarlierPipelineStages(reset_exec_scope);
+        const bool has_barrier = (reset_stage_mask & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) ||
+                                 (state->barriers & reset_exec_scope) || (state->barriers & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
+        if (!has_barrier) {
+            const char* vuid = loc.function == vvl::Func::vkCmdResetEvent
+                                   ? (state->last_wait_command == vvl::Func::vkCmdWaitEvents ? "VUID-vkCmdResetEvent-event-03834"
+                                                                                             : "VUID-vkCmdResetEvent-event-03835")
+                                   : (state->last_wait_command == vvl::Func::vkCmdWaitEvents ? "VUID-vkCmdResetEvent2-event-03831"
+                                                                                             : "VUID-vkCmdResetEvent2-event-03832");
+            const LogObjectList objlist(cb_state.Handle(), event);
+            skip |= LogError(vuid, objlist, loc, "does not create an execution dependency with the previous %s for %s.",
+                             vvl::String(state->last_wait_command), FormatHandle(event).c_str());
+        }
+    }
+    return skip;
 }
 
 struct RenderPassDepState {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2022,6 +2022,8 @@ class CoreChecks : public vvl::DeviceProxy {
                                           const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                        const ErrorObject& error_obj) const override;
+    bool ValidateResetVsWaitRace(const vvl::CommandBuffer& cb_state, VkEvent event, VkPipelineStageFlags2 reset_stage_mask,
+                                 const Location& loc) const;
     bool PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                       VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
                                       uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -2190,9 +2190,10 @@ void CommandBuffer::RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_
     events.push_back(event);
 }
 
-void CommandBuffer::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) {
+void CommandBuffer::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask,
+                                     VkPipelineStageFlags dst_stage_mask, const Location& loc) {
     for (auto& item : sub_states_) {
-        item.second->RecordWaitEvents(events, src_stage_mask, loc);
+        item.second->RecordWaitEvents(events, src_stage_mask, dst_stage_mask, loc);
     }
     for (const VkEvent event : events) {
         if (!dev_data.disabled[command_buffer_state]) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -738,7 +738,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordSetEvent(VkEvent event, VkPipelineStageFlags stageMask, const Location& loc);
     void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc);
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2KHR stageMask, const Location &loc);
-    void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc);
+    void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
+                          const Location& loc);
     void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& dep_info_loc);
     void RecordPushConstants(const vvl::PipelineLayout& pipeline_layout_state, VkShaderStageFlags stage_flags, uint32_t offset,
                              uint32_t size, const void *values);
@@ -907,7 +908,8 @@ class CommandBufferSubState {
     virtual void RecordSetEvent(VkEvent event, VkPipelineStageFlags stage_mask) {}
     virtual void RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {}
     virtual void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const Location& loc) {}
-    virtual void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask, const Location& loc) {}
+    virtual void RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask,
+                                  VkPipelineStageFlags dst_stage_mask, const Location& loc) {}
     virtual void RecordWaitEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {}
     virtual void RecordBarriers(uint32_t buffer_barrier_count, const VkBufferMemoryBarrier *buffer_barriers,
                                 uint32_t image_barrier_count, const VkImageMemoryBarrier *image_barriers,

--- a/layers/state_tracker/event_state.h
+++ b/layers/state_tracker/event_state.h
@@ -55,7 +55,13 @@ struct EventSignalingState {
     bool HasKnownEffect(const EventSignalingState* prior_state = nullptr) const;
 };
 
+struct EventWaitState {
+    VkPipelineStageFlags2 barriers = VK_PIPELINE_STAGE_2_NONE;
+    vvl::Func last_wait_command = vvl::Func::Empty;
+};
+
 using EventSignalingStateMap = vvl::unordered_map<VkEvent, EventSignalingState>;
+using EventWaitStateMap = vvl::unordered_map<VkEvent, EventWaitState>;
 
 void UpdateEventSignalingStates(EventSignalingStateMap& accumulated_states, const EventSignalingStateMap& recorded_states);
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3538,7 +3538,7 @@ void DeviceState::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uin
                                               const RecordObject& record_obj) {
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
     cb_state->RecordCommand(record_obj.location);
-    cb_state->RecordWaitEvents(vvl::make_span(pEvents, eventCount), srcStageMask, record_obj.location);
+    cb_state->RecordWaitEvents(vvl::make_span(pEvents, eventCount), srcStageMask, dstStageMask, record_obj.location);
     cb_state->RecordBarrierObjects(bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers,
                                    srcStageMask, dstStageMask, record_obj.location);
 }

--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -68,31 +68,6 @@ static SyncAccessFlags AccessScopeByAccess(VkAccessFlags2 accesses) {
     return sync_accesses;
 }
 
-static VkPipelineStageFlags2 RelatedPipelineStages(
-    VkPipelineStageFlags2 stage_mask,
-    const vvl::unordered_map<VkPipelineStageFlagBits2, VkPipelineStageFlags2>& earlier_or_later_stages) {
-    VkPipelineStageFlags2 unscanned = stage_mask;
-    VkPipelineStageFlags2 related = 0;
-    for (const auto& [stage, related_stages] : earlier_or_later_stages) {
-        if (stage & unscanned) {
-            related |= related_stages;
-            unscanned &= ~stage;
-            if (!unscanned) {
-                break;
-            }
-        }
-    }
-    return related;
-}
-
-static VkPipelineStageFlags2 WithEarlierPipelineStages(VkPipelineStageFlags2 stage_mask) {
-    return stage_mask | RelatedPipelineStages(stage_mask, syncLogicallyEarlierStages());
-}
-
-static VkPipelineStageFlags2 WithLaterPipelineStages(VkPipelineStageFlags2 stage_mask) {
-    return stage_mask | RelatedPipelineStages(stage_mask, syncLogicallyLaterStages());
-}
-
 static SyncAccessFlags AccessScope(const SyncAccessFlags& stage_scope, VkAccessFlags2 accesses) {
     SyncAccessFlags access_scope = stage_scope & AccessScopeByAccess(accesses);
 
@@ -118,7 +93,7 @@ SyncExecScope SyncExecScope::MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFl
 
     SyncExecScope result;
     result.mask_param = mask_param;
-    result.exec_scope = WithEarlierPipelineStages(expanded_mask);
+    result.exec_scope = sync_utils::AddEarlierPipelineStages(expanded_mask);
     result.valid_accesses = AccessScopeByStage(expanded_mask);
 
     // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages
@@ -133,7 +108,7 @@ SyncExecScope SyncExecScope::MakeDst(VkQueueFlags queue_flags, VkPipelineStageFl
 
     SyncExecScope result;
     result.mask_param = mask_param;
-    result.exec_scope = WithLaterPipelineStages(expanded_mask);
+    result.exec_scope = sync_utils::AddLaterPipelineStages(expanded_mask);
     result.valid_accesses = AccessScopeByStage(expanded_mask);
 
     // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -688,17 +688,6 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext& exec_context, c
             switch (ignore_reason) {
                 case SyncEventState::ResetWaitRace:
                 case SyncEventState::Reset2WaitRace: {
-                    // Four permuations of Reset and Wait calls...
-                    const char* vuid = (command_ == vvl::Func::vkCmdWaitEvents) ? "VUID-vkCmdResetEvent-event-03834"
-                                                                                : "VUID-vkCmdResetEvent-event-03835";
-                    if (ignore_reason == SyncEventState::Reset2WaitRace) {
-                        vuid = (command_ == vvl::Func::vkCmdWaitEvents) ? "VUID-vkCmdResetEvent2-event-03831"
-                                                                        : "VUID-vkCmdResetEvent2-event-03832";
-                    }
-                    const char* const message =
-                        "%s %s operation following %s without intervening execution barrier, may cause race condition. %s";
-                    skip |= sync_state.LogError(vuid, event_handle, loc, message, sync_state.FormatHandle(event_handle).c_str(),
-                                                CmdName(), vvl::String(sync_event->last_command), kIgnored);
                     break;
                 }
                 case SyncEventState::SetRace: {
@@ -716,14 +705,9 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext& exec_context, c
                     break;
                 }
                 case SyncEventState::SetVsWait2: {
-                    skip |= sync_state.LogError(
-                        "VUID-vkCmdWaitEvents2-pEvents-03837", event_handle, loc, "Follows set of %s by %s. Disallowed.",
-                        sync_state.FormatHandle(event_handle).c_str(), vvl::String(sync_event->last_command));
                     break;
                 }
                 case SyncEventState::MissingSetEvent: {
-                    // TODO: There are conditions at queue submit time where we can definitively say that
-                    // a missing set event is an error.  Add those if not captured in CoreChecks
                     break;
                 }
                 default:
@@ -964,8 +948,7 @@ bool SyncOpResetEvent::DoValidate(const CommandExecutionContext& exec_context, c
             case vvl::Func::vkCmdWaitEvents:
             case vvl::Func::vkCmdWaitEvents2KHR:
             case vvl::Func::vkCmdWaitEvents2: {
-                // Needs to be in the barriers chain (either because of a barrier, or because of dstStageMask
-                vuid = "SYNC-vkCmdResetEvent-missingbarrier-wait";
+                // Handled by core checks
                 break;
             }
             case vvl::Func::Empty:
@@ -1149,11 +1132,7 @@ void SyncOpSetEvent::DoRecord(QueueId queue_id, ResourceUsageTag tag, const std:
     auto* sync_event = events_context->GetFromShared(event_);
     if (!sync_event) {
         return;
-    }  // Core, Lifetimes, or Param check needs to catch invalid events.
-
-    // NOTE: We're going to simply record the sync scope here, as anything else would be implementation defined/undefined
-    //       and we're issuing errors re: missing barriers between event commands, which if the user fixes would fix
-    //       any issues caused by naive scope setting here.
+    }
 
     // What happens with two SetEvent is that one cannot know what group of operations will be waited for.
     // Given:
@@ -1511,7 +1490,7 @@ SyncEventState::IgnoreReason SyncEventState::IsIgnoredByWait(vvl::Func command, 
         (vvl::Func::vkCmdSetEvent == last_command)) {
         reason = SetVsWait2;
     } else if ((last_command == vvl::Func::vkCmdResetEvent || last_command == vvl::Func::vkCmdResetEvent2KHR) &&
-               !HasBarrier(0U, 0U)) {
+               (barriers & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT) == 0) {
         reason = (last_command == vvl::Func::vkCmdResetEvent) ? ResetWaitRace : Reset2WaitRace;
     } else if (unsynchronized_set != vvl::Func::Empty) {
         reason = SetRace;
@@ -1524,7 +1503,6 @@ SyncEventState::IgnoreReason SyncEventState::IsIgnoredByWait(vvl::Func command, 
     } else {
         reason = MissingSetEvent;
     }
-
     return reason;
 }
 

--- a/layers/utils/sync_utils.cpp
+++ b/layers/utils/sync_utils.cpp
@@ -156,6 +156,31 @@ VkPipelineStageFlags2 ExpandPipelineStages(VkPipelineStageFlags2 stage_mask, VkQ
     return expanded;
 }
 
+static VkPipelineStageFlags2 RelatedPipelineStages(
+    VkPipelineStageFlags2 stage_mask,
+    const vvl::unordered_map<VkPipelineStageFlagBits2, VkPipelineStageFlags2>& earlier_or_later_stages) {
+    VkPipelineStageFlags2 unscanned = stage_mask;
+    VkPipelineStageFlags2 related = 0;
+    for (const auto& [stage, related_stages] : earlier_or_later_stages) {
+        if (stage & unscanned) {
+            related |= related_stages;
+            unscanned &= ~stage;
+            if (!unscanned) {
+                break;
+            }
+        }
+    }
+    return related;
+}
+
+VkPipelineStageFlags2 AddEarlierPipelineStages(VkPipelineStageFlags2 stage_mask) {
+    return stage_mask | RelatedPipelineStages(stage_mask, syncLogicallyEarlierStages());
+}
+
+VkPipelineStageFlags2 AddLaterPipelineStages(VkPipelineStageFlags2 stage_mask) {
+    return stage_mask | RelatedPipelineStages(stage_mask, syncLogicallyLaterStages());
+}
+
 VkAccessFlags2 CompatibleAccessMask(VkPipelineStageFlags2 stage_mask) {
     static constexpr uint32_t kNumPipelineStageBits = sizeof(VkPipelineStageFlags2) * 8;
     VkAccessFlags2 result = 0;

--- a/layers/utils/sync_utils.h
+++ b/layers/utils/sync_utils.h
@@ -295,6 +295,9 @@ std::string StringPipelineStageFlags(VkPipelineStageFlags2 mask, bool sync1 = fa
 VkPipelineStageFlags2 ExpandPipelineStages(VkPipelineStageFlags2 stage_mask, VkQueueFlags queue_flags,
                                            const VkPipelineStageFlags2 disabled_feature_mask = 0);
 
+VkPipelineStageFlags2 AddEarlierPipelineStages(VkPipelineStageFlags2 stage_mask);
+VkPipelineStageFlags2 AddLaterPipelineStages(VkPipelineStageFlags2 stage_mask);
+
 VkAccessFlags2 CompatibleAccessMask(VkPipelineStageFlags2 stage_mask);
 
 std::string StringAccessFlags(VkAccessFlags2 mask, bool sync1 = false);

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -2154,12 +2154,12 @@ void CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR& encodeInfo) { vk::Cm
 
 void CommandBuffer::EndVideoCoding(const VkVideoEndCodingInfoKHR& endInfo) { vk::CmdEndVideoCodingKHR(handle(), &endInfo); }
 
-void CommandBuffer::SetEvent(const Event& event, VkPipelineStageFlags src_stage_mask) {
-    vk::CmdSetEvent(handle(), event, src_stage_mask);
+void CommandBuffer::ResetEvent(const Event& event, VkPipelineStageFlags stage_mask) {
+    vk::CmdResetEvent(handle(), event, stage_mask);
 }
 
-void CommandBuffer::ResetEvent(const Event& event, VkPipelineStageFlags src_stageMask) {
-    vk::CmdResetEvent(handle(), event, src_stageMask);
+void CommandBuffer::SetEvent(const Event& event, VkPipelineStageFlags src_stage_mask) {
+    vk::CmdSetEvent(handle(), event, src_stage_mask);
 }
 
 void CommandBuffer::WaitEvent(const Event& event, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask) {
@@ -2179,6 +2179,10 @@ void CommandBuffer::WaitEvent(const Event& event, VkPipelineStageFlags src_stage
 void CommandBuffer::WaitEvent(const Event& event, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
                               const VkImageMemoryBarrier& image_barrier) {
     vk::CmdWaitEvents(handle(), 1, &event.handle(), src_stage_mask, dst_stage_mask, 0, nullptr, 0, nullptr, 1, &image_barrier);
+}
+
+void CommandBuffer::ResetEvent2(const Event& event, VkPipelineStageFlags2 stage_mask) {
+    vk::CmdResetEvent2(handle(), event, stage_mask);
 }
 
 void CommandBuffer::SetEvent2(const Event& event, const VkMemoryBarrier2& memory_barrier) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1126,8 +1126,8 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void EncodeVideo(const VkVideoEncodeInfoKHR &encodeInfo);
     void EndVideoCoding(const VkVideoEndCodingInfoKHR &endInfo);
 
+    void ResetEvent(const Event& event, VkPipelineStageFlags stage_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     void SetEvent(const Event& event, VkPipelineStageFlags src_stage_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-    void ResetEvent(const Event& event, VkPipelineStageFlags src_stageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     void WaitEvent(const Event& event, VkPipelineStageFlags src_stage_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                    VkPipelineStageFlags dst_stage_mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     void WaitEvent(const Event& event, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
@@ -1137,6 +1137,7 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void WaitEvent(const Event& event, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
                    const VkImageMemoryBarrier& image_barrier);
 
+    void ResetEvent2(const Event& event, VkPipelineStageFlags2 stage_mask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT);
     void SetEvent2(const Event& event, const VkMemoryBarrier2& memory_barrier);
     void WaitEvent2(const Event& event, const VkMemoryBarrier2& memory_barrier);
 

--- a/tests/unit/event.cpp
+++ b/tests/unit/event.cpp
@@ -1241,3 +1241,198 @@ TEST_F(NegativeEvent, Set2Wait2ThenWaitVersionMismatchSubmit) {
     monitor_.VerifyFound();
     m_default_queue->Wait();
 }
+
+TEST_F(NegativeEvent, ResetAfterWait) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent-event-03834");
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, ResetAfterWait2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, barrier);
+    m_command_buffer.WaitEvent2(event, barrier);
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent-event-03835");
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, Reset2AfterWait) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent2-event-03831");
+    m_command_buffer.ResetEvent2(event, VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, Reset2AfterWait2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, barrier);
+    m_command_buffer.WaitEvent2(event, barrier);
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent2-event-03832");
+    m_command_buffer.ResetEvent2(event, VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, ResetAfterWaitBarrierExecutionDependency) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+
+    VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+    barrier2.srcStageMask = VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT;
+    barrier2.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+
+    const VkMemoryBarrier2 barriers[2] = {barrier, barrier2};
+
+    VkDependencyInfo dep_info = vku::InitStructHelper();
+    dep_info.memoryBarrierCount = 2;
+    dep_info.pMemoryBarriers = barriers;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.Barrier(dep_info);
+
+    // Barriers are applied independently, so STAGE_COMPUTE from the first barrier can't
+    // create execution dependency with STAGE_COLOR_ATTACHMENT_OUTPUT from the second barrier
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent-event-03834");
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, ResetAfterWaitBarrierExecutionDependency2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+
+    VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
+    barrier2.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    barrier2.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+
+    const VkMemoryBarrier2 barriers[2] = {barrier, barrier2};
+
+    VkDependencyInfo dep_info = vku::InitStructHelper();
+    dep_info.memoryBarrierCount = 2;
+    dep_info.pMemoryBarriers = barriers;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.Barrier(dep_info);
+
+    // Barriers are applied independently, they do not form execution dependency between STAGE_COMPUTE
+    // and STAGE_COLOR_ATTACHMENT_OUTPUT as it would be in the case of two sequential barriers
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent-event-03834");
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, ResetAfterSecondaryWaitRace) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.ExecuteCommands(secondary);
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent-event-03834");
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, ResetAfterWaitMultipleEvents) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event0(*m_device);
+    vkt::Event event1(*m_device);
+    const VkEvent events[2] = {event0, event1};
+
+    VkMemoryBarrier2 barrier0 = vku::InitStructHelper();
+    barrier0.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    barrier0.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+
+    VkMemoryBarrier2 barrier1 = vku::InitStructHelper();
+    barrier1.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+    barrier1.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+
+    VkDependencyInfo dep_infos[2];
+    dep_infos[0] = vku::InitStructHelper();
+    dep_infos[0].memoryBarrierCount = 1;
+    dep_infos[0].pMemoryBarriers = &barrier0;
+    dep_infos[1] = vku::InitStructHelper();
+    dep_infos[1].memoryBarrierCount = 1;
+    dep_infos[1].pMemoryBarriers = &barrier1;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event0, barrier0);
+    m_command_buffer.SetEvent2(event1, barrier1);
+    vk::CmdWaitEvents2(m_command_buffer, 2, events, dep_infos);
+
+    // Reset must use COMPUTE_STAGE to sync with event0 wait.
+    // This test checks barriers are applied independently, so barrier1 does not
+    // have effect on event0 wait (does not introduce COPY_STAGE)
+    monitor_.SetDesiredError("VUID-vkCmdResetEvent2-event-03832");
+    m_command_buffer.ResetEvent2(event0, VK_PIPELINE_STAGE_2_COPY_BIT);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}

--- a/tests/unit/event_positive.cpp
+++ b/tests/unit/event_positive.cpp
@@ -450,3 +450,170 @@ TEST_F(PositiveEvent, AsymmetricEventNoMemorySubmit) {
     // Check that missing memory barrier does not confuse submit validation
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
+
+TEST_F(PositiveEvent, ResetAfterWait) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWait2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, barrier);
+    m_command_buffer.WaitEvent2(event, barrier);
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWait3) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, barrier);
+    m_command_buffer.WaitEvent2(event, barrier);
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_2_TRANSFER_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWaitBarrierExecutionDependency) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                           nullptr, 0, nullptr);
+
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWaitBarrierExecutionDependency2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.Barrier(barrier);
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWaitBarrierExecutionDependency3) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 wait_barrier = vku::InitStructHelper();
+    wait_barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    wait_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+
+    VkMemoryBarrier2 transfer_barrier = vku::InitStructHelper();
+    transfer_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
+    // Use TRANSFER meta stage (potentially expanded by the validation) to check it correctly
+    // chains with TRANSFER in the next barrier
+    transfer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+
+    VkMemoryBarrier2 color_barrier = vku::InitStructHelper();
+    color_barrier.srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+    color_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, wait_barrier);
+    m_command_buffer.WaitEvent2(event, wait_barrier);
+    m_command_buffer.Barrier(transfer_barrier);
+    m_command_buffer.Barrier(color_barrier);
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWaitEmptyBarrier2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    VkDependencyInfo empty_dep_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+
+    // The empty dependency should not affect execution dependency between Wait and Reset via COMPUTE_STAGE
+    m_command_buffer.Barrier(empty_dep_info);
+
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWaitSecondaryBarrier) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    vk::CmdPipelineBarrier(secondary, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                           nullptr, 0, nullptr);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveEvent, ResetAfterWaitSecondaryReset) {
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.ResetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_command_buffer.End();
+}

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -4020,14 +4020,6 @@ TEST_F(NegativeSyncVal, EventsCommandHazards) {
     vkt::Event event(*m_device);
 
     m_command_buffer.Begin();
-    m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
-    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
-    m_errorMonitor->SetDesiredError("SYNC-vkCmdResetEvent-missingbarrier-wait");
-    m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
-    m_errorMonitor->VerifyFound();
-    m_command_buffer.End();
-
-    m_command_buffer.Begin();
     m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
     m_errorMonitor->SetDesiredError("SYNC-vkCmdSetEvent-missingbarrier-reset");
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);


### PR DESCRIPTION
Validate the following VUIDs:

VUID-vkCmdResetEvent-event-03834
VUID-vkCmdResetEvent-event-03835
VUID-vkCmdResetEvent2-event-03831
VUID-vkCmdResetEvent2-event-03832

Previously it was part of syncval and now is moved to core validation. The tracking logic does not need anything from syncval's AccessContext (which tracks memory accesses) and it's nice to have them always enabled in core validation (that's regular VUIDs). Need to add some submit time checks later.