### PR TITLE
sync: Fix which aspects CmdClearAttachments clears

### DIFF
--- a/layers/sync/sync_command_buffer.cpp
+++ b/layers/sync/sync_command_buffer.cpp
@@ -1053,8 +1053,8 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
     }
 }
 
-static VkImageAspectFlags GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask, const vvl::ImageView& attachment_view,
-                                                      bool separate_depth_stencil_attachment_access) {
+VkImageAspectFlags CommandBufferAccessContext::GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask,
+                                                                           const vvl::ImageView& attachment_view) const {
     // Check if clear request is valid.
     const bool clear_color = (clear_aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) != 0;
     const bool clear_depth = (clear_aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0;
@@ -1066,29 +1066,40 @@ static VkImageAspectFlags GetAttachmentAspectsToClear(VkImageAspectFlags clear_a
         return 0;  // according to spec it's not allowed
     }
 
-    // View's aspect mask is used only for color attachment.
-    // For depth/stencil attachment view aspect mask is ignored according to spec.
-    const VkImageAspectFlags view_aspect_mask = attachment_view.normalized_subresource_range.aspectMask;
-
-    // Collect aspects that should be cleared.
-    VkImageAspectFlags aspects_to_clear = VK_IMAGE_ASPECT_NONE;
-    if (clear_color && (view_aspect_mask & kColorAspects) != 0) {
-        assert(CountSetBits(view_aspect_mask) == 1);
-        aspects_to_clear |= view_aspect_mask;
-    }
-    if (clear_depth && vkuFormatHasDepth(attachment_view.create_info.format)) {
-        aspects_to_clear |= VK_IMAGE_ASPECT_DEPTH_BIT;
-    }
-    if (clear_stencil && vkuFormatHasStencil(attachment_view.create_info.format)) {
-        aspects_to_clear |= VK_IMAGE_ASPECT_STENCIL_BIT;
+    // Color aspects to clear
+    if (clear_color) {
+        // The image view aspect mask is used only for color attachment.
+        // For depth/stencil attachment, it is ignored according to the spec.
+        const VkImageAspectFlags view_aspect_mask = attachment_view.normalized_subresource_range.aspectMask;
+        return view_aspect_mask & kColorAspects;
     }
 
-    // Even if only depth or stencil aspect is specified we validate access to
-    // both depth and stencil aspects because they can be interleaved.
-    if (!separate_depth_stencil_attachment_access && (aspects_to_clear & kDepthStencilAspects) != 0) {
-        aspects_to_clear = kDepthStencilAspects;
+    // Depth-stencil aspects to clear
+    bool has_depth_attachment = false;
+    bool has_stencil_attachment = false;
+    if (dynamic_rendering_info_) {
+        has_depth_attachment = dynamic_rendering_info_->info.pDepthAttachment != nullptr;
+        has_stencil_attachment = dynamic_rendering_info_->info.pStencilAttachment != nullptr;
+    } else if (current_renderpass_context_) {
+        const auto& rp_create_info = current_renderpass_context_->GetRenderPassState()->create_info;
+        const auto& subpass = rp_create_info.pSubpasses[current_renderpass_context_->GetCurrentSubpass()];
+        if (subpass.pDepthStencilAttachment) {
+            const uint32_t attachment = subpass.pDepthStencilAttachment->attachment;
+            if (attachment < rp_create_info.attachmentCount) {
+                const VkFormat ds_format = rp_create_info.pAttachments[attachment].format;
+                has_depth_attachment = vkuFormatHasDepth(ds_format);
+                has_stencil_attachment = vkuFormatHasStencil(ds_format);
+            }
+        }
     }
-    return aspects_to_clear;
+    VkImageAspectFlags ds_aspects_to_clear = VK_IMAGE_ASPECT_NONE;
+    if (clear_depth && has_depth_attachment) {
+        ds_aspects_to_clear |= VK_IMAGE_ASPECT_DEPTH_BIT;
+    }
+    if (clear_stencil && has_stencil_attachment) {
+        ds_aspects_to_clear |= VK_IMAGE_ASPECT_STENCIL_BIT;
+    }
+    return ds_aspects_to_clear;
 }
 
 static std::optional<VkImageSubresourceRange> RestrictSubresourceRangeToClearLayers(
@@ -1125,21 +1136,17 @@ std::optional<CommandBufferAccessContext::ClearAttachmentInfo> CommandBufferAcce
         return {};
     }
 
-    const bool separate_depth_stencil_attachment_access =
-        GetSyncState().device_state->enabled_features.maintenance7 &&
-        GetSyncState().device_state->phys_dev_ext_props.maintenance7_props.separateDepthStencilAttachmentAccess;
-    const VkImageAspectFlags aspects =
-        GetAttachmentAspectsToClear(clear_attachment.aspectMask, *attachment_view, separate_depth_stencil_attachment_access);
-    if (!aspects) {
+    const VkImageAspectFlags aspects_to_clear = GetAttachmentAspectsToClear(clear_attachment.aspectMask, *attachment_view);
+    if (!aspects_to_clear) {
         return {};
     }
 
-    const auto subresource_range =
+    std::optional<VkImageSubresourceRange> subresource_range =
         RestrictSubresourceRangeToClearLayers(attachment_view->normalized_subresource_range, clear_first_layer, clear_layer_count);
     if (!subresource_range.has_value()) {
         return {};
     }
-
+    subresource_range->aspectMask = aspects_to_clear;
     return ClearAttachmentInfo{*attachment_view, *subresource_range};
 }
 

--- a/layers/sync/sync_command_buffer.h
+++ b/layers/sync/sync_command_buffer.h
@@ -319,8 +319,10 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
         const vvl::ImageView &attachment_view;
         VkImageSubresourceRange subresource_range{};
     };
-    std::optional<ClearAttachmentInfo> GetClearAttachmentInfo(const VkClearAttachment &clear_attachment, uint32_t clear_first_layer,
+    std::optional<ClearAttachmentInfo> GetClearAttachmentInfo(const VkClearAttachment& clear_attachment, uint32_t clear_first_layer,
                                                               uint32_t clear_layer_count) const;
+    VkImageAspectFlags GetAttachmentAspectsToClear(VkImageAspectFlags clear_aspect_mask,
+                                                   const vvl::ImageView& attachment_view) const;
 
     void CheckCommandTagDebugCheckpoint();
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -418,21 +418,27 @@ TEST_F(NegativeSyncVal, ClearAttachmentStencilAspectWAW) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeSyncVal, ClearDepthCopyStencilWAW) {
-    TEST_DESCRIPTION("Clearing depth and copying to stencil causes hazard because depth and stencil can interleave");
+TEST_F(NegativeSyncVal, ClearAttachmentUsesClearAspectMask) {
+    TEST_DESCRIPTION("CmdClearAttachments uses the clear attachment aspect mask, not the view aspect mask");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncVal());
 
-    const uint32_t width = 256;
-    const uint32_t height = 128;
     const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
 
-    vkt::Image src_image(*m_device, width, height, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-    vkt::Image image(*m_device, width, height, depth_stencil_format,
+    vkt::Image src_image(*m_device, 64, 64, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, 64, 64, depth_stencil_format,
                      VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    // Spec: "The aspectMask of any image view specified for pDepthAttachment or pStencilAttachment is ignored.
+    // Instead, depth attachments are automatically treated as if VK_IMAGE_ASPECT_DEPTH_BIT was specified for
+    // their aspect masks, and stencil attachments are automatically treated as if VK_IMAGE_ASPECT_STENCIL_BIT
+    // was specified for their aspect masks".
+    //
+    // Use a depth-only view to verify that CmdClearAttachments uses STENCIL aspect when it is specified by
+    // VkClearAttachment::aspectMask.
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
 
     VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
     depth_attachment.imageView = image_view;
@@ -440,30 +446,38 @@ TEST_F(NegativeSyncVal, ClearDepthCopyStencilWAW) {
     depth_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_NONE;
     depth_attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
 
+    VkRenderingAttachmentInfo stencil_attachment = vku::InitStructHelper();
+    stencil_attachment.imageView = image_view;
+    stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    stencil_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_NONE;
+    stencil_attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
+
     VkRenderingInfo rendering_info = vku::InitStructHelper();
-    rendering_info.renderArea.extent = {width, height};
+    rendering_info.renderArea.extent = {64, 64};
     rendering_info.layerCount = 1;
     rendering_info.pDepthAttachment = &depth_attachment;
+    rendering_info.pStencilAttachment = &stencil_attachment;
 
-    // Copy to stencil
     VkImageCopy copy_region = {};
     copy_region.srcSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
     copy_region.dstSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
-    copy_region.extent = {width, height, 1};
+    copy_region.extent = {64, 64, 1};
 
-    // Clear depth
-    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_DEPTH_BIT};
+    // The render pass instance specifies both depth/stencil attachment.
+    // We can clear them both, the view aspect mask (DEPTH) is ignored
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT};
     VkClearRect clear_rect = {};
-    clear_rect.rect = {{0, 0}, {width, height}};
+    clear_rect.rect = {{0, 0}, {64, 64}};
     clear_rect.baseArrayLayer = 0;
     clear_rect.layerCount = 1;
 
     m_command_buffer.Begin();
     vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
-
-    // loadOp/storeOp=NONE, so no hazard can be detected at this point
     m_command_buffer.BeginRendering(rendering_info);
 
+    // Create a hazard by writing to the STENCIL aspect.
+    // We had regression where CmdClearAttachments used the view aspect (DEPTH),
+    // so this did not report a hazard with the previous STENCIL copy
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
     vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -4610,3 +4610,107 @@ TEST_F(PositiveSyncVal, ClearAttachmentSecondaryCb) {
     vk::CmdClearAttachments(secondary, 1, &clear_attachment, 1, &clear_rect);
     secondary.End();
 }
+
+TEST_F(PositiveSyncVal, ClearAttachmentOnlyDepthAttachment) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12345");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::separateDepthStencilLayouts);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
+    vkt::Image image(*m_device, 32, 32, depth_stencil_format,
+                     VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    VkImageMemoryBarrier2 transition_to_transfer = vku::InitStructHelper();
+    transition_to_transfer.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    transition_to_transfer.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    transition_to_transfer.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    transition_to_transfer.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    transition_to_transfer.image = image;
+    transition_to_transfer.subresourceRange = {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1};
+
+    VkImageMemoryBarrier2 transition_to_attachment = vku::InitStructHelper();
+    transition_to_attachment.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    transition_to_attachment.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    transition_to_attachment.dstStageMask = VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT;
+    transition_to_attachment.dstAccessMask = VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+    transition_to_attachment.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    transition_to_attachment.newLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    transition_to_attachment.image = image;
+    transition_to_attachment.subresourceRange = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1};
+
+    VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
+    depth_attachment.imageView = image_view;
+    depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    depth_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    depth_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {32, 32};
+    rendering_info.layerCount = 1;
+    rendering_info.pDepthAttachment = &depth_attachment;
+
+    VkClearAttachment clear_attachment = {};
+    clear_attachment.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect.extent = {32, 32};
+    clear_rect.layerCount = 1;
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(transition_to_transfer);
+    m_command_buffer.Barrier(transition_to_attachment);
+    vk::CmdBeginRendering(m_command_buffer, &rendering_info);
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    vk::CmdEndRendering(m_command_buffer);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveSyncVal, ClearAttachmentOnlyDepthAttachment2) {
+    TEST_DESCRIPTION("CmdClearAttachments ignores a depth/stencil clear aspect that is not backed by a rendering attachment");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
+
+    vkt::Image src_image(*m_device, 64, 64, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, 64, 64, depth_stencil_format,
+                     VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
+    depth_attachment.imageView = image_view;
+    depth_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    depth_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_NONE;
+    depth_attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {64, 64};
+    rendering_info.layerCount = 1;
+    rendering_info.pDepthAttachment = &depth_attachment;
+
+    VkImageCopy copy_region = {};
+    copy_region.srcSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
+    copy_region.dstSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
+    copy_region.extent = {64, 64, 1};
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect = {{0, 0}, {64, 64}};
+    clear_rect.layerCount = 1;
+
+    // Render pass instance specifies only pDepthAttachment. The stencil aspect has no effect.
+    // Syncval must not report a WAW hazard with the previous stencil copy.
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT};
+
+    m_command_buffer.Begin();
+    vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}

--- a/tests/unit/sync_val_render_pass.cpp
+++ b/tests/unit/sync_val_render_pass.cpp
@@ -181,19 +181,23 @@ TEST_F(NegativeSyncValRenderPass, ClearStencilAspectWAW) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeSyncValRenderPass, ClearDepthCopyStencilWAW) {
-    TEST_DESCRIPTION("Clearing depth and copying to stencil causes hazard because depth and stencil can interleave");
+TEST_F(NegativeSyncValRenderPass, ClearAttachmentUsesClearAspectMask) {
+    TEST_DESCRIPTION("CmdClearAttachments uses the clear attachment aspect mask, not the view aspect mask");
     AddRequiredExtensions(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
     RETURN_IF_SKIP(InitSyncVal());
 
-    const uint32_t width = 256;
-    const uint32_t height = 128;
     const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
 
-    vkt::Image src_image(*m_device, width, height, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-    vkt::Image image(*m_device, width, height, depth_stencil_format,
+    vkt::Image src_image(*m_device, 64, 64, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, 64, 64, depth_stencil_format,
                      VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    // Spec: "When an image view of a depth/stencil image is used as a depth/stencil framebuffer attachment,
+    // the aspectMask is ignored and both depth and stencil image subresources are used.
+    //
+    // Use a depth-only view to verify that CmdClearAttachments uses STENCIL aspect when it is specified by
+    // VkClearAttachment::aspectMask.
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
 
     VkAttachmentDescription attachment{};
     attachment.format = depth_stencil_format;
@@ -210,27 +214,28 @@ TEST_F(NegativeSyncValRenderPass, ClearDepthCopyStencilWAW) {
     render_pass.AddDepthStencilAttachment(0, VK_IMAGE_LAYOUT_GENERAL);
     render_pass.CreateRenderPass();
 
-    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), width, height);
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 64, 64);
 
-    // Copy to stencil
     VkImageCopy copy_region = {};
     copy_region.srcSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
     copy_region.dstSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
-    copy_region.extent = {width, height, 1};
+    copy_region.extent = {64, 64, 1};
 
-    // Clear depth
-    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_DEPTH_BIT};
+    // The render pass instance specifies both depth/stencil attachment.
+    // We can clear them both, the view aspect mask (DEPTH) is ignored
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT};
     VkClearRect clear_rect = {};
-    clear_rect.rect = {{0, 0}, {width, height}};
+    clear_rect.rect = {{0, 0}, {64, 64}};
     clear_rect.baseArrayLayer = 0;
     clear_rect.layerCount = 1;
 
     m_command_buffer.Begin();
     vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 64, 64);
 
-    // loadOp/storeOp/stencilLoadOp/stencilStoreOp=NONE, so no hazard can be detected at this point
-    m_command_buffer.BeginRenderPass(render_pass, framebuffer, width, height);
-
+    // Create a hazard by writing to the STENCIL aspect.
+    // We had regression where CmdClearAttachments used the view aspect (DEPTH),
+    // so this did not report a hazard with the previous STENCIL copy
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
     vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12345

This is partially a regression from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11614  (due to "Cleanup the implementation" part), but it looks like even the original code did not handle aspect  mask properly in the context of CmdClearAttachments.
