### PR TITLE
layers: Make CommandPool const ref

### DIFF
--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -664,7 +664,7 @@ void CommandBufferSubState::RecordBarriers(uint32_t, const VkBufferMemoryBarrier
 
         // Is a queue ownership acquisition barrier
         if (barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex &&
-            barrier.dstQueueFamilyIndex == base.command_pool->queueFamilyIndex) {
+            barrier.dstQueueFamilyIndex == base.command_pool.queueFamilyIndex) {
             auto subresource_range = barrier.subresourceRange;
             queue_submit_functions.emplace_back(
                 [image_state, subresource_range](const vvl::Queue& qs, const vvl::CommandBuffer& cbs) -> bool {
@@ -695,7 +695,7 @@ void CommandBufferSubState::RecordBarriers2(const VkDependencyInfo& dep_info, co
 
         // Is a queue ownership acquisition barrier
         if (barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex &&
-            barrier.dstQueueFamilyIndex == base.command_pool->queueFamilyIndex) {
+            barrier.dstQueueFamilyIndex == base.command_pool.queueFamilyIndex) {
             auto subresource_range = barrier.subresourceRange;
             queue_submit_functions.emplace_back(
                 [image_state, subresource_range](const vvl::Queue& qs, const vvl::CommandBuffer& cbs) -> bool {

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -432,7 +432,7 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     if (!IsExtEnabled(extensions.vk_khr_maintenance1)) {
         const VkQueueFlags required_flags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
         if (!HasRequiredQueueFlags(cb_state, *physical_device_state, required_flags)) {
-            const LogObjectList objlist_pool(cb_state.Handle(), cb_state.command_pool->Handle());
+            const LogObjectList objlist_pool(cb_state.Handle(), cb_state.command_pool.Handle());
             skip |= LogError("VUID-vkCmdFillBuffer-apiVersion-07894", objlist_pool, error_obj.location, "%s",
                              DescribeRequiredQueueFlag(cb_state, *physical_device_state, required_flags).c_str());
         }

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -72,7 +72,7 @@ bool CoreChecks::ValidateCmd(const vvl::CommandBuffer& cb_state, const Location&
 
     // Validate the command pool from which the command buffer is from that the command is allowed for queue type
     if (!HasRequiredQueueFlags(cb_state, *physical_device_state, info.queue_flags)) {
-        const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
+        const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool.Handle());
         skip |= LogError(info.queue_vuid, objlist, loc, "%s",
                          DescribeRequiredQueueFlag(cb_state, *physical_device_state, info.queue_flags).c_str());
     }
@@ -214,8 +214,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                          FormatHandle(commandBuffer).c_str());
     } else if (IsRecorded(cb_state->state)) {
         VkCommandPool cmd_pool = cb_state->allocate_info.commandPool;
-        const auto* pool = cb_state->command_pool;
-        if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & pool->createFlags)) {
+        if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & cb_state->command_pool.createFlags)) {
             const LogObjectList objlist(commandBuffer, cmd_pool);
             skip |= LogError("VUID-vkBeginCommandBuffer-commandBuffer-00050", objlist, error_obj.location,
                              "%s attempts to implicitly reset cmdBuffer created from "
@@ -235,13 +234,13 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                                          "VUID-VkDeviceGroupCommandBufferBeginInfo-deviceMask-00107");
     }
     if ((pBeginInfo->flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) != 0) {
-        if ((cb_state->command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
-            const LogObjectList objlist(commandBuffer, cb_state->command_pool->Handle());
+        if ((cb_state->command_pool.queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+            const LogObjectList objlist(commandBuffer, cb_state->command_pool.Handle());
             skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-09123", objlist, begin_info_loc.dot(Field::flags),
                              "contain VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT, but the command pool (created with "
                              "queueFamilyIndex %" PRIu32 ") the command buffer %s was allocated from only supports %s.",
-                             cb_state->command_pool->queueFamilyIndex, FormatHandle(commandBuffer).c_str(),
-                             string_VkQueueFlags(cb_state->command_pool->queue_flags).c_str());
+                             cb_state->command_pool.queueFamilyIndex, FormatHandle(commandBuffer).c_str(),
+                             string_VkQueueFlags(cb_state->command_pool.queue_flags).c_str());
         }
     }
     return skip;
@@ -583,13 +582,13 @@ bool CoreChecks::PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
 
     VkCommandPool cmd_pool = cb_state->allocate_info.commandPool;
-    const auto* pool = cb_state->command_pool;
 
-    if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & pool->createFlags)) {
+    if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & cb_state->command_pool.createFlags)) {
         const LogObjectList objlist(commandBuffer, cmd_pool);
-        skip |= LogError("VUID-vkResetCommandBuffer-commandBuffer-00046", objlist, error_obj.location,
-                         "%s was created from %s  which was created with %s.", FormatHandle(commandBuffer).c_str(),
-                         FormatHandle(cmd_pool).c_str(), string_VkCommandPoolCreateFlags(pool->createFlags).c_str());
+        skip |=
+            LogError("VUID-vkResetCommandBuffer-commandBuffer-00046", objlist, error_obj.location,
+                     "%s was created from %s  which was created with %s.", FormatHandle(commandBuffer).c_str(),
+                     FormatHandle(cmd_pool).c_str(), string_VkCommandPoolCreateFlags(cb_state->command_pool.createFlags).c_str());
     }
 
     if (cb_state->InUse()) {
@@ -898,15 +897,15 @@ bool CoreChecks::ValidateSecondaryCommandBufferState(const vvl::CommandBuffer& c
                                                      const core::CommandBufferSubState& secondary_sub_state,
                                                      const Location& secondary_cb_loc) const {
     bool skip = false;
-    const auto primary_pool = cb_state.command_pool;
-    const auto secondary_pool = secondary_sub_state.base.command_pool;
-    if (primary_pool && secondary_pool && (primary_pool->queueFamilyIndex != secondary_pool->queueFamilyIndex)) {
+    const vvl::CommandPool& primary_pool = cb_state.command_pool;
+    const vvl::CommandPool& secondary_pool = secondary_sub_state.base.command_pool;
+    if (primary_pool.queueFamilyIndex != secondary_pool.queueFamilyIndex) {
         const LogObjectList objlist(cb_state.Handle(), secondary_sub_state.Handle());
         skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-00094", objlist, secondary_cb_loc,
                          "(%s) was created in queue family %" PRIu32
                          " but the primary command buffer (%s) was created in queue family %" PRIu32 ".",
-                         FormatHandle(secondary_sub_state.base).c_str(), secondary_pool->queueFamilyIndex,
-                         FormatHandle(cb_state).c_str(), primary_pool->queueFamilyIndex);
+                         FormatHandle(secondary_sub_state.base).c_str(), secondary_pool.queueFamilyIndex,
+                         FormatHandle(cb_state).c_str(), primary_pool.queueFamilyIndex);
     }
 
     // All commands buffers involved must be protected or unprotected

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -180,11 +180,7 @@ static inline bool IsExtentAligned(const VkExtent3D& extent, const VkExtent3D& g
 }
 
 VkExtent3D CoreChecks::GetImageTransferGranularity(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state) const {
-    if (cb_state.command_pool) {
-        return physical_device_state->queue_family_properties[cb_state.command_pool->queueFamilyIndex].minImageTransferGranularity;
-    }
-    // Default to (0, 0, 0) granularity in case we can't find the real granularity for the physical device.
-    return {0, 0, 0};
+    return physical_device_state->queue_family_properties[cb_state.command_pool.queueFamilyIndex].minImageTransferGranularity;
 }
 
 // Check elements of a VkOffset3D structure against a queue family's Image Transfer Granularity values
@@ -775,7 +771,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer& cb_state,
         const VkQueueFlags required_flags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
         if (!HasRequiredQueueFlags(cb_state, *physical_device_state, required_flags)) {
             const char* vuid = GetCopyBufferImageDeviceVUID(region_loc, vvl::CopyError::BufferOffset_07737).c_str();
-            const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
+            const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool.Handle());
             skip |= LogError(
                 vuid, objlist, region_loc.dot(Field::bufferOffset),
                 "(%" PRIu64
@@ -4073,11 +4069,11 @@ bool CoreChecks::PreCallValidateCmdCopyMemoryIndirectKHR(VkCommandBuffer command
                          "The indirectMemoryCopy feature must be enabled.");
     }
 
-    if (!(phys_dev_ext_props.copy_memory_indirect_props.supportedQueues & cb_state->command_pool->queue_flags)) {
+    if (!(phys_dev_ext_props.copy_memory_indirect_props.supportedQueues & cb_state->command_pool.queue_flags)) {
         skip |= LogError("VUID-vkCmdCopyMemoryIndirectKHR-commandBuffer-10936", commandBuffer, error_obj.location,
                          "was allocated from a VkCommandPool with queue flags %s\nNone are supported by "
                          "VkPhysicalDeviceCopyMemoryIndirectPropertiesKHR::supportedQueues %s",
-                         string_VkQueueFlags(cb_state->command_pool->queue_flags).c_str(),
+                         string_VkQueueFlags(cb_state->command_pool.queue_flags).c_str(),
                          string_VkQueueFlags(phys_dev_ext_props.copy_memory_indirect_props.supportedQueues).c_str());
     }
 
@@ -4181,14 +4177,14 @@ bool CoreChecks::ValidateCopyMemoryToImageIndirectInfo(const vvl::CommandBuffer&
                              string_VkImageAspectFlags(aspect_mask).c_str());
         }
 
-        if (!(cb_state.command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) &&
+        if (!(cb_state.command_pool.queue_flags & VK_QUEUE_GRAPHICS_BIT) &&
             (aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT))) {
             skip |= LogError(
                 "VUID-VkCopyMemoryToImageIndirectInfoKHR-commandBuffer-07674", dst_objlist, subresource_loc.dot(Field::aspectMask),
                 "(%s) must not be VK_IMAGE_ASPECT_DEPTH_BIT "
                 "or VK_IMAGE_ASPECT_STENCIL_BIT when the queue family does not support VK_QUEUE_GRAPHICS_BIT\n VkCommandPool queue "
                 "flags: %s.",
-                string_VkImageAspectFlags(aspect_mask).c_str(), string_VkQueueFlags(cb_state.command_pool->queue_flags).c_str());
+                string_VkImageAspectFlags(aspect_mask).c_str(), string_VkQueueFlags(cb_state.command_pool.queue_flags).c_str());
         }
 
         const uint32_t mip_level = subresource_layers.mipLevel;
@@ -4235,11 +4231,11 @@ bool CoreChecks::PreCallValidateCmdCopyMemoryToImageIndirectKHR(
                          error_obj.location, "The indirectMemoryToImageCopy feature must be enabled.");
     }
 
-    if (!(phys_dev_ext_props.copy_memory_indirect_props.supportedQueues & cb_state->command_pool->queue_flags)) {
+    if (!(phys_dev_ext_props.copy_memory_indirect_props.supportedQueues & cb_state->command_pool.queue_flags)) {
         skip |= LogError("VUID-vkCmdCopyMemoryToImageIndirectKHR-commandBuffer-10948", commandBuffer, error_obj.location,
                          "was allocated from a VkCommandPool with queue flags %s\nNone are supported by "
                          "VkPhysicalDeviceCopyMemoryIndirectPropertiesKHR::supportedQueues %s",
-                         string_VkQueueFlags(cb_state->command_pool->queue_flags).c_str(),
+                         string_VkQueueFlags(cb_state->command_pool.queue_flags).c_str(),
                          string_VkQueueFlags(phys_dev_ext_props.copy_memory_indirect_props.supportedQueues).c_str());
     }
 
@@ -4340,7 +4336,7 @@ bool CoreChecks::ValidateCmdCopyMemoryToImage(VkCommandBuffer command_buffer,
                 skip |= LogError(vuid, objlist, region_loc.dot(Field::addressRange).dot(Field::address),
                                  "(%" PRIu64 ") is not a multiple of 4, but is %s (From %s)", region.addressRange.address,
                                  DescribeRequiredQueueFlag(cb_state, *physical_device_state, required_flags).c_str(),
-                                 FormatHandle(cb_state.command_pool->Handle()).c_str());
+                                 FormatHandle(cb_state.command_pool.Handle()).c_str());
             }
         }
 
@@ -4373,7 +4369,7 @@ bool CoreChecks::ValidateCmdCopyMemoryToImage(VkCommandBuffer command_buffer,
                     LogError(vuid, objlist, region_loc.dot(Field::imageSubresource).dot(Field::aspectMask),
                              "is %s, but is %s (From %s)", string_VkImageAspectFlags(region.imageSubresource.aspectMask).c_str(),
                              DescribeRequiredQueueFlag(cb_state, *physical_device_state, required_flags).c_str(),
-                             FormatHandle(cb_state.command_pool->Handle()).c_str());
+                             FormatHandle(cb_state.command_pool.Handle()).c_str());
             }
             if (!IsIntegerMultipleOf(region.addressRange.address, 4)) {
                 skip |= LogError("VUID-VkCopyDeviceMemoryImageInfoKHR-image-13031", objlist,

--- a/layers/core_checks/cc_data_graph.cpp
+++ b/layers/core_checks/cc_data_graph.cpp
@@ -424,7 +424,7 @@ bool CoreChecks::PreCallValidateCmdDispatchDataGraphARM(VkCommandBuffer commandB
     }
 
     skip |=
-        ValidateDataGraphOperations(*last_bound_state.pipeline_state, cb_state.command_pool->queueFamilyIndex, error_obj.location);
+        ValidateDataGraphOperations(*last_bound_state.pipeline_state, cb_state.command_pool.queueFamilyIndex, error_obj.location);
 
     const auto* optical_flow_di =
         pInfo ? vku::FindStructInPNextChain<VkDataGraphPipelineOpticalFlowDispatchInfoARM>(pInfo->pNext) : nullptr;

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -429,11 +429,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
 bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer& cb_state, VkPipelineBindPoint bind_point,
                                            const Location& loc) const {
     bool skip = false;
-    const auto* pool = cb_state.command_pool;
-    // The loss of a pool in a recording cmd is reported in DestroyCommandPool
-    if (!pool) {
-        return skip;
-    }
+    const vvl::CommandPool& pool = cb_state.command_pool;
 
     const VkQueueFlags required_mask = (VK_PIPELINE_BIND_POINT_GRAPHICS == bind_point)         ? VK_QUEUE_GRAPHICS_BIT
                                        : (VK_PIPELINE_BIND_POINT_COMPUTE == bind_point)        ? VK_QUEUE_COMPUTE_BIT
@@ -442,9 +438,9 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer& cb_state, V
                                            ? (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT)
                                            : VK_QUEUE_FLAG_BITS_MAX_ENUM;
 
-    const auto& qfp = physical_device_state->queue_family_properties[pool->queueFamilyIndex];
+    const auto& qfp = physical_device_state->queue_family_properties[pool.queueFamilyIndex];
     if (0 == (qfp.queueFlags & required_mask)) {
-        const LogObjectList objlist(cb_state.Handle(), pool->Handle());
+        const LogObjectList objlist(cb_state.Handle(), pool.Handle());
         const char* vuid = kVUIDUndefined;
         switch (loc.function) {
             case Func::vkCmdBindDescriptorSets:
@@ -497,7 +493,7 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer& cb_state, V
                 break;
         }
         skip |= LogError(vuid, objlist, loc, "%s was allocated from %s that does not support %s.",
-                         FormatHandle(cb_state.Handle()).c_str(), FormatHandle(pool->Handle()).c_str(),
+                         FormatHandle(cb_state.Handle()).c_str(), FormatHandle(pool.Handle()).c_str(),
                          string_VkPipelineBindPoint(bind_point));
     }
     return skip;

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -445,13 +445,10 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
 
 bool CoreChecks::HasRequiredQueueFlags(const vvl::CommandBuffer& cb_state, const vvl::PhysicalDevice& physical_device_state,
                                        VkQueueFlags required_flags) const {
-    auto pool = cb_state.command_pool;
-    if (pool) {
-        const uint32_t queue_family_index = pool->queueFamilyIndex;
-        const VkQueueFlags queue_flags = physical_device_state.queue_family_properties[queue_family_index].queueFlags;
-        if (!(required_flags & queue_flags)) {
-            return false;
-        }
+    const uint32_t queue_family_index = cb_state.command_pool.queueFamilyIndex;
+    const VkQueueFlags queue_flags = physical_device_state.queue_family_properties[queue_family_index].queueFlags;
+    if (!(required_flags & queue_flags)) {
+        return false;
     }
     return true;
 }
@@ -460,8 +457,7 @@ std::string CoreChecks::DescribeRequiredQueueFlag(const vvl::CommandBuffer& cb_s
                                                   const vvl::PhysicalDevice& physical_device_state,
                                                   VkQueueFlags required_flags) const {
     std::ostringstream ss;
-    auto pool = cb_state.command_pool;
-    const uint32_t queue_family_index = pool->queueFamilyIndex;
+    const uint32_t queue_family_index = cb_state.command_pool.queueFamilyIndex;
     const VkQueueFlags queue_flags = physical_device_state.queue_family_properties[queue_family_index].queueFlags;
     std::string required_flags_string;
     for (const auto& flag : AllVkQueueFlags) {
@@ -473,7 +469,7 @@ std::string CoreChecks::DescribeRequiredQueueFlag(const vvl::CommandBuffer& cb_s
         }
     }
 
-    ss << "called in " << FormatHandle(cb_state) << " which was allocated from the " << FormatHandle(pool->Handle())
+    ss << "called in " << FormatHandle(cb_state) << " which was allocated from the " << FormatHandle(cb_state.command_pool.Handle())
        << " which was created with "
           "queueFamilyIndex "
        << queue_family_index << " which contains the capability flags " << string_VkQueueFlags(queue_flags) << " (but requires "
@@ -503,7 +499,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
             if (!HasRequiredQueueFlags(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT)) {
                 const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-02338" : "VUID-vkCmdBeginQuery-queryType-02327";
-                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
+                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool.Handle());
                 skip |= LogError(vuid, objlist, loc, "%s",
                                  DescribeRequiredQueueFlag(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT).c_str());
             }
@@ -523,7 +519,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
             if (!HasRequiredQueueFlags(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT)) {
                 const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-00803" : "VUID-vkCmdBeginQuery-queryType-00803";
-                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
+                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool.Handle());
                 skip |= LogError(vuid, objlist, loc, "%s",
                                  DescribeRequiredQueueFlag(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT).c_str());
             }
@@ -560,15 +556,15 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
                                  FormatHandle(query_obj.pool).c_str(), loc.StringFunc());
             }
 
