### PR TITLE
sync: Fix access scopes for semaphore operations

### DIFF
--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -137,7 +137,28 @@ SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst
     : src_exec_scope(src_exec),
       src_access_scope(src_exec.valid_accesses),
       dst_exec_scope(dst_exec),
-      dst_access_scope(dst_exec.valid_accesses) {}
+      dst_access_scope(dst_exec.valid_accesses) {
+
+    // No accesses are happening on TOP_OF_PIPE/BOTTOM_OF_PIPE stages
+    // (valid_accesses bitmask is empty). Explicitly enforce the spec
+    // rule that access scopes of semaphore operations include all
+    // device accesses.
+    //
+    // NOTE: we still use valid_accesses for other scenarios and implementation
+    // in some cases relies on this (for example,
+    // NegativeSyncValTimelineSemaphore.WaitAfterSignalStageMismatch will fail
+    // if we use all device accesss for access scopes uncoditionally).
+    //
+    // TODO: if we find new issues we might need to rework implementation so
+    // for semaphore operations, the src/dst access scopes always include all
+    // device accesses
+    if (src_exec.mask_param & VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT) {
+        src_access_scope = syncAccessReadMask | syncAccessWriteMask;
+    }
+    if (dst_exec.mask_param & VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT) {
+        dst_access_scope = syncAccessReadMask | syncAccessWriteMask;
+    }
+}
 
 SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope& dst_exec,
                          VkAccessFlags2 dst_access_mask)

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -4736,3 +4736,32 @@ TEST_F(PositiveSyncVal, CmdSetEventAfterHostReset) {
     event.Reset();
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
+
+TEST_F(PositiveSyncVal, BinaryWaitWithTopOfPipeStage) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12397");
+    RETURN_IF_SKIP(InitSyncVal());
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer dst_buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    VkBufferCopy copy_region = {};
+    copy_region.size = 256;
+
+    m_command_buffer.Begin();
+    vk::CmdFillBuffer(m_command_buffer, buffer, 0, VK_WHOLE_SIZE, 0x42);
+    m_command_buffer.End();
+
+    vkt::CommandBuffer copy_command_buffer(*m_device, m_command_pool);
+    copy_command_buffer.Begin();
+    vk::CmdCopyBuffer(copy_command_buffer, buffer, dst_buffer, 1, &copy_region);
+    copy_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device);
+    m_default_queue->Submit(m_command_buffer, vkt::Signal(semaphore));
+
+    // Semaphore access scope are defined as all device accesses.
+    // It does not matter which accesses are allowed on specific stage.
+    // For example, no access is happening on TOP_OF_PIPE/BOTTOM_OF_PIPE stages.
+    m_default_queue->Submit(copy_command_buffer, vkt::Wait(semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT));
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12397

Semaphore operations use ALL device accesses as their access scopes. The specified stages for semaphore wait/signal do not restrict access scopes.

This is in contrast to pipeline barriers where the access scopes are restricted by the possible accesses on the specified stages.

NOTE!!: This part of code is still not perfect and I don't have good understanding. We use all device accessses (`syncAccessReadMask |  syncAccessWriteMask`) selectively only for `TOP_OF_PIPE` and `BOTTOM_OF_PIPE`
(there are no accesses associated with these stages, so we enforce the rule that semaphore use all device accesses).

Why not to use ALL accesses uncoditionally?

Current intuition is this is likely related to how the current implementation merges stages/acccesses into a single representation - `SyncAccessFlags` and the algorithm that applies semaphores works with this mixed representation. If we find new not supported scenarios we might need to rework it to be more explicit about separation between stages and accesses.