### PR TITLE
gpuav: Handle Atomic Storage Image

### DIFF
--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -823,6 +823,13 @@ const char* not_going_to_do[] = {
     // This is a crazy VU that is just not practical to track/test as it involves
     // pipeline binaries from the user's system
     "VUID-VkPipelineBinaryInfoKHR-binaryCount-09603",
+
+    // This should be a single VU as
+    // VUID-RuntimeSpirv-imageDescriptorAlignment-11349
+    // already cover imageDescriptorAlignment, but there is a seperate VU
+    // for atomic storage images.
+    // Instead of wasting effort/memory tracking that, we just combine the VU
+    "VUID-RuntimeSpirv-imageDescriptorAlignment-11383",
 };
 
 // VUs from deprecated extensions that would require complex codegen to get working

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -1499,9 +1499,14 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
     vvl::unordered_map<uint32_t, HeapAccesses> accesses;
 
     auto add_access = [&](const VkDescriptorType descriptor_type, const spirv::Instruction& ac_inst) {
+        if (ac_inst.Opcode() != spv::OpUntypedAccessChainKHR) {
+            // will happen when mixing typed (set/binding) and untyped
+            // just a dirty way to detect it is not going to be from the heap
+            return;
+        }
+
         const VkDeviceSize descriptor_size =
             GetUntypedDescriptorSize(dev_data.phys_dev_ext_props.descriptor_heap_props, descriptor_type);
-        assert(ac_inst.Opcode() == spv::OpUntypedAccessChainKHR);
         const spirv::Instruction* base_type_inst = module.FindDef(ac_inst.Word(3));
         if (base_type_inst->Opcode() != spv::OpTypeBufferEXT && base_type_inst->Opcode() != spv::OpTypeStruct &&
             !base_type_inst->IsArray()) {
@@ -1573,8 +1578,11 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
                 next_access_chain = module.FindDef(access_chain_base_id);
             }
             const spirv::Instruction* base_type = next_access_chain;
+            if (!base_type) {
+                continue;
+            }
 
-            if (base_type && base_type->Opcode() == spv::OpBufferPointerEXT) {
+            if (base_type->Opcode() == spv::OpBufferPointerEXT) {
                 // Ignore old BufferBlock + Uniform
                 const VkDescriptorType descriptor_type =
                     module.FindDef(base_type->TypeId())->StorageClass() == spv::StorageClassUniform
@@ -1582,6 +1590,11 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
                         : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 
                 const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(3));
+                add_access(descriptor_type, *ac_inst);
+            } else if (base_type->Opcode() == spv::OpUntypedImageTexelPointerEXT) {
+                // Atomic storage image
+                const VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+                const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(4));
                 add_access(descriptor_type, *ac_inst);
             }
         }
