### PR TITLE
layers: Fix VUID-07990 false positive in image processing

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1554,6 +1554,13 @@ struct ShaderResourceType {
             if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_TENSOR_ARM)) {
                 ss << "\n - VK_DESCRIPTOR_TYPE_TENSOR_ARM is an OpTypeTensorARM in UniformConstant";
             }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM is an OpTypeImage, with Sampled = 1, in UniformConstant";
+            }
+            if (descriptor_type_set.count(VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM)) {
+                ss << "\n - VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM is an OpTypeImage, with Sampled = 1 and Arrayed = 1, in "
+                      "UniformConstant";
+            }
             ss << "\nFull list of mappings can be found at "
                   "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-resources-storage-class-correspondence";
         }

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2443,6 +2443,12 @@ VkDescriptorType ResourceInterfaceVariable::GetPotentialDescriptorType() const {
     } else if (is_sampler) {
         return VK_DESCRIPTOR_TYPE_SAMPLER;
     } else if (is_sampled_image) {
+        if ((info.image_insn.image_proc_usage_mask & ImageProcUsageBit::kBlockMatch) != 0) {
+            return VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM;
+        } else if ((info.image_insn.image_proc_usage_mask & ImageProcUsageBit::kSampleWeighted) != 0 &&
+                   info.is_image_array) {
+            return VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM;
+        }
         return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     } else if (is_combined_image_sampler) {
         return VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -2462,9 +2468,16 @@ vvl::unordered_set<VkDescriptorType> ResourceInterfaceVariable::GetAllDescriptor
         // See PositivePipeline.CombinedImageSamplerConsumedAsSampler
         types.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     } else if (is_sampled_image) {
-        types.insert(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-        // See PositivePipeline.CombinedImageSamplerConsumedAsImage
-        types.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+        if ((info.image_insn.image_proc_usage_mask & ImageProcUsageBit::kBlockMatch) != 0) {
+            types.insert(VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
+        } else if ((info.image_insn.image_proc_usage_mask & ImageProcUsageBit::kSampleWeighted) != 0 &&
+                   info.is_image_array) {
+            types.insert(VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM);
+        } else {
+            types.insert(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+            // See PositivePipeline.CombinedImageSamplerConsumedAsImage
+            types.insert(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+        }
     } else if (is_storage_buffer) {
         types.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
         types.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC);

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -3325,7 +3325,6 @@ TEST_F(NegativeTileShading, UseSampleWeightedImageOpButTileShadingImageProcessin
         }
     )glsl";
 
-    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
     CreateComputePipelineHelper compute_pipe{*this};
     compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
     compute_pipe.dsl_bindings_ = {
@@ -3538,7 +3537,6 @@ TEST_F(NegativeTileShading, UseBlockMatchImageOpButTileShadingImageProcessingNot
         }
     )glsl";
 
-    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
     CreateComputePipelineHelper compute_pipe{*this};
     compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
     compute_pipe.dsl_bindings_ = {
@@ -3665,7 +3663,6 @@ TEST_F(NegativeTileShading, UseBlockMatchWindowImageOpButTileShadingImageProcess
         }
     )glsl";
 
-    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
     CreateComputePipelineHelper compute_pipe{*this};
     compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
     compute_pipe.dsl_bindings_ = {
@@ -3792,7 +3789,6 @@ TEST_F(NegativeTileShading, UseBlockMatchGatherImageOpButTileShadingImageProcess
         }
     )glsl";
 
-    m_errorMonitor->SetAllowedFailureMsg("VUID-VkComputePipelineCreateInfo-layout-07990");
     CreateComputePipelineHelper compute_pipe{*this};
     compute_pipe.cs_ = VkShaderObj{*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL};
     compute_pipe.dsl_bindings_ = {


### PR DESCRIPTION
# Overview

Fixes false positive `VUID-VkComputePipelineCreateInfo-layout-07990` for `VK_QCOM_image_processing` and `VK_QCOM_image_processing2` descriptor types.

Now detect QCOM image processing usage from `image_proc_usage_mask` inside the `is_sampled_image` branch of both `GetAllDescriptorTypes()` and `GetPotentialDescriptorType()`:
- `kBlockMatch` → `VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM`
- `kSampleWeighted` + `arrayed` → `VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM` (weight image is always `array`, see https://github.com/KhronosGroup/GLSL/blob/main/extensions/qcom/GLSL_QCOM_image_processing.txt)

Also adds SPIR-V mapping hints for both QCOM descriptor types to the mismatch error message.
