### PR TITLE
dump: Initial Untyped Pointer support

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -14,31 +14,38 @@
  * limitations under the License.
  */
 
-#include "containers/container_utils.h"
-#include "containers/limits.h"
-#include "error_message/log_message_type.h"
-#include "generated/error_location_helper.h"
 #include "gpu_dump_state.h"
 #include "gpu_dump.h"
 #include <vulkan/vk_enum_string_helper.h>
 #include <vulkan/vulkan_core.h>
 #include <cstdint>
 #include <iostream>
+#include <spirv-tools/libspirv.hpp>
+#include <spirv-tools/optimizer.hpp>
+#include <spirv/unified1/spirv.hpp>
 #include <sstream>
 #include <algorithm>
+#include <vector>
 #include "containers/range.h"
 #include "containers/small_vector.h"
+#include "containers/container_utils.h"
+#include "containers/custom_containers.h"
+#include "containers/limits.h"
 #include "generated/dispatch_functions.h"
+#include "error_message/log_message_type.h"
+#include "generated/error_location_helper.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/descriptor_mode.h"
 #include "state_tracker/pipeline_layout_state.h"
 #include "state_tracker/pipeline_state.h"
+#include "state_tracker/shader_instruction.h"
 #include "state_tracker/shader_module.h"
 #include "state_tracker/shader_stage_state.h"
 #include "state_tracker/state_tracker.h"
 #include "utils/math_utils.h"
 #include "utils/descriptor_utils.h"
+#include "utils/spirv_tools_utils.h"
 
 namespace gpudump {
 
@@ -282,6 +289,40 @@ static const vvl::Buffer* GetLargestBuffer(const GpuDump& dev_data, uint64_t add
     return longer_buffer;
 }
 
+static VkDeviceSize GetDescriptorAlignment(VkDescriptorType type, const vvl::DeviceExtensionProperties& phys_dev_ext_props) {
+    if (type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+        return phys_dev_ext_props.descriptor_heap_tensor_props.tensorDescriptorAlignment;
+    } else if (type == VK_DESCRIPTOR_TYPE_SAMPLER) {
+        return phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment;
+    } else if (IsValueIn(type,
+                         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER})) {
+        return phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment;
+    } else if (IsValueIn(type, {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                                VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR})) {
+        return phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment;
+    }
+    assert(false);
+    return 0;
+}
+
+static vvl::Field GetDescriptorAlignmentField(VkDescriptorType type) {
+    if (type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
+        return vvl::Field::tensorDescriptorAlignment;
+    } else if (type == VK_DESCRIPTOR_TYPE_SAMPLER) {
+        return vvl::Field::samplerDescriptorAlignment;
+    } else if (IsValueIn(type,
+                         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER})) {
+        return vvl::Field::imageDescriptorAlignment;
+    } else if (IsValueIn(type, {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                                VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR})) {
+        return vvl::Field::bufferDescriptorAlignment;
+    }
+    assert(false);
+    return vvl::Field::Empty;
+}
+
 bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, const MappingInfo& mapping_info) const {
     const VkDescriptorSetAndBindingMappingEXT& mapping = *mapping_info.mapping;
     const spirv::ResourceInterfaceVariable& resource_variable = *mapping_info.resource_variable;
@@ -325,25 +366,8 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         descriptor_size = dev_data.device_state->cached_descriptor_size.GetSize(descriptor_type);
     }
 
-    // TODO - Make common util if others need it
-    VkDeviceSize required_alignment = 0;
-    vvl::Field alignment_name = vvl::Field::Empty;
-    if (descriptor_type == VK_DESCRIPTOR_TYPE_TENSOR_ARM) {
-        required_alignment = dev_data.phys_dev_ext_props.descriptor_heap_tensor_props.tensorDescriptorAlignment;
-        alignment_name = vvl::Field::tensorDescriptorAlignment;
-    } else if (descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLER) {
-        required_alignment = dev_data.phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment;
-        alignment_name = vvl::Field::samplerDescriptorAlignment;
-    } else if (IsValueIn(descriptor_type,
-                         {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                          VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER})) {
-        required_alignment = dev_data.phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment;
-        alignment_name = vvl::Field::imageDescriptorAlignment;
-    } else if (IsValueIn(descriptor_type, {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
-                                           VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR})) {
-        required_alignment = dev_data.phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment;
-        alignment_name = vvl::Field::bufferDescriptorAlignment;
-    }
+    VkDeviceSize required_alignment = GetDescriptorAlignment(descriptor_type, dev_data.phys_dev_ext_props);
+    vvl::Field alignment_name = GetDescriptorAlignmentField(descriptor_type);
 
     // attempts to catch obvious OOB offsets in mappings
     std::ostringstream warn_ss;
