### PR TITLE
scripts: Cleanup ExtendedFlags

### DIFF
--- a/layers/vulkan/generated/extended_flags_helper_generator.cpp
+++ b/layers/vulkan/generated/extended_flags_helper_generator.cpp
@@ -74,22 +74,6 @@ Location GetUsageLocation(const VkImageCreateInfo& create_info, const Location& 
     return loc.dot(vvl::Field::usage);
 }
 
-VkBufferUsageFlags2 GetBufferViewCreateFlags(const VkBufferViewCreateInfo& create_info) {
-    const auto extended = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(create_info.pNext);
-    if (extended) {
-        return extended->usage;
-    }
-    return static_cast<VkBufferUsageFlags2>(create_info.flags);
-}
-
-Location GetFlagsLocation(const VkBufferViewCreateInfo& create_info, const Location& loc) {
-    const auto extended = vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(create_info.pNext);
-    if (extended) {
-        return loc.pNext(vvl::Struct::VkBufferUsageFlags2CreateInfo).dot(vvl::Field::usage);
-    }
-    return loc.dot(vvl::Field::flags);
-}
-
 VkPipelineCreateFlags2 GetPipelineCreateFlags(const VkComputePipelineCreateInfo& create_info) {
     const auto extended = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfo>(create_info.pNext);
     if (extended) {

--- a/layers/vulkan/generated/extended_flags_helper_generator.h
+++ b/layers/vulkan/generated/extended_flags_helper_generator.h
@@ -32,9 +32,6 @@ Location GetFlagsLocation(const VkImageCreateInfo& create_info, const Location& 
 VkImageUsageFlags2KHR GetImageUsageFlags(const VkImageCreateInfo& create_info);
 Location GetUsageLocation(const VkImageCreateInfo& create_info, const Location& loc);
 
-VkBufferUsageFlags2 GetBufferViewCreateFlags(const VkBufferViewCreateInfo& create_info);
-Location GetFlagsLocation(const VkBufferViewCreateInfo& create_info, const Location& loc);
-
 VkPipelineCreateFlags2 GetPipelineCreateFlags(const VkComputePipelineCreateInfo& create_info);
 Location GetFlagsLocation(const VkComputePipelineCreateInfo& create_info, const Location& loc);
 

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -10213,10 +10213,11 @@ bool Device::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateIn
                                             allowed_structs_VkBufferCreateInfo.data(), GeneratedVulkanHeaderVersion,
                                             "VUID-VkBufferCreateInfo-pNext-pNext", "VUID-VkBufferCreateInfo-sType-unique", true);
 
-        skip |= context.ValidateFlags(pCreateInfo_loc.dot(Field::flags), vvl::FlagBitmask::VkBufferCreateFlagBits,
-                                      AllVkBufferCreateFlagBits, pCreateInfo->flags, kOptionalFlags,
-                                      "VUID-VkBufferCreateInfo-flags-parameter", nullptr, false);
-
+        if (!vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pCreateInfo->pNext)) {
+            skip |= context.ValidateFlags(pCreateInfo_loc.dot(Field::flags), vvl::FlagBitmask::VkBufferCreateFlagBits,
+                                          AllVkBufferCreateFlagBits, pCreateInfo->flags, kOptionalFlags,
+                                          "VUID-VkBufferCreateInfo-flags-parameter", nullptr, false);
+        }
         skip |= context.ValidateRangedEnum(pCreateInfo_loc.dot(Field::sharingMode), vvl::Enum::VkSharingMode,
                                            pCreateInfo->sharingMode, "VUID-VkBufferCreateInfo-sharingMode-parameter");
     }
@@ -14630,10 +14631,11 @@ bool Device::PreCallValidateGetDeviceBufferMemoryRequirements(VkDevice device, c
                                             allowed_structs_VkBufferCreateInfo.data(), GeneratedVulkanHeaderVersion,
                                             "VUID-VkBufferCreateInfo-pNext-pNext", "VUID-VkBufferCreateInfo-sType-unique", true);
 
