### PR TITLE
gpuav: Move CooperativeMatrixAccess to common code

### DIFF
--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -60,8 +60,7 @@ void DescriptorClassGeneralBufferPass::CreateFunctionCall(BasicBlock& block, Ins
     const Constant& desc_set_constant = type_manager_.GetConstantUInt32(interface.set);
     const uint32_t desc_index_id = CastToUint32(meta.access_path.descriptor_index_id, block, inst_it);  // might be int32
 
-    const uint32_t descriptor_offset_id =
-        GetLastByte(*meta.access_path.pointer_type, meta.access_path.ac_list, meta.coop_mat_access, block, inst_it);
+    const uint32_t descriptor_offset_id = GetLastByte(meta.access_path, block, inst_it);
 
     const auto& layout_lut = module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut;
     BindingLayout binding_layout = layout_lut[interface.set][interface.binding];
@@ -71,7 +70,7 @@ void DescriptorClassGeneralBufferPass::CreateFunctionCall(BasicBlock& block, Ins
     const uint32_t inst_position_id = type_manager_.CreateConstantUInt32(inst_position).Id();
 
     const uint32_t function_result = module_.TakeNextId();
-    const bool is_coop_mat = meta.coop_mat_access.used;
+    const bool is_coop_mat = meta.access_path.coop_mat.used;
     const uint32_t function_def = GetLinkFunctionId(is_coop_mat);
     const uint32_t void_type = type_manager_.GetTypeVoid().Id();
 
@@ -124,14 +123,9 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
         return false;
     }
 
-    // The way CoopMat works, we need to get the size here as the type is not found in the access chains
-    if (is_coop_mat) {
-        meta.coop_mat_access = GetCooperativeMatrixAccess(inst, function);
-    }
-
     if (!module_.settings_.safe_mode) {
-        meta.access_offset =
-            FindOffsetInStruct(meta.descriptor_block_type_id, &meta.coop_mat_access, is_descriptor_array, meta.access_path.ac_list);
+        meta.access_offset = FindOffsetInStruct(meta.descriptor_block_type_id, &meta.access_path.coop_mat, is_descriptor_array,
+                                                meta.access_path.ac_list);
     }
 
     // Save information to be used to make the Function

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
@@ -45,8 +45,6 @@ class DescriptorClassGeneralBufferPass : public Pass {
         // Capture the upper bound offset into the struct the instruction accesses
         // Will be zero if we can't determine it (or in Safe Mode)
         uint32_t access_offset = 0;
-
-        CooperativeMatrixAccess coop_mat_access{};
     };
 
     bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta);

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -336,13 +336,13 @@ uint32_t Pass::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride, bool c
 // Find outermost buffer type and its access chain index.
 // Because access chains indexes can be runtime values, we need to build arithmetic logic in the SPIR-V to get the runtime value of
 // the indexing
