### PR TITLE
gpuav: Use PipelineSubState

### DIFF
--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -407,7 +407,8 @@ void AnalyzeAndGenerateMessage(Validator& gpuav, VkCommandBuffer command_buffer,
 
 static bool HasDebugPrintf(const LastBound& last_bound) {
     if (last_bound.pipeline_state) {
-        return last_bound.pipeline_state->instrumentation_data.status.has_debug_printf;
+        const PipelineSubState& pipeline_sub_state = SubState(*last_bound.pipeline_state);
+        return pipeline_sub_state.status.has_debug_printf;
     }
     for (uint32_t i = 0; i < kShaderObjectStageCount; ++i) {
         const auto stage = static_cast<ShaderObjectStage>(i);

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -363,7 +363,8 @@ void UpdateInstrumentationDescSet(Validator& gpuav, CommandBufferSubState& cb_st
 
 static bool WasInstrumented(const LastBound& last_bound) {
     if (last_bound.pipeline_state) {
-        return last_bound.pipeline_state->instrumentation_data.status.is_instrumented;
+        const PipelineSubState& pipeline_sub_state = SubState(*last_bound.pipeline_state);
+        return pipeline_sub_state.status.is_instrumented;
     }
     for (uint32_t i = 0; i < kShaderObjectStageCount; ++i) {
         const auto stage = static_cast<ShaderObjectStage>(i);

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -445,8 +445,9 @@ void GpuShaderInstrumentor::PreCallRecordSetDebugUtilsObjectNameEXT(VkDevice dev
     VkPipeline wrapped_pipeline = CastFromUint64<VkPipeline>(pNameInfo->objectHandle);
     auto pipeline_state = Get<vvl::Pipeline>(wrapped_pipeline);
     ASSERT_AND_RETURN(pipeline_state);
+    PipelineSubState& pipeline_sub_state = SubState(*pipeline_state);
 
-    if (pipeline_state->instrumentation_data.status.is_instrumented) {
+    if (pipeline_sub_state.status.is_instrumented) {
         return;
     }
 
@@ -533,7 +534,6 @@ void GpuShaderInstrumentor::PreCallRecordSetDebugUtilsObjectNameEXT(VkDevice dev
     }
 
     const VkPipeline old_pipeline = layer_data->Replace(pipeline_state->VkHandle(), instrumented_pipeline);
-    gpuav::PipelineSubState& pipeline_sub_state = SubState(*pipeline_state);
     pipeline_sub_state.AddHandleToDestroy(old_pipeline);
 }
 
@@ -1032,11 +1032,13 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
                 std::shared_ptr<vvl::Pipeline> pipeline_state = ((GpuShaderInstrumentor*)this)->Get<vvl::Pipeline>(pipe);
                 ASSERT_AND_CONTINUE(pipeline_state);
                 if (pipeline_state->ray_tracing_library_ci) {
+                    PipelineSubState& pipeline_sub_state = SubState(*pipeline_state);
                     for (VkPipeline lib : vvl::make_span(pipeline_state->ray_tracing_library_ci->pLibraries,
                                                          pipeline_state->ray_tracing_library_ci->libraryCount)) {
                         auto lib_state = ((GpuShaderInstrumentor*)this)->Get<vvl::Pipeline>(lib);
                         ASSERT_AND_CONTINUE(lib_state);
-                        pipeline_state->instrumentation_data.status.Append(lib_state->instrumentation_data.status);
+                        PipelineSubState& lib_sub_state = SubState(*lib_state);
+                        pipeline_sub_state.status.Append(lib_sub_state.status);
                     }
                 }
                 auto& shader_instrumentation_metadata = held_chassis_state->shader_instrumentations_metadata[pipe_i];
@@ -1061,13 +1063,14 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
             UtilCopyCreatePipelineFeedbackData(pCreateInfos[i], chassis_state->modified_create_infos[i]);
 
             auto pipeline_state = Get<vvl::Pipeline>(pipeline_handle);
-
+            PipelineSubState& pipeline_sub_state = SubState(*pipeline_state);
             if (pipeline_state->ray_tracing_library_ci) {
                 for (VkPipeline lib : vvl::make_span(pipeline_state->ray_tracing_library_ci->pLibraries,
                                                      pipeline_state->ray_tracing_library_ci->libraryCount)) {
                     auto lib_state = Get<vvl::Pipeline>(lib);
                     ASSERT_AND_CONTINUE(lib_state);
-                    pipeline_state->instrumentation_data.status.Append(lib_state->instrumentation_data.status);
+                    PipelineSubState& lib_sub_state = SubState(*lib_state);
+                    pipeline_sub_state.status.Append(lib_sub_state.status);
                 }
             }
 
@@ -1088,11 +1091,12 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
 void GpuShaderInstrumentor::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline,
                                                          const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
     if (auto pipeline_state = Get<vvl::Pipeline>(pipeline)) {
-        for (auto shader_module_handle : pipeline_state->instrumentation_data.shader_modules) {
+        const PipelineSubState& pipeline_sub_state = SubState(*pipeline_state);
+        for (auto shader_module_handle : pipeline_sub_state.shader_modules) {
             DispatchDestroyShaderModule(device, shader_module_handle, pAllocator);
         }
-        if (pipeline_state->instrumentation_data.instrumented_pipeline_lib != VK_NULL_HANDLE) {
-            DispatchDestroyPipeline(device, pipeline_state->instrumentation_data.instrumented_pipeline_lib, pAllocator);
+        if (pipeline_sub_state.instrumented_pipeline_lib != VK_NULL_HANDLE) {
+            DispatchDestroyPipeline(device, pipeline_sub_state.instrumented_pipeline_lib, pAllocator);
         }
     }
 }
@@ -1379,6 +1383,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
     bool is_pipeline_selected_for_instrumentation =
         IsPipelineSelectedForInstrumentation(modified_pipeline_ci.pNext, VK_NULL_HANDLE, loc);
 
+    PipelineSubState& pipeline_sub_state = SubState(pipeline_state);
     for (uint32_t stage_state_i = 0; stage_state_i < stages_count; ++stage_state_i) {
         const auto& stage_state = pipeline_state.stage_states[stage_state_i];
         auto modified_module_state = std::const_pointer_cast<vvl::ShaderModule>(stage_state.module_state);
@@ -1429,7 +1434,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
         InstrumentShader(modified_module_state->spirv->words_, interface, instrumentation_metadata.status, instrumented_spirv);
 
         if (instrumentation_metadata.status.is_instrumented) {
-            pipeline_state.instrumentation_data.status.Append(instrumentation_metadata.status);
+            pipeline_sub_state.status.Append(instrumentation_metadata.status);
             instrumentation_metadata.unique_shader_id = unique_shader_id;
             if (modified_module_state->VkHandle() != VK_NULL_HANDLE) {
                 // If the user used vkCreateShaderModule, we create a new VkShaderModule to replace with the instrumented
@@ -1444,7 +1449,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
                     SetShaderModule(modified_pipeline_ci, *stage_state.pipeline_create_info, instrumented_shader_module,
                                     stage_state_i);
 
-                    pipeline_state.instrumentation_data.shader_modules.emplace_back(instrumented_shader_module);
+                    pipeline_sub_state.shader_modules.emplace_back(instrumented_shader_module);
                 } else {
                     InternalError(device, loc, "Unable to replace non-instrumented shader with instrumented one.");
                     return false;
@@ -1537,21 +1542,23 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             continue;
         }
 
+        PipelineSubState& modified_lib_sub_state = SubState(*modified_lib);
+        PipelineSubState& linked_pipeline_sub_state = SubState(linked_pipeline_state);
+
         // without this, would get ASAN for things like
         //   modified_lib->instrumentation_data.shader_modules.emplace_back()
-        std::unique_lock<std::mutex> lib_lock(modified_lib->instrumentation_data.mutex);
+        std::unique_lock<std::mutex> lib_lock(modified_lib_sub_state.mutex_);
 
         // If a library is used to create multiple executable pipelines, we don't want to instrument it again.
         // Check that there is indeed an instrumented_pipeline_lib:
         // The library could be considered instrumented if itself it was made up of instrumented libraries,
         // but in this case instrumented_pipeline_lib would not have been set.
         // Note: Well in this case we could use modified_lib->VkHandle()?
-        if (modified_lib->instrumentation_data.status.is_instrumented &&
-            (modified_lib->instrumentation_data.instrumented_pipeline_lib != VK_NULL_HANDLE)) {
-            assert(modified_lib->instrumentation_data.instrumented_pipeline_lib != VK_NULL_HANDLE);
+        if (modified_lib_sub_state.status.is_instrumented && (modified_lib_sub_state.instrumented_pipeline_lib != VK_NULL_HANDLE)) {
+            assert(modified_lib_sub_state.instrumented_pipeline_lib != VK_NULL_HANDLE);
             const_cast<VkPipeline*>(modified_library_ci->pLibraries)[modified_lib_i] =
-                modified_lib->instrumentation_data.instrumented_pipeline_lib;
-            linked_pipeline_state.instrumentation_data.status.Append(modified_lib->instrumentation_data.status);
+                modified_lib_sub_state.instrumented_pipeline_lib;
+            linked_pipeline_sub_state.status.Append(modified_lib_sub_state.status);
             continue;
         }
 
@@ -1664,7 +1671,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
                         new_lib_ci.pStages[stage_state_i] = *modified_stage_state.pipeline_create_info;
                         new_lib_ci.pStages[stage_state_i].module = new_shader_module;
 
-                        modified_lib->instrumentation_data.shader_modules.emplace_back(new_shader_module);
+                        modified_lib_sub_state.shader_modules.emplace_back(new_shader_module);
                     } else {
                         InternalError(device, loc, "Unable to replace non-instrumented shader with instrumented one.");
                         return VK_NULL_HANDLE;
@@ -1693,8 +1700,8 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             if (instrumented_shader_module != VK_NULL_HANDLE) {
                 is_library_instrumented = true;
 
-                modified_lib->instrumentation_data.status.Append(stage_status);
-                linked_pipeline_state.instrumentation_data.status.Append(stage_status);
+                modified_lib_sub_state.status.Append(stage_status);
+                linked_pipeline_sub_state.status.Append(stage_status);
 
                 std::vector<uint32_t> original_spirv_copy;
                 if (modified_module_state && modified_module_state->spirv) {
@@ -1723,7 +1730,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
                 return false;
             }
 
-            modified_lib->instrumentation_data.instrumented_pipeline_lib = instrumented_pipeline_lib;
+            modified_lib_sub_state.instrumented_pipeline_lib = instrumented_pipeline_lib;
 
             const_cast<VkPipeline*>(modified_library_ci->pLibraries)[modified_lib_i] = instrumented_pipeline_lib;
         }

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -436,10 +436,18 @@ class PipelineSubState : public vvl::PipelineSubState {
     void AddHandleToDestroy(VkPipeline pipeline);
     VkPipelineLayout GetPipelineLayoutUnion(const Location &loc, vvl::DescriptorMode mode) const;
 
-  private:
+    // We create a VkShaderModule that is instrumented and it needs to be destroyed before leaving the pipeline call
+    std::vector<VkShaderModule> shader_modules;
+
+    gpuav::spirv::InstrumentationStatus status;
+    // When we instrument GPL at link time, we need to hold the libraries created by GPU-AV so they can be re-used
+    VkPipeline instrumented_pipeline_lib = VK_NULL_HANDLE;
+
     // Multiple threads can record multiple commands using the same pipeline,
     // so layout recreation and deferred pipeline destruction have to be thread safe
     mutable std::mutex mutex_{};
+
+  private:
     mutable VkPipelineLayout recreated_layout_ = VK_NULL_HANDLE;
     Validator &gpuav_;
     VkPipeline uninstrumented_pipeline = VK_NULL_HANDLE;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -152,21 +152,6 @@ class Pipeline : public StateObject, public SubStateManager<PipelineSubState> {
 
     const uint32_t descriptor_heap_embedded_samplers_count;
 
-    // TODO - Because we have hack to create a pipeline at PreCallValidate time (for GPL) we have no proper way to create inherited
-    // state objects of the pipeline This is to make it clear that while currently everyone has to allocate this memory, it is only
-    // meant for GPU-AV
-    struct InstrumentationData {
-        // We create a VkShaderModule that is instrumented and it needs to be destroyed before leaving the pipeline call
-        std::vector<VkShaderModule> shader_modules;
-        gpuav::spirv::InstrumentationStatus status;
-        // When we instrument GPL at link time, we need to hold the libraries created by GPU-AV
-        // so they can be re-used
-        VkPipeline instrumented_pipeline_lib = VK_NULL_HANDLE;
-        // We need to lock the pipelines when doig GPL
-        // while we have one in vvl::ShaderModule GPL needs it also at the pipeline library scope
-        std::mutex mutex;
-    } instrumentation_data;
-
     Pipeline(const DeviceState &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> pipe_cache, std::shared_ptr<const vvl::RenderPass> &&rpstate,
              std::shared_ptr<const vvl::PipelineLayout> &&layout,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2263,6 +2263,31 @@ bool DeviceState::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipe
     return skip;
 }
 
+void DeviceState::PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                                       const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                                       const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                       const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                       chassis::CreateGraphicsPipelines& chassis_state) {
+    // Can't call in PreCallValidate as that is a const function
+    //
+    // Normally this would be called during
+    //    Add(std::move(pipeline_states[i]));
+    // but we do the notify first to create subset
+    for (uint32_t i = 0; i < count; i++) {
+        NotifyCreatedPipeline(*pipeline_states[i]);
+    }
+}
+
+// GPL was the worst thing ever added... we have to make MORE hacks around the fact we create a Pipeline state object in
+// PreCallValidate. The goal of this is go ahead of create the PipelineSubState such that GPU-AV can use it in PreCallRecord...I'm
+// just as mad as you are reading this that we have this.
+void DeviceState::NotifyCreatedPipeline(vvl::Pipeline& pipeline_state) {
+    // Normally called on Add()
+    for (auto& item : proxies) {
+        item.second.Created(pipeline_state);
+    }
+}
+
 void DeviceState::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                         const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                         const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
@@ -2307,6 +2332,16 @@ bool DeviceState::PreCallValidateCreateComputePipelines(VkDevice device, VkPipel
             &pCreateInfos[i], pipeline_cache, Get<PipelineLayout>(pCreateInfos[i].layout), &chassis_state.stateless_data));
     }
     return false;
+}
+
+void DeviceState::PreCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                                      const VkComputePipelineCreateInfo* pCreateInfos,
+                                                      const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                      const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                      chassis::CreateComputePipelines& chassis_state) {
+    for (uint32_t i = 0; i < count; i++) {
+        NotifyCreatedPipeline(*pipeline_states[i]);
+    }
 }
 
 void DeviceState::PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -2395,6 +2430,17 @@ bool DeviceState::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, V
             &pCreateInfos[i], pipeline_cache, Get<PipelineLayout>(pCreateInfos[i].layout), chassis_state.stateless_data));
     }
     return false;
+}
+
+void DeviceState::PreCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
+                                                            VkPipelineCache pipelineCache, uint32_t count,
+                                                            const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                            const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                            chassis::CreateRayTracingPipelinesKHR& chassis_state) {
+    for (uint32_t i = 0; i < count; i++) {
+        NotifyCreatedPipeline(*pipeline_states[i]);
+    }
 }
 
 void DeviceState::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -962,6 +962,11 @@ class DeviceState : public vvl::BaseDevice {
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                const ErrorObject& error_obj, PipelineStates& pipeline_states,
                                                chassis::CreateComputePipelines& chassis_state) const override;
+    void PreCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                             const VkComputePipelineCreateInfo* pCreateInfos,
+                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                             const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                             chassis::CreateComputePipelines& chassis_state) override;
     void PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                               const VkComputePipelineCreateInfo* pCreateInfos,
                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
@@ -1019,6 +1024,11 @@ class DeviceState : public vvl::BaseDevice {
                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                 const ErrorObject& error_obj, PipelineStates& pipeline_states,
                                                 chassis::CreateGraphicsPipelines& chassis_state) const override;
+    void PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
+                                              const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                              const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                              const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                              chassis::CreateGraphicsPipelines& chassis_state) override;
     void PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
@@ -1090,6 +1100,12 @@ class DeviceState : public vvl::BaseDevice {
                                                      const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                      const ErrorObject& error_obj, PipelineStates& pipeline_states,
                                                      chassis::CreateRayTracingPipelinesKHR& chassis_state) const override;
+    void PreCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
+                                                   VkPipelineCache pipelineCache, uint32_t count,
+                                                   const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                   const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
+                                                   const RecordObject& record_obj, PipelineStates& pipeline_states,
+                                                   chassis::CreateRayTracingPipelinesKHR& chassis_state) override;
     void PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                     VkPipelineCache pipelineCache, uint32_t count,
                                                     const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
