### PR TITLE
layers: Add tile properties core checks

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -797,7 +797,8 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const core::RenderingAttachment& vvl_attachment) const {
+bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuffer& cb_state,
+                                                          const core::RenderingAttachment& vvl_attachment) const {
     bool skip = false;
     if (disabled[image_layout_validation]) {
         return skip;
@@ -812,7 +813,7 @@ bool CoreChecks::ValidateRenderingAttachmentCurrentLayout(const core::RenderingA
             continue;
         }
         const vvl::Image& image_state = *image_view_state->image_state;
-        const auto image_layout_map = vvl_attachment.cb_state.GetImageLayoutMap(image_state.VkHandle());
+        const auto image_layout_map = cb_state.GetImageLayoutMap(image_state.VkHandle());
         if (!image_layout_map) {
             continue;
         };

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -653,7 +653,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
             layer_or_view_count = fb_state->create_info.layers;
         }
 
-        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(commandBuffer, *counters_begin_info, objlist,
+        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(objlist, *counters_begin_info,
                                                                        rp_state->create_info.subpassCount, layer_or_view_count,
                                                                        pRenderPassBegin->renderArea, rp_begin_loc);
     }
@@ -694,9 +694,8 @@ bool CoreChecks::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffe
 }
 
 bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(
-    VkCommandBuffer commandBuffer, const VkRenderPassPerformanceCountersByRegionBeginInfoARM& counters_begin_info,
-    const LogObjectList& objlist, uint32_t subpass_count, uint32_t layer_or_view_count, VkRect2D render_area,
-    const Location& begin_loc) const {
+    const LogObjectList& objlist, const VkRenderPassPerformanceCountersByRegionBeginInfoARM& counters_begin_info,
+    uint32_t subpass_count, uint32_t layer_or_view_count, VkRect2D render_area, const Location& begin_loc) const {
     bool skip = false;
 
     if (counters_begin_info.counterAddressCount != subpass_count * layer_or_view_count) {
@@ -724,7 +723,7 @@ bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(
 
         for (auto& buffer_state : buffer_states) {
             skip |= ValidateMemoryIsBoundToBuffer(
-                commandBuffer, *buffer_state,
+                objlist, *buffer_state,
                 begin_loc.pNext(Struct::VkRenderPassPerformanceCountersByRegionBeginInfoARM, Field::pCounterAddresses),
                 "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11816");
         }
@@ -3063,7 +3062,7 @@ bool CoreChecks::ValidateRenderingInfoAttachment(const vvl::ImageView& image_vie
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+bool CoreChecks::ValidateRenderingAttachmentInfo(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
                                                  const VkRenderingAttachmentInfo& attachment_info,
                                                  const Location& attachment_loc) const {
     bool skip = false;
@@ -3076,22 +3075,24 @@ bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, 
 
     const auto image_view_state = Get<vvl::ImageView>(attachment_info.imageView);
     ASSERT_AND_RETURN_SKIP(image_view_state);
-    skip |= ValidateRenderingAttachmentInfoResolveMode(commandBuffer, rendering_info, attachment_info, *image_view_state,
+    skip |= ValidateRenderingAttachmentInfoResolveMode(objlist, rendering_info, attachment_info, *image_view_state,
                                                        attachment_loc);
-    skip |= ValidateRenderingAttachmentInfoMultisampledResolveMode(commandBuffer, rendering_info, attachment_info,
+    skip |= ValidateRenderingAttachmentInfoMultisampledResolveMode(objlist, rendering_info, attachment_info,
                                                                    *image_view_state, attachment_loc);
-    skip |= ValidateRenderingAttachmentInfoFeedbackLoop(commandBuffer, attachment_info, *image_view_state, attachment_loc);
-    skip |= ValidateRenderingAttachmentFlagsInfo(commandBuffer, attachment_info, *image_view_state, attachment_loc);
+    skip |= ValidateRenderingAttachmentInfoFeedbackLoop(objlist, attachment_info, *image_view_state, attachment_loc);
+    skip |= ValidateRenderingAttachmentFlagsInfo(objlist, attachment_info, *image_view_state, attachment_loc);
 
     if (image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_3D) {
-        const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-12470", objlist, attachment_loc.dot(Field::imageView),
+        const LogObjectList image_view_objlist(objlist, attachment_info.imageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-12470", image_view_objlist,
+                         attachment_loc.dot(Field::imageView),
                          "was created with VK_IMAGE_VIEW_TYPE_3D");
     }
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(const LogObjectList& objlist,
+                                                            const VkRenderingInfo& rendering_info,
                                                             const VkRenderingAttachmentInfo& attachment_info,
                                                             const vvl::ImageView& image_view_state,
                                                             const Location& attachment_loc) const {
@@ -3102,8 +3103,9 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
     if ((!vkuFormatIsSINT(image_view_format) && !vkuFormatIsUINT(image_view_format)) && vkuFormatIsColor(image_view_format) &&
         !IsValueIn(attachment_info.resolveMode,
                    {VK_RESOLVE_MODE_NONE, VK_RESOLVE_MODE_AVERAGE_BIT, VK_RESOLVE_MODE_CUSTOM_BIT_EXT})) {
-        const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06129", objlist, attachment_loc.dot(Field::resolveMode),
+        const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06129", attachment_objlist,
+                         attachment_loc.dot(Field::resolveMode),
                          "(%s) must be VK_RESOLVE_MODE_NONE or VK_RESOLVE_MODE_AVERAGE_BIT for non-integer formats (%s)",
                          string_VkResolveModeFlagBits(attachment_info.resolveMode), string_VkFormat(image_view_format));
     }
@@ -3111,8 +3113,9 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
     if ((vkuFormatIsSINT(image_view_format) || vkuFormatIsUINT(image_view_format)) && vkuFormatIsColor(image_view_format) &&
         !IsValueIn(attachment_info.resolveMode,
                    {VK_RESOLVE_MODE_NONE, VK_RESOLVE_MODE_SAMPLE_ZERO_BIT, VK_RESOLVE_MODE_CUSTOM_BIT_EXT})) {
-        const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06130", objlist, attachment_loc.dot(Field::resolveMode),
+        const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06130", attachment_objlist,
+                         attachment_loc.dot(Field::resolveMode),
                          "(%s) must be VK_RESOLVE_MODE_NONE or VK_RESOLVE_MODE_SAMPLE_ZERO_BIT for integer formats (%s)",
                          string_VkResolveModeFlagBits(attachment_info.resolveMode), string_VkFormat(image_view_format));
     }
@@ -3123,22 +3126,23 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
 
     if (auto resolve_view_state = Get<vvl::ImageView>(attachment_info.resolveImageView)) {
         if (resolve_view_state->samples != VK_SAMPLE_COUNT_1_BIT) {
-            const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06864", commandBuffer,
+            const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06864", attachment_objlist,
                              attachment_loc.dot(Field::resolveMode), "%s but resolveImageView has a sample count of %s",
                              string_VkResolveModeFlagBits(attachment_info.resolveMode),
                              string_VkSampleCountFlagBits(resolve_view_state->samples));
         }
         if (resolve_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_3D) {
-            const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-            skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveImageView-12471", objlist,
+            const LogObjectList image_view_objlist(objlist, attachment_info.resolveImageView);
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveImageView-12471", image_view_objlist,
                              attachment_loc.dot(Field::resolveImageView), "was created with VK_IMAGE_VIEW_TYPE_3D");
         }
 
         if (attachment_info.resolveMode != VK_RESOLVE_MODE_CUSTOM_BIT_EXT &&
             (image_view_format != resolve_view_state->create_info.format)) {
-            const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView, image_view_state.Handle());
-            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06865", objlist, attachment_loc.dot(Field::resolveImageView),
+            const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView, image_view_state.Handle());
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06865", attachment_objlist,
+                             attachment_loc.dot(Field::resolveImageView),
                              "format (%s) and %s format (%s) are different (resolveMode is %s).",
                              string_VkFormat(resolve_view_state->create_info.format),
                              attachment_loc.dot(Field::imageView).Fields().c_str(), string_VkFormat(image_view_format),
@@ -3148,8 +3152,8 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
         if (enabled_features.tileMemoryHeap && !resolve_view_state->image_state->GetBoundMemoryStates().empty()) {
             for (const auto& bound_memory : resolve_view_state->image_state->GetBoundMemoryStates()) {
                 if (bound_memory && HasTileMemoryType(bound_memory->allocate_info.memoryTypeIndex)) {
-                    const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView, bound_memory->VkHandle());
-                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveImageView-10728", objlist, attachment_loc,
+                    const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView, bound_memory->VkHandle());
+                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveImageView-10728", attachment_objlist, attachment_loc,
                                      "was created with %s which is bound to %s created from a VkMemoryHeap with"
                                      " VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM",
                                      FormatHandle(resolve_view_state->image_state->VkHandle()).c_str(),
@@ -3160,32 +3164,35 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
     }
 
     if (attachment_info.resolveImageLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
-        const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06146", objlist, attachment_loc.dot(Field::resolveImageLayout),
+        const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06146", attachment_objlist,
+                         attachment_loc.dot(Field::resolveImageLayout),
                          "must not be VK_IMAGE_LAYOUT_PRESENT_SRC_KHR (resolveMode is %s)",
                          string_VkResolveModeFlagBits(attachment_info.resolveMode));
     }
 
     if (attachment_info.resolveImageLayout == VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR) {
-        const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
+        const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
         const char* vuid = IsExtEnabled(extensions.vk_khr_fragment_shading_rate) ? "VUID-VkRenderingAttachmentInfo-imageView-06144"
                                                                                  : "VUID-VkRenderingAttachmentInfo-imageView-06139";
-        skip |= LogError(vuid, objlist, attachment_loc.dot(Field::resolveImageLayout),
+        skip |= LogError(vuid, attachment_objlist, attachment_loc.dot(Field::resolveImageLayout),
                          "must not be VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR "
                          "(or the alias VK_IMAGE_LAYOUT_SHADING_RATE_OPTIMAL_NV) (resolveMode is %s)",
                          string_VkResolveModeFlagBits(attachment_info.resolveMode));
     }
 
     if (attachment_info.resolveImageLayout == VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT) {
-        const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06141", objlist, attachment_loc.dot(Field::resolveImageLayout),
+        const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06141", attachment_objlist,
+                         attachment_loc.dot(Field::resolveImageLayout),
                          "must not be VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT (resolveMode is %s)",
                          string_VkResolveModeFlagBits(attachment_info.resolveMode));
     }
 
     if (attachment_info.resolveImageLayout == VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL) {
-        const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06142", objlist, attachment_loc.dot(Field::resolveImageLayout),
+        const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06142", attachment_objlist,
+                         attachment_loc.dot(Field::resolveImageLayout),
                          "must not be VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL (resolveMode is %s)",
                          string_VkResolveModeFlagBits(attachment_info.resolveMode));
     }
@@ -3194,16 +3201,18 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
                   {VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
                    VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_PREINITIALIZED, VK_IMAGE_LAYOUT_ZERO_INITIALIZED_EXT})) {
-        const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06136", objlist, attachment_loc.dot(Field::resolveImageLayout),
+        const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06136", attachment_objlist,
+                         attachment_loc.dot(Field::resolveImageLayout),
                          "is %s (resolveMode is %s).", string_VkImageLayout(attachment_info.resolveImageLayout),
                          string_VkResolveModeFlagBits(attachment_info.resolveMode));
     }
 
     if (((attachment_info.resolveImageLayout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL) ||
          (attachment_info.resolveImageLayout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL))) {
-        const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06137", objlist, attachment_loc.dot(Field::resolveImageLayout),
+        const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
+        skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06137", attachment_objlist,
+                         attachment_loc.dot(Field::resolveImageLayout),
                          "is %s (resolveMode is %s).", string_VkImageLayout(attachment_info.resolveImageLayout),
                          string_VkResolveModeFlagBits(attachment_info.resolveMode));
     }