-            skip |= context.ValidateFlags(pCreateInfo_loc.dot(Field::flags), vvl::FlagBitmask::VkBufferCreateFlagBits,
-                                          AllVkBufferCreateFlagBits, pInfo->pCreateInfo->flags, kOptionalFlags,
-                                          "VUID-VkBufferCreateInfo-flags-parameter", nullptr, false);
-
+            if (!vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pInfo->pCreateInfo->pNext)) {
+                skip |= context.ValidateFlags(pCreateInfo_loc.dot(Field::flags), vvl::FlagBitmask::VkBufferCreateFlagBits,
+                                              AllVkBufferCreateFlagBits, pInfo->pCreateInfo->flags, kOptionalFlags,
+                                              "VUID-VkBufferCreateInfo-flags-parameter", nullptr, false);
+            }
             skip |= context.ValidateRangedEnum(pCreateInfo_loc.dot(Field::sharingMode), vvl::Enum::VkSharingMode,
                                                pInfo->pCreateInfo->sharingMode, "VUID-VkBufferCreateInfo-sharingMode-parameter");
         }
@@ -26108,10 +26110,11 @@ bool Device::PreCallValidateSetBufferCollectionBufferConstraintsFUCHSIA(
                                             GeneratedVulkanHeaderVersion, "VUID-VkBufferCreateInfo-pNext-pNext",
                                             "VUID-VkBufferCreateInfo-sType-unique", true);
 
-        skip |= context.ValidateFlags(createInfo_loc.dot(Field::flags), vvl::FlagBitmask::VkBufferCreateFlagBits,
-                                      AllVkBufferCreateFlagBits, pBufferConstraintsInfo->createInfo.flags, kOptionalFlags,
-                                      "VUID-VkBufferCreateInfo-flags-parameter", nullptr, false);
-
+        if (!vku::FindStructInPNextChain<VkBufferUsageFlags2CreateInfo>(pBufferConstraintsInfo->createInfo.pNext)) {
+            skip |= context.ValidateFlags(createInfo_loc.dot(Field::flags), vvl::FlagBitmask::VkBufferCreateFlagBits,
+                                          AllVkBufferCreateFlagBits, pBufferConstraintsInfo->createInfo.flags, kOptionalFlags,
+                                          "VUID-VkBufferCreateInfo-flags-parameter", nullptr, false);
+        }
         skip |= context.ValidateRangedEnum(createInfo_loc.dot(Field::sharingMode), vvl::Enum::VkSharingMode,
                                            pBufferConstraintsInfo->createInfo.sharingMode,
                                            "VUID-VkBufferCreateInfo-sharingMode-parameter");

