### PR TITLE
Add debug printf + ray tracing + descriptor heap tests

### DIFF
--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2025 Valve Corporation
-# Copyright (c) 2025 LunarG, Inc.
+# Copyright (c) 2026 Valve Corporation
+# Copyright (c) 2026 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,8 @@ add_library(vk_test_framework STATIC
     sync_val_tests.h
     descriptor_helper.h
     descriptor_helper.cpp
+    descriptor_heap_object.h
+    descriptor_heap_object.cpp
     thread_helper.h
     thread_helper.cpp
     gpu_av_helper.h

--- a/tests/framework/descriptor_heap_object.cpp
+++ b/tests/framework/descriptor_heap_object.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "descriptor_heap_object.h"
+
+#include "containers/container_utils.h"
+#include "../framework/layer_validation_tests.h"
+#include "../framework/ray_tracing_objects.h"
+#include "utils/math_utils.h"
+
+namespace vkt {
+
+void DescriptorHeap::AddDescriptorHeapRequirements(VkLayerTest& test) {
+    test.AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    test.AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    test.AddRequiredFeature(vkt::Feature::descriptorHeap);
+}
+
+void DescriptorHeap::AddUntypedDescriptorHeapRequirements(VkLayerTest &test) {
+    test.AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    test.AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    test.AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    test.AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    test.AddRequiredFeature(vkt::Feature::descriptorHeap);
+}
+
+DescriptorHeap::DescriptorHeap(VkLayerTest& test) : test_(&test) {
+    heap_props.pNext = &tensor_heap_props;
+    test_->GetPhysicalDeviceProperties2(heap_props);
+}
+
+void DescriptorHeap::CreateResourceHeap(VkDeviceSize app_size, bool reserved_range_in_front) {
+    resource_reserved_range_in_front_ = reserved_range_in_front;
+    const VkDeviceSize heap_size = AlignResource(app_size + heap_props.minResourceHeapReservedRange);
+
+    VkBufferUsageFlags2CreateInfo buffer_usage = vku::InitStructHelper();
+    buffer_usage.usage = VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT | VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT;
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    resource_heap_.Init(*test_->DeviceObj(), vkt::Buffer::CreateInfo(heap_size, 0, {}, &buffer_usage),
+                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &allocate_flag_info);
+    resource_heap_data_ = static_cast<uint8_t*>(resource_heap_.Memory().Map());
+    if (reserved_range_in_front) {
+        heap_offset_ = AlignResource(heap_props.minResourceHeapReservedRange);
+    }
+}
+
+void DescriptorHeap::CreateSamplerHeap(VkDeviceSize app_size, bool reserved_range_in_front, bool use_embedded_samplers) {
+    embedded_samplers = use_embedded_samplers;
+    sampler_reserved_range_in_front_ = reserved_range_in_front;
+    const VkDeviceSize reserved_range =
+        (embedded_samplers ? heap_props.minSamplerHeapReservedRangeWithEmbedded : heap_props.minSamplerHeapReservedRange);
+    const VkDeviceSize heap_size = AlignSampler(app_size + reserved_range);
+
+    VkBufferUsageFlags2CreateInfo buffer_usage = vku::InitStructHelper();
+    buffer_usage.usage = VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT | VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT;
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    sampler_heap_.Init(*test_->DeviceObj(), vkt::Buffer::CreateInfo(heap_size, 0, {}, &buffer_usage),
+                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &allocate_flag_info);
+    sampler_heap_data_ = static_cast<uint8_t*>(sampler_heap_.Memory().Map());
+    if (reserved_range_in_front) {
+        heap_offset_ = AlignSampler(reserved_range);
+    }
+}
+
+VkDeviceSize DescriptorHeap::WriteBufferDescriptor(const vkt::Buffer& buffer, VkDescriptorType desc_type) {
+    const VkDeviceAddressRangeKHR addr_range = buffer.AddressRange();
+    return WriteBufferDescriptor(addr_range, desc_type);
+}
+
+VkDeviceSize DescriptorHeap::WriteBufferDescriptor(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type) {
+    heap_offset_ = Align(heap_offset_, heap_props.bufferDescriptorAlignment);
+    const VkDeviceSize write_offset = WriteBufferDescriptorAtOffset(addr_range, desc_type, heap_offset_);
+
+    const VkDeviceSize buffer_desc_size = vk::GetPhysicalDeviceDescriptorSizeEXT(test_->DeviceObj()->Physical(), desc_type);
+    heap_offset_ += buffer_desc_size;
+    assert(heap_offset_ <= resource_heap_.CreateInfo().size);
+
+    return write_offset;
+}
+
+VkDeviceSize DescriptorHeap::WriteBufferDescriptorAtOffset(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type,
+                                                           VkDeviceSize heap_offset) {
+    assert(IsValueIn(desc_type, {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                                 VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER}));
+    return WriteDescriptorAtOffset(addr_range, desc_type, heap_offset);
+}
+
+VkDeviceSize DescriptorHeap::WriteAccelerationStructureDescriptor(vkt::as::AccelerationStructureKHR& as) {
+    const VkDeviceAddress as_addr = as.GetAccelerationStructureDeviceAddress();
+    return WriteAccelerationStructureDescriptor(as_addr);
+}
+
+VkDeviceSize DescriptorHeap::WriteAccelerationStructureDescriptor(VkDeviceAddress as_addr) {
+    constexpr VkDescriptorType as_desc_type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
+    heap_offset_ = Align(heap_offset_, heap_props.bufferDescriptorAlignment);
+    // Per the spec, size can be 0
+    const VkDeviceAddressRangeEXT as_addr_range = {as_addr, 0};
+    const VkDeviceSize write_offset = WriteDescriptorAtOffset(as_addr_range, as_desc_type, heap_offset_);
+
+    const VkDeviceSize buffer_desc_size = vk::GetPhysicalDeviceDescriptorSizeEXT(test_->DeviceObj()->Physical(), as_desc_type);
+    heap_offset_ += buffer_desc_size;
+    assert(heap_offset_ <= resource_heap_.CreateInfo().size);
+
+    return write_offset;
+}
+
+VkDeviceSize DescriptorHeap::AlignResource(VkDeviceSize offset) {
+    VkDeviceSize aligned_offset = Align(offset, heap_props.bufferDescriptorAlignment);
+    aligned_offset = Align(aligned_offset, heap_props.imageDescriptorAlignment);
+    return aligned_offset;
+}
+
+VkDeviceSize DescriptorHeap::AlignSampler(VkDeviceSize offset) { return Align(offset, heap_props.samplerDescriptorAlignment); }
+
+VkDeviceSize DescriptorHeap::GetResourceHeapReservedRangeOffset() const {
+    if (resource_reserved_range_in_front_) {
+        return 0;
+    } else {
+        return resource_heap_.CreateInfo().size - heap_props.minResourceHeapReservedRange;
+    }
+}
+
+VkDeviceSize DescriptorHeap::GetSamplerHeapReservedRangeOffset() const {
+    const VkDeviceSize min_reserved_range =
+        embedded_samplers ? heap_props.minSamplerHeapReservedRangeWithEmbedded : heap_props.minSamplerHeapReservedRange;
+    if (resource_reserved_range_in_front_) {
+        return 0;
+    } else {
+        return sampler_heap_.CreateInfo().size - min_reserved_range;
+    }
+}
+
+void DescriptorHeap::BindResourceHeap(vkt::CommandBuffer& cmd_buffer) {
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = resource_heap_.AddressRange();
+    bind_resource_info.reservedRangeOffset = GetResourceHeapReservedRangeOffset();
+    bind_resource_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
+    vk::CmdBindResourceHeapEXT(cmd_buffer, &bind_resource_info);
+}
+
+void DescriptorHeap::BindSamplerHeap(vkt::CommandBuffer &cmd_buffer) {
+    const VkDeviceSize min_reserved_range =
+        embedded_samplers ? heap_props.minSamplerHeapReservedRangeWithEmbedded : heap_props.minSamplerHeapReservedRange;
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = sampler_heap_.AddressRange();
+    bind_resource_info.reservedRangeOffset = GetSamplerHeapReservedRangeOffset();
+    bind_resource_info.reservedRangeSize = min_reserved_range;
+    vk::CmdBindSamplerHeapEXT(cmd_buffer, &bind_resource_info);
+}
+
+VkDeviceSize DescriptorHeap::WriteDescriptorAtOffset(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type,
+                                                     VkDeviceSize heap_offset) {
+    assert(resource_heap_.handle() != VK_NULL_HANDLE);
+    VkResourceDescriptorInfoEXT desc_info = vku::InitStructHelper();
+    desc_info.type = desc_type;
+    desc_info.data.pAddressRange = &addr_range;
+
+    const VkDeviceSize desc_size = vk::GetPhysicalDeviceDescriptorSizeEXT(test_->DeviceObj()->Physical(), desc_type);
+
+    VkHostAddressRangeEXT desc_host_data{};
+    desc_host_data.address = resource_heap_data_ + heap_offset;
+    desc_host_data.size = desc_size;
+
+    vk::WriteResourceDescriptorsEXT(*test_->DeviceObj(), 1, &desc_info, &desc_host_data);
+
+    return heap_offset;
+}
+
+}  // namespace vkt

