### PR TITLE
layers: Fix event mismatch checks for ignored signals

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1145,14 +1145,11 @@ static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent 
     return {};
 }
 
-// Return the last signaling command and does not take into acccount if it was ignored or not.
-// This is used for the set-wait version mismatch. The current validation logic considers
-// version mismtach to be an issue even if the command is ignored.
 static vvl::Func ResolveSignalingCommand(const EventSignalState* prior_state, const EventSignalState* secondary_state) {
-    if (secondary_state) {
+    if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
         return secondary_state->last_signaling_command;
     }
-    if (prior_state) {
+    if (prior_state && prior_state->HasKnownEffect() && prior_state->signaled) {
         return prior_state->last_signaling_command;
     }
     return vvl::Func::Empty;
@@ -1177,6 +1174,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
     for (const WaitEventSubmitInfo& secondary_wait : secondary_cb_sub_state.wait_event_submit_infos) {
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
         bool can_validate_stage_mask = true;
+        bool set_wait_version_mismatch = false;
         bool found_known_signals = false;
 
         for (VkEvent event : secondary_wait.wait_events) {
@@ -1189,6 +1187,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
                 skip |=
                     LogError("VUID-vkCmdWaitEvents-pEvents-03847", event, secondary_cb_loc, "%s: %s was set by %s.",
                              vvl::String(secondary_wait.wait_command), FormatHandle(event).c_str(), vvl::String(signal_command));
+                set_wait_version_mismatch = true;
             }
 
             // Determine if stage mask validation is possible during execution time
@@ -1202,7 +1201,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
             }
         }
         // Validate state mask
-        if (can_validate_stage_mask && secondary_wait.wait_src_stage_mask != signals_src_stage_mask) {
+        if (!set_wait_version_mismatch && can_validate_stage_mask && secondary_wait.wait_src_stage_mask != signals_src_stage_mask) {
             const LogObjectList objlist(secondary_cb_sub_state.Handle());
             if (found_known_signals) {
                 std::ostringstream ss;
@@ -1225,13 +1224,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
         const EventSignalState* local_state = vvl::Find(local_signal_states, secondary_wait.wait_event);
         const EventSignalState* secondary_state = secondary_wait.signal_state.has_value() ? &*secondary_wait.signal_state : nullptr;
 
-        // Set-wait version mismatch is always reported. Do not try to determine whether signal is ignored
-        vvl::Func signaling_command = vvl::Func::Empty;
-        if (secondary_wait.signal_state.has_value() && secondary_wait.signal_state->signaled) {
-            signaling_command = secondary_wait.signal_state->last_signaling_command;
-        } else if (local_state && local_state->signaled) {
-            signaling_command = local_state->last_signaling_command;
-        }
+        const vvl::Func signaling_command = ResolveSignalingCommand(local_state, secondary_state);
 
         if (signaling_command == vvl::Func::vkCmdSetEvent) {
             skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03837", secondary_wait.wait_event, secondary_cb_loc,

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -444,15 +444,15 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
             if (const auto* submit_signaling = vvl::Find(submit_signal_states, event)) {
                 if (!last_signal || submit_signaling->HasKnownEffect()) {
                     stage_mask = submit_signaling->signal_src_stage_mask;
+                    signal_command = submit_signaling->last_signaling_command;
                 }
-                last_signal = submit_signaling->signal_src_stage_mask;
-                signal_command = submit_signaling->last_signaling_command;
+                last_signal = submit_signaling->signaled;
             }
             if (const auto* cb_signaling = vvl::Find(signal_states, event)) {
                 if (!last_signal || cb_signaling->HasKnownEffect()) {
                     stage_mask = cb_signaling->signal_src_stage_mask;
+                    signal_command = cb_signaling->last_signaling_command;
                 }
-                signal_command = cb_signaling->last_signaling_command;
             }
             signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(stage_mask);
 
@@ -1609,27 +1609,28 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
 
     if (pEvents) {
         auto& cb_sub_state = core::SubState(*cb_state);
-        bool can_validate_stage_mask = true;
+        bool can_validate_stage_mask = true;  // whether record-time validation is possible
+        bool set_wait_version_mismatch = false;
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
         for (uint32_t i = 0; i < eventCount; i++) {
             const EventSignalState* signal_state = vvl::Find(cb_sub_state.event_signal_states, pEvents[i]);
+            const bool has_effect = signal_state && signal_state->HasKnownEffect();
 
             // Record phase also uses this logic to determine stage mask validation status
-            if (!signal_state || !signal_state->HasKnownEffect()) {
+            if (!has_effect) {
                 can_validate_stage_mask = false;
             } else {
                 signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signal_state->signal_src_stage_mask);
             }
 
-            // Set-wait version mismatch is always reported.
-            // Do not try to determine whether signal is ignored
-            if (signal_state &&
+            if (has_effect &&
                 IsValueIn(signal_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
                 skip |= LogError("VUID-vkCmdWaitEvents-pEvents-03847", pEvents[i], error_obj.location, "%s was set by %s.",
                                  FormatHandle(pEvents[i]).c_str(), vvl::String(signal_state->last_signaling_command));
+                set_wait_version_mismatch = true;
             }
         }
-        if (can_validate_stage_mask) {
+        if (!set_wait_version_mismatch && can_validate_stage_mask) {
             if (srcStageMask != signals_src_stage_mask) {
                 skip |= LogError("VUID-vkCmdWaitEvents-srcStageMask-01158", objlist, error_obj.location.dot(Field::srcStageMask),
                                  "is %s, but the bitwise OR of stageMask values from the most recent vkCmdSetEvent call for each "
@@ -1700,18 +1701,16 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
         }
         if (const EventSignalState* signal_state = vvl::Find(cb_sub_state.event_signal_states, pEvents[i])) {
             const VkPipelineStageFlags2 union_src_stage_mask = sync_utils::GetExecScopes(dep_info).src;
-            if (signal_state->last_signaling_command == vvl::Func::vkCmdSetEvent) {
-                // Set-wait version mismatch is always reported.
-                // Do not try to determine whether signal is ignored
+            if (signal_state->HasKnownEffect() && signal_state->last_signaling_command == vvl::Func::vkCmdSetEvent) {
                 skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03837", objlist, error_obj.location, "%s was set by %s.",
                                  FormatHandle(pEvents[i]).c_str(), vvl::String(signal_state->last_signaling_command));
-            } else {
-                if ((union_src_stage_mask & VK_PIPELINE_STAGE_2_HOST_BIT) == 0 &&
-                    !IsValueIn(signal_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
-                    skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03841", objlist, error_obj.location,
-                                     "%s was not set by vkCmdSetEvent2.", FormatHandle(pEvents[i]).c_str());
-                }
+            } else if ((union_src_stage_mask & VK_PIPELINE_STAGE_2_HOST_BIT) == 0 &&
+                       !IsValueIn(signal_state->last_signaling_command,
+                                  {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03841", objlist, error_obj.location,
+                                 "%s was not set by vkCmdSetEvent2.", FormatHandle(pEvents[i]).c_str());
             }
+
             if (union_src_stage_mask == VK_PIPELINE_STAGE_2_HOST_BIT && signal_state->HasKnownEffect() && !signal_state->signaled) {
                 skip |=
                     LogError("VUID-vkCmdWaitEvents2-pEvents-03840", objlist, error_obj.location,

--- a/tests/unit/event.cpp
+++ b/tests/unit/event.cpp
@@ -1054,8 +1054,8 @@ TEST_F(NegativeEvent, StageMaskHost) {
     m_default_queue->Wait();
 }
 
-TEST_F(NegativeEvent, SetWait2VersionMismatch) {
-    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents2");
+TEST_F(NegativeEvent, SetWait2Mismatch) {
+    TEST_DESCRIPTION("CmdSetEvent -> CmdWaitEvents2");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
@@ -1066,6 +1066,7 @@ TEST_F(NegativeEvent, SetWait2VersionMismatch) {
     barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 
     m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);  // ensure that event is in known (unsignaled) state
     m_command_buffer.SetEvent(event);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents2-pEvents-03837");
     m_command_buffer.WaitEvent2(event, barrier);
@@ -1073,8 +1074,8 @@ TEST_F(NegativeEvent, SetWait2VersionMismatch) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeEvent, SetWait2VersionMismatchSecondary) {
-    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents2");
+TEST_F(NegativeEvent, SetWait2MismatchSecondary) {
+    TEST_DESCRIPTION("CmdSetEvent -> CmdWaitEvents2");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
@@ -1090,6 +1091,7 @@ TEST_F(NegativeEvent, SetWait2VersionMismatchSecondary) {
     secondary.End();
 
     m_command_buffer.Begin();
+    m_command_buffer.ResetEvent(event);  // ensure that event is in known (unsignaled) state
     m_command_buffer.SetEvent(event);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents2-pEvents-03837");
     m_command_buffer.ExecuteCommands(secondary);
@@ -1097,8 +1099,8 @@ TEST_F(NegativeEvent, SetWait2VersionMismatchSecondary) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeEvent, SetWait2VersionMismatchSubmit) {
-    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents2");
+TEST_F(NegativeEvent, SetWait2MismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent -> CmdWaitEvents2");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
@@ -1124,8 +1126,8 @@ TEST_F(NegativeEvent, SetWait2VersionMismatchSubmit) {
     m_default_queue->Wait();
 }
 
-TEST_F(NegativeEvent, SetWaitThenWait2VersionMismatchSubmit) {
-    TEST_DESCRIPTION("CmdSetEvent followed by CmdWaitEvents, then CmdWaitEvents2");
+TEST_F(NegativeEvent, SetWaitThenWait2MismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent -> CmdWaitEvents -> CmdWaitEvents2");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
@@ -1152,8 +1154,8 @@ TEST_F(NegativeEvent, SetWaitThenWait2VersionMismatchSubmit) {
     m_default_queue->Wait();
 }
 
-TEST_F(NegativeEvent, Set2WaitVersionMismatch) {
-    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents");
+TEST_F(NegativeEvent, Set2WaitMismatch) {
+    TEST_DESCRIPTION("CmdSetEvent2 -> CmdWaitEvents");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
@@ -1164,6 +1166,7 @@ TEST_F(NegativeEvent, Set2WaitVersionMismatch) {
     barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 
     m_command_buffer.Begin();
+    m_command_buffer.ResetEvent2(event);  // ensure the event is in known (unsignaled) state
     m_command_buffer.SetEvent2(event, barrier);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
     m_command_buffer.WaitEvent(event);
@@ -1171,8 +1174,8 @@ TEST_F(NegativeEvent, Set2WaitVersionMismatch) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeEvent, Set2WaitVersionMismatchSecondary) {
-    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents");
+TEST_F(NegativeEvent, Set2WaitMismatchSecondary) {
+    TEST_DESCRIPTION("CmdSetEvent2 -> CmdWaitEvents");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
@@ -1188,6 +1191,7 @@ TEST_F(NegativeEvent, Set2WaitVersionMismatchSecondary) {
     secondary.End();
 
     m_command_buffer.Begin();
+    m_command_buffer.ResetEvent2(event);  // put event in known (unsignaled) state
     m_command_buffer.SetEvent2(event, barrier);
     monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
     m_command_buffer.ExecuteCommands(secondary);
@@ -1195,8 +1199,34 @@ TEST_F(NegativeEvent, Set2WaitVersionMismatchSecondary) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeEvent, Set2WaitVersionMismatchSubmit) {
-    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents");
+TEST_F(NegativeEvent, Set2WaitMismatchIgnoredSignalSecondary) {
+    TEST_DESCRIPTION("CmdSetEvent2 in primary -> ignored CmdSetEvent in secondary -> CmdWaitEvents in secondary");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.SetEvent(event);  // ignored signal
+    secondary.WaitEvent(event);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ResetEvent2(event);
+    m_command_buffer.SetEvent2(event, barrier);
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
+    m_command_buffer.ExecuteCommands(secondary);
+    monitor_.VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeEvent, Set2WaitMismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent2 -> CmdWaitEvents");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
@@ -1222,8 +1252,58 @@ TEST_F(NegativeEvent, Set2WaitVersionMismatchSubmit) {
     m_default_queue->Wait();
 }
 
-TEST_F(NegativeEvent, Set2Wait2ThenWaitVersionMismatchSubmit) {
-    TEST_DESCRIPTION("CmdSetEvent2 followed by CmdWaitEvents2, then CmdWaitEvents");
+TEST_F(NegativeEvent, Set2WaitMismatchIgnoredSignal) {
+    TEST_DESCRIPTION("CmdSetEvent2 -> ignored CmdSetEvent -> CmdWaitEvents");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.ResetEvent(event);
+    command_buffer.SetEvent2(event, barrier);
+    command_buffer.SetEvent(event);  // ignored signal
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
+    command_buffer.WaitEvent(event);
+    monitor_.VerifyFound();
+    command_buffer.End();
+}
+
+TEST_F(NegativeEvent, Set2WaitMismatchIgnoredSignalSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent2 -> ignored CmdSetEvent -> CmdWaitEvents");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    const vkt::Event event(*m_device);
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+
+    vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
+    command_buffer.Begin();
+    command_buffer.SetEvent2(event, barrier);
+    command_buffer.End();
+
+    vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
+    command_buffer2.Begin();
+    command_buffer2.SetEvent(event);  // ignored signal
+    command_buffer2.WaitEvent(event);
+    command_buffer2.End();
+
+    monitor_.SetDesiredError("VUID-vkCmdWaitEvents-pEvents-03847");
+    m_default_queue->Submit({command_buffer, command_buffer2});
+    monitor_.VerifyFound();
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeEvent, Set2Wait2ThenWaitMismatchSubmit) {
+    TEST_DESCRIPTION("CmdSetEvent2 -> CmdWaitEvents2 -> CmdWaitEvents");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());

--- a/tests/unit/event_positive.cpp
+++ b/tests/unit/event_positive.cpp
@@ -703,6 +703,65 @@ TEST_F(PositiveEvent, WaitWithOnlyHostDependencySecondary) {
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
 
+TEST_F(PositiveEvent, WaitWithOnlyHostDependencyIgnoredSignal) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    event.Set();
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_HOST_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent2(event, barrier);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveEvent, WaitWithOnlyHostDependencyIgnoredSignalSecondary) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    event.Set();  // signals event, the next signal is ignored
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_HOST_BIT;
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    secondary.SetEvent(event);  // ignored signal
+    secondary.WaitEvent2(event, barrier);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.ExecuteCommands(secondary);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveEvent, WaitHostStageAndIgnoredSignal) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    event.Set();  // signals event, the next signal is ignored
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT;
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent2(event, barrier);  // ignored signal
+    m_command_buffer.WaitEvent(event, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
 TEST_F(PositiveEvent, WaitEventsSameLayoutInsideRenderPass) {
     RETURN_IF_SKIP(Init());
 


### PR DESCRIPTION
Extend validation that detects mismatch between event api versions (set2/wait, set/wait2) so it detects duplicated signals and ignores them (requested by the spec).