### PR TITLE
layers: Fix WHOLE_SIZE for buffer ownership transfer

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2413,10 +2413,21 @@ void CoreChecks::RecordBarrierValidationInfo(const Location& barrier_loc, vvl::C
                                              const BufferBarrier& barrier,
                                              QFOTransferBarrierSets<QFOBufferTransferBarrier>& barrier_sets) {
     if (IsOwnershipTransfer(barrier)) {
+        BufferBarrier adjusted_barrier = barrier;
+        if (adjusted_barrier.size == VK_WHOLE_SIZE) {
+            if (auto buffer_state = Get<vvl::Buffer>(barrier.buffer)) {
+                if (buffer_state->GetSize() >= barrier.offset) {
+                    adjusted_barrier.size = buffer_state->GetSize() - barrier.offset;
+                } else {
+                    adjusted_barrier.size = 0;  // Invalid offset, should be reported elsewhere
+                }
+            }
+        }
+
         if (cb_state.IsReleaseOp(barrier) && !IsQueueFamilyExternal(barrier.dstQueueFamilyIndex)) {
-            barrier_sets.release.emplace(barrier);
+            barrier_sets.release.emplace(adjusted_barrier);
         } else if (cb_state.IsAcquireOp(barrier) && !IsQueueFamilyExternal(barrier.srcQueueFamilyIndex)) {
-            barrier_sets.acquire.emplace(barrier);
+            barrier_sets.acquire.emplace(adjusted_barrier);
         }
     }
 }

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -2892,3 +2892,53 @@ TEST_F(PositiveSyncObject, Maintenance9ImageBarriers) {
     m_command_buffer.Barrier(layout_transition);
     m_command_buffer.End();
 }
+
+TEST_F(PositiveSyncObject, BufferOwnershipTransferWholeSize) {
+    TEST_DESCRIPTION("Use VK_WHOLE_SIZE for release and an explicit size for acquire");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
+    if (!transfer_queue) {
+        GTEST_SKIP() << "Transfer-only queue is not present";
+    }
+    vkt::CommandPool release_pool(*m_device, transfer_queue->family_index);
+    vkt::CommandBuffer release_cb(*m_device, release_pool);
+    vkt::CommandBuffer acquire_cb(*m_device, m_command_pool);
+
+    const VkDeviceSize buffer_size = 256;
+    vkt::Buffer buffer(*m_device, buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    // Release with VK_WHOLE_SIZE
+    VkBufferMemoryBarrier2 release_barrier = vku::InitStructHelper();
+    release_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    release_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    release_barrier.srcQueueFamilyIndex = transfer_queue->family_index;
+    release_barrier.dstQueueFamilyIndex = m_default_queue->family_index;
+    release_barrier.buffer = buffer;
+    release_barrier.size = VK_WHOLE_SIZE;
+
+    release_cb.Begin();
+    release_cb.Barrier(release_barrier);
+    release_cb.End();
+
+    // Acquire with an explicit size
+    VkBufferMemoryBarrier2 acquire_barrier = vku::InitStructHelper();
+    acquire_barrier.dstStageMask = VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR;
+    acquire_barrier.dstAccessMask = VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT;
+    acquire_barrier.srcQueueFamilyIndex = transfer_queue->family_index;
+    acquire_barrier.dstQueueFamilyIndex = m_default_queue->family_index;
+    acquire_barrier.buffer = buffer;
+    acquire_barrier.size = buffer_size;
+
+    acquire_cb.Begin();
+    acquire_cb.Barrier(acquire_barrier);
+    acquire_cb.End();
+
+    // Test for regression when VK_WHOLE_SIZE is not normalized
+    vkt::Semaphore semaphore(*m_device);
+    transfer_queue->Submit2(release_cb, vkt::Signal(semaphore));
+    m_default_queue->Submit2(acquire_cb, vkt::Wait(semaphore));
+    m_device->Wait();
+}


### PR DESCRIPTION
The `RecordBarrierValidationInfo` overload for images normalizes subresource ranges. This fix does symmetric change for buffers with regard to `VK_WHOLE_SIZE`.

Related to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4903
