### PR TITLE
layers: Rename EventSignalingState

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1131,8 +1131,8 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer& 
 }
 
 // Return the signal stage mask when it can be identified from recorded state
-static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent event, const EventSignalingState* prior_state,
-                                                                        const EventSignalingState* secondary_state) {
+static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent event, const EventSignalState* prior_state,
+                                                                        const EventSignalState* secondary_state) {
     if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
         if (secondary_state->signaled) {
             return secondary_state->signal_src_stage_mask;
@@ -1148,7 +1148,7 @@ static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent 
 // Return the last signaling command and does not take into acccount if it was ignored or not.
 // This is used for the set-wait version mismatch. The current validation logic considers
 // version mismtach to be an issue even if the command is ignored.
-static vvl::Func ResolveSignalingCommand(const EventSignalingState* prior_state, const EventSignalingState* secondary_state) {
+static vvl::Func ResolveSignalingCommand(const EventSignalState* prior_state, const EventSignalState* secondary_state) {
     if (secondary_state) {
         return secondary_state->last_signaling_command;
     }
@@ -1159,10 +1159,10 @@ static vvl::Func ResolveSignalingCommand(const EventSignalingState* prior_state,
 }
 
 // Return true when recorded state proves the event is unsignaled at the wait
-static bool IsKnownUnsignaled(VkEvent event, const EventSignalingStateMap& prior_signaling_states,
-                              const EventSignalingStateMap& secondary_signaling_states) {
-    const EventSignalingState* prior_state = vvl::Find(prior_signaling_states, event);
-    const EventSignalingState* secondary_state = vvl::Find(secondary_signaling_states, event);
+static bool IsKnownUnsignaled(VkEvent event, const EventSignalStateMap& prior_signal_states,
+                              const EventSignalStateMap& secondary_signal_states) {
+    const EventSignalState* prior_state = vvl::Find(prior_signal_states, event);
+    const EventSignalState* secondary_state = vvl::Find(secondary_signal_states, event);
 
     if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
         return !secondary_state->signaled;
@@ -1172,7 +1172,7 @@ static bool IsKnownUnsignaled(VkEvent event, const EventSignalingStateMap& prior
 
 bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBufferSubState& secondary_cb_sub_state,
                                                           const Location& secondary_cb_loc,
-                                                          EventSignalingStateMap& local_signaling_states) const {
+                                                          EventSignalStateMap& local_signal_states) const {
     bool skip = false;
     for (const WaitEventSubmitInfo& secondary_wait : secondary_cb_sub_state.wait_event_submit_infos) {
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
@@ -1180,8 +1180,8 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
         bool found_known_signals = false;
 
         for (VkEvent event : secondary_wait.wait_events) {
-            const EventSignalingState* local_state = vvl::Find(local_signaling_states, event);
-            const EventSignalingState* secondary_state = vvl::Find(secondary_wait.signaling_states, event);
+            const EventSignalState* local_state = vvl::Find(local_signal_states, event);
+            const EventSignalState* secondary_state = vvl::Find(secondary_wait.signal_states, event);
 
             // Validate set-wait version mismatch
             const vvl::Func signal_command = ResolveSignalingCommand(local_state, secondary_state);
@@ -1195,7 +1195,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
             if (auto stage_mask = ResolveKnownSignalStageMask(event, local_state, secondary_state)) {
                 signals_src_stage_mask |= *stage_mask;
                 found_known_signals = true;
-            } else if (IsKnownUnsignaled(event, local_signaling_states, secondary_wait.signaling_states)) {
+            } else if (IsKnownUnsignaled(event, local_signal_states, secondary_wait.signal_states)) {
                 // Contribute 0 (nothing) to signals_src_stage_mask
             } else {
                 can_validate_stage_mask = false;
@@ -1224,9 +1224,9 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
     for (const WaitEvent2SubmitInfo& secondary_wait : secondary_cb_sub_state.wait_event2_submit_infos) {
         // Set-wait version mismatch is always reported. Do not try to determine whether signal is ignored
         vvl::Func signaling_command = vvl::Func::Empty;
-        if (secondary_wait.signaling_state.has_value() && secondary_wait.signaling_state->signaled) {
-            signaling_command = secondary_wait.signaling_state->last_signaling_command;
-        } else if (const EventSignalingState* local_state = vvl::Find(local_signaling_states, secondary_wait.wait_event);
+        if (secondary_wait.signal_state.has_value() && secondary_wait.signal_state->signaled) {
+            signaling_command = secondary_wait.signal_state->last_signaling_command;
+        } else if (const EventSignalState* local_state = vvl::Find(local_signal_states, secondary_wait.wait_event);
                    local_state && local_state->signaled) {
             signaling_command = local_state->last_signaling_command;
         }
@@ -1236,7 +1236,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
                              FormatHandle(secondary_wait.wait_event).c_str(), vvl::String(signaling_command));
         }
     }
-    UpdateEventSignalingStates(local_signaling_states, secondary_cb_sub_state.event_signaling_states);
+    UpdateEventSignalStates(local_signal_states, secondary_cb_sub_state.event_signal_states);
     return skip;
 }
 
@@ -1517,7 +1517,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
     }
 
     vvl::unordered_map<VkCommandBuffer, uint32_t> duplicate_secondary_cb;
-    EventSignalingStateMap local_signaling_states = cb_sub_state.event_signaling_states;
+    EventSignalStateMap local_signal_states = cb_sub_state.event_signal_states;
     bool suspended_render_pass_instance =
         cb_state.last_suspend_state == vvl::CommandBuffer::SuspendState::Suspended && !cb_state.active_render_pass;
 
@@ -1640,7 +1640,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         skip |= ValidateSecondaryCommandBufferState(cb_state, secondary_sub_state, secondary_cb_loc);
         skip |= ValidateSecondaryCommandBufferQuery(cb_state, secondary_cb_state, secondary_cb_loc);
         skip |= ValidateSecondaryCommandBufferLayout(cb_state, secondary_cb_state, secondary_cb_loc);
-        skip |= ValidateSecondaryCommandBufferWaitEvents(secondary_sub_state, secondary_cb_loc, local_signaling_states);
+        skip |= ValidateSecondaryCommandBufferWaitEvents(secondary_sub_state, secondary_cb_loc, local_signal_states);
     }
 
     return skip;

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -49,7 +49,7 @@ struct CommandBufferSubmitState {
     // The "local" prefix is about tracking state accross command buffers of a *single* QueueSubmit command.
     // This does not accumulate state from the previous submissions.
     QueryMap local_query_to_state_map;
-    EventSignalingStateMap local_event_signal_info;
+    EventSignalStateMap local_event_signal_info;
     vvl::unordered_map<VkVideoSessionKHR, vvl::VideoSessionDeviceState> local_video_session_state{};
 
     CommandBufferSubmitState(const CoreChecks& c, const vvl::Queue& q) : core(c), queue_state(q) {
@@ -83,7 +83,7 @@ struct CommandBufferSubmitState {
         for (const WaitEvent2SubmitInfo& submit_info : cb_sub_state.wait_event2_submit_infos) {
             skip |= submit_info.Validate(core, queue_state, cb_state, local_event_signal_info, loc);
         }
-        UpdateEventSignalingStates(local_event_signal_info, cb_sub_state.event_signaling_states);
+        UpdateEventSignalStates(local_event_signal_info, cb_sub_state.event_signal_states);
 
         VkQueryPool first_perf_query_pool = VK_NULL_HANDLE;
         for (auto& function : cb_sub_state.query_updates) {

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -587,7 +587,7 @@ void CommandBufferSubState::RecordClearAttachments(uint32_t attachment_count, co
 }
 
 void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags stage_mask) {
-    if (EventSignalingState* state = vvl::Find(event_signaling_states, event)) {
+    if (EventSignalState* state = vvl::Find(event_signal_states, event)) {
         if (!state->signaled) {
             state->signaled = true;
             state->signal_src_stage_mask = stage_mask;
@@ -595,16 +595,16 @@ void CommandBufferSubState::RecordSetEvent(VkEvent event, VkPipelineStageFlags s
             // Keep was_reset unchanged
         }
     } else {
-        EventSignalingState new_state;
+        EventSignalState new_state;
         new_state.signaled = true;
         new_state.signal_src_stage_mask = stage_mask;
         new_state.last_signaling_command = vvl::Func::vkCmdSetEvent;
-        event_signaling_states.insert(std::make_pair(event, std::move(new_state)));
+        event_signal_states.insert(std::make_pair(event, std::move(new_state)));
     }
 }
 
 void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInfo& dependency_info, const Location& loc) {
-    if (EventSignalingState* state = vvl::Find(event_signaling_states, event)) {
+    if (EventSignalState* state = vvl::Find(event_signal_states, event)) {
         if (!state->signaled) {
             state->signaled = true;
             state->signal_dependency_info.emplace(&dependency_info);
@@ -612,19 +612,19 @@ void CommandBufferSubState::RecordSetEvent2(VkEvent event, const VkDependencyInf
             // Keep was_reset unchanged
         }
     } else {
-        EventSignalingState new_state;
+        EventSignalState new_state;
         new_state.signaled = true;
         new_state.signal_dependency_info.emplace(&dependency_info);
         new_state.last_signaling_command = loc.function;
-        event_signaling_states.insert(std::make_pair(event, std::move(new_state)));
+        event_signal_states.insert(std::make_pair(event, std::move(new_state)));
     }
 }
 
 void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags2, const Location& loc) {
-    EventSignalingState& signaling_state = event_signaling_states[event];
-    signaling_state = {};
-    signaling_state.was_reset = true;
-    signaling_state.last_signaling_command = loc.function;
+    EventSignalState& signal_state = event_signal_states[event];
+    signal_state = {};
+    signal_state.was_reset = true;
+    signal_state.last_signaling_command = loc.function;
     event_wait_states.erase(event);
 }
 
@@ -655,19 +655,19 @@ static VkPipelineStageFlags2 GetNewEventBarriersFromDependency(VkPipelineStageFl
 void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, VkPipelineStageFlags src_stage_mask,
                                              VkPipelineStageFlags dst_stage_mask, const Location& loc) {
     bool submit_validation = false;
-    EventSignalingStateMap signaling_states;
+    EventSignalStateMap signal_states;
 
     const VkPipelineStageFlags2 barriers = MakeEventBarriers(dst_stage_mask, base.GetQueueFlags());
 
     for (VkEvent event : events) {
         event_wait_states[event] = EventWaitState{barriers, loc.function};
 
-        EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
-        if (signaling_state) {
-            signaling_states.emplace(event, *signaling_state);
+        EventSignalState* signal_state = vvl::Find(event_signal_states, event);
+        if (signal_state) {
+            signal_states.emplace(event, *signal_state);
         }
         // NOTE: the same logic is used by the validation phase
-        const bool already_validated = signaling_state && signaling_state->HasKnownEffect();
+        const bool already_validated = signal_state && signal_state->HasKnownEffect();
         if (!already_validated) {
             submit_validation = true;
         }
@@ -676,7 +676,7 @@ void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, Vk
         WaitEventSubmitInfo submit_info;
         submit_info.wait_events.assign(events.begin(), events.end());
         submit_info.wait_src_stage_mask = src_stage_mask;
-        submit_info.signaling_states = std::move(signaling_states);
+        submit_info.signal_states = std::move(signal_states);
         submit_info.wait_command = loc.function;
         wait_event_submit_infos.emplace_back(std::move(submit_info));
     }
@@ -687,15 +687,15 @@ void CommandBufferSubState::RecordWaitEvent2(VkEvent event, const VkDependencyIn
     const VkPipelineStageFlags2 barriers = MakeEventBarriers(dst_stage_mask, base.GetQueueFlags());
     event_wait_states[event] = EventWaitState{barriers, loc.function};
 
-    EventSignalingState* signaling_state = vvl::Find(event_signaling_states, event);
-    const bool already_validated = signaling_state && signaling_state->was_reset;
+    EventSignalState* signal_state = vvl::Find(event_signal_states, event);
+    const bool already_validated = signal_state && signal_state->was_reset;
     const bool submit_validation = !already_validated;
     if (submit_validation) {
         WaitEvent2SubmitInfo submit_info;
         submit_info.wait_event = event;
         submit_info.wait_dependency_info = &dependency_info;
-        if (signaling_state) {
-            submit_info.signaling_state = *signaling_state;
+        if (signal_state) {
+            submit_info.signal_state = *signal_state;
         }
         submit_info.wait_command = loc.function;
         wait_event2_submit_infos.emplace_back(std::move(submit_info));
@@ -1210,7 +1210,7 @@ void CommandBufferSubState::ResetCBState() {
     custom_primitive_restart_index = 0;
 
     push_data_mask.clear();
-    event_signaling_states.clear();
+    event_signal_states.clear();
     event_wait_states.clear();
 
     // Submit time validation
@@ -1236,32 +1236,32 @@ void CommandBufferSubState::ResetCBState() {
 }
 
 static std::optional<WaitEventSubmitInfo> BuildSubmitTimeWaitInfo(const WaitEventSubmitInfo& secondary_wait,
-                                                                  const EventSignalingStateMap& primary_states) {
-    EventSignalingStateMap wait_signaling_states;
-    bool all_signaling_states_known = true;
+                                                                  const EventSignalStateMap& primary_states) {
+    EventSignalStateMap wait_signal_states;
+    bool all_signal_states_known = true;
     for (VkEvent event : secondary_wait.wait_events) {
-        const EventSignalingState* primary_state = vvl::Find(primary_states, event);
-        const EventSignalingState* secondary_state = vvl::Find(secondary_wait.signaling_states, event);
+        const EventSignalState* primary_state = vvl::Find(primary_states, event);
+        const EventSignalState* secondary_state = vvl::Find(secondary_wait.signal_states, event);
 
         const bool primary_state_known = primary_state && primary_state->HasKnownEffect();
         const bool secondary_state_known = secondary_state && secondary_state->HasKnownEffect(primary_state);
         if (secondary_state_known || (!primary_state && secondary_state)) {
-            wait_signaling_states[event] = *secondary_state;
+            wait_signal_states[event] = *secondary_state;
         } else if (primary_state) {
-            wait_signaling_states[event] = *primary_state;
+            wait_signal_states[event] = *primary_state;
         }
 
         const bool state_known = primary_state_known || secondary_state_known;
         if (!state_known) {
-            all_signaling_states_known = false;
+            all_signal_states_known = false;
         }
     }
-    if (all_signaling_states_known) {
+    if (all_signal_states_known) {
         // Record-time validation already had enough information, no need to schedule submit-time validation
         return {};
     }
     WaitEventSubmitInfo wait = secondary_wait;
-    wait.signaling_states = std::move(wait_signaling_states);
+    wait.signal_states = std::move(wait_signal_states);
     return wait;
 }
 
@@ -1272,17 +1272,17 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
     }
 
     for (const WaitEventSubmitInfo& secondary_wait : secondary_sub_state.wait_event_submit_infos) {
-        if (auto wait = BuildSubmitTimeWaitInfo(secondary_wait, event_signaling_states)) {
+        if (auto wait = BuildSubmitTimeWaitInfo(secondary_wait, event_signal_states)) {
             wait_event_submit_infos.emplace_back(std::move(*wait));
         }
     }
     for (const WaitEvent2SubmitInfo& secondary_wait : secondary_sub_state.wait_event2_submit_infos) {
-        const bool found_signaling_state = vvl::Contains(event_signaling_states, secondary_wait.wait_event);
-        if (!found_signaling_state) {
+        const bool found_signal_state = vvl::Contains(event_signal_states, secondary_wait.wait_event);
+        if (!found_signal_state) {
             wait_event2_submit_infos.emplace_back(secondary_wait);
         }
     }
-    UpdateEventSignalingStates(event_signaling_states, secondary_sub_state.event_signaling_states);
+    UpdateEventSignalStates(event_signal_states, secondary_sub_state.event_signal_states);
 
     // We don't currently merge secondary wait state precisely. Use a simplified model
     // that clears the current wait state and keeps only the secondary's final wait state.
@@ -1328,14 +1328,14 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
     }
 
     // Update global vvl:Event state with signaling state at the end of the command buffer
-    for (const auto& [event, signaling_state] : event_signaling_states) {
+    for (const auto& [event, signal_state] : event_signal_states) {
         if (auto event_state = base.dev_data.Get<vvl::Event>(event)) {
-            if (signaling_state.signaled) {
-                const bool can_signal = !event_state->signaled || signaling_state.was_reset;
+            if (signal_state.signaled) {
+                const bool can_signal = !event_state->signaled || signal_state.was_reset;
                 if (can_signal) {
                     event_state->signaled = true;
-                    event_state->signal_src_stage_mask = signaling_state.signal_src_stage_mask;
-                    event_state->signal_dependency_info = signaling_state.signal_dependency_info;
+                    event_state->signal_src_stage_mask = signal_state.signal_src_stage_mask;
+                    event_state->signal_dependency_info = signal_state.signal_dependency_info;
                     event_state->signaling_queue = queue_state.VkHandle();
                 }
             } else {
@@ -1344,7 +1344,7 @@ void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit
                 event_state->signal_dependency_info.reset();
                 event_state->signaling_queue = VK_NULL_HANDLE;
             }
-            event_state->last_signaling_command = signaling_state.last_signaling_command;
+            event_state->last_signaling_command = signal_state.last_signaling_command;
         }
     }
 

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -207,7 +207,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     std::vector<VkOffset2D> fragment_density_offsets;
 
     // Event state tracking
-    EventSignalingStateMap event_signaling_states;
+    EventSignalStateMap event_signal_states;
     EventWaitStateMap event_wait_states;
     std::vector<WaitEventSubmitInfo> wait_event_submit_infos;
     std::vector<WaitEvent2SubmitInfo> wait_event2_submit_infos;

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -401,13 +401,13 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location& signal_semaph
 }
 
 static bool ValidateEventQueueMismatch(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                                       const vvl::Event& event_state, const EventSignalingStateMap& submit_signaling_states,
+                                       const vvl::Event& event_state, const EventSignalStateMap& submit_signal_states,
                                        const Location& loc) {
     bool skip = false;
 
     // Check if prior command buffers from this submit contain signaling operation.
     // If yes, then everything is on the same queue
-    if (vvl::Contains(submit_signaling_states, event_state.VkHandle())) {
+    if (vvl::Contains(submit_signal_states, event_state.VkHandle())) {
         return skip;
     }
     // Check global event state
@@ -422,15 +422,15 @@ static bool ValidateEventQueueMismatch(const CoreChecks& core, const vvl::Queue&
 }
 
 bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                                   EventSignalingStateMap& submit_signaling_states, const Location& loc) const {
+                                   EventSignalStateMap& submit_signal_states, const Location& loc) const {
     bool skip = false;
 
     VkPipelineStageFlags signals_src_stage_mask = 0;
     bool set_wait_version_mismatch = false;  // if version mismatch is detected some other validations make no sense
     for (VkEvent event : wait_events) {
         if (auto event_state = core.Get<vvl::Event>(event)) {
-            if (!vvl::Contains(signaling_states, event)) {
-                skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signaling_states, loc);
+            if (!vvl::Contains(signal_states, event)) {
+                skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signal_states, loc);
             }
             // NOTE: for unsignaled events the signal_src_stage_mask is NONE
             VkPipelineStageFlags2 stage_mask = 0;
@@ -441,14 +441,14 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
                 last_signal = event_state->signaled;
                 signal_command = event_state->last_signaling_command;
             }
-            if (const auto* submit_signaling = vvl::Find(submit_signaling_states, event)) {
+            if (const auto* submit_signaling = vvl::Find(submit_signal_states, event)) {
                 if (!last_signal || submit_signaling->HasKnownEffect()) {
                     stage_mask = submit_signaling->signal_src_stage_mask;
                 }
                 last_signal = submit_signaling->signal_src_stage_mask;
                 signal_command = submit_signaling->last_signaling_command;
             }
-            if (const auto* cb_signaling = vvl::Find(signaling_states, event)) {
+            if (const auto* cb_signaling = vvl::Find(signal_states, event)) {
                 if (!last_signal || cb_signaling->HasKnownEffect()) {
                     stage_mask = cb_signaling->signal_src_stage_mask;
                 }
@@ -490,7 +490,7 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
 }
 
 bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                                    EventSignalingStateMap& submit_signaling_states, const Location& loc) const {
+                                    EventSignalStateMap& submit_signal_states, const Location& loc) const {
     bool skip = false;
 
     auto event_state = core.Get<vvl::Event>(wait_event);
@@ -498,16 +498,16 @@ bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& qu
         return skip;
     }
 
-    skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signaling_states, loc);
+    skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signal_states, loc);
 
     std::optional<vku::safe_VkDependencyInfo> signal_dependency_info;
     vvl::Func signal_command = vvl::Func::Empty;
-    if (signaling_state.has_value()) {
-        signal_dependency_info = signaling_state->signal_dependency_info;
-        signal_command = signaling_state->last_signaling_command;
-    } else if (const auto* submit_signaling_state = vvl::Find(submit_signaling_states, wait_event)) {
-        signal_dependency_info = submit_signaling_state->signal_dependency_info;
-        signal_command = submit_signaling_state->last_signaling_command;
+    if (signal_state.has_value()) {
+        signal_dependency_info = signal_state->signal_dependency_info;
+        signal_command = signal_state->last_signaling_command;
+    } else if (const auto* submit_signal_state = vvl::Find(submit_signal_states, wait_event)) {
+        signal_dependency_info = submit_signal_state->signal_dependency_info;
+        signal_command = submit_signal_state->last_signaling_command;
     } else {
         signal_dependency_info = event_state->signal_dependency_info;
         signal_command = event_state->last_signaling_command;
@@ -1567,21 +1567,21 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
         bool can_validate_stage_mask = true;
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
         for (uint32_t i = 0; i < eventCount; i++) {
-            const EventSignalingState* signaling_state = vvl::Find(cb_sub_state.event_signaling_states, pEvents[i]);
+            const EventSignalState* signal_state = vvl::Find(cb_sub_state.event_signal_states, pEvents[i]);
 
             // Record phase also uses this logic to determine stage mask validation status
-            if (!signaling_state || !signaling_state->HasKnownEffect()) {
+            if (!signal_state || !signal_state->HasKnownEffect()) {
                 can_validate_stage_mask = false;
             } else {
-                signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signaling_state->signal_src_stage_mask);
+                signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signal_state->signal_src_stage_mask);
             }
 
             // Set-wait version mismatch is always reported.
             // Do not try to determine whether signal is ignored
-            if (signaling_state &&
-                IsValueIn(signaling_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+            if (signal_state &&
+                IsValueIn(signal_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
                 skip |= LogError("VUID-vkCmdWaitEvents-pEvents-03847", pEvents[i], error_obj.location, "%s was set by %s.",
-                                 FormatHandle(pEvents[i]).c_str(), vvl::String(signaling_state->last_signaling_command));
+                                 FormatHandle(pEvents[i]).c_str(), vvl::String(signal_state->last_signaling_command));
             }
         }
         if (can_validate_stage_mask) {
@@ -1642,12 +1642,12 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
         }
         skip |= ValidateDependencyInfo(objlist, dep_info_loc, *cb_state, pDependencyInfos[i]);
 
-        if (const EventSignalingState* signaling_state = vvl::Find(cb_sub_state.event_signaling_states, pEvents[i])) {
+        if (const EventSignalState* signal_state = vvl::Find(cb_sub_state.event_signal_states, pEvents[i])) {
             // Set-wait version mismatch is always reported.
             // Do not try to determine whether signal is ignored
-            if (signaling_state->last_signaling_command == vvl::Func::vkCmdSetEvent) {
+            if (signal_state->last_signaling_command == vvl::Func::vkCmdSetEvent) {
                 skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03837", pEvents[i], error_obj.location, "%s was set by %s.",
-                                 FormatHandle(pEvents[i]).c_str(), vvl::String(signaling_state->last_signaling_command));
+                                 FormatHandle(pEvents[i]).c_str(), vvl::String(signal_state->last_signaling_command));
             }
         }
     }

--- a/layers/core_checks/cc_synchronization.h
+++ b/layers/core_checks/cc_synchronization.h
@@ -76,20 +76,20 @@ struct WaitEventSubmitInfo {
     VkPipelineStageFlags wait_src_stage_mask = VK_PIPELINE_STAGE_NONE;
 
     // Subset of waited events with known signaling state
-    EventSignalingStateMap signaling_states;
+    EventSignalStateMap signal_states;
 
     vvl::Func wait_command = vvl::Func::Empty;
 
     bool Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                  EventSignalingStateMap& submit_signaling_states, const Location& loc) const;
+                  EventSignalStateMap& submit_signal_states, const Location& loc) const;
 };
 
 struct WaitEvent2SubmitInfo {
     VkEvent wait_event = VK_NULL_HANDLE;
     vku::safe_VkDependencyInfo wait_dependency_info;
-    std::optional<EventSignalingState> signaling_state;
+    std::optional<EventSignalState> signal_state;
     vvl::Func wait_command = vvl::Func::Empty;
 
     bool Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                  EventSignalingStateMap& submit_signaling_states, const Location& loc) const;
+                  EventSignalStateMap& submit_signal_states, const Location& loc) const;
 };

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -434,8 +434,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                                                  const vvl::CommandBuffer& secondary_cb_state,
                                                                  const Location& secondary_cb_loc) const;
     bool ValidateSecondaryCommandBufferWaitEvents(const core::CommandBufferSubState& secondary_cb_sub_state,
-                                                  const Location& secondary_cb_loc,
-                                                  EventSignalingStateMap& local_signaling_state) const;
+                                                  const Location& secondary_cb_loc, EventSignalStateMap& local_signal_state) const;
     bool ValidateInheritanceInfoFramebuffer(const vvl::CommandBuffer& cb_state,
                                             const core::CommandBufferSubState& secondary_cb_state,
                                             const VkCommandBufferInheritanceInfo& secondary_inheritance_info,

--- a/layers/state_tracker/event_state.cpp
+++ b/layers/state_tracker/event_state.cpp
@@ -17,7 +17,7 @@
 
 #include "state_tracker/event_state.h"
 
-bool EventSignalingState::HasKnownEffect(const EventSignalingState* prior_state) const {
+bool EventSignalState::HasKnownEffect(const EventSignalState* prior_state) const {
     // After a reset, later signal/reset commands define the event state
     if (was_reset) {
         return true;
@@ -28,9 +28,9 @@ bool EventSignalingState::HasKnownEffect(const EventSignalingState* prior_state)
     return is_prior_unsignaled;
 }
 
-void UpdateEventSignalingStates(EventSignalingStateMap& accumulated_states, const EventSignalingStateMap& recorded_states) {
+void UpdateEventSignalStates(EventSignalStateMap& accumulated_states, const EventSignalStateMap& recorded_states) {
     for (const auto& [event, recorded_state] : recorded_states) {
-        EventSignalingState& accumulated_state = accumulated_states[event];
+        EventSignalState& accumulated_state = accumulated_states[event];
 
         const bool keep_accumulated_state = accumulated_state.signaled && !recorded_state.was_reset;
         if (keep_accumulated_state) {

--- a/layers/state_tracker/event_state.h
+++ b/layers/state_tracker/event_state.h
@@ -25,7 +25,7 @@
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <optional>
 
-struct EventSignalingState {
+struct EventSignalState {
     // Tracks how the event signaling state changes as command buffer recording progresses.
     // When recording is finished, this is the event state at the end of the command buffer
     bool signaled = false;
@@ -52,7 +52,7 @@ struct EventSignalingState {
     // are also ignored. We do not currently keep data associated with unsignals,
     // (and for signals we store stage mask/dependency info). Update this if we
     // need to track associated unsignal data.
-    bool HasKnownEffect(const EventSignalingState* prior_state = nullptr) const;
+    bool HasKnownEffect(const EventSignalState* prior_state = nullptr) const;
 };
 
 struct EventWaitState {
@@ -60,10 +60,10 @@ struct EventWaitState {
     vvl::Func last_wait_command = vvl::Func::Empty;
 };
 
-using EventSignalingStateMap = vvl::unordered_map<VkEvent, EventSignalingState>;
+using EventSignalStateMap = vvl::unordered_map<VkEvent, EventSignalState>;
 using EventWaitStateMap = vvl::unordered_map<VkEvent, EventWaitState>;
 
-void UpdateEventSignalingStates(EventSignalingStateMap& accumulated_states, const EventSignalingStateMap& recorded_states);
+void UpdateEventSignalStates(EventSignalStateMap& accumulated_states, const EventSignalStateMap& recorded_states);
 
 namespace vvl {
 


### PR DESCRIPTION
This state describes whether an event is signaled or unsignaled. "Signaling" was originally chosen to avoid implying it is only about signal but it felt always a bit awkward. SignalState feels more natural and pairs nicely with EventWaitState.