-            if (cb_state.command_pool->queueFamilyIndex != query_pool_state->perf_counter_queue_family_index) {
+            if (cb_state.command_pool.queueFamilyIndex != query_pool_state->perf_counter_queue_family_index) {
                 const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-07289" : "VUID-vkCmdBeginQuery-queryPool-07289";
-                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc.dot(Field::queryPool),
                                  "was created with VkQueryPoolPerformanceCreateInfoKHR::queueFamilyIndex (%" PRIu32
                                  ") but the command buffer is from a command pool created with "
                                  "VkCommandPoolCreateInfo::queueFamilyIndex (%" PRIu32 ").",
-                                 query_pool_state->perf_counter_queue_family_index, cb_state.command_pool->queueFamilyIndex);
+                                 query_pool_state->perf_counter_queue_family_index, cb_state.command_pool.queueFamilyIndex);
             }
             break;
         }
@@ -599,7 +595,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
             break;
         }
         case VK_QUERY_TYPE_PIPELINE_STATISTICS: {
-            if ((cb_state.command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+            if ((cb_state.command_pool.queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
                 if (query_pool_ci.pipelineStatistics &
                     (VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT |
                      VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT |
@@ -620,10 +616,10 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
                         "the command pool the command buffer %s was allocated from does not support graphics operations (%s).",
                         FormatHandle(query_obj.pool).c_str(),
                         string_VkQueryPipelineStatisticFlags(query_pool_ci.pipelineStatistics).c_str(),
-                        FormatHandle(cb_state).c_str(), string_VkQueueFlags(cb_state.command_pool->queue_flags).c_str());
+                        FormatHandle(cb_state).c_str(), string_VkQueueFlags(cb_state.command_pool.queue_flags).c_str());
                 }
             }
-            if ((cb_state.command_pool->queue_flags & VK_QUEUE_COMPUTE_BIT) == 0) {
+            if ((cb_state.command_pool.queue_flags & VK_QUEUE_COMPUTE_BIT) == 0) {
                 if (query_pool_ci.pipelineStatistics & VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT) {
                     const char* vuid =
                         is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-00805" : "VUID-vkCmdBeginQuery-queryType-00805";
@@ -635,13 +631,13 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
                         "the command pool the command buffer %s was allocated from does not support compute operations (%s).",
                         FormatHandle(query_obj.pool).c_str(),
                         string_VkQueryPipelineStatisticFlags(query_pool_ci.pipelineStatistics).c_str(),
-                        FormatHandle(cb_state).c_str(), string_VkQueueFlags(cb_state.command_pool->queue_flags).c_str());
+                        FormatHandle(cb_state).c_str(), string_VkQueueFlags(cb_state.command_pool.queue_flags).c_str());
                 }
             }
             break;
         }
         case VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT: {
-            if ((cb_state.command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+            if ((cb_state.command_pool.queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
                 const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-06689" : "VUID-vkCmdBeginQuery-queryType-06687";
                 const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
@@ -650,12 +646,12 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
                              "(%s) was created with queryType VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, but "
                              "the command pool the command buffer %s was allocated from does not support graphics operations (%s).",
                              FormatHandle(query_obj.pool).c_str(), FormatHandle(cb_state).c_str(),
-                             string_VkQueueFlags(cb_state.command_pool->queue_flags).c_str());
+                             string_VkQueueFlags(cb_state.command_pool.queue_flags).c_str());
             }
             break;
         }
         case VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR: {
-            const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state.command_pool->queueFamilyIndex];
+            const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state.command_pool.queueFamilyIndex];
             if (!qf_ext_props.query_result_status_props.queryResultStatusSupport) {
                 const char* vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07126" : "VUID-vkCmdBeginQuery-queryType-07126";
@@ -664,7 +660,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
                                  "the command pool's queue family (index %" PRIu32
                                  ") the command buffer %s was allocated "
                                  "from does not support result status queries.",
-                                 cb_state.command_pool->queueFamilyIndex, FormatHandle(cb_state).c_str());
+                                 cb_state.command_pool.queueFamilyIndex, FormatHandle(cb_state).c_str());
             }
             break;
         }
