### PR TITLE
layers: Dont use concurrent_unordered_map for AHB formats

### DIFF
--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2021-2025 LunarG, Inc. -->
+<!-- Copyright 2021-2026 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -275,7 +275,6 @@ Since VkDevice’s state is a ValidationStateTracker, we don’t have a real C++
 
 State tracker Per-Device state that is changed:
 
-* ahb_ext_formats_map - map of android external format to VkFormatFeatureFlags. Thread safe because it uses `vvl::concurrent_unordered_map`.
 * custom_border_color_sampler_count - simple counter
 * performance_lock_acquired - boolean flag
 * fake_memory - fake address generator for synchronization validation, basically a uint64_t counter of the next free address

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -576,6 +576,7 @@ bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo& create_info
                              "(%" PRIu64 ") is non-zero, but layout is %s.", ext_fmt_android->externalFormat,
                              string_VkImageTiling(create_info.tiling));
         }
+        ReadLockGuard guard(device_state->ahb_lock_);
         if (device_state->ahb_ext_formats_map.find(ext_fmt_android->externalFormat) == device_state->ahb_ext_formats_map.end()) {
             skip |= LogError("VUID-VkExternalFormatANDROID-externalFormat-01894", device,
                              create_info_loc.pNext(Struct::VkExternalFormatANDROID, Field::externalFormat),

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -58,12 +58,8 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo& create_inf
 
     if (image_format == VK_FORMAT_UNDEFINED) {
         // VU 01975 states format can't be undefined unless an android externalFormat
-        const uint64_t external_format = GetExternalFormat(create_info.pNext);
-        if ((image_tiling == VK_IMAGE_TILING_OPTIMAL) && (0 != external_format)) {
-            auto it = device_state->ahb_ext_formats_map.find(external_format);
-            if (it != device_state->ahb_ext_formats_map.end()) {
-                tiling_features = it->second;
-            }
+        if (image_tiling == VK_IMAGE_TILING_OPTIMAL) {
+            tiling_features = device_state->GetExternalFormatFeaturesANDROID(create_info.pNext);
         }
     } else if (image_tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
         vvl::unordered_set<uint64_t> drm_format_modifiers;

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -1269,18 +1269,15 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
             }
             const uint64_t attachment_external_format =
                 GetExternalFormat(render_pass_create_info->pAttachments[resolve_attachment].pNext);
-            auto it = device_state->ahb_ext_resolve_formats_map.find(attachment_external_format);
-            if (it != device_state->ahb_ext_resolve_formats_map.end()) {
-                VkFormat color_format = render_pass_create_info->pAttachments[color_attachment].format;
-                if (it->second != color_format) {
-                    const LogObjectList objlist(begin_info.renderPass, begin_info.framebuffer);
-                    skip |=
-                        LogError("VUID-VkRenderPassBeginInfo-framebuffer-09353", objlist, begin_info_loc,
+            const VkFormat ahb_resolve_format = device_state->GetExternalFormatResolveANDROID(attachment_external_format);
+            const VkFormat color_format = render_pass_create_info->pAttachments[color_attachment].format;
+            if (ahb_resolve_format != VK_FORMAT_UNDEFINED && ahb_resolve_format != color_format) {
+                const LogObjectList objlist(begin_info.renderPass, begin_info.framebuffer);
+                skip |= LogError("VUID-VkRenderPassBeginInfo-framebuffer-09353", objlist, begin_info_loc,
                                  "subpass[%" PRIu32 "].pResolveAttachments[0].attachment %" PRIu32 " has externalFormat %" PRIu64
                                  " which corresponds to needing a color attachment format of %s, but the format is %s.",
-                                 i, resolve_attachment, attachment_external_format, string_VkFormat(it->second),
+                                 i, resolve_attachment, attachment_external_format, string_VkFormat(ahb_resolve_format),
                                  string_VkFormat(color_format));
-                }
             }
         }
     }
@@ -4264,19 +4261,18 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
                                          color_attachment_loc.dot(Field::imageView), "is not null (%s).",
                                          FormatHandle(color_attachment.imageView).c_str());
                     } else {
-                        auto it = device_state->ahb_ext_resolve_formats_map.find(resolve_view_state->image_state->ahb_format);
-                        if (it != device_state->ahb_ext_resolve_formats_map.end()) {
-                            if (it->second != color_view_state->create_info.format) {
-                                const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView,
-                                                            color_attachment.imageView);
-                                skip |=
-                                    LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09330", commandBuffer,
+                        const VkFormat ahb_resolve_format =
+                            device_state->GetExternalFormatResolveANDROID(resolve_view_state->image_state->ahb_format);
+                        if (ahb_resolve_format != VK_FORMAT_UNDEFINED &&
+                            ahb_resolve_format != color_view_state->create_info.format) {
+                            const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView,
+                                                        color_attachment.imageView);
+                            skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09330", commandBuffer,
                                              color_attachment_loc.dot(Field::imageView),
                                              "has externalFormat %" PRIu64
                                              " which corresponds to needing a color attachment format of %s, but the format is %s.",
-                                             resolve_view_state->image_state->ahb_format, string_VkFormat(it->second),
+                                             resolve_view_state->image_state->ahb_format, string_VkFormat(ahb_resolve_format),
                                              string_VkFormat(color_view_state->create_info.format));
-                            }
                         }
                     }
                 } else if (!device_state->android_external_format_resolve_null_color_attachment_prop) {
@@ -5249,18 +5245,15 @@ bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo& c
                 subpass.pResolveAttachments[0].attachment == i && subpass.pColorAttachments) {
                 const uint64_t attachment_external_format =
                     GetExternalFormat(rpci.pAttachments[subpass.pResolveAttachments[0].attachment].pNext);
-                auto it = device_state->ahb_ext_resolve_formats_map.find(attachment_external_format);
-                if (it != device_state->ahb_ext_resolve_formats_map.end()) {
-                    VkFormat color_format = rpci.pAttachments[subpass.pColorAttachments[0].attachment].format;
-                    if (it->second != color_format) {
-                        LogObjectList objlist(create_info.renderPass, image_views[i]);
-                        skip |= LogError(
-                            "VUID-VkFramebufferCreateInfo-nullColorAttachmentWithExternalFormatResolve-09349", objlist,
-                            attachment_loc,
-                            "subpass[%" PRIu32 "].pResolveAttachments[0].attachment %" PRIu32 " has externalFormat %" PRIu64
-                            " which corresponds to needing a color attachment format of %s, but the format is %s.",
-                            j, i, attachment_external_format, string_VkFormat(it->second), string_VkFormat(color_format));
-                    }
+                const VkFormat ahb_resolve_format = device_state->GetExternalFormatResolveANDROID(attachment_external_format);
+                const VkFormat color_format = rpci.pAttachments[subpass.pColorAttachments[0].attachment].format;
+                if (ahb_resolve_format != VK_FORMAT_UNDEFINED && ahb_resolve_format != color_format) {
+                    LogObjectList objlist(create_info.renderPass, image_views[i]);
+                    skip |= LogError(
+                        "VUID-VkFramebufferCreateInfo-nullColorAttachmentWithExternalFormatResolve-09349", objlist, attachment_loc,
+                        "subpass[%" PRIu32 "].pResolveAttachments[0].attachment %" PRIu32 " has externalFormat %" PRIu64
+                        " which corresponds to needing a color attachment format of %s, but the format is %s.",
+                        j, i, attachment_external_format, string_VkFormat(ahb_resolve_format), string_VkFormat(color_format));
                 }
             }
         }