@@ -3211,7 +3220,7 @@ bool CoreChecks::ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer comm
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentInfoMultisampledResolveMode(VkCommandBuffer commandBuffer,
+bool CoreChecks::ValidateRenderingAttachmentInfoMultisampledResolveMode(const LogObjectList& objlist,
                                                                         const VkRenderingInfo& rendering_info,
                                                                         const VkRenderingAttachmentInfo& attachment_info,
                                                                         const vvl::ImageView& image_view_state,
@@ -3223,15 +3232,17 @@ bool CoreChecks::ValidateRenderingAttachmentInfoMultisampledResolveMode(VkComman
     if (is_multisampled_resolve) {
         if (image_view_state.samples == VK_SAMPLE_COUNT_1_BIT) {
             if (attachment_info.resolveMode == VK_RESOLVE_MODE_NONE) {
-                const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-                skip |= LogError("VUID-VkRenderingAttachmentInfo-None-12256", commandBuffer, attachment_loc.dot(Field::resolveMode),
+                const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
+                skip |= LogError("VUID-VkRenderingAttachmentInfo-None-12256", attachment_objlist,
+                                 attachment_loc.dot(Field::resolveMode),
                                  "is VK_RESOLVE_MODE_NONE but imageView is VK_SAMPLE_COUNT_1_BIT and "
                                  "VkMultisampledRenderToSingleSampledInfoEXT::multisampledRenderToSingleSampledEnable is VK_TRUE");
             }
             if (attachment_info.resolveImageView != VK_NULL_HANDLE) {
-                const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
+                const LogObjectList attachment_objlist(objlist, attachment_info.resolveImageView);
                 skip |= LogError(
-                    "VUID-VkRenderingAttachmentInfo-imageView-06863", objlist, attachment_loc.dot(Field::resolveMode),
+                    "VUID-VkRenderingAttachmentInfo-imageView-06863", attachment_objlist,
+                    attachment_loc.dot(Field::resolveMode),
                     "is %s and VkMultisampledRenderToSingleSampledInfoEXT::multisampledRenderToSingleSampledEnable is VK_TRUE, and "
                     "%s.imageView has a sample count of VK_SAMPLE_COUNT_1_BIT, and resolveImageView (%s) is not VK_NULL_HANDLE.",
                     string_VkResolveModeFlagBits(attachment_info.resolveMode),
@@ -3241,13 +3252,15 @@ bool CoreChecks::ValidateRenderingAttachmentInfoMultisampledResolveMode(VkComman
         }
     } else if (attachment_info.resolveMode != VK_RESOLVE_MODE_NONE) {
         if (attachment_info.resolveImageView == VK_NULL_HANDLE) {
-            const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06862", objlist, attachment_loc.dot(Field::resolveMode),
+            const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06862", attachment_objlist,
+                             attachment_loc.dot(Field::resolveMode),
                              "(%s) is not VK_RESOLVE_MODE_NONE, resolveImageView must not be VK_NULL_HANDLE",
                              string_VkResolveModeFlagBits(attachment_info.resolveMode));
         } else if (image_view_state.samples == VK_SAMPLE_COUNT_1_BIT) {
-            const LogObjectList objlist(commandBuffer, attachment_info.imageView, attachment_info.resolveImageView);
-            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06861", objlist, attachment_loc.dot(Field::imageView),
+            const LogObjectList attachment_objlist(objlist, attachment_info.imageView, attachment_info.resolveImageView);
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06861", attachment_objlist,
+                             attachment_loc.dot(Field::imageView),
                              "must not have a VK_SAMPLE_COUNT_1_BIT when resolveMode is %s",
                              string_VkResolveModeFlagBits(attachment_info.resolveMode));
         }
@@ -3256,7 +3269,7 @@ bool CoreChecks::ValidateRenderingAttachmentInfoMultisampledResolveMode(VkComman
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentInfoFeedbackLoop(VkCommandBuffer commandBuffer,
+bool CoreChecks::ValidateRenderingAttachmentInfoFeedbackLoop(const LogObjectList& objlist,
                                                              const VkRenderingAttachmentInfo& attachment_info,
                                                              const vvl::ImageView& image_view_state,
                                                              const Location& attachment_loc) const {
@@ -3271,14 +3284,15 @@ bool CoreChecks::ValidateRenderingAttachmentInfoFeedbackLoop(VkCommandBuffer com
         const bool has_input_sample =
             image_view_state.inherited_usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
         if (!has_feedback_loop || !has_color_ds || !has_input_sample) {
-            const LogObjectList objlist(commandBuffer, attachment_info.imageView);
+            const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
             if (explicit_enabled) {
-                skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-10780", objlist,
+                skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-10780", attachment_objlist,
                                  attachment_loc.pNext(Struct::VkAttachmentFeedbackLoopInfoEXT, Field::feedbackLoopEnable),
                                  "is VK_TRUE, but image view usage is %s.",
                                  string_VkImageUsageFlags2KHR(image_view_state.inherited_usage).c_str());
             } else {
-                skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-10780", objlist, attachment_loc.dot(Field::imageLayout),
+                skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-10780", attachment_objlist,
+                                 attachment_loc.dot(Field::imageLayout),
                                  "is VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT, but image view usage is %s.",
                                  string_VkImageUsageFlags2KHR(image_view_state.inherited_usage).c_str());
             }
@@ -3288,7 +3302,7 @@ bool CoreChecks::ValidateRenderingAttachmentInfoFeedbackLoop(VkCommandBuffer com
     return skip;
 }
 
-bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuffer,
+bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(const LogObjectList& objlist,
                                                       const VkRenderingAttachmentInfo& attachment_info,
                                                       const vvl::ImageView& image_view_state,
                                                       const Location& attachment_loc) const {
@@ -3301,17 +3315,18 @@ bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuf
     if (attachment_flags->flags & (VK_RENDERING_ATTACHMENT_RESOLVE_SKIP_TRANSFER_FUNCTION_BIT_KHR |
                                    VK_RENDERING_ATTACHMENT_RESOLVE_ENABLE_TRANSFER_FUNCTION_BIT_KHR)) {
         if (!vkuFormatIsSRGB(image_view_state.create_info.format)) {
-            const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-            skip |= LogError("VUID-VkRenderingAttachmentInfo-pNext-11752", objlist,
+            const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-pNext-11752", attachment_objlist,
                              attachment_loc.pNext(Struct::VkRenderingAttachmentFlagsInfoKHR, Field::flags),
                              "is %s but image view has format %s.",
                              string_VkRenderingAttachmentFlagsKHR(attachment_flags->flags).c_str(),
                              string_VkFormat(image_view_state.create_info.format));
         }
         if (attachment_info.resolveMode != VK_RESOLVE_MODE_AVERAGE_BIT) {
-            const LogObjectList objlist(commandBuffer, attachment_info.imageView);
+            const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
             skip |=
-                LogError("VUID-VkRenderingAttachmentInfo-pNext-11753", objlist, attachment_loc.dot(Field::resolveMode),
+                LogError("VUID-VkRenderingAttachmentInfo-pNext-11753", attachment_objlist,
+                         attachment_loc.dot(Field::resolveMode),
                          "is %s but a VkRenderingAttachmentFlagsInfoKHR is included in the attachment pNext chain with flags (%s).",
                          string_VkResolveModeFlags(attachment_info.resolveMode).c_str(),
                          string_VkRenderingAttachmentFlagsKHR(attachment_flags->flags).c_str());
@@ -3319,15 +3334,15 @@ bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuf
     }
     if (attachment_flags->flags & VK_RENDERING_ATTACHMENT_INPUT_ATTACHMENT_FEEDBACK_BIT_KHR) {
         if (!(image_view_state.inherited_usage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) {
-            const LogObjectList objlist(commandBuffer, attachment_info.imageView);
-            skip |= LogError("VUID-VkRenderingAttachmentInfo-pNext-11754", objlist,
+            const LogObjectList attachment_objlist(objlist, attachment_info.imageView);
+            skip |= LogError("VUID-VkRenderingAttachmentInfo-pNext-11754", attachment_objlist,
                              attachment_loc.pNext(Struct::VkRenderingAttachmentFlagsInfoKHR, Field::flags),
                              "is %s but references an image which was not created with VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT\n%s.",
                              string_VkRenderingAttachmentFlagsKHR(attachment_flags->flags).c_str(),
                              image_view_state.DescribeImageUsage(*this).c_str());
         }
         if (!enabled_features.dynamicRenderingLocalRead) {
-            skip |= LogError("VUID-VkRenderingAttachmentFlagsInfoKHR-flags-11755", commandBuffer,
+            skip |= LogError("VUID-VkRenderingAttachmentFlagsInfoKHR-flags-11755", objlist,
                              attachment_loc.pNext(Struct::VkRenderingAttachmentFlagsInfoKHR, Field::flags), "is %s.",
                              string_VkRenderingAttachmentFlagsKHR(attachment_flags->flags).c_str());
         }
@@ -3335,7 +3350,7 @@ bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuf
 
     if (attachment_flags->flags & VK_RENDERING_ATTACHMENT_RESOLVE_SKIP_TRANSFER_FUNCTION_BIT_KHR) {
         if (attachment_flags->flags & VK_RENDERING_ATTACHMENT_RESOLVE_ENABLE_TRANSFER_FUNCTION_BIT_KHR) {
-            skip |= LogError("VUID-VkRenderingAttachmentFlagsInfoKHR-flags-11756", commandBuffer,
+            skip |= LogError("VUID-VkRenderingAttachmentFlagsInfoKHR-flags-11756", objlist,
                              attachment_loc.pNext(Struct::VkRenderingAttachmentFlagsInfoKHR, Field::flags), "is %s.",
                              string_VkRenderingAttachmentFlagsKHR(attachment_flags->flags).c_str());
         }
@@ -3344,7 +3359,7 @@ bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuf
     if (attachment_flags->flags & (VK_RENDERING_ATTACHMENT_RESOLVE_SKIP_TRANSFER_FUNCTION_BIT_KHR |
                                    VK_RENDERING_ATTACHMENT_RESOLVE_ENABLE_TRANSFER_FUNCTION_BIT_KHR)) {
         if (!phys_dev_ext_props.maintenance10_props.resolveSrgbFormatSupportsTransferFunctionControl) {
-            skip |= LogError("VUID-VkRenderingAttachmentFlagsInfoKHR-flags-11757", commandBuffer,
+            skip |= LogError("VUID-VkRenderingAttachmentFlagsInfoKHR-flags-11757", objlist,
                              attachment_loc.pNext(Struct::VkRenderingAttachmentFlagsInfoKHR, Field::flags),
                              "is %s but resolveSrgbFormatSupportsTransferFunctionControl is VK_FALSE.",
                              string_VkRenderingAttachmentFlagsKHR(attachment_flags->flags).c_str());
@@ -3353,8 +3368,8 @@ bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuf
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                                          const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoFragmentDensityMap(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                         const Location& rendering_info_loc) const {
     bool skip = false;
 
     const auto* fdm_attachment_info =
@@ -3371,8 +3386,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
                     continue;
                 }
                 if (!(image_view_state->image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
-                    const LogObjectList objlist(commandBuffer, rendering_info.pColorAttachments[j].imageView);
-                    skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
+                    const LogObjectList attachment_objlist(objlist, rendering_info.pColorAttachments[j].imageView);
+                    skip |= LogError("VUID-VkRenderingInfo-imageView-06107", attachment_objlist,
                                      rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                      "must be created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
                 }
@@ -3382,8 +3397,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         if (rendering_info.pDepthAttachment && (rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE)) {
             auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
             if (depth_view_state && !(depth_view_state->image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
-                const LogObjectList objlist(commandBuffer, rendering_info.pDepthAttachment->imageView);
-                skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
+                const LogObjectList attachment_objlist(objlist, rendering_info.pDepthAttachment->imageView);
+                skip |= LogError("VUID-VkRenderingInfo-imageView-06107", attachment_objlist,
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "must be created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
             }
@@ -3392,8 +3407,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         if (rendering_info.pStencilAttachment && (rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE)) {
             auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
             if (stencil_view_state && !(stencil_view_state->image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
-                const LogObjectList objlist(commandBuffer, rendering_info.pStencilAttachment->imageView);
-                skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
+                const LogObjectList attachment_objlist(objlist, rendering_info.pStencilAttachment->imageView);
+                skip |= LogError("VUID-VkRenderingInfo-imageView-06107", attachment_objlist,
                                  rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "must be created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
             }
@@ -3409,33 +3424,33 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         ASSERT_AND_RETURN_SKIP(fdm_image_state);
 
         if ((fdm_image_view->inherited_usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) == 0) {
-            const LogObjectList objlist(commandBuffer, fdm_attachment_info->imageView, fdm_image_state->Handle());
-            skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158", objlist, view_loc,
+            const LogObjectList attachment_objlist(objlist, fdm_attachment_info->imageView, fdm_image_state->Handle());
+            skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158", attachment_objlist, view_loc,
                              "references %s which was not created with VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT.\n%s",
                              FormatHandle(fdm_image_state->Handle()).c_str(), fdm_image_view->DescribeImageUsage(*this).c_str());
         }
         if ((fdm_image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) != 0) {
-            const LogObjectList objlist(commandBuffer, fdm_attachment_info->imageView, fdm_image_state->Handle());
-            skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06159", objlist, view_loc,
+            const LogObjectList attachment_objlist(objlist, fdm_attachment_info->imageView, fdm_image_state->Handle());
+            skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06159", attachment_objlist, view_loc,
                              "references %s which was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT "
                              "(VkRenderingFragmentDensityMapAttachmentInfoEXT is for non-subsampled images).",
                              FormatHandle(fdm_image_state->Handle()).c_str());
         }
         int32_t layer_count = static_cast<int32_t>(fdm_image_view->normalized_subresource_range.layerCount);
         if (layer_count != 1 && !enabled_features.multiview) {
-            const LogObjectList objlist(commandBuffer, fdm_attachment_info->imageView);
-            skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-apiVersion-07908", objlist, view_loc,
+            const LogObjectList attachment_objlist(objlist, fdm_attachment_info->imageView);
+            skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-apiVersion-07908", attachment_objlist, view_loc,
                              "must have a layerCount (%" PRId32 ") equal to 1.", layer_count);
         }
         if ((rendering_info.viewMask == 0) && (layer_count != 1)) {
-            const LogObjectList objlist(commandBuffer, fdm_attachment_info->imageView);
-            skip |= LogError("VUID-VkRenderingInfo-imageView-06109", objlist, view_loc,
+            const LogObjectList attachment_objlist(objlist, fdm_attachment_info->imageView);
+            skip |= LogError("VUID-VkRenderingInfo-imageView-06109", attachment_objlist, view_loc,
                              "must have a layerCount (%" PRId32 ") equal to 1 when viewMask is equal to 0", layer_count);
         }
 
         if ((rendering_info.viewMask != 0) && (layer_count < MostSignificantBit(rendering_info.viewMask))) {
-            const LogObjectList objlist(commandBuffer, fdm_attachment_info->imageView);
-            skip |= LogError("VUID-VkRenderingInfo-imageView-06108", objlist, view_loc,
+            const LogObjectList attachment_objlist(objlist, fdm_attachment_info->imageView);
+            skip |= LogError("VUID-VkRenderingInfo-imageView-06108", attachment_objlist, view_loc,
                              "must have a layerCount (%" PRId32
                              ") greater than or equal to the most significant bit (%d) in viewMask (0x%" PRIx32 ")",
                              layer_count, MostSignificantBit(rendering_info.viewMask), rendering_info.viewMask);
@@ -3443,8 +3458,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
 
         const VkComponentMapping components = fdm_image_view->create_info.components;
         if (!IsIdentitySwizzle(components)) {
-            const LogObjectList objlist(commandBuffer, fdm_image_view->Handle());
-            skip |= LogError("VUID-VkRenderingInfo-imageView-09486", objlist, view_loc,
+            const LogObjectList attachment_objlist(objlist, fdm_image_view->Handle());
+            skip |= LogError("VUID-VkRenderingInfo-imageView-09486", attachment_objlist, view_loc,
                              "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
                              string_VkComponentMapping(components).c_str());
         }
@@ -3463,9 +3478,9 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
                 vvl::GetQuotientCeil(
                     x_adjusted_extent,
                     static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width))) {
-                const LogObjectList objlist(commandBuffer, fdm_attachment_info->imageView, fdm_image_state->Handle());
+                const LogObjectList attachment_objlist(objlist, fdm_attachment_info->imageView, fdm_image_state->Handle());
                 skip |= LogError(
-                    "VUID-VkRenderingInfo-pNext-06112", objlist,
+                    "VUID-VkRenderingInfo-pNext-06112", attachment_objlist,
                     rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                     "width  (%" PRIu32 ") must not be less than (pRenderingInfo->renderArea.offset.x (%" PRId32
                     ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
@@ -3477,9 +3492,9 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
                 vvl::GetQuotientCeil(
                     y_adjusted_extent,
                     static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height))) {
-                const LogObjectList objlist(commandBuffer, fdm_attachment_info->imageView, fdm_image_state->Handle());
+                const LogObjectList attachment_objlist(objlist, fdm_attachment_info->imageView, fdm_image_state->Handle());
                 skip |= LogError(
-                    "VUID-VkRenderingInfo-pNext-06114", objlist,
+                    "VUID-VkRenderingInfo-pNext-06114", attachment_objlist,
                     rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                     "height (%" PRIu32 ") must not be less than (pRenderingInfo->renderArea.offset.y (%" PRId32
                     ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
@@ -3493,8 +3508,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                                           const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoFragmentShadingRate(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                          const Location& rendering_info_loc) const {
     bool skip = false;
     const auto* rendering_fragment_shading_rate_attachment_info =
         vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(rendering_info.pNext);
@@ -3505,11 +3520,12 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer comma
 
     auto view_state = Get<vvl::ImageView>(rendering_fragment_shading_rate_attachment_info->imageView);
     ASSERT_AND_RETURN_SKIP(view_state);
-    const LogObjectList objlist(commandBuffer, view_state->Handle());
+    const LogObjectList attachment_objlist(objlist, view_state->Handle());
     if (rendering_info.viewMask == 0) {
         if (view_state->normalized_subresource_range.layerCount != 1 &&
             view_state->normalized_subresource_range.layerCount < rendering_info.layerCount) {
-            skip |= LogError("VUID-VkRenderingInfo-imageView-06123", objlist, rendering_info_loc.dot(Field::layerCount),
+            skip |= LogError("VUID-VkRenderingInfo-imageView-06123", attachment_objlist,
+                             rendering_info_loc.dot(Field::layerCount),
                              "is (%" PRIu32
                              ") but VkRenderingFragmentShadingRateAttachmentInfoKHR::imageView was created with (%" PRIu32 ").",
                              rendering_info.layerCount, view_state->normalized_subresource_range.layerCount);
@@ -3518,7 +3534,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer comma
         int highest_view_bit = MostSignificantBit(rendering_info.viewMask);
         int32_t layer_count = view_state->normalized_subresource_range.layerCount;
         if (layer_count != 1 && layer_count < highest_view_bit) {
-            skip |= LogError("VUID-VkRenderingInfo-imageView-06124", objlist,
+            skip |= LogError("VUID-VkRenderingInfo-imageView-06124", attachment_objlist,
                              rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                              "has a layerCount (%" PRId32
                              ") but must either is equal to 1 or greater than "
@@ -3529,7 +3545,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer comma
 
     if ((view_state->inherited_usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) == 0) {
         skip |=
-            LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148", objlist,
+            LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148", attachment_objlist,
                      rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                      "references an image which was not created with VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR.\n%s",
                      view_state->DescribeImageUsage(*this).c_str());
@@ -3537,19 +3553,19 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer comma
 
     const VkComponentMapping components = view_state->create_info.components;
     if (!IsIdentitySwizzle(components)) {
-        skip |= LogError("VUID-VkRenderingInfo-imageView-09485", objlist,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-09485", attachment_objlist,
                          rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                          "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
                          string_VkComponentMapping(components).c_str());
     }
 
-    skip |= ValidateBeginRenderingFragmentShadingRateRenderArea(
-        commandBuffer, *view_state, *rendering_fragment_shading_rate_attachment_info, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoFragmentShadingRateRenderArea(
+        objlist, *view_state, *rendering_fragment_shading_rate_attachment_info, rendering_info, rendering_info_loc);
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
-    VkCommandBuffer commandBuffer, const vvl::ImageView& view_state,
+bool CoreChecks::ValidateRenderingInfoFragmentShadingRateRenderArea(
+    const LogObjectList& objlist, const vvl::ImageView& view_state,
     const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info, const VkRenderingInfo& rendering_info,
     const Location& rendering_info_loc) const {
     bool skip = false;
@@ -3560,7 +3576,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
         return skip;
     }
 
-    const LogObjectList objlist(commandBuffer, view_state.Handle());
+    const LogObjectList attachment_objlist(objlist, view_state.Handle());
     const auto* device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
     const bool non_zero_device_render_area = device_group_begin_info && device_group_begin_info->deviceRenderAreaCount != 0;
     if (!non_zero_device_render_area) {
@@ -3574,7 +3590,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
         if (static_cast<int64_t>(view_state.image_state->GetExtent().width) <
             vvl::GetQuotientCeil(x_adjusted_extent,
                                  static_cast<int64_t>(fsr_attachment_info.shadingRateAttachmentTexelSize.width))) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-06119", objlist,
+            skip |= LogError("VUID-VkRenderingInfo-pNext-06119", attachment_objlist,
                              rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                              "width (%" PRIu32 ") must not be less than (pRenderingInfo->renderArea.offset.x (%" PRId32
                              ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
@@ -3586,7 +3602,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
         if (static_cast<int64_t>(view_state.image_state->GetExtent().height) <
             vvl::GetQuotientCeil(y_adjusted_extent,
                                  static_cast<int64_t>(fsr_attachment_info.shadingRateAttachmentTexelSize.height))) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-06121", objlist,
+            skip |= LogError("VUID-VkRenderingInfo-pNext-06121", attachment_objlist,
                              rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                              "height (%" PRIu32 ") must not be less than (pRenderingInfo->renderArea.offset.y (%" PRId32
                              ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
@@ -3607,7 +3623,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
                 if (image_state->GetExtent().width <
                     vvl::GetQuotientCeil(offset_x + width, fsr_attachment_info.shadingRateAttachmentTexelSize.width)) {
                     skip |= LogError(
-                        "VUID-VkRenderingInfo-pNext-06120", objlist,
+                        "VUID-VkRenderingInfo-pNext-06120", attachment_objlist,
                         rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                         "width (%" PRIu32 ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                         "].offset.x (%" PRId32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
@@ -3618,7 +3634,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
                 if (image_state->GetExtent().height <
                     vvl::GetQuotientCeil(offset_y + height, fsr_attachment_info.shadingRateAttachmentTexelSize.height)) {
                     skip |= LogError(
-                        "VUID-VkRenderingInfo-pNext-06122", objlist,
+                        "VUID-VkRenderingInfo-pNext-06122", attachment_objlist,
                         rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                         "height (%" PRIu32 ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                         "].offset.y (%" PRId32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
@@ -3635,8 +3651,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                                   const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoSampleCount(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                  const Location& rendering_info_loc) const {
     bool skip = false;
     const VkSampleCountFlagBits unused = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
 
@@ -3654,9 +3670,9 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
             ASSERT_AND_CONTINUE(image_view);
             color_sample_count = (color_sample_count == unused) ? image_view->samples : color_sample_count;
             if (color_sample_count != image_view->samples) {
-                const LogObjectList objlist(commandBuffer, color_attachment.imageView,
-                                            rendering_info.pColorAttachments[first_color_index].imageView);
-                skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+                const LogObjectList attachment_objlist(objlist, color_attachment.imageView,
+                                                       rendering_info.pColorAttachments[first_color_index].imageView);
+                skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", attachment_objlist,
                                  rendering_info_loc.dot(Field::pColorAttachments, i).dot(Field::imageView),
                                  "was created with %s, but the pColorAttachments[%" PRId32 "]->imageView was created with %s.",
                                  string_VkSampleCountFlagBits(image_view->samples), first_color_index,
@@ -3681,24 +3697,24 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
 
         // Now we have sample from all 3 (color, depth, stencil), check each combo to produce a helpful message
         if (depth_sample_count != stencil_sample_count && depth_sample_count != unused && stencil_sample_count != unused) {
-            const LogObjectList objlist(commandBuffer, rendering_info.pDepthAttachment->imageView,
-                                        rendering_info.pStencilAttachment->imageView);
-            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+            const LogObjectList attachment_objlist(objlist, rendering_info.pDepthAttachment->imageView,
+                                                   rendering_info.pStencilAttachment->imageView);
+            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", attachment_objlist,
                              rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                              "was created with %s, but the pStencilAttachment->imageView was created with %s.",
                              string_VkSampleCountFlagBits(depth_sample_count), string_VkSampleCountFlagBits(stencil_sample_count));
         } else if (depth_sample_count != color_sample_count && depth_sample_count != unused && color_sample_count != unused) {
-            const LogObjectList objlist(commandBuffer, rendering_info.pDepthAttachment->imageView,
-                                        rendering_info.pColorAttachments[first_color_index].imageView);
-            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+            const LogObjectList attachment_objlist(objlist, rendering_info.pDepthAttachment->imageView,
+                                                   rendering_info.pColorAttachments[first_color_index].imageView);
+            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", attachment_objlist,
                              rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                              "was created with %s, but the pColorAttachments[%" PRId32 "]->imageView was created with %s.",
                              string_VkSampleCountFlagBits(depth_sample_count), first_color_index,
                              string_VkSampleCountFlagBits(color_sample_count));
         } else if (stencil_sample_count != color_sample_count && stencil_sample_count != unused && color_sample_count != unused) {
-            const LogObjectList objlist(commandBuffer, rendering_info.pStencilAttachment->imageView,
-                                        rendering_info.pColorAttachments[first_color_index].imageView);
-            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+            const LogObjectList attachment_objlist(objlist, rendering_info.pStencilAttachment->imageView,
+                                                   rendering_info.pColorAttachments[first_color_index].imageView);
+            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", attachment_objlist,
                              rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                              "was created with %s, but the pColorAttachments[%" PRId32 "]->imageView was created with %s.",
                              string_VkSampleCountFlagBits(stencil_sample_count), first_color_index,
@@ -3718,23 +3734,23 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
             ASSERT_AND_CONTINUE(image_view);
             first_sample_count = (first_sample_count == unused) ? image_view->samples : first_sample_count;
             if (first_sample_count != image_view->samples) {
-                const LogObjectList objlist(commandBuffer, color_attachment.imageView);
+                const LogObjectList attachment_objlist(objlist, color_attachment.imageView);
                 skip |=
-                    LogError("VUID-VkRenderingInfo-imageView-09429", objlist,
+                    LogError("VUID-VkRenderingInfo-imageView-09429", attachment_objlist,
                              rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                              "was created with %s, but pColorAttachments[0].imageView was created with %s.",
                              string_VkSampleCountFlagBits(image_view->samples), string_VkSampleCountFlagBits(first_sample_count));
             }
         }
     } else if (enabled_features.multisampledRenderToSingleSampled) {
-        skip |= ValidateBeginRenderingMultisampledRenderToSingleSampled(commandBuffer, rendering_info, rendering_info_loc);
+        skip |= ValidateRenderingInfoMultisampledRenderToSingleSampled(objlist, rendering_info, rendering_info_loc);
     }
 
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                                   const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoDeviceGroup(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                  const Location& rendering_info_loc) const {
     bool skip = false;
 
     const auto* device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
@@ -3744,18 +3760,18 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         const VkRect2D& render_area = rendering_info.renderArea;
         // if the renderArea was set with garbage, only want to report 1 error
         if (render_area.offset.x < 0) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-06077", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-pNext-06077", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::offset).dot(Field::x),
                              "is %" PRId32 " (offset can't be negative).", render_area.offset.x);
         } else if (render_area.offset.y < 0) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-06078", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-pNext-06078", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::offset).dot(Field::y),
                              "is %" PRId32 " (offset can't be negative).", render_area.offset.y);
         } else if (render_area.extent.width == 0) {
-            skip |= LogError("VUID-VkRenderingInfo-None-08994", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-None-08994", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::extent).dot(Field::width), "is zero.");
         } else if (render_area.extent.height == 0) {
-            skip |= LogError("VUID-VkRenderingInfo-None-08995", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-None-08995", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::extent).dot(Field::height), "is zero.");
         }
 
@@ -3765,13 +3781,13 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         const int64_t y_adjusted_extent =
             static_cast<int64_t>(render_area.offset.y) + static_cast<int64_t>(render_area.extent.height);
         if (x_adjusted_extent > phys_dev_props.limits.maxFramebufferWidth) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-07815", commandBuffer, rendering_info_loc.dot(Field::renderArea),
+            skip |= LogError("VUID-VkRenderingInfo-pNext-07815", objlist, rendering_info_loc.dot(Field::renderArea),
                              "offset.x (%" PRId32 ") + extent.width (%" PRIu32
                              ") is not less than or equal to maxFramebufferWidth (%" PRIu32 ").",
                              render_area.offset.x, render_area.extent.width, phys_dev_props.limits.maxFramebufferWidth);
         }
         if (y_adjusted_extent > phys_dev_props.limits.maxFramebufferHeight) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-07816", commandBuffer, rendering_info_loc.dot(Field::renderArea),
+            skip |= LogError("VUID-VkRenderingInfo-pNext-07816", objlist, rendering_info_loc.dot(Field::renderArea),
                              "offset.y (%" PRId32 ") + extent.height (%" PRIu32
                              ") is not less than or equal to maxFramebufferHeight (%" PRIu32 ").",
                              render_area.offset.y, render_area.extent.height, phys_dev_props.limits.maxFramebufferHeight);
@@ -3790,27 +3806,27 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         const uint32_t height = render_area.extent.height;
 
         if (offset_x < 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166", objlist,
                              group_loc.dot(Field::offset).dot(Field::x), "is %" PRId32 " (offset can't be negative).", offset_x);
         } else if (offset_y < 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167", objlist,
                              group_loc.dot(Field::offset).dot(Field::y), "is %" PRId32 " (offset can't be negative).", offset_y);
         } else if (width == 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08998", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08998", objlist,
                              group_loc.dot(Field::extent).dot(Field::width), "is zero.");
         } else if (height == 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08999", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08999", objlist,
                              group_loc.dot(Field::extent).dot(Field::height), "is zero.");
         }
 
         if ((offset_x + width) > phys_dev_props.limits.maxFramebufferWidth) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168", commandBuffer, group_loc,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168", objlist, group_loc,
                              "sum of offset.x (%" PRId32 ") and extent.width (%" PRIu32
                              ") is greater than maxFramebufferWidth (%" PRIu32 ").",
                              offset_x, width, phys_dev_props.limits.maxFramebufferWidth);
         }
         if ((offset_y + height) > phys_dev_props.limits.maxFramebufferHeight) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169", commandBuffer, group_loc,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169", objlist, group_loc,
                              "sum of offset.y (%" PRId32 ") and extent.height (%" PRIu32
                              ") is greater than maxFramebufferHeight (%" PRIu32 ").",
                              offset_y, height, phys_dev_props.limits.maxFramebufferHeight);
@@ -3822,8 +3838,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             ASSERT_AND_CONTINUE(image_view_state);
             vvl::Image* image_state = image_view_state->image_state.get();
             if (image_state->GetExtent().width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
+                const LogObjectList attachment_objlist(objlist, image_view_state->Handle(), image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", attachment_objlist,
                                  rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                  "width (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3831,8 +3847,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->GetExtent().width, offset_x, width);
             }
             if (image_state->GetExtent().height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
+                const LogObjectList attachment_objlist(objlist, image_view_state->Handle(), image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", attachment_objlist,
                                  rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                  "height (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3846,8 +3862,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             ASSERT_AND_RETURN_SKIP(depth_view_state);
             vvl::Image* image_state = depth_view_state->image_state.get();
             if (image_state->GetExtent().width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
+                const LogObjectList attachment_objlist(objlist, depth_view_state->Handle(), image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", attachment_objlist,
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "width (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3855,8 +3871,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->GetExtent().width, offset_x, width);
             }
             if (image_state->GetExtent().height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
+                const LogObjectList attachment_objlist(objlist, depth_view_state->Handle(), image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", attachment_objlist,
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "height (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3870,8 +3886,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             ASSERT_AND_RETURN_SKIP(stencil_view_state);
             vvl::Image* image_state = stencil_view_state->image_state.get();
             if (image_state->GetExtent().width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
+                const LogObjectList attachment_objlist(objlist, stencil_view_state->Handle(), image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", attachment_objlist,
                                  rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "width (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3879,8 +3895,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->GetExtent().width, offset_x, width);
             }
             if (image_state->GetExtent().height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
+                const LogObjectList attachment_objlist(objlist, stencil_view_state->Handle(), image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", attachment_objlist,
                                  rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "height (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3899,9 +3915,9 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             if (image_state->GetExtent().width <
                 vvl::GetQuotientCeil(offset_x + width,
                                      phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width)) {
-                const LogObjectList objlist(commandBuffer, view_state->Handle(), image_state->Handle());
+                const LogObjectList attachment_objlist(objlist, view_state->Handle(), image_state->Handle());
                 skip |= LogError(
-                    "VUID-VkRenderingInfo-pNext-06113", objlist,
+                    "VUID-VkRenderingInfo-pNext-06113", attachment_objlist,
                     rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                     "width (%" PRIu32 ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                     "].offset.x (%" PRId32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
@@ -3913,9 +3929,9 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             if (image_state->GetExtent().height <
                 vvl::GetQuotientCeil(offset_y + height,
                                      phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height)) {
-                const LogObjectList objlist(commandBuffer, view_state->Handle(), image_state->Handle());
+                const LogObjectList attachment_objlist(objlist, view_state->Handle(), image_state->Handle());
                 skip |= LogError(
-                    "VUID-VkRenderingInfo-pNext-06115", objlist,
+                    "VUID-VkRenderingInfo-pNext-06115", attachment_objlist,
                     rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                     "height (%" PRIu32 ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                     "].offset.y (%" PRId32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
@@ -3930,9 +3946,9 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkCommandBuffer commandBuffer,
-                                                                         const VkRenderingInfo& rendering_info,
-                                                                         const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoMultisampledRenderToSingleSampled(const LogObjectList& objlist,
+                                                                        const VkRenderingInfo& rendering_info,
+                                                                        const Location& rendering_info_loc) const {
     bool skip = false;
 
     const auto* msrtss_info = vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(rendering_info.pNext);
@@ -3943,7 +3959,7 @@ bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkComma
         if (rendering_info.pColorAttachments[j].imageView != VK_NULL_HANDLE) {
             if (const auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[j].imageView)) {
                 skip |= ValidateMultisampledRenderToSingleSampleView(
-                    commandBuffer, *image_view_state, *msrtss_info,
+                    objlist, *image_view_state, *msrtss_info,
                     rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView), rendering_info_loc);
             }
         }
@@ -3951,22 +3967,57 @@ bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkComma
     if (rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
         if (const auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView)) {
             skip |= ValidateMultisampledRenderToSingleSampleView(
-                commandBuffer, *depth_view_state, *msrtss_info,
+                objlist, *depth_view_state, *msrtss_info,
                 rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView), rendering_info_loc);
         }
     }
     if (rendering_info.pStencilAttachment && rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
         if (const auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView)) {
             skip |= ValidateMultisampledRenderToSingleSampleView(
-                commandBuffer, *stencil_view_state, *msrtss_info,
+                objlist, *stencil_view_state, *msrtss_info,
                 rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView), rendering_info_loc);
         }
     }
     if (msrtss_info->rasterizationSamples == VK_SAMPLE_COUNT_1_BIT) {
-        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878", commandBuffer,
+        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878", objlist,
                          rendering_info_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples),
                          "is VK_SAMPLE_COUNT_1_BIT.");
     }
+    return skip;
+}
+
+bool CoreChecks::ValidateRenderingInfoCommon(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                             const Location& rendering_info_loc) const {
+    bool skip = false;
+
+    skip |= ValidateRenderingInfoFragmentDensityMap(objlist, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoFragmentShadingRate(objlist, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoSampleCount(objlist, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoDeviceGroup(objlist, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoColorAttachment(objlist, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoDepthAttachment(objlist, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoStencilAttachment(objlist, rendering_info, rendering_info_loc);
+    skip |= ValidateRenderingInfoDepthAndStencilAttachment(objlist, rendering_info, rendering_info_loc);
+
+    if (MostSignificantBit(rendering_info.viewMask) >= static_cast<int32_t>(phys_dev_props_core11.maxMultiviewViewCount)) {
+        skip |= LogError("VUID-VkRenderingInfo-viewMask-06128", objlist, rendering_info_loc.dot(Field::viewMask),
+                         "(0x%" PRIx32 ") most significant bit must be less than maxMultiviewViewCount (%" PRIu32 ")",
+                         rendering_info.viewMask, phys_dev_props_core11.maxMultiviewViewCount);
+    }
+
+    if (const auto counters_begin_info =
+            vku::FindStructInPNextChain<VkRenderPassPerformanceCountersByRegionBeginInfoARM>(rendering_info.pNext)) {
+        const uint32_t layer_or_view_count =
+            enabled_features.multiview ? MostSignificantBit(rendering_info.viewMask) : rendering_info.layerCount;
+        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(objlist, *counters_begin_info, 1u, layer_or_view_count,
+                                                                       rendering_info.renderArea, rendering_info_loc);
+    }
+
+    if (const auto* rp_tile_shading_ci =
+            vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(rendering_info.pNext)) {
+        skip |= ValidateRenderingInfoTileShadingCreateInfo(objlist, rendering_info, *rp_tile_shading_ci, rendering_info_loc);
+    }
+
     return skip;
 }
 
@@ -3985,34 +4036,10 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     }
 
     skip |= ValidateBeginRenderingResume(*cb_state, *pRenderingInfo, rendering_info_loc);
-    skip |= ValidateBeginRenderingFragmentDensityMap(commandBuffer, *pRenderingInfo, rendering_info_loc);
-    skip |= ValidateBeginRenderingFragmentShadingRate(commandBuffer, *pRenderingInfo, rendering_info_loc);
-    skip |= ValidateBeginRenderingSampleCount(commandBuffer, *pRenderingInfo, rendering_info_loc);
-    skip |= ValidateBeginRenderingDeviceGroup(commandBuffer, *pRenderingInfo, rendering_info_loc);
+    skip |= ValidateRenderingInfoCommon(LogObjectList(commandBuffer), *pRenderingInfo, rendering_info_loc);
     skip |= ValidateBeginRenderingColorAttachment(*cb_state, *pRenderingInfo, rendering_info_loc);
     skip |= ValidateBeginRenderingDepthAttachment(*cb_state, *pRenderingInfo, rendering_info_loc);
     skip |= ValidateBeginRenderingStencilAttachment(*cb_state, *pRenderingInfo, rendering_info_loc);
-    skip |= ValidateBeginRenderingDepthAndStencilAttachment(commandBuffer, *pRenderingInfo, rendering_info_loc);
-
-    if (MostSignificantBit(pRenderingInfo->viewMask) >= static_cast<int32_t>(phys_dev_props_core11.maxMultiviewViewCount)) {
-        skip |= LogError("VUID-VkRenderingInfo-viewMask-06128", commandBuffer, rendering_info_loc.dot(Field::viewMask),
-                         "(0x%" PRIx32 ") most significant bit must be less than maxMultiviewViewCount (%" PRIu32 ")",
-                         pRenderingInfo->viewMask, phys_dev_props_core11.maxMultiviewViewCount);
-    }
-
-    if (const auto counters_begin_info =
-            vku::FindStructInPNextChain<VkRenderPassPerformanceCountersByRegionBeginInfoARM>(pRenderingInfo->pNext)) {
-        const LogObjectList objlist(cb_state->Handle());
-        uint32_t layer_or_view_count = 0;
-        if (enabled_features.multiview) {
-            layer_or_view_count = MostSignificantBit(pRenderingInfo->viewMask);
-        } else {
-            layer_or_view_count = pRenderingInfo->layerCount;
-        }
-
-        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(
-            commandBuffer, *counters_begin_info, objlist, 1u, layer_or_view_count, pRenderingInfo->renderArea, rendering_info_loc);
-    }
 
     if (const auto* rp_tile_shading_ci =
             vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(pRenderingInfo->pNext)) {
@@ -4020,6 +4047,13 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     }
 
     return skip;
+}
+
+bool CoreChecks::PreCallValidateGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo* pRenderingInfo,
+                                                                      VkTilePropertiesQCOM* pProperties,
+                                                                      const ErrorObject& error_obj) const {
+    const Location rendering_info_loc = error_obj.location.dot(Field::pRenderingInfo);
+    return ValidateRenderingInfoCommon(LogObjectList(device), *pRenderingInfo, rendering_info_loc);
 }
 
 static bool CheckAttachmentNullMismatch(const CoreChecks& validator, const char* vuid, const LogObjectList& objlist,
@@ -4199,30 +4233,29 @@ bool CoreChecks::ValidateBeginRenderingResume(const vvl::CommandBuffer& cb_state
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
-                                                       const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoColorAttachment(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                      const Location& rendering_info_loc) const {
     bool skip = false;
-    const VkCommandBuffer commandBuffer = cb_state.VkHandle();
     for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
         const VkRenderingAttachmentInfo& color_attachment = rendering_info.pColorAttachments[i];
         const Location color_attachment_loc = rendering_info_loc.dot(Field::pColorAttachments, i);
-        skip |= ValidateRenderingAttachmentInfo(commandBuffer, rendering_info, color_attachment, color_attachment_loc);
-        skip |= ValidateRenderingAttachmentCurrentLayout(cb_state, color_attachment, color_attachment_loc);
+        skip |= ValidateRenderingAttachmentInfo(objlist, rendering_info, color_attachment, color_attachment_loc);
 
         if (color_attachment.imageView != VK_NULL_HANDLE) {
             auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView);
             ASSERT_AND_CONTINUE(image_view_state);
             const vvl::Image& image_state = *image_view_state->image_state;
-            const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state.Handle());
+            const LogObjectList attachment_objlist(objlist, image_view_state->Handle(), image_state.Handle());
 
             if (!(image_view_state->inherited_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
                 skip |=
-                    LogError("VUID-VkRenderingInfo-colorAttachmentCount-06087", objlist, color_attachment_loc.dot(Field::imageView),
+                    LogError("VUID-VkRenderingInfo-colorAttachmentCount-06087",
+                             attachment_objlist, color_attachment_loc.dot(Field::imageView),
                              "references an image which was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.\n%s",
                              image_view_state->DescribeImageUsage(*this).c_str());
             }
 
-            skip |= ValidateRenderingInfoAttachment(*image_view_state, rendering_info, objlist, color_attachment_loc);
+            skip |= ValidateRenderingInfoAttachment(*image_view_state, rendering_info, attachment_objlist, color_attachment_loc);
         }
 
         auto resolve_view_state = Get<vvl::ImageView>(color_attachment.resolveImageView);
@@ -4230,8 +4263,9 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
         if (resolve_view_state) {
             if (rendering_info.viewMask == 0 &&
                 rendering_info.layerCount > resolve_view_state->normalized_subresource_range.layerCount) {
-                const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView);
-                skip |= LogError("VUID-VkRenderingInfo-viewMask-10859", objlist, color_attachment_loc.dot(Field::layerCount),
+                const LogObjectList attachment_objlist(objlist, color_attachment.resolveImageView);
+                skip |= LogError("VUID-VkRenderingInfo-viewMask-10859", attachment_objlist,
+                                 color_attachment_loc.dot(Field::layerCount),
                                  "(%" PRIu32
                                  ") is greater than the resolveImageView which was created with a layerCount of %" PRIu32 ".",
                                  rendering_info.layerCount, resolve_view_state->normalized_subresource_range.layerCount);
@@ -4239,8 +4273,9 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
 
             if (rendering_info.viewMask != 0 && resolve_view_state->normalized_subresource_range.layerCount <=
                                                     (uint32_t)MostSignificantBit(rendering_info.viewMask)) {
-                const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView);
-                skip |= LogError("VUID-VkRenderingInfo-viewMask-12403", objlist, color_attachment_loc.dot(Field::resolveImageView),
+                const LogObjectList attachment_objlist(objlist, color_attachment.resolveImageView);
+                skip |= LogError("VUID-VkRenderingInfo-viewMask-12403", attachment_objlist,
+                                 color_attachment_loc.dot(Field::resolveImageView),
                                  "must have a layerCount (%" PRIu32
                                  ") greater than the most significant bit index (%d) in viewMask (0x%" PRIx32 ")",
                                  resolve_view_state->normalized_subresource_range.layerCount,
@@ -4250,13 +4285,13 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
 
         if (color_attachment.resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID) {
             if (!enabled_features.externalFormatResolve) {
-                skip |= LogError("VUID-VkRenderingAttachmentInfo-externalFormatResolve-09323", commandBuffer,
+                skip |= LogError("VUID-VkRenderingAttachmentInfo-externalFormatResolve-09323", objlist,
                                  color_attachment_loc.dot(Field::resolveMode),
                                  "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID.");
             }
             if (rendering_info.colorAttachmentCount != 1) {
                 skip |= LogError(
-                    "VUID-VkRenderingInfo-colorAttachmentCount-09320", commandBuffer, color_attachment_loc.dot(Field::resolveMode),
+                    "VUID-VkRenderingInfo-colorAttachmentCount-09320", objlist, color_attachment_loc.dot(Field::resolveMode),
                     "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID and colorAttachmentCount is %" PRIu32 ".",
                     rendering_info.colorAttachmentCount);
                 break;  // only print first index with error
@@ -4264,7 +4299,7 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
             const auto* fragment_density_info_ext =
                 vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext);
             if (fragment_density_info_ext && fragment_density_info_ext->imageView != VK_NULL_HANDLE) {
-                skip |= LogError("VUID-VkRenderingInfo-resolveMode-09321", commandBuffer,
+                skip |= LogError("VUID-VkRenderingInfo-resolveMode-09321", objlist,
                                  rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                                  "is not null (%s).", FormatHandle(fragment_density_info_ext->imageView).c_str());
             }
@@ -4272,39 +4307,41 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
                 vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(rendering_info.pNext);
             if (fragment_shading_rate_info_khr && fragment_shading_rate_info_khr->imageView != VK_NULL_HANDLE) {
                 skip |=
-                    LogError("VUID-VkRenderingInfo-resolveMode-09322", commandBuffer,
+                    LogError("VUID-VkRenderingInfo-resolveMode-09322", objlist,
                              rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                              "is not null (%s).", FormatHandle(fragment_shading_rate_info_khr->imageView).c_str());
             }
 
             if (!resolve_view_state) {
-                skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09324", commandBuffer,
+                skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09324", objlist,
                                  color_attachment_loc.dot(Field::resolveImageView), "is not valid (%s).",
                                  FormatHandle(color_attachment.resolveImageView).c_str());
             } else {
                 if (device_state->android_external_format_resolve_null_color_attachment_prop &&
                     resolve_view_state->image_state->GetSamples() != VK_SAMPLE_COUNT_1_BIT) {
-                    const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView);
+                    const LogObjectList attachment_objlist(objlist, color_attachment.resolveImageView);
                     skip |= LogError("VUID-VkRenderingAttachmentInfo-nullColorAttachmentWithExternalFormatResolve-09325",
-                                     commandBuffer, color_attachment_loc.dot(Field::resolveImageView), "image was created with %s.",
+                                     attachment_objlist, color_attachment_loc.dot(Field::resolveImageView),
+                                     "image was created with %s.",
                                      string_VkSampleCountFlagBits(resolve_view_state->image_state->GetSamples()));
                 }
                 if (!resolve_view_state->image_state->HasAHBFormat()) {
-                    const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView);
-                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09326", commandBuffer,
+                    const LogObjectList attachment_objlist(objlist, color_attachment.resolveImageView);
+                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09326", attachment_objlist,
                                      color_attachment_loc.dot(Field::resolveImageView), "was not created with an external format.");
                 }
                 if (resolve_view_state->create_info.subresourceRange.layerCount != 1) {
-                    const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView);
-                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09327", commandBuffer,
+                    const LogObjectList attachment_objlist(objlist, color_attachment.resolveImageView);
+                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09327", attachment_objlist,
                                      color_attachment_loc.dot(Field::resolveImageView),
                                      "was created with subresourceRange.layerCount of %" PRIu32 ".",
                                      resolve_view_state->create_info.subresourceRange.layerCount);
                 }
                 if (auto color_view_state = Get<vvl::ImageView>(color_attachment.imageView)) {
                     if (device_state->android_external_format_resolve_null_color_attachment_prop) {
-                        const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView, color_attachment.imageView);
-                        skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09328", commandBuffer,
+                        const LogObjectList attachment_objlist(objlist, color_attachment.resolveImageView,
+                                                               color_attachment.imageView);
+                        skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09328", attachment_objlist,
                                          color_attachment_loc.dot(Field::imageView), "is not null (%s).",
                                          FormatHandle(color_attachment.imageView).c_str());
                     } else {
@@ -4312,9 +4349,9 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
                             device_state->GetExternalFormatResolveANDROID(resolve_view_state->image_state->ahb_format);
                         if (ahb_resolve_format != VK_FORMAT_UNDEFINED &&
                             ahb_resolve_format != color_view_state->create_info.format) {
-                            const LogObjectList objlist(commandBuffer, color_attachment.resolveImageView,
-                                                        color_attachment.imageView);
-                            skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09330", commandBuffer,
+                            const LogObjectList attachment_objlist(objlist, color_attachment.resolveImageView,
+                                                                   color_attachment.imageView);
+                            skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09330", attachment_objlist,
                                              color_attachment_loc.dot(Field::imageView),
                                              "has externalFormat %" PRIu64
                                              " which corresponds to needing a color attachment format of %s, but the format is %s.",
@@ -4323,7 +4360,7 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
                         }
                     }
                 } else if (!device_state->android_external_format_resolve_null_color_attachment_prop) {
-                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09329", commandBuffer,
+                    skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09329", objlist,
                                      color_attachment_loc.dot(Field::imageView), "is not valid.");
                 }
             }
@@ -4332,16 +4369,17 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
         if (color_attachment.resolveMode != VK_RESOLVE_MODE_NONE && resolve_view_state) {
             const VkComponentMapping components = resolve_view_state->create_info.components;
             if (!IsIdentitySwizzle(components)) {
-                const LogObjectList objlist(commandBuffer, resolve_view_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-09480", objlist,
+                const LogObjectList attachment_objlist(objlist, resolve_view_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-09480", attachment_objlist,
                                  color_attachment_loc.dot(Field::resolveImageView),
                                  "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
                                  string_VkComponentMapping(components).c_str());
             }
 
             if ((resolve_view_state->inherited_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) == 0) {
-                const LogObjectList objlist(commandBuffer, resolve_view_state->Handle(), resolve_view_state->image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-09476", objlist,
+                const LogObjectList attachment_objlist(objlist, resolve_view_state->Handle(),
+                                                       resolve_view_state->image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-09476", attachment_objlist,
                                  color_attachment_loc.dot(Field::resolveImageView),
                                  "references an image which was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT "
                                  "(resolveMode is %s).\n%s",
@@ -4353,57 +4391,57 @@ bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer&
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
-                                                       const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoDepthAttachment(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                      const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pDepthAttachment) return skip;
 
-    const VkCommandBuffer commandBuffer = cb_state.VkHandle();
     const VkRenderingAttachmentInfo& depth_attachment = *rendering_info.pDepthAttachment;
     const Location depth_attachment_loc = rendering_info_loc.dot(Field::pDepthAttachment);
-    skip |= ValidateRenderingAttachmentInfo(commandBuffer, rendering_info, depth_attachment, depth_attachment_loc);
-    skip |= ValidateRenderingAttachmentCurrentLayout(cb_state, depth_attachment, depth_attachment_loc);
+    skip |= ValidateRenderingAttachmentInfo(objlist, rendering_info, depth_attachment, depth_attachment_loc);
 
     if (depth_attachment.imageView != VK_NULL_HANDLE) {
         auto depth_view_state = Get<vvl::ImageView>(depth_attachment.imageView);
         ASSERT_AND_RETURN_SKIP(depth_view_state);
         const vvl::Image& image_state = *depth_view_state->image_state;
-        const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state.Handle());
+        const LogObjectList attachment_objlist(objlist, depth_view_state->Handle(), image_state.Handle());
 
         if (!(depth_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06088", objlist, depth_attachment_loc.dot(Field::imageView),
+            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06088",
+                             attachment_objlist, depth_attachment_loc.dot(Field::imageView),
                              "references an image which was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.\n%s",
                              depth_view_state->DescribeImageUsage(*this).c_str());
         }
 
         if (!vkuFormatHasDepth(depth_view_state->create_info.format)) {
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06547", objlist, depth_attachment_loc.dot(Field::imageView),
+            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06547",
+                             attachment_objlist, depth_attachment_loc.dot(Field::imageView),
                              "was created with a format (%s) that does not have a depth aspect.",
                              string_VkFormat(depth_view_state->create_info.format));
         }
 
-        skip |= ValidateRenderingInfoAttachment(*depth_view_state, rendering_info, objlist, depth_attachment_loc);
+        skip |= ValidateRenderingInfoAttachment(*depth_view_state, rendering_info, attachment_objlist, depth_attachment_loc);
     }
 
     if (depth_attachment.resolveMode != VK_RESOLVE_MODE_NONE) {
         if (depth_attachment.resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID) {
             skip |=
-                LogError("VUID-VkRenderingInfo-pDepthAttachment-09318", commandBuffer, depth_attachment_loc.dot(Field::resolveMode),
+                LogError("VUID-VkRenderingInfo-pDepthAttachment-09318", objlist, depth_attachment_loc.dot(Field::resolveMode),
                          "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID.");
         }
         if (auto depth_resolve_view_state = Get<vvl::ImageView>(depth_attachment.resolveImageView)) {
             const VkComponentMapping components = depth_resolve_view_state->create_info.components;
             if (!IsIdentitySwizzle(components)) {
-                const LogObjectList objlist(commandBuffer, depth_resolve_view_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09482", objlist,
+                const LogObjectList attachment_objlist(objlist, depth_resolve_view_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09482", attachment_objlist,
                                  depth_attachment_loc.dot(Field::resolveImageView),
                                  "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
                                  string_VkComponentMapping(components).c_str());
             }
             if ((depth_resolve_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-                const LogObjectList objlist(commandBuffer, depth_resolve_view_state->Handle(),
-                                            depth_resolve_view_state->image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09477", objlist,
+                const LogObjectList attachment_objlist(objlist, depth_resolve_view_state->Handle(),
+                                                       depth_resolve_view_state->image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09477", attachment_objlist,
                                  depth_attachment_loc.dot(Field::resolveImageView),
                                  "references an image which was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT "
                                  "(resolveMode is %s).\n%s",
@@ -4413,9 +4451,9 @@ bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer&
 
             if (rendering_info.viewMask == 0 &&
                 rendering_info.layerCount > depth_resolve_view_state->normalized_subresource_range.layerCount) {
-                const LogObjectList objlist(commandBuffer, depth_resolve_view_state->Handle());
+                const LogObjectList attachment_objlist(objlist, depth_resolve_view_state->Handle());
                 skip |=
-                    LogError("VUID-VkRenderingInfo-viewMask-10860", objlist, depth_attachment_loc.dot(Field::layerCount),
+                    LogError("VUID-VkRenderingInfo-viewMask-10860", attachment_objlist, depth_attachment_loc.dot(Field::layerCount),
                              "(%" PRIu32 ") is greater than the resolveImageView which was created with a layerCount of %" PRIu32
                              " (resolveMode is %s).",
                              rendering_info.layerCount, depth_resolve_view_state->normalized_subresource_range.layerCount,
@@ -4423,9 +4461,10 @@ bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer&
             }
 
             if (rendering_info.viewMask != 0 && depth_resolve_view_state->normalized_subresource_range.layerCount <=
-                                                    (uint32_t)MostSignificantBit(rendering_info.viewMask)) {
-                const LogObjectList objlist(commandBuffer, depth_resolve_view_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-viewMask-12404", objlist, depth_attachment_loc.dot(Field::resolveImageView),
+                                                    static_cast<uint32_t>(MostSignificantBit(rendering_info.viewMask))) {
+                const LogObjectList attachment_objlist(objlist, depth_resolve_view_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-viewMask-12404", attachment_objlist,
+                                 depth_attachment_loc.dot(Field::resolveImageView),
                                  "must have a layerCount (%" PRIu32
                                  ") greater than the most significant bit index (%d) in viewMask (0x%" PRIx32 ")",
                                  depth_resolve_view_state->normalized_subresource_range.layerCount,
@@ -4436,40 +4475,40 @@ bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer&
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
-                                                         const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoStencilAttachment(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                        const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pStencilAttachment) return skip;
 
-    const VkCommandBuffer commandBuffer = cb_state.VkHandle();
     const VkRenderingAttachmentInfo& stencil_attachment = *rendering_info.pStencilAttachment;
     const Location stencil_attachment_loc = rendering_info_loc.dot(Field::pStencilAttachment);
-    skip |= ValidateRenderingAttachmentInfo(commandBuffer, rendering_info, stencil_attachment, stencil_attachment_loc);
-    skip |= ValidateRenderingAttachmentCurrentLayout(cb_state, stencil_attachment, stencil_attachment_loc);
+    skip |= ValidateRenderingAttachmentInfo(objlist, rendering_info, stencil_attachment, stencil_attachment_loc);
 
     if (stencil_attachment.imageView != VK_NULL_HANDLE) {
         auto stencil_view_state = Get<vvl::ImageView>(stencil_attachment.imageView);
         ASSERT_AND_RETURN_SKIP(stencil_view_state);
         const vvl::Image& image_state = *stencil_view_state->image_state;
-        const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state.Handle());
+        const LogObjectList attachment_objlist(objlist, stencil_view_state->Handle(), image_state.Handle());
 
         if (!(stencil_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06089", objlist, stencil_attachment_loc.dot(Field::imageView),
+            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06089",
+                             attachment_objlist, stencil_attachment_loc.dot(Field::imageView),
                              "references an image which was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.\n%s",
                              stencil_view_state->DescribeImageUsage(*this).c_str());
         }
 
         if (!vkuFormatHasStencil(stencil_view_state->create_info.format)) {
-            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06548", objlist, stencil_attachment_loc.dot(Field::imageView),
+            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06548",
+                             attachment_objlist, stencil_attachment_loc.dot(Field::imageView),
                              "was created with a format (%s) that does not have a stencil aspect.",
                              string_VkFormat(stencil_view_state->create_info.format));
         }
 
-        skip |= ValidateRenderingInfoAttachment(*stencil_view_state, rendering_info, objlist, stencil_attachment_loc);
+        skip |= ValidateRenderingInfoAttachment(*stencil_view_state, rendering_info, attachment_objlist, stencil_attachment_loc);
     }
     if (stencil_attachment.resolveMode != VK_RESOLVE_MODE_NONE) {
         if (stencil_attachment.resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID) {
-            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09319", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09319", objlist,
                              stencil_attachment_loc.dot(Field::resolveMode),
                              "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID.");
         }
@@ -4477,16 +4516,16 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffe
         if (auto stencil_resolve_view_state = Get<vvl::ImageView>(stencil_attachment.resolveImageView)) {
             const VkComponentMapping components = stencil_resolve_view_state->create_info.components;
             if (!IsIdentitySwizzle(components)) {
-                const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09484", objlist,
+                const LogObjectList attachment_objlist(objlist, stencil_resolve_view_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09484", attachment_objlist,
                                  stencil_attachment_loc.dot(Field::resolveImageView),
                                  "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
                                  string_VkComponentMapping(components).c_str());
             }
             if ((stencil_resolve_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-                const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->Handle(),
-                                            stencil_resolve_view_state->image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09478", objlist,
+                const LogObjectList attachment_objlist(objlist, stencil_resolve_view_state->Handle(),
+                                                       stencil_resolve_view_state->image_state->Handle());
+                skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09478", attachment_objlist,
                                  stencil_attachment_loc.dot(Field::resolveImageView),
                                  "references an image which was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT "
                                  "(resolveMode is %s).\n%s",
@@ -4496,9 +4535,10 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffe
 
             if (rendering_info.viewMask == 0 &&
                 rendering_info.layerCount > stencil_resolve_view_state->normalized_subresource_range.layerCount) {
-                const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->Handle());
+                const LogObjectList attachment_objlist(objlist, stencil_resolve_view_state->Handle());
                 skip |=
-                    LogError("VUID-VkRenderingInfo-viewMask-10861", objlist, stencil_attachment_loc.dot(Field::layerCount),
+                    LogError("VUID-VkRenderingInfo-viewMask-10861", attachment_objlist,
+                             stencil_attachment_loc.dot(Field::layerCount),
                              "(%" PRIu32 ") is greater than the resolveImageView which was created with a layerCount of %" PRIu32
                              " (resolveMode is %s).",
                              rendering_info.layerCount, stencil_resolve_view_state->normalized_subresource_range.layerCount,
@@ -4506,10 +4546,11 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffe
             }
 
             if (rendering_info.viewMask != 0 && stencil_resolve_view_state->normalized_subresource_range.layerCount <=
-                                                    (uint32_t)MostSignificantBit(rendering_info.viewMask)) {
-                const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->Handle());
+                                                    static_cast<uint32_t>(MostSignificantBit(rendering_info.viewMask))) {
+                const LogObjectList attachment_objlist(objlist, stencil_resolve_view_state->Handle());
                 skip |=
-                    LogError("VUID-VkRenderingInfo-viewMask-12405", objlist, stencil_attachment_loc.dot(Field::resolveImageView),
+                    LogError("VUID-VkRenderingInfo-viewMask-12405", attachment_objlist,
+                             stencil_attachment_loc.dot(Field::resolveImageView),
                              "must have a layerCount (%" PRIu32
                              ") greater than the most significant bit index (%d) in viewMask (0x%" PRIx32 ")",
                              stencil_resolve_view_state->normalized_subresource_range.layerCount,
@@ -4520,9 +4561,33 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffe
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer commandBuffer,
-                                                                 const VkRenderingInfo& rendering_info,
-                                                                 const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                       const Location& rendering_info_loc) const {
+    bool skip = false;
+    for (uint32_t index = 0; index < rendering_info.colorAttachmentCount; ++index) {
+        const Location attachment_loc = rendering_info_loc.dot(Field::pColorAttachments, index);
+        skip |= ValidateRenderingAttachmentCurrentLayout(cb_state, rendering_info.pColorAttachments[index], attachment_loc);
+    }
+    return skip;
+}
+
+bool CoreChecks::ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                       const Location& rendering_info_loc) const {
+    if (!rendering_info.pDepthAttachment) return false;
+    return ValidateRenderingAttachmentCurrentLayout(cb_state, *rendering_info.pDepthAttachment,
+                                                    rendering_info_loc.dot(Field::pDepthAttachment));
+}
+
+bool CoreChecks::ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                         const Location& rendering_info_loc) const {
+    if (!rendering_info.pStencilAttachment) return false;
+    return ValidateRenderingAttachmentCurrentLayout(cb_state, *rendering_info.pStencilAttachment,
+                                                    rendering_info_loc.dot(Field::pStencilAttachment));
+}
+
+bool CoreChecks::ValidateRenderingInfoDepthAndStencilAttachment(const LogObjectList& objlist,
+                                                                const VkRenderingInfo& rendering_info,
+                                                                const Location& rendering_info_loc) const {
     bool skip = false;
     if (!rendering_info.pDepthAttachment || !rendering_info.pStencilAttachment) return skip;
 
@@ -4531,16 +4596,16 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer
 
     if (depth_attachment.imageView != VK_NULL_HANDLE && stencil_attachment.imageView != VK_NULL_HANDLE) {
         if (depth_attachment.imageView != stencil_attachment.imageView) {
-            const LogObjectList objlist(commandBuffer, depth_attachment.imageView, stencil_attachment.imageView);
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06085", objlist, rendering_info_loc,
+            const LogObjectList attachment_objlist(objlist, depth_attachment.imageView, stencil_attachment.imageView);
+            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06085", attachment_objlist, rendering_info_loc,
                              "imageView of pDepthAttachment and pStencilAttachment must be the same.");
         }
 
         if ((phys_dev_props_core12.independentResolveNone == VK_FALSE) &&
             (depth_attachment.resolveMode != stencil_attachment.resolveMode)) {
-            const LogObjectList objlist(commandBuffer, depth_attachment.imageView, stencil_attachment.imageView);
+            const LogObjectList attachment_objlist(objlist, depth_attachment.imageView, stencil_attachment.imageView);
             skip |=
-                LogError("VUID-VkRenderingInfo-pDepthAttachment-06104", objlist, rendering_info_loc,
+                LogError("VUID-VkRenderingInfo-pDepthAttachment-06104", attachment_objlist, rendering_info_loc,
                          "values of pDepthAttachment->resolveMode (%s) and pStencilAttachment->resolveMode (%s) must be identical.",
                          string_VkResolveModeFlagBits(depth_attachment.resolveMode),
                          string_VkResolveModeFlagBits(stencil_attachment.resolveMode));
@@ -4549,8 +4614,8 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer
         if ((phys_dev_props_core12.independentResolve == VK_FALSE) && (depth_attachment.resolveMode != VK_RESOLVE_MODE_NONE) &&
             (stencil_attachment.resolveMode != VK_RESOLVE_MODE_NONE) &&
             (stencil_attachment.resolveMode != depth_attachment.resolveMode)) {
-            const LogObjectList objlist(commandBuffer, depth_attachment.imageView, stencil_attachment.imageView);
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06105", objlist, rendering_info_loc,
+            const LogObjectList attachment_objlist(objlist, depth_attachment.imageView, stencil_attachment.imageView);
+            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06105", attachment_objlist, rendering_info_loc,
                              "values of pDepthAttachment->resolveMode (%s) and pStencilAttachment->resolveMode (%s) must "
                              "be identical, or one of them must be VK_RESOLVE_MODE_NONE.",
                              string_VkResolveModeFlagBits(depth_attachment.resolveMode),
@@ -4560,8 +4625,8 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer
 
     if (depth_attachment.resolveMode != VK_RESOLVE_MODE_NONE && stencil_attachment.resolveMode != VK_RESOLVE_MODE_NONE) {
         if (depth_attachment.resolveImageView != stencil_attachment.resolveImageView) {
-            const LogObjectList objlist(commandBuffer, depth_attachment.resolveImageView, stencil_attachment.resolveImageView);
-            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06086", objlist, rendering_info_loc,
+            const LogObjectList attachment_objlist(objlist, depth_attachment.resolveImageView, stencil_attachment.resolveImageView);
+            skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06086", attachment_objlist, rendering_info_loc,
                              "resolveImageView of pDepthAttachment and pStencilAttachment must be the same.\ndepth resolveMode is "
                              "%s and stencil resolveMode is %s",
                              string_VkResolveModeFlagBits(depth_attachment.resolveMode),
@@ -4571,18 +4636,17 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
-                                                             const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
-                                                             const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoTileShadingCreateInfo(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                            const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                            const Location& rendering_info_loc) const {
     bool skip = false;
     const bool has_rp_enable_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0;
-    const bool has_rp_per_tile_exec_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0;
     const auto* fragment_density_map_info =
             vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext);
 
     if (fragment_density_map_info && fragment_density_map_info->imageView != VK_NULL_HANDLE && has_rp_enable_bit) {
-        const LogObjectList objlist(cb_state.Handle(), fragment_density_map_info->imageView);
-        skip |= LogError("VUID-VkRenderingInfo-imageView-10643", objlist,
+        const LogObjectList attachment_objlist(objlist, fragment_density_map_info->imageView);
+        skip |= LogError("VUID-VkRenderingInfo-imageView-10643", attachment_objlist,
                          rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                          "is not VK_NULL_HANDLE, but VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes "
                          "VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
@@ -4592,14 +4656,24 @@ bool CoreChecks::ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandB
     for (uint32_t index = 0; index < rendering_info.colorAttachmentCount; ++index) {
         if (rendering_info.pColorAttachments[index].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID &&
             has_rp_enable_bit) {
-            const LogObjectList objlist(cb_state.Handle(), rendering_info.pColorAttachments[index].resolveImageView);
-            skip |= LogError("VUID-VkRenderingInfo-resolveMode-10644", objlist,
+            const LogObjectList attachment_objlist(objlist, rendering_info.pColorAttachments[index].resolveImageView);
+            skip |= LogError("VUID-VkRenderingInfo-resolveMode-10644", attachment_objlist,
                              rendering_info_loc.dot(Field::pColorAttachments, index).dot(Field::resolveMode),
                              "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID, but "
                              "VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit",
                              string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
         }
     }
+
+    return skip;
+}
+
+bool CoreChecks::ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                             const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                             const Location& rendering_info_loc) const {
+    bool skip = false;
+    const bool has_rp_enable_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0;
+    const bool has_rp_per_tile_exec_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0;
 
     if (has_rp_enable_bit && (cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) != 0) {
         skip |= LogError("VUID-vkCmdBeginRendering-flags-10641", cb_state.Handle(),
@@ -4791,7 +4865,8 @@ bool CoreChecks::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer
     return PreCallValidateCmdEndRendering(commandBuffer, error_obj);
 }
 
-bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
+bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(const LogObjectList& objlist,
+                                                              const vvl::ImageView& image_view_state,
                                                               const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
                                                               const Location& attachment_loc,
                                                               const Location& rendering_info_loc) const {
@@ -4800,8 +4875,8 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
         return false;
     }
     if ((image_view_state.samples != VK_SAMPLE_COUNT_1_BIT) && (image_view_state.samples != msrtss_info.rasterizationSamples)) {
-        const LogObjectList objlist(commandBuffer, image_view_state.Handle());
-        skip |= LogError("VUID-VkRenderingInfo-imageView-06858", objlist,
+        const LogObjectList attachment_objlist(objlist, image_view_state.Handle());
+        skip |= LogError("VUID-VkRenderingInfo-imageView-06858", attachment_objlist,
                          rendering_info_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT,
                                                   Field::multisampledRenderToSingleSampledEnable),
                          "is %s, but %s was created with %s, which is not VK_SAMPLE_COUNT_1_BIT.",
@@ -4811,8 +4886,8 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
     vvl::Image* image_state = image_view_state.image_state.get();
     if ((image_view_state.samples == VK_SAMPLE_COUNT_1_BIT) &&
         !(image_state->create_flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT)) {
-        const LogObjectList objlist(commandBuffer, image_view_state.Handle());
-        skip |= LogError("VUID-VkRenderingInfo-imageView-06859", objlist, attachment_loc,
+        const LogObjectList attachment_objlist(objlist, image_view_state.Handle());
+        skip |= LogError("VUID-VkRenderingInfo-imageView-06859", attachment_objlist, attachment_loc,
                          "was created with VK_SAMPLE_COUNT_1_BIT but "
                          "VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT was not set in "
                          "pImageCreateInfo.flags when the image used to create the imageView (%s) was created",
@@ -4825,8 +4900,8 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
         }
     }
     if (!(image_state->image_format_properties.sampleCounts & msrtss_info.rasterizationSamples)) {
-        const LogObjectList objlist(commandBuffer, image_view_state.Handle());
-        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880", objlist,
+        const LogObjectList attachment_objlist(objlist, image_view_state.Handle());
+        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880", attachment_objlist,
                          rendering_info_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples),
                          "is %s, but %s format %s does not support sample count %s from an image with imageType: %s, tiling: "
                          "%s, usage: %s, flags: %s.",

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -653,7 +653,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
             layer_or_view_count = fb_state->create_info.layers;
         }
 
-        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(commandBuffer, *counters_begin_info, objlist,
+        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(objlist, *counters_begin_info,
                                                                        rp_state->create_info.subpassCount, layer_or_view_count,
                                                                        pRenderPassBegin->renderArea, rp_begin_loc);
     }
@@ -694,8 +694,8 @@ bool CoreChecks::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffe
 }
 
 bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(
-    VkCommandBuffer commandBuffer, const VkRenderPassPerformanceCountersByRegionBeginInfoARM& counters_begin_info,
-    const LogObjectList& objlist, uint32_t subpass_count, uint32_t layer_or_view_count, VkRect2D render_area,
+    const LogObjectList& objlist, const VkRenderPassPerformanceCountersByRegionBeginInfoARM& counters_begin_info,
+    uint32_t subpass_count, uint32_t layer_or_view_count, VkRect2D render_area,
     const Location& begin_loc) const {
     bool skip = false;
 
@@ -724,7 +724,7 @@ bool CoreChecks::ValidateRenderPassPerformanceCountersByRegionBeginInfo(
 
         for (auto& buffer_state : buffer_states) {
             skip |= ValidateMemoryIsBoundToBuffer(
-                commandBuffer, *buffer_state,
+                objlist, *buffer_state,
                 begin_loc.pNext(Struct::VkRenderPassPerformanceCountersByRegionBeginInfoARM, Field::pCounterAddresses),
                 "VUID-VkRenderPassPerformanceCountersByRegionBeginInfoARM-pCounterAddresses-11816");
         }
@@ -3344,10 +3344,10 @@ bool CoreChecks::ValidateRenderingAttachmentFlagsInfo(const core::RenderingAttac
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer,
-                                                          const VkRenderingFragmentDensityMapAttachmentInfoEXT& fdm_attachment_info,
-                                                          const VkRenderingInfo& rendering_info,
-                                                          const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoFragmentDensityMap(const LogObjectList& objlist,
+                                                         const VkRenderingFragmentDensityMapAttachmentInfoEXT& fdm_attachment_info,
+                                                         const VkRenderingInfo& rendering_info,
+                                                         const Location& rendering_info_loc) const {
     bool skip = false;
     if (fdm_attachment_info.imageView == VK_NULL_HANDLE) {
         return skip;
@@ -3367,8 +3367,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
                     continue;
                 }
                 if (!(image_view_state->image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
-                    const LogObjectList objlist(commandBuffer, rendering_info.pColorAttachments[j].imageView);
-                    skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
+                    skip |= LogError("VUID-VkRenderingInfo-imageView-06107",
+                                     LogObjectList(objlist, rendering_info.pColorAttachments[j].imageView),
                                      rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                      "must be created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
                 }
@@ -3378,8 +3378,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         if (rendering_info.pDepthAttachment && (rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE)) {
             auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
             if (depth_view_state && !(depth_view_state->image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
-                const LogObjectList objlist(commandBuffer, rendering_info.pDepthAttachment->imageView);
-                skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-imageView-06107",
+                                 LogObjectList(objlist, rendering_info.pDepthAttachment->imageView),
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "must be created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
             }
@@ -3388,8 +3388,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         if (rendering_info.pStencilAttachment && (rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE)) {
             auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
             if (stencil_view_state && !(stencil_view_state->image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
-                const LogObjectList objlist(commandBuffer, rendering_info.pStencilAttachment->imageView);
-                skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-imageView-06107",
+                                 LogObjectList(objlist, rendering_info.pStencilAttachment->imageView),
                                  rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "must be created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
             }
@@ -3397,33 +3397,33 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
     }
 
     if ((fdm_image_view->inherited_usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) == 0) {
-        const LogObjectList objlist(commandBuffer, fdm_attachment_info.imageView, fdm_image_state->Handle());
-        skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158", objlist, view_loc,
+        skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158",
+                         LogObjectList(objlist, fdm_attachment_info.imageView, fdm_image_state->Handle()), view_loc,
                          "references %s which was not created with VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT.\n%s",
                          FormatHandle(fdm_image_state->Handle()).c_str(), fdm_image_view->DescribeImageUsage(*this).c_str());
     }
     if ((fdm_image_state->create_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) != 0) {
-        const LogObjectList objlist(commandBuffer, fdm_attachment_info.imageView, fdm_image_state->Handle());
-        skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06159", objlist, view_loc,
+        skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06159",
+                         LogObjectList(objlist, fdm_attachment_info.imageView, fdm_image_state->Handle()), view_loc,
                          "references %s which was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT "
                          "(VkRenderingFragmentDensityMapAttachmentInfoEXT is for non-subsampled images).",
                          FormatHandle(fdm_image_state->Handle()).c_str());
     }
     int32_t layer_count = static_cast<int32_t>(fdm_image_view->normalized_subresource_range.layerCount);
     if (layer_count != 1 && !enabled_features.multiview) {
-        const LogObjectList objlist(commandBuffer, fdm_attachment_info.imageView);
-        skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-apiVersion-07908", objlist, view_loc,
+        skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-apiVersion-07908",
+                         LogObjectList(objlist, fdm_attachment_info.imageView), view_loc,
                          "must have a layerCount (%" PRId32 ") equal to 1.", layer_count);
     }
     if ((rendering_info.viewMask == 0) && (layer_count != 1)) {
-        const LogObjectList objlist(commandBuffer, fdm_attachment_info.imageView);
-        skip |= LogError("VUID-VkRenderingInfo-imageView-06109", objlist, view_loc,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-06109",
+                         LogObjectList(objlist, fdm_attachment_info.imageView), view_loc,
                          "must have a layerCount (%" PRId32 ") equal to 1 when viewMask is equal to 0", layer_count);
     }
 
     if ((rendering_info.viewMask != 0) && (layer_count < MostSignificantBit(rendering_info.viewMask))) {
-        const LogObjectList objlist(commandBuffer, fdm_attachment_info.imageView);
-        skip |= LogError("VUID-VkRenderingInfo-imageView-06108", objlist, view_loc,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-06108",
+                         LogObjectList(objlist, fdm_attachment_info.imageView), view_loc,
                          "must have a layerCount (%" PRId32
                          ") greater than or equal to the most significant bit (%d) in viewMask (0x%" PRIx32 ")",
                          layer_count, MostSignificantBit(rendering_info.viewMask), rendering_info.viewMask);
@@ -3431,8 +3431,8 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
 
     const VkComponentMapping components = fdm_image_view->create_info.components;
     if (!IsIdentitySwizzle(components)) {
-        const LogObjectList objlist(commandBuffer, fdm_image_view->Handle());
-        skip |= LogError("VUID-VkRenderingInfo-imageView-09486", objlist, view_loc,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-09486",
+                         LogObjectList(objlist, fdm_image_view->Handle()), view_loc,
                          "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
                          string_VkComponentMapping(components).c_str());
     }
@@ -3451,9 +3451,9 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
             vvl::GetQuotientCeil(
                 x_adjusted_extent,
                 static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width))) {
-            const LogObjectList objlist(commandBuffer, fdm_attachment_info.imageView, fdm_image_state->Handle());
             skip |=
-                LogError("VUID-VkRenderingInfo-pNext-06112", objlist,
+                LogError("VUID-VkRenderingInfo-pNext-06112",
+                         LogObjectList(objlist, fdm_attachment_info.imageView, fdm_image_state->Handle()),
                          rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                          "width (%" PRIu32 ") must not be less than (pRenderingInfo->renderArea.offset.x (%" PRId32
                          ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
@@ -3465,9 +3465,9 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
             vvl::GetQuotientCeil(
                 y_adjusted_extent,
                 static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height))) {
-            const LogObjectList objlist(commandBuffer, fdm_attachment_info.imageView, fdm_image_state->Handle());
             skip |=
-                LogError("VUID-VkRenderingInfo-pNext-06114", objlist,
+                LogError("VUID-VkRenderingInfo-pNext-06114",
+                         LogObjectList(objlist, fdm_attachment_info.imageView, fdm_image_state->Handle()),
                          rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                          "height (%" PRIu32 ") must not be less than (pRenderingInfo->renderArea.offset.y (%" PRId32
                          ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
@@ -3480,8 +3480,9 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(
-    VkCommandBuffer commandBuffer, const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info,
+bool CoreChecks::ValidateRenderingInfoFragmentShadingRate(
+    const LogObjectList& objlist,
+    const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info,
     const VkRenderingInfo& rendering_info, const Location& rendering_info_loc) const {
     bool skip = false;
     if (fsr_attachment_info.imageView == VK_NULL_HANDLE) {
@@ -3490,11 +3491,11 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(
 
     auto view_state = Get<vvl::ImageView>(fsr_attachment_info.imageView);
     ASSERT_AND_RETURN_SKIP(view_state);
-    const LogObjectList objlist(commandBuffer, view_state->Handle());
+    const LogObjectList view_objlist(objlist, view_state->Handle());
     if (rendering_info.viewMask == 0) {
         if (view_state->normalized_subresource_range.layerCount != 1 &&
             view_state->normalized_subresource_range.layerCount < rendering_info.layerCount) {
-            skip |= LogError("VUID-VkRenderingInfo-imageView-06123", objlist, rendering_info_loc.dot(Field::layerCount),
+            skip |= LogError("VUID-VkRenderingInfo-imageView-06123", view_objlist, rendering_info_loc.dot(Field::layerCount),
                              "is (%" PRIu32
                              ") but VkRenderingFragmentShadingRateAttachmentInfoKHR::imageView was created with (%" PRIu32 ").",
                              rendering_info.layerCount, view_state->normalized_subresource_range.layerCount);
@@ -3503,7 +3504,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(
         int highest_view_bit = MostSignificantBit(rendering_info.viewMask);
         int32_t layer_count = view_state->normalized_subresource_range.layerCount;
         if (layer_count != 1 && layer_count < highest_view_bit) {
-            skip |= LogError("VUID-VkRenderingInfo-imageView-06124", objlist,
+            skip |= LogError("VUID-VkRenderingInfo-imageView-06124", view_objlist,
                              rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                              "has a layerCount (%" PRId32
                              ") but must either is equal to 1 or greater than "
@@ -3514,7 +3515,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(
 
     if ((view_state->inherited_usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) == 0) {
         skip |=
-            LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148", objlist,
+            LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148", view_objlist,
                      rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                      "references an image which was not created with VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR.\n%s",
                      view_state->DescribeImageUsage(*this).c_str());
@@ -3522,19 +3523,19 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(
 
     const VkComponentMapping components = view_state->create_info.components;
     if (!IsIdentitySwizzle(components)) {
-        skip |= LogError("VUID-VkRenderingInfo-imageView-09485", objlist,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-09485", view_objlist,
                          rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
                          "has a non-identiy swizzle component, here are the actual swizzle values:\n%s",
                          string_VkComponentMapping(components).c_str());
     }
 
-    skip |= ValidateBeginRenderingFragmentShadingRateRenderArea(commandBuffer, *view_state, fsr_attachment_info, rendering_info,
-                                                                rendering_info_loc);
+    skip |= ValidateRenderingInfoFragmentShadingRateRenderArea(view_objlist, *view_state, fsr_attachment_info, rendering_info,
+                                                               rendering_info_loc);
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
-    VkCommandBuffer commandBuffer, const vvl::ImageView& view_state,
+bool CoreChecks::ValidateRenderingInfoFragmentShadingRateRenderArea(
+    const LogObjectList& objlist, const vvl::ImageView& view_state,
     const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info, const VkRenderingInfo& rendering_info,
     const Location& rendering_info_loc) const {
     bool skip = false;
@@ -3545,7 +3546,6 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
         return skip;
     }
 
-    const LogObjectList objlist(commandBuffer, view_state.Handle());
     const auto* device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
     const bool non_zero_device_render_area = device_group_begin_info && device_group_begin_info->deviceRenderAreaCount != 0;
     if (!non_zero_device_render_area) {
@@ -3620,8 +3620,9 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRateRenderArea(
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                                   const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoSampleCount(const LogObjectList& objlist,
+                                                  const VkRenderingInfo& rendering_info,
+                                                  const Location& rendering_info_loc) const {
     bool skip = false;
     const VkSampleCountFlagBits unused = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
 
@@ -3641,9 +3642,9 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
                 first_color_index = i;
             }
             if (color_sample_count != image_view->samples) {
-                const LogObjectList objlist(commandBuffer, color_attachment.imageView,
-                                            rendering_info.pColorAttachments[first_color_index].imageView);
-                skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+                const LogObjectList color_objlist(objlist, color_attachment.imageView,
+                                                  rendering_info.pColorAttachments[first_color_index].imageView);
+                skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", color_objlist,
                                  rendering_info_loc.dot(Field::pColorAttachments, i).dot(Field::imageView),
                                  "was created with %s, but the pColorAttachments[%" PRIu32 "].imageView was created with %s.",
                                  string_VkSampleCountFlagBits(image_view->samples), first_color_index,
@@ -3668,24 +3669,24 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
 
         // Now we have sample from all 3 (color, depth, stencil), check each combo to produce a helpful message
         if (depth_sample_count != stencil_sample_count && depth_sample_count != unused && stencil_sample_count != unused) {
-            const LogObjectList objlist(commandBuffer, rendering_info.pDepthAttachment->imageView,
-                                        rendering_info.pStencilAttachment->imageView);
-            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+            const LogObjectList depth_stencil_objlist(objlist, rendering_info.pDepthAttachment->imageView,
+                                                      rendering_info.pStencilAttachment->imageView);
+            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", depth_stencil_objlist,
                              rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                              "was created with %s, but the pStencilAttachment->imageView was created with %s.",
                              string_VkSampleCountFlagBits(depth_sample_count), string_VkSampleCountFlagBits(stencil_sample_count));
         } else if (depth_sample_count != color_sample_count && depth_sample_count != unused && color_sample_count != unused) {
-            const LogObjectList objlist(commandBuffer, rendering_info.pDepthAttachment->imageView,
-                                        rendering_info.pColorAttachments[first_color_index].imageView);
-            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+            const LogObjectList depth_color_objlist(objlist, rendering_info.pDepthAttachment->imageView,
+                                                    rendering_info.pColorAttachments[first_color_index].imageView);
+            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", depth_color_objlist,
                              rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                              "was created with %s, but the pColorAttachments[%" PRId32 "]->imageView was created with %s.",
                              string_VkSampleCountFlagBits(depth_sample_count), first_color_index,
                              string_VkSampleCountFlagBits(color_sample_count));
         } else if (stencil_sample_count != color_sample_count && stencil_sample_count != unused && color_sample_count != unused) {
-            const LogObjectList objlist(commandBuffer, rendering_info.pStencilAttachment->imageView,
-                                        rendering_info.pColorAttachments[first_color_index].imageView);
-            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", objlist,
+            const LogObjectList stencil_color_objlist(objlist, rendering_info.pStencilAttachment->imageView,
+                                                      rendering_info.pColorAttachments[first_color_index].imageView);
+            skip |= LogError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857", stencil_color_objlist,
                              rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                              "was created with %s, but the pColorAttachments[%" PRId32 "]->imageView was created with %s.",
                              string_VkSampleCountFlagBits(stencil_sample_count), first_color_index,
@@ -3705,23 +3706,24 @@ bool CoreChecks::ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer
             ASSERT_AND_CONTINUE(image_view);
             first_sample_count = (first_sample_count == unused) ? image_view->samples : first_sample_count;
             if (first_sample_count != image_view->samples) {
-                const LogObjectList objlist(commandBuffer, color_attachment.imageView);
+                const LogObjectList color_objlist(objlist, color_attachment.imageView);
                 skip |=
-                    LogError("VUID-VkRenderingInfo-imageView-09429", objlist,
+                    LogError("VUID-VkRenderingInfo-imageView-09429", color_objlist,
                              rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                              "was created with %s, but pColorAttachments[0].imageView was created with %s.",
                              string_VkSampleCountFlagBits(image_view->samples), string_VkSampleCountFlagBits(first_sample_count));
             }
         }
     } else if (enabled_features.multisampledRenderToSingleSampled) {
-        skip |= ValidateBeginRenderingMultisampledRenderToSingleSampled(commandBuffer, rendering_info, rendering_info_loc);
+        skip |= ValidateRenderingInfoMultisampledRenderToSingleSampled(objlist, rendering_info, rendering_info_loc);
     }
 
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                                   const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoDeviceGroup(const LogObjectList& objlist,
+                                                  const VkRenderingInfo& rendering_info,
+                                                  const Location& rendering_info_loc) const {
     bool skip = false;
     const auto* device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(rendering_info.pNext);
 
@@ -3730,18 +3732,18 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         const VkRect2D& render_area = rendering_info.renderArea;
         // if the renderArea was set with garbage, only want to report 1 error
         if (render_area.offset.x < 0) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-06077", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-pNext-06077", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::offset).dot(Field::x),
                              "is %" PRId32 " (offset can't be negative).", render_area.offset.x);
         } else if (render_area.offset.y < 0) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-06078", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-pNext-06078", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::offset).dot(Field::y),
                              "is %" PRId32 " (offset can't be negative).", render_area.offset.y);
         } else if (render_area.extent.width == 0) {
-            skip |= LogError("VUID-VkRenderingInfo-None-08994", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-None-08994", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::extent).dot(Field::width), "is zero.");
         } else if (render_area.extent.height == 0) {
-            skip |= LogError("VUID-VkRenderingInfo-None-08995", commandBuffer,
+            skip |= LogError("VUID-VkRenderingInfo-None-08995", objlist,
                              rendering_info_loc.dot(Field::renderArea).dot(Field::extent).dot(Field::height), "is zero.");
         }
 
@@ -3751,13 +3753,13 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         const int64_t y_adjusted_extent =
             static_cast<int64_t>(render_area.offset.y) + static_cast<int64_t>(render_area.extent.height);
         if (x_adjusted_extent > phys_dev_props.limits.maxFramebufferWidth) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-07815", commandBuffer, rendering_info_loc.dot(Field::renderArea),
+            skip |= LogError("VUID-VkRenderingInfo-pNext-07815", objlist, rendering_info_loc.dot(Field::renderArea),
                              "offset.x (%" PRId32 ") + extent.width (%" PRIu32
                              ") is not less than or equal to maxFramebufferWidth (%" PRIu32 ").",
                              render_area.offset.x, render_area.extent.width, phys_dev_props.limits.maxFramebufferWidth);
         }
         if (y_adjusted_extent > phys_dev_props.limits.maxFramebufferHeight) {
-            skip |= LogError("VUID-VkRenderingInfo-pNext-07816", commandBuffer, rendering_info_loc.dot(Field::renderArea),
+            skip |= LogError("VUID-VkRenderingInfo-pNext-07816", objlist, rendering_info_loc.dot(Field::renderArea),
                              "offset.y (%" PRId32 ") + extent.height (%" PRIu32
                              ") is not less than or equal to maxFramebufferHeight (%" PRIu32 ").",
                              render_area.offset.y, render_area.extent.height, phys_dev_props.limits.maxFramebufferHeight);
@@ -3778,27 +3780,27 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
         const uint32_t height = render_area.extent.height;
 
         if (offset_x < 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166", objlist,
                              group_loc.dot(Field::offset).dot(Field::x), "is %" PRId32 " (offset can't be negative).", offset_x);
         } else if (offset_y < 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167", objlist,
                              group_loc.dot(Field::offset).dot(Field::y), "is %" PRId32 " (offset can't be negative).", offset_y);
         } else if (width == 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08998", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08998", objlist,
                              group_loc.dot(Field::extent).dot(Field::width), "is zero.");
         } else if (height == 0) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08999", commandBuffer,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-extent-08999", objlist,
                              group_loc.dot(Field::extent).dot(Field::height), "is zero.");
         }
 
         if ((offset_x + width) > phys_dev_props.limits.maxFramebufferWidth) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168", commandBuffer, group_loc,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168", objlist, group_loc,
                              "sum of offset.x (%" PRId32 ") and extent.width (%" PRIu32
                              ") is greater than maxFramebufferWidth (%" PRIu32 ").",
                              offset_x, width, phys_dev_props.limits.maxFramebufferWidth);
         }
         if ((offset_y + height) > phys_dev_props.limits.maxFramebufferHeight) {
-            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169", commandBuffer, group_loc,
+            skip |= LogError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169", objlist, group_loc,
                              "sum of offset.y (%" PRId32 ") and extent.height (%" PRIu32
                              ") is greater than maxFramebufferHeight (%" PRIu32 ").",
                              offset_y, height, phys_dev_props.limits.maxFramebufferHeight);
@@ -3810,8 +3812,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             ASSERT_AND_CONTINUE(image_view_state);
             vvl::Image* image_state = image_view_state->image_state.get();
             if (image_state->GetExtent().width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06083",
+                                 LogObjectList(objlist, image_view_state->Handle(), image_state->Handle()),
                                  rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                  "width (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3819,8 +3821,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->GetExtent().width, offset_x, width);
             }
             if (image_state->GetExtent().height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06084",
+                                 LogObjectList(objlist, image_view_state->Handle(), image_state->Handle()),
                                  rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                  "height (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3834,8 +3836,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             ASSERT_AND_RETURN_SKIP(depth_view_state);
             vvl::Image* image_state = depth_view_state->image_state.get();
             if (image_state->GetExtent().width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06083",
+                                 LogObjectList(objlist, depth_view_state->Handle(), image_state->Handle()),
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "width (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3843,8 +3845,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->GetExtent().width, offset_x, width);
             }
             if (image_state->GetExtent().height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06084",
+                                 LogObjectList(objlist, depth_view_state->Handle(), image_state->Handle()),
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "height (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3858,8 +3860,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             ASSERT_AND_RETURN_SKIP(stencil_view_state);
             vvl::Image* image_state = stencil_view_state->image_state.get();
             if (image_state->GetExtent().width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06083",
+                                 LogObjectList(objlist, stencil_view_state->Handle(), image_state->Handle()),
                                  rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "width (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3867,8 +3869,8 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->GetExtent().width, offset_x, width);
             }
             if (image_state->GetExtent().height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
-                skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
+                skip |= LogError("VUID-VkRenderingInfo-pNext-06084",
+                                 LogObjectList(objlist, stencil_view_state->Handle(), image_state->Handle()),
                                  rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "height (%" PRIu32
                                  ") must be greater than or equal to"
@@ -3887,9 +3889,9 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             if (image_state->GetExtent().width <
                 vvl::GetQuotientCeil(offset_x + width,
                                      phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width)) {
-                const LogObjectList objlist(commandBuffer, view_state->Handle(), image_state->Handle());
                 skip |= LogError(
-                    "VUID-VkRenderingInfo-pNext-06113", objlist,
+                    "VUID-VkRenderingInfo-pNext-06113",
+                    LogObjectList(objlist, view_state->Handle(), image_state->Handle()),
                     rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                     "width (%" PRIu32 ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                     "].offset.x (%" PRId32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
@@ -3901,9 +3903,9 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             if (image_state->GetExtent().height <
                 vvl::GetQuotientCeil(offset_y + height,
                                      phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height)) {
-                const LogObjectList objlist(commandBuffer, view_state->Handle(), image_state->Handle());
                 skip |= LogError(
-                    "VUID-VkRenderingInfo-pNext-06115", objlist,
+                    "VUID-VkRenderingInfo-pNext-06115",
+                    LogObjectList(objlist, view_state->Handle(), image_state->Handle()),
                     rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                     "height (%" PRIu32 ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                     "].offset.y (%" PRId32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
@@ -3918,9 +3920,9 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkCommandBuffer commandBuffer,
-                                                                         const VkRenderingInfo& rendering_info,
-                                                                         const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoMultisampledRenderToSingleSampled(const LogObjectList& objlist,
+                                                                        const VkRenderingInfo& rendering_info,
+                                                                        const Location& rendering_info_loc) const {
     bool skip = false;
 
     const auto* msrtss_info = vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(rendering_info.pNext);
@@ -3931,7 +3933,7 @@ bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkComma
         if (rendering_info.pColorAttachments[j].imageView != VK_NULL_HANDLE) {
             if (const auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[j].imageView)) {
                 skip |= ValidateMultisampledRenderToSingleSampleView(
-                    commandBuffer, *image_view_state, *msrtss_info,
+                    objlist, *image_view_state, *msrtss_info,
                     rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView), rendering_info_loc);
             }
         }
@@ -3939,22 +3941,102 @@ bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkComma
     if (rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
         if (const auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView)) {
             skip |= ValidateMultisampledRenderToSingleSampleView(
-                commandBuffer, *depth_view_state, *msrtss_info,
+                objlist, *depth_view_state, *msrtss_info,
                 rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView), rendering_info_loc);
         }
     }
     if (rendering_info.pStencilAttachment && rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
         if (const auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView)) {
             skip |= ValidateMultisampledRenderToSingleSampleView(
-                commandBuffer, *stencil_view_state, *msrtss_info,
+                objlist, *stencil_view_state, *msrtss_info,
                 rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView), rendering_info_loc);
         }
     }
     if (msrtss_info->rasterizationSamples == VK_SAMPLE_COUNT_1_BIT) {
-        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878", commandBuffer,
+        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878", objlist,
                          rendering_info_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples),
                          "is VK_SAMPLE_COUNT_1_BIT.");
     }
+    return skip;
+}
+
+// VkRenderingInfo validation shared by vkCmdBeginRendering and vkGetDynamicRenderingTilePropertiesQCOM.
+// This wraps the command-buffer-state-independent checks (ValidateRenderingInfo*); the
+// ValidateBeginRendering* variants depend on command-buffer state and are used only by vkCmdBeginRendering.
+bool CoreChecks::ValidateRenderingInfoCommon(const LogObjectList& objlist,
+                                             const VkRenderingInfo& rendering_info,
+                                             const Location& rendering_info_loc) const {
+    bool skip = false;
+
+    // --- Color
+    for (uint32_t index = 0; index < rendering_info.colorAttachmentCount; ++index) {
+        const core::RenderingAttachment color_attachment(
+            rendering_info, rendering_info.pColorAttachments[index], rendering_info_loc.dot(Field::pColorAttachments, index),
+            objlist, Get<vvl::ImageView>(rendering_info.pColorAttachments[index].imageView),
+            Get<vvl::ImageView>(rendering_info.pColorAttachments[index].resolveImageView),
+            core::RenderingAttachment::Type::Color);
+        skip |= ValidateRenderingInfoColorAttachment(color_attachment);
+    }
+
+    // --- Depth
+    std::optional<core::RenderingAttachment> depth_attachment;
+    if (rendering_info.pDepthAttachment) {
+        depth_attachment.emplace(rendering_info, *rendering_info.pDepthAttachment,
+                                 rendering_info_loc.dot(Field::pDepthAttachment), objlist,
+                                 Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView),
+                                 Get<vvl::ImageView>(rendering_info.pDepthAttachment->resolveImageView),
+                                 core::RenderingAttachment::Type::Depth);
+        skip |= ValidateRenderingInfoDepthAttachment(*depth_attachment);
+    }
+
+    // --- Stencil
+    std::optional<core::RenderingAttachment> stencil_attachment;
+    if (rendering_info.pStencilAttachment) {
+        stencil_attachment.emplace(rendering_info, *rendering_info.pStencilAttachment,
+                                   rendering_info_loc.dot(Field::pStencilAttachment), objlist,
+                                   Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView),
+                                   Get<vvl::ImageView>(rendering_info.pStencilAttachment->resolveImageView),
+                                   core::RenderingAttachment::Type::Stencil);
+        skip |= ValidateRenderingInfoStencilAttachment(*stencil_attachment);
+    }
+
+    if (depth_attachment && stencil_attachment) {
+        skip |= ValidateRenderingDepthAndStencilAttachment(*depth_attachment, *stencil_attachment);
+    }
+
+    // VK_AMD_mixed_attachment_samples / VK_NV_framebuffer_mixed_samples / VK_EXT_multisampled_render_to_single_sampled
+    skip |= ValidateRenderingInfoSampleCount(objlist, rendering_info, rendering_info_loc);
+
+    // VK_KHR_device_group
+    skip |= ValidateRenderingInfoDeviceGroup(objlist, rendering_info, rendering_info_loc);
+
+    // VK_EXT_fragment_density_map
+    if (const auto* fdm_attachment_info =
+            vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext)) {
+        skip |= ValidateRenderingInfoFragmentDensityMap(objlist, *fdm_attachment_info, rendering_info, rendering_info_loc);
+    }
+
+    // VK_KHR_fragment_shading_rate
+    if (const auto* fsr_attachment_info =
+            vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(rendering_info.pNext)) {
+        skip |= ValidateRenderingInfoFragmentShadingRate(objlist, *fsr_attachment_info, rendering_info, rendering_info_loc);
+    }
+
+    // VK_ARM_performance_counters_by_region
+    if (const auto counters_begin_info =
+            vku::FindStructInPNextChain<VkRenderPassPerformanceCountersByRegionBeginInfoARM>(rendering_info.pNext)) {
+        const uint32_t layer_or_view_count =
+            enabled_features.multiview ? MostSignificantBit(rendering_info.viewMask) : rendering_info.layerCount;
+        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(
+            objlist, *counters_begin_info, 1u, layer_or_view_count, rendering_info.renderArea, rendering_info_loc);
+    }
+
+    // VK_QCOM_tile_shading
+    if (const auto* rp_tile_shading_ci =
+            vku::FindStructInPNextChain<VkRenderPassTileShadingCreateInfoQCOM>(rendering_info.pNext)) {
+        skip |= ValidateRenderingInfoTileShadingCreateInfo(objlist, *rp_tile_shading_ci, rendering_info, rendering_info_loc);
+    }
+
     return skip;
 }
 
@@ -3972,67 +4054,40 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
                          "must not include VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT in a secondary command buffer.");
     }
 
-    // --- Color
-    for (uint32_t i = 0; i < pRenderingInfo->colorAttachmentCount; ++i) {
-        const core::RenderingAttachment color_attachment(*cb_state, *pRenderingInfo, pRenderingInfo->pColorAttachments[i],
-                                                         rendering_info_loc.dot(Field::pColorAttachments, i),
-                                                         core::RenderingAttachment::Type::Color);
-        skip |= ValidateBeginRenderingColorAttachment(color_attachment);
-    }
-
-    // --- Depth
-    std::optional<core::RenderingAttachment> depth_attachment;
-    if (pRenderingInfo->pDepthAttachment) {
-        depth_attachment.emplace(*cb_state, *pRenderingInfo, *pRenderingInfo->pDepthAttachment,
-                                 rendering_info_loc.dot(Field::pDepthAttachment), core::RenderingAttachment::Type::Depth);
-        skip |= ValidateBeginRenderingDepthAttachment(*depth_attachment);
-    }
-
-    // --- Stencil
-    std::optional<core::RenderingAttachment> stencil_attachment;
-    if (pRenderingInfo->pStencilAttachment) {
-        stencil_attachment.emplace(*cb_state, *pRenderingInfo, *pRenderingInfo->pStencilAttachment,
-                                   rendering_info_loc.dot(Field::pStencilAttachment), core::RenderingAttachment::Type::Stencil);
-        skip |= ValidateBeginRenderingStencilAttachment(*stencil_attachment);
-    }
-
-    if (depth_attachment.has_value() && stencil_attachment.has_value()) {
-        skip |= ValidateBeginRenderingDepthAndStencilAttachment(*depth_attachment, *stencil_attachment);
-    }
-
     skip |= ValidateBeginRenderingResume(*cb_state, *pRenderingInfo, rendering_info_loc);
+    skip |= ValidateRenderingInfoCommon(LogObjectList(commandBuffer), *pRenderingInfo, rendering_info_loc);
 
-    // VK_AMD_mixed_attachment_samples / VK_NV_framebuffer_mixed_samples / VK_EXT_multisampled_render_to_single_sampled
-    skip |= ValidateBeginRenderingSampleCount(commandBuffer, *pRenderingInfo, rendering_info_loc);
-
-    // VK_KHR_device_group
-    skip |= ValidateBeginRenderingDeviceGroup(commandBuffer, *pRenderingInfo, rendering_info_loc);
-
-    // VK_EXT_fragment_density_map
-    if (const auto* fdm_attachment_info =
-            vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(pRenderingInfo->pNext)) {
-        skip |= ValidateBeginRenderingFragmentDensityMap(commandBuffer, *fdm_attachment_info, *pRenderingInfo, rendering_info_loc);
+    // --- Color layout
+    for (uint32_t index = 0; index < pRenderingInfo->colorAttachmentCount; ++index) {
+        const core::RenderingAttachment color_attachment(
+            *pRenderingInfo, pRenderingInfo->pColorAttachments[index], rendering_info_loc.dot(Field::pColorAttachments, index),
+            LogObjectList(commandBuffer),
+            cb_state->dev_data.Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[index].imageView),
+            cb_state->dev_data.Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[index].resolveImageView),
+            core::RenderingAttachment::Type::Color);
+        skip |= ValidateRenderingAttachmentCurrentLayout(*cb_state, color_attachment);
     }
 
-    // VK_KHR_fragment_shading_rate
-    if (const auto* fsr_attachment_info =
-            vku::FindStructInPNextChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(pRenderingInfo->pNext)) {
-        skip |= ValidateBeginRenderingFragmentShadingRate(commandBuffer, *fsr_attachment_info, *pRenderingInfo, rendering_info_loc);
+    // --- Depth layout
+    if (pRenderingInfo->pDepthAttachment) {
+        const core::RenderingAttachment depth_attachment(
+            *pRenderingInfo, *pRenderingInfo->pDepthAttachment, rendering_info_loc.dot(Field::pDepthAttachment),
+            LogObjectList(commandBuffer),
+            cb_state->dev_data.Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->imageView),
+            cb_state->dev_data.Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->resolveImageView),
+            core::RenderingAttachment::Type::Depth);
+        skip |= ValidateRenderingAttachmentCurrentLayout(*cb_state, depth_attachment);
     }
 
-    // VK_ARM_performance_counters_by_region
-    if (const auto counters_begin_info =
-            vku::FindStructInPNextChain<VkRenderPassPerformanceCountersByRegionBeginInfoARM>(pRenderingInfo->pNext)) {
-        const LogObjectList objlist(cb_state->Handle());
-        uint32_t layer_or_view_count = 0;
-        if (enabled_features.multiview) {
-            layer_or_view_count = MostSignificantBit(pRenderingInfo->viewMask);
-        } else {
-            layer_or_view_count = pRenderingInfo->layerCount;
-        }
-
-        skip |= ValidateRenderPassPerformanceCountersByRegionBeginInfo(
-            commandBuffer, *counters_begin_info, objlist, 1u, layer_or_view_count, pRenderingInfo->renderArea, rendering_info_loc);
+    // --- Stencil layout
+    if (pRenderingInfo->pStencilAttachment) {
+        const core::RenderingAttachment stencil_attachment(
+            *pRenderingInfo, *pRenderingInfo->pStencilAttachment, rendering_info_loc.dot(Field::pStencilAttachment),
+            LogObjectList(commandBuffer),
+            cb_state->dev_data.Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->imageView),
+            cb_state->dev_data.Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->resolveImageView),
+            core::RenderingAttachment::Type::Stencil);
+        skip |= ValidateRenderingAttachmentCurrentLayout(*cb_state, stencil_attachment);
     }
 
     // VK_QCOM_tile_shading
@@ -4042,6 +4097,13 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     }
 
     return skip;
+}
+
+bool CoreChecks::PreCallValidateGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo* pRenderingInfo,
+                                                                      VkTilePropertiesQCOM* pProperties,
+                                                                      const ErrorObject& error_obj) const {
+    const Location rendering_info_loc = error_obj.location.dot(Field::pRenderingInfo);
+    return ValidateRenderingInfoCommon(LogObjectList(device), *pRenderingInfo, rendering_info_loc);
 }
 
 static bool CheckAttachmentNullMismatch(const CoreChecks& validator, const char* vuid, const LogObjectList& objlist,
@@ -4308,11 +4370,10 @@ bool CoreChecks::ValidateBeginRenderingExternalDownsample(const core::RenderingA
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingColorAttachment(const core::RenderingAttachment& vvl_attachment) const {
+bool CoreChecks::ValidateRenderingInfoColorAttachment(const core::RenderingAttachment& vvl_attachment) const {
     bool skip = false;
 
     skip |= ValidateRenderingAttachmentInfo(vvl_attachment);
-    skip |= ValidateRenderingAttachmentCurrentLayout(vvl_attachment);
     skip |= ValidateBeginRenderingColorResolveAttachment(vvl_attachment);
     // VK_ANDROID_external_format_resolve
     skip |= ValidateBeginRenderingExternalDownsample(vvl_attachment);
@@ -4384,10 +4445,9 @@ bool CoreChecks::ValidateBeginRenderingColorResolveAttachment(const core::Render
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDepthAttachment(const core::RenderingAttachment& vvl_attachment) const {
+bool CoreChecks::ValidateRenderingInfoDepthAttachment(const core::RenderingAttachment& vvl_attachment) const {
     bool skip = false;
     skip |= ValidateRenderingAttachmentInfo(vvl_attachment);
-    skip |= ValidateRenderingAttachmentCurrentLayout(vvl_attachment);
 
     if (vvl_attachment.image_view_state) {
         if (!(vvl_attachment.image_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
@@ -4455,11 +4515,10 @@ bool CoreChecks::ValidateBeginRenderingDepthAttachment(const core::RenderingAtta
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingStencilAttachment(const core::RenderingAttachment& vvl_attachment) const {
+bool CoreChecks::ValidateRenderingInfoStencilAttachment(const core::RenderingAttachment& vvl_attachment) const {
     bool skip = false;
 
     skip |= ValidateRenderingAttachmentInfo(vvl_attachment);
-    skip |= ValidateRenderingAttachmentCurrentLayout(vvl_attachment);
 
     if (vvl_attachment.image_view_state) {
         if (!(vvl_attachment.image_view_state->inherited_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
@@ -4528,8 +4587,8 @@ bool CoreChecks::ValidateBeginRenderingStencilAttachment(const core::RenderingAt
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(const core::RenderingAttachment& depth_attachment,
-                                                                 const core::RenderingAttachment& stencil_attachment) const {
+bool CoreChecks::ValidateRenderingDepthAndStencilAttachment(const core::RenderingAttachment& depth_attachment,
+                                                            const core::RenderingAttachment& stencil_attachment) const {
     bool skip = false;
 
     if (depth_attachment.image_view_state && stencil_attachment.image_view_state) {
@@ -4575,19 +4634,18 @@ bool CoreChecks::ValidateBeginRenderingDepthAndStencilAttachment(const core::Ren
     return skip;
 }
 
-bool CoreChecks::ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state,
-                                                             const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
-                                                             const VkRenderingInfo& rendering_info,
-                                                             const Location& rendering_info_loc) const {
+bool CoreChecks::ValidateRenderingInfoTileShadingCreateInfo(const LogObjectList& objlist,
+                                                            const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                            const VkRenderingInfo& rendering_info,
+                                                            const Location& rendering_info_loc) const {
     bool skip = false;
     const bool has_rp_enable_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0;
-    const bool has_rp_per_tile_exec_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0;
     const auto* fragment_density_map_info =
             vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext);
 
     if (fragment_density_map_info && fragment_density_map_info->imageView != VK_NULL_HANDLE && has_rp_enable_bit) {
-        const LogObjectList objlist(cb_state.Handle(), fragment_density_map_info->imageView);
-        skip |= LogError("VUID-VkRenderingInfo-imageView-10643", objlist,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-10643",
+                         LogObjectList(objlist, fragment_density_map_info->imageView),
                          rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                          "is not VK_NULL_HANDLE, but VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes "
                          "VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
@@ -4597,14 +4655,25 @@ bool CoreChecks::ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandB
     for (uint32_t index = 0; index < rendering_info.colorAttachmentCount; ++index) {
         if (rendering_info.pColorAttachments[index].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID &&
             has_rp_enable_bit) {
-            const LogObjectList objlist(cb_state.Handle(), rendering_info.pColorAttachments[index].resolveImageView);
-            skip |= LogError("VUID-VkRenderingInfo-resolveMode-10644", objlist,
+            skip |= LogError("VUID-VkRenderingInfo-resolveMode-10644",
+                             LogObjectList(objlist, rendering_info.pColorAttachments[index].resolveImageView),
                              rendering_info_loc.dot(Field::pColorAttachments, index).dot(Field::resolveMode),
                              "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_BIT_ANDROID, but "
-                             "VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit",
+                             "VkRenderPassTileShadingCreateInfoQCOM::flags (%s) includes VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM bit.",
                              string_VkTileShadingRenderPassFlagsQCOM(rp_tile_shading_ci.flags).c_str());
         }
     }
+
+    return skip;
+}
+
+bool CoreChecks::ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state,
+                                                             const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                             const VkRenderingInfo& rendering_info,
+                                                             const Location& rendering_info_loc) const {
+    bool skip = false;
+    const bool has_rp_enable_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM) != 0;
+    const bool has_rp_per_tile_exec_bit = (rp_tile_shading_ci.flags & VK_TILE_SHADING_RENDER_PASS_PER_TILE_EXECUTION_BIT_QCOM) != 0;
 
     if (has_rp_enable_bit && (cb_state.begin_info_flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) != 0) {
         skip |= LogError("VUID-vkCmdBeginRendering-flags-10641", cb_state.Handle(),
@@ -4796,7 +4865,7 @@ bool CoreChecks::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer
     return PreCallValidateCmdEndRendering(commandBuffer, error_obj);
 }
 
-bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
+bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(const LogObjectList& objlist, const vvl::ImageView& image_view_state,
                                                               const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
                                                               const Location& attachment_loc,
                                                               const Location& rendering_info_loc) const {
@@ -4805,8 +4874,7 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
         return false;
     }
     if ((image_view_state.samples != VK_SAMPLE_COUNT_1_BIT) && (image_view_state.samples != msrtss_info.rasterizationSamples)) {
-        const LogObjectList objlist(commandBuffer, image_view_state.Handle());
-        skip |= LogError("VUID-VkRenderingInfo-imageView-06858", objlist,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-06858", LogObjectList(objlist, image_view_state.Handle()),
                          rendering_info_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT,
                                                   Field::multisampledRenderToSingleSampledEnable),
                          "is %s, but %s was created with %s, which is not VK_SAMPLE_COUNT_1_BIT.",
@@ -4816,8 +4884,8 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
     vvl::Image* image_state = image_view_state.image_state.get();
     if ((image_view_state.samples == VK_SAMPLE_COUNT_1_BIT) &&
         !(image_state->create_flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT)) {
-        const LogObjectList objlist(commandBuffer, image_view_state.Handle());
-        skip |= LogError("VUID-VkRenderingInfo-imageView-06859", objlist, attachment_loc,
+        skip |= LogError("VUID-VkRenderingInfo-imageView-06859",
+                         LogObjectList(objlist, image_view_state.Handle()), attachment_loc,
                          "was created with VK_SAMPLE_COUNT_1_BIT but "
                          "VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT was not set in "
                          "pImageCreateInfo.flags when the image used to create the imageView (%s) was created",
@@ -4830,8 +4898,8 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
         }
     }
     if (!(image_state->image_format_properties.sampleCounts & msrtss_info.rasterizationSamples)) {
-        const LogObjectList objlist(commandBuffer, image_view_state.Handle());
-        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880", objlist,
+        skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880",
+                         LogObjectList(objlist, image_view_state.Handle()),
                          rendering_info_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples),
                          "is %s, but %s format %s does not support sample count %s from an image with imageType: %s, tiling: "
                          "%s, usage: %s, flags: %s.",

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -1422,33 +1422,34 @@ void QueueSubState::Retire(vvl::QueueSubmission& submission) {
     }
 }
 
-RenderingAttachment::RenderingAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
-                                         const VkRenderingAttachmentInfo& info, const Location& loc, RenderingAttachment::Type type)
-    : cb_state(cb_state), rendering_info(rendering_info), info(info), loc(loc), type(type) {
-    image_view_state = cb_state.dev_data.Get<vvl::ImageView>(info.imageView);
-    resolve_view_state = cb_state.dev_data.Get<vvl::ImageView>(info.resolveImageView);
-}
+RenderingAttachment::RenderingAttachment(const VkRenderingInfo& rendering_info, const VkRenderingAttachmentInfo& info,
+                                         const Location& loc, const LogObjectList& objlist,
+                                         std::shared_ptr<const vvl::ImageView> image_view_state,
+                                         std::shared_ptr<const vvl::ImageView> resolve_view_state,
+                                         Type type)
+    : rendering_info(rendering_info), info(info), loc(loc), type(type), objlist(objlist),
+      image_view_state(std::move(image_view_state)), resolve_view_state(std::move(resolve_view_state)) {}
 
 LogObjectList RenderingAttachment::GetObjectList() const {
-    LogObjectList objlist(cb_state.Handle());
+    LogObjectList result = objlist;
     if (image_view_state) {
-        objlist.add(image_view_state->Handle(), image_view_state->image_state->Handle());
+        result.add(image_view_state->Handle(), image_view_state->image_state->Handle());
     }
     if (resolve_view_state) {
-        objlist.add(resolve_view_state->Handle(), resolve_view_state->image_state->Handle());
+        result.add(resolve_view_state->Handle(), resolve_view_state->image_state->Handle());
     }
-    return objlist;
+    return result;
 }
 
 LogObjectList RenderingAttachment::GetObjectList(const core::RenderingAttachment& other_attachment) const {
-    LogObjectList objlist = GetObjectList();
+    LogObjectList result = GetObjectList();
     if (other_attachment.image_view_state) {
-        objlist.add(other_attachment.image_view_state->Handle(), other_attachment.image_view_state->image_state->Handle());
+        result.add(other_attachment.image_view_state->Handle(), other_attachment.image_view_state->image_state->Handle());
     }
     if (other_attachment.resolve_view_state) {
-        objlist.add(other_attachment.resolve_view_state->Handle(), other_attachment.resolve_view_state->image_state->Handle());
+        result.add(other_attachment.resolve_view_state->Handle(), other_attachment.resolve_view_state->image_state->Handle());
     }
-    return objlist;
+    return result;
 }
 
 }  // namespace core

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -258,7 +258,7 @@ class QueueSubState : public vvl::QueueSubState {
     vvl::SubmitTimeTracker* submit_time_tracker = nullptr;
 };
 
-// When validating vkCmdBeginRendering we need to loop the Color attachments, depth, stencil and their resolve attachments as well
+// When validating rendering info we need to loop the color attachments, depth, stencil and their resolve attachments as well
 // The goal is to have a single object so we only need to walk these attachments once and then all the various checks can use the
 // same data
 struct RenderingAttachment {
@@ -269,15 +269,17 @@ struct RenderingAttachment {
         Stencil,
     };
 
-    RenderingAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
-                        const VkRenderingAttachmentInfo& info, const Location& loc, Type type);
+    RenderingAttachment(const VkRenderingInfo& rendering_info, const VkRenderingAttachmentInfo& info, const Location& loc,
+                        const LogObjectList& objlist, std::shared_ptr<const vvl::ImageView> image_view_state,
+                        std::shared_ptr<const vvl::ImageView> resolve_view_state, Type type);
 
-    const vvl::CommandBuffer& cb_state;
     const VkRenderingInfo& rendering_info;
 
     const VkRenderingAttachmentInfo& info;
     vvl::LocationCapture loc;
     const Type type;
+
+    LogObjectList objlist;
 
     std::shared_ptr<const vvl::ImageView> image_view_state;
     std::shared_ptr<const vvl::ImageView> resolve_view_state;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -681,7 +681,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                                        const vvl::RenderPass& rp_state, const Location& loc) const;
     bool ValidateDrawPipelineRasterizationState(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                 const Location& loc) const;
-    bool ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
+    bool ValidateMultisampledRenderToSingleSampleView(const LogObjectList& objlist, const vvl::ImageView& image_view_state,
                                                       const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
                                                       const Location& attachment_loc, const Location& rendering_info_loc) const;
 
@@ -1729,34 +1729,41 @@ class CoreChecks : public vvl::DeviceProxy {
                                                                    const Location& inheritance_loc) const;
     bool ValidateRenderingInfoAttachment(const vvl::ImageView& image_view_state, const VkRenderingInfo& rendering_info,
                                          const LogObjectList& objlist, const Location& attachment_loc) const;
-    bool ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer,
-                                                  const VkRenderingFragmentDensityMapAttachmentInfoEXT& fdm_attachment_info,
-                                                  const VkRenderingInfo& rendering_info, const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer commandBuffer,
-                                                   const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info,
-                                                   const VkRenderingInfo& rendering_info, const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingFragmentShadingRateRenderArea(
-        VkCommandBuffer commandBuffer, const vvl::ImageView& view_state,
-        const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info, const VkRenderingInfo& rendering_info,
-        const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                           const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                           const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingMultisampledRenderToSingleSampled(VkCommandBuffer commandBuffer,
-                                                                 const VkRenderingInfo& rendering_info,
-                                                                 const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoCommon(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                     const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoFragmentDensityMap(const LogObjectList& objlist,
+                                                 const VkRenderingFragmentDensityMapAttachmentInfoEXT& fdm_attachment_info,
+                                                 const VkRenderingInfo& rendering_info, const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoFragmentShadingRate(const LogObjectList& objlist,
+                                                  const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info,
+                                                  const VkRenderingInfo& rendering_info,
+                                                  const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoFragmentShadingRateRenderArea(const LogObjectList& objlist, const vvl::ImageView& view_state,
+                                                            const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info,
+                                                            const VkRenderingInfo& rendering_info,
+                                                            const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoSampleCount(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                          const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoDeviceGroup(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                          const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoMultisampledRenderToSingleSampled(const LogObjectList& objlist,
+                                                                const VkRenderingInfo& rendering_info,
+                                                                const Location& rendering_info_loc) const;
     bool ValidateSuspendResumeMismatch(const char* vuid, const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
                                        const VkRenderingInfo& last_rendering_info, const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingResume(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
                                       const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingColorAttachment(const core::RenderingAttachment& vvl_attachment) const;
+    bool ValidateRenderingInfoColorAttachment(const core::RenderingAttachment& vvl_attachment) const;
     bool ValidateBeginRenderingColorResolveAttachment(const core::RenderingAttachment& vvl_attachment) const;
-    bool ValidateBeginRenderingDepthAttachment(const core::RenderingAttachment& vvl_attachment) const;
-    bool ValidateBeginRenderingStencilAttachment(const core::RenderingAttachment& vvl_attachment) const;
-    bool ValidateBeginRenderingDepthAndStencilAttachment(const core::RenderingAttachment& depth_attachment,
-                                                         const core::RenderingAttachment& stencil_attachment) const;
+    bool ValidateRenderingInfoDepthAttachment(const core::RenderingAttachment& vvl_attachment) const;
+    bool ValidateRenderingInfoStencilAttachment(const core::RenderingAttachment& vvl_attachment) const;
+    bool ValidateRenderingDepthAndStencilAttachment(const core::RenderingAttachment& depth_attachment,
+                                                    const core::RenderingAttachment& stencil_attachment) const;
     bool ValidateBeginRenderingExternalDownsample(const core::RenderingAttachment& vvl_attachment) const;
+    bool ValidateRenderingInfoTileShadingCreateInfo(const LogObjectList& objlist,
+                                                    const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                    const VkRenderingInfo& rendering_info,
+                                                    const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state,
                                                      const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
                                                      const VkRenderingInfo& rendering_info,
@@ -1765,12 +1772,16 @@ class CoreChecks : public vvl::DeviceProxy {
                                              const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                           const ErrorObject& error_obj) const override;
+    bool PreCallValidateGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo* pRenderingInfo,
+                                                              VkTilePropertiesQCOM* pProperties,
+                                                              const ErrorObject& error_obj) const override;
     bool ValidateRenderingAttachmentInfo(const core::RenderingAttachment& vvl_attachment) const;
     bool ValidateRenderingAttachmentInfoResolveMode(const core::RenderingAttachment& vvl_attachment) const;
     bool ValidateRenderingAttachmentInfoMultisampledResolveMode(const core::RenderingAttachment& vvl_attachment) const;
     bool ValidateRenderingAttachmentInfoFeedbackLoop(const core::RenderingAttachment& vvl_attachment) const;
     bool ValidateRenderingAttachmentFlagsInfo(const core::RenderingAttachment& vvl_attachment) const;
-    bool ValidateRenderingAttachmentCurrentLayout(const core::RenderingAttachment& vvl_attachment) const;
+    bool ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuffer& cb_state,
+                                                  const core::RenderingAttachment& vvl_attachment) const;
     bool PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const override;
     bool ValidateCmdEndRendering(const vvl::CommandBuffer& cb_state, const ErrorObject& error_obj) const;
     bool PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const override;
@@ -2136,9 +2147,9 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                             const VkSubpassBeginInfo* pSubpassBeginInfo,
                                             const ErrorObject& error_obj) const override;
-    bool ValidateRenderPassPerformanceCountersByRegionBeginInfo(VkCommandBuffer commandBuffer,
-                                                                const VkRenderPassPerformanceCountersByRegionBeginInfoARM &counters_begin_info,
-                                                                const LogObjectList& objlist, uint32_t subpass_count,
+    bool ValidateRenderPassPerformanceCountersByRegionBeginInfo(const LogObjectList& objlist,
+                                                                const VkRenderPassPerformanceCountersByRegionBeginInfoARM& counters_begin_info,
+                                                                uint32_t subpass_count,
                                                                 uint32_t layer_or_view_count, VkRect2D render_area,
                                                                 const Location& begin_loc) const;
     bool PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -675,7 +675,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                                        const vvl::RenderPass& rp_state, const Location& loc) const;
     bool ValidateDrawPipelineRasterizationState(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                 const Location& loc) const;
-    bool ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
+    bool ValidateMultisampledRenderToSingleSampleView(const LogObjectList& objlist, const vvl::ImageView& image_view_state,
                                                       const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
                                                       const Location& attachment_loc, const Location& rendering_info_loc) const;
 
@@ -1712,33 +1712,44 @@ class CoreChecks : public vvl::DeviceProxy {
                                                                    const Location& inheritance_loc) const;
     bool ValidateRenderingInfoAttachment(const vvl::ImageView& image_view_state, const VkRenderingInfo& rendering_info,
                                          const LogObjectList& objlist, const Location& attachment_loc) const;
-    bool ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+    bool ValidateRenderingInfoCommon(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                     const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoFragmentDensityMap(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                 const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoFragmentShadingRate(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
                                                   const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                                   const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingFragmentShadingRateRenderArea(
-        VkCommandBuffer commandBuffer, const vvl::ImageView& view_state,
+    bool ValidateRenderingInfoFragmentShadingRateRenderArea(
+        const LogObjectList& objlist, const vvl::ImageView& view_state,
         const VkRenderingFragmentShadingRateAttachmentInfoKHR& fsr_attachment_info, const VkRenderingInfo& rendering_info,
         const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingSampleCount(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                           const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
-                                           const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingMultisampledRenderToSingleSampled(VkCommandBuffer commandBuffer,
-                                                                 const VkRenderingInfo& rendering_info,
-                                                                 const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoSampleCount(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                          const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoDeviceGroup(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                          const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoMultisampledRenderToSingleSampled(const LogObjectList& objlist,
+                                                                const VkRenderingInfo& rendering_info,
+                                                                const Location& rendering_info_loc) const;
     bool ValidateSuspendResumeMismatch(const char* vuid, const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
                                        const VkRenderingInfo& last_rendering_info, const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingResume(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
                                       const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
                                                const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoColorAttachment(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                              const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
                                                const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoDepthAttachment(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                              const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingStencilAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
                                                  const Location& rendering_info_loc) const;
-    bool ValidateBeginRenderingDepthAndStencilAttachment(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+    bool ValidateRenderingInfoStencilAttachment(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoDepthAndStencilAttachment(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
                                                          const Location& rendering_info_loc) const;
+    bool ValidateRenderingInfoTileShadingCreateInfo(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
+                                                    const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
+                                                    const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingTileShadingCreateInfo(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
                                                      const VkRenderPassTileShadingCreateInfoQCOM& rp_tile_shading_ci,
                                                      const Location& rendering_info_loc) const;
@@ -1746,20 +1757,23 @@ class CoreChecks : public vvl::DeviceProxy {
                                              const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                           const ErrorObject& error_obj) const override;
-    bool ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+    bool PreCallValidateGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo* pRenderingInfo,
+                                                              VkTilePropertiesQCOM* pProperties,
+                                                              const ErrorObject& error_obj) const override;
+    bool ValidateRenderingAttachmentInfo(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
                                          const VkRenderingAttachmentInfo& attachment_info, const Location& attachment_loc) const;
-    bool ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
+    bool ValidateRenderingAttachmentInfoResolveMode(const LogObjectList& objlist, const VkRenderingInfo& rendering_info,
                                                     const VkRenderingAttachmentInfo& attachment_info,
                                                     const vvl::ImageView& image_view_state, const Location& attachment_loc) const;
-    bool ValidateRenderingAttachmentInfoMultisampledResolveMode(VkCommandBuffer commandBuffer,
+    bool ValidateRenderingAttachmentInfoMultisampledResolveMode(const LogObjectList& objlist,
                                                                 const VkRenderingInfo& rendering_info,
                                                                 const VkRenderingAttachmentInfo& attachment_info,
                                                                 const vvl::ImageView& image_view_state,
                                                                 const Location& attachment_loc) const;
-    bool ValidateRenderingAttachmentInfoFeedbackLoop(VkCommandBuffer commandBuffer,
+    bool ValidateRenderingAttachmentInfoFeedbackLoop(const LogObjectList& objlist,
                                                      const VkRenderingAttachmentInfo& attachment_info,
                                                      const vvl::ImageView& image_view_state, const Location& attachment_loc) const;
-    bool ValidateRenderingAttachmentFlagsInfo(VkCommandBuffer commandBuffer, const VkRenderingAttachmentInfo& attachment_info,
+    bool ValidateRenderingAttachmentFlagsInfo(const LogObjectList& objlist, const VkRenderingAttachmentInfo& attachment_info,
                                               const vvl::ImageView& image_view_state, const Location& attachment_loc) const;
     bool ValidateRenderingAttachmentCurrentLayout(const vvl::CommandBuffer& cb_state,
                                                   const VkRenderingAttachmentInfo& attachment_info, const Location& loc) const;
@@ -2128,9 +2142,9 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                             const VkSubpassBeginInfo* pSubpassBeginInfo,
                                             const ErrorObject& error_obj) const override;
-    bool ValidateRenderPassPerformanceCountersByRegionBeginInfo(VkCommandBuffer commandBuffer,
+    bool ValidateRenderPassPerformanceCountersByRegionBeginInfo(const LogObjectList& objlist,
                                                                 const VkRenderPassPerformanceCountersByRegionBeginInfoARM &counters_begin_info,
-                                                                const LogObjectList& objlist, uint32_t subpass_count,
+                                                                uint32_t subpass_count,
                                                                 uint32_t layer_or_view_count, VkRect2D render_area,
                                                                 const Location& begin_loc) const;
     bool PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -8597,3 +8597,220 @@ TEST_F(NegativeDynamicRendering, ImageView3D) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithInvalidFragmentDensityMapUsage) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with an invalid fragment density map attachment.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMap);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMapNonSubsampledImages);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image_ci.flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
+    vkt::Image color_image{*m_device, image_ci};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    vkt::Image fdm_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView fdm_view = fdm_image.CreateView();
+
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
+    fragment_density_map.imageView = fdm_view;
+    fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&fragment_density_map);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithInvalidFragmentShadingRateUsage) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with an invalid fragment shading rate attachment.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::attachmentFragmentShadingRate);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    vkt::Image color_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(fsr_properties);
+
+    vkt::Image fsr_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView fsr_view = fsr_image.CreateView();
+
+    VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
+    fragment_shading_rate.imageView = fsr_view;
+    fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&fragment_shading_rate);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithInvalidMultisampledRenderToSingleSampledInfo) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with invalid multisampled render-to-single-sampled information.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::multisampledRenderToSingleSampled);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image_ci.flags = VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT;
+    vkt::Image color_image{*m_device, image_ci};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkMultisampledRenderToSingleSampledInfoEXT msrtss_info = vku::InitStructHelper();
+    msrtss_info.multisampledRenderToSingleSampledEnable = VK_TRUE;
+    msrtss_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&msrtss_info);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithTileShadingAndFragmentDensityMap) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with tile shading and a fragment density map attachment.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMap);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMapNonSubsampledImages);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+                                    VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
+        GTEST_SKIP() << "VK_FORMAT_R8G8_UNORM doesn't support VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT format feature, "
+                        "skipping test.";
+    }
+
+    vkt::Image color_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    vkt::Image fdm_image{*m_device, 64, 64, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT};
+    vkt::ImageView fdm_view = fdm_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
+    fragment_density_map.imageView = fdm_view;
+    fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_info = vku::InitStructHelper(&fragment_density_map);
+    tile_shading_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_info.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_info);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-10643");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithResolveAttachmentBoundToTileMemory) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with a resolve attachment bound to tile memory.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_QCOM_TILE_MEMORY_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::tileMemoryHeap);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
+    vkt::Image msaa_image{*m_device, image_ci, vkt::set_layout};
+    vkt::ImageView msaa_image_view = msaa_image.CreateView();
+
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.usage |= VK_IMAGE_USAGE_TILE_MEMORY_BIT_QCOM;
+    vkt::Image tile_memory_image{*m_device, image_ci, vkt::no_mem};
+
+    VkImageMemoryRequirementsInfo2 image_info = vku::InitStructHelper();
+    VkTileMemoryRequirementsQCOM tile_mem_reqs = vku::InitStructHelper();
+    VkMemoryRequirements2 image_reqs = vku::InitStructHelper(&tile_mem_reqs);
+    image_info.image = tile_memory_image;
+    vk::GetImageMemoryRequirements2(device(), &image_info, &image_reqs);
+    if (tile_mem_reqs.size == 0) {
+        GTEST_SKIP() << "Image is not eligible for tile memory binding, skipping test.";
+    }
+
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
+    alloc_info.memoryTypeIndex = 0;
+    alloc_info.allocationSize = tile_mem_reqs.size;
+    if (!m_device->Physical().SetMemoryType(image_reqs.memoryRequirements.memoryTypeBits, &alloc_info,
+                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0, VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM)) {
+        GTEST_SKIP() << "Failed to find an eligible tile memory type, skipping test.";
+    }
+
+    vkt::DeviceMemory image_memory{*m_device, alloc_info};
+    vk::BindImageMemory(device(), tile_memory_image, image_memory, 0);
+    vkt::ImageView resolve_image_view = tile_memory_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = msaa_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    color_attachment.resolveImageView = resolve_image_view;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+    rendering_info.layerCount = 1;
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-resolveImageView-10728");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -8606,3 +8606,220 @@ TEST_F(NegativeDynamicRendering, ImageView3D) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithInvalidFragmentDensityMapUsage) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with an invalid fragment density map attachment.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMap);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMapNonSubsampledImages);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image_ci.flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
+    vkt::Image color_image{*m_device, image_ci};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    vkt::Image fdm_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView fdm_view = fdm_image.CreateView();
+
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
+    fragment_density_map.imageView = fdm_view;
+    fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&fragment_density_map);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithInvalidFragmentShadingRateUsage) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with an invalid fragment shading rate attachment.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::attachmentFragmentShadingRate);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    vkt::Image color_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(fsr_properties);
+
+    vkt::Image fsr_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView fsr_view = fsr_image.CreateView();
+
+    VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
+    fragment_shading_rate.imageView = fsr_view;
+    fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&fragment_shading_rate);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithInvalidMultisampledRenderToSingleSampledInfo) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with invalid multisampled render-to-single-sampled information.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::multisampledRenderToSingleSampled);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image_ci.flags = VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT;
+    vkt::Image color_image{*m_device, image_ci};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkMultisampledRenderToSingleSampledInfoEXT msrtss_info = vku::InitStructHelper();
+    msrtss_info.multisampledRenderToSingleSampledEnable = VK_TRUE;
+    msrtss_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&msrtss_info);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithTileShadingAndFragmentDensityMap) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with tile shading and a fragment density map attachment.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_QCOM_TILE_SHADING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::tileShading);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMap);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMapNonSubsampledImages);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+                                    VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
+        GTEST_SKIP() << "VK_FORMAT_R8G8_UNORM doesn't support VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT format feature, "
+                        "skipping test.";
+    }
+
+    vkt::Image color_image{*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT};
+    vkt::ImageView color_image_view = color_image.CreateView();
+
+    vkt::Image fdm_image{*m_device, 64, 64, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT};
+    vkt::ImageView fdm_view = fdm_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = color_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
+    fragment_density_map.imageView = fdm_view;
+    fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkRenderPassTileShadingCreateInfoQCOM tile_shading_info = vku::InitStructHelper(&fragment_density_map);
+    tile_shading_info.flags = VK_TILE_SHADING_RENDER_PASS_ENABLE_BIT_QCOM;
+    tile_shading_info.tileApronSize = {0, 0};
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper(&tile_shading_info);
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-10643");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingTilePropertiesWithResolveAttachmentBoundToTileMemory) {
+    TEST_DESCRIPTION("Try to query dynamic rendering tile properties with a resolve attachment bound to tile memory.");
+    AddRequiredExtensions(VK_QCOM_TILE_PROPERTIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_QCOM_TILE_MEMORY_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::tileProperties);
+    AddRequiredFeature(vkt::Feature::tileMemoryHeap);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                                                  VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
+    vkt::Image msaa_image{*m_device, image_ci, vkt::set_layout};
+    vkt::ImageView msaa_image_view = msaa_image.CreateView();
+
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.usage |= VK_IMAGE_USAGE_TILE_MEMORY_BIT_QCOM;
+    vkt::Image tile_memory_image{*m_device, image_ci, vkt::no_mem};
+
+    VkImageMemoryRequirementsInfo2 image_info = vku::InitStructHelper();
+    VkTileMemoryRequirementsQCOM tile_mem_reqs = vku::InitStructHelper();
+    VkMemoryRequirements2 image_reqs = vku::InitStructHelper(&tile_mem_reqs);
+    image_info.image = tile_memory_image;
+    vk::GetImageMemoryRequirements2(device(), &image_info, &image_reqs);
+    if (tile_mem_reqs.size == 0) {
+        GTEST_SKIP() << "Image is not eligible for tile memory binding, skipping test.";
+    }
+
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
+    alloc_info.memoryTypeIndex = 0;
+    alloc_info.allocationSize = tile_mem_reqs.size;
+    if (!m_device->Physical().SetMemoryType(image_reqs.memoryRequirements.memoryTypeBits, &alloc_info,
+                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 0, VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM)) {
+        GTEST_SKIP() << "Failed to find an eligible tile memory type, skipping test.";
+    }
+
+    vkt::DeviceMemory image_memory{*m_device, alloc_info};
+    vk::BindImageMemory(device(), tile_memory_image, image_memory, 0);
+    vkt::ImageView resolve_image_view = tile_memory_image.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = msaa_image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    color_attachment.resolveImageView = resolve_image_view;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+    rendering_info.layerCount = 1;
+    rendering_info.renderArea = {{0, 0}, {64, 64}};
+
+    VkTilePropertiesQCOM tile_properties = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-resolveImageView-10728");
+    vk::GetDynamicRenderingTilePropertiesQCOM(device(), &rendering_info, &tile_properties);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
# Overview
`vkGetDynamicRenderingTilePropertiesQCOM` now triggers the same core VUIDs defined on `VkRenderingInfo` as `vkCmdBeginRendering`.

This change extracts the command-buffer-independent `VkRenderingInfo` validation from `PreCallValidateCmdBeginRendering` into a new shared helper `ValidateRenderingInfoCommon`, with functions renamed from `ValidateBeginRendering*` to `ValidateRenderingInfo*` and signatures changed from `VkCommandBuffer` to `const LogObjectList&`.

`ValidateBeginRenderingColorAttachment`, `ValidateBeginRenderingDepthAttachment`, and `ValidateBeginRenderingStencilAttachment` are intentionally excluded, they check current image layout tracked in command buffer state.
`ValidateBeginRenderingTileShadingCreateInfo` is also excluded, it needs command buffer begin flags.

# Unit Tests
| Test | VUID & Description |
|------|------|
| `DynamicRenderingTilePropertiesWithInvalidFragmentDensityMapUsage` | `VUID VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158` |
| `DynamicRenderingTilePropertiesWithInvalidFragmentShadingRateUsage` | `VUID VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148` |
| `DynamicRenderingTilePropertiesWithInvalidMultisampledRenderToSingleSampledInfo` | `VUID VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878` |
| `DynamicRenderingTilePropertiesWithTileShadingAndFragmentDensityMap` | `VUID-VkRenderingInfo-imageView-10643` |
| `DynamicRenderingTilePropertiesWithResolveAttachmentBoundToTileMemory` | `VUID-VkRenderingAttachmentInfo-resolveImageView-10728` |