@@ -1256,6 +1280,308 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
     return found_warning;
 }
 
+static uint32_t GetUntypedSize(const spirv::Module& module, const spirv::Instruction& size_inst, VkDeviceSize descriptor_size) {
+    if (size_inst.Opcode() == spv::OpConstantSizeOfEXT) {
+        const spirv::Instruction* constant_type_inst = module.FindDef(size_inst.Word(3));
+        if (!IsValueIn((spv::Op)constant_type_inst->Opcode(), {spv::OpTypeBufferEXT, spv::OpTypeImage, spv::OpTypeSampler})) {
+            assert(false);  // assumptions
+            return 0;
+        }
+        return (uint32_t)descriptor_size;
+    } else if (size_inst.Opcode() == spv::OpConstant) {
+        return size_inst.GetConstantValue();
+    } else if (size_inst.Opcode() == spv::OpSpecConstantOp) {
+        // TODO - We will need some sort of internal constant folding here... fun!
+        return 0;
+    }
+    assert(false);  // assumptions
+    return 0;
+}
+
+static uint32_t GetUntypedHeapOffset(const spirv::Module& module, const spirv::Instruction& access_chain,
+                                     const spirv::Instruction& base_type_inst, VkDeviceSize descriptor_size) {
+    if (base_type_inst.Opcode() != spv::OpTypeStruct) {
+        return 0;
+    }
+
+    const uint32_t struct_id = base_type_inst.ResultId();
+    for (const auto& type_struct : module.static_data_.type_structs) {
+        if (type_struct->id == struct_id) {
+            uint32_t struct_member = module.FindDef(access_chain.Word(5))->GetConstantValue();
+            const auto& member = type_struct->members[struct_member];
+            if (member.decorations->offset != vvl::kNoIndex32) {
+                return member.decorations->offset;
+            }
+            const spirv::Instruction* offset_id_inst = module.FindDef(member.decorations->offset_id);
+            return GetUntypedSize(module, *offset_id_inst, descriptor_size);
+        }
+    }
+    assert(false);
+    return 0;
+}
+
+static uint32_t GetUntypedArrayStride(const spirv::Module& module, const spirv::Instruction& access_chain,
+                                      const spirv::Instruction& base_type_inst, VkDeviceSize descriptor_size) {
+    uint32_t type_array_id = vvl::kNoIndex32;
+    if (base_type_inst.Opcode() == spv::OpTypeBufferEXT) {
+        return 0;  // single element
+    } else if (base_type_inst.Opcode() == spv::OpTypeStruct) {
+        // required to be a constant into the struct
+        uint32_t struct_member = module.FindDef(access_chain.Word(5))->GetConstantValue();
+        type_array_id = base_type_inst.Word(2 + struct_member);
+    } else if (base_type_inst.IsArray()) {
+        type_array_id = base_type_inst.ResultId();
+    }
+    const auto decoration_set = module.GetDecorationSet(type_array_id);
+    if (decoration_set.array_stride_id == spirv::kInvalidValue) {
+        return 0; // struct with no array in it
+    }
+
+    const spirv::Instruction* array_stride_inst = module.FindDef(decoration_set.array_stride_id);
+    return GetUntypedSize(module, *array_stride_inst, descriptor_size);
+}
+
+static uint32_t GetUntypedDescriptorIndex(const spirv::Module& module, const spirv::Instruction& access_chain,
+                                          const spirv::Instruction& base_type_inst) {
+    const spirv::Instruction* index_inst = nullptr;
+    if (base_type_inst.Opcode() == spv::OpTypeBufferEXT) {
+        return 0;  // single element
+    } else if (base_type_inst.IsArray()) {
+        if (access_chain.Length() < 6) {
+            return 0;  // implicit zero index
+        } else {
+            index_inst = module.FindDef(access_chain.Word(5));
+        }
+    } else if (base_type_inst.Opcode() == spv::OpTypeStruct) {
+        if (access_chain.Length() < 7) {
+            return 0;  // implicit zero index
+        } else {
+            index_inst = module.FindDef(access_chain.Word(6));
+        }
+    }
+
+    uint32_t descriptor_index = vvl::kNoIndex32;
+    if (index_inst) {
+        module.GetInt32IfConstant(*index_inst, &descriptor_index);
+    }
+    return descriptor_index;
+}
+
+static uint32_t GetUntypedVariableId(const spirv::Module& module, const spirv::Instruction& access_chain) {
+    assert(access_chain.Opcode() == spv::OpUntypedAccessChainKHR);
+
+    const spirv::Instruction* base_inst = module.FindDef(access_chain.Word(4));
+    if (base_inst->Opcode() != spv::OpUntypedVariableKHR) {
+        assert(false);  // assumptions
+        return vvl::kNoIndex32;
+    }
+    return base_inst->ResultId();
+}
+
+// "Friends to let friends become compiler engineers" ~Spencer
+vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptorHeapUntypedFindAccess(
+    const spirv::Module& module, const spirv::EntryPoint& entrypoint) const {
+    vvl::unordered_map<uint32_t, HeapAccesses> accesses;
+
+    auto add_access = [&](const VkDescriptorType descriptor_type, const spirv::Instruction& ac_inst) {
+        const VkDeviceSize descriptor_size = dev_data.device_state->cached_descriptor_size.GetSize(descriptor_type);
+        assert(ac_inst.Opcode() == spv::OpUntypedAccessChainKHR);
+        // Totally asserts a 1D array access here
+        // https://gitlab.khronos.org/spirv/SPIR-V/-/issues/942
+        const spirv::Instruction* base_type_inst = module.FindDef(ac_inst.Word(3));
+        if (base_type_inst->Opcode() != spv::OpTypeBufferEXT && base_type_inst->Opcode() != spv::OpTypeStruct &&
+            !base_type_inst->IsArray()) {
+            assert(false);
+            return;
+        }
+
+        const uint32_t heap_offset = GetUntypedHeapOffset(module, ac_inst, *base_type_inst, descriptor_size);
+
+        const uint32_t array_stride_value = GetUntypedArrayStride(module, ac_inst, *base_type_inst, descriptor_size);
+
+        const uint32_t descriptor_index = GetUntypedDescriptorIndex(module, ac_inst, *base_type_inst);
+
+        const uint32_t variable_id = GetUntypedVariableId(module, ac_inst);
+        if (variable_id == vvl::kNoIndex32) {
+            return;
+        }
+
+        accesses[variable_id].insert(HeapAccess{descriptor_type, heap_offset, array_stride_value, descriptor_index});
+    };
+
+    for (auto accessible_id : entrypoint.accessible_ids) {
+        const spirv::Instruction* inst = module.FindDef(accessible_id);
+
+        if (inst->Opcode() == spv::OpBufferPointerEXT) {
+            const spirv::Instruction* ac_inst = module.FindDef(inst->Word(3));
+            if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
+                assert(false);  // assumptions
+                continue;
+            }
+
+            // Ignore old BufferBlock + Uniform
+            const VkDescriptorType descriptor_type = module.FindDef(inst->TypeId())->StorageClass() == spv::StorageClassUniform
+                                                         ? VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+                                                         : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            add_access(descriptor_type, *ac_inst);
+        } else if (inst->Opcode() == spv::OpSampledImage) {
+            const spirv::Instruction* image_load = module.FindDef(inst->Word(3));
+            if (image_load->Opcode() == spv::OpLoad) {
+                const spirv::Instruction* ac_inst = module.FindDef(image_load->Word(3));
+                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
+                    assert(false);  // assumptions
+                    continue;
+                }
+
+                add_access(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, *ac_inst);
+            }
+
+            const spirv::Instruction* sampler_load = module.FindDef(inst->Word(4));
+            if (sampler_load->Opcode() == spv::OpLoad) {
+                const spirv::Instruction* ac_inst = module.FindDef(sampler_load->Word(3));
+                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
+                    assert(false);  // assumptions
+                    continue;
+                }
+
+                add_access(VK_DESCRIPTOR_TYPE_SAMPLER, *ac_inst);
+            }
+        }
+    }
+    return accesses;
+}
+
+bool CommandBufferSubState::DumpDescriptorHeapUntyped(std::ostringstream& ss, const ShaderStageState& stage) const {
+    bool found_warning = false;
+
+    std::shared_ptr<const spirv::Module> module_state_ptr = stage.spirv_state;
+    std::shared_ptr<const spirv::EntryPoint> entrypoint_ptr = stage.entrypoint;
+
+    // TODO - try to not to have to call spirv-opt here
+    auto const& specialization_info = stage.GetSpecializationInfo();
+    if (module_state_ptr->static_data_.has_specialization_constants && specialization_info != nullptr &&
+        specialization_info->mapEntryCount > 0 && specialization_info->pMapEntries != nullptr) {
+        spvtools::OptimizerOptions spirv_options;
+        spvtools::Optimizer optimizer(PickSpirvEnv(dev_data.api_version, IsExtEnabled(dev_data.extensions.vk_khr_spirv_1_4)));
+
+        // Gather the specialization-constant values.
+        auto const& specialization_data = reinterpret_cast<uint8_t const*>(specialization_info->pData);
+        std::unordered_map<uint32_t, std::vector<uint32_t>> id_value_map;
+        id_value_map.reserve(specialization_info->mapEntryCount);
+
+        // < spec_id, map_entry_index >
+        vvl::unordered_map<uint32_t, uint32_t> spec_constant_data;
+
+        for (const auto& [result_id, spec_id] : module_state_ptr->static_data_.id_to_spec_id) {
+            for (uint32_t i = 0; i < specialization_info->mapEntryCount; i++) {
+                if (specialization_info->pMapEntries[i].constantID != spec_id) {
+                    continue;
+                }
+                const VkSpecializationMapEntry map_entry = specialization_info->pMapEntries[i];
+                if ((map_entry.offset + map_entry.size) <= specialization_info->dataSize) {
+                    // Allocate enough room for ceil(map_entry.size / 4) to store entries
+                    std::vector<uint32_t> entry_data((map_entry.size + 4 - 1) / 4, 0);
+                    uint8_t* out_p = reinterpret_cast<uint8_t*>(entry_data.data());
+                    const uint8_t* const start_in_p = specialization_data + map_entry.offset;
+                    const uint8_t* const end_in_p = start_in_p + map_entry.size;
+
+                    std::copy(start_in_p, end_in_p, out_p);
+                    id_value_map.emplace(map_entry.constantID, std::move(entry_data));
+                }
+                break;
+            }
+        }
+        optimizer.RegisterPass(spvtools::CreateSetSpecConstantDefaultValuePass(id_value_map));
+        optimizer.RegisterPass(spvtools::CreateFreezeSpecConstantValuePass());
+        optimizer.RegisterPass(spvtools::CreateFoldSpecConstantOpAndCompositePass());
+
+        std::vector<uint32_t> specialized_spirv;
+        auto const optimized =
+            optimizer.Run(module_state_ptr->words_.data(), module_state_ptr->words_.size(), &specialized_spirv, spirv_options);
+        if (optimized) {
+            module_state_ptr =
+                std::make_shared<spirv::Module>(vvl::make_span<const uint32_t>(specialized_spirv.data(), specialized_spirv.size()));
+            entrypoint_ptr = module_state_ptr->FindEntrypoint(entrypoint_ptr->name.c_str(), entrypoint_ptr->stage);
+        }
+    }
+
+    const spirv::Module& module = *module_state_ptr;
+    const spirv::EntryPoint& entrypoint = *entrypoint_ptr;
+
+    // The idea is to go through and find all the access and afterwards sort/group them to make sense to the user
+    // < variable id, [accesses]>
+    vvl::unordered_map<uint32_t, HeapAccesses> accesses = DumpDescriptorHeapUntypedFindAccess(module, entrypoint);
+
+    // We print out the variables, but the real "value" comes from scaning the accesses
+    // (due to how untyped pointers work)
+    for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
+        if (!resource_variable.IsHeap()) {
+            continue;
+        }
+        ss << "  - " << resource_variable.DescribeDescriptor() << " accesses detected:\n";
+        auto it = accesses.find(resource_variable.id);
+        if (it == accesses.end()) {
+            ss << "    - No accesses found to this heap variable\n";
+            continue;
+        }
+
+        const bool is_sampler = resource_variable.is_sampler_heap;
+        auto heap_range = is_sampler ? base.descriptor_heap.sampler_range : base.descriptor_heap.resource_range;
+        auto reserve_range = is_sampler ? base.descriptor_heap.sampler_reserved : base.descriptor_heap.resource_reserved;
+
+        for (const HeapAccess& access : it->second) {
+            ss << "    - heap offset: 0x" << std::hex << access.heap_offset;
+            if (access.array_stride != 0) {
+                ss << ", array stride: 0x" << access.array_stride;
+            }
+
+            const bool dynamic_index = access.descriptor_index == vvl::kNoIndex32;
+            VkDeviceSize final_address = vvl::kNoIndex32;
+            if (!dynamic_index) {
+                if (access.descriptor_index != 0) {
+                    ss << ", array index[" << std::dec << access.descriptor_index << "]\n";
+                } else if (access.array_stride != 0) {
+                    ss << ", single element\n";  // if not array stride, this is pointless
+                }
+                const VkDeviceSize final_offset = access.heap_offset + (access.array_stride * access.descriptor_index);
+                final_address = heap_range.begin + final_offset;
+                ss << "      - " << (is_sampler ? "Sampler" : "Resource") << " heap address: 0x" << std::hex << final_address
+                   << '\n';
+            } else {
+                ss << " (dynamic index)\n";
+            }
+
+            VkDeviceSize descriptor_size = dev_data.device_state->cached_descriptor_size.GetSize(access.descriptor_type);
+            ss << "      - descriptor size: 0x" << std::hex << descriptor_size << " ("
+               << string_VkDescriptorType(access.descriptor_type) << ")\n";
+
+            // if we know the real address, see if invalid
+            if (final_address != vvl::kNoIndex32) {
+                if (final_address > heap_range.end) {
+                    ss << "      - [WARNING] OUT OF BOUNDS - the descriptor is not in the " << (is_sampler ? "sampler" : "resource")
+                       << " heap\n";
+                    found_warning = true;
+                }
+                vvl::range<VkDeviceAddress> final_range{final_address, final_address + descriptor_size};
+                if (final_range.intersects(reserve_range)) {
+                    ss << "      - [WARNING] RESERVED RANGE - this descriptor overlaps with the reserved range\n";
+                    found_warning = true;
+                }
+
+                VkDeviceSize required_alignment = GetDescriptorAlignment(access.descriptor_type, dev_data.phys_dev_ext_props);
+                if (!IsPointerAligned(final_address, required_alignment)) {
+                    vvl::Field alignment_name = GetDescriptorAlignmentField(access.descriptor_type);
+                    ss << "      - [WARNING] MISALIGNED - the descriptor is not aligned to " << String(alignment_name);
+                    ss << " (0x" << std::hex << required_alignment << ")\n";
+                    found_warning = true;
+                }
+            }
+        }
+    }
+
+    return found_warning;
+}
+
 bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const LastBound& last_bound) const {
     bool found_warning = false;
     const vvl::CommandBuffer& cb_state = last_bound.cb_state;
@@ -1309,13 +1635,15 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
         // Want to sort and print all the mappings for a given Set together
         std::map<uint32_t, std::vector<MappingInfo>> mapping_info_map;
 
+        // possible to have a mix-and-match
+        bool has_non_heap = false;
+        bool has_heap = false;
         for (const spirv::ResourceInterfaceVariable& resource_variable : entry_point.resource_interface_variables) {
             if (resource_variable.IsHeap()) {
-                // TODO detect offsets from start of heap and other info
-                ss << "  - " << resource_variable.DescribeDescriptor();
-                continue;
+                has_heap = true;
+                continue;  // handled later
             }
-
+            has_non_heap = true;
             const uint32_t var_set = resource_variable.decorations.set;
 
             for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
@@ -1327,7 +1655,7 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             }
         }
 