@@ -675,7 +671,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
                                  "(%s) was created with queryType %s.", FormatHandle(query_obj.pool).c_str(),
                                  string_VkQueryType(query_pool_ci.queryType));
             } else if (!HasRequiredQueueFlags(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT)) {
-                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
+                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool.Handle());
                 skip |= LogError("VUID-vkCmdBeginQuery-queryType-07070", objlist, loc, "%s",
                                  DescribeRequiredQueueFlag(cb_state, *physical_device_state, VK_QUEUE_GRAPHICS_BIT).c_str());
             }
@@ -1331,14 +1327,14 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer& cb_state, V
     const bool is_2 = loc.function == Func::vkCmdWriteTimestamp2 || loc.function == Func::vkCmdWriteTimestamp2KHR;
 
     const uint32_t timestamp_valid_bits =
-        physical_device_state->queue_family_properties[cb_state.command_pool->queueFamilyIndex].timestampValidBits;
+        physical_device_state->queue_family_properties[cb_state.command_pool.queueFamilyIndex].timestampValidBits;
     if (timestamp_valid_bits == 0) {
         const char* vuid =
             is_2 ? "VUID-vkCmdWriteTimestamp2-timestampValidBits-03863" : "VUID-vkCmdWriteTimestamp-timestampValidBits-00829";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |=
             LogError(vuid, objlist, loc, "Query Pool %s has a timestampValidBits value of zero for queueFamilyIndex %" PRIu32 ".",
-                     FormatHandle(queryPool).c_str(), cb_state.command_pool->queueFamilyIndex);
+                     FormatHandle(queryPool).c_str(), cb_state.command_pool.queueFamilyIndex);
     }
 
     const auto query_pool_state = Get<vvl::QueryPool>(queryPool);

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -548,17 +548,16 @@ bool CoreChecks::ValidImageBufferQueue(const vvl::CommandBuffer& cb_state, const
 bool CoreChecks::ValidateQueueFamilyIndices(const Location& loc, const vvl::CommandBuffer& cb_state,
                                             const vvl::Queue& queue_state) const {
     bool skip = false;
-    auto pool = cb_state.command_pool;
-    ASSERT_AND_RETURN_SKIP(pool);
+    const vvl::CommandPool& pool = cb_state.command_pool;
 
-    if (pool->queueFamilyIndex != queue_state.queue_family_index) {
+    if (pool.queueFamilyIndex != queue_state.queue_family_index) {
         const LogObjectList objlist(cb_state.Handle(), queue_state.Handle());
         const auto& vuid = GetQueueSubmitVUID(loc, vvl::SubmitError::kCmdWrongQueueFamily);
         skip |= LogError(vuid, objlist, loc,
                          "Primary command buffer %s created in queue family %" PRIu32
                          " is being submitted on %s "
                          "from queue family %" PRIu32 ".",
-                         FormatHandle(cb_state).c_str(), pool->queueFamilyIndex, FormatHandle(queue_state.Handle()).c_str(),
+                         FormatHandle(cb_state).c_str(), pool.queueFamilyIndex, FormatHandle(queue_state.Handle()).c_str(),
                          queue_state.queue_family_index);
     }
 

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -500,35 +500,35 @@ bool CoreChecks::PreCallValidateCmdBindShadersEXT(VkCommandBuffer commandBuffer,
         } else if (stage == VK_SHADER_STAGE_MESH_BIT_EXT && shader != VK_NULL_HANDLE) {
             mesh_stage_index = i;
         } else if (stage == VK_SHADER_STAGE_COMPUTE_BIT) {
-            if ((cb_state->command_pool->queue_flags & VK_QUEUE_COMPUTE_BIT) == 0) {
-                const LogObjectList objlist(commandBuffer, cb_state->command_pool->Handle());
+            if ((cb_state->command_pool.queue_flags & VK_QUEUE_COMPUTE_BIT) == 0) {
+                const LogObjectList objlist(commandBuffer, cb_state->command_pool.Handle());
                 skip |= LogError(
                     "VUID-vkCmdBindShadersEXT-pShaders-08476", objlist, stage_loc,
                     "is VK_SHADER_STAGE_COMPUTE_BIT, but %s was allocated from %s that does not support compute operations (%s).",
-                    FormatHandle(commandBuffer).c_str(), FormatHandle(cb_state->command_pool->Handle()).c_str(),
-                    string_VkQueueFlags(cb_state->command_pool->queue_flags).c_str());
+                    FormatHandle(commandBuffer).c_str(), FormatHandle(cb_state->command_pool.Handle()).c_str(),
+                    string_VkQueueFlags(cb_state->command_pool.queue_flags).c_str());
             }
         }
         if ((stage & (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
                       VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)) >
             0) {
-            if ((cb_state->command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
-                const LogObjectList objlist(commandBuffer, cb_state->command_pool->Handle());
+            if ((cb_state->command_pool.queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+                const LogObjectList objlist(commandBuffer, cb_state->command_pool.Handle());
                 skip |= LogError("VUID-vkCmdBindShadersEXT-pShaders-08477", objlist, stage_loc,
                                  "is %s, but %s was allocated from %s that does not support graphics operations (%s).",
                                  string_VkShaderStageFlagBits(stage), FormatHandle(commandBuffer).c_str(),
-                                 FormatHandle(cb_state->command_pool->Handle()).c_str(),
-                                 string_VkQueueFlags(cb_state->command_pool->queue_flags).c_str());
+                                 FormatHandle(cb_state->command_pool.Handle()).c_str(),
+                                 string_VkQueueFlags(cb_state->command_pool.queue_flags).c_str());
             }
         }
         if ((stage & (VK_SHADER_STAGE_MESH_BIT_EXT | VK_SHADER_STAGE_TASK_BIT_EXT)) > 0) {
-            if ((cb_state->command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
-                const LogObjectList objlist(commandBuffer, cb_state->command_pool->Handle());
+            if ((cb_state->command_pool.queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+                const LogObjectList objlist(commandBuffer, cb_state->command_pool.Handle());
                 skip |= LogError("VUID-vkCmdBindShadersEXT-pShaders-08478", objlist, stage_loc,
                                  "is %s, but %s was allocated from %s that does not support graphics operations (%s).",
                                  string_VkShaderStageFlagBits(stage), FormatHandle(commandBuffer).c_str(),
-                                 FormatHandle(cb_state->command_pool->Handle()).c_str(),
-                                 string_VkQueueFlags(cb_state->command_pool->queue_flags).c_str());
+                                 FormatHandle(cb_state->command_pool.Handle()).c_str(),
+                                 string_VkQueueFlags(cb_state->command_pool.queue_flags).c_str());
             }
         }
         if (stage == VK_SHADER_STAGE_ALL_GRAPHICS || stage == VK_SHADER_STAGE_ALL) {

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2052,7 +2052,7 @@ bool CoreChecks::ValidateImageBarrierAgainstImage(const vvl::CommandBuffer& cb_s
     const bool has_stencil_aspect = (barrier_aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) != 0;
 
     skip |= ValidateBarrierQueueFamilies(cb_state.Handle(), barrier_loc, image_loc, barrier, image_state.Handle(),
-                                         image_state.GetSharingMode(), cb_state.command_pool->queueFamilyIndex);
+                                         image_state.GetSharingMode(), cb_state.command_pool.queueFamilyIndex);
     const auto& vuid_aspect = GetImageBarrierVUID(barrier_loc, vvl::ImageError::kAspectMask);
     skip |= ValidateImageAspectMask(image_state.VkHandle(), image_state.GetFormat(), barrier.subresourceRange.aspectMask,
                                     image_state.disjoint, image_loc, vuid_aspect.c_str());
@@ -2590,7 +2590,7 @@ bool CoreChecks::ValidateBufferBarrier(const LogObjectList& objects, const Locat
         }
 
         skip |= ValidateBarrierQueueFamilies(objects, barrier_loc, buf_loc, mem_barrier, buffer_state->Handle(),
-                                             buffer_state->GetSharingMode(), cb_state.command_pool->queueFamilyIndex);
+                                             buffer_state->GetSharingMode(), cb_state.command_pool.queueFamilyIndex);
 
         auto buffer_size = buffer_state->GetSize();
         if (mem_barrier.offset >= buffer_size) {
@@ -2698,14 +2698,14 @@ bool CoreChecks::ValidateBarriers(const Location& outer_loc, const vvl::CommandB
     for (uint32_t i = 0; i < imageMemoryBarrierCount; ++i) {
         const Location barrier_loc = outer_loc.dot(Struct::VkImageMemoryBarrier, Field::pImageMemoryBarriers, i);
         const ImageBarrier barrier(pImageMemoryBarriers[i], src_stage_mask, dst_stage_mask);
-        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool->queueFamilyIndex);
+        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool.queueFamilyIndex);
         skip |= ValidateMemoryBarrier(objects, barrier_loc, cb_state, barrier, transfer_op);
         skip |= ValidateImageBarrier(objects, cb_state, barrier, barrier_loc, local_layout_registry);
     }
     for (uint32_t i = 0; i < bufferBarrierCount; ++i) {
         const Location barrier_loc = outer_loc.dot(Struct::VkBufferMemoryBarrier, Field::pBufferMemoryBarriers, i);
         const BufferBarrier barrier(pBufferMemoryBarriers[i], src_stage_mask, dst_stage_mask);
-        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool->queueFamilyIndex);
+        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool.queueFamilyIndex);
         skip |= ValidateMemoryBarrier(objects, barrier_loc, cb_state, barrier, transfer_op);
         skip |= ValidateBufferBarrier(objects, barrier_loc, cb_state, barrier);
     }
@@ -2728,14 +2728,14 @@ bool CoreChecks::ValidateDependencyInfo(const LogObjectList& objects, const Loca
     for (uint32_t i = 0; i < dep_info.imageMemoryBarrierCount; ++i) {
         const Location barrier_loc = dep_info_loc.dot(Struct::VkImageMemoryBarrier2, Field::pImageMemoryBarriers, i);
         const ImageBarrier barrier(dep_info.pImageMemoryBarriers[i]);
-        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool->queueFamilyIndex);
+        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool.queueFamilyIndex);
         skip |= ValidateMemoryBarrier(objects, barrier_loc, cb_state, barrier, transfer_op, dep_info.dependencyFlags);
         skip |= ValidateImageBarrier(objects, cb_state, barrier, barrier_loc, local_layout_registry);
     }
     for (uint32_t i = 0; i < dep_info.bufferMemoryBarrierCount; ++i) {
         const Location barrier_loc = dep_info_loc.dot(Struct::VkBufferMemoryBarrier2, Field::pBufferMemoryBarriers, i);
         const BufferBarrier barrier(dep_info.pBufferMemoryBarriers[i]);
-        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool->queueFamilyIndex);
+        const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool.queueFamilyIndex);
         skip |= ValidateMemoryBarrier(objects, barrier_loc, cb_state, barrier, transfer_op, dep_info.dependencyFlags);
         skip |= ValidateBufferBarrier(objects, barrier_loc, cb_state, barrier);
     }
@@ -2763,7 +2763,7 @@ bool CoreChecks::ValidateDependencyInfo(const LogObjectList& objects, const Loca
             const auto buffer_states = GetBuffersByAddress(memory_range_barrier.addressRange.address);
             for (const auto buffer_state : buffer_states) {
                 const BufferBarrier barrier(memory_range_barrier, *buffer_state);
-                const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool->queueFamilyIndex);
+                const OwnershipTransferOp transfer_op = barrier.TransferOp(cb_state.command_pool.queueFamilyIndex);
                 skip |= ValidateMemoryBarrier(objects, barrier_loc, cb_state, barrier, transfer_op, dep_info.dependencyFlags);
                 skip |= ValidateBufferBarrier(objects, barrier_loc, cb_state, barrier);
             }

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -5047,13 +5047,13 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
 
     const Location begin_info_loc = error_obj.location.dot(Field::pBeginInfo);
 
-    if (vs_state->create_info.queueFamilyIndex != cb_state->command_pool->queueFamilyIndex) {
-        const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession, cb_state->command_pool->Handle());
+    if (vs_state->create_info.queueFamilyIndex != cb_state->command_pool.queueFamilyIndex) {
+        const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession, cb_state->command_pool.Handle());
         skip |= LogError("VUID-vkCmdBeginVideoCodingKHR-commandBuffer-11760", objlist, begin_info_loc.dot(Field::videoSession),
                          "%s (queue family index %" PRIu32 ") and %s (queue family index %" PRIu32
                          ") are not created with the same queue family index.",
                          FormatHandle(pBeginInfo->videoSession).c_str(), vs_state->create_info.queueFamilyIndex,
-                         FormatHandle(cb_state->command_pool->Handle()).c_str(), cb_state->command_pool->queueFamilyIndex);
+                         FormatHandle(cb_state->command_pool.Handle()).c_str(), cb_state->command_pool.queueFamilyIndex);
     }
 
     if (vs_state->GetUnboundMemoryBindingCount() > 0) {
@@ -5771,14 +5771,14 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                     }
                 }
 
