### PR TITLE
layers: Cleanup event validation naming

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -49,7 +49,7 @@ struct CommandBufferSubmitState {
     // The "local" prefix is about tracking state accross command buffers of a *single* QueueSubmit command.
     // This does not accumulate state from the previous submissions.
     QueryMap local_query_to_state_map;
-    EventSignalStateMap local_event_signal_info;
+    EventSignalStateMap local_event_signal_states;
     vvl::unordered_map<VkVideoSessionKHR, vvl::VideoSessionDeviceState> local_video_session_state{};
 
     CommandBufferSubmitState(const CoreChecks& c, const vvl::Queue& q) : core(c), queue_state(q) {
@@ -78,12 +78,12 @@ struct CommandBufferSubmitState {
         auto& cb_sub_state = core::SubState(cb_state);
 
         for (const WaitEventSubmitInfo& submit_info : cb_sub_state.wait_event_submit_infos) {
-            skip |= submit_info.Validate(core, queue_state, cb_state, local_event_signal_info, loc);
+            skip |= submit_info.Validate(core, queue_state, cb_state, local_event_signal_states, loc);
         }
         for (const WaitEvent2SubmitInfo& submit_info : cb_sub_state.wait_event2_submit_infos) {
-            skip |= submit_info.Validate(core, queue_state, cb_state, local_event_signal_info, loc);
+            skip |= submit_info.Validate(core, queue_state, cb_state, local_event_signal_states, loc);
         }
-        UpdateEventSignalStates(local_event_signal_info, cb_sub_state.event_signal_states);
+        UpdateEventSignalStates(local_event_signal_states, cb_sub_state.event_signal_states);
 
         VkQueryPool first_perf_query_pool = VK_NULL_HANDLE;
         for (auto& function : cb_sub_state.query_updates) {

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -401,13 +401,13 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location& signal_semaph
 }
 
 static bool ValidateEventQueueMismatch(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                                       const vvl::Event& event_state, const EventSignalStateMap& submit_signal_states,
+                                       const vvl::Event& event_state, const EventSignalStateMap& local_signal_states,
                                        const Location& loc) {
     bool skip = false;
 
     // Check if prior command buffers from this submit contain signaling operation.
     // If yes, then everything is on the same queue
-    if (vvl::Contains(submit_signal_states, event_state.VkHandle())) {
+    if (vvl::Contains(local_signal_states, event_state.VkHandle())) {
         return skip;
     }
     // Check global event state
@@ -422,7 +422,7 @@ static bool ValidateEventQueueMismatch(const CoreChecks& core, const vvl::Queue&
 }
 
 bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                                   EventSignalStateMap& submit_signal_states, const Location& loc) const {
+                                   EventSignalStateMap& local_signal_states, const Location& loc) const {
     bool skip = false;
 
     VkPipelineStageFlags signals_src_stage_mask = 0;
@@ -430,11 +430,11 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
     for (VkEvent event : wait_events) {
         if (auto event_state = core.Get<vvl::Event>(event)) {
             if (!vvl::Contains(signal_states, event)) {
-                skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signal_states, loc);
+                skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, local_signal_states, loc);
             }
-            const EventSignalState* submit_signal_state = vvl::Find(submit_signal_states, event);
+            const EventSignalState* local_signal_state = vvl::Find(local_signal_states, event);
             const EventSignalState* cb_signal_state = vvl::Find(signal_states, event);
-            const EventSignalState resolved_state = ResolveEventSignal(*event_state, submit_signal_state, cb_signal_state);
+            const EventSignalState resolved_state = ResolveEventSignal(*event_state, local_signal_state, cb_signal_state);
 
             // Collect source stages from all signals
             if (resolved_state.signaled) {
@@ -475,7 +475,7 @@ bool WaitEventSubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& que
 }
 
 bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                                    EventSignalStateMap& submit_signal_states, const Location& loc) const {
+                                    EventSignalStateMap& local_signal_states, const Location& loc) const {
     bool skip = false;
 
     auto event_state = core.Get<vvl::Event>(wait_event);
@@ -483,11 +483,11 @@ bool WaitEvent2SubmitInfo::Validate(const CoreChecks& core, const vvl::Queue& qu
         return skip;
     }
 
-    skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, submit_signal_states, loc);
+    skip |= ValidateEventQueueMismatch(core, queue_state, cb_state, *event_state, local_signal_states, loc);
 
-    const EventSignalState* submit_signal_state = vvl::Find(submit_signal_states, wait_event);
+    const EventSignalState* local_signal_state = vvl::Find(local_signal_states, wait_event);
     const EventSignalState* cb_signal_state = signal_state.has_value() ? &*signal_state : nullptr;
-    const EventSignalState resolved_state = ResolveEventSignal(*event_state, submit_signal_state, cb_signal_state);
+    const EventSignalState resolved_state = ResolveEventSignal(*event_state, local_signal_state, cb_signal_state);
 
     const VkPipelineStageFlags2 union_src_stage_mask = sync_utils::GetExecScopes(*wait_dependency_info.ptr()).src;
 

--- a/layers/core_checks/cc_synchronization.h
+++ b/layers/core_checks/cc_synchronization.h
@@ -81,7 +81,7 @@ struct WaitEventSubmitInfo {
     vvl::Func wait_command = vvl::Func::Empty;
 
     bool Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                  EventSignalStateMap& submit_signal_states, const Location& loc) const;
+                  EventSignalStateMap& local_signal_states, const Location& loc) const;
 };
 
 struct WaitEvent2SubmitInfo {
@@ -91,5 +91,5 @@ struct WaitEvent2SubmitInfo {
     vvl::Func wait_command = vvl::Func::Empty;
 
     bool Validate(const CoreChecks& core, const vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state,
-                  EventSignalStateMap& submit_signal_states, const Location& loc) const;
+                  EventSignalStateMap& local_signal_states, const Location& loc) const;
 };

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -434,7 +434,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                                                  const vvl::CommandBuffer& secondary_cb_state,
                                                                  const Location& secondary_cb_loc) const;
     bool ValidateSecondaryCommandBufferWaitEvents(const core::CommandBufferSubState& secondary_cb_sub_state,
-                                                  const Location& secondary_cb_loc, EventSignalStateMap& local_signal_state) const;
+                                                  const Location& secondary_cb_loc, EventSignalStateMap& local_signal_states) const;
     bool ValidateInheritanceInfoFramebuffer(const vvl::CommandBuffer& cb_state,
                                             const core::CommandBufferSubState& secondary_cb_state,
                                             const VkCommandBufferInheritanceInfo& secondary_inheritance_info,

--- a/layers/state_tracker/event_state.cpp
+++ b/layers/state_tracker/event_state.cpp
@@ -38,22 +38,22 @@ const EventSignalState* ResolveSecondarySignal(const EventSignalState* prior_sta
     return nullptr;
 }
 
-EventSignalState ResolveEventSignal(const vvl::Event& event_state, const EventSignalState* submit_state,
-                                    const EventSignalState* cb_state) {
+EventSignalState ResolveEventSignal(const vvl::Event& event_state, const EventSignalState* local_signal_state,
+                                    const EventSignalState* cb_signal_state) {
     EventSignalState state;
     state.signaled = event_state.signaled;
-    state.was_reset = true;
+    state.was_reset = true;  // the global event state is known (so HasKnownEffect works as expected)
     state.signal_src_stage_mask = event_state.signal_src_stage_mask;
     state.signal_dependency_info = event_state.signal_dependency_info;
     state.last_signaling_command = event_state.last_signaling_command;
 
     const EventSignalState* prior_state = &state;
-    if (submit_state && submit_state->HasKnownEffect(prior_state)) {
-        state = *submit_state;
+    if (local_signal_state && local_signal_state->HasKnownEffect(prior_state)) {
+        state = *local_signal_state;
     }
-    prior_state = submit_state ? submit_state : prior_state;
-    if (cb_state && cb_state->HasKnownEffect(prior_state)) {
-        state = *cb_state;
+    prior_state = local_signal_state ? local_signal_state : prior_state;
+    if (cb_signal_state && cb_signal_state->HasKnownEffect(prior_state)) {
+        state = *cb_signal_state;
     }
     return state;
 }

--- a/layers/state_tracker/event_state.h
+++ b/layers/state_tracker/event_state.h
@@ -55,7 +55,7 @@ struct EventSignalState {
     // NOTE: this implementation is about handling repeated signals. It does not try
     // to handle repeated unsignals, which are also ignored. The reason for this is
     // that we don't track associated data with unsignals, so original unsignal and
-    // duplicated ones are the same from the tracking perspective. The implementatio
+    // duplicated ones are the same from the tracking perspective. The implementation
     // has to be updated if we need to track data associated with the unsignal (then
     // it's important to keep the original unsignal data)
     bool HasKnownEffect(const EventSignalState* prior_state = nullptr) const;
@@ -77,7 +77,7 @@ const EventSignalState* ResolveSecondarySignal(const EventSignalState* prior_sta
 
 // Resolve the effective signaling state from three levels: the global state, the local submit
 // state (between command buffers of submission), and the command buffer state
-EventSignalState ResolveEventSignal(const vvl::Event& event_state, const EventSignalState* submit_signal_state,
+EventSignalState ResolveEventSignal(const vvl::Event& event_state, const EventSignalState* local_signal_state,
                                     const EventSignalState* cb_signal_state);
 
 void UpdateEventSignalStates(EventSignalStateMap& accumulated_states, const EventSignalStateMap& recorded_states);


### PR DESCRIPTION
Naming consistency cleanup. Mostly about "local_" convention when Validate phase processes sequence of objects and needs to temporary store state from already processed ones.