### PR TITLE
dump: Fixes and add Untyped MultiDimensional test

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -19,6 +19,7 @@
 #include "gpu_dump.h"
 #include <vulkan/vk_enum_string_helper.h>
 #include <vulkan/vulkan_core.h>
+#include <cassert>
 #include <cstdint>
 #include <iostream>
 #include <spirv-tools/libspirv.hpp>
@@ -1351,6 +1352,49 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
     return found_warning;
 }
 
+// if we hit this, its because of OpConstantSizeOfEXT can't be folded (https://godbolt.org/z/3z6Pao4sf)
+// TODO - We will need some sort of internal constant folding here... fun!
+// ... for now lets make assumption only thing people will use here is IMul/IAdd/Isub and just do some folding
+static uint32_t GetConstantFoldValue(const spirv::Module& module, const spirv::Instruction& spec_constant_op,
+                                     VkDeviceSize descriptor_size) {
+    const uint32_t spec_op = spec_constant_op.Word(3);
+    if (spec_op != spv::OpIMul && spec_op != spv::OpIAdd && spec_op != spv::OpISub) {
+        assert(false);  // hit another case
+        return 0;
+    }
+
+    const spirv::Instruction& operand_0_inst = *module.FindDef(spec_constant_op.Word(4));
+    const spirv::Instruction& operand_1_inst = *module.FindDef(spec_constant_op.Word(5));
+
+    uint32_t operand_0 = 0;
+    if (operand_0_inst.Opcode() == spv::OpConstantSizeOfEXT) {
+        operand_0 = (uint32_t)descriptor_size;
+    } else if (operand_0_inst.Opcode() == spv::OpSpecConstantOp) {
+        operand_0 = GetConstantFoldValue(module, operand_0_inst, descriptor_size);
+    } else {
+        operand_0 = operand_0_inst.GetConstantValue();
+    }
+
+    uint32_t operand_1 = 0;
+    if (operand_1_inst.Opcode() == spv::OpConstantSizeOfEXT) {
+        operand_1 = (uint32_t)descriptor_size;
+    } else if (operand_1_inst.Opcode() == spv::OpSpecConstantOp) {
+        operand_1 = GetConstantFoldValue(module, operand_1_inst, descriptor_size);
+    } else {
+        operand_1 = operand_1_inst.GetConstantValue();
+    }
+
+    if (spec_op == spv::OpIMul) {
+        return operand_0 * operand_1;
+    } else if (spec_op == spv::OpIAdd) {
+        return operand_0 + operand_1;
+    } else if (spec_op == spv::OpISub) {
+        return operand_0 - operand_1;
+    }
+    assert(false);
+    return 0;
+}
+
 static uint32_t GetUntypedSize(const spirv::Module& module, const spirv::Instruction& size_inst, VkDeviceSize descriptor_size) {
     if (size_inst.Opcode() == spv::OpConstantSizeOfEXT) {
         const spirv::Instruction* constant_type_inst = module.FindDef(size_inst.Word(3));
@@ -1362,8 +1406,7 @@ static uint32_t GetUntypedSize(const spirv::Module& module, const spirv::Instruc
     } else if (size_inst.Opcode() == spv::OpConstant) {
         return size_inst.GetConstantValue();
     } else if (size_inst.Opcode() == spv::OpSpecConstantOp) {
-        // TODO - We will need some sort of internal constant folding here... fun!
-        return 0;
+        return GetConstantFoldValue(module, size_inst, descriptor_size);
     }
     assert(false);  // assumptions
     return 0;
@@ -1457,8 +1500,6 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
     auto add_access = [&](const VkDescriptorType descriptor_type, const spirv::Instruction& ac_inst) {
         const VkDeviceSize descriptor_size = dev_data.device_state->cached_descriptor_size.GetSize(descriptor_type);
         assert(ac_inst.Opcode() == spv::OpUntypedAccessChainKHR);
-        // Totally asserts a 1D array access here
-        // https://gitlab.khronos.org/spirv/SPIR-V/-/issues/942
         const spirv::Instruction* base_type_inst = module.FindDef(ac_inst.Word(3));
         if (base_type_inst->Opcode() != spv::OpTypeBufferEXT && base_type_inst->Opcode() != spv::OpTypeStruct &&
             !base_type_inst->IsArray()) {
@@ -1506,17 +1547,9 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
             if (sampler_load_inst) {
                 // TODO - Assertion sampled images are 1D
                 const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
-                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
-                    assert(false);  // assumptions
-                    continue;
-                }
                 add_access(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, *ac_inst);
 
                 ac_inst = module.FindDef(sampler_load_inst->Word(3));
-                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
-                    assert(false);  // assumptions
-                    continue;
-                }
                 add_access(VK_DESCRIPTOR_TYPE_SAMPLER, *ac_inst);
             } else {
                 const spirv::Instruction* image_type = module.FindDef(image_load_inst->TypeId());
@@ -1524,10 +1557,6 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
                 const VkDescriptorType image_descriptor_type = image_type->GetImageType();
 
                 const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
-                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
-                    assert(false);  // assumptions
-                    continue;
-                }
                 add_access(image_descriptor_type, *ac_inst);
             }
         } else {
@@ -1544,17 +1573,13 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
             const spirv::Instruction* base_type = next_access_chain;
 
             if (base_type && base_type->Opcode() == spv::OpBufferPointerEXT) {
-                const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(3));
-                if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
-                    assert(false);  // assumptions
-                    continue;
-                }
-
                 // Ignore old BufferBlock + Uniform
                 const VkDescriptorType descriptor_type =
                     module.FindDef(base_type->TypeId())->StorageClass() == spv::StorageClassUniform
                         ? VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
                         : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+
