### PR TITLE
layers: Add tile shading runtime spirv vuids (2/2)

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -34,6 +34,7 @@
 #include "generated/error_location_helper.h"
 #include "generated/spirv_grammar_helper.h"
 #include "generated/vk_extension_helper.h"
+#include "generated/dispatch_functions.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/descriptor_mode.h"
 #include "state_tracker/image_state.h"
@@ -1687,6 +1688,26 @@ bool CoreChecks::ValidateActionStateTileShading(const LastBound& last_bound_stat
     const VkPipelineBindPoint bind_point = last_bound_state.bind_point;
     const LogObjectList objlist = cb_state.GetObjectList(bind_point);
     const bool in_tile_shading_rp = cb_state.active_render_pass && cb_state.active_render_pass->has_tile_shading_enabled;
+    std::vector<uint32_t> tile_size_depths{};
+
+    // Note: Only query VkTilePropertiesQCOM when enabled tileProperties feature
+    if (enabled_features.tileProperties && cb_state.active_render_pass && cb_state.active_render_pass->has_tile_shading_enabled) {
+        if (cb_state.active_render_pass->use_dynamic_rendering) {
+            VkTilePropertiesQCOM queried_tile_props = vku::InitStructHelper();
+            DispatchGetDynamicRenderingTilePropertiesQCOM(device, cb_state.active_render_pass->dynamic_rendering_begin_rendering_info.ptr(),
+                                                          &queried_tile_props);
+            tile_size_depths.emplace_back(queried_tile_props.tileSize.depth);
+        } else {
+            std::vector<VkTilePropertiesQCOM> queried_tile_props{};
+            uint32_t tile_props_size = 0;
+            DispatchGetFramebufferTilePropertiesQCOM(device, cb_state.active_framebuffer->VkHandle(), &tile_props_size, nullptr);
+            queried_tile_props.resize(tile_props_size, vku::InitStructHelper());
+            DispatchGetFramebufferTilePropertiesQCOM(device, cb_state.active_framebuffer->VkHandle(), &tile_props_size, queried_tile_props.data());
+            for (uint32_t index = 0; index < tile_props_size; ++index) {
+                tile_size_depths.emplace_back(queried_tile_props[index].tileSize.depth);
+            }
+        }
+    }
 
     if (cb_state.per_tile_execution_model_enabled) {
         if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS && !enabled_features.tileShadingPerTileDraw) {
@@ -1735,6 +1756,33 @@ bool CoreChecks::ValidateActionStateTileShading(const LastBound& last_bound_stat
                              "model is not enabled in the current render pass. "
                              "(Did you forget to call vkCmdBeginPerTileExecutionQCOM)",
                              shader_stage->entrypoint->Describe().c_str());
+        }
+
+        if (shader_stage->entrypoint->stage != VK_SHADER_STAGE_COMPUTE_BIT ||
+            !shader_stage->entrypoint->execution_mode.Has(spirv::ExecutionModeSet::tile_shading_rate_bit)) {
+            continue;
+        }
+
+        const uint32_t tile_shading_rate_z = shader_stage->entrypoint->execution_mode.local_size.z;
+        for (uint32_t index = 0; index < tile_size_depths.size(); ++index) {
+            if (tile_shading_rate_z > tile_size_depths[index]) {
+                skip |= LogError("VUID-RuntimeSpirv-z-10704", objlist, loc,
+                                 "shader %s has OpExecutionMode TileShadingRateQCOM with z = %" PRIu32
+                                 ", which exceeds VkTilePropertiesQCOM::tileSize.depth (%" PRIu32 ").",
+                                 shader_stage->entrypoint->Describe().c_str(),
+                                 tile_shading_rate_z, tile_size_depths[index]);
+
+            }
+            if (tile_shading_rate_z != 0 &&
+                (tile_size_depths[index] % tile_shading_rate_z) != 0) {
+                skip |= LogError("VUID-RuntimeSpirv-tileSize-10705", objlist, loc,
+                                 "shader %s has OpExecutionMode TileShadingRateQCOM, but "
+                                 "VkTilePropertiesQCOM::tileSize.depth (%" PRIu32 ") is not divisible by "
+                                 "TileShadingRateQCOM::z (%" PRIu32 ").",
+                                 shader_stage->entrypoint->Describe().c_str(),
+                                 tile_size_depths[index], tile_shading_rate_z);
+
+            }
         }
     }
 

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -801,6 +801,18 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
                          FormatHandle(image_view).c_str(), DescribeInstruction().c_str());
     }
 
