### PR TITLE
tests: Framework for optical flow

### DIFF
--- a/layers/vulkan/generated/test_icd_helper.h
+++ b/layers/vulkan/generated/test_icd_helper.h
@@ -6270,12 +6270,6 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphProcessin
     const VkPhysicalDeviceQueueFamilyDataGraphProcessingEngineInfoARM* pQueueFamilyDataGraphProcessingEngineInfo,
     VkQueueFamilyDataGraphProcessingEnginePropertiesARM* pQueueFamilyDataGraphProcessingEngineProperties) {}
 
-static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
-    VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
-    const VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties, VkBaseOutStructure* pProperties) {
-    return VK_SUCCESS;
-}
-
 static VKAPI_ATTR void VKAPI_CALL CmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer,
                                                                         VkImageAspectFlags aspectMask) {}
 
@@ -6429,14 +6423,6 @@ static VKAPI_ATTR void VKAPI_CALL CmdEndRendering2EXT(VkCommandBuffer commandBuf
 
 static VKAPI_ATTR void VKAPI_CALL CmdBeginCustomResolveEXT(VkCommandBuffer commandBuffer,
                                                            const VkBeginCustomResolveInfoEXT* pBeginCustomResolveInfo) {}
-
-static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
-    VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
-    const VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties,
-    const VkDataGraphOpticalFlowImageFormatInfoARM* pOpticalFlowImageFormatInfo, uint32_t* pFormatCount,
-    VkDataGraphOpticalFlowImageFormatPropertiesARM* pImageFormatProperties) {
-    return VK_SUCCESS;
-}
 
 static VKAPI_ATTR void VKAPI_CALL CmdSetComputeOccupancyPriorityNV(VkCommandBuffer commandBuffer,
                                                                    const VkComputeOccupancyPriorityParametersNV* pParameters) {}

--- a/scripts/generators/test_icd_generator.py
+++ b/scripts/generators/test_icd_generator.py
@@ -72,6 +72,8 @@ class TestIcdGenerator(BaseGenerator):
             'vkGetPhysicalDeviceExternalFenceProperties',
             'vkGetPhysicalDeviceExternalBufferProperties',
             'vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM',
+            'vkGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM',
+            'vkGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM',
             'vkGetBufferMemoryRequirements',
             'vkGetBufferMemoryRequirements2',
             'vkGetDeviceBufferMemoryRequirements',

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -5096,6 +5096,79 @@
                         ]
                     }
                 },