-uint32_t Pass::GetLastByte(const Type& descriptor_type, const std::vector<const Instruction*>& access_chain_insts,
-                           const CooperativeMatrixAccess& coop_mat_access, BasicBlock& block, InstructionIt* inst_it) {
-    assert(!access_chain_insts.empty());
+uint32_t Pass::GetLastByte(const AccessPath& access_path, BasicBlock& block, InstructionIt* inst_it) {
+    assert(!access_path.ac_list.empty());
     uint32_t current_type_id = 0;
     const uint32_t reset_ac_word = 4;  // points to first "Index" operand of an OpAccessChain
     uint32_t ac_word_index = reset_ac_word;
 
+    const Type& descriptor_type = *access_path.pointer_type;
     if (descriptor_type.IsArray()) {
         current_type_id = descriptor_type.inst_.Operand(0);
         ac_word_index++;  // this jumps over the array of descriptors so we first start on the descriptor itself
@@ -372,7 +372,7 @@ uint32_t Pass::GetLastByte(const Type& descriptor_type, const std::vector<const 
     // }
     //
     // it will get us to 20 bytes
-    auto access_chain_iter = access_chain_insts.begin();
+    auto access_chain_iter = access_path.ac_list.begin();
 
     // This occurs in things like Slang where they have a single OpAccessChain for the descriptor
     // (GLSL/HLSL will combine 2 indexes into the last OpAccessChain)
@@ -381,7 +381,7 @@ uint32_t Pass::GetLastByte(const Type& descriptor_type, const std::vector<const 
         ac_word_index = reset_ac_word;
     }
 
-    while (access_chain_iter != access_chain_insts.end()) {
+    while (access_chain_iter != access_path.ac_list.end()) {
         const uint32_t ac_index_id = (*access_chain_iter)->Word(ac_word_index);
         uint32_t current_offset_id = 0;
 
@@ -492,7 +492,8 @@ uint32_t Pass::GetLastByte(const Type& descriptor_type, const std::vector<const 
     uint32_t accessed_type_size = 0;
 
     // For CooperativeMatrix the |current_type_id| will be an an Int or Float as that is the element type being accessed
-    if (coop_mat_access.used) {
+    if (access_path.coop_mat.used) {
+        const CooperativeMatrixAccess& coop_mat_access = access_path.coop_mat;
         // The stride here could be constant, so if it is, just use it, otherwise will need to build it via SPIR-V
         if (coop_mat_access.stride_value != 0) {
             accessed_type_size = coop_mat_access.Size();
@@ -689,50 +690,6 @@ uint32_t Pass::FindOffsetInStruct(uint32_t struct_id, const CooperativeMatrixAcc
     last_byte_offset += last_byte_index;
 
     return last_byte_offset;
-}
-
-// Unlike a normal load/store where we get the size by looking at the type that is loaded/stored,
-// With CoopMat, we need both the OpTypeCooperativeMatrixKHR and the OpCooperativeMatrixLoadKHR/OpCooperativeMatrixStoreKHR together
-// to calculate the access size.
-CooperativeMatrixAccess Pass::GetCooperativeMatrixAccess(const Instruction& inst, const Function& function) const {
-    CooperativeMatrixAccess info;
-
-    // TODO - When adding Coop Mat to Descriptor Indexing, will likely want a better way to signal things than this bool
-    info.used = true;
-
-    info.is_load = inst.Opcode() == spv::OpCooperativeMatrixLoadKHR;  // else is store
-
-    // For stores, we assume the Object operand points to a load to get the type
-    uint32_t coop_mat_type_id = info.is_load ? inst.TypeId() : function.FindInstruction(inst.Word(2))->TypeId();
-    info.type = type_manager_.FindTypeById(coop_mat_type_id);
-    assert(info.type && info.type->spv_type_ == SpvType::kCooperativeMatrixKHR);
-
-    // Currently we don't save/cache the size of each type because we still need to extract the rows/column info. This the tradeoff
-    // of having a simplified single Type class
-    const Type* component_type = type_manager_.FindTypeById(info.type->inst_.Word(2));
-    info.component_size = type_manager_.GetTypeBytesSize(*component_type);
-
-    const Constant* rows_const = type_manager_.FindConstantById(info.type->inst_.Word(4));
-    const Constant* columns_const = type_manager_.FindConstantById(info.type->inst_.Word(5));
-    assert(rows_const && !rows_const->is_spec_constant_ && columns_const && !columns_const->is_spec_constant_);
-    info.rows = rows_const->inst_.Operand(0);
-    info.columns = columns_const->inst_.Operand(0);
-
-    info.stride_id = info.is_load ? inst.Word(5) : inst.Word(4);
-    if (const Constant* stride = type_manager_.FindConstantById(info.stride_id)) {
-        info.stride_value = stride->inst_.Operand(0);
-    } else {
-        info.stride_value = 0;
-    }
-
-    const uint32_t memory_layout_id = info.is_load ? inst.Word(4) : inst.Word(3);
-    const Constant* memory_layout = type_manager_.FindConstantById(memory_layout_id);
-    assert(memory_layout && !memory_layout->is_spec_constant_);
-    const uint32_t memory_layout_value = memory_layout->inst_.Operand(0);
-    info.is_row_major = memory_layout_value == spv::CooperativeMatrixLayoutRowMajorKHR;
-    assert(info.is_row_major || memory_layout_value == spv::CooperativeMatrixLayoutColumnMajorKHR);
-
-    return info;
 }
 
 // Generate code to convert integer id to 32bit, if needed.

--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -30,6 +30,7 @@ class TypeManager;
 struct Variable;
 struct BasicBlock;
 struct Type;
+struct AccessPath;
 
 // The goal is to have the complex conditional inject control flow to be in a single spot
 // To allow this, we create all the pieces for Pass, let it make its own function call, then use this data to apply the final
@@ -66,11 +67,9 @@ class Pass {
 
     uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false) const;
     // Currently only used in the General Buffer OOB check, put here so it can be adapted for general use if needed
-    uint32_t GetLastByte(const Type& descriptor_type, const std::vector<const Instruction*>& access_chain_insts,
-                         const CooperativeMatrixAccess& coop_mat_access, BasicBlock& block, InstructionIt* inst_it);
+    uint32_t GetLastByte(const AccessPath& access_path, BasicBlock& block, InstructionIt* inst_it);
     uint32_t FindOffsetInStruct(uint32_t struct_id, const CooperativeMatrixAccess* coop_mat_access, bool is_descriptor_array,
                                 const std::vector<const Instruction*>& access_chain_insts) const;
-    CooperativeMatrixAccess GetCooperativeMatrixAccess(const Instruction& inst, const Function& function) const;
 
     // Generate SPIR-V needed to help convert things to be uniformly uint32_t
     // If no inst_it is passed in, any new instructions will be added to end of the Block

--- a/layers/gpuav/spirv/sanitizer_pass.cpp
+++ b/layers/gpuav/spirv/sanitizer_pass.cpp
@@ -413,7 +413,7 @@ bool SanitizerPass::RequiresInstrumentation(const Function& function, const Inst
         meta.result_type = type_manager_.FindTypeById(inst.TypeId());
         return true;
     } else if (opcode == spv::OpCooperativeMatrixLoadKHR || opcode == spv::OpCooperativeMatrixStoreKHR) {
-        CooperativeMatrixAccess cma = GetCooperativeMatrixAccess(inst, function);
+        CooperativeMatrixAccess cma = type_manager_.BuildCooperativeMatrixAccess(function, inst);
         const uint32_t natural_alignment = (cma.is_row_major ? cma.columns : cma.rows) * cma.component_size;
         const uint32_t required_alignment = natural_alignment < 16 ? natural_alignment : 16;
         if (required_alignment <= 1) {

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -904,6 +904,11 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
     }
     assert(path.pointer_type);
 
+    // The way CoopMat works, we need to get the size here as the type is not found in the access chains
+    if (opcode == spv::OpCooperativeMatrixLoadKHR || opcode == spv::OpCooperativeMatrixStoreKHR) {
+        path.coop_mat = BuildCooperativeMatrixAccess(function, inst);
+    }
+
     // Everything else is just for descriptor variable access
     if (!path.variable->IsDescriptor()) {
         return path;
@@ -1004,6 +1009,50 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
     assert(path.descriptor_type != invalid_type);
 
     return path;
+}
+
+// Unlike a normal load/store where we get the size by looking at the type that is loaded/stored,
+// With CoopMat, we need both the OpTypeCooperativeMatrixKHR and the OpCooperativeMatrixLoadKHR/OpCooperativeMatrixStoreKHR together
+// to calculate the access size.
+const CooperativeMatrixAccess TypeManager::BuildCooperativeMatrixAccess(const Function& function, const Instruction& inst) {
+    CooperativeMatrixAccess info;
+
+    // TODO - When adding Coop Mat to Descriptor Indexing, will likely want a better way to signal things than this bool
+    info.used = true;
+
+    info.is_load = inst.Opcode() == spv::OpCooperativeMatrixLoadKHR;  // else is store
+
+    // For stores, we assume the Object operand points to a load to get the type
+    uint32_t coop_mat_type_id = info.is_load ? inst.TypeId() : function.FindInstruction(inst.Word(2))->TypeId();
+    info.type = FindTypeById(coop_mat_type_id);
+    assert(info.type && info.type->spv_type_ == SpvType::kCooperativeMatrixKHR);
+
+    // Currently we don't save/cache the size of each type because we still need to extract the rows/column info. This the tradeoff
+    // of having a simplified single Type class
+    const Type* component_type = FindTypeById(info.type->inst_.Word(2));
+    info.component_size = GetTypeBytesSize(*component_type);
+
+    const Constant* rows_const = FindConstantById(info.type->inst_.Word(4));
+    const Constant* columns_const = FindConstantById(info.type->inst_.Word(5));
+    assert(rows_const && !rows_const->is_spec_constant_ && columns_const && !columns_const->is_spec_constant_);
+    info.rows = rows_const->inst_.Operand(0);
+    info.columns = columns_const->inst_.Operand(0);
+
+    info.stride_id = info.is_load ? inst.Word(5) : inst.Word(4);
+    if (const Constant* stride = FindConstantById(info.stride_id)) {
+        info.stride_value = stride->inst_.Operand(0);
+    } else {
+        info.stride_value = 0;
+    }
+
+    const uint32_t memory_layout_id = info.is_load ? inst.Word(4) : inst.Word(3);
+    const Constant* memory_layout = FindConstantById(memory_layout_id);
+    assert(memory_layout && !memory_layout->is_spec_constant_);
+    const uint32_t memory_layout_value = memory_layout->inst_.Operand(0);
+    info.is_row_major = memory_layout_value == spv::CooperativeMatrixLayoutRowMajorKHR;
+    assert(info.is_row_major || memory_layout_value == spv::CooperativeMatrixLayoutColumnMajorKHR);
+
+    return info;
 }
 
 const Variable& TypeManager::AddVariable(std::unique_ptr<Instruction> new_inst, const Type& type) {

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include "containers/custom_containers.h"
 #include "containers/limits.h"
+#include "cooperative_matrix.h"
 #include "state_tracker/shader_instruction.h"
 #include "generated/spirv_grammar_helper.h"
 
@@ -207,6 +208,8 @@ struct AccessPath {
 
     // As defined in gpuav_descriptor_validation.h
     uint8_t descriptor_type = 0;
+
+    CooperativeMatrixAccess coop_mat{};
 };
 
 // In charge of tracking all Types, Constants, and Variable in the module.
@@ -269,6 +272,7 @@ class TypeManager {
     const Constant& GetConstantNull(const Type& type);
 
     const AccessPath BuildAccessPath(const Function& function, const Instruction& inst);
+    const CooperativeMatrixAccess BuildCooperativeMatrixAccess(const Function& function, const Instruction& inst);
 
     const Variable& AddVariable(std::unique_ptr<Instruction> new_inst, const Type& type);
     const Variable* FindVariableById(uint32_t id) const;


### PR DESCRIPTION
Not that we have a proper `AccessPath`, just throw the CoopMat stuff in there as that code is ugly and only should be done once