### PR TITLE
layers: Don't assume memory_priority is enabled

### DIFF
--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -45,7 +45,8 @@ bool BestPractices::PreCallValidateAllocateMemory(VkDevice device, const VkMemor
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         if (!IsExtEnabled(extensions.vk_ext_pageable_device_local_memory) &&
-            !vku::FindStructInPNextChain<VkMemoryPriorityAllocateInfoEXT>(pAllocateInfo->pNext)) {
+            (!IsExtEnabled(extensions.vk_ext_memory_priority) ||
+             !vku::FindStructInPNextChain<VkMemoryPriorityAllocateInfoEXT>(pAllocateInfo->pNext))) {
             skip |= LogPerformanceWarning(
                 "BestPractices-NVIDIA-AllocateMemory-SetPriority", device, error_obj.location,
                 "%s Use VkMemoryPriorityAllocateInfoEXT to provide the operating system information on the allocations that "


### PR DESCRIPTION
If vk_ext_pageable_device_local_memory is disabled, the bpa doesn't actually check vk_ext_memory_priority is enabled before reading VkMemoryPriorityAllocateInfoEXT. It probably should.