+                "VK_FORMAT_R16G16_SFLOAT": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
+                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                            "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
+                            "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
+                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                            "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
+                            "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"
+                        ],
+                        "bufferFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
+                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
+                            "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
+                            "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"
+                        ]
+                    }
+                },
                 "VK_FORMAT_R16G16B16A16_UNORM": {
                     "VkFormatProperties3": {
                         "linearTilingFeatures": [

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -446,5 +446,152 @@ void DataGraphPipelineHelper::Destroy() {
 }
 
 DataGraphPipelineHelper::~DataGraphPipelineHelper() { Destroy(); }
+
+namespace of {
+void OpticalFlowHelper::QueryOpticalFlowProperties() {
+    uint32_t n_properties = 0;
+    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+                              layer_test_.Gpu(), device_->graphics_queue_node_index_, &n_properties, nullptr));
+    std::vector<VkQueueFamilyDataGraphPropertiesARM> properties(n_properties,
+                                                                {VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM});
+    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
+                              layer_test_.Gpu(), device_->graphics_queue_node_index_, &n_properties, properties.data()));
+    for (uint32_t i = 0; i < n_properties; i++) {
+        if (properties[i].operation.operationType != VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM) {
+            continue;
+        }
+
+        VkQueueFamilyDataGraphOpticalFlowPropertiesARM properties_query = vku::InitStructHelper();
+        if (vk::GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+                layer_test_.Gpu(), device_->graphics_queue_node_index_, &properties[i],
+                reinterpret_cast<VkBaseOutStructure*>(&properties_query)) != VK_SUCCESS) {
+            continue;
+        }
+
+        const VkDataGraphOpticalFlowGridSizeFlagsARM supported_grid_sizes =
+            properties_query.supportedOutputGridSizes & properties_query.supportedHintGridSizes;
+        if (!properties_query.hintSupported || supported_grid_sizes == VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM) {
+            continue;
+        }
+
+        selected_properties_ = properties[i];
+        for (const VkDataGraphOpticalFlowGridSizeFlagsARM grid_size :
+             {VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM, VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM,
+              VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM, VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM}) {
+            if (supported_grid_sizes & grid_size) {
+                optical_flow_grid_size_ = grid_size;
+                break;
+            }
+        }
+        break;
+    }
+}
+
+VkFormat OpticalFlowHelper::GetOpticalFlowFormat(VkDataGraphOpticalFlowImageUsageFlagsARM usage) {
+    VkDataGraphOpticalFlowImageFormatInfoARM format_info = vku::InitStructHelper();
+    format_info.usage = usage;
+    VkDataGraphOpticalFlowImageFormatPropertiesARM format_properties = vku::InitStructHelper();
+    uint32_t format_count = 1;
+    VkResult result = vk::GetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+        layer_test_.Gpu(), device_->graphics_queue_node_index_, &selected_properties_, &format_info, &format_count,
+        &format_properties);
+    return result == VK_SUCCESS || result == VK_INCOMPLETE ? format_properties.format : VK_FORMAT_UNDEFINED;
+}
+
+void OpticalFlowHelper::CreateOpticalFlow() {
+    single_node_ci_ = vku::InitStructHelper();
+    single_node_ci_.nodeType = VK_DATA_GRAPH_PIPELINE_NODE_TYPE_OPTICAL_FLOW_ARM;
+
+    for (auto& connection : connections_) {
+        connection = vku::InitStructHelper();
+    }
+    connections_[0].set = 0;
+    connections_[0].binding = 0;
+    connections_[0].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_INPUT_ARM;
+    connections_[1].set = 0;
+    connections_[1].binding = 1;
+    connections_[1].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_REFERENCE_ARM;
+    connections_[2].set = 0;
+    connections_[2].binding = 3;
+    connections_[2].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_FLOW_VECTOR_ARM;
+    connections_[3].set = 0;
+    connections_[3].binding = 2;
+    connections_[3].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_HINT_ARM;
+    single_node_ci_.connectionCount = static_cast<uint32_t>(connections_.size());
+    single_node_ci_.pConnections = connections_.data();
+
+    optical_flow_ci_ = vku::InitStructHelper(&single_node_ci_);
+    optical_flow_ci_.height = params_.height;
+    optical_flow_ci_.width = params_.width;
+    optical_flow_ci_.imageFormat = GetOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM);
+    optical_flow_ci_.flowVectorFormat = GetOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM);
+    optical_flow_ci_.outputGridSize = params_.outputGridSize ? params_.outputGridSize : optical_flow_grid_size_;
+    optical_flow_ci_.hintGridSize = params_.hintGridSize ? params_.hintGridSize : optical_flow_grid_size_;
+    optical_flow_ci_.performanceLevel = VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_MEDIUM_ARM;
+    optical_flow_ci_.flags = VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM;
+}
+
+void OpticalFlowHelper::SetupImageDescriptors() {
+    VkImageCreateInfo input_image_ci =
+        vkt::Image::ImageCreateInfo2D(optical_flow_ci_.width, optical_flow_ci_.height, 1, 1, optical_flow_ci_.imageFormat,
+                                      VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image input_image(*device_, input_image_ci, vkt::set_layout);
+    vkt::Image reference_image(*device_, input_image_ci, vkt::set_layout);
+    VkImageCreateInfo flow_image_ci =
+        vkt::Image::ImageCreateInfo2D(optical_flow_ci_.width, optical_flow_ci_.height, 1, 1, optical_flow_ci_.flowVectorFormat,
+                                      VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image hint_image(*device_, flow_image_ci, vkt::set_layout);
+    flow_image_ci.usage = VK_IMAGE_USAGE_STORAGE_BIT;
+    vkt::Image flow_image(*device_, flow_image_ci, vkt::set_layout);
+    vkt::ImageView input_view = input_image.CreateView();
+    vkt::ImageView reference_view = reference_image.CreateView();
+    vkt::ImageView hint_view = hint_image.CreateView();
+    vkt::ImageView flow_view = flow_image.CreateView();
+
+    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(0, input_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(1, reference_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(2, hint_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(3, flow_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                           VK_IMAGE_LAYOUT_GENERAL);
+    dg_pipeline_.descriptor_set_->UpdateDescriptorSets();
+}
+
+void OpticalFlowHelper::InitDataGraphPipeline() {
+    dg_pipeline_.descriptor_set_layout_bindings_ = {
+        {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+        {1, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+        {2, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+        {3, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+    };
+    dg_pipeline_.descriptor_set_.reset(new OneOffDescriptorSet(device_, dg_pipeline_.descriptor_set_layout_bindings_));
+    dg_pipeline_.CreatePipelineLayout();
+
+    std::array<VkDataGraphPipelineResourceInfoImageLayoutARM, 4> image_layouts;
+    for (auto& image_layout : image_layouts) {
+        image_layout = vku::InitStructHelper();
+        image_layout.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    }
+    image_layouts[3].layout = VK_IMAGE_LAYOUT_GENERAL;
+    std::array<VkDataGraphPipelineResourceInfoARM, 4> resources;
+    for (uint32_t i = 0; i < resources.size(); i++) {
+        resources[i] = vku::InitStructHelper(&image_layouts[i]);
+        resources[i].descriptorSet = 0;
+        resources[i].binding = i;
+    }
+    dg_pipeline_.pipeline_ci_.resourceInfoCount = static_cast<uint32_t>(resources.size());
+    dg_pipeline_.pipeline_ci_.pResourceInfos = resources.data();
+    dg_pipeline_.pipeline_ci_.pNext = &optical_flow_ci_;
+    ASSERT_EQ(VK_SUCCESS, dg_pipeline_.CreateDataGraphPipeline());
+}
+
+OpticalFlowHelper::OpticalFlowHelper(VkLayerTest& test, const HelperParameters& params)
+    : dg_pipeline_(test), layer_test_(test), params_(params) {
+    device_ = layer_test_.DeviceObj();
+    QueryOpticalFlowProperties();
+    CreateOpticalFlow();
+    InitDataGraphPipeline();
+    SetupImageDescriptors();
+}
+}  // namespace of
 }  // namespace dg
 }  // namespace vkt

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -130,5 +130,41 @@ class DataGraphPipelineHelper {
     VkPipeline pipeline_ = VK_NULL_HANDLE;
     HelperParameters params_ = HelperParameters();
 };
+
+namespace of {
+struct HelperParameters {
+    uint32_t height = 100;
+    uint32_t width = 100;
+    VkDataGraphOpticalFlowGridSizeFlagsARM outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    VkDataGraphOpticalFlowGridSizeFlagsARM hintGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+};
+
+class OpticalFlowHelper {
+  public:
+    VkDataGraphPipelineOpticalFlowCreateInfoARM optical_flow_ci_ = {};
+    std::array<VkDataGraphPipelineSingleNodeConnectionARM, 4> connections_;
+    VkDataGraphPipelineSingleNodeCreateInfoARM single_node_ci_ = {};
+    VkQueueFamilyDataGraphPropertiesARM selected_properties_ = {};
+    VkDataGraphOpticalFlowGridSizeFlagsARM optical_flow_grid_size_ = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    DataGraphPipelineHelper dg_pipeline_;
+
+    VkLayerTest &layer_test_;
+    vkt::Device *device_ = nullptr;
+
+    explicit OpticalFlowHelper(VkLayerTest &test, const HelperParameters &params = HelperParameters());
+
+    void QueryOpticalFlowProperties();
+    VkFormat GetOpticalFlowFormat(VkDataGraphOpticalFlowImageUsageFlagsARM usage);
+    void CreateOpticalFlow();
+    void SetupImageDescriptors();
+    void InitDataGraphPipeline();
+
+    VkPipelineLayout PipelineLayout() const { return dg_pipeline_.pipeline_layout_; };
+    const VkDescriptorSet* DescriptorSet() const { return &dg_pipeline_.descriptor_set_.get()->set_; };
+
+  private:
+    HelperParameters params_ = HelperParameters();
+};
+}  // namespace of
 }  // namespace dg
 }  // namespace vkt

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -512,7 +512,7 @@ class TensorTest : public VkLayerTest {
 
 class DataGraphTest : public VkLayerTest {
   public:
-    void InitBasicDataGraph();
+    void InitBasicDataGraph(bool optical_flow = false);
     static void CheckSessionMemory(const vkt::DataGraphPipelineSession& session);
     static std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> InitSessionBindInfo(const vkt::DataGraphPipelineSession& session, const std::vector<vkt::DeviceMemory>& device_mem);
     static VkTensorDescriptionARM DefaultDesc();

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <algorithm>
+#include <array>
 #include "test_icd.h"
 #include "test_icd_helper.h"
 #include <vulkan/utility/vk_format_utils.h>
@@ -1457,12 +1458,81 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphPrope
     // TODO: Need a way for test to decide to support or not support various engines
 
     if (pQueueFamilyDataGraphProperties == nullptr) {
-        *pQueueFamilyDataGraphPropertyCount = 1;
+        *pQueueFamilyDataGraphPropertyCount = 2;
     } else {
         pQueueFamilyDataGraphProperties[0].sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM;
         pQueueFamilyDataGraphProperties[0].engine = {VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM, false};
         pQueueFamilyDataGraphProperties[0].operation = {
             VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM, "TOSA.001000.1", 0};
+        pQueueFamilyDataGraphProperties[1].sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM;
+        pQueueFamilyDataGraphProperties[1].engine = {VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM, false};
+        pQueueFamilyDataGraphProperties[1].operation = {VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM,
+                                                        "OpticalFlow", 1};
+    }
+    return VK_SUCCESS;
+}
+
+static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+    VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
+    const VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties, VkBaseOutStructure* pProperties) {
+    if (pProperties->sType == VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_OPTICAL_FLOW_PROPERTIES_ARM) {
+        auto* properties = reinterpret_cast<VkQueueFamilyDataGraphOpticalFlowPropertiesARM*>(pProperties);
+        properties->supportedOutputGridSizes =
+            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM |
+            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM;
+        properties->supportedHintGridSizes =
+            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM |
+            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM;
+        properties->hintSupported = VK_TRUE;
+        properties->costSupported = VK_TRUE;
+        properties->minWidth = 10;
+        properties->minHeight = 10;
+        properties->maxWidth = 10000;
+        properties->maxHeight = 10000;
+    }
+    return VK_SUCCESS;
+}
+
+static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+    VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
+    const VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties,
+    const VkDataGraphOpticalFlowImageFormatInfoARM* pOpticalFlowImageFormatInfo, uint32_t* pFormatCount,
+    VkDataGraphOpticalFlowImageFormatPropertiesARM* pImageFormatProperties) {
+    switch (pOpticalFlowImageFormatInfo->usage) {
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM: {
+            static constexpr std::array<VkFormat, 6> input_formats = {
+                VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8_UNORM,
+                VK_FORMAT_B8G8R8_UNORM,   VK_FORMAT_R8_UNORM,       VK_FORMAT_B10G11R11_UFLOAT_PACK32,
+            };
+            if (pImageFormatProperties != nullptr) {
+                for (uint32_t i = 0; i < *pFormatCount; ++i) {
+                    pImageFormatProperties[i].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+                    pImageFormatProperties[i].format = input_formats[i];
+                }
+            } else {
+                *pFormatCount = static_cast<uint32_t>(input_formats.size());
+            }
+            break;
+        }
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM:
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_HINT_BIT_ARM:
+            if (pImageFormatProperties != nullptr) {
+                pImageFormatProperties[0].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+                pImageFormatProperties[0].format = VK_FORMAT_R16G16_SFLOAT;
+            } else {
+                *pFormatCount = 1;
+            }
+            break;
+        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM:
+            if (pImageFormatProperties != nullptr) {
+                pImageFormatProperties[0].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+                pImageFormatProperties[0].format = VK_FORMAT_R16_UINT;
+            } else {
+                *pFormatCount = 1;
+            }
+            break;
+        default:
+            break;
     }
     return VK_SUCCESS;
 }

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -14,7 +14,7 @@
 
 class PositiveDataGraph : public DataGraphTest {};
 
-void DataGraphTest::InitBasicDataGraph() {
+void DataGraphTest::InitBasicDataGraph(bool optical_flow) {
     SetTargetApiVersion(VK_API_VERSION_1_4);
     AddRequiredExtensions(VK_ARM_TENSORS_EXTENSION_NAME);
     AddRequiredExtensions(VK_ARM_DATA_GRAPH_EXTENSION_NAME);
@@ -24,6 +24,10 @@ void DataGraphTest::InitBasicDataGraph() {
     AddRequiredFeature(vkt::Feature::shaderTensorAccess);
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     AddRequiredFeature(vkt::Feature::shaderInt8);
+    if (optical_flow) {
+        AddRequiredExtensions(VK_ARM_DATA_GRAPH_OPTICAL_FLOW_EXTENSION_NAME);
+        AddRequiredFeature(vkt::Feature::dataGraphOpticalFlow);
+    }
     RETURN_IF_SKIP(Init());
 }
 
@@ -319,5 +323,36 @@ TEST_F(PositiveDataGraph, CmdDispatchDescriptorBuffer) {
                                          &offset);
     vk::CmdDispatchDataGraphARM(m_command_buffer, session, nullptr);
     m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveDataGraph, OpticalFlow) {
+    TEST_DESCRIPTION("Execute a datagraph with an optical flow node");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+
+    VkDataGraphPipelineSessionCreateInfoARM session_ci = vku::InitStructHelper();
+    session_ci.dataGraphPipeline = optical_flow.dg_pipeline_;
+    vkt::DataGraphPipelineSession session(*m_device, session_ci);
+    session.GetMemoryReqs();
+    CheckSessionMemory(session);
+
+    auto& bind_point_reqs = session.BindPointReqs();
+    std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
+    session.AllocSessionMem(device_mem);
+    auto session_bind_infos = InitSessionBindInfo(session, device_mem);
+    vk::BindDataGraphPipelineSessionMemoryARM(*m_device, session_bind_infos.size(), session_bind_infos.data());
+
+    VkDataGraphPipelineOpticalFlowDispatchInfoARM optical_flow_di = vku::InitStructHelper();
+    optical_flow_di.meanFlowL1NormHint =
+        optical_flow.optical_flow_ci_.height;  // must be less than or equal to optical_flow_ci.height/optical_flow_ci.width
+    VkDataGraphPipelineDispatchInfoARM pipeline_di = vku::InitStructHelper(&optical_flow_di);
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, optical_flow.dg_pipeline_);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, optical_flow.PipelineLayout(), 0, 1,
+                              optical_flow.DescriptorSet(), 0, nullptr);
+    vk::CmdDispatchDataGraphARM(m_command_buffer, session, &pipeline_di);
     m_command_buffer.End();
 }


### PR DESCRIPTION
Implement the framework for  the VK_ARM_data_graph_optical_flow extension and add a positive test.