### PR TITLE
dump: Fix when different types share same descriptor

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
@@ -158,8 +158,7 @@ bool BindingInfo::ValidateDescriptor(std::ostringstream& ss, GpuDump& dev_data) 
         }
     }
 
-    const vvlDescriptorType found_type = (vvlDescriptorType)it->second.type;
-    if (found_type != GetMaskFromDescriptorType(type)) {
+    if ((it->second.types & (1 << (uint8_t)GetMaskFromDescriptorType(type))) == 0) {
         ss << "      - [WARNING] WRONG DESCRIPTOR - expected a " << string_VkDescriptorType(type)
            << " descriptor, but instead found a descriptor for: " << descriptor_hash.Describe(*dev_data.device_state, key) << "\n";
         return true;

--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -484,8 +484,7 @@ std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address) {
         }
     }
 
-    const vvlDescriptorType found_type = (vvlDescriptorType)it->second.type;
-    if (found_type != GetMaskFromDescriptorType(dump.descriptor_type)) {
+    if ((it->second.types & (1 << (uint8_t)GetMaskFromDescriptorType(dump.descriptor_type))) == 0) {
         ss << new_bullet_line << "[WARNING] WRONG DESCRIPTOR - At 0x" << std::hex << address << " expected a "
            << string_VkDescriptorType(dump.descriptor_type)
            << " descriptor, but instead found a descriptor for: " << descriptor_hash.Describe(*dump.dev_data.device_state, key);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -7084,9 +7084,23 @@ std::string DeviceState::DescriptorHash::Describe(const DeviceState& device_stat
         return "[Bad Key]";
     }
 
-    const vvlDescriptorType vvl_type = (vvlDescriptorType)it->second.type;
-    const VkDescriptorType vk_type = GetDescriptorTypeFromMask(vvl_type);
-    ss << string_VkDescriptorType(vk_type);
+    vvlDescriptorType vvl_type = vvlDescriptorType::Invalid;
+
+    bool first = true;
+    // Loop all possible vvlDescriptorType (as might be multiple types)
+    for (uint8_t i = 0; i < vvlDescriptorMaxBit; i++) {
+        if (it->second.types & (1 << i)) {
+            // ok to set the second time (if more than one type)
+            // as they should be in the same group below
+            vvl_type = static_cast<vvlDescriptorType>(i);
+            VkDescriptorType vk_type = GetDescriptorTypeFromMask(vvl_type);
+            if (!first) {
+                ss << " | ";
+            }
+            ss << string_VkDescriptorType(vk_type);
+            first = false;
+        }
+    }
 
     auto list_buffers = [&device_state, &ss](VkDeviceAddress address) {
         auto buffer_states = device_state.GetBuffersByAddress(address);
@@ -7143,6 +7157,7 @@ std::string DeviceState::DescriptorHash::Describe(const DeviceState& device_stat
             break;
         }
         case vvlDescriptorType::CombinedSampler:
+        case vvlDescriptorType::Invalid:
             assert(false);  // this should not be hit
             break;
     }
@@ -7175,6 +7190,16 @@ void DeviceState::PostCallRecordWriteResourceDescriptorsEXT(VkDevice device, uin
                 descriptor_hash.debug_names.emplace(key, debug_info->pObjectName);
             }
         }
+
+        // It is possible that 2 descriptor of different types create the same descriptor
+        // Since we don't add null descriptors, should just skip those
+        // (Note - should only need to do for same "group" of descriptors
+        auto search_it = descriptor_hash.map.find(key);
+        if (search_it != descriptor_hash.map.end()) {
+            search_it->second.types |= 1 << vvl_type;
+            continue;
+        }
+
         switch (resource.type) {
             case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
             case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER: {
@@ -7280,6 +7305,14 @@ void DeviceState::PostCallRecordGetDescriptorEXT(VkDevice device, const VkDescri
         if (debug_info->pObjectName) {
             descriptor_hash.debug_names.emplace(key, debug_info->pObjectName);
         }
+    }
+
+    // It is possible that 2 descriptor of different types create the same descriptor
+    // Since we don't add null descriptors, should just skip those
+    auto search_it = descriptor_hash.map.find(key);
+    if (search_it != descriptor_hash.map.end()) {
+        search_it->second.types |= 1 << vvl_type;
+        return;
     }
 
     switch (vk_type) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -2246,7 +2246,12 @@ class DeviceState : public vvl::BaseDevice {
         };
         struct EntrySampler {};
         struct Entry {
-            uint8_t type;  // vvlDescriptorType
+            // It is possible two different types are the same descriptor hash, so need a bit mask here
+            // each type is applied here as
+            //    1 << vvlDescriptorType
+            // Will be updated if a second type is found
+            uint32_t types;
+
             union Data {
                 EntryBuffer buffer;
                 EntryTexelBuffer texel_buffer;
@@ -2261,11 +2266,12 @@ class DeviceState : public vvl::BaseDevice {
                 explicit Data(EntrySampler s) : sampler(s) {}
             } data;
 
-            Entry(uint8_t t, EntryBuffer b) : type(t), data(b) {}
-            Entry(uint8_t t, EntryTexelBuffer j) : type(t), data(j) {}
-            Entry(uint8_t t, EntryAS a) : type(t), data(a) {}
-            Entry(uint8_t t, EntryImage i) : type(t), data(i) {}
-            Entry(uint8_t t, EntrySampler s) : type(t), data(s) {}
+            // Pass in vvlDescriptorType
+            Entry(uint8_t t, EntryBuffer b) : types(1 << t), data(b) {}
+            Entry(uint8_t t, EntryTexelBuffer j) : types(1 << t), data(j) {}
+            Entry(uint8_t t, EntryAS a) : types(1 << t), data(a) {}
+            Entry(uint8_t t, EntryImage i) : types(1 << t), data(i) {}
+            Entry(uint8_t t, EntrySampler s) : types(1 << t), data(s) {}
         };
         vvl::unordered_map<uint64_t, Entry> map;
         // Users can pass in VkDebugUtilsObjectNameInfoEXT when getting the descriptor to provide a name

--- a/layers/utils/descriptor_utils.h
+++ b/layers/utils/descriptor_utils.h
@@ -124,10 +124,13 @@ enum class vvlDescriptorType : uint8_t {
     ImageTexelBufferUniform = 0xA,  // VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
     ImageTexelBufferStorage = 0xB,  // VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER
     ImageInputAttachment = 0xC,     // VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT
+
+    Invalid = 0xFF
 };
 
 inline constexpr uint8_t vvlDescriptorBufferMask = 0x2;
 inline constexpr uint8_t vvlDescriptorImageMask = 0x8;
+inline constexpr uint8_t vvlDescriptorMaxBit = 12;  // 0xC
 
 constexpr VkDescriptorType GetDescriptorTypeFromMask(vvlDescriptorType vvl_type) noexcept {
     switch (vvl_type) {
@@ -150,6 +153,8 @@ constexpr VkDescriptorType GetDescriptorTypeFromMask(vvlDescriptorType vvl_type)
             return VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
         case vvlDescriptorType::ImageInputAttachment:
             return VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+        case vvlDescriptorType::Invalid:
+            assert(false);
     }
     assert(false && "Invalid compressed descriptor type mask");
     return VK_DESCRIPTOR_TYPE_MAX_ENUM;

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -12,6 +12,7 @@
 #include <spirv-tools/libspirv.h>
 #include <vulkan/vulkan_core.h>
 #include <cstdint>
+#include <cstring>
 #include "../framework/layer_validation_tests.h"
 #include "descriptor_helper.h"
 #include "generated/vk_function_pointers.h"
@@ -2000,6 +2001,89 @@ TEST_F(NegativeGpuDump, DescriptorHeapWrongDescriptorDebugNames) {
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     m_errorMonitor->SetDesiredWarning("[My Sampler]");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeGpuDump, DescriptorHeapHashConflict) {
+    static const VkLayerSettingEXT layer_settings[2] = {
+        {OBJECT_LAYER_NAME, "gpu_dump_descriptors", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+    };
+    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2, layer_settings};
+    RETURN_IF_SKIP(InitDescriptorHeap(&layer_setting_ci));
+
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
+    // storage image and sampled image might be the exact same descriptor
+    uint8_t storage_descriptor[256];
+    uint8_t sampled_descriptor[256];
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
+    VkImageViewCreateInfo view_info = image.BasicViewCreatInfo(VK_IMAGE_ASPECT_COLOR_BIT);
+    VkHostAddressRangeEXT resource_host{storage_descriptor, heap_props.imageDescriptorSize};
+    VkImageDescriptorInfoEXT image_info = vku::InitStructHelper();
+    image_info.pView = &view_info;
+    image_info.layout = VK_IMAGE_LAYOUT_GENERAL;
+    VkResourceDescriptorInfoEXT descriptor_info = vku::InitStructHelper();
+    descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    descriptor_info.data.pImage = &image_info;
+    vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &resource_host);
+    resource_host.address = sampled_descriptor;
+    descriptor_info.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &resource_host);
+
+    if (memcmp(storage_descriptor, sampled_descriptor, heap_props.bufferDescriptorSize) != 0) {
+        GTEST_SKIP() << "UBO and SSBO are different descriptors";
+    }
+
+    vkt::Buffer resource_heap(*m_device, 1024, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+    void* heap_data = resource_heap.Memory().Map();
+    memcpy(heap_data, storage_descriptor, heap_props.bufferDescriptorSize);
+
+    vkt::Buffer sampler_heap(*m_device, 1024, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
+    heap_data = sampler_heap.Memory().Map();
+    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
+    VkHostAddressRangeEXT sampler_host{heap_data, heap_props.samplerDescriptorSize};
+    vk::WriteSamplerDescriptorsEXT(*m_device, 1u, &sampler_info, &sampler_host);
+
+    VkDescriptorSetAndBindingMappingEXT mappings[3];
+    mappings[0] = MakeSetAndBindingMapping(0, 0);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[1] = MakeSetAndBindingMapping(0, 1);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset.heapOffset = 0;
+    mappings[2] = MakeSetAndBindingMapping(0, 2);
+    mappings[2].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[2].sourceData.constantOffset.heapOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 3;
+    mapping_info.pMappings = mappings;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 2) uniform sampler s;
+        layout(set = 0, binding = 0) uniform texture2D sampledImage;
+        layout(set = 0, binding = 1, rgba8) uniform image2D storageImage;
+        void main(){
+            vec4 color = texture(sampler2D(sampledImage, s), vec2(0));
+            imageStore(storageImage, ivec2(1), color);
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange = resource_heap.AddressRange();
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+    bind_resource_info.heapRange = sampler_heap.AddressRange();
+    vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_resource_info);
+
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredInfo("GPU-DUMP");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();


### PR DESCRIPTION
Found some `VkDescriptorType` will generate the same descriptor blob such that we were giving a false positive (see new test) when they happened to be the same