+    if (!dev_proxy.enabled_features.tileShadingImageProcessing &&
+        !sampler_states.empty() && resource_variable.storage_class == spv::StorageClassTileAttachmentQCOM &&
+        (resource_variable.info.image_insn.image_proc_usage_mask & spirv::ImageProcUsageBit::kImageSampled) != 0) {
+        const LogObjectList objlist(this->objlist, descriptor_set.Handle(), image_view);
+        skip |= LogError("VUID-RuntimeSpirv-tileShadingImageProcessing-10712", objlist, loc.Get(),
+                         "the %s is TileAttachmentQCOM storage class, it is backed by %s which is "
+                         "consumed by image-processing instruction, but "
+                         "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShadingImageProcessing isn't enabled.%s",
+                         DescribeDescriptor(resource_variable, index, descriptor_type).c_str(),
+                         FormatHandle(image_view).c_str(), DescribeInstruction().c_str());
+    }
+
     // If the Image View is invalid, the combined sampler mayb have the same issue
     if (skip) return skip;
 

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -624,6 +624,31 @@ ImageInstruction::ImageInstruction(const uint32_t* words) {
         case spv::OpAtomicExchange:
             break;
 
+        case spv::OpImageSampleWeightedQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kSampleWeighted;
+            break;
+        case spv::OpImageBoxFilterQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kBoxFilter;
+            break;
+        case spv::OpImageBlockMatchSADQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kBlockMatchSad;
+            break;
+        case spv::OpImageBlockMatchSSDQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kBlockMatchSsd;
+            break;
+        case spv::OpImageBlockMatchGatherSADQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kBlockMatchGatherSad;
+            break;
+        case spv::OpImageBlockMatchGatherSSDQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kBlockMatchGatherSsd;
+            break;
+        case spv::OpImageBlockMatchWindowSADQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kBlockMatchWindowSad;
+            break;
+        case spv::OpImageBlockMatchWindowSSDQCOM:
+            image_proc_usage_mask |= ImageProcUsageBit::kBlockMatchWindowSsd;
+            break;
+
         case spv::OpImageSparseTexelsResident:
             assert(false);  // This is not a proper OpImage* instruction, has no OpImage operand
             break;

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -153,6 +153,26 @@ class Instruction {
 #endif
 };
 
+namespace ImageProcUsageBit {
+    constexpr uint32_t kNone = 0;
+    // VK_QCOM_image_processing
+    constexpr uint32_t kSampleWeighted = 1 << 0;
+    constexpr uint32_t kBoxFilter = 1 << 1;
+    constexpr uint32_t kBlockMatchSsd = 1 << 2;
+    constexpr uint32_t kBlockMatchSad = 1 << 3;
+    // VK_QCOM_image_processing2
+    constexpr uint32_t kBlockMatchWindowSsd = 1 << 4;
+    constexpr uint32_t kBlockMatchWindowSad = 1 << 5;
+    constexpr uint32_t kBlockMatchGatherSsd = 1 << 6;
+    constexpr uint32_t kBlockMatchGatherSad = 1 << 7;
+    // Aggregate
+    constexpr uint32_t kBlockMatchWindow = kBlockMatchWindowSsd | kBlockMatchWindowSad |
+                                           kBlockMatchGatherSsd | kBlockMatchGatherSad;
+    constexpr uint32_t kBlockMatch = kBlockMatchSsd | kBlockMatchSad | kBlockMatchWindow;
+    constexpr uint32_t kNonBoxFilter = kSampleWeighted | kBlockMatch;
+    constexpr uint32_t kImageSampled = kSampleWeighted | kBoxFilter | kBlockMatch;
+}  // namespace ImageProcUsageBit
+
 // All information about a OpImage* instructions
 //
 // It is deliberately here to showcase how it is independent of the module itself
@@ -167,6 +187,9 @@ struct ImageInstruction {
     // Only need to check if one access has explicit signedness, mixing should be caught in spirv-val
     bool is_sign_extended = false;
     bool is_zero_extended = false;
+
+    // Image processing instruction usage mask
+    uint32_t image_proc_usage_mask = ImageProcUsageBit::kNone;
 
     explicit ImageInstruction(const uint32_t* words);
     ImageInstruction(){};  // used for static variables to set defaults

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -815,12 +815,24 @@ StaticImageAccess::StaticImageAccess(const Module& module_state, const Instructi
         }
     };
 
-    const uint32_t image_operand = OpcodeImageAccessPosition(image_opcode);
+    // VK_QCOM_image_processing
+    const bool has_image_proc = ((image_insn.image_proc_usage_mask & ImageProcUsageBit::kImageSampled) != 0);
+
+    const uint32_t image_operand = has_image_proc ? 3 : OpcodeImageAccessPosition(image_opcode);
     assert(image_operand != 0);
     const Instruction* find_insn = module_state.FindDef(insn.Word(image_operand));
     walk_to_variables(find_insn, false);
     for (const auto* sampler_insn : sampler_insn_to_search) {
         walk_to_variables(sampler_insn, true);
+    }
+
+    // Need to walk again for the reference/weights
+    if (has_image_proc && ((image_insn.image_proc_usage_mask & ImageProcUsageBit::kNonBoxFilter) != 0)) {
+        const Instruction* ref_insn = module_state.FindDef(insn.Word(5));
+        walk_to_variables(ref_insn, false);
+        for (const auto* sampler_insn : sampler_insn_to_search) {
+            walk_to_variables(sampler_insn, true);
+        }
     }
 }
 
@@ -1096,7 +1108,15 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
             case spv::OpImageSparseFetch:
             case spv::OpImageSparseGather:
             case spv::OpFragmentFetchAMD:
