### PR TITLE
layers: Add VK_DBG_LAYER_ACTION_FAIL

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1381,6 +1381,11 @@
                             "key": "VK_DBG_LAYER_ACTION_BREAK",
                             "label": "Break",
                             "description": "Trigger a breakpoint if a debugger is in use."
+                        },
+                        {
+                            "key": "VK_DBG_LAYER_ACTION_FAIL",
+                            "label": "Fail",
+                            "description": "Fail the command with VK_ERROR_VALIDATION_FAILED_EXT (prevents invalid commands from reaching the ICD)."
                         }
                     ],
                     "default": [

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -1,6 +1,7 @@
 /* Copyright (c) 2015-2026 The Khronos Group Inc.
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2026 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -743,6 +744,13 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback([[maybe_unused]] VkDebugUt
 #endif
 
     return false;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerFailCallback([[maybe_unused]] VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                     [[maybe_unused]] VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                     [[maybe_unused]] const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
+                                                     [[maybe_unused]] void* user_data) {
+    return true;
 }
 
 static std::string CreateDefaultCallbackMessage(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -1,6 +1,7 @@
 /* Copyright (c) 2015-2026 The Khronos Group Inc.
  * Copyright (c) 2015-2026 Valve Corporation
  * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2026 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -365,6 +366,10 @@ VKAPI_ATTR void DeactivateInstanceDebugCallbacks(DebugReport *debug_report);
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                       VkDebugUtilsMessageTypeFlagsEXT message_type,
                                                       const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data);
+
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerFailCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                     VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                     const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data);
 
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                     VkDebugUtilsMessageTypeFlagsEXT message_type,

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -1,6 +1,7 @@
 /* Copyright (c) 2020-2026 The Khronos Group Inc.
  * Copyright (c) 2020-2026 Valve Corporation
  * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2026 RasterGrid Kft.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -593,6 +594,7 @@ enum VkLayerDbgActionBits {
     VK_DBG_LAYER_ACTION_LOG_MSG = 0x00000002,
     VK_DBG_LAYER_ACTION_BREAK = 0x00000004,
     VK_DBG_LAYER_ACTION_DEBUG_OUTPUT = 0x00000008,
+    VK_DBG_LAYER_ACTION_FAIL = 0x00000010,
     VK_DBG_LAYER_ACTION_DEFAULT = 0x40000000,
 };
 using VkLayerDbgActionFlags = VkFlags;
@@ -656,6 +658,7 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuL
         {std::string("VK_DBG_LAYER_ACTION_LOG_MSG"), VK_DBG_LAYER_ACTION_LOG_MSG},
         {std::string("VK_DBG_LAYER_ACTION_BREAK"), VK_DBG_LAYER_ACTION_BREAK},
         {std::string("VK_DBG_LAYER_ACTION_DEBUG_OUTPUT"), VK_DBG_LAYER_ACTION_DEBUG_OUTPUT},
+        {std::string("VK_DBG_LAYER_ACTION_FAIL"), VK_DBG_LAYER_ACTION_FAIL},
         {std::string("VK_DBG_LAYER_ACTION_DEFAULT"), VK_DBG_LAYER_ACTION_DEFAULT}};
     for (const auto& element : debug_actions_list) {
         auto enum_value = debug_actions_option.find(element);
@@ -671,7 +674,8 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuL
                     "\"" + element +
                     "\" was not a valid option for VK_LAYER_DEBUG_ACTION (ignoring).\nValid options are "
                     "[VK_DBG_LAYER_ACTION_IGNORE, VK_DBG_LAYER_ACTION_CALLBACK, VK_DBG_LAYER_ACTION_LOG_MSG, "
-                    "VK_DBG_LAYER_ACTION_BREAK, VK_DBG_LAYER_ACTION_DEBUG_OUTPUT, VK_DBG_LAYER_ACTION_DEFAULT]");
+                    "VK_DBG_LAYER_ACTION_BREAK, VK_DBG_LAYER_ACTION_DEBUG_OUTPUT, VK_DBG_LAYER_ACTION_FAIL, "
+                    "VK_DBG_LAYER_ACTION_DEFAULT]");
             }
         }
     }
@@ -822,6 +826,13 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuL
     messenger = VK_NULL_HANDLE;
     if (debug_action & VK_DBG_LAYER_ACTION_BREAK) {
         dbg_create_info.pfnUserCallback = MessengerBreakCallback;
+        dbg_create_info.pUserData = nullptr;
+        LayerCreateMessengerCallback(debug_report, default_layer_callback, &dbg_create_info, &messenger);
+    }
+
+    messenger = VK_NULL_HANDLE;
+    if (debug_action & VK_DBG_LAYER_ACTION_FAIL) {
+        dbg_create_info.pfnUserCallback = MessengerFailCallback;
         dbg_create_info.pUserData = nullptr;
         LayerCreateMessengerCallback(debug_report, default_layer_callback, &dbg_create_info, &messenger);
     }


### PR DESCRIPTION
Apparently, VVL never had a way to trigger commands failing validation to return `VK_ERROR_VALIDATION_FAILED_EXT` using environment variables or settings, only through custom callbacks. This fills that gap.