### PR TITLE
layers: Fix QFOT validation with timeline semaphores

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -39,8 +39,6 @@
 struct CommandBufferSubmitState {
     const CoreChecks& core;
     const vvl::Queue& queue_state;
-    QFOTransferCBScoreboards<QFOImageTransferBarrier> qfo_image_scoreboards;
-    QFOTransferCBScoreboards<QFOBufferTransferBarrier> qfo_buffer_scoreboards;
     std::vector<VkCommandBuffer> current_cmds;
     std::vector<std::string> cmdbuf_label_stack;
     std::string last_closed_cmdbuf_label;
@@ -65,8 +63,7 @@ struct CommandBufferSubmitState {
         const VkCommandBuffer cmd = cb_state.VkHandle();
         current_cmds.push_back(cmd);
         skip |= core.ValidatePrimaryCommandBufferState(
-            loc, cb_state, static_cast<uint32_t>(std::count(current_cmds.begin(), current_cmds.end(), cmd)), &qfo_image_scoreboards,
-            &qfo_buffer_scoreboards);
+            loc, cb_state, static_cast<uint32_t>(std::count(current_cmds.begin(), current_cmds.end(), cmd)));
         skip |= core.ValidateQueueFamilyIndices(loc, cb_state, queue_state);
         skip |= ValidateCmdBufLabelMatching(loc, cb_state);
 
@@ -470,56 +467,6 @@ bool CoreChecks::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount
     return ValidateQueueSubmit2(queue, submitCount, pSubmits, fence, error_obj);
 }
 
