### PR TITLE
layers: PushData saved as a list of dwords

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -2222,27 +2222,43 @@ bool CoreChecks::ValidateActionStatePushConstantDescriptorHeap(const vvl::Comman
         return skip;
     }
 
-    const auto& cb_sub_state = core::SubState(cb_state);
+    if (!cb_state.push_data_dword_mask.empty()) {
+        const uint32_t begin_byte = pc_variable.offset;
+        const uint32_t end_byte = pc_variable.offset + pc_variable.size;  // Exclusive end for easier range math
+        const uint32_t size_dword = static_cast<uint32_t>(cb_state.push_data_dword_mask.size());
 
-    const uint32_t begin = pc_variable.offset;
-    const uint32_t end = begin + pc_variable.size - 1;
+        const uint32_t begin_dword = begin_byte / 4;
+        const uint32_t end_dword = (end_byte + 3) / 4;  // Round up to cover the partial last dword
 
-    if (!cb_sub_state.push_data_mask.empty()) {
-        const uint32_t size = static_cast<uint32_t>(cb_sub_state.push_data_mask.size());
-        // Find the first range of bytes which were not set
-        uint32_t unset_start = size;
-        uint32_t unset_end = end;
-        for (uint32_t i = begin; i <= end; i++) {
-            if (i >= size || !cb_sub_state.push_data_mask[i]) {
-                if (unset_start == size) {
-                    unset_start = i;
+        uint32_t unset_start = spirv::kInvalidValue;
+        uint32_t unset_end = spirv::kInvalidValue;
+
+        bool found_error = false;
+        for (uint32_t i = begin_dword; i < end_dword; ++i) {
+            const bool is_not_set = (i >= size_dword) || !cb_state.push_data_dword_mask[i];
+
+            if (is_not_set) {
+                const uint32_t dword_start_byte = i * 4;
+                const uint32_t dword_end_byte = dword_start_byte + 4;
+
+                // Find the overlapping byte range between this unmasked DWORD and the variable
+                const uint32_t overlap_start = std::max(begin_byte, dword_start_byte);
+                const uint32_t overlap_end = std::min(end_byte, dword_end_byte);
+
+                // guard if the user does something like offset = 3, size = 1
+                if (overlap_start < overlap_end) {
+                    if (!found_error) {
+                        // first bad dword
+                        unset_start = overlap_start;
+                        found_error = true;
+                    }
+                    unset_end = overlap_end;
                 }
-            } else if (unset_start != size) {
-                unset_end = i - 1;
-                break;
+            } else if (found_error) {
+                break;  // found unset_end
             }
         }
-        if (unset_start != size) {
+        if (found_error) {
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::DESCRIPTOR_HEAP_11376),
                              cb_state.GetObjectList(bind_point), loc,
                              "shader %s uses push-constant statically at range [%" PRIu32 ", %" PRIu32

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -245,19 +245,6 @@ void CommandBufferSubState::RecordSetPrimitiveRestartIndex(uint32_t primitive_re
     custom_primitive_restart_index = primitive_restart_index;
 }
 
-void CommandBufferSubState::RecordPushData(const VkPushDataInfoEXT& push_data_info) {
-    if (push_data_info.data.size > 0) {
-        const size_t begin = push_data_info.offset;
-        const size_t end = push_data_info.offset + push_data_info.data.size;
-        if (push_data_mask.size() < end) {
-            push_data_mask.resize(end);
-        }
-        memset(push_data_mask.data() + begin, 1, end - begin);
-    }
-}
-
-void CommandBufferSubState::ClearPushData() { push_data_mask.clear(); }
-
 void CommandBufferSubState::RecordNextSubpass(const VkSubpassBeginInfo&, const VkSubpassEndInfo*, const Location&) {
     ASSERT_AND_RETURN(base.active_render_pass);
     validator.TransitionSubpassLayouts(base, *base.active_render_pass, base.GetActiveSubpass());
@@ -1215,7 +1202,6 @@ void CommandBufferSubState::ResetCBState() {
 
     custom_primitive_restart_index = 0;
 
-    push_data_mask.clear();
     event_signal_states.clear();
     event_wait_barriers.clear();
     first_event_wait_commands.clear();

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -49,9 +49,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordBindIndexbuffer() final;
     void RecordSetPrimitiveRestartIndex(uint32_t primitive_restart_index) final;
 
-    void RecordPushData(const VkPushDataInfoEXT& push_data_info) final;
-    void ClearPushData() final;
-
     void RecordBeginRendering(const VkRenderingInfo &rendering_info, const Location &loc) final;
     void RecordBeginRenderPass(const VkRenderPassBeginInfo &render_pass_begin, const VkSubpassBeginInfo &subpass_begin_info,
                                const Location &loc) final;
@@ -186,10 +183,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     // VK_EXT_primitive_restart_index
     uint32_t custom_primitive_restart_index;
-
-    // VK_EXT_descriptor_heap
-    // Mark which ranges vkCmdPushDataKHR has set (will be 0 or 1)
-    std::vector<uint8_t> push_data_mask{};
 
     uint32_t used_viewport_scissor_count;
 

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -600,11 +600,19 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
 
     auto get_push_data = [&](uint32_t offset, uint32_t size) {
         VkDeviceSize push_index = 0;
+        ss << new_bullet_line << "pushData[" << std::dec << offset << ":" << offset + (size - 1) << "] = ";
+
         // This is caught by core validation already, but don't want to crash here
         if ((offset + size) > push_data_value.size()) {
+            ss << "UNDEFINED";
             warn_ss << new_bullet_line << "[WARNING] PUSH DATA - " << std::dec << offset << " is over the maxPushDataSize ("
                     << push_data_value.size() << ") limit";
             return push_index;  // something to not blow up other calculations too bad
+        } else if (!base.VerifyPushData(offset, size)) {
+            ss << "UNDEFINED";
+            warn_ss << new_bullet_line << "[WARNING] PUSH DATA - [" << std::dec << offset << ":" << (offset + size) - 1
+                    << "] has not been set by vkCmdPushDataEXT and the value being read is undefined";
+            return push_index;  // value being tracked in state tracking is undefined
         }
 
         if (size == 4) {
@@ -613,8 +621,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
             push_index = (VkDeviceSize) * ((VkDeviceAddress*)&push_data_value[offset]);
         }
 
-        ss << new_bullet_line << "pushData[" << std::dec << offset << ":" << offset + (size - 1) << "] = 0x" << std::hex
-           << push_index;
+        ss << "0x" << std::hex << push_index;
         return push_index;
     };
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -351,6 +351,7 @@ void CommandBuffer::ResetCBState() {
     label_commands_.clear();
 
     push_constant_ranges_layout.reset();
+    push_data_dword_mask.clear();
 
     transform_feedback_active = false;
     transform_feedback_buffers_bound = 0;
@@ -2283,17 +2284,52 @@ void CommandBuffer::RecordPushConstants(const vvl::PipelineLayout& pipeline_layo
 
     for (auto& item : sub_states_) {
         item.second->RecordPushConstants(pipeline_layout_state.VkHandle(), stage_flags, offset, size, values);
-        item.second->ClearPushData();  // vkspec.html#descriptorheaps-invalidate-sets
+
+        // vkspec.html#descriptorheaps-invalidate-sets
+        item.second->ClearPushData();
+        push_data_dword_mask.clear();
     }
 }
 
 void CommandBuffer::RecordPushData(const VkPushDataInfoEXT& push_data_info, const Location& loc) {
     RecordCommand(loc);
 
+    if (push_data_info.data.size > 0) {
+        const size_t begin_byte = push_data_info.offset;
+        const size_t end_byte = push_data_info.offset + push_data_info.data.size;
+        // offset/size required to be multiple of 4
+        const size_t begin_dword = begin_byte / 4;
+        const size_t end_dword = end_byte / 4;
+        if (push_data_dword_mask.size() < end_dword) {
+            push_data_dword_mask.resize(end_dword, false);
+        }
+        for (size_t i = begin_dword; i < end_dword; ++i) {
+            push_data_dword_mask[i] = true;
+        }
+    }
+
     for (auto& item : sub_states_) {
         item.second->RecordPushData(push_data_info);
         item.second->ClearPushConstants();  // vkspec.html#descriptorheaps-invalidate-sets
     }
+}
+
+bool CommandBuffer::VerifyPushData(uint32_t offset_byte, uint32_t size_byte) const {
+    // no other reason we should need this function
+    assert(size_byte == 4 || size_byte == 8);
+    // offset required to be a multiple of 4
+    const uint32_t dwords_used = (offset_byte + size_byte) / 4;
+    if (dwords_used > push_data_dword_mask.size()) {
+        return false;
+    }
+    uint32_t dword_offset = offset_byte / 4;
+    if (!push_data_dword_mask[dword_offset]) {
+        return false;
+    }
+    if (size_byte == 8 && !push_data_dword_mask[dword_offset + 1]) {
+        return false;
+    }
+    return true;
 }
 
 void CommandBuffer::RecordBindResourceHeap(const Location& loc) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -511,6 +511,10 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
 
     PushConstantRangesId push_constant_ranges_layout;
 
+    // VK_EXT_descriptor_heap - Mark which ranges vkCmdPushDataKHR has been set
+    // Note - this is one boolean per 32-bit dword as VkPushDataInfoEXT offset/size are required to be multiple of 4
+    std::vector<bool> push_data_dword_mask{};
+
     // Video coding related state tracking
     std::shared_ptr<vvl::VideoSession> bound_video_session;
     std::shared_ptr<vvl::VideoSessionParameters> bound_video_session_parameters;
@@ -744,6 +748,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordPushConstants(const vvl::PipelineLayout& pipeline_layout_state, VkShaderStageFlags stage_flags, uint32_t offset,
                              uint32_t size, const void *values);
     void RecordPushData(const VkPushDataInfoEXT& push_data_info, const Location& loc);
+    bool VerifyPushData(uint32_t offset, uint32_t size) const;
 
     void RecordBindResourceHeap(const Location& loc);
     void RecordBindSamplerHeap(const Location& loc);

--- a/tests/unit/descriptor_heap.cpp
+++ b/tests/unit/descriptor_heap.cpp
@@ -4689,35 +4689,22 @@ TEST_F(NegativeDescriptorHeap, PushDataRange) {
 
     float src_data[4] = {1.0f, 2.0f, 3.0f, 4.0f};
 
-    VkPushDataInfoEXT push_data_info1 = vku::InitStructHelper();
-    push_data_info1.offset = 0u;
-    push_data_info1.data.size = 8u;
-    push_data_info1.data.address = src_data;
-
-    VkPushDataInfoEXT push_data_info2 = vku::InitStructHelper();
-    push_data_info2.offset = 12u;
-    push_data_info2.data.size = 4u;
-    push_data_info2.data.address = src_data;
-
     // Set from 0-7 and 12-15, unset from 8-11
     m_command_buffer.Begin();
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info1);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info2);
+    m_command_buffer.PushData(0, 8, src_data);
+    m_command_buffer.PushData(12, 4, src_data);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11376");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
-
-    push_data_info1.offset = 4u;
-    push_data_info1.data.size = 16u;
 
     // Set from 4-19, unset from 0-3
     m_command_buffer.Begin();
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info1);
+    m_command_buffer.PushData(4, 16, src_data);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11376");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
@@ -4725,21 +4712,12 @@ TEST_F(NegativeDescriptorHeap, PushDataRange) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    push_data_info1.offset = 0u;
-    push_data_info1.data.size = 8u;
-    push_data_info2.offset = 4u;
-    push_data_info2.data.size = 8u;
-    VkPushDataInfoEXT push_data_info3 = vku::InitStructHelper();
-    push_data_info3.offset = 8u;
-    push_data_info3.data.size = 8u;
-    push_data_info3.data.address = src_data;
-
     // Set multiple times with overlap
     m_command_buffer.Begin();
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info1);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info2);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info3);
+    m_command_buffer.PushData(0, 8, src_data);
+    m_command_buffer.PushData(4, 8, src_data);
+    m_command_buffer.PushData(8, 8, src_data);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
@@ -4755,26 +4733,78 @@ TEST_F(NegativeDescriptorHeap, PushDataRange) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
-    push_data_info1.offset = 0u;
-    push_data_info1.data.size = 16u;
-
     const std::vector<VkPushConstantRange> pc_range = {{VK_SHADER_STAGE_COMPUTE_BIT, 0, 16}};
     vkt::PipelineLayout pipeline_layout(*m_device, {}, pc_range);
 
     // Full range set, invalidated by vkCmdPushConstants, only part of the range set again
     m_command_buffer.Begin();
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info1);
+    m_command_buffer.PushData(0, 16, src_data);
     vk::CmdPushConstants(m_command_buffer, pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0u, 16u, src_data);
-    push_data_info1.data.size = 8u;
     vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
-    vk::CmdPushDataEXT(m_command_buffer, &push_data_info1);
+    m_command_buffer.PushData(0, 8, src_data);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11376");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(NegativeDescriptorHeap, PushDataRangeNonDword) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::shaderInt8);
+    AddRequiredFeature(vkt::Feature::storagePushConstant8);
+    RETURN_IF_SKIP(InitBasicDescriptorHeap());
+    CreateResourceHeap(heap_props.bufferDescriptorSize);
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_shader_explicit_arithmetic_types_int8 : enable
+        layout(set = 0, binding = 0) buffer A { uint a; };
+        layout(push_constant) uniform PushConstant {
+            layout(offset = 4) uint8_t b[5];
+        };
+        void main() {
+            a = uint(b[0]);
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    char const* cs_source2 = R"glsl(
+        #version 450
+        #extension GL_EXT_shader_explicit_arithmetic_types_int8 : enable
+        layout(set = 0, binding = 0) buffer A { uint a; };
+        layout(push_constant) uniform PushConstant {
+            layout(offset = 3) uint8_t b[5];
+        };
+        void main() {
+            a = uint(b[1]);
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe2(*m_device, cs_source2, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    BindResourceHeap();
+    uint32_t data = 0;
+    m_command_buffer.PushData(4, 4, &data);
+
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11376");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe2);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11376");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorHeap, MaxPushDataSizeStatic) {

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -1582,3 +1582,44 @@ TEST_F(NegativeGpuDump, DISABLED_UntypedPointersMultiDimensional) {
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 }
+
+TEST_F(NegativeGpuDump, DescriptorHeapPushOffsetOOB) {
+    RETURN_IF_SKIP(InitDescriptorHeap());
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+    vkt::Buffer resource_heap(*m_device, heap_props.bufferDescriptorSize, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT,
+                              vkt::device_address);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT;
+    mapping.sourceData.pushAddressOffset = 8;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1;
+    mapping_info.pMappings = &mapping;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) buffer A { uint a; };
+        void main() {
+            a = 2;
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = resource_heap.AddressRange();
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    uint32_t push_index = 0;
+    m_command_buffer.PushData(8, sizeof(uint32_t), &push_index);
+    VkDeviceAddress indirect_data = 0;
+    m_command_buffer.PushData(16, sizeof(VkDeviceAddress), &indirect_data);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredWarning("PUSH DATA");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
We use to have a `std::vector<uint8_t> push_data_mask{};` that would hold a `1`/`0` depending if the `vkCmdPushDataEXT` had been called on that range

These 2 VUs

<img width="331" height="121" alt="image" src="https://github.com/user-attachments/assets/1a692ecb-92b8-4f99-98dc-c286e1505811" />

allow us to just have a `std::vector<bool>` where we track a boolean for each dword, not even byte... this greatly reduces the size allocation and still works the same

I also moved the state tracking OUT of substate so GPU Dump (and in future GPU-AV) can actually detect this and provide a proper warning