-        if (mapping_info_map.empty()) {
+        if (mapping_info_map.empty() && has_non_heap) {
             ss << "    - No VkDescriptorSetAndBindingMappingEXT were found for this shader\n";
             continue;
         }
@@ -1338,6 +1666,10 @@ bool CommandBufferSubState::DumpDescriptorHeap(std::ostringstream& ss, const Las
             for (const MappingInfo& set_info : mapping_info_list) {
                 found_warning |= DumpDescriptorHeapMapping(ss, set_info);
             }
+        }
+
+        if (has_heap) {
+            found_warning |= DumpDescriptorHeapUntyped(ss, *stage);
         }
     }
     return found_warning;

--- a/layers/gpu_dump/gpu_dump_state.h
+++ b/layers/gpu_dump/gpu_dump_state.h
@@ -14,14 +14,42 @@
  * limitations under the License.
  */
 #pragma once
+#include <vulkan/vulkan_core.h>
 #include <cstdint>
 #include "chassis/layer_object_id.h"
+#include "containers/custom_containers.h"
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/cmd_buffer_state.h"
 
 namespace gpudump {
 class GpuDump;
 struct MappingInfo;
+
+struct HeapAccess {
+    VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+    // These are zero because if not found, it means it is implicitly zero
+    // This also allows for better hashes being the same
+    uint32_t heap_offset = 0;
+    uint32_t array_stride = 0;
+    uint32_t descriptor_index = vvl::kNoIndex32;
+
+    struct compare {
+        bool operator()(HeapAccess const& lhs, HeapAccess const& rhs) const {
+            return lhs.descriptor_type == rhs.descriptor_type && lhs.heap_offset == rhs.heap_offset &&
+                   lhs.array_stride == rhs.array_stride && lhs.descriptor_index == rhs.descriptor_index;
+        }
+    };
+
+    // We don't want duplicate accesses being spammed
+    struct hash {
+        std::size_t operator()(HeapAccess const& access) const {
+            hash_util::HashCombiner hc;
+            hc << access.descriptor_type << access.heap_offset << access.array_stride << access.descriptor_index;
+            return hc.Value();
+        }
+    };
+};
+using HeapAccesses = vvl::unordered_set<HeapAccess, HeapAccess::hash, HeapAccess::compare>;
 
 class CommandBufferSubState : public vvl::CommandBufferSubState {
   public:
@@ -45,6 +73,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     // Return true if warning found
     bool DumpDescriptorHeap(std::ostringstream& ss, const LastBound& last_bound) const;
     bool DumpDescriptorHeapMapping(std::ostringstream& ss, const MappingInfo& mapping_info) const;
+    vvl::unordered_map<uint32_t, HeapAccesses> DumpDescriptorHeapUntypedFindAccess(const spirv::Module& module,
+                                                                                   const spirv::EntryPoint& entrypoint) const;
+    bool DumpDescriptorHeapUntyped(std::ostringstream& ss, const ShaderStageState& stage) const;
 
     bool DumpCopyMemoryIndirectCommon(std::ostringstream& ss, uint32_t copy_count,
                                       VkStridedDeviceAddressRangeKHR copy_address_range) const;

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "type_manager.h"
+#include <vulkan/vulkan_core.h>
 #include <cstdint>
 #include <spirv/unified1/spirv.hpp>
 #include "containers/container_utils.h"
@@ -986,20 +987,17 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
             if (image_type->spv_type_ == SpvType::kSampledImage) {
                 path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_SAMPLED;
             } else {
-                const bool is_sampled_without_sampler = image_type->inst_.Word(7) == 2;
-                spv::Dim image_dim = spv::Dim(image_type->inst_.Word(3));
-                if (is_sampled_without_sampler) {
-                    if (image_dim == spv::DimSubpassData) {
-                        path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_INPUT_ATTACHMENT;
-                    } else if (image_dim == spv::DimBuffer) {
-                        path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_TEXEL_BUFFER_STORAGE;
-                    } else {
-                        path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_STORAGE;
-                    }
-                } else if (image_dim == spv::DimBuffer) {
-                    path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_TEXEL_BUFFER_UNIFORM;
-                } else {
+                const VkDescriptorType image_descriptor_type = image_type->inst_.GetImageType();
+                if (image_descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) {
                     path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_SAMPLED;
+                } else if (image_descriptor_type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
+                    path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_INPUT_ATTACHMENT;
+                } else if (image_descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
+                    path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_STORAGE;
+                } else if (image_descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
+                    path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_TEXEL_BUFFER_STORAGE;
+                } else if (image_descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
+                    path.descriptor_type = gpuav::descriptor::TYPE_IMAGE_TEXEL_BUFFER_UNIFORM;
                 }
             }
         } else if (path.access_type->spv_type_ == SpvType::kAccelerationStructureKHR) {

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -16,6 +16,7 @@
 #include <spirv/unified1/spirv.hpp>
 #include <sstream>
 #include "state_tracker/shader_instruction.h"
+#include <vulkan/vulkan_core.h>
 #include "generated/spirv_grammar_helper.h"
 #include "state_tracker/shader_module.h"
 
@@ -212,6 +213,25 @@ bool Instruction::IsUntypedAccessChain() const {
            opcode == spv::OpUntypedPtrAccessChainKHR || opcode == spv::OpUntypedInBoundsPtrAccessChainKHR;
 }
 
+VkDescriptorType Instruction::GetImageType() const {
+    assert(Opcode() == spv::OpTypeImage);
+    const bool is_sampled_without_sampler = Word(7) == 2;
+    spv::Dim image_dim = spv::Dim(Word(3));
+    if (is_sampled_without_sampler) {
+        if (image_dim == spv::DimSubpassData) {
+            return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+        } else if (image_dim == spv::DimBuffer) {
+            return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+        } else {
+            return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        }
+    } else if (image_dim == spv::DimBuffer) {
+        return VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    } else {
+        return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    }
+}
+
 bool Instruction::IsTensor() const { return (Opcode() == spv::OpTypeTensorARM); }
 
 // Returns "any" constant
@@ -255,6 +275,7 @@ spv::StorageClass Instruction::StorageClass() const {
         case spv::OpTypePointer:
         case spv::OpTypeForwardPointer:
         case spv::OpTypeUntypedPointerKHR:
+        case spv::OpTypeBufferEXT:
             storage_class = static_cast<spv::StorageClass>(Word(2));
             break;
         case spv::OpVariable:

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <vulkan/vulkan.h>
 #include <cassert>
 #include <cstdint>
 #include <string>
@@ -81,6 +82,7 @@ class Instruction {
     bool IsAccessChain() const;
     bool IsUntypedAccessChain() const;
     // Helpers for OpTypeImage
+    VkDescriptorType GetImageType() const;
     bool IsTensor() const;
     bool IsConstant() const;
     bool IsSpecConstant() const;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -98,6 +98,9 @@ void DecorationBase::AddId(uint32_t decoration, uint32_t id) {
         case spv::DecorationOffsetIdEXT:
             offset_id = id;
             break;
+        case spv::DecorationArrayStrideIdEXT:
+            array_stride_id = id;
+            break;
         default:
             break;
     }
@@ -1019,6 +1022,12 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
                 } else if (insn.Word(2) == spv::DecorationSpecId) {
                     id_to_spec_id[target_id] = insn.Word(3);
                 }
+            } break;
+            case spv::OpDecorateId: {
+                const uint32_t target_id = insn.Word(1);
+                decorations[target_id].AddId(insn.Word(2), insn.Word(3));
+                // TODO - Not adding to decoration_inst until find a reason
+                // (loops using it likely assume it is only OpDecorate)
             } break;
             case spv::OpMemberDecorate: {
                 const uint32_t target_id = insn.Word(1);

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -89,7 +89,9 @@ struct DecorationBase {
 
     uint32_t offset = kInvalidValue;
     uint32_t offset_id = kInvalidValue;  // OffsetIdEXT
+    uint32_t array_stride_id = kInvalidValue;  // ArrayStrideIdEXT
     uint32_t GetOffset(const Module& module_state) const;
+    uint32_t GetArrayStride(const Module& module_state) const;
 
     // A given object can only have a single BuiltIn OpDecoration
     spv::BuiltIn built_in = kInvalidBuiltIn;
@@ -569,6 +571,7 @@ struct EntryPoint {
 
     // All ids that can be accessed from the entry point
     // being accessed doesn't guarantee it is statically used
+    // TODO - Break this into a Function struct
     const vvl::unordered_set<uint32_t> accessible_ids;
 
     // only one Push Constant block is allowed per entry point

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -9,12 +9,14 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 // stype-check off
+#include <spirv-tools/libspirv.h>
 #include <vulkan/vulkan_core.h>
 #include <cstdint>
 #include "../framework/layer_validation_tests.h"
 #include "descriptor_helper.h"
 #include "generated/vk_function_pointers.h"
 #include "pipeline_helper.h"
+#include "shader_helper.h"
 #include "shader_templates.h"
 #include "utils/math_utils.h"
 
@@ -1507,6 +1509,88 @@ TEST_F(NegativeGpuDump, DescriptorHeapPushAddressBufferType) {
     m_command_buffer.PushData(8, sizeof(VkDeviceAddress), &indirect_ubo_address);
 
     m_errorMonitor->SetDesiredWarning("BUFFER TYPE");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, DescriptorHeapUntypedPointers) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitDescriptorHeap());
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0 || heap_props.minSamplerHeapReservedRange != 0) {
+        GTEST_SKIP() << "heapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    VkDeviceSize heap_size = Align((resource_stride * 4), resource_stride);
+    vkt::Buffer resource_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+    vkt::Buffer sampler_heap(*m_device, heap_props.samplerDescriptorSize, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT,
+                             vkt::device_address);
+
+    const char* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_descriptor_heap : require
+        #extension GL_EXT_nonuniform_qualifier : require
+        layout (set = 0, binding = 0) uniform UBO { uint a; };
+        layout (set = 0, binding = 1) buffer SSBO { uint b; };
+        layout(descriptor_heap) buffer Heap { uint c; } heap[];
+        layout(descriptor_heap) uniform HeapX { uint d; } heapX[];
+        layout(descriptor_heap) uniform texture2D heapT[];
+        layout(descriptor_heap) uniform sampler heapS[];
+        layout(push_constant) uniform PushConstant {
+            uint pc;
+        };
+        void main() {
+            b = a;
+            heap[0].c = a;
+            heap[2].c = pc;
+            heap[2].c += 2;
+            uint x = heapX[b].d;
+            uint y = heapX[a].d;
+            uint z = heapX[114].d;
+
+            vec4 data = texture(sampler2D(heapT[0], heapS[0]), vec2(0));
+            vec4 data2 = texture(sampler2D(heapT[b], heapS[1]), vec2(0));
+        }
+    )glsl";
+    VkShaderObj cs_module = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3);
+
+    m_command_buffer.Begin();
+
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = resource_heap.AddressRange();
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+    bind_resource_info.heapRange = sampler_heap.AddressRange();
+    vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_resource_info);
+
+    VkDescriptorSetAndBindingMappingEXT mappings[2];
+    mappings[0] = MakeSetAndBindingMapping(0, 0);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[1] = MakeSetAndBindingMapping(0, 1);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset.heapOffset = (uint32_t)resource_stride;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 2u;
+    mapping_info.pMappings = mappings;
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo(&mapping_info);
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    pipe.CreateComputePipeline(false);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+
+    uint32_t push_data = 0;
+    m_command_buffer.PushData(0, sizeof(uint32_t), &push_data);
+    m_errorMonitor->SetDesiredWarning("OUT OF BOUNDS");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
Provides message like

```
- Shader descriptors:
  [VK_SHADER_STAGE_COMPUTE_BIT] VkShaderModule 0x110000000011
  - [Sampler Heap, variable "sampler_heap"] accesses detected:
    - heap offset: 0x0, array stride: 0x20, single element
      - Sampler heap address: 0x300010000
      - descriptor size: 0x20 (VK_DESCRIPTOR_TYPE_SAMPLER)
  - [Resource Heap, variable "resource_heap"] accesses detected:
    - heap offset: 0x0, array stride: 0x40, single element
      - Resource heap address: 0x300000000
      - descriptor size: 0x40 (VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)
    - heap offset: 0x0, array stride: 0x40, array index[16]
      - Resource heap address: 0x300000400
      - descriptor size: 0x40 (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
```

and provides 3 warnings (OOB, Reserved Range, and alignment)

ran on all our untyped pointer tests and CTS