### PR TITLE
layers: Use XXH3_64bits for hashing

### DIFF
--- a/layers/utils/hash_util.cpp
+++ b/layers/utils/hash_util.cpp
@@ -33,18 +33,17 @@ static_assert(XXH_VERSION_RELEASE == 3);
 namespace hash_util {
 
 uint32_t VuidHash(std::string_view vuid) {
+    // While the XXH32 is known to be slower, unfortunately people are likely relying on the
+    // exact hashes being returned, so we need to keep this stable.
     constexpr uint32_t seed = 8;
     return XXH32(vuid.data(), vuid.size(), seed);
 }
 
 uint32_t Hash32(const void* info, const size_t info_size) {
-    constexpr uint32_t seed = 0;
-    return XXH32(info, info_size, seed);
+    // Documentation shows XXH32 is a legacy function and XXH3_64bits is much faster
+    return static_cast<uint32_t>(XXH3_64bits(info, info_size));
 }
 
-uint64_t Hash64(const void* info, const size_t info_size) {
-    constexpr uint64_t seed = 0;
-    return XXH64(info, info_size, seed);
-}
+uint64_t Hash64(const void* info, const size_t info_size) { return XXH3_64bits(info, info_size); }
 
 }  // namespace hash_util


### PR DESCRIPTION
reading the documentation in `xxhash.h` it shows that `XXH3_64bits` is much faster than `HHX32` or `HHX64` so this replaces it