### PR TITLE
layer: Handle Untyped pointer of struct with no array

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -44,6 +44,7 @@
 #include "state_tracker/shader_module.h"
 #include "state_tracker/shader_stage_state.h"
 #include "state_tracker/pipeline_state.h"
+#include "utils/assert_utils.h"
 #include "utils/shader_utils.h"
 #include "utils/hash_util.h"
 #include "utils/descriptor_utils.h"
@@ -3830,6 +3831,8 @@ bool CoreChecks::ValidateDescriptorHeapStructs(const spirv::Module& module_state
         return skip;
     }
 
+    const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props = phys_dev_ext_props.descriptor_heap_props;
+
     // There are to ways to set the offset with decorations
     //  - classic Offset
     //  - using new OffsetIdEXT, which is designed to be used with a spec constant
@@ -3840,57 +3843,64 @@ bool CoreChecks::ValidateDescriptorHeapStructs(const spirv::Module& module_state
         // Even if there is a struct inside member, we don't need to go into it, it will be it's own iteration inside
         // |static_data_.type_structs|
         for (uint32_t i = 0; i < type_struct->members.size(); i++) {
-            const auto& member = type_struct->members[i];
+            const spirv::TypeStructInfo::Member& member = type_struct->members[i];
+            if (!member.insn->IsDescriptorType()) {
+                continue;
+            }
 
-            const uint32_t opcode = member.insn->Opcode();
+            // If using the old, hardcoded Offset
+            uint32_t offset_value = member.decorations->offset;
+            if (offset_value == spirv::kInvalidValue) {
+                // Using OffsetIdEXT
+                const spirv::Instruction& offset_inst = *module_state.FindDef(member.decorations->offset_id);
+                offset_value = module_state.GetHeapUntypedSize(props, offset_inst);
+            }
+            ASSERT_AND_CONTINUE(offset_value != spirv::kInvalidValue);
+
+            const spv::Op opcode = (spv::Op)member.insn->Opcode();
             if (opcode == spv::OpTypeSampler) {
-                const uint32_t offset = member.decorations->GetOffset(module_state);
-                if (!IsIntegerMultipleOf(offset, phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment)) {
+                if (!IsIntegerMultipleOf(offset_value, phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment)) {
                     skip |= LogError("VUID-RuntimeSpirv-samplerDescriptorAlignment-11476", module_state.handle(), loc,
                                      "shader %s has a struct (ID %" PRIu32 ") where member %" PRIu32
                                      " is an OpTypeSampler with an offset of %" PRIu32
                                      " which is not aligned with samplerDescriptorAlignment (%" PRIu64 ")",
-                                     entrypoint.Describe().c_str(), type_struct->id, i, offset,
+                                     entrypoint.Describe().c_str(), type_struct->id, i, offset_value,
                                      phys_dev_ext_props.descriptor_heap_props.samplerDescriptorAlignment);
                 }
             } else if (opcode == spv::OpTypeImage) {
-                const uint32_t offset = member.decorations->GetOffset(module_state);
-                if (!IsIntegerMultipleOf(offset, phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment)) {
+                if (!IsIntegerMultipleOf(offset_value, phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment)) {
                     skip |= LogError("VUID-RuntimeSpirv-imageDescriptorAlignment-11477", module_state.handle(), loc,
                                      "shader %s has a struct (ID %" PRIu32 ") where member %" PRIu32
                                      " is an OpTypeImage with an offset of %" PRIu32
                                      " which is not aligned with imageDescriptorAlignment (%" PRIu64 ")",
-                                     entrypoint.Describe().c_str(), type_struct->id, i, offset,
+                                     entrypoint.Describe().c_str(), type_struct->id, i, offset_value,
                                      phys_dev_ext_props.descriptor_heap_props.imageDescriptorAlignment);
                 }
             } else if (opcode == spv::OpTypeBufferEXT) {
-                const uint32_t offset = member.decorations->GetOffset(module_state);
-                if (!IsIntegerMultipleOf(offset, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment)) {
+                if (!IsIntegerMultipleOf(offset_value, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment)) {
                     skip |= LogError("VUID-RuntimeSpirv-bufferDescriptorAlignment-11478", module_state.handle(), loc,
                                      "shader %s has a struct (ID %" PRIu32 ") where member %" PRIu32
                                      " is an OpTypeBufferEXT with an offset of %" PRIu32
                                      " which is not aligned with bufferDescriptorAlignment (%" PRIu64 ")",
-                                     entrypoint.Describe().c_str(), type_struct->id, i, offset,
+                                     entrypoint.Describe().c_str(), type_struct->id, i, offset_value,
                                      phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment);
                 }
             } else if (opcode == spv::OpTypeAccelerationStructureKHR) {
-                const uint32_t offset = member.decorations->GetOffset(module_state);
-                if (!IsIntegerMultipleOf(offset, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment)) {
+                if (!IsIntegerMultipleOf(offset_value, phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment)) {
                     skip |= LogError("VUID-RuntimeSpirv-bufferDescriptorAlignment-11479", module_state.handle(), loc,
                                      "shader %s has a struct (ID %" PRIu32 ") where member %" PRIu32
                                      " is an OpTypeAccelerationStructureKHR with an offset of %" PRIu32
                                      " which is not aligned with bufferDescriptorAlignment (%" PRIu64 ")",
-                                     entrypoint.Describe().c_str(), type_struct->id, i, offset,
+                                     entrypoint.Describe().c_str(), type_struct->id, i, offset_value,
                                      phys_dev_ext_props.descriptor_heap_props.bufferDescriptorAlignment);
                 }
             } else if (opcode == spv::OpTypeTensorARM) {
-                const uint32_t offset = member.decorations->GetOffset(module_state);
-                if (!IsIntegerMultipleOf(offset, phys_dev_ext_props.descriptor_heap_tensor_props.tensorDescriptorAlignment)) {
+                if (!IsIntegerMultipleOf(offset_value, phys_dev_ext_props.descriptor_heap_tensor_props.tensorDescriptorAlignment)) {
                     skip |= LogError("VUID-RuntimeSpirv-tensorDescriptorAlignment-11480", module_state.handle(), loc,
                                      "shader %s has a struct (ID %" PRIu32 ") where member %" PRIu32
                                      " is an OpTypeTensorARM with an offset of %" PRIu32
                                      " which is not aligned with tensorDescriptorAlignment (%" PRIu64 ")",
-                                     entrypoint.Describe().c_str(), type_struct->id, i, offset,
+                                     entrypoint.Describe().c_str(), type_struct->id, i, offset_value,
                                      phys_dev_ext_props.descriptor_heap_tensor_props.tensorDescriptorAlignment);
                 }
             }

--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -1418,68 +1418,8 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
     return found_warning;
 }
 
-// if we hit this, its because of OpConstantSizeOfEXT can't be folded (https://godbolt.org/z/3z6Pao4sf)
-// TODO - We will need some sort of internal constant folding here... fun!
-// ... for now lets make assumption only thing people will use here is IMul/IAdd/Isub and just do some folding
-static uint32_t GetConstantFoldValue(const spirv::Module& module, const spirv::Instruction& spec_constant_op,
-                                     VkDeviceSize descriptor_size) {
-    const uint32_t spec_op = spec_constant_op.Word(3);
-    if (spec_op != spv::OpIMul && spec_op != spv::OpIAdd && spec_op != spv::OpISub) {
-        assert(false);  // hit another case
-        return 0;
-    }
-
-    const spirv::Instruction& operand_0_inst = *module.FindDef(spec_constant_op.Word(4));
-    const spirv::Instruction& operand_1_inst = *module.FindDef(spec_constant_op.Word(5));
-
-    uint32_t operand_0 = 0;
-    if (operand_0_inst.Opcode() == spv::OpConstantSizeOfEXT) {
-        operand_0 = (uint32_t)descriptor_size;
-    } else if (operand_0_inst.Opcode() == spv::OpSpecConstantOp) {
-        operand_0 = GetConstantFoldValue(module, operand_0_inst, descriptor_size);
-    } else {
-        operand_0 = operand_0_inst.GetConstantValue();
-    }
-
-    uint32_t operand_1 = 0;
-    if (operand_1_inst.Opcode() == spv::OpConstantSizeOfEXT) {
-        operand_1 = (uint32_t)descriptor_size;
-    } else if (operand_1_inst.Opcode() == spv::OpSpecConstantOp) {
-        operand_1 = GetConstantFoldValue(module, operand_1_inst, descriptor_size);
-    } else {
-        operand_1 = operand_1_inst.GetConstantValue();
-    }
-
-    if (spec_op == spv::OpIMul) {
-        return operand_0 * operand_1;
-    } else if (spec_op == spv::OpIAdd) {
-        return operand_0 + operand_1;
-    } else if (spec_op == spv::OpISub) {
-        return operand_0 - operand_1;
-    }
-    assert(false);
-    return 0;
-}
-
-static uint32_t GetUntypedSize(const spirv::Module& module, const spirv::Instruction& size_inst, VkDeviceSize descriptor_size) {
-    if (size_inst.Opcode() == spv::OpConstantSizeOfEXT) {
-        const spirv::Instruction* constant_type_inst = module.FindDef(size_inst.Word(3));
-        if (!IsValueIn((spv::Op)constant_type_inst->Opcode(), {spv::OpTypeBufferEXT, spv::OpTypeImage, spv::OpTypeSampler})) {
-            assert(false);  // assumptions
-            return 0;
-        }
-        return (uint32_t)descriptor_size;
-    } else if (size_inst.Opcode() == spv::OpConstant) {
-        return size_inst.GetConstantValue();
-    } else if (size_inst.Opcode() == spv::OpSpecConstantOp) {
-        return GetConstantFoldValue(module, size_inst, descriptor_size);
-    }
-    assert(false);  // assumptions
-    return 0;
-}
-
-static uint32_t GetUntypedHeapOffset(const spirv::Module& module, const spirv::Instruction& access_chain,
-                                     const spirv::Instruction& base_type_inst, VkDeviceSize descriptor_size) {
+static uint32_t GetUntypedHeapOffset(const spirv::Module& module, const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
+                                     const spirv::Instruction& access_chain, const spirv::Instruction& base_type_inst) {
     if (base_type_inst.Opcode() != spv::OpTypeStruct) {
         return 0;
     }
@@ -1487,27 +1427,35 @@ static uint32_t GetUntypedHeapOffset(const spirv::Module& module, const spirv::I
     const uint32_t struct_id = base_type_inst.ResultId();
     for (const auto& type_struct : module.static_data_.type_structs) {
         if (type_struct->id == struct_id) {
-            uint32_t struct_member = module.FindDef(access_chain.Word(5))->GetConstantValue();
+            uint32_t struct_member = 0;
+            // If doesn't have an index, it's implicitly the zero index
+            if (access_chain.Length() > 5) {
+                struct_member = module.FindDef(access_chain.Word(5))->GetConstantValue();
+            }
             const auto& member = type_struct->members[struct_member];
             if (member.decorations->offset != vvl::kNoIndex32) {
                 return member.decorations->offset;
             }
             const spirv::Instruction* offset_id_inst = module.FindDef(member.decorations->offset_id);
-            return GetUntypedSize(module, *offset_id_inst, descriptor_size);
+            return module.GetHeapUntypedSize(props, *offset_id_inst);
         }
     }
     assert(false);
     return 0;
 }
 
-static uint32_t GetUntypedArrayStride(const spirv::Module& module, const spirv::Instruction& access_chain,
-                                      const spirv::Instruction& base_type_inst, VkDeviceSize descriptor_size) {
+static uint32_t GetUntypedArrayStride(const spirv::Module& module, const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
+                                      const spirv::Instruction& access_chain, const spirv::Instruction& base_type_inst) {
     uint32_t type_array_id = vvl::kNoIndex32;
     if (base_type_inst.Opcode() == spv::OpTypeBufferEXT) {
         return 0;  // single element
     } else if (base_type_inst.Opcode() == spv::OpTypeStruct) {
         // required to be a constant into the struct
-        uint32_t struct_member = module.FindDef(access_chain.Word(5))->GetConstantValue();
+        uint32_t struct_member = 0;
+        // If doesn't have an index, it's implicitly the zero index
+        if (access_chain.Length() > 5) {
+            struct_member = module.FindDef(access_chain.Word(5))->GetConstantValue();
+        }
         type_array_id = base_type_inst.Word(2 + struct_member);
     } else if (base_type_inst.IsArray()) {
         type_array_id = base_type_inst.ResultId();
@@ -1518,7 +1466,7 @@ static uint32_t GetUntypedArrayStride(const spirv::Module& module, const spirv::
     }
 
     const spirv::Instruction* array_stride_inst = module.FindDef(decoration_set.array_stride_id);
-    return GetUntypedSize(module, *array_stride_inst, descriptor_size);
+    return module.GetHeapUntypedSize(props, *array_stride_inst);
 }
 
 static uint32_t GetUntypedDescriptorIndex(const spirv::Module& module, const spirv::Instruction& access_chain,
@@ -1563,6 +1511,8 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
     const spirv::Module& module, const spirv::EntryPoint& entrypoint) const {
     vvl::unordered_map<uint32_t, HeapAccesses> accesses;
 
+    const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props = dev_data.phys_dev_ext_props.descriptor_heap_props;
+
     auto add_access = [&](const VkDescriptorType descriptor_type, const spirv::Instruction& ac_inst) {
         if (ac_inst.Opcode() != spv::OpUntypedAccessChainKHR) {
             // will happen when mixing typed (set/binding) and untyped
@@ -1570,8 +1520,6 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
             return;
         }
 
-        const VkDeviceSize descriptor_size =
-            GetUntypedDescriptorSize(dev_data.phys_dev_ext_props.descriptor_heap_props, descriptor_type);
         const spirv::Instruction* base_type_inst = module.FindDef(ac_inst.Word(3));
         if (base_type_inst->Opcode() != spv::OpTypeBufferEXT && base_type_inst->Opcode() != spv::OpTypeStruct &&
             !base_type_inst->IsArray()) {
@@ -1579,9 +1527,9 @@ vvl::unordered_map<uint32_t, HeapAccesses> CommandBufferSubState::DumpDescriptor
             return;
         }
 
-        const uint32_t heap_offset = GetUntypedHeapOffset(module, ac_inst, *base_type_inst, descriptor_size);
+        const uint32_t heap_offset = GetUntypedHeapOffset(module, props, ac_inst, *base_type_inst);
 
-        const uint32_t array_stride_value = GetUntypedArrayStride(module, ac_inst, *base_type_inst, descriptor_size);
+        const uint32_t array_stride_value = GetUntypedArrayStride(module, props, ac_inst, *base_type_inst);
 
         const uint32_t descriptor_index = GetUntypedDescriptorIndex(module, ac_inst, *base_type_inst);
 
@@ -1770,8 +1718,7 @@ bool CommandBufferSubState::DumpDescriptorHeapUntyped(std::ostringstream& ss, co
                 ss << " (dynamic index)\n";
             }
 
-            const VkDeviceSize descriptor_size =
-                GetUntypedDescriptorSize(dev_data.phys_dev_ext_props.descriptor_heap_props, access.descriptor_type);
+            const VkDeviceSize descriptor_size = dev_data.device_state->cached_descriptor_size.GetSize(access.descriptor_type);
             ss << "      - descriptor size: " << std::dec << descriptor_size << " ("
                << string_VkDescriptorType(access.descriptor_type) << ")\n";
 

--- a/layers/gpuav/spirv/descriptor_heap_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_heap_pass.cpp
@@ -183,8 +183,7 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
         const bool is_untyped = mapping_index_encoded == glsl::kInst_DescriptorHeap_MappingIndexUntyped;
         mapping = is_untyped ? nullptr : &module_.out_status.device.heap_mappings[mapping_index_encoded].mapping_data;
 
-        const uint32_t desc_size_value = (uint32_t)(is_untyped ? GetUntypedDescriptorSize(descriptor_heap_props, vk_desc_type)
-                                                               : module_.settings_.cached_descriptor_size->GetSize(vk_desc_type));
+        const uint32_t desc_size_value = (uint32_t)module_.settings_.cached_descriptor_size->GetSize(vk_desc_type);
 
         const uint32_t desc_encoding = (desc_type_mask << glsl::kInst_DescriptorHeap_DescriptorTypeShift) |
                                        (desc_size_value << glsl::kInst_DescriptorHeap_DescriptorSizeShift) |
@@ -244,16 +243,17 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
 
             descriptor_array =
                 type_manager_.FindTypeById(meta.access_path.pointer_type->inst_.Operand(meta.access_path.heap_offset_member_index));
-            assert(descriptor_array->IsArray());
         } else {
-            assert(meta.access_path.pointer_type->IsArray());
             descriptor_array = meta.access_path.pointer_type;
             heap_offset_id = type_manager_.GetConstantZeroUint32().Id();
         }
 
-        const uint32_t array_stride_dec = GetDecoration(descriptor_array->Id(), spv::DecorationArrayStrideIdEXT)->Word(3);
-        const Constant* array_stride = type_manager_.FindConstantById(array_stride_dec);
-        const uint32_t array_stride_id = CastToUint32(array_stride->Id(), block, inst_it);  // might be int32
+        uint32_t array_stride_id = type_manager_.GetConstantZeroUint32().Id();
+        if (descriptor_array->IsArray()) {
+            const uint32_t array_stride_dec = GetDecoration(descriptor_array->Id(), spv::DecorationArrayStrideIdEXT)->Word(3);
+            const Constant* array_stride = type_manager_.FindConstantById(array_stride_dec);
+            array_stride_id = CastToUint32(array_stride->Id(), block, inst_it);  // might be int32
+        }
 
         const uint32_t function_def = GetLinkFunctionId(UNTYPED);
 

--- a/layers/gpuav/spirv/module.h
+++ b/layers/gpuav/spirv/module.h
@@ -138,6 +138,7 @@ class Module {
     bool ConstantFoldVectorShuffle(Instruction* inst, const Type& type);
     bool ConstantFoldCompositeExtract(Instruction* inst, const Type& type);
     bool ConstantFoldCompositeInsert(Instruction* inst, const Type& type);
+    uint32_t ResolveConstantSizeOf(const Instruction& inst);
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/spec_constant.cpp
+++ b/layers/gpuav/spirv/spec_constant.cpp
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include "chassis/dispatch_object.h"
 #include "containers/limits.h"
 #include "containers/small_vector.h"
 #include "generated/spirv_grammar_helper.h"
@@ -355,6 +356,23 @@ bool Module::ConstantFoldCompositeInsert(Instruction* inst, const Type& result_t
     return true;
 }
 
+uint32_t Module::ResolveConstantSizeOf(const Instruction& inst) {
+    assert(inst.Opcode() == spv::OpConstantSizeOfEXT);
+    const Type* descriptor_type = type_manager_.FindTypeById(inst.Word(3));
+    assert(descriptor_type);
+
+    if (descriptor_type->spv_type_ == SpvType::kSampler) {
+        return (uint32_t)settings_.phys_dev_ext_props->descriptor_heap_props.samplerDescriptorSize;
+    } else if (descriptor_type->spv_type_ == SpvType::kBufferEXT ||
+               descriptor_type->spv_type_ == SpvType::kAccelerationStructureKHR) {
+        return (uint32_t)settings_.phys_dev_ext_props->descriptor_heap_props.bufferDescriptorSize;
+    } else if (descriptor_type->spv_type_ == SpvType::kImage) {
+        return (uint32_t)settings_.phys_dev_ext_props->descriptor_heap_props.imageDescriptorSize;
+    }
+    assert(false);
+    return 0;
+}
+
 bool Module::ConstantFold(Instruction* inst, const Type& result_type) {
     assert(inst->Opcode() == spv::OpSpecConstantOp);
     if (result_type.spv_type_ == SpvType::kStruct) {
@@ -405,6 +423,8 @@ bool Module::ConstantFold(Instruction* inst, const Type& result_type) {
 
             if (lane_constant->inst_.Opcode() == spv::OpConstantNull) {
                 args.emplace_back(0ul);
+            } else if (lane_constant->inst_.Opcode() == spv::OpConstantSizeOfEXT) {
+                args.emplace_back(ResolveConstantSizeOf(lane_constant->inst_));
             } else if (lane_constant->type_.spv_type_ == SpvType::kBool) {
                 if (lane_constant->inst_.Opcode() == spv::OpConstantTrue) {
                     args.emplace_back(1ul);

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -936,12 +936,18 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
 
         // Hack for Offset in Heaps until get better understanding
         if (path.variable->interface_.IsHeap() && path.pointer_type->spv_type_ == SpvType::kStruct) {
-            assert(next_access_chain->IsUntypedAccessChain() && next_access_chain->Length() == 7);
+            assert(next_access_chain->IsUntypedAccessChain());
             // https://godbolt.org/z/hWz84zdTW - this is required to be a constant
-            const Constant* struct_member_index_constant = FindConstantById(next_access_chain->Operand(2));
-            assert(struct_member_index_constant);
-            path.heap_offset_member_index = struct_member_index_constant->GetValueUint32();
-            path.descriptor_index_id = next_access_chain->Operand(3);
+
+            // If doesn't have an index, it's implicitly the zero index
+            if (next_access_chain->Length() > 5) {
+                const Constant* struct_member_index_constant = FindConstantById(next_access_chain->Word(5));
+                assert(struct_member_index_constant);
+                path.heap_offset_member_index = struct_member_index_constant->GetValueUint32();
+            }
+            if (next_access_chain->Length() > 6) {
+                path.descriptor_index_id = next_access_chain->Word(6);
+            }
         }
     }
 

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -226,6 +226,13 @@ bool Instruction::IsMemoryAccess() const {
            opcode == spv::OpCooperativeMatrixStoreKHR || AtomicOperation(opcode) || (OpcodeImageAccessPosition(opcode) != 0);
 }
 
+// As defined in https://github.khronos.org/SPIRV-Registry/extensions/EXT/SPV_EXT_descriptor_heap.html
+bool Instruction::IsDescriptorType() const {
+    const uint32_t opcode = Opcode();
+    return opcode == spv::OpTypeSampler || opcode == spv::OpTypeImage || opcode == spv::OpTypeBufferEXT ||
+           opcode == spv::OpTypeAccelerationStructureKHR || opcode == spv::OpTypeTensorARM;
+}
+
 VkDescriptorType Instruction::GetImageType() const {
     assert(Opcode() == spv::OpTypeImage);
     const bool is_sampled_without_sampler = Word(7) == 2;

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -82,6 +82,7 @@ class Instruction {
     bool IsAccessChain() const;
     bool IsUntypedAccessChain() const;
     bool IsMemoryAccess() const;
+    bool IsDescriptorType() const;
     // Helpers for OpTypeImage
     VkDescriptorType GetImageType() const;
     bool IsTensor() const;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -106,16 +106,6 @@ void DecorationBase::AddId(uint32_t decoration, uint32_t id) {
     }
 }
 
-uint32_t DecorationBase::GetOffset(const Module& module_state) const {
-    // Only at most one can offset can be set
-    if (offset != kInvalidValue) {
-        return offset;
-    }
-    // If offset is a spec constant, should be resolved by now
-    // Spec ensures us OffsetIdEXT will be an unsigned 32-bit int
-    return module_state.GetConstantValueById(offset_id);
-}
-
 // Some decorations are only avaiable for variables, so can't be in OpMemberDecorate
 void DecorationSet::Add(uint32_t decoration, uint32_t value) {
     switch (decoration) {
@@ -1698,6 +1688,83 @@ uint32_t Module::CalculateWorkgroupSharedMemory() const {
     return total_size;
 }
 
+// See https://gitlab.khronos.org/vulkan/vulkan/-/issues/4858
+// When we hit a OpConstantSizeOfEXT, we get the <Type ID> and use this function to map it to the correct prop
+uint32_t Module::ResolveConstantSizeOf(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
+                                       const spirv::Instruction& inst) const {
+    assert(inst.Opcode() == spv::OpConstantSizeOfEXT);
+    const spirv::Instruction* type_inst = FindDef(inst.Word(3));
+    const spv::Op opcode = (spv::Op)type_inst->Opcode();
+
+    if (opcode == spv::OpTypeSampler) {
+        return (uint32_t)props.samplerDescriptorSize;
+    } else if (opcode == spv::OpTypeBufferEXT || opcode == spv::OpTypeAccelerationStructureKHR) {
+        return (uint32_t)props.bufferDescriptorSize;
+    } else if (opcode == spv::OpTypeImage) {
+        return (uint32_t)props.imageDescriptorSize;
+    }
+    assert(false);
+    return 0;
+}
+
+// if we hit this, its because of OpConstantSizeOfEXT can't be folded (https://godbolt.org/z/3z6Pao4sf)
+// TODO - We will need some sort of internal constant folding here... fun!
+// ... for now lets make assumption only thing people will use here is IMul/IAdd/Isub and just do some folding
+uint32_t Module::ResolveConstantFoldHeaps(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
+                                          const spirv::Instruction& spec_constant_op) const {
+    assert(spec_constant_op.Opcode() == spv::OpSpecConstantOp);
+    const uint32_t spec_op = spec_constant_op.Word(3);
+    if (spec_op != spv::OpIMul && spec_op != spv::OpIAdd && spec_op != spv::OpISub) {
+        assert(false);  // hit another case
+        return 0;
+    }
+
+    const spirv::Instruction& operand_0_inst = *FindDef(spec_constant_op.Word(4));
+    const spirv::Instruction& operand_1_inst = *FindDef(spec_constant_op.Word(5));
+
+    uint32_t operand_0 = 0;
+    if (operand_0_inst.Opcode() == spv::OpConstantSizeOfEXT) {
+        operand_0 = ResolveConstantSizeOf(props, operand_0_inst);
+    } else if (operand_0_inst.Opcode() == spv::OpSpecConstantOp) {
+        operand_0 = ResolveConstantFoldHeaps(props, operand_0_inst);
+    } else {
+        operand_0 = operand_0_inst.GetConstantValue();
+    }
+
+    uint32_t operand_1 = 0;
+    if (operand_1_inst.Opcode() == spv::OpConstantSizeOfEXT) {
+        operand_1 = ResolveConstantSizeOf(props, operand_1_inst);
+    } else if (operand_1_inst.Opcode() == spv::OpSpecConstantOp) {
+        operand_1 = ResolveConstantFoldHeaps(props, operand_1_inst);
+    } else {
+        operand_1 = operand_1_inst.GetConstantValue();
+    }
+
+    if (spec_op == spv::OpIMul) {
+        return operand_0 * operand_1;
+    } else if (spec_op == spv::OpIAdd) {
+        return operand_0 + operand_1;
+    } else if (spec_op == spv::OpISub) {
+        return operand_0 - operand_1;
+    }
+    assert(false);
+    return 0;
+}
+
+uint32_t Module::GetHeapUntypedSize(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
+                                    const spirv::Instruction& inst) const {
+    const spv::Op opcode = (spv::Op)inst.Opcode();
+    if (opcode == spv::OpConstantSizeOfEXT) {
+        return ResolveConstantSizeOf(props, inst);
+    } else if (opcode == spv::OpConstant) {
+        return inst.GetConstantValue();
+    } else if (opcode == spv::OpSpecConstantOp) {
+        return ResolveConstantFoldHeaps(props, inst);
+    }
+    assert(false);  // assumptions
+    return 0;
+}
+
 // If the instruction at |id| is a OpConstant or copy of a constant, returns the instruction
 // Cases such as runtime arrays, will not find a constant and return NULL
 // Might return a OpSpecConstant
@@ -2748,8 +2815,7 @@ TypeStructInfo::TypeStructInfo(const Module& module_state, const Instruction& st
         const spv::Op member_opcode = (spv::Op)member.insn->Opcode();
         if (member_opcode == spv::OpTypeRuntimeArray) {
             has_runtime_array = true;
-        } else if (IsValueIn(member_opcode, {spv::OpTypeSampler, spv::OpTypeImage, spv::OpTypeBufferEXT,
-                                             spv::OpTypeAccelerationStructureKHR, spv::OpTypeTensorARM})) {
+        } else if (member.insn->IsDescriptorType()) {
             has_descriptor_type = true;
         }
     }
@@ -2781,7 +2847,12 @@ TypeStructSize TypeStructInfo::GetSize(const Module& module_state) const {
     for (uint32_t i = 0; i < members.size(); i++) {
         const auto& member = members[i];
         // all struct elements are required to have offset decorations in Block
-        const uint32_t member_offset = member.decorations->GetOffset(module_state);
+        const uint32_t member_offset = member.decorations->offset;
+        if (member_offset == spirv::kInvalidValue) {
+            // This will occur if using OffsetIdEXT... currently no reason we should need a size for these case.
+            // If we find a case, see GetHeapUntypedSize()
+            continue;
+        }
         offset = std::min(offset, member_offset);
         if (member_offset > highest_element_offset) {
             highest_element_index = i;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -21,6 +21,7 @@
 
 #include <vulkan/vulkan_core.h>
 #include <cassert>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -90,8 +91,6 @@ struct DecorationBase {
     uint32_t offset = kInvalidValue;
     uint32_t offset_id = kInvalidValue;  // OffsetIdEXT
     uint32_t array_stride_id = kInvalidValue;  // ArrayStrideIdEXT
-    uint32_t GetOffset(const Module& module_state) const;
-    uint32_t GetArrayStride(const Module& module_state) const;
 
     // A given object can only have a single BuiltIn OpDecoration
     spv::BuiltIn built_in = kInvalidBuiltIn;
@@ -826,6 +825,11 @@ struct Module {
     LocalSize FindLocalSize(const EntryPoint &entrypoint) const;
 
     uint32_t CalculateWorkgroupSharedMemory() const;
+
+    uint32_t ResolveConstantSizeOf(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props, const spirv::Instruction& inst) const;
+    uint32_t ResolveConstantFoldHeaps(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
+                                      const spirv::Instruction& spec_constant_op) const;
+    uint32_t GetHeapUntypedSize(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props, const spirv::Instruction& inst) const;
 
     const Instruction *GetAnyConstantDef(uint32_t id) const;
     uint32_t GetConstantValueById(uint32_t id) const;

--- a/layers/utils/descriptor_utils.cpp
+++ b/layers/utils/descriptor_utils.cpp
@@ -255,37 +255,6 @@ std::string DescribeResourceTypeMismatch(VkSpirvResourceTypeFlagsEXT resource_ty
     return "[UNKNOWN]";
 }
 
-// See https://gitlab.khronos.org/vulkan/vulkan/-/issues/4858
-// For the mapping API, we use vkGetPhysicalDeviceDescriptorSizeEXT to determine the size
-// For SPV_EXT_descriptor_heap, the property values are used
-VkDeviceSize GetUntypedDescriptorSize(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props, VkDescriptorType type) {
-    switch (type) {
-        case VK_DESCRIPTOR_TYPE_SAMPLER:
-            return props.samplerDescriptorSize;
-        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
-        case VK_DESCRIPTOR_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_NV:
-            return props.bufferDescriptorSize;
-        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:  // not valid, but handle in case
-            return props.imageDescriptorSize;
-        case VK_DESCRIPTOR_TYPE_TENSOR_ARM:
-        case VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM:
-        case VK_DESCRIPTOR_TYPE_BLOCK_MATCH_IMAGE_QCOM:
-            return 0;  // TODO - vendors handle their own types
-        default:
-            assert(false);
-            break;
-    }
-    return 0;
-}
-
 VkDeviceSize GetDescriptorHeapAlignment(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props, VkDescriptorType type) {
     switch (type) {
         case VK_DESCRIPTOR_TYPE_SAMPLER:

--- a/layers/utils/descriptor_utils.h
+++ b/layers/utils/descriptor_utils.h
@@ -73,7 +73,6 @@ bool ResourceTypeMatchesBinding(VkSpirvResourceTypeFlagsEXT resource_type,
 std::string DescribeResourceTypeMismatch(VkSpirvResourceTypeFlagsEXT resource_type,
                                          const spirv::ResourceInterfaceVariable& resource_variable);
 
-VkDeviceSize GetUntypedDescriptorSize(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props, VkDescriptorType type);
 VkDeviceSize GetDescriptorHeapAlignment(const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props, VkDescriptorType type);
 vvl::Field GetDescriptorHeapAlignmentField(VkDescriptorType type);
 

--- a/tests/unit/descriptor_heap_untyped.cpp
+++ b/tests/unit/descriptor_heap_untyped.cpp
@@ -371,6 +371,73 @@ TEST_F(NegativeDescriptorHeapUntyped, OffsetIdNotAlignedBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeDescriptorHeapUntyped, OffsetIdNotAlignedMixedType) {
+    RETURN_IF_SKIP(InitUntypedDescriptorHeap());
+
+    bool is_aligned = (heap_props.samplerDescriptorSize & (heap_props.imageDescriptorAlignment - 1)) == 0;
+    if (is_aligned) {
+        GTEST_SKIP() << "properties aren't different to trigger error";
+    }
+
+    // struct heap {
+    //     (offset = samplerDescriptorSize) image;
+    //     (offset = samplerDescriptorSize) sampler;
+    // };
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap %sampler_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorate %sampler_heap BuiltIn SamplerHeapEXT
+               OpMemberDecorateIdEXT %heap_struct 0 OffsetIdEXT %sampler_size
+               OpMemberDecorateIdEXT %heap_struct 1 OffsetIdEXT %sampler_size
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+%_ptr_Uniform = OpTypeUntypedPointerKHR Uniform
+%sampler_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+  %float_0_5 = OpConstant %float 0.5
+    %float_0 = OpConstant %float 0
+    %v2float = OpTypeVector %float 2
+         %30 = OpConstantComposite %v2float %float_0_5 %float_0_5
+ %type_image = OpTypeImage %float 2D 0 0 0 1 Unknown
+%type_sampler = OpTypeSampler
+         %26 = OpTypeSampledImage %type_image
+
+%sampler_size = OpConstantSizeOfEXT %int %type_sampler
+%image_size = OpConstantSizeOfEXT %int %type_image
+%heap_struct = OpTypeStruct %type_image %type_sampler
+
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+       %data = OpVariable %_ptr_Function_v4float Function
+         %16 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_struct %resource_heap %int_0
+         %19 = OpLoad %type_image %16
+         %22 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_struct %sampler_heap %int_1
+         %25 = OpLoad %type_sampler %22
+         %27 = OpSampledImage %26 %19 %25
+         %32 = OpImageSampleExplicitLod %v4float %27 %30 Lod %float_0
+               OpStore %data %32
+               OpReturn
+               OpFunctionEnd
+    )";
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-imageDescriptorAlignment-11477");
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, nullptr, SPV_SOURCE_ASM);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeDescriptorHeapUntyped, OffsetIdNotAlignedImageAndSampler) {
     RETURN_IF_SKIP(InitUntypedDescriptorHeap());
 

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -1863,6 +1863,99 @@ TEST_F(NegativeGpuAVDescriptorHeap, ResourceOOBUntypedPointersOffsetId) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeGpuAVDescriptorHeap, UntypedPointersOffsetIdNonArray) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    if ((heap_props.minResourceHeapReservedRange / heap_props.imageDescriptorSize) >= 10000) {
+        GTEST_SKIP() << "reserved range is too large, access will not be OOB";
+    }
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    CreateResourceHeap(resource_stride * 3);
+
+    vkt::Buffer buffer_0(*m_device, 64, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    vkt::Buffer buffer_1(*m_device, 64, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    WriteBufferToHeap(buffer_0, 2);
+    WriteBufferToHeap(buffer_1, 1);
+
+    // layout(storage_buffer) SSBO {
+    //     uint data;
+    // };
+    // heap {
+    //     layout(offset = buffer_size * 2) SSBO buffer_0;
+    //     layout(offset = buffer_size * 10000) SSBO buffer_1;
+    // } heap_layout;
+    //
+    // heap_layout.buffer_0.data = 42;
+    // heap_layout.buffer_1.data = 43;
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %heap_layout Block
+               OpMemberDecorateIdEXT %heap_layout 0 OffsetIdEXT %buf_size2
+               OpMemberDecorateIdEXT %heap_layout 1 OffsetIdEXT %bad_offset
+       %void = OpTypeVoid
+    %void_fn = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+       %uint = OpTypeInt 32 0
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+      %int_2 = OpConstant %int 2
+    %uint_42 = OpConstant %uint 42
+    %uint_43 = OpConstant %uint 43
+    %int_10k = OpConstant %int 10000
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+        %SSBO = OpTypeStruct %uint
+%_ptr_StorageBuffer = OpTypeUntypedPointerKHR StorageBuffer
+
+%type_buffer = OpTypeBufferEXT StorageBuffer
+   %buf_size = OpConstantSizeOfEXT %int %type_buffer
+  %buf_size2 = OpSpecConstantOp %int IMul %buf_size %int_2
+ %buf_size_again = OpSpecConstantOp %int ISub %buf_size2 %buf_size
+ %bad_offset = OpSpecConstantOp %int IMul %buf_size_again %int_10k
+
+ %heap_layout = OpTypeStruct %type_buffer %type_buffer
+
+       %main = OpFunction %void None %void_fn
+          %5 = OpLabel
+
+%heap_index_0 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_layout %resource_heap
+  %buf_ptr_0 = OpBufferPointerEXT %_ptr_StorageBuffer %heap_index_0
+   %member_0 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %SSBO %buf_ptr_0 %int_0
+               OpStore %member_0 %uint_42
+
+%heap_index_1 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_layout %resource_heap %int_1
+  %buf_ptr_1 = OpBufferPointerEXT %_ptr_StorageBuffer %heap_index_1
+   %member_1 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %SSBO %buf_ptr_1 %int_0
+               OpStore %member_1 %uint_43
+
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    BindResourceHeap();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11309");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeGpuAVDescriptorHeap, BufferDescriptorAlignmentMapping) {
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;

--- a/tests/unit/gpu_av_descriptor_heap_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_heap_positive.cpp
@@ -1215,6 +1215,91 @@ TEST_F(PositiveGpuAVDescriptorHeap, GraphicsPipelineLibraryWithShaderModule) {
     ASSERT_TRUE(exe_pipe.initialized());
 }
 
+TEST_F(PositiveGpuAVDescriptorHeap, UntypedPointersOffsetIdNonArray) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    CreateResourceHeap(resource_stride * 3);
+
+    vkt::Buffer buffer_0(*m_device, 64, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    vkt::Buffer buffer_1(*m_device, 64, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    WriteBufferToHeap(buffer_0, 2);
+    WriteBufferToHeap(buffer_1, 1);
+
+    // layout(storage_buffer) SSBO {
+    //     uint data;
+    // };
+    // heap {
+    //     layout(offset = buffer_size * 2) SSBO buffer_0;
+    //     layout(offset = buffer_size) SSBO buffer_1;
+    // } heap_layout;
+    //
+    // heap_layout.buffer_0.data = 42;
+    // heap_layout.buffer_1.data = 43;
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %heap_layout Block
+               OpMemberDecorateIdEXT %heap_layout 0 OffsetIdEXT %buf_size2
+               OpMemberDecorateIdEXT %heap_layout 1 OffsetIdEXT %buf_size
+       %void = OpTypeVoid
+    %void_fn = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+       %uint = OpTypeInt 32 0
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+      %int_2 = OpConstant %int 2
+    %uint_42 = OpConstant %uint 42
+    %uint_43 = OpConstant %uint 43
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+        %SSBO = OpTypeStruct %uint
+%_ptr_StorageBuffer = OpTypeUntypedPointerKHR StorageBuffer
+
+%type_buffer = OpTypeBufferEXT StorageBuffer
+   %buf_size = OpConstantSizeOfEXT %int %type_buffer
+  %buf_size2 = OpSpecConstantOp %int IMul %buf_size %int_2
+
+ %heap_layout = OpTypeStruct %type_buffer %type_buffer
+
+       %main = OpFunction %void None %void_fn
+          %5 = OpLabel
+
+%heap_index_0 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_layout %resource_heap
+  %buf_ptr_0 = OpBufferPointerEXT %_ptr_StorageBuffer %heap_index_0
+   %member_0 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %SSBO %buf_ptr_0 %int_0
+               OpStore %member_0 %uint_42
+
+%heap_index_1 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_layout %resource_heap %int_1
+  %buf_ptr_1 = OpBufferPointerEXT %_ptr_StorageBuffer %heap_index_1
+   %member_1 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %SSBO %buf_ptr_1 %int_0
+               OpStore %member_1 %uint_43
+
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    BindResourceHeap();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
 // TODO - Handle Secondary command buffers correctly
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_SecondaryInheritance) {
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());


### PR DESCRIPTION
Was crashing `dEQP-VK.binding_model.descriptor_heap.spirv.simple_sampler_heap`, lead me to learning if you have a shader that looks like


```glsl
layout(descriptor_heap) heap {
    layout(offset = bufferDescriptorSize) buffer;
    layout(offset = samplerDescriptorSize) sampler;
}
```

we were not handling it anywhere at all due to early assumptions made... this adds some tests and cleans it up in Layers, GPU Dump, and GPU-AV

#TMB