@@ -2249,11 +2265,14 @@ class DeviceState : public vvl::BaseDevice {
     // When adding a new state tracker, make sure to add to DestroyObjectMaps()
 
     // For state objects that have sub states.  Requires the definition of DeviceProxy, which is below.
-    template <typename State, std::enable_if_t<HasSubStates<State>::value, bool> = true>
+    // vvl::Pipeline are special... because GPL, duh
+    template <typename State, std::enable_if_t<HasSubStates<State>::value && !std::is_same_v<State, vvl::Pipeline>, bool> = true>
     void NotifyCreated(State& state_object);
 
-    template <typename State, std::enable_if_t<!HasSubStates<State>::value, bool> = true>
+    template <typename State, std::enable_if_t<!HasSubStates<State>::value || std::is_same_v<State, vvl::Pipeline>, bool> = true>
     void NotifyCreated(State& state_object) {}
+
+    void NotifyCreatedPipeline(vvl::Pipeline& pipeline_state);
 
     std::atomic<uint32_t> object_id_{1};  // 0 is an invalid id
 
@@ -2426,10 +2445,11 @@ class DeviceProxy : public vvl::BaseDevice {
     virtual void DebugCapture() {}
 };
 
-template <typename State, std::enable_if_t<HasSubStates<State>::value, bool>>
+template <typename State, std::enable_if_t<HasSubStates<State>::value && !std::is_same_v<State, vvl::Pipeline>, bool>>
 void DeviceState::NotifyCreated(State& state_object) {
     for (auto& item : proxies) {
         item.second.Created(state_object);
     }
 }
+
 }  // namespace vvl


### PR DESCRIPTION
Some C++ template sins and a lot of ugly code all for the sake to keep GPL working and more importantly allow for `PipelineSubState` to be used in GPU-AV

The core issue was were not creating the substate until `PostCallRecord`, but we need in in GPL at `PreCallRecord`... because GPL