### PR TITLE
docs: fix typo in tests README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,7 +3,7 @@
 The Validation Layers use [Google Test (gtest)](https://github.com/google/googletest) for testing the
 Validation Layers. This helps make sure all new changes are correct and prevent regressions.
 
-The following is information how to setup and run the tests. There is seperate documentation for [creating tests](../docs/creating_tests.md).
+The following is information how to setup and run the tests. There is separate documentation for [creating tests](../docs/creating_tests.md).
 
 ## Building the tests
 


### PR DESCRIPTION
Fixes a small spelling typo in the tests README: `seperate` -> `separate`.

This PR was made using the GitHub API without cloning the repository locally.