--- a/layers/core_checks/cc_ycbcr.cpp
+++ b/layers/core_checks/cc_ycbcr.cpp
@@ -61,13 +61,11 @@ bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, co
     // (vkspec.html#potential-format-features)
     VkFormatFeatureFlags2 format_features = ~0ULL;
     if (conversion_format == VK_FORMAT_UNDEFINED) {
-        // only check for external format inside VK_FORMAT_UNDEFINED check to prevent unnecessary extra errors from no format
-        // features being supported
-        if (external_format != 0) {
-            auto it = device_state->ahb_ext_formats_map.find(external_format);
-            if (it != device_state->ahb_ext_formats_map.end()) {
-                format_features = it->second;
-            }
+        format_features = device_state->GetExternalFormatFeaturesANDROID(pCreateInfo->pNext);
+        if (format_features == 0) {
+            // only check for external format inside VK_FORMAT_UNDEFINED check to prevent unnecessary extra errors from no format
+            // features being supported
+            format_features = ~0ULL;
         }
     } else {
         format_features = GetPotentialFormatFeatures(conversion_format);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -222,6 +222,7 @@ VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void* 
     VkFormatFeatureFlags2 format_features = 0;
     const uint64_t external_format = GetExternalFormat(pNext);
     if ((0 != external_format)) {
+        ReadLockGuard guard(ahb_lock_);
         // VUID 01894 will catch if not found in map
         auto it = ahb_ext_formats_map.find(external_format);
         if (it != ahb_ext_formats_map.end()) {
@@ -231,22 +232,32 @@ VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void* 
     return format_features;
 }
 
+VkFormat DeviceState::GetExternalFormatResolveANDROID(uint64_t external_format) const {
+    ReadLockGuard guard(ahb_lock_);
+    auto it = ahb_ext_resolve_formats_map.find(external_format);
+    if (it != ahb_ext_resolve_formats_map.end()) {
+        return it->second;
+    }
+    return VK_FORMAT_UNDEFINED;
+}
+
 void DeviceState::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
                                                                           VkAndroidHardwareBufferPropertiesANDROID* pProperties,
                                                                           const RecordObject& record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
+    WriteLockGuard guard(ahb_lock_);
     uint64_t external_format = 0;
     auto ahb_format_props2 = vku::FindStructInPNextChain<VkAndroidHardwareBufferFormatProperties2ANDROID>(pProperties->pNext);
     if (ahb_format_props2) {
         external_format = ahb_format_props2->externalFormat;
-        ahb_ext_formats_map.insert(external_format, ahb_format_props2->formatFeatures);
+        ahb_ext_formats_map.emplace(external_format, ahb_format_props2->formatFeatures);
     } else {
         auto ahb_format_props = vku::FindStructInPNextChain<VkAndroidHardwareBufferFormatPropertiesANDROID>(pProperties->pNext);
         if (ahb_format_props) {
             external_format = ahb_format_props->externalFormat;
-            ahb_ext_formats_map.insert(external_format, static_cast<VkFormatFeatureFlags2>(ahb_format_props->formatFeatures));
+            ahb_ext_formats_map.emplace(external_format, static_cast<VkFormatFeatureFlags2>(ahb_format_props->formatFeatures));
         }
     }
 
@@ -256,7 +267,7 @@ void DeviceState::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevi
             vku::FindStructInPNextChain<VkAndroidHardwareBufferFormatResolvePropertiesANDROID>(pProperties->pNext);
         if (ahb_format_resolve_props && external_format != 0) {
             // easy case, caller provided both structs for us
-            ahb_ext_resolve_formats_map.insert(external_format, ahb_format_resolve_props->colorAttachmentFormat);
+            ahb_ext_resolve_formats_map.emplace(external_format, ahb_format_resolve_props->colorAttachmentFormat);
         } else {
             // If caller didn't provide both struct, re-call for them
             VkAndroidHardwareBufferFormatResolvePropertiesANDROID new_ahb_format_resolve_props = vku::InitStructHelper();
@@ -264,8 +275,8 @@ void DeviceState::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevi
                 vku::InitStructHelper(&new_ahb_format_resolve_props);
             VkAndroidHardwareBufferPropertiesANDROID new_ahb_props = vku::InitStructHelper(&new_ahb_format_props);
             DispatchGetAndroidHardwareBufferPropertiesANDROID(device, buffer, &new_ahb_props);
-            ahb_ext_resolve_formats_map.insert(new_ahb_format_props.externalFormat,
-                                               new_ahb_format_resolve_props.colorAttachmentFormat);
+            ahb_ext_resolve_formats_map.emplace(new_ahb_format_props.externalFormat,
+                                                new_ahb_format_resolve_props.colorAttachmentFormat);
         }
     }
 }
@@ -275,6 +286,11 @@ void DeviceState::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevi
 VkFormatFeatureFlags2 DeviceState::GetExternalFormatFeaturesANDROID(const void* pNext) const {
     (void)pNext;
     return 0;
+}
+
+VkFormat DeviceState::GetExternalFormatResolveANDROID(uint64_t external_format) const {
+    (void)external_format;
+    return VK_FORMAT_UNDEFINED;
 }
 
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1797,6 +1797,7 @@ class DeviceState : public vvl::BaseDevice {
                                       const RecordObject& record_obj) override;
 
     VkFormatFeatureFlags2 GetExternalFormatFeaturesANDROID(const void* pNext) const;
+    VkFormat GetExternalFormatResolveANDROID(uint64_t external_format) const;
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     void PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
@@ -2189,9 +2190,10 @@ class DeviceState : public vvl::BaseDevice {
     } as_with_addresses;
 
     // < external format, features >
-    vvl::concurrent_unordered_map<uint64_t, VkFormatFeatureFlags2> ahb_ext_formats_map;
+    vvl::unordered_map<uint64_t, VkFormatFeatureFlags2> ahb_ext_formats_map;
     // < external format, colorAttachmentFormat > (VK_ANDROID_external_format_resolve)
-    vvl::concurrent_unordered_map<uint64_t, VkFormat> ahb_ext_resolve_formats_map;
+    vvl::unordered_map<uint64_t, VkFormat> ahb_ext_resolve_formats_map;
+    mutable std::shared_mutex ahb_lock_;
 
     // For VK_EXT_descriptor_buffer need to track global buffer size allocated
     struct DescriptorBufferAddressSpace {


### PR DESCRIPTION
noticed this today, `concurrent_unordered_map` is a heavy util designed for the state objects... the AHB formats are not that, just needed someone comfortable to know this could simply use a lock