-            case spv::OpFragmentMaskFetchAMD: {
+            case spv::OpFragmentMaskFetchAMD:
+            case spv::OpImageSampleWeightedQCOM:
+            case spv::OpImageBoxFilterQCOM:
+            case spv::OpImageBlockMatchSADQCOM:
+            case spv::OpImageBlockMatchSSDQCOM:
+            case spv::OpImageBlockMatchGatherSADQCOM:
+            case spv::OpImageBlockMatchGatherSSDQCOM:
+            case spv::OpImageBlockMatchWindowSADQCOM:
+            case spv::OpImageBlockMatchWindowSSDQCOM: {
                 image_instructions.push_back(&insn);
                 break;
             }
@@ -1144,6 +1164,15 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
                 // All Image atomics go through here.
                 // Currrently only interested if used/accessed
                 image_instructions.push_back(&insn);
+                if (stateless_data) {
+                    stateless_data->image_texel_pointer_inst.push_back(&insn);
+                }
+                break;
+            }
+            case spv::OpUntypedImageTexelPointerEXT: {
+                if (stateless_data) {
+                    stateless_data->image_texel_pointer_inst.push_back(&insn);
+                }
                 break;
             }
             case spv::OpTypeStruct: {
@@ -2544,6 +2573,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
                 info.image_insn.is_sampler_offset |= image_access.image_insn.is_sampler_offset;
                 info.image_insn.is_sign_extended |= image_access.image_insn.is_sign_extended;
                 info.image_insn.is_zero_extended |= image_access.image_insn.is_zero_extended;
+                info.image_insn.image_proc_usage_mask |= image_access.image_insn.image_proc_usage_mask;
 
                 access_mask |= image_access.access_mask;
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -658,6 +658,7 @@ struct StatelessData {
     std::vector<const Instruction *> transform_feedback_stream_inst;
     std::vector<const Instruction *> fma_inst;
     std::vector<const Instruction *> tensor_inst;
+    std::vector<const Instruction *> image_texel_pointer_inst;
 
     // simpler to just track all OpExecutionModeId and parse things needed later
     std::vector<const Instruction *> execution_mode_id_inst;

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -61,6 +61,18 @@ static void GetVariableInfo(const spirv::Module& module_state, const spirv::Inst
     }
 }
 
+static bool IsTileAttachmentImagePointer(const spirv::Module& module_state, uint32_t image_id) {
+    const auto* insn = module_state.FindDef(image_id);
+    if (!insn) {
+        return false;
+    }
+
+    // Note: Every pointer-producing instruction carries a result type of OpTypePointer
+    //       or OpTypeUntypedPointerKHR, both of which encode the storage class.
+    const auto* type_insn = module_state.FindDef(insn->TypeId());
+    return type_insn && type_insn->StorageClass() == spv::StorageClassTileAttachmentQCOM;
+}
+
 SpirvValidator::SpirvValidator(DebugReport* debug_report, const vvl::StatelessDeviceData& stateless_device_data, bool disabled)
     : Logger(debug_report),
       disabled(disabled),
@@ -120,6 +132,10 @@ bool SpirvValidator::Validate(const spirv::Module& module_state, const spirv::St
         skip |= ValidateTransformFeedbackEmitStreams(module_state, entry_point, stateless_data, loc);
         skip |= ValidateShaderTensor(module_state, entry_point, stateless_data, loc);
         skip |= ValidateTileShadingCapability(module_state, entry_point, stateless_data, loc);
+    }
+
+    if (enabled_features.tileShading) {
+        skip |= ValidateTileShadingAtomicAccess(module_state, stateless_data, loc);
     }
 
     return skip;
@@ -1669,6 +1685,29 @@ bool SpirvValidator::ValidateTileShadingCapability(const spirv::Module& module_s
                              entrypoint.Describe().c_str(),
                              entrypoint.execution_mode.local_size.y,
                              phys_dev_ext_props.tile_shading_props.maxTileShadingRate.height);
+        }
+    }
+
+    return skip;
+}
+
+
+bool SpirvValidator::ValidateTileShadingAtomicAccess(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,
+                                                     const Location &loc) const {
+    bool skip = false;
+    const bool has_tile_shading_capability = module_state.HasCapability(spv::CapabilityTileShadingQCOM);
+
+    if (has_tile_shading_capability && !enabled_features.tileShadingAtomicOps) {
+        for (auto &instruction : stateless_data.image_texel_pointer_inst) {
+            const uint32_t opcode = instruction->Opcode();
+            const uint32_t image_id = (opcode == spv::OpImageTexelPointer) ? instruction->Word(3) : instruction->Word(4);
+            if (IsTileAttachmentImagePointer(module_state, image_id)) {
+                skip |= LogError("VUID-RuntimeSpirv-OpImage-10706", module_state.handle(), loc,
+                                 "SPIR-V is using an image pointer with TileAttachmentQCOM storage class consumed by %s, "
+                                 "but tileShadingAtomicOps was not enabled.\n%s\n",
+                                 opcode == spv::OpImageTexelPointer ? "OpImageTexelPointer" : "OpUntypedImageTexelPointerEXT",
+                                 module_state.DescribeInstruction(*instruction).c_str());
+            }
         }
     }
 

--- a/layers/stateless/sl_spirv.h
+++ b/layers/stateless/sl_spirv.h
@@ -97,6 +97,7 @@ class SpirvValidator : public Logger {
     bool ValidateShaderTensor(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint, const spirv::StatelessData &stateless_data, const Location& loc) const;
     bool ValidateTileShadingCapability(const spirv::Module &module_state, const spirv::EntryPoint &entrypoint,
                                        const spirv::StatelessData &stateless_data, const Location &loc) const;
+    bool ValidateTileShadingAtomicAccess(const spirv::Module &module_state, const spirv::StatelessData &stateless_data, const Location &loc) const;
 
     // Auto-generated helper functions
     bool ValidateShaderCapabilitiesAndExtensions(const spirv::Module& module_state, const spirv::Instruction& insn,

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -2340,6 +2340,12 @@
                         "height": 64
                     }
                 },
+                "VkPhysicalDeviceImageProcessing2PropertiesQCOM": {
+                    "maxBlockMatchWindow": {
+                        "width": 32,
+                        "height": 32
+                    }
+                },
                 "VkPhysicalDeviceExternalFormatResolvePropertiesANDROID": {
                     "nullColorAttachmentWithExternalFormatResolve": false
                 },
@@ -3206,6 +3212,8 @@
                             "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM",
+                            "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
+                            "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM",
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_QUANTIZATION_DELTA_MAP_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_EMPHASIS_MAP_BIT_KHR"
                         ],
