### PR TITLE
layers: Add helpers to resolve event signal state

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1130,43 +1130,6 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer& 
     return skip;
 }
 
-// Return the signal stage mask when it can be identified from recorded state
-static std::optional<VkPipelineStageFlags2> ResolveKnownSignalStageMask(VkEvent event, const EventSignalState* prior_state,
-                                                                        const EventSignalState* secondary_state) {
-    if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
-        if (secondary_state->signaled) {
-            return secondary_state->signal_src_stage_mask;
-        }
-        return {};
-    }
-    if (prior_state && prior_state->HasKnownEffect() && prior_state->signaled) {
-        return prior_state->signal_src_stage_mask;
-    }
-    return {};
-}
-
-static vvl::Func ResolveSignalingCommand(const EventSignalState* prior_state, const EventSignalState* secondary_state) {
-    if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
-        return secondary_state->last_signaling_command;
-    }
-    if (prior_state && prior_state->HasKnownEffect() && prior_state->signaled) {
-        return prior_state->last_signaling_command;
-    }
-    return vvl::Func::Empty;
-}
-
-// Return true when recorded state proves the event is unsignaled at the wait
-static bool IsKnownUnsignaled(VkEvent event, const EventSignalStateMap& prior_signal_states,
-                              const EventSignalStateMap& secondary_signal_states) {
-    const EventSignalState* prior_state = vvl::Find(prior_signal_states, event);
-    const EventSignalState* secondary_state = vvl::Find(secondary_signal_states, event);
-
-    if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
-        return !secondary_state->signaled;
-    }
-    return prior_state && prior_state->HasKnownEffect() && !prior_state->signaled;
-}
-
 bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBufferSubState& secondary_cb_sub_state,
                                                           const Location& secondary_cb_loc,
                                                           EventSignalStateMap& local_signal_states) const {
@@ -1175,35 +1138,36 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
         bool can_validate_stage_mask = true;
         bool set_wait_version_mismatch = false;
-        bool found_known_signals = false;
+        bool found_signals = false;
 
         for (VkEvent event : secondary_wait.wait_events) {
             const EventSignalState* local_state = vvl::Find(local_signal_states, event);
             const EventSignalState* secondary_state = vvl::Find(secondary_wait.signal_states, event);
+            const EventSignalState* known_state = ResolveSecondarySignal(local_state, secondary_state);
 
-            // Validate set-wait version mismatch
-            const vvl::Func signal_command = ResolveSignalingCommand(local_state, secondary_state);
-            if (IsValueIn(signal_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
-                skip |=
-                    LogError("VUID-vkCmdWaitEvents-pEvents-03847", event, secondary_cb_loc, "%s: %s was set by %s.",
-                             vvl::String(secondary_wait.wait_command), FormatHandle(event).c_str(), vvl::String(signal_command));
-                set_wait_version_mismatch = true;
-            }
-
-            // Determine if stage mask validation is possible during execution time
-            if (auto stage_mask = ResolveKnownSignalStageMask(event, local_state, secondary_state)) {
-                signals_src_stage_mask |= *stage_mask;
-                found_known_signals = true;
-            } else if (IsKnownUnsignaled(event, local_signal_states, secondary_wait.signal_states)) {
-                // Contribute 0 (nothing) to signals_src_stage_mask
+            if (known_state) {
+                // Validate set-wait version mismatch
+                if (IsValueIn(known_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                    skip |= LogError("VUID-vkCmdWaitEvents-pEvents-03847", event, secondary_cb_loc, "%s: %s was set by %s.",
+                                     vvl::String(secondary_wait.wait_command), FormatHandle(event).c_str(),
+                                     vvl::String(known_state->last_signaling_command));
+                    set_wait_version_mismatch = true;
+                }
+                // Collect source stages from all known signals
+                if (known_state->signaled) {
+                    signals_src_stage_mask |= known_state->signal_src_stage_mask;
+                    found_signals = true;
+                }
             } else {
+                // Can't validate at secondary command buffer execution time
+                // because the signal's state is not known yet
                 can_validate_stage_mask = false;
             }
         }
         // Validate state mask
         if (!set_wait_version_mismatch && can_validate_stage_mask && secondary_wait.wait_src_stage_mask != signals_src_stage_mask) {
             const LogObjectList objlist(secondary_cb_sub_state.Handle());
-            if (found_known_signals) {
+            if (found_signals) {
                 std::ostringstream ss;
                 ss << "(" << FormatHandle(secondary_cb_sub_state.Handle()) << ") contains a vkCmdWaitEvents call with srcStageMask "
                    << string_VkPipelineStageFlags(secondary_wait.wait_src_stage_mask)
@@ -1223,39 +1187,33 @@ bool CoreChecks::ValidateSecondaryCommandBufferWaitEvents(const core::CommandBuf
     for (const WaitEvent2SubmitInfo& secondary_wait : secondary_cb_sub_state.wait_event2_submit_infos) {
         const EventSignalState* local_state = vvl::Find(local_signal_states, secondary_wait.wait_event);
         const EventSignalState* secondary_state = secondary_wait.signal_state.has_value() ? &*secondary_wait.signal_state : nullptr;
+        const EventSignalState* known_state = ResolveSecondarySignal(local_state, secondary_state);
 
-        const vvl::Func signaling_command = ResolveSignalingCommand(local_state, secondary_state);
-
-        if (signaling_command == vvl::Func::vkCmdSetEvent) {
+        if (!known_state) {
+            continue;
+        }
+        if (known_state->last_signaling_command == vvl::Func::vkCmdSetEvent) {
             skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03837", secondary_wait.wait_event, secondary_cb_loc,
                              "%s: %s was set by %s.", vvl::String(secondary_wait.wait_command),
-                             FormatHandle(secondary_wait.wait_event).c_str(), vvl::String(signaling_command));
+                             FormatHandle(secondary_wait.wait_event).c_str(), vvl::String(known_state->last_signaling_command));
         } else {
             const VkPipelineStageFlags2 union_src_stage_mask =
                 sync_utils::GetExecScopes(*secondary_wait.wait_dependency_info.ptr()).src;
-            const EventSignalState* signal_state = nullptr;
-            if (secondary_state && secondary_state->HasKnownEffect(local_state)) {
-                signal_state = secondary_state;
-            } else if (local_state && local_state->HasKnownEffect()) {
-                signal_state = local_state;
-            }
-            if (signal_state) {
-                if ((union_src_stage_mask & VK_PIPELINE_STAGE_2_HOST_BIT) == 0) {
-                    if (!IsValueIn(signal_state->last_signaling_command,
-                                   {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
-                        const LogObjectList objlist(secondary_cb_sub_state.Handle(), secondary_wait.wait_event);
-                        skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03841", objlist, secondary_cb_loc,
-                                         "contains %s but %s was not set by vkCmdSetEvent2.",
-                                         vvl::String(secondary_wait.wait_command), FormatHandle(secondary_wait.wait_event).c_str());
-                    }
-                } else if (union_src_stage_mask == VK_PIPELINE_STAGE_2_HOST_BIT) {
-                    if (signal_state->HasKnownEffect() && !signal_state->signaled) {
-                        const LogObjectList objlist(secondary_cb_sub_state.Handle(), secondary_wait.wait_event);
-                        skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03840", objlist, secondary_cb_loc,
-                                         "contains %s and the first synchronization scope specified by pDependencyInfos is "
-                                         "VK_PIPELINE_STAGE_2_HOST_BIT but %s is not signaled",
-                                         vvl::String(secondary_wait.wait_command), FormatHandle(secondary_wait.wait_event).c_str());
-                    }
+
+            if ((union_src_stage_mask & VK_PIPELINE_STAGE_2_HOST_BIT) == 0) {
+                if (!IsValueIn(known_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                    const LogObjectList objlist(secondary_cb_sub_state.Handle(), secondary_wait.wait_event);
+                    skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03841", objlist, secondary_cb_loc,
+                                     "contains %s but %s was not set by vkCmdSetEvent2.", vvl::String(secondary_wait.wait_command),
+                                     FormatHandle(secondary_wait.wait_event).c_str());
+                }
+            } else if (union_src_stage_mask == VK_PIPELINE_STAGE_2_HOST_BIT) {
+                if (!known_state->signaled) {
+                    const LogObjectList objlist(secondary_cb_sub_state.Handle(), secondary_wait.wait_event);
+                    skip |= LogError("VUID-vkCmdWaitEvents2-pEvents-03840", objlist, secondary_cb_loc,
+                                     "contains %s and the first synchronization scope specified by pDependencyInfos is "
+                                     "VK_PIPELINE_STAGE_2_HOST_BIT but %s is not signaled",
+                                     vvl::String(secondary_wait.wait_command), FormatHandle(secondary_wait.wait_event).c_str());
                 }
             }
         }

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -657,7 +657,6 @@ void CommandBufferSubState::RecordWaitEvents(vvl::span<const VkEvent> events, Vk
         if (signal_state) {
             signal_states.emplace(event, *signal_state);
         }
-        // NOTE: the same logic is used by the validation phase
         const bool already_validated = signal_state && signal_state->HasKnownEffect();
         if (!already_validated) {
             submit_validation = true;
@@ -1235,17 +1234,14 @@ static std::optional<WaitEventSubmitInfo> BuildSubmitTimeWaitInfo(const WaitEven
     for (VkEvent event : secondary_wait.wait_events) {
         const EventSignalState* primary_state = vvl::Find(primary_states, event);
         const EventSignalState* secondary_state = vvl::Find(secondary_wait.signal_states, event);
+        const EventSignalState* known_state = ResolveSecondarySignal(primary_state, secondary_state);
 
-        const bool primary_state_known = primary_state && primary_state->HasKnownEffect();
-        const bool secondary_state_known = secondary_state && secondary_state->HasKnownEffect(primary_state);
-        if (secondary_state_known || (!primary_state && secondary_state)) {
+        if (secondary_state && (known_state == secondary_state || !primary_state)) {
             wait_signal_states[event] = *secondary_state;
         } else if (primary_state) {
             wait_signal_states[event] = *primary_state;
         }
-
-        const bool state_known = primary_state_known || secondary_state_known;
-        if (!state_known) {
+        if (known_state == nullptr) {
             all_signal_states_known = false;
         }
     }

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -432,36 +432,21 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
             if (!vvl::Contains(signal_states, event)) {
                 skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signal_states, loc);
             }
-            // NOTE: for unsignaled events the signal_src_stage_mask is NONE
-            VkPipelineStageFlags2 stage_mask = 0;
-            vvl::Func signal_command = vvl::Func::Empty;
-            bool last_signal = false;
-            if (event_state->signaled) {
-                stage_mask = event_state->signal_src_stage_mask;
-                last_signal = event_state->signaled;
-                signal_command = event_state->last_signaling_command;
-            }
-            if (const auto* submit_signaling = vvl::Find(submit_signal_states, event)) {
-                if (!last_signal || submit_signaling->HasKnownEffect()) {
-                    stage_mask = submit_signaling->signal_src_stage_mask;
-                    signal_command = submit_signaling->last_signaling_command;
-                }
-                last_signal = submit_signaling->signaled;
-            }
-            if (const auto* cb_signaling = vvl::Find(signal_states, event)) {
-                if (!last_signal || cb_signaling->HasKnownEffect()) {
-                    stage_mask = cb_signaling->signal_src_stage_mask;
-                    signal_command = cb_signaling->last_signaling_command;
-                }
-            }
-            signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(stage_mask);
+            const EventSignalState* submit_signal_state = vvl::Find(submit_signal_states, event);
+            const EventSignalState* cb_signal_state = vvl::Find(signal_states, event);
+            const EventSignalState resolved_state = ResolveEventSignal(*event_state, submit_signal_state, cb_signal_state);
 
+            // Collect source stages from all signals
+            if (resolved_state.signaled) {
+                signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(resolved_state.signal_src_stage_mask);
+            }
             // Validate set-wait mismatch
-            if (IsValueIn(signal_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+            if (IsValueIn(resolved_state.last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
                 set_wait_version_mismatch = true;
                 const LogObjectList objlist(cb_state.Handle(), event_state->Handle());
                 skip |= core.LogError("VUID-vkCmdWaitEvents-pEvents-03847", objlist, loc, "%s: %s was set by %s.",
-                                      vvl::String(wait_command), core.FormatHandle(event).c_str(), vvl::String(signal_command));
+                                      vvl::String(wait_command), core.FormatHandle(event).c_str(),
+                                      vvl::String(resolved_state.last_signaling_command));
             }
         }
     }
@@ -500,38 +485,19 @@ bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& qu
 
     skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signal_states, loc);
 
-    const auto* submit_signal_state = vvl::Find(submit_signal_states, wait_event);
-
-    std::optional<vku::safe_VkDependencyInfo> signal_dependency_info;
-    vvl::Func signal_command = vvl::Func::Empty;
-
-    signal_dependency_info = event_state->signal_dependency_info;
-    signal_command = event_state->last_signaling_command;
-    bool last_signal = event_state->signaled;
-    if (submit_signal_state) {
-        if (!last_signal || submit_signal_state->HasKnownEffect()) {
-            signal_dependency_info = submit_signal_state->signal_dependency_info;
-            signal_command = submit_signal_state->last_signaling_command;
-        }
-        last_signal = submit_signal_state->signaled;
-    }
-    if (signal_state.has_value()) {
-        if (!last_signal || signal_state->HasKnownEffect()) {
-            signal_dependency_info = signal_state->signal_dependency_info;
-            signal_command = signal_state->last_signaling_command;
-        }
-    }
+    const EventSignalState* submit_signal_state = vvl::Find(submit_signal_states, wait_event);
+    const EventSignalState* cb_signal_state = signal_state.has_value() ? &*signal_state : nullptr;
+    const EventSignalState resolved_state = ResolveEventSignal(*event_state, submit_signal_state, cb_signal_state);
 
     const VkPipelineStageFlags2 union_src_stage_mask = sync_utils::GetExecScopes(*wait_dependency_info.ptr()).src;
-    const bool local_unsignaled = submit_signal_state && submit_signal_state->HasKnownEffect() && !submit_signal_state->signaled;
 
-    if (union_src_stage_mask == VK_PIPELINE_STAGE_2_HOST_BIT && (local_unsignaled || !event_state->signaled)) {
+    if (union_src_stage_mask == VK_PIPELINE_STAGE_2_HOST_BIT && !resolved_state.signaled) {
         const LogObjectList objlist(cb_state.Handle(), event_state->Handle());
         skip |= core.LogError("VUID-vkCmdWaitEvents2-pEvents-03840", objlist, loc,
                               "contains %s and the first synchronization scope specified by pDependencyInfos is "
                               "VK_PIPELINE_STAGE_2_HOST_BIT but %s is not signaled",
                               vvl::String(wait_command), core.FormatHandle(event_state->Handle()).c_str());
-    } else if (signal_command == vvl::Func::vkSetEvent) {
+    } else if (resolved_state.last_signaling_command == vvl::Func::vkSetEvent) {
         if ((union_src_stage_mask & VK_PIPELINE_STAGE_2_HOST_BIT) == 0) {
             const LogObjectList objlist(cb_state.Handle(), event_state->Handle());
             skip |= core.LogError("VUID-vkCmdWaitEvents2-pEvents-03839", objlist, loc,
@@ -546,12 +512,12 @@ bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& qu
                                   vvl::String(wait_command), core.FormatHandle(event_state->Handle()).c_str(),
                                   string_VkPipelineStageFlags2(union_src_stage_mask).c_str());
         }
-    } else if (signal_command == vvl::Func::vkCmdSetEvent) {
+    } else if (resolved_state.last_signaling_command == vvl::Func::vkCmdSetEvent) {
         const LogObjectList objlist(cb_state.Handle(), event_state->Handle());
         skip |=
             core.LogError("VUID-vkCmdWaitEvents2-pEvents-03837", objlist, loc, "%s: %s was set by %s.", vvl::String(wait_command),
-                          core.FormatHandle(event_state->Handle()).c_str(), vvl::String(signal_command));
-    } else if (!IsValueIn(signal_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                          core.FormatHandle(event_state->Handle()).c_str(), vvl::String(resolved_state.last_signaling_command));
+    } else if (!IsValueIn(resolved_state.last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
         if ((union_src_stage_mask & VK_PIPELINE_STAGE_2_HOST_BIT) == 0) {
             const LogObjectList objlist(cb_state.Handle(), event_state->Handle());
             skip |= core.LogError("VUID-vkCmdWaitEvents2-pEvents-03841", objlist, loc,
@@ -560,6 +526,7 @@ bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& qu
         }
     }
 
+    const std::optional<vku::safe_VkDependencyInfo>& signal_dependency_info = resolved_state.signal_dependency_info;
     if (signal_dependency_info.has_value()) {
         const bool signal_has_asymmetric = (signal_dependency_info->dependencyFlags & VK_DEPENDENCY_ASYMMETRIC_EVENT_BIT_KHR) != 0;
         const bool wait_has_asymmetric = (wait_dependency_info.dependencyFlags & VK_DEPENDENCY_ASYMMETRIC_EVENT_BIT_KHR) != 0;
@@ -1614,20 +1581,17 @@ bool CoreChecks::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uin
         VkPipelineStageFlags signals_src_stage_mask = VK_PIPELINE_STAGE_NONE;
         for (uint32_t i = 0; i < eventCount; i++) {
             const EventSignalState* signal_state = vvl::Find(cb_sub_state.event_signal_states, pEvents[i]);
-            const bool has_effect = signal_state && signal_state->HasKnownEffect();
-
-            // Record phase also uses this logic to determine stage mask validation status
-            if (!has_effect) {
-                can_validate_stage_mask = false;
+            if (signal_state && signal_state->HasKnownEffect()) {
+                if (IsValueIn(signal_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
+                    skip |= LogError("VUID-vkCmdWaitEvents-pEvents-03847", pEvents[i], error_obj.location, "%s was set by %s.",
+                                     FormatHandle(pEvents[i]).c_str(), vvl::String(signal_state->last_signaling_command));
+                    set_wait_version_mismatch = true;
+                }
+                if (signal_state->signaled) {
+                    signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signal_state->signal_src_stage_mask);
+                }
             } else {
-                signals_src_stage_mask |= static_cast<VkPipelineStageFlags>(signal_state->signal_src_stage_mask);
-            }
-
-            if (has_effect &&
-                IsValueIn(signal_state->last_signaling_command, {vvl::Func::vkCmdSetEvent2, vvl::Func::vkCmdSetEvent2KHR})) {
-                skip |= LogError("VUID-vkCmdWaitEvents-pEvents-03847", pEvents[i], error_obj.location, "%s was set by %s.",
-                                 FormatHandle(pEvents[i]).c_str(), vvl::String(signal_state->last_signaling_command));
-                set_wait_version_mismatch = true;
+                can_validate_stage_mask = false;
             }
         }
         if (!set_wait_version_mismatch && can_validate_stage_mask) {

--- a/layers/state_tracker/event_state.cpp
+++ b/layers/state_tracker/event_state.cpp
@@ -28,6 +28,36 @@ bool EventSignalState::HasKnownEffect(const EventSignalState* prior_state) const
     return is_prior_unsignaled;
 }
 
+const EventSignalState* ResolveSecondarySignal(const EventSignalState* prior_state, const EventSignalState* secondary_state) {
+    if (secondary_state && secondary_state->HasKnownEffect(prior_state)) {
+        return secondary_state;
+    }
+    if (prior_state && prior_state->HasKnownEffect()) {
+        return prior_state;
+    }
+    return nullptr;
+}
+
+EventSignalState ResolveEventSignal(const vvl::Event& event_state, const EventSignalState* submit_state,
+                                    const EventSignalState* cb_state) {
+    EventSignalState state;
+    state.signaled = event_state.signaled;
+    state.was_reset = true;
+    state.signal_src_stage_mask = event_state.signal_src_stage_mask;
+    state.signal_dependency_info = event_state.signal_dependency_info;
+    state.last_signaling_command = event_state.last_signaling_command;
+
+    const EventSignalState* prior_state = &state;
+    if (submit_state && submit_state->HasKnownEffect(prior_state)) {
+        state = *submit_state;
+    }
+    prior_state = submit_state ? submit_state : prior_state;
+    if (cb_state && cb_state->HasKnownEffect(prior_state)) {
+        state = *cb_state;
+    }
+    return state;
+}
+
 void UpdateEventSignalStates(EventSignalStateMap& accumulated_states, const EventSignalStateMap& recorded_states) {
     for (const auto& [event, recorded_state] : recorded_states) {
         EventSignalState& accumulated_state = accumulated_states[event];

--- a/layers/state_tracker/event_state.h
+++ b/layers/state_tracker/event_state.h
@@ -25,6 +25,10 @@
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <optional>
 
+namespace vvl {
+class Event;
+}  // namespace vvl
+
 struct EventSignalState {
     // Tracks how the event signaling state changes as command buffer recording progresses.
     // When recording is finished, this is the event state at the end of the command buffer
@@ -44,14 +48,16 @@ struct EventSignalState {
     // Last command that changed the event signal state: Set/Set2/Reset/Reset2
     vvl::Func last_signaling_command = vvl::Func::Empty;
 
-    // Return true if this state's effect on the event is known.
-    // Without a reset or known prior state, we cannot tell whether a signal
-    // in this state is a repeated signal, which the spec says is ignored
+    // Return true if we can guarantee that this signal state is not ignored.
+    // Without a reset or known prior state, we cannot tell whether this state
+    // should be ignored or not (repeated signals/unsignals are ignored).
     //
-    // NOTE: this implementation does not try to handle repeated unsignals, which
-    // are also ignored. We do not currently keep data associated with unsignals,
-    // (and for signals we store stage mask/dependency info). Update this if we
-    // need to track associated unsignal data.
+    // NOTE: this implementation is about handling repeated signals. It does not try
+    // to handle repeated unsignals, which are also ignored. The reason for this is
+    // that we don't track associated data with unsignals, so original unsignal and
+    // duplicated ones are the same from the tracking perspective. The implementatio
+    // has to be updated if we need to track data associated with the unsignal (then
+    // it's important to keep the original unsignal data)
     bool HasKnownEffect(const EventSignalState* prior_state = nullptr) const;
 };
 
@@ -63,6 +69,16 @@ struct EventWaitBarrierState {
 using EventSignalStateMap = vvl::unordered_map<VkEvent, EventSignalState>;
 using EventWaitBarrierMap = vvl::unordered_map<VkEvent, EventWaitBarrierState>;
 using EventWaitCommandMap = vvl::unordered_map<VkEvent, vvl::Func>;
+
+// Resolve the known signaling state from two levels: the secondary command buffer state and
+// the prior command buffer state (primary or prior secondary).
+// Returns null if it can't be determined whether the signal is effective (not ignored)
+const EventSignalState* ResolveSecondarySignal(const EventSignalState* prior_state, const EventSignalState* secondary_state);
+
+// Resolve the effective signaling state from three levels: the global state, the local submit
+// state (between command buffers of submission), and the command buffer state
+EventSignalState ResolveEventSignal(const vvl::Event& event_state, const EventSignalState* submit_signal_state,
+                                    const EventSignalState* cb_signal_state);
 
 void UpdateEventSignalStates(EventSignalStateMap& accumulated_states, const EventSignalStateMap& recorded_states);
 


### PR DESCRIPTION
We had several places with the logic that resolves event signal state. Each place had a bit different implementation and it was also not the most intuitive code.

This unifies most of such code by introducing two helpers: `ResolveSecondarySignal` (secondary command buffer level) and `ResolveEventSignal` (global event level).