--- a/tests/framework/descriptor_heap_object.h
+++ b/tests/framework/descriptor_heap_object.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "binding.h"
+
+class VkLayerTest;
+
+namespace vkt {
+
+class Buffer;
+namespace as {
+class AccelerationStructureKHR;
+}
+
+class DescriptorHeap {
+  public:
+    static void AddDescriptorHeapRequirements(VkLayerTest& test);
+    static void AddUntypedDescriptorHeapRequirements(VkLayerTest &test);
+
+    DescriptorHeap(VkLayerTest& test);
+    void CreateResourceHeap(VkDeviceSize app_size, bool reserved_range_in_front = false);
+    void CreateSamplerHeap(VkDeviceSize app_size, bool reserved_range_in_front = false, bool use_embedded_samplers = false);
+
+    // Writes a descriptor at the internally maintained heap write offset.
+    // Heap write offset is first aligned according to descriptor type,
+    // then descriptor is written, finally heap write offset is incremented by descriptor size.
+    // Returns write offset.
+    VkDeviceSize WriteBufferDescriptor(const vkt::Buffer& buffer, VkDescriptorType desc_type);
+    VkDeviceSize WriteBufferDescriptor(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type);
+    VkDeviceSize WriteAccelerationStructureDescriptor(vkt::as::AccelerationStructureKHR& as);
+    VkDeviceSize WriteAccelerationStructureDescriptor(VkDeviceAddress as_addr);
+    // Write at supplied heap offset
+    // *Warning* Internally maintained heap write offset will not be touched at all,
+    // so this probably should not be used with the above functions.
+    VkDeviceSize WriteBufferDescriptorAtOffset(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type,
+                                               VkDeviceSize heap_offset);
+
+    VkDeviceSize AlignResource(VkDeviceSize offset);
+    VkDeviceSize AlignSampler(VkDeviceSize offset);
+
+    VkDeviceSize GetCurrentHeapWriteOffset() const { return heap_offset_; }
+    VkDeviceSize GetResourceHeapReservedRangeOffset() const;
+    VkDeviceSize GetSamplerHeapReservedRangeOffset() const;
+
+    void BindResourceHeap(vkt::CommandBuffer &cmd_buffer);
+    void BindSamplerHeap(vkt::CommandBuffer &cmd_buffer);
+
+    VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
+    VkPhysicalDeviceDescriptorHeapTensorPropertiesARM tensor_heap_props = vku::InitStructHelper();
+
+    vkt::Buffer resource_heap_;
+    uint8_t* resource_heap_data_ = nullptr;
+
+    vkt::Buffer sampler_heap_;
+    uint8_t *sampler_heap_data_ = nullptr;
+
+  private:
+    VkDeviceSize WriteDescriptorAtOffset(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type, VkDeviceSize heap_offset);
+
+    VkLayerTest* test_ = nullptr;
+    bool resource_reserved_range_in_front_ = false;
+    bool sampler_reserved_range_in_front_ = false;
+    bool embedded_samplers = false;
+    VkDeviceSize heap_offset_ = 0;
+};
+
+}  // namespace vkt

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -1196,6 +1196,8 @@ GeometryKHR GeometrySimpleOnDeviceIndexedTriangleInfo(const vkt::Device& device,
     vkt::Buffer transform_buffer(device, sizeof(VkTransformMatrixKHR), buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
     // Fill vertex and index buffers with one triangle
+    // Warning: Changing vertices will break some tests implicitly
+    // relying on this
     triangle_geometry.SetPrimitiveCount(triangles_count);
     constexpr std::array vertices = {// Vertex 0
                                      10.0f, 10.0f, 0.0f,
@@ -2125,8 +2127,11 @@ void Pipeline::AddSlangRayGenShader(const char* slang, const char* entry_point) 
                                                                 SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
-void Pipeline::AddGlslMissShader(const char* glsl) {
-    miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, glsl, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2));
+void Pipeline::AddGlslMissShader(const char* glsl, const void* shader_module_create_info_pnext,
+                                 const void* pipeline_shader_stage_create_info_pNext) {
+    miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(*device_, glsl, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
+                                                             SPV_SOURCE_GLSL, nullptr, "main", shader_module_create_info_pnext,
+                                                             pipeline_shader_stage_create_info_pNext));
 }
 
 void Pipeline::AddSpirvMissShader(const char* spirv, const char* entry_point) {
@@ -2139,9 +2144,11 @@ void Pipeline::AddSlangMissShader(const char* slang, const char* entry_point) {
                                                              SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
-void Pipeline::AddGlslClosestHitShader(const char* glsl) {
-    hit_shaders_.emplace_back(
-        HitShader{std::make_unique<VkShaderObj>(*device_, glsl, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, SPV_ENV_VULKAN_1_2), nullptr});
+void Pipeline::AddGlslClosestHitShader(const char* glsl, const void* shader_module_create_info_pnext,
+                                       const void* pipeline_shader_stage_create_info_pNext) {
+    hit_shaders_.emplace_back(HitShader{
+        std::make_unique<VkShaderObj>(*device_, glsl, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL,
+                                      nullptr, "main", shader_module_create_info_pnext, pipeline_shader_stage_create_info_pNext)});
 }
 
 void Pipeline::AddGlslHitGroupShader(const char* closest_hit_glsl, const char* intersection_glsl) {
@@ -2585,7 +2592,7 @@ void Pipeline::BuildSbt() {
     sbt_buffer_.Memory().Unmap();
 }
 
-void Pipeline::UpdateRayGenShaderRecord(uint32_t ray_gen_i, void* data, size_t size) {
+void Pipeline::UpdateRayGenShaderRecord(uint32_t ray_gen_i, const void* data, size_t size) {
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_pipeline_props = vku::InitStructHelper();
     test_.GetPhysicalDeviceProperties2(rt_pipeline_props);
     const uint32_t sbt_ray_gen_shader_size = rt_pipeline_props.shaderGroupHandleSize + shader_record_size_;
@@ -2595,9 +2602,10 @@ void Pipeline::UpdateRayGenShaderRecord(uint32_t ray_gen_i, void* data, size_t s
     const uint32_t offset = ray_gen_i * sbt_ray_gen_shader_size_aligned + rt_pipeline_props.shaderGroupHandleSize;
     auto sbt_ray_gen_shader_record_start_ptr = sbt_buffer_ptr + offset;
     std::memcpy(sbt_ray_gen_shader_record_start_ptr, data, size);
+    sbt_buffer_.Memory().Unmap();
 }
 
-void Pipeline::UpdateMissShaderRecord(uint32_t miss_i, void* data, size_t size) {
+void Pipeline::UpdateMissShaderRecord(uint32_t miss_i, const void* data, size_t size) {
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_pipeline_props = vku::InitStructHelper();
     test_.GetPhysicalDeviceProperties2(rt_pipeline_props);
     const uint32_t sbt_shader_size = rt_pipeline_props.shaderGroupHandleSize + shader_record_size_;
@@ -2614,7 +2622,7 @@ void Pipeline::UpdateMissShaderRecord(uint32_t miss_i, void* data, size_t size) 
     sbt_buffer_.Memory().Unmap();
 }
 
-void Pipeline::UpdateHitShaderRecord(uint32_t hit_i, void* data, size_t size) {
+void Pipeline::UpdateHitShaderRecord(uint32_t hit_i, const void* data, size_t size) {
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_pipeline_props = vku::InitStructHelper();
     test_.GetPhysicalDeviceProperties2(rt_pipeline_props);
     const uint32_t sbt_shader_size = rt_pipeline_props.shaderGroupHandleSize + shader_record_size_;

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -456,10 +456,12 @@ class Pipeline {
                              const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddSpirvRayGenShader(const char* spirv, const char* entry_point);
     void AddSlangRayGenShader(const char* slang, const char* entry_point);
-    void AddGlslMissShader(const char* glsl);
+    void AddGlslMissShader(const char* glsl, const void* shader_module_create_info_pnext = nullptr,
+                           const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddSpirvMissShader(const char* spirv, const char* entry_point);
     void AddSlangMissShader(const char* slang, const char* entry_point);
-    void AddGlslClosestHitShader(const char* glsl);
+    void AddGlslClosestHitShader(const char* glsl, const void* shader_module_create_info_pnext = nullptr,
+                                 const void* pipeline_shader_stage_create_info_pNext = nullptr);
     void AddGlslHitGroupShader(const char* closest_hit_glsl, const char* intersection_glsl = nullptr);
     void AddSpirvClosestHitShader(const char* spirv, const char* entry_point);
     void AddSlangClosestHitShader(const char* slang, const char* entry_point);
@@ -478,9 +480,9 @@ class Pipeline {
     // Updates
     // -------
     // (SBT needs to be built)
-    void UpdateRayGenShaderRecord(uint32_t ray_gen_i, void* data, size_t size);
-    void UpdateMissShaderRecord(uint32_t miss_i, void* data, size_t size);
-    void UpdateHitShaderRecord(uint32_t hit_i, void* data, size_t size);
+    void UpdateRayGenShaderRecord(uint32_t ray_gen_i, const void* data, size_t size);
+    void UpdateMissShaderRecord(uint32_t miss_i, const void* data, size_t size);
+    void UpdateHitShaderRecord(uint32_t hit_i, const void* data, size_t size);
 
     // Get
     // ---

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -13,10 +13,12 @@
 
 #include <vulkan/vulkan_core.h>
 #include <cstdint>
+#include <cinttypes>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 #include "../framework/ray_tracing_objects.h"
+#include "../framework/descriptor_heap_object.h"
 
 class NegativeDebugPrintfRayTracing : public DebugPrintfTests {
   public:
@@ -149,6 +151,80 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenShaderRecord) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeDebugPrintfRayTracing, RaygenShaderRecordDescriptorHeap) {
+    TEST_DESCRIPTION("Test debug printf in raygen shader. Use shader records.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    vkt::DescriptorHeap::AddDescriptorHeapRequirements(*this);
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    RETURN_IF_SKIP(InitState());
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+    pipeline.AddCreateInfoFlags2(VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT);
+
+    const char* ray_gen = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+        layout(location = 0) rayPayloadEXT vec3 hit;
+
+        layout(shaderRecordEXT) buffer sbt {
+            uvec3 sbt_vec;
+        };
+
+        void main() {
+            debugPrintfEXT("shader record: %v3u\n", sbt_vec);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1000.0, 0);
+        }
+    )glsl";
+
+    vkt::as::BuildGeometryInfoKHR tlas(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, m_command_buffer));
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(1024, true);
+    const VkDeviceSize as_heap_offset = desc_heap.WriteAccelerationStructureDescriptor(*tlas.GetDstAS());
+
+    const VkDeviceSize as_descriptor_size =
+        vk::GetPhysicalDeviceDescriptorSizeEXT(m_device->Physical(), VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = vku::InitStructHelper();
+    mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT;
+    mapping.sourceData.shaderRecordIndex = {};
+    mapping.sourceData.shaderRecordIndex.heapOffset = (uint32_t)as_heap_offset;
+    mapping.sourceData.shaderRecordIndex.shaderRecordOffset = 0;
+    mapping.sourceData.shaderRecordIndex.heapIndexStride = (uint32_t)as_descriptor_size;
+    mapping.sourceData.shaderRecordIndex.heapArrayStride = (uint32_t)as_descriptor_size;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    pipeline.SetGlslRayGenShader(ray_gen, nullptr, &mapping_info);
+    pipeline.SetShaderRecordSize(3 * sizeof(uint32_t));
+    pipeline.AddGlslMissShader(kRayTracingPayloadMinimalGlsl);
+    pipeline.AddGlslClosestHitShader(kRayTracingPayloadMinimalGlsl);
+
+    pipeline.Build();
+
+    uint32_t vec[3] = {0, 2, 4};
+    pipeline.UpdateRayGenShaderRecord(0, vec, 3 * sizeof(uint32_t));
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline);
+    vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+    vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
+                        &trace_rays_sbt.callable_sbt, 1, 1, 1);
+    m_command_buffer.End();
+    m_errorMonitor->SetDesiredInfo("shader record: 0, 2, 4");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -159,8 +235,6 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     RETURN_IF_SKIP(InitFrameworkWithPrintfBufferSize(1024 * 1024));
     RETURN_IF_SKIP(InitState());
 
-    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
-    // implicitly depends on the default triangle position.
     vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
 
     // Build Bottom Level Acceleration Structure
@@ -324,6 +398,466 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     ASSERT_EQ(debug_buffer_ptr[2], 2 * ray_gen_rays_count * frames_count);
 }
 
+TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShaderDescriptorHeap) {
+    TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders. Use descriptor heaps.");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    vkt::DescriptorHeap::AddDescriptorHeapRequirements(*this);
+    RETURN_IF_SKIP(InitFrameworkWithPrintfBufferSize(1024 * 1024));
+    RETURN_IF_SKIP(InitState());
+
+    vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+
+    // Build Bottom Level Acceleration Structure
+    m_command_buffer.Begin();
+    blas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Build Top Level Acceleration Structure
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, *blas.GetDstAS());
+    m_command_buffer.Begin();
+    tlas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    vkt::Buffer dummy_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(1024, true);
+    const VkDeviceSize buffer_heap_offset = desc_heap.WriteBufferDescriptor(dummy_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    const VkDeviceSize as_heap_offset = desc_heap.WriteAccelerationStructureDescriptor(*tlas.GetDstAS());
+
+    const VkDeviceSize as_descriptor_size =
+        vk::GetPhysicalDeviceDescriptorSizeEXT(m_device->Physical(), VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = vku::InitStructHelper();
+    mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT;
+    mapping.sourceData.shaderRecordIndex = {};
+    mapping.sourceData.shaderRecordIndex.heapOffset = (uint32_t)buffer_heap_offset;
+    mapping.sourceData.shaderRecordIndex.shaderRecordOffset = 4;
+    mapping.sourceData.shaderRecordIndex.heapIndexStride = (uint32_t)(as_heap_offset - buffer_heap_offset);
+    mapping.sourceData.shaderRecordIndex.heapArrayStride = (uint32_t)as_descriptor_size;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+    pipeline.AddCreateInfoFlags2(VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT);
+
+    const char* ray_gen = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+
+        layout(location = 0) rayPayloadEXT vec3 hit;
+
+        void main() {
+            vec3 ray_origin = vec3(0,0,-50);
+            vec3 ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,-50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,0);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+        }
+    )glsl";
+    pipeline.SetGlslRayGenShader(ray_gen, nullptr, &mapping_info);
+
+    const char* miss = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+
+        void main() {
+            hit = vec3(0.1, 0.2, 0.3);
+        }
+    )glsl";
+    pipeline.AddGlslMissShader(miss, nullptr, &mapping_info);
+
+    const char* closest_hit = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+
+        layout(shaderRecordEXT) buffer sbt {
+            uvec3 sbt_vec;
+        };
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+        hitAttributeEXT vec2 baryCoord;
+
+        void main() {
+            debugPrintfEXT("In Closest Hit %v3u", sbt_vec);
+            const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
+            hit = barycentricCoords;
+        }
+    )glsl";
+    pipeline.AddGlslClosestHitShader(closest_hit, nullptr, &mapping_info);
+    pipeline.SetShaderRecordSize(3 * sizeof(uint32_t));
+    pipeline.Build();
+
+    // vec[1] == 1
+    // ==> Because of the offset computed as described in
+    // https://docs.vulkan.org/refpages/latest/refpages/source/VkDescriptorMappingSourceShaderRecordIndexEXT.html
+    // `shaderRecordIndex` in `shaderRecordIndex * heapIndexStride` will be 1
+    uint32_t vec[3] = {678, 1, 42};
+    pipeline.UpdateRayGenShaderRecord(0, vec, 3 * sizeof(uint32_t));
+    pipeline.UpdateMissShaderRecord(0, vec, 3 * sizeof(uint32_t));
+    pipeline.UpdateHitShaderRecord(0, vec, 3 * sizeof(uint32_t));
+
+    constexpr uint32_t frames_count = 14;
+    const uint32_t ray_gen_width = 1;
+    const uint32_t ray_gen_height = 4;
+    const uint32_t ray_gen_depth = 1;
+    const uint32_t ray_gen_rays_count = ray_gen_width * ray_gen_height * ray_gen_depth;
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.Begin();
+        desc_heap.BindResourceHeap(m_command_buffer);
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline);
+        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+
+        vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
+                            &trace_rays_sbt.callable_sbt, ray_gen_width, ray_gen_height, ray_gen_depth);
+
+        m_command_buffer.End();
+        for (uint32_t i = 0; i < 2 * ray_gen_rays_count; ++i) {
+            m_errorMonitor->SetDesiredInfo("In Closest Hit 678, 1, 42");
+        }
+
+        m_default_queue->SubmitAndWait(m_command_buffer);
+
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShaderDescriptorHeapShaderRecordData) {
+    TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders. Use descriptor heaps.");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::shaderInt64);
+    vkt::DescriptorHeap::AddDescriptorHeapRequirements(*this);
+    RETURN_IF_SKIP(InitFrameworkWithPrintfBufferSize(1024 * 1024));
+    RETURN_IF_SKIP(InitState());
+
+    vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+
+    // Build Bottom Level Acceleration Structure
+    m_command_buffer.Begin();
+    blas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Build Top Level Acceleration Structure
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, *blas.GetDstAS());
+    m_command_buffer.Begin();
+    tlas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    VkDescriptorSetAndBindingMappingEXT mapping = vku::InitStructHelper();
+    mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_DATA_EXT;
+    mapping.sourceData.shaderRecordDataOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+    pipeline.AddCreateInfoFlags2(VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT);
+
+    const char* ray_gen = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform Buffer {
+            uvec2 tlas_addr;
+        };
+
+        layout(location = 0) rayPayloadEXT vec3 hit;
+
+        void main() {
+            vec3 ray_origin = vec3(0,0,-50);
+            vec3 ray_direction = vec3(0,0,1);
+            traceRayEXT(accelerationStructureEXT(tlas_addr), gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,-50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(accelerationStructureEXT(tlas_addr), gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(accelerationStructureEXT(tlas_addr), gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(accelerationStructureEXT(tlas_addr), gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,0);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(accelerationStructureEXT(tlas_addr), gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+        }
+    )glsl";
+    pipeline.SetGlslRayGenShader(ray_gen, nullptr, &mapping_info);
+
+    const char* miss = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform Buffer {
+            uvec2 tlas_addr;
+        };
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+
+        void main() {
+            hit = vec3(0.1, 0.2, 0.3);
+        }
+    )glsl";
+    pipeline.AddGlslMissShader(miss, nullptr, &mapping_info);
+
+    const char* closest_hit = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_ARB_gpu_shader_int64 : enable
+
+        layout(binding = 0, set = 0) uniform Buffer {
+            uint64_t tlas_addr;
+        };
+
+        layout(shaderRecordEXT) buffer sbt {
+            uvec3 sbt_vec;
+        };
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+        hitAttributeEXT vec2 baryCoord;
+
+        void main() {
+
+            debugPrintfEXT("In Closest Hit %ul", tlas_addr);
+            const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
+            hit = barycentricCoords;
+        }
+    )glsl";
+    pipeline.AddGlslClosestHitShader(closest_hit, nullptr, &mapping_info);
+    pipeline.SetShaderRecordSize(3 * sizeof(uint32_t));
+    pipeline.Build();
+
+    const VkDeviceAddress as_addr = tlas.GetDstAS()->GetAccelerationStructureDeviceAddress();
+    pipeline.UpdateRayGenShaderRecord(0, &as_addr, sizeof(as_addr));
+    pipeline.UpdateMissShaderRecord(0, &as_addr, sizeof(as_addr));
+    pipeline.UpdateHitShaderRecord(0, &as_addr, sizeof(as_addr));
+
+    constexpr uint32_t frames_count = 14;
+    const uint32_t ray_gen_width = 1;
+    const uint32_t ray_gen_height = 4;
+    const uint32_t ray_gen_depth = 1;
+    const uint32_t ray_gen_rays_count = ray_gen_width * ray_gen_height * ray_gen_depth;
+    char msg[512];
+    snprintf(msg, sizeof(msg), "In Closest Hit %" PRIx64 "", tlas.GetDstAS()->GetAccelerationStructureDeviceAddress());
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.Begin();
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline);
+        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+
+        vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
+                            &trace_rays_sbt.callable_sbt, ray_gen_width, ray_gen_height, ray_gen_depth);
+
+        m_command_buffer.End();
+        for (uint32_t i = 0; i < 2 * ray_gen_rays_count; ++i) {
+            m_errorMonitor->SetDesiredInfo(msg);
+        }
+
+        m_default_queue->SubmitAndWait(m_command_buffer);
+
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShaderDescriptorHeapShaderRecordAddress) {
+    TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders. Use descriptor heaps.");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::shaderInt64);
+    vkt::DescriptorHeap::AddDescriptorHeapRequirements(*this);
+    RETURN_IF_SKIP(InitFrameworkWithPrintfBufferSize(1024 * 1024));
+    RETURN_IF_SKIP(InitState());
+
+    vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+
+    // Build Bottom Level Acceleration Structure
+    m_command_buffer.Begin();
+    blas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Build Top Level Acceleration Structure
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, *blas.GetDstAS());
+    m_command_buffer.Begin();
+    tlas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    VkDescriptorSetAndBindingMappingEXT mapping = vku::InitStructHelper();
+    mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_SHADER_RECORD_ADDRESS_EXT;
+    mapping.sourceData.shaderRecordAddressOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+    pipeline.AddCreateInfoFlags2(VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT);
+
+    const char* ray_gen = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+
+        layout(location = 0) rayPayloadEXT vec3 hit;
+
+        void main() {
+            vec3 ray_origin = vec3(0,0,-50);
+            vec3 ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,-50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+
+            // Will miss
+            ray_origin = vec3(0,0,0);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+        }
+    )glsl";
+    pipeline.SetGlslRayGenShader(ray_gen, nullptr, &mapping_info);
+
+    const char* miss = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+
+        void main() {
+            hit = vec3(0.1, 0.2, 0.3);
+        }
+    )glsl";
+    pipeline.AddGlslMissShader(miss, nullptr, &mapping_info);
+
+    const char* closest_hit = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_ARB_gpu_shader_int64 : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+        hitAttributeEXT vec2 baryCoord;
+
+        void main() {
+
+            debugPrintfEXT("In Closest Hit");
+            const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
+            hit = barycentricCoords;
+        }
+    )glsl";
+    pipeline.AddGlslClosestHitShader(closest_hit, nullptr, &mapping_info);
+    pipeline.SetShaderRecordSize(3 * sizeof(uint32_t));
+    pipeline.Build();
+
+    const VkDeviceAddress as_addr = tlas.GetDstAS()->GetAccelerationStructureDeviceAddress();
+    pipeline.UpdateRayGenShaderRecord(0, &as_addr, sizeof(as_addr));
+    pipeline.UpdateMissShaderRecord(0, &as_addr, sizeof(as_addr));
+    pipeline.UpdateHitShaderRecord(0, &as_addr, sizeof(as_addr));
+
+    constexpr uint32_t frames_count = 14;
+    const uint32_t ray_gen_width = 1;
+    const uint32_t ray_gen_height = 4;
+    const uint32_t ray_gen_depth = 1;
+    const uint32_t ray_gen_rays_count = ray_gen_width * ray_gen_height * ray_gen_depth;
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.Begin();
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline);
+        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+
+        vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
+                            &trace_rays_sbt.callable_sbt, ray_gen_width, ray_gen_height, ray_gen_depth);
+
+        m_command_buffer.End();
+        for (uint32_t i = 0; i < 2 * ray_gen_rays_count; ++i) {
+            m_errorMonitor->SetDesiredInfo("In Closest Hit");
+        }
+
+        m_default_queue->SubmitAndWait(m_command_buffer);
+
+        m_errorMonitor->VerifyFound();
+    }
+}
+
 TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShaderShaderRecord) {
     TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders. Use shader records.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -334,8 +868,6 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShaderShad
     RETURN_IF_SKIP(InitFrameworkWithPrintfBufferSize(1024 * 1024));
     RETURN_IF_SKIP(InitState());
 
-    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
-    // implicitly depends on the default triangle position.
     vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
 
     // Build Bottom Level Acceleration Structure
@@ -527,8 +1059,6 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
 
     RETURN_IF_SKIP(InitState());
 
-    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
-    // implicitly depends on the default triangle position.
     vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
 
     // Build Bottom Level Acceleration Structure


### PR DESCRIPTION
Add the printf tests for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12398
I added a `vkt::DescriptorHeap`, for now only used in DebugPrintf. After inputs from @ziga-lunarg and @spencer-lunarg I will spread it wherever it is needed