### PR TITLE
dump: Use GetActionDescriptorMode

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor.cpp
@@ -22,7 +22,7 @@
 namespace gpudump {
 
 void CommandBufferSubState::DumpDescriptors(const LastBound& last_bound, const Location& loc) const {
-    vvl::DescriptorMode descriptor_mode = last_bound.GetDescriptorMode();
+    vvl::DescriptorMode descriptor_mode = last_bound.GetActionDescriptorMode();
     if (descriptor_mode != vvl::DescriptorModeBuffer && descriptor_mode != vvl::DescriptorModeHeap) {
         return;
     }

--- a/layers/state_tracker/last_bound_state.h
+++ b/layers/state_tracker/last_bound_state.h
@@ -169,6 +169,8 @@ struct LastBound {
 
     // Since GPU-AV uses this to access an array, force a getter to ensure people use this correctly.
     vvl::DescriptorMode GetActionDescriptorMode() const;
+    // Will be Unknown if shader is not using any descriptor
+    // GetActionDescriptorMode() will check the bound pipeline/shaders if Unknown
     vvl::DescriptorMode GetDescriptorMode() const { return descriptor_mode; };
     void SetDescriptorMode(vvl::DescriptorMode new_mode, vvl::Func function) {
         previous_descriptor_mode = descriptor_mode;


### PR DESCRIPTION
Found GPU Dump was not working with `NegativeDebugPrintfRayTracing.RaygenOneMissShaderOneClosestHitShaderDescriptorHeapShaderRecordData` and it was because the `DescriptorMode` logic is crazy needing to handle all the ways you can set (or not set) things

cc @arno-lunarg 