### PR TITLE
layers: Fix VK_FORMAT_E5B9G9R9_UFLOAT_PACK32

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1199,12 +1199,14 @@ bool CoreChecks::ValidateDrawDynamicStateValue(const LastBound& last_bound_state
             if (attachment && attachment->create_info.format == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32) {
                 const uint32_t color_index = attachment_info.type_index;
                 const auto color_write_mask = cb_state.dynamic_state_value.color_write_masks[color_index];
-                VkColorComponentFlags rgb = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
-                if ((color_write_mask & rgb) != rgb && (color_write_mask & rgb) != 0) {
+                const VkColorComponentFlags rgba =
+                    VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+                if ((color_write_mask & rgba) != rgba && (color_write_mask & rgba) != 0) {
                     skip |= LogError(
                         CreateActionVuid(loc.function, vvl::ActionVUID::COLOR_WRITE_MASK_09116), cb_state.Handle(), loc,
                         "%s has format VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, but vkCmdSetColorWriteMaskEXT::pColorWriteMasks[%" PRIu32
-                        "] is %s.",
+                        "] is %s\nThe 999E5 format is special as it overlaps the traditional 8-bit boundary and has no real alpha "
+                        "channel. When updating, the driver needs the full RGBA mask in order to properly handle this format.",
                         attachment_info.Describe(cb_state, i).c_str(), color_index,
                         string_VkColorComponentFlags(color_write_mask).c_str());
                 }

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1373,12 +1373,15 @@ bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline& pipeli
         if (attachment_desc.format == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 &&
             !pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT)) {
             const VkColorComponentFlags& color_write_mask = pipeline.AttachmentStates()[i].colorWriteMask;
-            VkColorComponentFlags rgb = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
-            if ((color_write_mask & rgb) != rgb && (color_write_mask & rgb) != 0) {
+            const VkColorComponentFlags rgba =
+                VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+            if ((color_write_mask & rgba) != rgba && (color_write_mask & rgba) != 0) {
                 skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-None-09043", device, create_info_loc.dot(Field::renderPass),
                                  "was created with pAttachments[%" PRIu32
                                  "].format of VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, but pColorBlendState->pAttachments[%" PRIu32
-                                 "].colorWriteMask is %s.",
+                                 "].colorWriteMask is %s.\nThe 999E5 format is special as it overlaps the traditional 8-bit "
+                                 "boundary and has no real alpha channel. When updating, the driver needs the full RGBA mask in "
+                                 "order to properly handle this format.",
                                  attachment, i, string_VkColorComponentFlags(color_write_mask).c_str());
             }
         }
@@ -3321,14 +3324,17 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline& p
 
                 if (color_format == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 &&
                     !pipeline.IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT)) {
-                    VkColorComponentFlags rgb = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
-                    if ((color_blend_attachment.colorWriteMask & rgb) != rgb &&
-                        (color_blend_attachment.colorWriteMask & rgb) != 0) {
+                    const VkColorComponentFlags rgba =
+                        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+                    if ((color_blend_attachment.colorWriteMask & rgba) != rgba &&
+                        (color_blend_attachment.colorWriteMask & rgba) != 0) {
                         skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-None-09043", device,
                                          create_info_loc.pNext(Struct::VkPipelineRenderingCreateInfo,
                                                                Field::pColorAttachmentFormats, color_index),
                                          "is VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, but pColorBlendState->pAttachments[%" PRIu32
-                                         "].colorWriteMask is %s.",
+                                         "].colorWriteMask is %s.\nThe 999E5 format is special as it overlaps the traditional "
+                                         "8-bit boundary and has no real alpha channel. When updating, the driver needs the full "
+                                         "RGBA mask in order to properly handle this format.",
                                          color_index, string_VkColorComponentFlags(color_blend_attachment.colorWriteMask).c_str());
                     }
                 }

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -183,12 +183,7 @@ TEST_F(NegativePipeline, ColorWriteMaskE5B9G9R9) {
 
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = rp;
-    pipe.cb_attachments_.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_A_BIT;
-    m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-None-09043");
-    pipe.CreateGraphicsPipeline();
-    m_errorMonitor->VerifyFound();
-
-    pipe.cb_attachments_.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT;
+    pipe.cb_attachments_.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-None-09043");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -1895,18 +1895,6 @@ TEST_F(PositivePipeline, ColorWriteMaskE5B9G9R9) {
 
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = rp;
-    pipe.cb_attachments_.colorWriteMask = VK_COLOR_COMPONENT_A_BIT;
-    {
-        pipe.CreateGraphicsPipeline();
-        pipe.Destroy();
-    }
-
-    pipe.cb_attachments_.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
-    {
-        pipe.CreateGraphicsPipeline();
-        pipe.Destroy();
-    }
-
     pipe.cb_attachments_.colorWriteMask =
         VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
     {

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -4974,8 +4974,8 @@ TEST_F(NegativeShaderObject, InvalidColorWriteMask) {
     m_command_buffer.BeginRenderingColor(image_view, GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindShaders(m_vert_shader, m_frag_shader);
-    VkColorComponentFlags colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-    vk::CmdSetColorWriteMaskEXT(m_command_buffer, 0u, 1u, &colorWriteMask);
+    VkColorComponentFlags rgb_mask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
+    vk::CmdSetColorWriteMaskEXT(m_command_buffer, 0u, 1u, &rgb_mask);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09116");
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);


### PR DESCRIPTION
Updated in the 355 headers - from https://gitlab.khronos.org/vulkan/vulkan/-/issues/4758