### PR TITLE
gpuav: Option to disable DontInline

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1117,6 +1117,19 @@
                                                     { "key": "gpuav_enable", "value": true }
                                                 ]
                                             }
+                                        },
+                                        {
+                                            "key": "gpuav_debug_disable_dontinline",
+                                            "label": "Disable DontInline function hint",
+                                            "description": "Found that some drivers crash when using DontInline, but the perf gain is too good to have always off",
+                                            "type": "BOOL",
+                                            "default": false,
+                                            "dependence": {
+                                                "mode": "ALL",
+                                                "settings": [
+                                                    { "key": "gpuav_enable", "value": true }
+                                                ]
+                                            }
                                         }
                                     ]
                                 }

--- a/layers/gpuav/core/gpuav_settings.cpp
+++ b/layers/gpuav/core/gpuav_settings.cpp
@@ -118,6 +118,7 @@ void GpuAVSettings::TracyLogSettings() const {
     VVL_TRACY_PRINT_GPUAV_SETTING(debug_validate_instrumented_shaders);
     VVL_TRACY_PRINT_GPUAV_SETTING(debug_dump_instrumented_shaders);
     VVL_TRACY_PRINT_GPUAV_SETTING(debug_max_instrumentations_count);
+    VVL_TRACY_PRINT_GPUAV_SETTING(debug_disable_dontinline);
     VVL_TRACY_PRINT_GPUAV_SETTING(debug_print_instrumentation_info);
 #define VVL_TRACY_PRINT_INSTRUMENTATION_SETTING(setting) \
     VVL_TracyMessageStream("    " #setting ": " << shader_instrumentation.setting);

--- a/layers/gpuav/core/gpuav_settings.h
+++ b/layers/gpuav/core/gpuav_settings.h
@@ -46,6 +46,7 @@ struct GpuAVSettings {
     bool debug_dump_instrumented_shaders = false;
     uint32_t debug_max_instrumentations_count = 0;  // zero is same as "unlimited"
     bool debug_print_instrumentation_info = false;
+    bool debug_disable_dontinline = false;
 
     // We create a buffer of N slots as [0, N-1],
     // but N-1 is used to signal the app everything after is garbage.

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -275,6 +275,7 @@ void GpuShaderInstrumentor::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateI
     instrumentation_device_settings_.safe_mode = gpuav_settings.safe_mode;
     instrumentation_device_settings_.print_debug_info = gpuav_settings.debug_print_instrumentation_info;
     instrumentation_device_settings_.max_instrumentations_count = gpuav_settings.debug_max_instrumentations_count;
+    instrumentation_device_settings_.disable_dontinline = gpuav_settings.debug_disable_dontinline;
     instrumentation_device_settings_.support_non_semantic_info =
         IsExtEnabled(extensions.vk_khr_shader_non_semantic_info) && !IsExtEnabled(extensions.vk_khr_portability_subset);
     instrumentation_device_settings_.error_buffer_data_length = glsl::kErrorBufferDataLength;

--- a/layers/gpuav/spirv/interface.h
+++ b/layers/gpuav/spirv/interface.h
@@ -112,6 +112,7 @@ struct DeviceSettings {
     bool print_debug_info;
     // zero is same as "unlimited"
     uint32_t max_instrumentations_count;
+    bool disable_dontinline;
     bool support_non_semantic_info;
     // Lets us embed the size instead of calling OpArrayLength
     uint32_t error_buffer_data_length;

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -882,6 +882,10 @@ void Module::LinkFunctions(const LinkInfo& info) {
                     // Found on NVIDIA there are nasty bugs/behavior using this in RTX stages
                     // (clearly no CTS is written to use it)
                     new_inst->UpdateWord(3, spv::FunctionControlMaskNone);
+                } else if (settings_.disable_dontinline) {
+                    // We have found on some drivers (RTX 5090 with 610.62 driver) will crash on some shaders
+                    // This is here to provide a way to turn off DontInline if needed for unblocking people
+                    new_inst->UpdateWord(3, spv::FunctionControlMaskNone);
                 } else {
                     new_inst->UpdateWord(3, spv::FunctionControlDontInlineMask);
                 }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -223,6 +223,7 @@ const char* VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_va
 const char* VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
 const char* VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTATIONS_COUNT = "gpuav_debug_max_instrumentations_count";
 const char* VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO = "gpuav_debug_print_instrumentation_info";
+const char* VK_LAYER_GPUAV_DEBUG_DISABLE_DONTINLINE = "gpuav_debug_disable_dontinline";
 
 // SyncVal
 // ---
@@ -1168,6 +1169,11 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO,
                                 gpuav_settings.debug_print_instrumentation_info);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_DISABLE_DONTINLINE)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_DEBUG_DISABLE_DONTINLINE,
+                                gpuav_settings.debug_disable_dontinline);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_PRINTF_TO_STDOUT)) {


### PR DESCRIPTION
replacement for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12477

We want the perf of `DontInline` and if it is crashing people, we now have an option to turn it off... it is still rare to see it cause any issues, so feels safe to hide behind a debug flag for now