+                const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(3));
                 add_access(descriptor_type, *ac_inst);
             }
         }
@@ -1673,10 +1698,12 @@ bool CommandBufferSubState::DumpDescriptorHeapUntyped(std::ostringstream& ss, co
                        << " heap\n";
                     found_warning = true;
                 }
-                vvl::range<VkDeviceAddress> final_range{final_address, final_address + descriptor_size};
-                if (final_range.intersects(reserve_range)) {
-                    ss << "      - [WARNING] RESERVED RANGE - this descriptor overlaps with the reserved range\n";
-                    found_warning = true;
+                if (!reserve_range.empty()) {
+                    vvl::range<VkDeviceAddress> final_range{final_address, final_address + descriptor_size};
+                    if (final_range.intersects(reserve_range)) {
+                        ss << "      - [WARNING] RESERVED RANGE - this descriptor overlaps with the reserved range\n";
+                        found_warning = true;
+                    }
                 }
 
                 VkDeviceSize required_alignment = GetDescriptorAlignment(access.descriptor_type, dev_data.phys_dev_ext_props);

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -18,6 +18,7 @@
 #include "pipeline_helper.h"
 #include "shader_helper.h"
 #include "shader_templates.h"
+#include "test_framework.h"
 #include "utils/math_utils.h"
 
 static const VkLayerSettingEXT kAllDumpSettings[3] = {
@@ -1505,5 +1506,79 @@ TEST_F(NegativeGpuDump, DescriptorHeapBindingCount) {
     m_errorMonitor->SetDesiredWarning("OUT OF BOUNDS");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+// TODO - Handle proper support
+TEST_F(NegativeGpuDump, DISABLED_UntypedPointersMultiDimensional) {
+    TEST_DESCRIPTION("https://gitlab.khronos.org/spirv/SPIR-V/-/issues/942");
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitDescriptorHeap());
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0 || heap_props.minSamplerHeapReservedRange != 0) {
+        GTEST_SKIP() << "heapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    VkDeviceSize heap_size = Align((resource_stride * 8), resource_stride);
+    vkt::Buffer resource_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    // layout(descriptor_heap) buffer Heap { uint data; } heap[3][3];
+    // void main() {
+    //     heap[1][2].data = 42;
+    // }
+    const char* cs_source = R"asm(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorate %Heap Block
+               OpMemberDecorate %Heap 0 Offset 0
+               OpDecorateId %out_array ArrayStrideIdEXT %buf_size
+               OpDecorateId %in_array ArrayStrideIdEXT %stride_3
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+       %uint = OpTypeInt 32 0
+      %uint_0 = OpConstant %uint 0
+      %uint_1 = OpConstant %uint 1
+      %uint_2 = OpConstant %uint 2
+      %uint_3 = OpConstant %uint 3
+    %uint_42 = OpConstant %uint 42
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+       %Heap = OpTypeStruct %uint
+%_ptr_StorageBuffer = OpTypeUntypedPointerKHR StorageBuffer
+   %buf_type = OpTypeBufferEXT StorageBuffer
+   %buf_size = OpConstantSizeOfEXT %uint %buf_type
+   %stride_3 = OpSpecConstantOp %int IMul %buf_size %uint_3
+ %in_array = OpTypeArray %buf_type %uint_3
+%out_array = OpTypeArray %in_array %uint_3
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %15 = OpUntypedAccessChainKHR %_ptr_UniformConstant %out_array %resource_heap %uint_1 %uint_2
+         %19 = OpBufferPointerEXT %_ptr_StorageBuffer %15
+         %20 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %Heap %19 %uint_0
+               OpStore %20 %uint_42
+               OpReturn
+               OpFunctionEnd
+    )asm";
+
+    m_command_buffer.Begin();
+
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = resource_heap.AddressRange();
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, nullptr, SPV_SOURCE_ASM);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 }


### PR DESCRIPTION
Adds some basic OpSpecConstant support and gets some test for MultiDimensional descriptors, but going to wait until https://gitlab.khronos.org/Tracker/vk-gl-cts/-/issues/6645#note_612544 comes back before spending time supporting that madness