--- a/scripts/generators/extended_flags_helper_generator.py
+++ b/scripts/generators/extended_flags_helper_generator.py
@@ -61,22 +61,24 @@ class ExtendedFlagsHelperOutputGenerator(BaseGenerator):
 
         # Todo: move to vulkan object
         self.vk.structs['VkBufferCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct='VkBufferUsageFlags2CreateInfo')
-        self.vk.structs['VkBufferViewCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct= 'VkBufferUsageFlags2CreateInfo')
-        self.vk.structs['VkImageCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct='VkImageCreateFlags2CreateInfoKHR')
-        self.vk.structs['VkImageCreateInfo'].members[10].extendedFlag = ExtendedFlag(struct='VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkDescriptorBufferBindingInfoEXT'].members[2].extendedFlag = ExtendedFlag(struct= 'VkBufferUsageFlags2CreateInfo')
+        self.vk.structs['VkPhysicalDeviceExternalBufferInfo'].members[3].extendedFlag = ExtendedFlag(struct= 'VkBufferUsageFlags2CreateInfo')
+
         self.vk.structs['VkComputePipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
         self.vk.structs['VkGraphicsPipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
-        self.vk.structs['VkSwapchainCreateInfoKHR'].members[9].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
-        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[5].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
-        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[6].extendedFlag = ExtendedFlag(struct= 'VkImageCreateFlags2CreateInfoKHR')
-        self.vk.structs['VkPhysicalDeviceSparseImageFormatInfo2'].members[5].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
-        self.vk.structs['VkPhysicalDeviceExternalBufferInfo'].members[3].extendedFlag = ExtendedFlag(struct= 'VkBufferUsageFlags2CreateInfo')
         self.vk.structs['VkRayTracingPipelineCreateInfoNV'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
         self.vk.structs['VkRayTracingPipelineCreateInfoKHR'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
+
+        self.vk.structs['VkImageCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct='VkImageCreateFlags2CreateInfoKHR')
+        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[6].extendedFlag = ExtendedFlag(struct= 'VkImageCreateFlags2CreateInfoKHR')
         self.vk.structs['VkFramebufferAttachmentImageInfo'].members[2].extendedFlag = ExtendedFlag(struct= 'VkImageCreateFlags2CreateInfoKHR')
+
+        self.vk.structs['VkImageCreateInfo'].members[10].extendedFlag = ExtendedFlag(struct='VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkSwapchainCreateInfoKHR'].members[9].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[5].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkPhysicalDeviceSparseImageFormatInfo2'].members[5].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
         self.vk.structs['VkFramebufferAttachmentImageInfo'].members[3].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
         self.vk.structs['VkPhysicalDeviceVideoFormatInfoKHR'].members[2].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
-        self.vk.structs['VkDescriptorBufferBindingInfoEXT'].members[2].extendedFlag = ExtendedFlag(struct= 'VkBufferUsageFlags2CreateInfo')
 
         if self.filename == 'extended_flags_helper_generator.h':
             out.append(self.generateHeader())
@@ -95,8 +97,6 @@ class ExtendedFlagsHelperOutputGenerator(BaseGenerator):
 
         for struct in [x for x in self.vk.structs.values()]:
             for member in [x for x in struct.members if x.extendedFlag]:
-                if (struct.name == 'VkSurfaceCapabilitiesKHR'):
-                    continue
                 extend_struct = self.vk.structs[member.extendedFlag.struct]
                 member_type_name = member.type[2:]
                 assert(len(extend_struct.members) == 3)
@@ -116,8 +116,6 @@ class ExtendedFlagsHelperOutputGenerator(BaseGenerator):
 
         for struct in [x for x in self.vk.structs.values()]:
             for member in [x for x in struct.members if x.extendedFlag]:
-                if (struct.name == 'VkSurfaceCapabilitiesKHR'):
-                    continue
                 extend_struct = self.vk.structs[member.extendedFlag.struct]
                 member_type_name = member.type[2:]
                 assert(len(extend_struct.members) == 3)

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -406,28 +406,26 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
         for member in (m for s in self.vk.structs.values() for m in s.members):
             member.extendedFlag = None
 
-        buffer_usage2 = self.vk.structs['VkBufferUsageFlags2CreateInfo']
-        pipe_flags2 = self.vk.structs['VkPipelineCreateFlags2CreateInfo']
-        image_flags2 = self.vk.structs['VkImageCreateFlags2CreateInfoKHR']
-        image_usage2 = self.vk.structs['VkImageUsageFlags2CreateInfoKHR']
-        self.vk.structs['VkBufferCreateInfo'].members[4].extendedFlag = ExtendedFlag(struct=buffer_usage2.name)
-        self.vk.structs['VkPhysicalDeviceExternalBufferInfo'].members[3].extendedFlag = ExtendedFlag(struct=buffer_usage2.name)
-        self.vk.structs['VkDescriptorBufferBindingInfoEXT'].members[3].extendedFlag =ExtendedFlag(struct=buffer_usage2.name)
-        self.vk.structs['VkComputePipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name)
-        self.vk.structs['VkGraphicsPipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name)
-        self.vk.structs['VkRayTracingPipelineCreateInfoNV'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name)
-        self.vk.structs['VkRayTracingPipelineCreateInfoKHR'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name)
+        self.vk.structs['VkBufferCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct='VkBufferUsageFlags2CreateInfo')
+        self.vk.structs['VkDescriptorBufferBindingInfoEXT'].members[2].extendedFlag = ExtendedFlag(struct= 'VkBufferUsageFlags2CreateInfo')
+        self.vk.structs['VkPhysicalDeviceExternalBufferInfo'].members[3].extendedFlag = ExtendedFlag(struct= 'VkBufferUsageFlags2CreateInfo')
 
-        self.vk.structs['VkImageCreateInfo'].members[2].flagsextend = ExtendedFlag(struct=image_flags2.name)
-        self.vk.structs['VkImageCreateInfo'].members[10].flagsextend = ExtendedFlag(struct=image_usage2.name)
-        self.vk.structs['VkSurfaceCapabilitiesKHR'].members[9].flagsextend = ExtendedFlag(struct=image_usage2.name)
-        self.vk.structs['VkSwapchainCreateInfoKHR'].members[9].flagsextend = ExtendedFlag(struct=image_usage2.name)
-        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[5].flagsextend = ExtendedFlag(struct=image_usage2.name)
-        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[6].flagsextend = ExtendedFlag(struct=image_flags2.name)
-        self.vk.structs['VkPhysicalDeviceSparseImageFormatInfo2'].members[5].flagsextend = ExtendedFlag(struct=image_usage2.name)
-        self.vk.structs['VkFramebufferAttachmentImageInfo'].members[2].flagsextend = ExtendedFlag(struct=image_flags2.name)
-        self.vk.structs['VkFramebufferAttachmentImageInfo'].members[3].flagsextend = ExtendedFlag(struct=image_usage2.name)
-        self.vk.structs['VkPhysicalDeviceVideoFormatInfoKHR'].members[2].flagsextend = ExtendedFlag(struct=image_usage2.name)
+        self.vk.structs['VkComputePipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
+        self.vk.structs['VkGraphicsPipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
+        self.vk.structs['VkRayTracingPipelineCreateInfoNV'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
+        self.vk.structs['VkRayTracingPipelineCreateInfoKHR'].members[2].extendedFlag = ExtendedFlag(struct= 'VkPipelineCreateFlags2CreateInfo')
+
+        self.vk.structs['VkImageCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct='VkImageCreateFlags2CreateInfoKHR')
+        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[6].extendedFlag = ExtendedFlag(struct= 'VkImageCreateFlags2CreateInfoKHR')
+        self.vk.structs['VkFramebufferAttachmentImageInfo'].members[2].extendedFlag = ExtendedFlag(struct= 'VkImageCreateFlags2CreateInfoKHR')
+
+        self.vk.structs['VkImageCreateInfo'].members[10].extendedFlag = ExtendedFlag(struct='VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkSwapchainCreateInfoKHR'].members[9].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkPhysicalDeviceImageFormatInfo2'].members[5].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkPhysicalDeviceSparseImageFormatInfo2'].members[5].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkFramebufferAttachmentImageInfo'].members[3].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
+        self.vk.structs['VkPhysicalDeviceVideoFormatInfoKHR'].members[2].extendedFlag = ExtendedFlag(struct= 'VkImageUsageFlags2CreateInfoKHR')
+
         for member in (m for s in self.vk.structs.values() for m in s.members):
             if member.extendedFlag:
                 self.extended_structs.add(member.extendedFlag.struct)
@@ -1245,7 +1243,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
                         else:
                             if self.vk.commands[funcName].instance:
                                 isInstanceFunction = 'true'
-                        extended = getattr(member, 'flagsextend', None)
+                        extended = getattr(member, 'extendedFlag', None)
                         if (extended):
                             usedLines.append(f'if (!vku::FindStructInPNextChain<{extended.struct}>({valuePrefix}pNext)) {{')
                         usedLines.append(f'skip |= {context}ValidateFlags({errorLoc}.dot(Field::{member.name}), vvl::FlagBitmask::{flagBitsName}, {allFlagsName}, {valuePrefix}{member.name}, {flagsType}, {invalidVuid}{zeroVuidArg}, {isInstanceFunction});\n')


### PR DESCRIPTION
Seems we had `VkSurfaceCapabilitiesKHR` and `VkBufferViewCreateInfo` still marked as extended which we removed

this just unifies the two locations as well