### PR TITLE
layers: Fix entrypoint access tracking

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2999,7 +2999,7 @@ bool CoreChecks::ValidateDataGraphConstants(const spirv::Module& module_spirv, c
 
     // loop over spirv constant definitions
     std::vector<bool> pConstant_matched(dg_shader_ci.constantCount, false);
-    for (auto constant_instr : entry_point.datagraph_constants) {
+    for (auto constant_instr : entry_point.accessible.graph_constant) {
         const spirv::Instruction& tensor_type_instr = *module_spirv.FindDef(constant_instr->TypeId());
 
         // the following checks are only for tensors. Any type other than tensor will throw an error executing spirv-val, which

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "generated/spirv_grammar_helper.h"
 #include "gpu_dump_state.h"
 #include "gpu_dump.h"
 #include <vulkan/vk_enum_string_helper.h>
@@ -1409,42 +1410,82 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
         accesses[variable_id].insert(HeapAccess{descriptor_type, heap_offset, array_stride_value, descriptor_index});
     };
 
-    for (auto accessible_id : entrypoint.accessible_ids) {
-        const spirv::Instruction* inst = module.FindDef(accessible_id);
+    for (const spirv::Instruction* memory_access_inst : entrypoint.accessible.memory_accesses) {
+        // Basically there are 2 flows, images and non-images
+        uint32_t ptr_id = OpcodeImageAccessPosition(memory_access_inst->Opcode());
+        const bool image_access = ptr_id != 0;
 
-        if (inst->Opcode() == spv::OpBufferPointerEXT) {
-            const spirv::Instruction* ac_inst = module.FindDef(inst->Word(3));
-            if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
-                assert(false);  // assumptions
+        if (image_access) {
+            const spirv::Instruction* sampler_load_inst = nullptr;
+
+            const spirv::Instruction* next_inst = module.FindDef(memory_access_inst->Word(ptr_id));
+            while (next_inst && (next_inst->Opcode() == spv::OpSampledImage || next_inst->Opcode() == spv::OpImage ||
+                                 next_inst->Opcode() == spv::OpCopyObject)) {
+                if (next_inst->Opcode() == spv::OpSampledImage) {
+                    sampler_load_inst = module.FindDef(next_inst->Operand(1));
+                }
+                next_inst = module.FindDef(next_inst->Operand(0));
+            }
+            const spirv::Instruction* image_load_inst = next_inst;
+            if (!image_load_inst || image_load_inst->Opcode() != spv::OpLoad) {
+                assert(false);
                 continue;
             }
 
-            // Ignore old BufferBlock + Uniform
-            const VkDescriptorType descriptor_type = module.FindDef(inst->TypeId())->StorageClass() == spv::StorageClassUniform
-                                                         ? VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
-                                                         : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            add_access(descriptor_type, *ac_inst);
-        } else if (inst->Opcode() == spv::OpSampledImage) {
-            const spirv::Instruction* image_load = module.FindDef(inst->Word(3));
-            if (image_load->Opcode() == spv::OpLoad) {
-                const spirv::Instruction* ac_inst = module.FindDef(image_load->Word(3));
+            // From here two types of images, sampled and non-sampled images
+            if (sampler_load_inst) {
+                // TODO - Assertion sampled images are 1D
+                const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
                 if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
                     assert(false);  // assumptions
                     continue;
                 }
-
                 add_access(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, *ac_inst);
-            }
 
-            const spirv::Instruction* sampler_load = module.FindDef(inst->Word(4));
-            if (sampler_load->Opcode() == spv::OpLoad) {
-                const spirv::Instruction* ac_inst = module.FindDef(sampler_load->Word(3));
+                ac_inst = module.FindDef(sampler_load_inst->Word(3));
+                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
+                    assert(false);  // assumptions
+                    continue;
+                }
+                add_access(VK_DESCRIPTOR_TYPE_SAMPLER, *ac_inst);
+            } else {
+                const spirv::Instruction* image_type = module.FindDef(image_load_inst->TypeId());
+                assert(image_type->Opcode() == spv::OpTypeImage);
+                const VkDescriptorType image_descriptor_type = image_type->GetImageType();
+
+                const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
+                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
+                    assert(false);  // assumptions
+                    continue;
+                }
+                add_access(image_descriptor_type, *ac_inst);
+            }
+        } else {
+            // |Operand 0| works for both Store/Load
+            ptr_id = memory_access_inst->Operand(0);
+
+            // We need to walk down possibly multiple chained OpAccessChains
+            const spirv::Instruction* next_access_chain = module.FindDef(ptr_id);
+            while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
+                const uint32_t base_operand = next_access_chain->IsUntypedAccessChain() ? 1 : 0;
+                const uint32_t access_chain_base_id = next_access_chain->Operand(base_operand);
+                next_access_chain = module.FindDef(access_chain_base_id);
+            }
+            const spirv::Instruction* base_type = next_access_chain;
+
+            if (base_type && base_type->Opcode() == spv::OpBufferPointerEXT) {
+                const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(3));
                 if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
                     assert(false);  // assumptions
                     continue;
                 }
 
-                add_access(VK_DESCRIPTOR_TYPE_SAMPLER, *ac_inst);
+                // Ignore old BufferBlock + Uniform
+                const VkDescriptorType descriptor_type =
+                    module.FindDef(base_type->TypeId())->StorageClass() == spv::StorageClassUniform
+                        ? VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+                        : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                add_access(descriptor_type, *ac_inst);
             }
         }
     }

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -767,28 +767,11 @@ const Constant& TypeManager::GetConstantNull(const Type& type) {
     return AddConstant(std::move(new_inst), type);
 }
 