-                const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool->queueFamilyIndex];
+                const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool.queueFamilyIndex];
                 if (!qf_ext_props.query_result_status_props.queryResultStatusSupport) {
                     const LogObjectList objlist(commandBuffer, inline_query_info->queryPool);
                     skip |= LogError("VUID-vkCmdDecodeVideoKHR-queryType-08369", objlist, error_obj.location,
                                      "the command pool's queue family (index %" PRIu32
                                      ") the command "
                                      "buffer %s was allocated from does not support result status queries.",
-                                     cb_state->command_pool->queueFamilyIndex, FormatHandle(*cb_state).c_str());
+                                     cb_state->command_pool.queueFamilyIndex, FormatHandle(*cb_state).c_str());
                 }
             }
         }
@@ -6241,7 +6241,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                     }
                 }
 
-                const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool->queueFamilyIndex];
+                const auto& qf_ext_props = device_state->queue_family_ext_props[cb_state->command_pool.queueFamilyIndex];
                 if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
                     !qf_ext_props.query_result_status_props.queryResultStatusSupport) {
                     const LogObjectList objlist(commandBuffer, inline_query_info->queryPool);
@@ -6249,7 +6249,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                                      "the command pool's queue family (index %" PRIu32
                                      ") the command "
                                      "buffer %s was allocated from does not support result status queries.",
-                                     cb_state->command_pool->queueFamilyIndex, FormatHandle(*cb_state).c_str());
+                                     cb_state->command_pool.queueFamilyIndex, FormatHandle(*cb_state).c_str());
                 }
             }
         }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -127,7 +127,7 @@ CommandPool::CommandPool(DeviceState& dev, VkCommandPool handle, const VkCommand
 
 void CommandPool::Allocate(const VkCommandBufferAllocateInfo* allocate_info, const VkCommandBuffer* command_buffers) {
     for (uint32_t i = 0; i < allocate_info->commandBufferCount; i++) {
-        auto new_cb = dev_data.CreateCmdBufferState(command_buffers[i], allocate_info, this);
+        auto new_cb = dev_data.CreateCmdBufferState(command_buffers[i], allocate_info, *this);
         commandBuffers.emplace(command_buffers[i], new_cb.get());
         dev_data.Add(std::move(new_cb));
     }
@@ -176,10 +176,10 @@ const char* CommandBuffer::DescribeActiveColorAttachment() const {
 }
 
 CommandBuffer::CommandBuffer(DeviceState& dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* allocate_info,
-                             const vvl::CommandPool* pool)
+                             const vvl::CommandPool& pool)
     : RefcountedStateObject(handle, kVulkanObjectTypeCommandBuffer),
       allocate_info(*allocate_info),
-      unprotected(pool->unprotected),
+      unprotected(pool.unprotected),
       command_pool(pool),
       dev_data(dev),
       lastBound({{{*this, VK_PIPELINE_BIND_POINT_GRAPHICS},

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -177,7 +177,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     vku::safe_VkCommandBufferInheritanceInfo inheritance_info;
 
     // since command buffers can only be destroyed by their command pool, this does not need to be a shared_ptr
-    const vvl::CommandPool *command_pool;
+    const vvl::CommandPool& command_pool;
     DeviceState &dev_data;
 
     CbState state;           // Track cmd buffer update state
@@ -595,8 +595,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock); }
 
-    CommandBuffer(DeviceState &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *allocate_info,
-                  const vvl::CommandPool *cmd_pool);
+    CommandBuffer(DeviceState& dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* allocate_info,
+                  const vvl::CommandPool& cmd_pool);
 
     virtual ~CommandBuffer() { Destroy(); }
 
@@ -630,13 +630,13 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     LogObjectList GetObjectList(VkShaderStageFlagBits stage) const;
     LogObjectList GetObjectList(VkPipelineBindPoint pipeline_bind_point) const;
 
-    VkQueueFlags GetQueueFlags() const { return command_pool->queue_flags; }
+    VkQueueFlags GetQueueFlags() const { return command_pool.queue_flags; }
 
     bool IsReleaseOp(const OwnershipTransferBarrier &barrier) const {
-        return (IsOwnershipTransfer(barrier)) && (command_pool->queueFamilyIndex == barrier.srcQueueFamilyIndex);
+        return (IsOwnershipTransfer(barrier)) && (command_pool.queueFamilyIndex == barrier.srcQueueFamilyIndex);
     }
     bool IsAcquireOp(const OwnershipTransferBarrier &barrier) const {
-        return (IsOwnershipTransfer(barrier)) && (command_pool->queueFamilyIndex == barrier.dstQueueFamilyIndex);
+        return (IsOwnershipTransfer(barrier)) && (command_pool.queueFamilyIndex == barrier.dstQueueFamilyIndex);
     }
 
     void Begin(const VkCommandBufferBeginInfo *pBeginInfo);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -6707,7 +6707,7 @@ std::shared_ptr<Swapchain> DeviceState::CreateSwapchainState(const VkSwapchainCr
 
 std::shared_ptr<CommandBuffer> DeviceState::CreateCmdBufferState(VkCommandBuffer handle,
                                                                  const VkCommandBufferAllocateInfo* allocate_info,
-                                                                 const CommandPool* pool) {
+                                                                 const CommandPool& pool) {
     return std::make_shared<CommandBuffer>(*this, handle, allocate_info, pool);
 }
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1269,7 +1269,7 @@ class DeviceState : public vvl::BaseDevice {
 
     virtual std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle,
                                                                      const VkCommandBufferAllocateInfo* allocate_info,
-                                                                     const vvl::CommandPool* pool);
+                                                                     const vvl::CommandPool& pool);
     // Allocate/Free
     void PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
                                               VkCommandBuffer* pCommandBuffer, const RecordObject& record_obj) override;


### PR DESCRIPTION
found no reason why this was a pointer and not a ref, the comment even says

>     // since command buffers can only be destroyed by their command pool, this does not need to be a shared_ptr