### PR TITLE
layers: Cache vkGetPhysicalDeviceDescriptorSizeEXT

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -5321,9 +5321,8 @@ bool CoreChecks::PreCallValidateWriteResourceDescriptorsEXT(VkDevice device, uin
 
         const bool is_texel_buffer = IsDescriptorHeapTexelBuffer(resource.type);
         const bool is_image = IsDescriptorHeapImage(resource.type);
-        // TODO - Cache these once on device creation
         // The main thing to be careful of is |bufferDescriptorSize| is not for texel buffer
-        const VkDeviceSize expected_size = DispatchGetPhysicalDeviceDescriptorSizeEXT(physical_device, resource.type);
+        const VkDeviceSize expected_size = device_state->cached_descriptor_size.GetSize(resource.type);
 
         const VkHostAddressRangeEXT& descriptor_range = pDescriptors[i];
         if (static_cast<VkDeviceSize>(descriptor_range.size) < expected_size) {

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -306,8 +306,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         descriptor_type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
         descriptor_size = dev_data.phys_dev_ext_props.descriptor_heap_props.imageDescriptorSize;
     } else if (descriptor_type != VK_DESCRIPTOR_TYPE_MAX_ENUM) {
-        // TODO - Cache these once on device creation
-        descriptor_size = DispatchGetPhysicalDeviceDescriptorSizeEXT(dev_data.physical_device, descriptor_type);
+        descriptor_size = dev_data.device_state->cached_descriptor_size.GetSize(descriptor_type);
     }
 
     // TODO - Make common util if others need it

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1264,6 +1264,10 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
         }
     }
 
+    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+        cached_descriptor_size.Init(physical_device, extensions);
+    }
+
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     android_external_format_resolve_null_color_attachment_prop =
         phys_dev_ext_props.android_format_resolve_props.nullColorAttachmentWithExternalFormatResolve;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -23,6 +23,7 @@
 #pragma once
 #include <vulkan/vulkan_core.h>
 #include "chassis/validation_object.h"
+#include "utils/descriptor_utils.h"
 #include "utils/hash_vk_types.h"
 #include "state_tracker/descriptor_sets.h"      // DescriptorSetLayoutDict can't be forward declared
 #include "state_tracker/video_session_state.h"  // TODO - Remove from this header
@@ -2113,6 +2114,9 @@ class DeviceState : public vvl::BaseDevice {
     bool disable_internal_pipeline_cache;
 
     SpecialSupported special_supported;
+
+    // VK_EXT_descriptor_heap
+    CachedDescriptorSize cached_descriptor_size;
 
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties_nv;
     std::vector<VkCooperativeMatrixPropertiesKHR> cooperative_matrix_properties_khr;

--- a/layers/utils/descriptor_utils.cpp
+++ b/layers/utils/descriptor_utils.cpp
@@ -18,10 +18,16 @@
  */
 
 #include "utils/descriptor_utils.h"
+#include <vulkan/vulkan_core.h>
 
+#include "containers/container_utils.h"
+#include "generated/dispatch_functions.h"
 #include "generated/spirv_grammar_helper.h"
+#include "generated/vk_extension_helper.h"
 #include "state_tracker/shader_module.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <string>
 
@@ -247,4 +253,56 @@ std::string DescribeResourceTypeMismatch(VkSpirvResourceTypeFlagsEXT resource_ty
     }
 
     return "[UNKNOWN]";
+}
+
+void CachedDescriptorSize::Init(VkPhysicalDevice gpu, const DeviceExtensions& extensions) {
+    size_[0] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_SAMPLER);
+    size_[2] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    size_[3] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+    size_[4] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    size_[5] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+    size_[6] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+    size_[7] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    size_[10] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
+    if (IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
+        size_[1] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
+    }
+    if (IsExtEnabled(extensions.vk_nv_ray_tracing)) {
+        size_[8] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV);
+    }
+    if (IsExtEnabled(extensions.vk_nv_partitioned_acceleration_structure)) {
+        size_[9] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV);
+    }
+    if (IsExtEnabled(extensions.vk_arm_tensors)) {
+        size_[11] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_TENSOR_ARM);
+    }
+    if (IsExtEnabled(extensions.vk_qcom_image_processing)) {
+        size_[12] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM);
+        size_[13] = DispatchGetPhysicalDeviceDescriptorSizeEXT(gpu, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
+    }
+}
+
+VkDeviceSize CachedDescriptorSize::GetSize(VkDescriptorType type) const {
+    if (type == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR) {
+        // takes VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER value at index 1
+        return size_[1];
+    } else if (type == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV) {
+        // takes VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC value at index 8
+        return size_[8];
+    } else if (type == VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV) {
+        // takes VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC value at index 9
+        return size_[9];
+    } else if (type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+        return size_[11];
+    } else if (type == VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM) {
+        return size_[12];
+    } else if (type == VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM) {
+        return size_[13];
+    }
+    assert(IsValueIn(
+        type, {VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+               VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+               VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT}));
+    uint32_t index = (uint32_t)type;
+    return size_[index];
 }

--- a/layers/utils/descriptor_utils.h
+++ b/layers/utils/descriptor_utils.h
@@ -71,3 +71,17 @@ bool ResourceTypeMatchesBinding(VkSpirvResourceTypeFlagsEXT resource_type,
                                 const spirv::ResourceInterfaceVariable& resource_variable);
 std::string DescribeResourceTypeMismatch(VkSpirvResourceTypeFlagsEXT resource_type,
                                          const spirv::ResourceInterfaceVariable& resource_variable);
+
+// Way to cache vkGetPhysicalDeviceDescriptorSizeEXT as a flat array
+// This is a very quick way to use the VkDescriptorType enum and knowledge of the limited VkDescriptorType allowed to make this fast
+// and not making it impossible to update if a new VkDescriptorType is added later
+struct DeviceExtensions;
+struct CachedDescriptorSize {
+    void Init(VkPhysicalDevice gpu, const DeviceExtensions& extensions);
+    VkDeviceSize GetSize(VkDescriptorType type) const;
+
+  private:
+    // The number of valid descriptors that can be queried is known in the spec
+    // (see VU 11362)
+    VkDeviceSize size_[14];
+};


### PR DESCRIPTION
GPU-AV is going to need this as well for untyped pointers to know the size of a given descriptor

rather do this than have to constantly call dispatch calls everywhere

also simpler to pass this struct around than the dispatch references