-static bool IsAccessInstruction(const Instruction& inst) {
-    const spv::Op opcode = (spv::Op)inst.Opcode();
-    if (IsValueIn(opcode, {spv::OpLoad, spv::OpStore, spv::OpCooperativeMatrixLoadKHR, spv::OpCooperativeMatrixStoreKHR})) {
-        return true;
-    } else if (IsValueIn(opcode, {spv::OpImageTexelPointer, spv::OpImage})) {
-        // OpImageTexelPointer is for image atomics handled at the atomic instruction
-        // OpImage is describing an action, rather than the input to or the output from an action.
-        return false;
-    } else if (AtomicOperation(opcode)) {
-        return true;  // any atomic
-    } else if (OpcodeImageAccessPosition(opcode) != 0) {
-        return true;  // image access
-    }
-
-    return false;
-}
-
 // |ignore_image_sampler_skip| used for passes that don't care about safe_mode that want to ignore until we fix support
 const AccessPath TypeManager::BuildAccessPath(const Function& function, const Instruction& inst, bool ignore_image_sampler_skip) {
     AccessPath path;
 
-    if (!IsAccessInstruction(inst)) {
+    if (!inst.IsMemoryAccess()) {
         return path;
     }
 

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -213,6 +213,19 @@ bool Instruction::IsUntypedAccessChain() const {
            opcode == spv::OpUntypedPtrAccessChainKHR || opcode == spv::OpUntypedInBoundsPtrAccessChainKHR;
 }
 
+// These are all things known that do a memory access
+bool Instruction::IsMemoryAccess() const {
+    const uint32_t opcode = Opcode();
+    if (opcode == spv::OpImageTexelPointer || opcode == spv::OpImage) {
+        // OpImageTexelPointer is for image atomics handled at the atomic instruction
+        // OpImage is describing an action, rather than the input to or the output from an action.
+        return false;
+    }
+
+    return opcode == spv::OpLoad || opcode == spv::OpStore || opcode == spv::OpCooperativeMatrixLoadKHR ||
+           opcode == spv::OpCooperativeMatrixStoreKHR || AtomicOperation(opcode) || (OpcodeImageAccessPosition(opcode) != 0);
+}
+
 VkDescriptorType Instruction::GetImageType() const {
     assert(Opcode() == spv::OpTypeImage);
     const bool is_sampled_without_sampler = Word(7) == 2;

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -81,6 +81,7 @@ class Instruction {
     bool IsNonPtrAccessChain() const;
     bool IsAccessChain() const;
     bool IsUntypedAccessChain() const;
+    bool IsMemoryAccess() const;
     // Helpers for OpTypeImage
     VkDescriptorType GetImageType() const;
     bool IsTensor() const;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -441,48 +441,6 @@ static void FindPointersAndObjects(const Instruction& insn, vvl::unordered_set<u
             // This is not an access of memory, but counts as static usage of the variable
             result.insert(insn.Word(3));
             break;
-        case spv::OpSampledImage:
-        case spv::OpImageSampleImplicitLod:
-        case spv::OpImageSampleExplicitLod:
-        case spv::OpImageSampleDrefImplicitLod:
-        case spv::OpImageSampleDrefExplicitLod:
-        case spv::OpImageSampleProjImplicitLod:
-        case spv::OpImageSampleProjExplicitLod:
-        case spv::OpImageSampleProjDrefImplicitLod:
-        case spv::OpImageSampleProjDrefExplicitLod:
-        case spv::OpImageFetch:
-        case spv::OpImageGather:
-        case spv::OpImageDrefGather:
-        case spv::OpImageRead:
-        case spv::OpImage:
-        case spv::OpImageQueryFormat:
-        case spv::OpImageQueryOrder:
-        case spv::OpImageQuerySizeLod:
-        case spv::OpImageQuerySize:
-        case spv::OpImageQueryLod:
-        case spv::OpImageQueryLevels:
-        case spv::OpImageQuerySamples:
-        case spv::OpImageSparseSampleImplicitLod:
-        case spv::OpImageSparseSampleExplicitLod:
-        case spv::OpImageSparseSampleDrefImplicitLod:
-        case spv::OpImageSparseSampleDrefExplicitLod:
-        case spv::OpImageSparseSampleProjImplicitLod:
-        case spv::OpImageSparseSampleProjExplicitLod:
-        case spv::OpImageSparseSampleProjDrefImplicitLod:
-        case spv::OpImageSparseSampleProjDrefExplicitLod:
-        case spv::OpImageSparseFetch:
-        case spv::OpImageSparseGather:
-        case spv::OpImageSparseDrefGather:
-        case spv::OpImageTexelPointer:
-        case spv::OpFragmentFetchAMD:
-        case spv::OpFragmentMaskFetchAMD:
-            // Note: we only explore parts of the image which might actually contain ids we care about for the above analyses.
-            //  - NOT the shader input/output interfaces.
-            result.insert(insn.Word(3));  // Image or sampled image
-            break;
-        case spv::OpImageWrite:
-            result.insert(insn.Word(1));  // Image -- different operand order to above
-            break;
         case spv::OpFunctionCall:
             for (uint32_t i = 3; i < insn.Length(); i++) {
                 result.insert(insn.Word(i));  // fn itself, and all args
@@ -503,7 +461,15 @@ static void FindPointersAndObjects(const Instruction& insn, vvl::unordered_set<u
         default: {
             if (AtomicOperation(insn.Opcode())) {
                 result.insert(insn.Operand(0));  // ptr
+            } else {
+                // Note: we only explore parts of the image which might actually contain ids we care about for the above analyses.
+                //  - NOT the shader input/output interfaces.
+                uint32_t image_access = OpcodeImageAccessPosition(insn.Opcode());
+                if (image_access != 0) {
+                    result.insert(insn.Word(image_access));  // Image or sampled image
+                }
             }
+
             break;
         }
     }
@@ -615,13 +581,19 @@ std::string EntryPoint::Describe() const {
     return ss.str().c_str();
 }
 
-vvl::unordered_set<uint32_t> EntryPoint::GetAccessibleIds(const Module& module_state, EntryPoint& entrypoint) {
-    vvl::unordered_set<uint32_t> result_ids;
+EntryPoint::Accessible EntryPoint::GetAccessibleIds(const Module& module_state, EntryPoint& entrypoint) {
+    Accessible accessible;
+
+    const bool is_untyped = module_state.HasCapability(spv::CapabilityUntypedPointersKHR);
+
+    vvl::unordered_set<uint32_t> seen_ids;
 
     // For some analyses, we need to know about all ids referenced by the static call tree of a particular entrypoint.
     // This is important for identifying the set of shader resources actually used by an entrypoint.
     vvl::unordered_set<uint32_t> worklist;
+
     if (entrypoint.entrypoint_insn.Opcode() == spv::OpGraphEntryPointARM) {
+        // Note - graph entry will not find untyped pointer memory access
         FindPointersAndObjects(entrypoint.entrypoint_insn, worklist);
     }
 
@@ -632,8 +604,12 @@ vvl::unordered_set<uint32_t> EntryPoint::GetAccessibleIds(const Module& module_s
     worklist.insert(entrypoint.id);
     while (!worklist.empty()) {
         auto worklist_id_iter = worklist.begin();
-        auto worklist_id = *worklist_id_iter;
+        const uint32_t worklist_id = *worklist_id_iter;
         worklist.erase(worklist_id_iter);
+
+        if (!seen_ids.insert(worklist_id).second) {
+            continue;  // If we already saw this id, we don't want to walk it again.
+        }
 
         const Instruction* next_insn = module_state.FindDef(worklist_id);
         if (!next_insn) {
@@ -641,19 +617,29 @@ vvl::unordered_set<uint32_t> EntryPoint::GetAccessibleIds(const Module& module_s
             // that we may not care about.
             continue;
         }
+        const uint32_t next_opcode = next_insn->Opcode();
 
-        // Try to add to the output set
-        if (!result_ids.insert(worklist_id).second) {
-            continue;  // If we already saw this id, we don't want to walk it again.
+        if (next_insn->IsAccessChain()) {
+            accessible.access_chains.insert(next_insn);
+        } else if (next_opcode == spv::OpVariable || next_opcode == spv::OpUntypedVariableKHR) {
+            accessible.variables.insert(next_insn);
+        } else if (next_opcode == spv::OpGraphConstantARM) {
+            accessible.graph_constant.insert(next_insn);
         }
 
-        if (entry_exit_pairs.find(next_insn->Opcode()) != entry_exit_pairs.end()) {
-            const auto& exit = entry_exit_pairs[next_insn->Opcode()];
+        if (entry_exit_pairs.find(next_opcode) != entry_exit_pairs.end()) {
+            const uint32_t exit = entry_exit_pairs[next_opcode];
             // Scan whole body of the function
             while (++next_insn, next_insn->Opcode() != exit) {
-                const auto& insn = *next_insn;
+                const Instruction& insn = *next_insn;
                 // Build up list of accessible ID
                 FindPointersAndObjects(insn, worklist);
+
+                // The way FindPointersAndObjects function works is we find things "up" in the SSA and return it back. For memory
+                // accesses, this is where things "start" and will never be added to |worklist|
+                if (is_untyped && insn.IsMemoryAccess()) {
+                    accessible.memory_accesses.insert(&insn);
+                }
 
                 // Gather any instructions info that is only for the EntryPoint and not whole module
                 switch (insn.Opcode()) {
@@ -668,7 +654,7 @@ vvl::unordered_set<uint32_t> EntryPoint::GetAccessibleIds(const Module& module_s
         }
     }
 
-    return result_ids;
+    return accessible;
 }
 
 std::vector<StageInterfaceVariable> EntryPoint::GetStageInterfaceVariables(const Module& module_state, EntryPoint& entrypoint,
@@ -702,39 +688,20 @@ std::vector<ResourceInterfaceVariable> EntryPoint::GetResourceInterfaceVariables
                                                                                  const ParsedInfo& parsed) {
     std::vector<ResourceInterfaceVariable> variables;
 
-    // Now that the accessible_ids list is known, fill in any information that can be statically known per EntryPoint
-    for (const auto& accessible_id : entrypoint.accessible_ids) {
-        const Instruction& insn = *module_state.FindDef(accessible_id);
-        if (insn.Opcode() != spv::OpVariable && insn.Opcode() != spv::OpUntypedVariableKHR) {
-            continue;
-        }
-        const uint32_t storage_class = insn.StorageClass();
+    // Now that the accessible list is known, fill in any information that can be statically known per EntryPoint
+    for (const Instruction* insn : entrypoint.accessible.variables) {
+        const uint32_t storage_class = insn->StorageClass();
         // These are the only storage classes that interface with a descriptor
         // see vkspec.html#interfaces-resources-descset
         if (storage_class == spv::StorageClassUniform || storage_class == spv::StorageClassUniformConstant ||
             storage_class == spv::StorageClassStorageBuffer || storage_class == spv::StorageClassTileAttachmentQCOM) {
-            variables.emplace_back(module_state, entrypoint, insn, parsed);
+            variables.emplace_back(module_state, entrypoint, *insn, parsed);
         } else if (storage_class == spv::StorageClassPushConstant) {
             entrypoint.push_constant_variable =
-                std::make_shared<PushConstantVariable>(module_state, insn, entrypoint.stage, parsed);
+                std::make_shared<PushConstantVariable>(module_state, *insn, entrypoint.stage, parsed);
         }
     }
     return variables;
-}
-
-std::vector<const Instruction*> EntryPoint::GetDataGraphConstants(const Module& module_state, EntryPoint& entrypoint,
-                                                                  const ParsedInfo& parsed) {
-    std::vector<const Instruction*> constants;
-    // Check to skip to not spend time if not using VK_ARM_data_graph
-    if (parsed.has_graph_constant_arm) {
-        for (const auto& accessible_id : entrypoint.accessible_ids) {
-            const Instruction& insn = *module_state.FindDef(accessible_id);
-            if (insn.Opcode() == spv::OpGraphConstantARM) {
-                constants.push_back(&insn);
-            }
-        }
-    }
-    return constants;
 }
 
 StaticImageAccess::StaticImageAccess(const Module& module_state, const Instruction& insn,
@@ -866,10 +833,9 @@ EntryPoint::EntryPoint(const Module& module_state, const Instruction& entrypoint
       name(is_data_graph ? entrypoint_insn.GetAsString(2) : entrypoint_insn.GetAsString(3)),
       execution_mode(module_state.GetExecutionModeSet(id)),
       emit_vertex_geometry(false),
-      accessible_ids(GetAccessibleIds(module_state, *this)),
+      accessible(GetAccessibleIds(module_state, *this)),
       resource_interface_variables(GetResourceInterfaceVariables(module_state, *this, parsed)),
       stage_interface_variables(GetStageInterfaceVariables(module_state, *this, parsed)),
-      datagraph_constants(GetDataGraphConstants(module_state, *this, parsed)),
       uses_tosa_1_0(parsed.uses_tosa_1_0),
       only_entry_point(parsed.total_entry_points == 1) {
     // Tried to just create this map in GetResourceInterfaceVariables() but ran into errors because the function is static
@@ -2667,22 +2633,19 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
         }
     }
 
-    for (const auto& accessible_id : entrypoint.accessible_ids) {
-        const Instruction* pointer = module_state.FindDef(accessible_id);
-        if (pointer->IsAccessChain()) {
-            const spirv::Instruction* base = module_state.FindDef(pointer->Word(3));
-            if (base->Opcode() == spv::OpVariable && type_id == base->Word(1)) {
-                const spirv::Instruction* base_pointer = module_state.FindDef(base->Word(1));
-                const spirv::Instruction* base_type = module_state.FindDef(base_pointer->Word(3));
-                if (base_type->IsArray()) {
-                    // Taking only the first index (word 4) as that one is used to access arrays of descriptors
-                    const spirv::Instruction* access_op = module_state.FindDef(pointer->Word(4));
-                    const auto access_opcode = (spv::Op)access_op->Opcode();
-                    if (!IsValueIn(access_opcode, {spv::OpConstant, spv::OpSpecConstant, spv::OpConstantComposite})) {
-                        all_constant_integral_expressions = false;
-                        non_constant_id = accessible_id;
-                        break;
-                    }
+    for (const Instruction* pointer : entrypoint.accessible.access_chains) {
+        const spirv::Instruction* base = module_state.FindDef(pointer->Word(3));
+        if (base->Opcode() == spv::OpVariable && type_id == base->Word(1)) {
+            const spirv::Instruction* base_pointer = module_state.FindDef(base->Word(1));
+            const spirv::Instruction* base_type = module_state.FindDef(base_pointer->Word(3));
+            if (base_type->IsArray()) {
+                // Taking only the first index (word 4) as that one is used to access arrays of descriptors
+                const spirv::Instruction* access_op = module_state.FindDef(pointer->Word(4));
+                const auto access_opcode = (spv::Op)access_op->Opcode();
+                if (!IsValueIn(access_opcode, {spv::OpConstant, spv::OpSpecConstant, spv::OpConstantComposite})) {
+                    all_constant_integral_expressions = false;
+                    non_constant_id = pointer->ResultId();
+                    break;
                 }
             }
         }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -486,7 +486,7 @@ struct ResourceInterfaceVariable : public VariableBase {
         bool is_read_without_format{false};   // For storage images
         bool is_write_without_format{false};  // For storage images
 
-        // If a variable is used as a function argument, but never actually used, it will be found in EntryPoint::accessible_ids so
+        // If a variable is used as a function argument, but never actually used, it will be found in EntryPoint::accessible so
         // we need to have a dedicated mark if it was accessed.
         // We use this for variable hashing, but the VariableBase has the helper functions to read this value.
         uint32_t access_mask{AccessBit::empty};
@@ -569,10 +569,18 @@ struct EntryPoint {
     // Values found while gather the Accessible Ids
     bool emit_vertex_geometry;
 
-    // All ids that can be accessed from the entry point
-    // being accessed doesn't guarantee it is statically used
-    // TODO - Break this into a Function struct
-    const vvl::unordered_set<uint32_t> accessible_ids;
+    // With multiple entry points we want to make sure we only look for instructions found in those entrypoints. These are all the
+    // list of various instructions that have been found looking through all statically reachable functions in the module
+    struct Accessible {
+        vvl::unordered_set<const Instruction*> variables;
+        vvl::unordered_set<const Instruction*> access_chains;
+        // Only is filled when OpCapability UntypedPointersKHR is set (to save lots of memory!)
+        // When there is no more types, we need the root memory access
+        vvl::unordered_set<const Instruction*> memory_accesses;
+        // VK_ARM_data_graph
+        vvl::unordered_set<const Instruction*> graph_constant;
+    };
+    const Accessible accessible;
 
     // only one Push Constant block is allowed per entry point
     // (This assumption is broken with VK_NV_push_constant_bank, but not fully supported)
@@ -581,7 +589,6 @@ struct EntryPoint {
     std::shared_ptr<const TaskPayloadVariable> task_payload_variable;
     const std::vector<ResourceInterfaceVariable> resource_interface_variables;
     const std::vector<StageInterfaceVariable> stage_interface_variables;
-    const std::vector<const Instruction *> datagraph_constants;
 
     bool uses_tosa_1_0{false};
 
@@ -626,13 +633,11 @@ struct EntryPoint {
     std::string Describe() const;
 
   protected:
-    static vvl::unordered_set<uint32_t> GetAccessibleIds(const Module &module_state, EntryPoint &entrypoint);
+    static Accessible GetAccessibleIds(const Module& module_state, EntryPoint& entrypoint);
     static std::vector<StageInterfaceVariable> GetStageInterfaceVariables(const Module &module_state, EntryPoint &entrypoint,
                                                                           const ParsedInfo &parsed);
-    static std::vector<ResourceInterfaceVariable> GetResourceInterfaceVariables(const Module &module_state, EntryPoint &entrypoint,
-                                                                                const ParsedInfo &parsed);
-    static std::vector<const Instruction*> GetDataGraphConstants(const Module& module_state, EntryPoint& entrypoint,
-                                                                 const ParsedInfo& parsed);
+    static std::vector<ResourceInterfaceVariable> GetResourceInterfaceVariables(const Module& module_state, EntryPoint& entrypoint,
+                                                                                const ParsedInfo& parsed);
 
     static bool IsBuiltInWritten(spv::BuiltIn built_in, const Module &module_state, const StageInterfaceVariable &variable,
                                  const ParsedInfo &parsed);


### PR DESCRIPTION
This was needed so GPU Dump could track things like Storage Images for Untyped Pointers (which it can now!)

This just reworks the whole "finding the instructions found in an entrypoint"... Greg (way before me) just created a global `set<uint32_t>` that we looped through, this makes 3 (ignore vendor ext) dedicated lists

- Memory access
- Access Chains
- Variables

as these are the 3 parts we care about for knowing what is "accessible"