### PR TITLE
tests: Fix image processing tests on qcom devices

### DIFF
--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -5005,10 +5005,8 @@ TEST_F(NegativeImage, CreateSamplerWithIncorrectBlockMatchWindowExtent) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
     AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_3_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::textureBlockMatch);
     AddRequiredFeature(vkt::Feature::textureBlockMatch2);
-    AddRequiredFeature(vkt::Feature::blockMatchExtendedClampToEdge);
     RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceImageProcessing2PropertiesQCOM image_processing2_props = vku::InitStructHelper();
@@ -5021,12 +5019,208 @@ TEST_F(NegativeImage, CreateSamplerWithIncorrectBlockMatchWindowExtent) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo(&block_match_window_ci);
     sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
     sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     sampler_ci.minLod = 0.0f;
     sampler_ci.maxLod = 0.0f;
 
     m_errorMonitor->SetDesiredError("VUID-VkSamplerBlockMatchWindowCreateInfoQCOM-WindowExtent-09210");
     vkt::Sampler sampler{ *m_device, sampler_ci };
     m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeImage, ImageSampleWeightedInstructionButInvalidFormatFeatures) {
+    TEST_DESCRIPTION("Try to launch a compute pass with an OpImageSampleWeightedQCOM instruction, while "
+                     "the used image views have the invalid format features.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureSampleWeighted);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceImageProcessingPropertiesQCOM image_processing_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(image_processing_props);
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    VkFormat weight_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : { VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8_UNORM, VK_FORMAT_R16G16_UNORM }) {
+        const auto format_features2 = m_device->FormatFeaturesOptimal(format);
+        if ((format_features2 & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (format_features2 & VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM) == 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+    for (VkFormat format : { VK_FORMAT_R16_SFLOAT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R8_UNORM }) {
+        const auto format_features2 = m_device->FormatFeaturesOptimal(format);
+        if ((format_features2 & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (format_features2 & VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM) == 0) {
+            weight_format = format;
+            break;
+        }
+    }
+
+    if ((sampled_format == VK_FORMAT_UNDEFINED) || (weight_format == VK_FORMAT_UNDEFINED)) {
+        GTEST_SKIP() << "Failed to find any format that doesn't support VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM "
+                        "or VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM format feature, skipping test.";
+    }
+
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.minLod = 0.0f;
+    sampler_ci.maxLod = 0.0f;
+    vkt::Sampler sampler{ *m_device, sampler_ci };
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(512, 512, 1, 1, sampled_format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image sampled_image{ *m_device, image_ci };
+    vkt::ImageView sampled_image_view = sampled_image.CreateView();
+
+    image_ci.format = weight_format;
+    image_ci.usage |= VK_IMAGE_USAGE_SAMPLE_WEIGHT_BIT_QCOM;
+    vkt::Image weight_image{ *m_device, image_ci };
+
+    VkImageViewSampleWeightCreateInfoQCOM weight_ci = vku::InitStructHelper();
+    weight_ci.filterCenter = { 0, 0 };
+    weight_ci.filterSize = image_processing_props.maxWeightFilterDimension;
+    weight_ci.numPhases = 1;
+    VkImageViewCreateInfo weight_view_ci = vku::InitStructHelper(&weight_ci);
+    weight_view_ci.image = weight_image;
+    weight_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+    weight_view_ci.format = weight_format;
+    weight_view_ci.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+    vkt::ImageView weight_image_view{ *m_device, weight_view_ci };
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+
+        layout(set = 0, binding = 0) uniform texture2D sampled_tex;
+        layout(set = 0, binding = 1) uniform texture2DArray weight_tex;
+        layout(set = 0, binding = 2) uniform sampler processing_sampler;
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+        void main() {
+            vec4 result = textureWeightedQCOM(
+                sampler2D(sampled_tex, processing_sampler),
+                vec2(0.5, 0.5),
+                sampler2DArray(weight_tex, processing_sampler)
+            );
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{ *this };
+    compute_pipe.cs_ = VkShaderObj{ *m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3 };
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                  {1, VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                  {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, sampled_image_view, nullptr, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, weight_image_view, nullptr, VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(2, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageSampleWeightedQCOM-06971");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageSampleWeightedQCOM-06972");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeImage, ImageBoxFilterInstructionButInvalidFormatFeatures) {
+    TEST_DESCRIPTION("Try to launch a compute pass with an OpImageBoxFilterQCOM instruction, while "
+                     "the used image views have the invalid format features.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureBoxFilter);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceImageProcessingPropertiesQCOM image_processing_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(image_processing_props);
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : { VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8_UNORM, VK_FORMAT_R16G16_UNORM }) {
+        const auto format_features2 = m_device->FormatFeaturesOptimal(format);
+        if ((format_features2 & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (format_features2 & VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM) == 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+
+    if (sampled_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find any format that doesn't support VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM "
+                        "format feature, skipping test.";
+    }
+
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.minLod = 0.0f;
+    sampler_ci.maxLod = 0.0f;
+    vkt::Sampler sampler{ *m_device, sampler_ci };
+
+    const auto image_ci = vkt::Image::ImageCreateInfo2D(512, 512, 1, 1, sampled_format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image sampled_image{ *m_device, image_ci };
+    vkt::ImageView sampled_image_view = sampled_image.CreateView();
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+
+        layout(constant_id = 0) const float BOX_SIZE_X = 8.0;
+        layout(constant_id = 1) const float BOX_SIZE_Y = 8.0;
+        layout(set = 0, binding = 0) uniform texture2D sampled_tex;
+        layout(set = 0, binding = 1) uniform sampler processing_sampler;
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+        void main() {
+            vec4 result = textureBoxFilterQCOM(
+                sampler2D(sampled_tex, processing_sampler),
+                vec2(0.5, 0.5),
+                vec2(BOX_SIZE_X, BOX_SIZE_Y)
+            );
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{ *this };
+    constexpr std::array<VkSpecializationMapEntry, 2> map_entries{
+        VkSpecializationMapEntry{ 0, 0, sizeof(uint32_t) },
+        VkSpecializationMapEntry{ 1, sizeof(uint32_t), sizeof(uint32_t) },
+    };
+    const std::array<float, 2> box_sizes{
+        std::min(8.0f, static_cast<float>(image_processing_props.maxBoxFilterBlockSize.width)),
+        std::min(8.0f, static_cast<float>(image_processing_props.maxBoxFilterBlockSize.height)),
+    };
+    VkSpecializationInfo specialization_info{};
+    specialization_info.mapEntryCount = map_entries.size();
+    specialization_info.pMapEntries = map_entries.data();
+    specialization_info.dataSize = sizeof(box_sizes);
+    specialization_info.pData = box_sizes.data();
+    compute_pipe.cs_ = VkShaderObj{ *m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3,
+                                    SPV_SOURCE_GLSL, &specialization_info };
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                  {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, sampled_image_view, nullptr, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageBoxFilterQCOM-06973");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, ImageBoxFilterInstructionButInvalidSamplerFlags) {
@@ -5161,6 +5355,239 @@ TEST_F(NegativeImage, ImageSampleImplicitInstructionButInvalidSamplerFlags) {
                               &compute_pipe.descriptor_set_.set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageSampleWeightedQCOM-06978");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeImage, ImageBlockMatchInstructionButInvalidFormatFeatures) {
+    TEST_DESCRIPTION("Try to launch a compute pass with an OpImageBlockMatchSADQCOM instruction and "
+                     "an OpImageBlockMatchSSDQCOM instruction, while the image views have the invalid format features.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceImageProcessingPropertiesQCOM image_processing_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(image_processing_props);
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : { VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8_UNORM, VK_FORMAT_R16_UNORM }) {
+        const auto format_features2 = m_device->FormatFeaturesOptimal(format);
+        if ((format_features2 & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (format_features2 & VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM) == 0 &&
+            (format_features2 & VK_FORMAT_FEATURE_2_BLOCK_MATCHING_SXD_BIT_QCOM) == 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+
+    if (sampled_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find any format that doesn't support VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM "
+                        "or VK_FORMAT_FEATURE_2_BLOCK_MATCHING_SXD_BIT_QCOM format feature, skipping test.";
+    }
+
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.minLod = 0.0f;
+    sampler_ci.maxLod = 0.0f;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    vkt::Sampler sampler{ *m_device, sampler_ci };
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
+
+    const auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, sampled_format,
+                                                        VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_SAMPLE_BLOCK_MATCH_BIT_QCOM);
+    vkt::Image target_image{ *m_device, image_ci };
+    vkt::Image reference_image{ *m_device, image_ci };
+    vkt::ImageView target_image_view = target_image.CreateView();
+    vkt::ImageView reference_image_view = reference_image.CreateView();
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+
+        layout(constant_id = 0) const uint BLOCK_SIZE_X = 8;
+        layout(constant_id = 1) const uint BLOCK_SIZE_Y = 8;
+        layout(set = 0, binding = 0) uniform texture2D target_tex;
+        layout(set = 0, binding = 1) uniform texture2D ref_tex;
+        layout(set = 0, binding = 2) uniform sampler processing_sampler;
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+        void main() {
+            uvec2 target_coord = uvec2(0, 0);
+            uvec2 ref_coord_1 = uvec2(12, 12);
+            uvec2 ref_coord_2 = uvec2(8, 8);
+            uvec2 block_size = uvec2(BLOCK_SIZE_X, BLOCK_SIZE_Y);
+            vec4 result_1 = textureBlockMatchSADQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord_1,
+                block_size
+            );
+            vec4 result_2 = textureBlockMatchSSDQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord_2,
+                block_size
+            );
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{ *this };
+    constexpr std::array<VkSpecializationMapEntry, 2> map_entries{
+        VkSpecializationMapEntry{ 0, 0, sizeof(uint32_t) },
+        VkSpecializationMapEntry{ 1, sizeof(uint32_t), sizeof(uint32_t) },
+    };
+    const std::array<uint32_t, 2> block_sizes{
+        std::min(8u, image_processing_props.maxBlockMatchRegion.width),
+        std::min(8u, image_processing_props.maxBlockMatchRegion.height),
+    };
+    VkSpecializationInfo specialization_info{};
+    specialization_info.mapEntryCount = map_entries.size();
+    specialization_info.pMapEntries = map_entries.data();
+    specialization_info.dataSize = sizeof(block_sizes);
+    specialization_info.pData = block_sizes.data();
+    compute_pipe.cs_ = VkShaderObj{ *m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3,
+                                    SPV_SOURCE_GLSL, &specialization_info };
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                  {1, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                  {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, target_image_view, nullptr, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, reference_image_view, nullptr, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(2, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageBlockMatchSSDQCOM-06974", 2);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageBlockMatchSADQCOM-12420", 2);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeImage, ImageBlockMatchWindowInstructionButInvalidFormatFeatures) {
+    TEST_DESCRIPTION("Try to launch a compute pass with an OpImageBlockMatchWindowSSDQCOM instruction and "
+                     "an OpImageBlockMatchGatherSADQCOM instruction, while the image views have the invalid format features.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch);
+    AddRequiredFeature(vkt::Feature::textureBlockMatch2);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceImageProcessingPropertiesQCOM image_processing_props = vku::InitStructHelper();
+    VkPhysicalDeviceImageProcessing2PropertiesQCOM image_processing2_props = vku::InitStructHelper(&image_processing_props);
+    GetPhysicalDeviceProperties2(image_processing2_props);
+
+    VkFormat sampled_format = VK_FORMAT_UNDEFINED;
+    for (VkFormat format : { VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8_UNORM, VK_FORMAT_R16G16B16A16_UNORM }) {
+        const auto format_features2 = m_device->FormatFeaturesOptimal(format);
+        if ((format_features2 & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) != 0 &&
+            (format_features2 & VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM) == 0) {
+            sampled_format = format;
+            break;
+        }
+    }
+
+    if (sampled_format == VK_FORMAT_UNDEFINED) {
+        GTEST_SKIP() << "Failed to find any format that doesn't support VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM "
+                        "from the format candidate list, skipping test.";
+    }
+
+    VkSamplerBlockMatchWindowCreateInfoQCOM block_match_window_ci = vku::InitStructHelper();
+    block_match_window_ci.windowExtent.width = std::min(8U, image_processing2_props.maxBlockMatchWindow.width);
+    block_match_window_ci.windowExtent.height = std::min(8U, image_processing2_props.maxBlockMatchWindow.height);
+    block_match_window_ci.windowCompareMode = VK_BLOCK_MATCH_WINDOW_COMPARE_MODE_MIN_QCOM;
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo(&block_match_window_ci);
+    sampler_ci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
+    sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
+    sampler_ci.minLod = 0.0f;
+    sampler_ci.maxLod = 0.0f;
+    vkt::Sampler sampler{ *m_device, sampler_ci };
+
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
+
+    const auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, sampled_format,
+                                                        VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_SAMPLE_BLOCK_MATCH_BIT_QCOM);
+    vkt::Image target_image{ *m_device, image_ci };
+    vkt::Image reference_image{ *m_device, image_ci };
+    vkt::ImageView target_image_view = target_image.CreateView();
+    vkt::ImageView reference_image_view = reference_image.CreateView();
+
+    const char* cs_source = R"glsl(
+        #version 460
+
+        #extension GL_QCOM_image_processing: require
+        #extension GL_QCOM_image_processing2: require
+
+        layout(constant_id = 0) const uint BLOCK_SIZE_X = 8;
+        layout(constant_id = 1) const uint BLOCK_SIZE_Y = 8;
+        layout(set = 0, binding = 0) uniform texture2D target_tex;
+        layout(set = 0, binding = 1) uniform texture2D ref_tex;
+        layout(set = 0, binding = 2) uniform sampler processing_sampler;
+        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+        void main() {
+            uvec2 target_coord = uvec2(0, 0);
+            uvec2 ref_coord_1 = uvec2(8, 8);
+            uvec2 ref_coord_2 = uvec2(0, 0);
+            uvec2 block_size = uvec2(BLOCK_SIZE_X, BLOCK_SIZE_Y);
+            vec4 result_1 = textureBlockMatchWindowSSDQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord_1,
+                block_size
+            );
+            vec4 result_2 = textureBlockMatchGatherSADQCOM(
+                sampler2D(target_tex, processing_sampler), target_coord,
+                sampler2D(ref_tex, processing_sampler), ref_coord_2,
+                block_size
+            );
+        }
+    )glsl";
+
+    CreateComputePipelineHelper compute_pipe{ *this };
+    constexpr std::array<VkSpecializationMapEntry, 2> map_entries{
+        VkSpecializationMapEntry{ 0, 0, sizeof(uint32_t) },
+        VkSpecializationMapEntry{ 1, sizeof(uint32_t), sizeof(uint32_t) }
+    };
+    const std::array<uint32_t, 2> block_sizes{
+        std::min(8u, image_processing_props.maxBlockMatchRegion.width),
+        std::min(8u, image_processing_props.maxBlockMatchRegion.height),
+    };
+    VkSpecializationInfo specialization_info{};
+    specialization_info.mapEntryCount = map_entries.size();
+    specialization_info.pMapEntries = map_entries.data();
+    specialization_info.dataSize = sizeof(block_sizes);
+    specialization_info.pData = block_sizes.data();
+    compute_pipe.cs_ = VkShaderObj{ *m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3,
+                                    SPV_SOURCE_GLSL, &specialization_info };
+    compute_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                  {1, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                  {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    compute_pipe.CreateComputePipeline();
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(0, target_image_view, nullptr, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(1, reference_image_view, nullptr, VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM);
+    compute_pipe.descriptor_set_.WriteDescriptorImageInfo(2, nullptr, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    compute_pipe.descriptor_set_.UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe.pipeline_layout_, 0, 1,
+                              &compute_pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageBlockMatchWindow-09215", 2);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageBlockMatchWindow-09216", 2);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -1254,6 +1254,10 @@ TEST_F(PositiveImage, ImageBlockMatchInstruction) {
     sampler_ci.minLod = 0.0f;
     sampler_ci.maxLod = 0.0f;
     sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     vkt::Sampler sampler{ *m_device, sampler_ci };
 
     const auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, sampled_format,
@@ -1330,10 +1334,8 @@ TEST_F(PositiveImage, ImageBlockMatchWindowInstruction) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);
     AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_3_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::textureBlockMatch);
     AddRequiredFeature(vkt::Feature::textureBlockMatch2);
-    AddRequiredFeature(vkt::Feature::blockMatchExtendedClampToEdge);
     RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceImageProcessingPropertiesQCOM image_processing_props = vku::InitStructHelper();
@@ -1363,6 +1365,10 @@ TEST_F(PositiveImage, ImageBlockMatchWindowInstruction) {
     sampler_ci.minLod = 0.0f;
     sampler_ci.maxLod = 0.0f;
     sampler_ci.unnormalizedCoordinates = VK_TRUE;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
+    sampler_ci.addressModeV = sampler_ci.addressModeU;
+    sampler_ci.addressModeW = sampler_ci.addressModeU;
+    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     vkt::Sampler sampler{ *m_device, sampler_ci };
 
     const auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, sampled_format,

--- a/tests/unit/tile_shading.cpp
+++ b/tests/unit/tile_shading.cpp
@@ -3260,6 +3260,7 @@ TEST_F(NegativeTileShading, UseSampleWeightedImageOpButTileShadingImageProcessin
         GTEST_SKIP() << "Failed to find a format supporting OpImageSampleWeightedQCOM, skipping test.";
     }
 
+    tile_shading_rp_config.format = sampled_format;
     InitTileShadingRenderTarget();
 
     VkPhysicalDeviceImageProcessingPropertiesQCOM image_processing_props = vku::InitStructHelper();
@@ -3381,6 +3382,7 @@ TEST_F(NegativeTileShading, UseBoxFilterImageOpButTileShadingImageProcessingNotE
         GTEST_SKIP() << "Failed to find a format supporting OpImageBoxFilterQCOM, skipping test.";
     }
 
+    tile_shading_rp_config.format = sampled_format;
     InitTileShadingRenderTarget();
 
     VkSamplerCreateInfo sampler_ci = vku::InitStructHelper();
@@ -3601,9 +3603,10 @@ TEST_F(NegativeTileShading, UseBlockMatchWindowImageOpButTileShadingImageProcess
     sampler_ci.magFilter = VK_FILTER_NEAREST;
     sampler_ci.minFilter = VK_FILTER_NEAREST;
     sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
     sampler_ci.addressModeV = sampler_ci.addressModeU;
     sampler_ci.addressModeW = sampler_ci.addressModeU;
+    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     vkt::Sampler sampler{*m_device, sampler_ci};
 
     const char* cs_source = R"glsl(
@@ -3720,9 +3723,10 @@ TEST_F(NegativeTileShading, UseBlockMatchGatherImageOpButTileShadingImageProcess
     sampler_ci.magFilter = VK_FILTER_NEAREST;
     sampler_ci.minFilter = VK_FILTER_NEAREST;
     sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    sampler_ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
     sampler_ci.addressModeV = sampler_ci.addressModeU;
     sampler_ci.addressModeW = sampler_ci.addressModeU;
+    sampler_ci.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK;
     vkt::Sampler sampler{*m_device, sampler_ci};
 
     const char* cs_source = R"glsl(


### PR DESCRIPTION
# Overview
Fixes `image_processing` / `image_processing2` unit tests on real QCOM devices (`SM8850 Android (A8x)`, `SM8750 Android (A8x)`, `X Elite Desktop (A7x)`).

- On QCOM hardware, `vkGetPhysicalDeviceImageFormatProperties2` returns `VK_ERROR_FORMAT_NOT_SUPPORTED` when a format lacks the QCOM feature bit for the requested usage flag.
- VVL's `PreCallValidateCreateImage` calls this function and fires `VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251`, preventing execution from reaching the intended dispatch-time VUIDs.

- Removes the `VK_QCOM_IMAGE_PROCESSING_3` extension and `blockMatchExtendedClampToEdge` feature dependency from tests that were skipping on `SM8850` via the latest driver version, replacing with `VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER` + `VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK`. See https://github.khronos.org/Vulkan-Site/spec/latest/chapters/textures.html#textures-blockmatch

# Unit Tests
| Test | VUID & Description |
|------|------|
| `ImageSampleWeightedInstructionButInvalidFormatFeatures` | 06971, 06972 |
| `ImageBoxFilterInstructionButInvalidFormatFeatures` | 06973 |
| `ImageBlockMatchInstructionButInvalidFormatFeatures` | 06974, 12420 |
| `CreateSamplerWithIncorrectBlockMatchWindowExtent` | 09210 |
| `ImageBlockMatchWindowInstructionButInvalidFormatFeatures` | 09215, 09216 |
| `ImageBlockMatchInstruction` | Positive |
| `ImageBlockMatchWindowInstruction` | Positive |
| `UseBlockMatchWindowImageOpButTileShadingImageProcessingNotEnabled` | use `CLAMP_TO_BORDER` |
| `UseBlockMatchGatherImageOpButTileShadingImageProcessingNotEnabled` | use `CLAMP_TO_BORDER` |