-void CoreChecks::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
-                                           const RecordObject& record_obj) {
-    if (record_obj.result != VK_SUCCESS) {
-        return;
-    }
-    // The triply nested for duplicates that in the StateTracker, but avoids the need for two additional callbacks.
-    for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        const VkSubmitInfo& submit = pSubmits[submit_idx];
-        for (uint32_t i = 0; i < submit.commandBufferCount; i++) {
-            auto cb_state = GetWrite<vvl::CommandBuffer>(submit.pCommandBuffers[i]);
-            ASSERT_AND_CONTINUE(cb_state);
-
-            for (auto* secondary_cmd_buffer : cb_state->linked_command_buffers) {
-                RecordQueuedQFOTransfers(*secondary_cmd_buffer);
-            }
-            RecordQueuedQFOTransfers(*cb_state);
-        }
-    }
-}
-
-void CoreChecks::RecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                    const RecordObject& record_obj) {
-    if (record_obj.result != VK_SUCCESS) {
-        return;
-    }
-    // The triply nested for duplicates that in the StateTracker, but avoids the need for two additional callbacks.
-    for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        const VkSubmitInfo2& submit = pSubmits[submit_idx];
-        for (uint32_t i = 0; i < submit.commandBufferInfoCount; i++) {
-            auto cb_state = GetWrite<vvl::CommandBuffer>(submit.pCommandBufferInfos[i].commandBuffer);
-            ASSERT_AND_CONTINUE(cb_state);
-
-            for (auto* secondary_cmd_buffer : cb_state->linked_command_buffers) {
-                RecordQueuedQFOTransfers(*secondary_cmd_buffer);
-            }
-            RecordQueuedQFOTransfers(*cb_state);
-        }
-    }
-}
-
-void CoreChecks::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                               const RecordObject& record_obj) {
-    PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
-}
-
-void CoreChecks::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                            const RecordObject& record_obj) {
-    RecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
-}
-
 // Check that the queue family index of 'queue' matches one of the entries in pQueueFamilyIndices
 bool CoreChecks::ValidImageBufferQueue(const vvl::CommandBuffer& cb_state, const VulkanTypedHandle& object,
                                        uint32_t queueFamilyIndex, uint32_t count, const uint32_t* indices,
@@ -644,10 +591,8 @@ bool CoreChecks::ValidateCommandBufferSimultaneousUse(const Location& loc, const
     return skip;
 }
 
-bool CoreChecks::ValidatePrimaryCommandBufferState(
-    const Location& loc, const vvl::CommandBuffer& cb_state, uint32_t current_submit_count,
-    QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
-    QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const {
+bool CoreChecks::ValidatePrimaryCommandBufferState(const Location& loc, const vvl::CommandBuffer& cb_state,
+                                                   uint32_t current_submit_count) const {
     // Track in-use for resources off of primary and any secondary CBs
     bool skip = false;
 
@@ -657,7 +602,6 @@ bool CoreChecks::ValidatePrimaryCommandBufferState(
                          FormatHandle(cb_state).c_str());
     } else {
         for (const auto* sub_cb : cb_state.linked_command_buffers) {
-            skip |= ValidateQueuedQFOTransfers(*sub_cb, qfo_image_scoreboards, qfo_buffer_scoreboards, loc);
             // TODO: replace with InvalidateCommandBuffers() at recording.
             if ((sub_cb->primary_command_buffer != cb_state.VkHandle()) &&
                 !(sub_cb->begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
@@ -684,8 +628,6 @@ bool CoreChecks::ValidatePrimaryCommandBufferState(
 
     // If USAGE_SIMULTANEOUS_USE_BIT not set then CB cannot already be executing on device
     skip |= ValidateCommandBufferSimultaneousUse(loc, cb_state, current_submit_count);
-
-    skip |= ValidateQueuedQFOTransfers(cb_state, qfo_image_scoreboards, qfo_buffer_scoreboards, loc);
 
     const char* const vuid = (loc.function == Func::vkQueueSubmit) ? "VUID-vkQueueSubmit-pCommandBuffers-00070"
                                                                    : "VUID-vkQueueSubmit2-commandBuffer-03874";
@@ -830,14 +772,26 @@ bool CoreChecks::ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
                      FormatHandle(semaphore).c_str(), signal_value, *current_value);
         }
     }
+    // Queue family ownership transfer (QFOT) validation
+    for (const auto& cb : command_buffers) {
+        if (cb) {
+            auto cb_guard = cb->ReadLock();
+            for (const vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
+                skip |= ValidateQueuedQFOTransfers(*secondary, submit_loc);
+            }
+            skip |= ValidateQueuedQFOTransfers(*cb, submit_loc);
+        }
+    }
     if (!skip) {
         for (const auto& cb : command_buffers) {
             if (cb) {
                 auto cb_guard = cb->WriteLock();
-                for (const vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
+                for (vvl::CommandBuffer* secondary : cb->linked_command_buffers) {
                     UpdateCmdBufImageLayouts(*secondary);
+                    RecordQueuedQFOTransfers(*secondary);
                 }
                 UpdateCmdBufImageLayouts(*cb);
+                RecordQueuedQFOTransfers(*cb);
             }
         }
     }

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2449,7 +2449,6 @@ void CoreChecks::RecordBarrierValidationInfo(const Location& barrier_loc, vvl::C
 
 template <typename TransferBarrier>
 bool CoreChecks::ValidateQueuedQFOTransferBarriers(const core::CommandBufferSubState& cb_sub_state,
-                                                   QFOTransferCBScoreboards<TransferBarrier>* scoreboards,
                                                    const GlobalQFOTransferBarrierMap<TransferBarrier>& global_release_barriers,
                                                    const Location& loc) const {
     bool skip = false;
@@ -2476,16 +2475,11 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(const core::CommandBufferSubS
     return skip;
 }
 
-bool CoreChecks::ValidateQueuedQFOTransfers(const vvl::CommandBuffer& cb_state,
-                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
-                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards,
-                                            const Location& loc) const {
+bool CoreChecks::ValidateQueuedQFOTransfers(const vvl::CommandBuffer& cb_state, const Location& loc) const {
     bool skip = false;
     auto& cb_sub_state = core::SubState(cb_state);
-    skip |= ValidateQueuedQFOTransferBarriers<QFOImageTransferBarrier>(cb_sub_state, qfo_image_scoreboards,
-                                                                       qfo_release_image_barrier_map, loc);
-    skip |= ValidateQueuedQFOTransferBarriers<QFOBufferTransferBarrier>(cb_sub_state, qfo_buffer_scoreboards,
-                                                                        qfo_release_buffer_barrier_map, loc);
+    skip |= ValidateQueuedQFOTransferBarriers<QFOImageTransferBarrier>(cb_sub_state, qfo_release_image_barrier_map, loc);
+    skip |= ValidateQueuedQFOTransferBarriers<QFOBufferTransferBarrier>(cb_sub_state, qfo_release_buffer_barrier_map, loc);
     return skip;
 }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -697,22 +697,17 @@ class CoreChecks : public vvl::DeviceProxy {
 
     template <typename TransferBarrier>
     bool ValidateQueuedQFOTransferBarriers(const core::CommandBufferSubState& cb_sub_state,
-                                           QFOTransferCBScoreboards<TransferBarrier>* scoreboards,
                                            const GlobalQFOTransferBarrierMap<TransferBarrier>& global_release_barriers,
                                            const Location& loc) const;
-    bool ValidateQueuedQFOTransfers(const vvl::CommandBuffer& cb_state,
-                                    QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
-                                    QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards,
-                                    const Location& loc) const;
+    bool ValidateQueuedQFOTransfers(const vvl::CommandBuffer& cb_state, const Location& loc) const;
 
     void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const BufferBarrier& barrier,
                                      QFOTransferBarrierSets<QFOBufferTransferBarrier>& barrier_sets);
     void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
                                      const vvl::Image& image_state, QFOTransferBarrierSets<QFOImageTransferBarrier>& barrier_sets);
 
-    bool ValidatePrimaryCommandBufferState(const Location& loc, const vvl::CommandBuffer& cb_state, uint32_t current_submit_count,
-                                           QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
-                                           QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const;
+    bool ValidatePrimaryCommandBufferState(const Location& loc, const vvl::CommandBuffer& cb_state,
+                                           uint32_t current_submit_count) const;
     bool ValidateDrawPipelineRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                         const vvl::RenderPass& rp_state, const Location& loc) const;
     bool ValidateDrawPipelineDynamicRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
@@ -1574,8 +1569,6 @@ class CoreChecks : public vvl::DeviceProxy {
                                     const RecordObject& record_obj) override;
     bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                     const ErrorObject& error_obj) const override;
-    void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
-                                   const RecordObject& record_obj) override;
     bool ValidateRenderPassStripeSubmitInfo(VkQueue queue, const vvl::CommandBuffer& cb_state, const void* pNext,
                                             const Location& loc) const;
     bool ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
@@ -1584,12 +1577,6 @@ class CoreChecks : public vvl::DeviceProxy {
                                         const ErrorObject& error_obj) const override;
     bool PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                      const ErrorObject& error_obj) const override;
-    void RecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                            const RecordObject& record_obj);
-    void PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence,
-                                       const RecordObject& record_obj) override;
-    void PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                    const RecordObject& record_obj) override;
     bool ProcessSubmissionBatch(const vvl::SubmitTimeTracker& tracker,
                                 const std::vector<std::shared_ptr<vvl::CommandBuffer>>& command_buffers,
                                 vvl::span<const VkSemaphoreSubmitInfo> signal_semaphores, const Location& submit_loc) override;

--- a/layers/utils/sync_utils.h
+++ b/layers/utils/sync_utils.h
@@ -273,17 +273,6 @@ template <typename TransferBarrier>
 using GlobalQFOTransferBarrierMap =
     vvl::concurrent_unordered_map<typename TransferBarrier::HandleType, QFOTransferBarrierSet<TransferBarrier>>;
 
-// Submit queue uses the Scoreboard to track all release/acquire operations in a batch.
-template <typename TransferBarrier>
-using QFOTransferCBScoreboard =
-    vvl::unordered_map<TransferBarrier, const vvl::CommandBuffer*, QFOTransferBarrierHash<TransferBarrier>>;
-
-template <typename TransferBarrier>
-struct QFOTransferCBScoreboards {
-    QFOTransferCBScoreboard<TransferBarrier> acquire;
-    QFOTransferCBScoreboard<TransferBarrier> release;
-};
-
 namespace sync_utils {
 VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures& features, const DeviceExtensions& device_extensions);
 VkAccessFlags2 DisabledAccesses(const DeviceExtensions& device_extensions);

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -2942,3 +2942,54 @@ TEST_F(PositiveSyncObject, BufferOwnershipTransferWholeSize) {
     m_default_queue->Submit2(acquire_cb, vkt::Wait(semaphore));
     m_device->Wait();
 }
+
+TEST_F(PositiveSyncObject, BufferOwnershipTransferTimelineReordering) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4903#issuecomment-4587980554");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
+    if (!transfer_queue) {
+        GTEST_SKIP() << "Transfer-only queue is not present";
+    }
+    vkt::CommandPool release_pool(*m_device, transfer_queue->family_index);
+    vkt::CommandBuffer release_cb(*m_device, release_pool);
+    vkt::CommandBuffer acquire_cb(*m_device, m_command_pool);
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+    // Release on the transfer queue
+    VkBufferMemoryBarrier2 release_barrier = vku::InitStructHelper();
+    release_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    release_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    release_barrier.srcQueueFamilyIndex = transfer_queue->family_index;
+    release_barrier.dstQueueFamilyIndex = m_default_queue->family_index;
+    release_barrier.buffer = buffer;
+    release_barrier.size = 256;
+
+    release_cb.Begin();
+    release_cb.Barrier(release_barrier);
+    release_cb.End();
+
+    // Acquire on the default queue
+    VkBufferMemoryBarrier2 acquire_barrier = vku::InitStructHelper();
+    acquire_barrier.dstStageMask = VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT_KHR;
+    acquire_barrier.dstAccessMask = VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT;
+    acquire_barrier.srcQueueFamilyIndex = transfer_queue->family_index;
+    acquire_barrier.dstQueueFamilyIndex = m_default_queue->family_index;
+    acquire_barrier.buffer = buffer;
+    acquire_barrier.size = 256;
+
+    acquire_cb.Begin();
+    acquire_cb.Barrier(acquire_barrier);
+    acquire_cb.End();
+
+    vkt::Semaphore timeline(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+
+    // Test that QFOT validation with wait-before-signal submission works correctly
+    m_default_queue->Submit2(acquire_cb, vkt::TimelineWait(timeline, 1));
+    transfer_queue->Submit2(release_cb, vkt::TimelineSignal(timeline, 1));
+    m_device->Wait();
+}


### PR DESCRIPTION
This is a standard (boring) fix of submit time validation. Submit time validation can't be done correctly during QueueSubmit calls due to reordering of submits by wait-before-signal synchronization (timeline semaphores).

We have a dedicated tool for this: SubmitTimeTracker. It waits until submission order is fully resolved and only then does validation.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4903 
(addresses [comment from @](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4903#issuecomment-4587980554) but not the original reason why the issue was opened, https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4903#issuecomment-4802787959 explains why)