### PR TITLE
sync: Fix access scopes for semaphore operations. Part 2

### DIFF
--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -873,10 +873,10 @@ void AccessState::ApplySemaphore(const SemaphoreScope& signal, const SemaphoreSc
         }
     }
     if (last_write.has_value() &&
-        last_write->WriteOrDependencyChainInSourceScope(signal.queue, signal.exec_scope, signal.valid_accesses)) {
+        last_write->WriteOrDependencyChainInSourceScope(signal.queue, signal.exec_scope, signal.stage_mask_accesses)) {
         // Will deflect RAW wait queue, WAW needs a chained barrier on wait queue
         read_execution_barriers = wait.exec_scope;
-        last_write->barriers = wait.valid_accesses;
+        last_write->barriers = wait.stage_mask_accesses;
     } else {
         read_execution_barriers = VK_PIPELINE_STAGE_2_NONE;
         if (last_write.has_value()) last_write->barriers.reset();

--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -873,10 +873,10 @@ void AccessState::ApplySemaphore(const SemaphoreScope& signal, const SemaphoreSc
         }
     }
     if (last_write.has_value() &&
-        last_write->WriteOrDependencyChainInSourceScope(signal.queue, signal.exec_scope, signal.stage_mask_accesses)) {
+        last_write->WriteOrDependencyChainInSourceScope(signal.queue, signal.exec_scope, signal.exec_scope_accesses)) {
         // Will deflect RAW wait queue, WAW needs a chained barrier on wait queue
         read_execution_barriers = wait.exec_scope;
-        last_write->barriers = wait.stage_mask_accesses;
+        last_write->barriers = wait.exec_scope_accesses;
     } else {
         read_execution_barriers = VK_PIPELINE_STAGE_2_NONE;
         if (last_write.has_value()) last_write->barriers.reset();

--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -87,46 +87,62 @@ static SyncAccessFlags AccessScope(const SyncAccessFlags& stage_scope, VkAccessF
 
 namespace syncval {
 
-SyncExecScope SyncExecScope::MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFlags2 mask_param,
+SyncExecScope SyncExecScope::MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFlags2 stage_mask,
                                      VkPipelineStageFlags2 disabled_feature_mask) {
-    const VkPipelineStageFlags2 expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags, disabled_feature_mask);
+    const VkPipelineStageFlags2 expanded_mask = sync_utils::ExpandPipelineStages(stage_mask, queue_flags, disabled_feature_mask);
 
     SyncExecScope result;
-    result.mask_param = mask_param;
+    result.stage_mask = stage_mask;
     result.exec_scope = sync_utils::AddEarlierPipelineStages(expanded_mask);
-    result.valid_accesses = AccessScopeByStage(expanded_mask);
+    result.stage_mask_accesses = AccessScopeByStage(expanded_mask);
+    result.exec_scope_accesses = AccessScopeByStage(result.exec_scope);
 
-    // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages
-    if (mask_param & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
-        result.valid_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
+    // ALL_COMMANDS stage includes all operations performed by the gpu, not only operations that run on the stages.
+    // BOTTOM_OF_PIPE has no accesses of its own, so does not add to stage_mask_accesses, but in the context of
+    // semaphoer scopes it adds to exec_scope_accesses
+    if (stage_mask & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
+        result.stage_mask_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
+    }
+    if (stage_mask & (VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT | VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT)) {
+        result.exec_scope_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
     }
     return result;
 }
 
-SyncExecScope SyncExecScope::MakeDst(VkQueueFlags queue_flags, VkPipelineStageFlags2 mask_param) {
-    const VkPipelineStageFlags2 expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags);
+SyncExecScope SyncExecScope::MakeDst(VkQueueFlags queue_flags, VkPipelineStageFlags2 stage_mask) {
+    const VkPipelineStageFlags2 expanded_mask = sync_utils::ExpandPipelineStages(stage_mask, queue_flags);
 
     SyncExecScope result;
-    result.mask_param = mask_param;
+    result.stage_mask = stage_mask;
     result.exec_scope = sync_utils::AddLaterPipelineStages(expanded_mask);
-    result.valid_accesses = AccessScopeByStage(expanded_mask);
+    result.stage_mask_accesses = AccessScopeByStage(expanded_mask);
+    result.exec_scope_accesses = AccessScopeByStage(result.exec_scope);
 
-    // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages
-    if (mask_param & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
-        result.valid_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
+    // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages.
+    // TOP_OF_PIPE has no accesses of its own, so does not add to stage_mask_accesses, but in the context of
+    // semaphore scopes it adds to exec_scope_accesses
+    if (stage_mask & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
+        result.stage_mask_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
+    }
+    if (stage_mask & (VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT | VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT)) {
+        result.exec_scope_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
     }
     return result;
 }
 
 bool SyncExecScope::operator==(const SyncExecScope& other) const {
-    return mask_param == other.mask_param && exec_scope == other.exec_scope && valid_accesses == other.valid_accesses;
+    // Check that the fields are packed without gaps so we can use fast memcmp.
+    // If not true, switch to memberwise compare
+    static_assert(sizeof(SyncExecScope) == 64, "Gap detected, use memberwise compare");
+    return memcmp(this, &other, sizeof(SyncExecScope)) == 0;
 }
 
 size_t SyncExecScope::Hash() const {
     hash_util::HashCombiner hc;
-    hc << mask_param;
+    hc << stage_mask;
     hc << exec_scope;
-    valid_accesses.HashCombine(hc);
+    stage_mask_accesses.HashCombine(hc);
+    exec_scope_accesses.HashCombine(hc);
     return hc.Value();
 }
 
@@ -135,16 +151,15 @@ SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst
 
 SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst_exec, const SyncBarrier::AllAccess&)
     : src_exec_scope(src_exec),
-      src_access_scope(src_exec.valid_accesses),
+      src_access_scope(src_exec.stage_mask_accesses),
       dst_exec_scope(dst_exec),
-      dst_access_scope(dst_exec.valid_accesses) {
-
+      dst_access_scope(dst_exec.stage_mask_accesses) {
     // No accesses are happening on TOP_OF_PIPE/BOTTOM_OF_PIPE stages
-    // (valid_accesses bitmask is empty). Explicitly enforce the spec
+    // (stage_mask_accesses bitmask is empty). Explicitly enforce the spec
     // rule that access scopes of semaphore operations include all
     // device accesses.
     //
-    // NOTE: we still use valid_accesses for other scenarios and implementation
+    // NOTE: we still use stage_mask_accesses for other scenarios and implementation
     // in some cases relies on this (for example,
     // NegativeSyncValTimelineSemaphore.WaitAfterSignalStageMismatch will fail
     // if we use all device accesss for access scopes uncoditionally).
@@ -152,10 +167,10 @@ SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst
     // TODO: if we find new issues we might need to rework implementation so
     // for semaphore operations, the src/dst access scopes always include all
     // device accesses
-    if (src_exec.mask_param & VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT) {
+    if (src_exec.stage_mask & VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT) {
         src_access_scope = syncAccessReadMask | syncAccessWriteMask;
     }
-    if (dst_exec.mask_param & VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT) {
+    if (dst_exec.stage_mask & VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT) {
         dst_access_scope = syncAccessReadMask | syncAccessWriteMask;
     }
 }
@@ -163,10 +178,10 @@ SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst
 SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope& dst_exec,
                          VkAccessFlags2 dst_access_mask)
     : src_exec_scope(src_exec),
-      src_access_scope(AccessScope(src_exec.valid_accesses, src_access_mask)),
+      src_access_scope(AccessScope(src_exec.stage_mask_accesses, src_access_mask)),
       original_src_access(src_access_mask),
       dst_exec_scope(dst_exec),
-      dst_access_scope(AccessScope(dst_exec.valid_accesses, dst_access_mask)),
+      dst_access_scope(AccessScope(dst_exec.stage_mask_accesses, dst_access_mask)),
       original_dst_access(dst_access_mask) {}
 
 SyncBarrier::SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2& subpass) {
@@ -174,22 +189,22 @@ SyncBarrier::SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2& s
     if (barrier) {
         auto src = SyncExecScope::MakeSrc(queue_flags, barrier->srcStageMask);
         src_exec_scope = src;
-        src_access_scope = AccessScope(src.valid_accesses, barrier->srcAccessMask);
+        src_access_scope = AccessScope(src.stage_mask_accesses, barrier->srcAccessMask);
         original_src_access = barrier->srcAccessMask;
 
         auto dst = SyncExecScope::MakeDst(queue_flags, barrier->dstStageMask);
         dst_exec_scope = dst;
-        dst_access_scope = AccessScope(dst.valid_accesses, barrier->dstAccessMask);
+        dst_access_scope = AccessScope(dst.stage_mask_accesses, barrier->dstAccessMask);
         original_dst_access = barrier->dstAccessMask;
     } else {
         auto src = SyncExecScope::MakeSrc(queue_flags, subpass.srcStageMask);
         src_exec_scope = src;
-        src_access_scope = AccessScope(src.valid_accesses, subpass.srcAccessMask);
+        src_access_scope = AccessScope(src.stage_mask_accesses, subpass.srcAccessMask);
         original_src_access = subpass.srcAccessMask;
 
         auto dst = SyncExecScope::MakeDst(queue_flags, subpass.dstStageMask);
         dst_exec_scope = dst;
-        dst_access_scope = AccessScope(dst.valid_accesses, subpass.dstAccessMask);
+        dst_access_scope = AccessScope(dst.stage_mask_accesses, subpass.dstAccessMask);
         original_dst_access = subpass.dstAccessMask;
     }
 }

--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -151,29 +151,9 @@ SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst
 
 SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst_exec, const SyncBarrier::AllAccess&)
     : src_exec_scope(src_exec),
-      src_access_scope(src_exec.stage_mask_accesses),
+      src_access_scope(src_exec.exec_scope_accesses),
       dst_exec_scope(dst_exec),
-      dst_access_scope(dst_exec.stage_mask_accesses) {
-    // No accesses are happening on TOP_OF_PIPE/BOTTOM_OF_PIPE stages
-    // (stage_mask_accesses bitmask is empty). Explicitly enforce the spec
-    // rule that access scopes of semaphore operations include all
-    // device accesses.
-    //
-    // NOTE: we still use stage_mask_accesses for other scenarios and implementation
-    // in some cases relies on this (for example,
-    // NegativeSyncValTimelineSemaphore.WaitAfterSignalStageMismatch will fail
-    // if we use all device accesss for access scopes uncoditionally).
-    //
-    // TODO: if we find new issues we might need to rework implementation so
-    // for semaphore operations, the src/dst access scopes always include all
-    // device accesses
-    if (src_exec.stage_mask & VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT) {
-        src_access_scope = syncAccessReadMask | syncAccessWriteMask;
-    }
-    if (dst_exec.stage_mask & VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT) {
-        dst_access_scope = syncAccessReadMask | syncAccessWriteMask;
-    }
-}
+      dst_access_scope(dst_exec.exec_scope_accesses) {}
 
 SyncBarrier::SyncBarrier(const SyncExecScope& src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope& dst_exec,
                          VkAccessFlags2 dst_access_mask)

--- a/layers/sync/sync_barrier.h
+++ b/layers/sync/sync_barrier.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,25 @@ namespace syncval {
 
 struct SyncExecScope {
     // The xxxStageMask parameter passed by the caller
-    VkPipelineStageFlags2 mask_param = 0;
+    VkPipelineStageFlags2 stage_mask = VK_PIPELINE_STAGE_2_NONE;
 
-    // All earlier or later stages that would be affected by a barrier using this scope
-    VkPipelineStageFlags2 exec_scope = 0;
+    // Stage mask with meta stages expanded, then extended with earlier/later stages.
+    // Used for execution dependency checks
+    VkPipelineStageFlags2 exec_scope = VK_PIPELINE_STAGE_2_NONE;
 
-    // All accesses that can be used with this scope
-    SyncAccessFlags valid_accesses;
+    // All accesses supported by stage_mask.
+    // Used for pipeline barriers to intersect access masks
+    SyncAccessFlags stage_mask_accesses;
+
+    // All accesses supported by exec_scope.
+    // Used for semaphore wait/signal access scopes
+    SyncAccessFlags exec_scope_accesses;
 
     static SyncExecScope MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFlags2 src_stage_mask,
                                  VkPipelineStageFlags2 disabled_feature_mask = 0);
     static SyncExecScope MakeDst(VkQueueFlags queue_flags, VkPipelineStageFlags2 src_stage_mask);
 
-    bool operator==(const SyncExecScope &other) const;
+    bool operator==(const SyncExecScope& other) const;
     size_t Hash() const;
 };
 
@@ -50,9 +56,9 @@ struct SyncBarrier {
     VkAccessFlags2 original_dst_access = VK_ACCESS_2_NONE;
 
     SyncBarrier() = default;
-    SyncBarrier(const SyncExecScope &src_exec, const SyncExecScope &dst_exec);
-    SyncBarrier(const SyncExecScope &src_exec, const SyncExecScope &dst_exec, const AllAccess &);
-    SyncBarrier(const SyncExecScope &src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope &dst_exec,
+    SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst_exec);
+    SyncBarrier(const SyncExecScope& src_exec, const SyncExecScope& dst_exec, const AllAccess&);
+    SyncBarrier(const SyncExecScope& src_exec, VkAccessFlags2 src_access_mask, const SyncExecScope& dst_exec,
                 VkAccessFlags2 dst_access_mask);
     SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2 &barrier);
     SyncBarrier(const std::vector<SyncBarrier> &barriers);

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -409,9 +409,9 @@ std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const C
 
     std::ostringstream ss;
     ss << "\npImageMemoryBarriers[" << barrier.barrier_index << "]: {\n";
-    ss << "  srcStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.src_exec_scope.mask_param) << ",\n";
+    ss << "  srcStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.src_exec_scope.stage_mask) << ",\n";
     ss << "  srcAccessMask = " << string_VkAccessFlags2(barrier.barrier.original_src_access) << ",\n";
-    ss << "  dstStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.dst_exec_scope.mask_param) << ",\n";
+    ss << "  dstStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.dst_exec_scope.stage_mask) << ",\n";
     ss << "  dstAccessMask = " << string_VkAccessFlags2(barrier.barrier.original_dst_access) << ",\n";
     ss << "}\n";
     additional_info.message_end_text = ss.str();

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -629,7 +629,7 @@ bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext& cb_context) co
         const auto& barrier_set = barrier_sets_[barrier_set_index];
         if (barrier_set.single_exec_scope) {
             const Location loc(command_);
-            if (barrier_set.src_exec_scope.mask_param & VK_PIPELINE_STAGE_HOST_BIT) {
+            if (barrier_set.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
                 const std::string vuid = std::string("SYNC-") + std::string(CmdName()) + std::string("-hostevent-unsupported");
                 sync_state.LogInfo(vuid, command_buffer_handle, loc,
                                    "srcStageMask includes %s, unsupported by synchronization validation.",
@@ -638,7 +638,7 @@ bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext& cb_context) co
                 const auto& barriers = barrier_set.memory_barriers;
                 for (size_t barrier_index = 0; barrier_index < barriers.size(); barrier_index++) {
                     const auto& barrier = barriers[barrier_index];
-                    if (barrier.src_exec_scope.mask_param & VK_PIPELINE_STAGE_HOST_BIT) {
+                    if (barrier.src_exec_scope.stage_mask & VK_PIPELINE_STAGE_HOST_BIT) {
                         const std::string vuid =
                             std::string("SYNC-") + std::string(CmdName()) + std::string("-hostevent-unsupported");
 
@@ -732,7 +732,7 @@ ResourceUsageTag SyncOpWaitEvents::Record(CommandBufferAccessContext* cb_context
 static SyncBarrier RestrictToEvent(const SyncBarrier& barrier, const SyncEventState& sync_event) {
     SyncBarrier result = barrier;
     result.src_exec_scope.exec_scope = sync_event.scope.exec_scope & barrier.src_exec_scope.exec_scope;
-    result.src_access_scope = sync_event.scope.valid_accesses & barrier.src_access_scope;
+    result.src_access_scope = sync_event.scope.stage_mask_accesses & barrier.src_access_scope;
     return result;
 }
 
@@ -863,7 +863,7 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext& exec_context, Resou
 
         // Apply the global barrier to the event itself (for race condition tracking)
         // Events don't happen at a stage, so we need to store the unexpanded ALL_COMMANDS if set for inter-event-calls
-        sync_event->barriers = dst.mask_param & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+        sync_event->barriers = dst.stage_mask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
         sync_event->barriers |= dst.exec_scope;
 
         barrier_set_index += barrier_set_incr;
@@ -905,7 +905,7 @@ bool SyncOpResetEvent::DoValidate(const CommandExecutionContext& exec_context, c
         return skip;  // if we validated this in recording of the secondary, don't repeat
     }
     if (IsValueIn(sync_event->last_command, {Func::vkCmdSetEvent, Func::vkCmdSetEvent2, Func::vkCmdSetEvent2KHR}) &&
-        !sync_event->HasBarrier(exec_scope_.mask_param, exec_scope_.exec_scope)) {
+        !sync_event->HasBarrier(exec_scope_.stage_mask, exec_scope_.exec_scope)) {
         skip |= sync_state.LogError("SYNC-vkCmdResetEvent-set-race", event_->Handle(), command_,
                                     "%s is reset after %s without an intervening execution dependency. This is a race condition "
                                     "and may result in data hazards.",
@@ -993,7 +993,7 @@ bool SyncOpSetEvent::DoValidate(const CommandExecutionContext& exec_context, con
     if (sync_event->last_command_tag >= base_tag) {
         return skip;  // for replay we don't want to revalidate internal "last commmand"
     }
-    if (!sync_event->HasBarrier(src_exec_scope_.mask_param, src_exec_scope_.exec_scope)) {
+    if (!sync_event->HasBarrier(src_exec_scope_.stage_mask, src_exec_scope_.exec_scope)) {
         const std::string vuid_prefix = std::string("SYNC-") + CmdName();
         if (IsValueIn(sync_event->last_command, {Func::vkCmdResetEvent, Func::vkCmdResetEvent2, Func::vkCmdResetEvent2KHR})) {
             skip |= sync_state.LogError(vuid_prefix + "-reset-race", event_->Handle(), command_,
@@ -1056,7 +1056,7 @@ void SyncOpSetEvent::DoRecord(QueueId queue_id, ResourceUsageTag tag, const std:
     //     Stuff1; SetEvent; Stuff2; SetEvent; WaitEvents;
     // WaitEvents cannot know which of Stuff1, Stuff2, or both has completed execution.
 
-    if (!sync_event->HasBarrier(src_exec_scope_.mask_param, src_exec_scope_.exec_scope)) {
+    if (!sync_event->HasBarrier(src_exec_scope_.stage_mask, src_exec_scope_.exec_scope)) {
         sync_event->unsynchronized_set = sync_event->last_command;
         sync_event->ResetFirstScope();
     } else if (!sync_event->first_scope) {
@@ -1351,7 +1351,7 @@ vvl::span<AccessContext> ReplayState::RenderPassReplayState::GetSubpassContexts(
 }
 
 void SyncEventsContext::ApplyBarrier(const SyncExecScope& src, const SyncExecScope& dst, ResourceUsageTag tag) {
-    const bool all_commands_bit = 0 != (src.mask_param & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    const bool all_commands_bit = 0 != (src.stage_mask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
     for (auto& event_pair : map_) {
         assert(event_pair.second);  // Shouldn't be storing empty
         auto& sync_event = *event_pair.second;
@@ -1359,7 +1359,7 @@ void SyncEventsContext::ApplyBarrier(const SyncExecScope& src, const SyncExecSco
         // But only if occuring before the tag
         if (((sync_event.barriers & src.exec_scope) || all_commands_bit) && (sync_event.last_command_tag <= tag)) {
             sync_event.barriers |= dst.exec_scope;
-            sync_event.barriers |= dst.mask_param & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+            sync_event.barriers |= dst.stage_mask & VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
         }
     }
 }

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -216,9 +216,10 @@ class ApplyAcquireNextSemaphoreAction {
     // and initialization of globals between compilation units is undefined. Instead they get initialized
     // on the first use (it's important to ensure this first use is also not initialization of some global!).
     static const SyncExecScope& getPresentSrcScope() {
-        static const SyncExecScope kPresentSrcScope{VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL,  // mask_param (unused)
+        static const SyncExecScope kPresentSrcScope{VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL,  // stage_mask (unused)
                                                     VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL,  // exec_scope
-                                                    getPresentValidAccesses()};                      // valid_accesses
+                                                    getPresentValidAccesses(),                       // stage_mask_accesses
+                                                    getPresentValidAccesses()};                      // exec_scope_accesses
         return kPresentSrcScope;
     }
     static const SyncAccessFlags& getPresentValidAccesses() {

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -70,7 +70,7 @@ struct SignalInfo {
     // Batch from the signal's first scope. It is null for a host signal (vkSignalSemaphore)
     std::shared_ptr<QueueBatchContext> batch;
 
-    // Use the first_scope.valid_accesses for the first access scope of non-host signals.
+    // Use the first_scope.stage_mask_accesses for the first access scope of non-host signals.
     // first_scope.queue is kQueueIdInvalid for a host signal (vkSignalSemaphore)
     SemaphoreScope first_scope;
 

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -70,7 +70,7 @@ struct SignalInfo {
     // Batch from the signal's first scope. It is null for a host signal (vkSignalSemaphore)
     std::shared_ptr<QueueBatchContext> batch;
 
-    // Use the first_scope.stage_mask_accesses for the first access scope of non-host signals.
+    // Use the first_scope.exec_scope_accesses for the first access scope of non-host signals.
     // first_scope.queue is kQueueIdInvalid for a host signal (vkSignalSemaphore)
     SemaphoreScope first_scope;
 

--- a/tests/unit/sync_val_semaphore.cpp
+++ b/tests/unit/sync_val_semaphore.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include "../framework/sync_val_tests.h"
 
 struct NegativeSyncValTimelineSemaphore : public VkSyncValTest {};
+struct NegativeSyncValBinarySemaphore : public VkSyncValTest {};
 
 TEST_F(NegativeSyncValTimelineSemaphore, WaitInitialValue) {
     TEST_DESCRIPTION("Wait on the initial value");
@@ -351,5 +352,36 @@ TEST_F(NegativeSyncValTimelineSemaphore, SignalResolvesTwoWaits4) {
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-RACING-WRITE");
     m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineWait(semaphore, 1));
     m_errorMonitor->VerifyFound();
+    m_device->Wait();
+}
+
+TEST_F(NegativeSyncValBinarySemaphore, WaitStageMismatchTwoQueues) {
+    TEST_DESCRIPTION("Hazard due to semaphore wait stage mask mismatch");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    if (!m_second_queue) {
+        GTEST_SKIP() << "Two queues are needed";
+    }
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    m_second_command_buffer.Begin();
+    vk::CmdFillBuffer(m_second_command_buffer, buffer, 0, 256, 0x42);
+    m_second_command_buffer.End();
+
+    m_command_buffer.Begin();
+    vk::CmdFillBuffer(m_command_buffer, buffer, 0, 256, 0x24);
+    m_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device);
+    m_second_queue->Submit2(m_second_command_buffer, vkt::Signal(semaphore, VK_PIPELINE_STAGE_2_TRANSFER_BIT));
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    // The wait stage does not include TRANSFER, so the second fill is not synchronized by the semaphore wait
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(semaphore, VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT));
+    m_errorMonitor->VerifyFound();
+
     m_device->Wait();
 }

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -22,6 +22,7 @@
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 struct PositiveSyncValTimelineSemaphore : public VkSyncValTest {};
+struct PositiveSyncValBinarySemaphore : public VkSyncValTest {};
 
 TEST_F(PositiveSyncValTimelineSemaphore, WaitInitialValue) {
     TEST_DESCRIPTION("Wait on the initial value");
@@ -895,5 +896,187 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSinglaBlocksAnotherSubmit) {
     queue1->Submit(command_buffer, vkt::TimelineSignal(timeline, 1));
 
     queue1->Submit(vkt::no_cmd, vkt::TimelineSignal(timeline, 2));
+    m_device->Wait();
+}
+
+TEST_F(PositiveSyncValBinarySemaphore, SemaphoreScopeIncludesAllAccesses) {
+    TEST_DESCRIPTION("Semaphore access scopes include all device accesses, not only accesses supported by the stage mask");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+
+    vkt::Image image(*m_device, 64, 64, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+    vkt::ImageView image_view = image.CreateView();
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+    vkt::Buffer dst_buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    const char* vs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) buffer StorageBuffer {
+            uint value;
+        } data;
+        void main() {
+            data.value = 1;
+            gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+        }
+    )glsl";
+
+    VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
+    pipeline_rendering_info.colorAttachmentCount = 1;
+    pipeline_rendering_info.pColorAttachmentFormats = &format;
+
+    OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT}});
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, 256, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set.UpdateDescriptorSets();
+
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
+    pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
+    pipe.CreateGraphicsPipeline();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {64, 64};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    // Write to storage buffer from VERTEX_SHADER
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_, 0, 1, &descriptor_set.set_,
+                              0, nullptr);
+    vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+
+    // Read storage buffer from COPY_STAGE
+    vkt::CommandBuffer copy_command_buffer(*m_device, m_command_pool);
+    copy_command_buffer.Begin();
+    copy_command_buffer.Copy(buffer, dst_buffer);
+    copy_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device);
+
+    // Specify FRAGMENT_SHADER stage to test that semaphore signal includes *all* device accesses.
+    // In case of regression we can expect that only FRAGMENT_SHADER accesses are included, but this
+    // won't synchronize VERTEX_SHADER writes to storage buffer and will result in READ_AFTER_WRITE hazard
+    m_default_queue->Submit2(m_command_buffer, vkt::Signal(semaphore, VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT));
+
+    m_default_queue->Submit2(copy_command_buffer, vkt::Wait(semaphore, VK_PIPELINE_STAGE_2_COPY_BIT));
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveSyncValBinarySemaphore, SemaphoreScopeIncludesAllAccessesTwoQueues) {
+    TEST_DESCRIPTION("Semaphore access scopes include all device accesses, not only accesses supported by the stage mask");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    if (!m_second_queue) {
+        GTEST_SKIP() << "Two queues are needed";
+    }
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer dst_buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    m_command_buffer.Begin();
+    vk::CmdFillBuffer(m_command_buffer, buffer, 0, 256, 0x42);
+    m_command_buffer.End();
+
+    m_second_command_buffer.Begin();
+    m_second_command_buffer.Copy(buffer, dst_buffer);
+    m_second_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device);
+
+    // Specify BOTTOM_OF_PIPE stage to test that semaphore signal includes *all* device accesses.
+    // There are no accesses on BOTTOM_OF_PIPE stage, but it does not define the semaphore access scope.
+    m_default_queue->Submit2(m_command_buffer, vkt::Signal(semaphore, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT));
+
+    m_second_queue->Submit2(m_second_command_buffer, vkt::Wait(semaphore));
+    m_device->Wait();
+}
+
+TEST_F(PositiveSyncValBinarySemaphore, SemaphoreScopeIncludesAllAccessesTwoQueues2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    if (!m_second_queue) {
+        GTEST_SKIP() << "Two queues are needed";
+    }
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    m_command_buffer.Begin();
+    vk::CmdFillBuffer(m_command_buffer, buffer, 0, 256, 0x42);
+    m_command_buffer.End();
+
+    m_second_command_buffer.Begin();
+    vk::CmdFillBuffer(m_second_command_buffer, buffer, 0, 256, 0x24);
+    m_second_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device);
+
+    m_default_queue->Submit2(m_command_buffer, vkt::Signal(semaphore, VK_PIPELINE_STAGE_2_TRANSFER_BIT));
+
+    // TOP_OF_PIPE has no accesses of its own, but semaphore wait access scope still includes all device accesses
+    m_second_queue->Submit2(m_second_command_buffer, vkt::Wait(semaphore, VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT));
+    m_device->Wait();
+}
+
+TEST_F(PositiveSyncValBinarySemaphore, SemaphoreScopeIncludesLayoutTransition) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    if (!m_second_queue) {
+        GTEST_SKIP() << "Two queues are needed";
+    }
+
+    vkt::Image image(*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Buffer buffer(*m_device, 64 * 64 * 4, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
+    layout_transition.srcStageMask = VK_PIPELINE_STAGE_2_NONE;
+    layout_transition.srcAccessMask = VK_ACCESS_2_NONE;
+    layout_transition.dstStageMask = VK_PIPELINE_STAGE_2_NONE;
+    layout_transition.dstAccessMask = VK_ACCESS_2_NONE;
+    layout_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    layout_transition.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+    layout_transition.image = image;
+    layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(layout_transition);
+    m_command_buffer.End();
+
+    VkBufferImageCopy region = {};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {64, 64, 1};
+
+    m_second_command_buffer.Begin();
+    vk::CmdCopyImageToBuffer(m_second_command_buffer, image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buffer, 1, &region);
+    m_second_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device);
+
+    // BOTTOM_OF_PIPE has no accesses of its own, but semaphore access scope still
+    // includes all device accesses, which includes layout transition accesses
+    m_default_queue->Submit2(m_command_buffer, vkt::Signal(semaphore, VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT));
+
+    m_second_queue->Submit2(m_second_command_buffer, vkt::Wait(semaphore));
     m_device->Wait();
 }


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12401
The previous solution focused on a specific issue and did not handle all scenarios. This PR is more of a proper fix.

Also cleanup/renames/new fields in `SyncExecScope` that the fix is based on.