@@ -1677,10 +1690,13 @@ bool CommandBufferSubState::DumpDescriptorHeapUntyped(std::ostringstream& ss, co
             VkDeviceSize final_address = vvl::kNoIndex32;
             if (!dynamic_index) {
                 if (access.descriptor_index != 0) {
-                    ss << ", array index[" << std::dec << access.descriptor_index << "]\n";
+                    ss << ", array index[" << std::dec << access.descriptor_index << "]";
                 } else if (access.array_stride != 0) {
-                    ss << ", single element\n";  // if not array stride, this is pointless
+                    ss << ", array index[0]";
+                } else {
+                    ss << ", single element";
                 }
+                ss << '\n';
                 const VkDeviceSize final_offset = access.heap_offset + (access.array_stride * access.descriptor_index);
                 final_address = heap_range.begin + final_offset;
                 ss << "      - " << (is_sampler ? "Sampler" : "Resource") << " heap address: 0x" << std::hex << final_address

--- a/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
@@ -203,7 +203,7 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
 
                         if (error_sub_code == kErrorSubCode_DescriptorHeap_DescriptorAlignmentUntyped) {
                             out_vuid_msg = is_sampler ? "VUID-RuntimeSpirv-samplerDescriptorAlignment-11348"
-                                           : is_image ? "VUID-RuntimeSpirv-imageDescriptorAlignment-11349"
+                                           : is_image ? "VUID-RuntimeSpirv-imageDescriptorAlignment-11349"  // (and 11383)
                                                       : "VUID-RuntimeSpirv-bufferDescriptorAlignment-11384";
                         } else {
                             vvl::ActionVUID action_vuid = is_buffer  ? vvl::ActionVUID::DESCRIPTOR_HEAP_ALIGNMENT_11297

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -872,13 +872,17 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
             path.ac_list.insert(path.ac_list.begin(), next_access_chain);
             const uint32_t untyped_variable_id = next_access_chain->Operand(1);
             path.variable = FindVariableById(untyped_variable_id);
-        } else if (next_access_chain->Opcode() == spv::OpImageTexelPointer) {
+        } else if (next_access_chain->Opcode() == spv::OpImageTexelPointer ||
+                   next_access_chain->Opcode() == spv::OpUntypedImageTexelPointerEXT) {
+            // Atomic Storage Image
             path.descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-            const Instruction* access_chain_inst = function.FindInstruction(next_access_chain->Operand(0));
+            const uint32_t image_operand = next_access_chain->Opcode() == spv::OpUntypedImageTexelPointerEXT ? 1 : 0;
+            const Instruction* access_chain_inst = function.FindInstruction(next_access_chain->Operand(image_operand));
             if (access_chain_inst && access_chain_inst->IsNonPtrAccessChain()) {
                 next_access_chain = access_chain_inst;
                 path.ac_list.insert(path.ac_list.begin(), next_access_chain);
-                path.variable = FindVariableById(access_chain_inst->Operand(0));
+                const uint32_t base_operand = next_access_chain->IsUntypedAccessChain() ? 1 : 0;
+                path.variable = FindVariableById(access_chain_inst->Operand(base_operand));
             } else {
                 // if no array, will point right to a variable
                 path.variable = FindVariableById(next_access_chain->Operand(0));
@@ -916,8 +920,16 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
 
     if (path.pointer_type->IsArray()) {
         assert(next_access_chain);  // no way to have an array otherwise
-        const uint32_t index_0_operand = next_access_chain->IsUntypedAccessChain() ? 2 : 1;
-        path.descriptor_index_id = next_access_chain->Operand(index_0_operand);
+        if (next_access_chain->IsUntypedAccessChain()) {
+            if (next_access_chain->Length() > 5) {
+                path.descriptor_index_id = next_access_chain->Word(5);
+            } else {
+                // using implicit zero index
+                path.descriptor_index_id = GetConstantZeroUint32().Id();
+            }
+        } else {
+            path.descriptor_index_id = next_access_chain->Word(4);
+        }
     } else {
         // There is no array of this descriptor, so we essentially have an array of 1
         path.descriptor_index_id = GetConstantZeroUint32().Id();

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -1973,6 +1973,149 @@ TEST_F(NegativeGpuAVDescriptorHeap, BufferDescriptorAlignmentUntypedPointers) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeGpuAVDescriptorHeap, StorageImageDescriptorAlignmentUntypedPointers) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    const VkDeviceSize resource_stride = heap_props.imageDescriptorSize;
+    CreateResourceHeap(resource_stride * 2);
+
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
+    WriteImageToHeap(image, 0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+    WriteImageToHeap(image, 1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+
+    // [stride: spec_constant_id = 1]
+    // layout(descriptor_heap, R32ui) uniform uimage2D si[];
+    //
+    // imageStore(si[1], ivec2(1), uvec4(1)); // bad
+    // imageStore(si[0], ivec2(1), uvec4(1)); // good
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorateId %runtime_image ArrayStrideIdEXT %bad_stride
+               OpDecorate %bad_stride SpecId 1
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+        %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+         %12 = OpTypeImage %uint 2D 0 0 0 2 R32ui
+ %bad_stride = OpSpecConstant %int 0
+%runtime_image = OpTypeRuntimeArray %12
+      %v2int = OpTypeVector %int 2
+         %18 = OpConstantComposite %v2int %int_1 %int_1
+     %v4uint = OpTypeVector %uint 4
+     %uint_1 = OpConstant %uint 1
+         %21 = OpConstantComposite %v4uint %uint_1 %uint_1 %uint_1 %uint_1
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+    %one_ac = OpUntypedAccessChainKHR %_ptr_UniformConstant %runtime_image %resource_heap %int_1
+  %si1_load = OpLoad %12 %one_ac
+               OpImageWrite %si1_load %18 %21 ZeroExtend
+    %zero_ac = OpUntypedAccessChainKHR %_ptr_UniformConstant %runtime_image %resource_heap
+   %si0_load = OpLoad %12 %zero_ac
+               OpImageWrite %si0_load %18 %21 ZeroExtend
+               OpReturn
+               OpFunctionEnd
+    )";
+    const uint32_t data = (uint32_t)heap_props.imageDescriptorSize - 1;
+    const VkSpecializationMapEntry entry = {1, 0, sizeof(uint32_t)};
+    const VkSpecializationInfo specialization_info = {1, &entry, sizeof(uint32_t), &data};
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM, &specialization_info);
+
+    m_command_buffer.Begin();
+    BindResourceHeap();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-imageDescriptorAlignment-11349");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeGpuAVDescriptorHeap, StorageImageAtomicDescriptorAlignmentUntypedPointers) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    const VkDeviceSize resource_stride = heap_props.imageDescriptorSize;
+    CreateResourceHeap(resource_stride * 2);
+
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8_SINT, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
+    WriteImageToHeap(image, 0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+    WriteImageToHeap(image, 1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
+
+    // [stride: spec_constant_id = 1]
+    // layout(descriptor_heap, r32i) uniform iimage1D si1[];
+    //
+    // imageAtomicAdd(si1[1], 1, 1); // bad
+    // imageAtomicAdd(si1[0], 1, 1); // good
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability Image1D
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorateId %runtime_image ArrayStrideIdEXT %bad_stride
+               OpDecorate %bad_stride SpecId 1
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+         %11 = OpTypeImage %int 1D 0 0 0 2 R32i
+%_runtimearr_11 = OpTypeRuntimeArray %11
+%_ptr_Image_int = OpTypePointer Image %int
+ %_ptr_Image = OpTypeUntypedPointerKHR Image
+ %bad_stride = OpSpecConstant %uint 0
+%runtime_image = OpTypeRuntimeArray %11
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+         %12 = OpUntypedAccessChainKHR %_ptr_UniformConstant %runtime_image %resource_heap %uint_1
+         %19 = OpUntypedImageTexelPointerEXT %_ptr_Image %11 %12 %int_1 %uint_0
+         %21 = OpAtomicIAdd %int %19 %uint_1 %uint_0 %int_1
+         %23 = OpUntypedAccessChainKHR %_ptr_UniformConstant %runtime_image %resource_heap %uint_0
+         %26 = OpUntypedImageTexelPointerEXT %_ptr_Image %11 %23 %int_1 %uint_0
+         %27 = OpAtomicIAdd %int %26 %uint_1 %uint_0 %int_1
+               OpReturn
+               OpFunctionEnd
+    )";
+    const uint32_t data = (uint32_t)heap_props.imageDescriptorSize - 1;
+    const VkSpecializationMapEntry entry = {1, 0, sizeof(uint32_t)};
+    const VkSpecializationInfo specialization_info = {1, &entry, sizeof(uint32_t), &data};
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM, &specialization_info);
+
+    m_command_buffer.Begin();
+    BindResourceHeap();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-imageDescriptorAlignment-11349");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeGpuAVDescriptorHeap, ResourceReservedRange) {
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     if (heap_props.minResourceHeapReservedRange == 0) {

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -1448,6 +1448,68 @@ TEST_F(NegativeGpuDump, DescriptorHeapUntypedPointers) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeGpuDump, DescriptorHeapUntypedPointersStorageImage) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitDescriptorHeap());
+
+    // We want to easily control it for testing
+    if (heap_props.minResourceHeapReservedRange != 0 || heap_props.minSamplerHeapReservedRange != 0) {
+        GTEST_SKIP() << "heapReservedRange is not zero";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.imageDescriptorSize;
+    VkDeviceSize heap_size = Align((resource_stride * 4), resource_stride);
+    vkt::Buffer resource_heap(*m_device, heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+
+    const char* cs_source = R"glsl(
+        #version 460 core
+        #extension GL_EXT_descriptor_heap: enable
+        layout(descriptor_heap, r32i) uniform iimage1D si1[];
+        layout(descriptor_heap, R32ui) uniform uimage2D si2[];
+        layout(set = 0, binding = 0, r32i) uniform iimage1D si3[];
+        layout(set = 0, binding = 1, R32ui) uniform uimage2D si4[];
+
+        void main() {
+            imageAtomicAdd(si1[2], 1, 1);
+            imageStore(si2[1], ivec2(1), uvec4(1));
+            imageAtomicAdd(si3[0], 1, 1);
+            imageStore(si4[1], ivec2(1), uvec4(1));
+        }
+    )glsl";
+
+    m_command_buffer.Begin();
+
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = resource_heap.AddressRange();
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+
+    VkDescriptorSetAndBindingMappingEXT mappings[2];
+    mappings[0] = MakeSetAndBindingMapping(0, 0);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[0].sourceData.constantOffset.heapArrayStride = (uint32_t)resource_stride;
+    mappings[1] = MakeSetAndBindingMapping(0, 1);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset.heapOffset = (uint32_t)resource_stride;
+    mappings[1].sourceData.constantOffset.heapArrayStride = (uint32_t)resource_stride;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 2u;
+    mapping_info.pMappings = mappings;
+
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, &mapping_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+
+    uint32_t push_data = 0;
+    m_command_buffer.PushData(0, sizeof(uint32_t), &push_data);
+    m_errorMonitor->SetDesiredInfo("GPU-DUMP");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeGpuDump, DescriptorHeapBindingCount) {
     RETURN_IF_SKIP(InitDescriptorHeap());
 


### PR DESCRIPTION
Add support for `OpUntypedImageTexelPointerEXT` (Atomic storage images) and tests for both GPU-AV and GPU Dump