@@ -3866,7 +3874,9 @@
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_COPY_IMAGE_INDIRECT_DST_BIT_KHR",
-                            "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM"
+                            "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM",
+                            "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM",
+                            "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM"
                         ],
                         "bufferFeatures": [
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -544,6 +544,7 @@ class TileShadingTest : public VkLayerTest {
         VkExtent2D rt_size = {64, 64};
         VkExtent2D tile_apron_size = {0, 0};
         bool use_render_pass2 = false;
+        bool block_match_usage = false;
     } tile_shading_rp_config;
 
     void InitBasicTileShading();

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -2983,3 +2983,855 @@ TEST_F(NegativeTileShading, TileShadingSampledAttachmentsFeatureNotEnabled) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }
+
+TEST_F(NegativeTileShading, MaxTileShadingRateDepth) {
+    TEST_DESCRIPTION("Launch a compute pass with TileShadingRateQCOM.z exceeding "
+                     "VkPhysicalDeviceTileShadingPropertiesQCOM::maxTileShadingRate::depth.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::tileShadingDispatchTile);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Don't support query dynamic tile properties on Vulkan Mock Device, skipping test.";
+    }
+
+    InitTileShadingRenderTarget();
+
+    uint32_t tile_prop_count = 0;
+    std::vector<VkTilePropertiesQCOM> tile_props{};
+    vk::GetFramebufferTilePropertiesQCOM(device(), m_tile_shading_framebuffer, &tile_prop_count, nullptr);
+    tile_props.resize(tile_prop_count, vku::InitStructHelper());
+    vk::GetFramebufferTilePropertiesQCOM(device(), m_tile_shading_framebuffer, &tile_prop_count, tile_props.data());
+
+    uint32_t invalid_depth = 1;
+    for (uint32_t index = 0; index < tile_prop_count; ++index) {
+        invalid_depth = std::max(invalid_depth, tile_props[index].tileSize.depth);
+    }
+    invalid_depth <<= 1;
+
+    const std::string cs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main"
+                OpExecutionMode %main TileShadingRateQCOM 1 1 )asm" + std::to_string(invalid_depth) + '\n' +
+                R"asm(
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    compute_pipe.CreateComputePipeline();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0,0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+    VkDispatchTileInfoQCOM dispatch_tile_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-z-10704");
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-tileSize-10705");
+    vk::CmdDispatchTileQCOM(m_command_buffer, &dispatch_tile_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, MaxTileShadingRateDepthInDynamicRendering) {
+    TEST_DESCRIPTION("Launch a compute pass with TileShadingRateQCOM.z exceeding "
+                     "VkPhysicalDeviceTileShadingPropertiesQCOM::maxTileShadingRate::depth.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::tileShadingDispatchTile);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Don't support query dynamic tile properties on Vulkan Mock Device, skipping test.";
+    }
+
+    tile_shading_rp_config.rt_size = {512, 512};
+    InitTileShadingRenderTarget();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = m_color_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_ci = vku::InitStructHelper();
+    tile_shading_ci.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_ci.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_ci);
+    rendering_info.renderArea = {{0, 0}, tile_shading_rp_config.rt_size};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_props = vku::InitStructHelper();
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_props);
+    const uint32_t invalid_depth = tile_props.tileSize.depth << 1;
+
+    const std::string cs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main"
+                OpExecutionMode %main TileShadingRateQCOM 1 1 )asm" + std::to_string(invalid_depth) + '\n' +
+                R"asm(
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    compute_pipe.CreateComputePipeline();
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+    VkDispatchTileInfoQCOM dispatch_tile_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-z-10704");
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-tileSize-10705");
+    vk::CmdDispatchTileQCOM(m_command_buffer, &dispatch_tile_info);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, TileImageConsumedByTexelPointerOpButAtomicOpsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Use OpImageTexelPointer that consumes an image variable with TileAttachmentQCOM storage class, "
+                     "but tileShadingAtomicOps is not enabled.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const char* cs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main" %tile_img
+                OpExecutionMode %main TileShadingRateQCOM 1 1 1
+                OpDecorate %tile_img DescriptorSet 0
+                OpDecorate %tile_img Binding 0
+        %void = OpTypeVoid
+          %fn = OpTypeFunction %void
+        %uint = OpTypeInt 32 0
+         %int = OpTypeInt 32 1
+       %v2int = OpTypeVector %int 2
+       %int_0 = OpConstant %int 0
+       %coord = OpConstantComposite %v2int %int_0 %int_0
+      %uint_0 = OpConstant %uint 0
+    %image_ty = OpTypeImage %uint 2D 0 0 0 2 R32ui
+ %tile_ptr_ty = OpTypePointer TileAttachmentQCOM %image_ty
+    %tile_img = OpVariable %tile_ptr_ty TileAttachmentQCOM
+%texel_ptr_ty = OpTypePointer Image %uint
+        %main = OpFunction %void None %fn
+       %label = OpLabel
+         %ptr = OpImageTexelPointer %texel_ptr_ty %tile_img %coord %uint_0
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpImage-10706");
+    VkShaderObj cs{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, TileImageConsumedByTexelPointerOpViaAccessChainButAtomicOpsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Use OpImageTexelPointer on a tile attachment image pointer obtained via OpAccessChain, "
+                     "but tileShadingAtomicOps feature is not enabled.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const char* cs_source = R"asm(
+                OpCapability Shader
+                OpCapability TileShadingQCOM
+                OpExtension "SPV_QCOM_tile_shading"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint GLCompute %main "main" %tile_img
+                OpExecutionMode %main TileShadingRateQCOM 1 1 1
+                OpDecorate %tile_img DescriptorSet 0
+                OpDecorate %tile_img Binding 0
+        %void = OpTypeVoid
+          %fn = OpTypeFunction %void
+        %uint = OpTypeInt 32 0
+         %int = OpTypeInt 32 1
+       %v2int = OpTypeVector %int 2
+       %int_0 = OpConstant %int 0
+       %int_1 = OpConstant %int 1
+       %coord = OpConstantComposite %v2int %int_0 %int_0
+      %uint_0 = OpConstant %uint 0
+    %image_ty = OpTypeImage %uint 2D 0 0 0 2 R32ui
+      %arr_ty = OpTypeArray %image_ty %int_1
+ %tile_ptr_ty = OpTypePointer TileAttachmentQCOM %arr_ty
+  %img_ptr_ty = OpTypePointer TileAttachmentQCOM %image_ty
+    %tile_img = OpVariable %tile_ptr_ty TileAttachmentQCOM
+%texel_ptr_ty = OpTypePointer Image %uint
+        %main = OpFunction %void None %fn
+       %label = OpLabel
+      %elem_p = OpAccessChain %img_ptr_ty %tile_img %int_0
+         %ptr = OpImageTexelPointer %texel_ptr_ty %elem_p %coord %uint_0
+                OpReturn
+                OpFunctionEnd
+    )asm";
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpImage-10706");
+    VkShaderObj cs{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM};
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, TileImageAtomicOpButAtomicOpsFeatureNotEnabled) {
+    TEST_DESCRIPTION("Execute an image atomic operation on a tile attachment, "
+                     "but tileShadingAtomicOps feature is not enabled.");
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM, r32ui) uniform uimage2D tile_img;
+
+        void main() {
+            imageAtomicExchange(tile_img, ivec2(0, 0), 1u);
+        }
+    )glsl";
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpImage-10706");
+    VkShaderObj cs{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeTileShading, UseSampleWeightedImageOpButTileShadingImageProcessingNotEnabled) {
+    TEST_DESCRIPTION("Use OpImageSampleWeightedQCOM with an OpTypeSampledImage declared in the TileAttachmentQCOM storage class, "
+                     "but tileShadingImageProcessing is not enabled.");
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureSampleWeighted);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const auto query_format_features2 = [this] (VkFormat format) {
+        VkFormatProperties3 format_props3 = vku::InitStructHelper();
+        VkFormatProperties2 format_props2 = vku::InitStructHelper(&format_props3);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props2);
+        return format_props3.optimalTilingFeatures;
+    };
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : {VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8_UNORM, VK_FORMAT_R16G16_UNORM}) {
+        const auto features = query_format_features2(format);
+        if ((features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (features & VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM) != 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+    VkFormat weight_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : {VK_FORMAT_R16_SFLOAT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_UNORM}) {
+        const auto features = query_format_features2(format);
+        if ((features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (features & VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM) != 0) {
+            weight_format = format;
+            break;
+        }
+    }
+    if (sampled_format == VK_FORMAT_UNDEFINED || weight_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find a format supporting OpImageSampleWeightedQCOM, skipping test.";
+    }
+
+    InitTileShadingRenderTarget();
+
+    VkPhysicalDeviceImageProcessingPropertiesQCOM image_processing_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(image_processing_props);
+
+    VkImageCreateInfo weight_image_ci = vku::InitStructHelper();
+    weight_image_ci.imageType = VK_IMAGE_TYPE_2D;
+    weight_image_ci.format = weight_format;
+    weight_image_ci.extent = {image_processing_props.maxWeightFilterDimension.width,
+                              image_processing_props.maxWeightFilterDimension.height, 1};
+    weight_image_ci.mipLevels = 1;
+    weight_image_ci.arrayLayers = 1;
+    weight_image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    weight_image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    weight_image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_SAMPLE_WEIGHT_BIT_QCOM;
+    vkt::Image weight_image{*m_device, weight_image_ci};
+
+    VkImageViewSampleWeightCreateInfoQCOM weight_view_weight_ci = vku::InitStructHelper();
+    weight_view_weight_ci.filterCenter = {0, 0};
+    weight_view_weight_ci.filterSize = image_processing_props.maxWeightFilterDimension;
+    weight_view_weight_ci.numPhases = 1;
+    VkImageViewCreateInfo weight_view_ci = vku::InitStructHelper(&weight_view_weight_ci);
+    weight_view_ci.image = weight_image;
+    weight_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+    weight_view_ci.format = weight_format;
+    weight_view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkt::ImageView weight_view{*m_device, weight_view_ci};
+
+    VkSamplerCreateInfo sampler_ci = vku::InitStructHelper();
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.magFilter = VK_FILTER_NEAREST;
+    sampler_ci.minFilter = VK_FILTER_NEAREST;
+    sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    vkt::Sampler sampler{*m_device, sampler_ci};
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM) uniform sampler2D sampled_tex;
+        layout(set = 0, binding = 1) uniform texture2DArray weight_tex;
+        layout(set = 0, binding = 2) uniform sampler processing_sampler;
+
+        void main() {
+            vec4 result = textureWeightedQCOM(
+                sampled_tex,
+                vec2(0.5, 0.5),
+                sampler2DArray(weight_tex, processing_sampler)
+            );
+        }
+    )glsl";
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
+    compute_pipe.dsl_bindings_ = {
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}
+    };
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                                          VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, weight_view, nullptr,
+                                                          VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(2, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0,0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-tileShadingImageProcessing-10712");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, UseBoxFilterImageOpButTileShadingImageProcessingNotEnabled) {
+    TEST_DESCRIPTION("Use OpImageBoxFilterQCOM with an OpTypeSampledImage declared in TileAttachmentQCOM storage class, "
+                     "but tileShadingImageProcessing is not enabled.");
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureBoxFilter);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const auto query_format_features2 = [this] (VkFormat format) {
+        VkFormatProperties3 format_props3 = vku::InitStructHelper();
+        VkFormatProperties2 format_props2 = vku::InitStructHelper(&format_props3);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props2);
+        return format_props3.optimalTilingFeatures;
+    };
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : {VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8_UNORM, VK_FORMAT_R16G16_UNORM}) {
+        const auto features = query_format_features2(format);
+        if ((features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (features & VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM) != 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+    if (sampled_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find a format supporting OpImageBoxFilterQCOM, skipping test.";
+    }
+
+    InitTileShadingRenderTarget();
+
+    VkSamplerCreateInfo sampler_ci = vku::InitStructHelper();
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.magFilter = VK_FILTER_NEAREST;
+    sampler_ci.minFilter = VK_FILTER_NEAREST;
+    sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    vkt::Sampler sampler{*m_device, sampler_ci};
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM) uniform sampler2D sampled_tex;
+
+        void main() {
+            vec4 result = textureBoxFilterQCOM(
+                sampled_tex,
+                vec2(0.5, 0.5),
+                vec2(2.0, 2.0)
+            );
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
+    compute_pipe.dsl_bindings_ = {
+        {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+    };
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                                          VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0,0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-tileShadingImageProcessing-10712");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, UseBlockMatchImageOpButTileShadingImageProcessingNotEnabled) {
+    TEST_DESCRIPTION("Use OpImageBlockMatchSADQCOM and OpImageBlockMatchSSDQCOM with an OpTypeSampledImage declared in "
+                     "TileAttachmentQCOM storage class as the target image, but tileShadingImageProcessing is not enabled.");
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const auto query_format_features2 = [this](VkFormat format) {
+        VkFormatProperties3 format_props3 = vku::InitStructHelper();
+        VkFormatProperties2 format_props2 = vku::InitStructHelper(&format_props3);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props2);
+        return format_props3.optimalTilingFeatures;
+    };
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : {VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8_UNORM, VK_FORMAT_R16_UNORM}) {
+        const auto features = query_format_features2(format);
+        if ((features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (features & VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM) != 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+    if (sampled_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find a format supporting OpImageBlockMatchSADQCOM, skipping test.";
+    }
+
+    tile_shading_rp_config.format = sampled_format;
+    tile_shading_rp_config.block_match_usage = true;
+    InitTileShadingRenderTarget();
+
+    vkt::Image ref_image{*m_device, tile_shading_rp_config.rt_size.width, tile_shading_rp_config.rt_size.height, sampled_format,
+                         VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_SAMPLE_BLOCK_MATCH_BIT_QCOM};
+    vkt::ImageView ref_view = ref_image.CreateView();
+
+    VkSamplerCreateInfo sampler_ci = vku::InitStructHelper();
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.magFilter = VK_FILTER_NEAREST;
+    sampler_ci.minFilter = VK_FILTER_NEAREST;
+    sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    vkt::Sampler sampler{*m_device, sampler_ci};
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM) uniform texture2D target_tex;
+        layout(set = 0, binding = 1) uniform texture2D ref_tex;
+        layout(set = 0, binding = 2) uniform sampler processing_sampler;
+
+        void main() {
+            uvec2 target_coord = uvec2(0, 0);
+            uvec2 ref_coord = uvec2(4, 4);
+            uvec2 block_size = uvec2(4, 4);
+            vec4 result1 = textureBlockMatchSADQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord,
+                block_size
+            );
+            vec4 result2 = textureBlockMatchSSDQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord,
+                block_size
+            );
+        }
+    )glsl";
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
+    compute_pipe.dsl_bindings_ = {
+        {0, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}
+    };
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, nullptr,
+                                                          VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, ref_view, nullptr,
+                                                          VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(2, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0, 0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-tileShadingImageProcessing-10712");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, UseBlockMatchWindowImageOpButTileShadingImageProcessingNotEnabled) {
+    TEST_DESCRIPTION("Use OpImageBlockMatchWindowSSDQCOM and OpImageBlockMatchWindowSADQCOM with an OpTypeSampledImage in "
+                     "TileAttachmentQCOM storage class as the target image, but tileShadingImageProcessing is not enabled.");
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const auto query_format_features2 = [this] (VkFormat format) {
+        VkFormatProperties3 format_props3 = vku::InitStructHelper();
+        VkFormatProperties2 format_props2 = vku::InitStructHelper(&format_props3);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props2);
+        return format_props3.optimalTilingFeatures;
+    };
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : {VK_FORMAT_R8_UNORM, VK_FORMAT_R16G16B16A16_UNORM, VK_FORMAT_R8G8B8A8_UNORM}) {
+        const auto features = query_format_features2(format);
+        if ((features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (features & VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM) != 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+    if (sampled_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find a format supporting OpImageBlockMatchWindowSSDQCOM, skipping test.";
+    }
+
+    VkPhysicalDeviceImageProcessing2PropertiesQCOM image_processing2_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(image_processing2_props);
+
+    tile_shading_rp_config.format = sampled_format;
+    tile_shading_rp_config.block_match_usage = true;
+    InitTileShadingRenderTarget();
+
+    vkt::Image ref_image{*m_device, tile_shading_rp_config.rt_size.width, tile_shading_rp_config.rt_size.height, sampled_format,
+                         VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_SAMPLE_BLOCK_MATCH_BIT_QCOM};
+    vkt::ImageView ref_view = ref_image.CreateView();
+
+    VkSamplerBlockMatchWindowCreateInfoQCOM block_match_window_ci = vku::InitStructHelper();
+    block_match_window_ci.windowExtent = image_processing2_props.maxBlockMatchWindow;
+    block_match_window_ci.windowCompareMode = VK_BLOCK_MATCH_WINDOW_COMPARE_MODE_MIN_QCOM;
+    VkSamplerCreateInfo sampler_ci = vku::InitStructHelper(&block_match_window_ci);
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.magFilter = VK_FILTER_NEAREST;
+    sampler_ci.minFilter = VK_FILTER_NEAREST;
+    sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    vkt::Sampler sampler{*m_device, sampler_ci};
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+        #extension GL_QCOM_image_processing2: require
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM) uniform texture2D target_tex;
+        layout(set = 0, binding = 1) uniform texture2D ref_tex;
+        layout(set = 0, binding = 2) uniform sampler processing_sampler;
+
+        void main() {
+            uvec2 target_coord = uvec2(0, 0);
+            uvec2 ref_coord = uvec2(0, 0);
+            uvec2 block_size = uvec2(4, 4);
+            vec4 result1 = textureBlockMatchWindowSSDQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord,
+                block_size
+            );
+            vec4 result2 = textureBlockMatchWindowSADQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord,
+                block_size
+            );
+        }
+    )glsl";
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
+    compute_pipe.dsl_bindings_ = {
+        {0, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}
+    };
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, nullptr,
+                                                          VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, ref_view, nullptr,
+                                                          VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(2, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0, 0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-tileShadingImageProcessing-10712");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeTileShading, UseBlockMatchGatherImageOpButTileShadingImageProcessingNotEnabled) {
+    TEST_DESCRIPTION("Use OpImageBlockMatchGatherSSDQCOM and OpImageBlockMatchGatherSADQCOM with an OpTypeSampledImage declared in "
+                     "TileAttachmentQCOM storage class as the target image, but tileShadingImageProcessing is not enabled.");
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch2);
+    RETURN_IF_SKIP(InitBasicTileShading());
+
+    const auto query_format_features2 = [this] (VkFormat format) {
+        VkFormatProperties3 format_props3 = vku::InitStructHelper();
+        VkFormatProperties2 format_props2 = vku::InitStructHelper(&format_props3);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props2);
+        return format_props3.optimalTilingFeatures;
+    };
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : {VK_FORMAT_R8_UNORM, VK_FORMAT_R16G16B16A16_UNORM, VK_FORMAT_R8G8B8A8_UNORM}) {
+        const auto features = query_format_features2(format);
+        if ((features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (features & VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM) != 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+    if (sampled_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find a format supporting OpImageBlockMatchGatherSSDQCOM, skipping test.";
+    }
+
+    VkPhysicalDeviceImageProcessing2PropertiesQCOM image_processing2_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(image_processing2_props);
+
+    tile_shading_rp_config.format = sampled_format;
+    tile_shading_rp_config.block_match_usage = true;
+    InitTileShadingRenderTarget();
+
+    vkt::Image ref_image{*m_device, tile_shading_rp_config.rt_size.width, tile_shading_rp_config.rt_size.height, sampled_format,
+                         VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_SAMPLE_BLOCK_MATCH_BIT_QCOM};
+    vkt::ImageView ref_view = ref_image.CreateView();
+
+    VkSamplerBlockMatchWindowCreateInfoQCOM block_match_window_ci = vku::InitStructHelper();
+    block_match_window_ci.windowExtent = image_processing2_props.maxBlockMatchWindow;
+    block_match_window_ci.windowCompareMode = VK_BLOCK_MATCH_WINDOW_COMPARE_MODE_MIN_QCOM;
+    VkSamplerCreateInfo sampler_ci = vku::InitStructHelper(&block_match_window_ci);
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.magFilter = VK_FILTER_NEAREST;
+    sampler_ci.minFilter = VK_FILTER_NEAREST;
+    sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    vkt::Sampler sampler{*m_device, sampler_ci};
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+        #extension GL_QCOM_image_processing2: require
+        #extension GL_QCOM_tile_shading : require
+
+        layout(shading_rate_xQCOM = 1, shading_rate_yQCOM = 1, shading_rate_zQCOM = 1) in;
+        layout(set = 0, binding = 0, tile_attachmentQCOM) uniform texture2D target_tex;
+        layout(set = 0, binding = 1) uniform texture2D ref_tex;
+        layout(set = 0, binding = 2) uniform sampler processing_sampler;
+
+        void main() {
+            uvec2 target_coord = uvec2(0, 0);
+            uvec2 ref_coord = uvec2(0, 0);
+            uvec2 block_size = uvec2(4, 4);
+            vec4 result1 = textureBlockMatchGatherSSDQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord,
+                block_size
+            );
+            vec4 result2 = textureBlockMatchGatherSADQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord,
+                block_size
+            );
+        }
+    )glsl";
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
+    CreateComputePipelineHelper compute_pipe{*this};
+    compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
+    compute_pipe.dsl_bindings_ = {
+        {0, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}
+    };
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, m_color_view, nullptr,
+                                                          VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, ref_view, nullptr,
+                                                          VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, VK_IMAGE_LAYOUT_GENERAL);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(2, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    VkClearValue clear_color{};
+    clear_color.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
+
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
+    rp_begin_info.renderPass = m_tile_shading_render_pass;
+    rp_begin_info.framebuffer = m_tile_shading_framebuffer;
+    rp_begin_info.renderArea = {{0, 0}, tile_shading_rp_config.rt_size};
+    rp_begin_info.clearValueCount = 1;
+    rp_begin_info.pClearValues = &clear_color;
+
+    VkPerTileBeginInfoQCOM per_tile_begin_info = vku::InitStructHelper();
+    VkPerTileEndInfoQCOM per_tile_end_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp_begin_info);
+    vk::CmdBeginPerTileExecutionQCOM(m_command_buffer, &per_tile_begin_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE,
+                              compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-tileShadingImageProcessing-10712");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    vk::CmdEndPerTileExecutionQCOM(m_command_buffer, &per_tile_end_info);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}

--- a/tests/unit/tile_shading_positive.cpp
+++ b/tests/unit/tile_shading_positive.cpp
@@ -31,10 +31,13 @@ void TileShadingTest::InitBasicTileShading() {
 }
 
 void TileShadingTest::InitTileShadingRenderTarget() {
+    VkImageUsageFlags image_usages = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                     VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+    if (tile_shading_rp_config.block_match_usage) {
+        image_usages |= VK_IMAGE_USAGE_SAMPLE_BLOCK_MATCH_BIT_QCOM;
+    }
     m_color_image.Init(*m_device, tile_shading_rp_config.rt_size.width, tile_shading_rp_config.rt_size.height, 1,
-                       tile_shading_rp_config.format,
-                       VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-                       VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
+                       tile_shading_rp_config.format, image_usages);
     m_color_view = m_color_image.CreateView();
 
     if (tile_shading_rp_config.use_render_pass2) {


### PR DESCRIPTION
# Overview
Add runtime SPIR-V validation for 4 tile shading VUIDs:

- **`VUID-RuntimeSpirv-z-10704`**
- **`VUID-RuntimeSpirv-tileSize-10705`**
- **`VUID-RuntimeSpirv-OpImage-10706`**
- **`VUID-RuntimeSpirv-tileShadingImageProcessing-10712`**

Add format feature and `maxBlockMatchWindow` properties information for `VK_QCOM_image_processing` and `VK_QCOM_image_processing2` in `max_profile.json`.

When using extensions such as `VK_QCOM_image_processing`, a false positive of **`VUID-VkComputePipelineCreateInfo-layout-07990`** may be triggered; this will be addressed in a follow-up.

Mark **`VUID-RuntimeSpirv-Coordinate-10713`** and **`VUID-RuntimeSpirv-Coordinate-10714`** validation as **`TODO`**, as they cannot be statically detected and require GPU-AV.

# Unit Tests
| Test | VUID |
|---|---|
| `MaxTileShadingRateDepth` | 10704 |
| `MaxTileShadingRateDepthInDynamicRendering` | 10704 |
| `TileImageConsumedByTexelPointerOpButAtomicOpsFeatureNotEnabled` | 10706, `OpVariable` via `SPIR-V ASM` |
| `TileImageConsumedByTexelPointerOpViaAccessChainButAtomicOpsFeatureNotEnabled` | 10706, `OpAccessChain` array index via `SPIR-V ASM` |
| `TileImageAtomicOpButAtomicOpsFeatureNotEnabled` | 10706, `imageAtomicExchange` via `GLSL` |
| `UseSampleWeightedImageOpButTileShadingImageProcessingNotEnabled` | 10712 |
| `UseBoxFilterImageOpButTileShadingImageProcessingNotEnabled` | 10712 |
| `UseBlockMatchImageOpButTileShadingImageProcessingNotEnabled` | 10712 |
| `UseBlockMatchWindowImageOpButTileShadingImageProcessingNotEnabled` | 10712 |
| `UseBlockMatchGatherImageOpButTileShadingImageProcessingNotEnabled` | 10712 |