### PR TITLE
layers: Track image layout only for statically used images

### DIFF
--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -894,7 +894,8 @@ void vvl::DescriptorSet::UpdateImageLayoutDrawStates(vvl::DeviceState* device_da
         ASSERT_AND_CONTINUE(binding);
 
         // core validation doesn't handle descriptor indexing, that is only done by GPU-AV
-        if (ValidateBindingOnGPU(*binding, *binding_req_pair.second.variable)) {
+        const spirv::ResourceInterfaceVariable& variable = *binding_req_pair.second.variable;
+        if (ValidateBindingOnGPU(*binding, variable)) {
             continue;
         }
 
@@ -902,21 +903,27 @@ void vvl::DescriptorSet::UpdateImageLayoutDrawStates(vvl::DeviceState* device_da
             case DescriptorClass::Image: {
                 auto* image_binding = static_cast<ImageBinding*>(binding);
                 for (uint32_t i = 0; i < image_binding->count; ++i) {
-                    image_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
+                    if (variable.IsImageAtIndexStaticallyAccessed(i)) {
+                        image_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
+                    }
                 }
                 break;
             }
             case DescriptorClass::ImageSampler: {
                 auto* image_binding = static_cast<ImageSamplerBinding*>(binding);
                 for (uint32_t i = 0; i < image_binding->count; ++i) {
-                    image_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
+                    if (variable.IsImageAtIndexStaticallyAccessed(i)) {
+                        image_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
+                    }
                 }
                 break;
             }
             case DescriptorClass::Mutable: {
                 auto* mutable_binding = static_cast<MutableBinding*>(binding);
                 for (uint32_t i = 0; i < mutable_binding->count; ++i) {
-                    mutable_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
+                    if (variable.IsImageAtIndexStaticallyAccessed(i)) {
+                        mutable_binding->descriptors[i].UpdateImageLayoutDrawState(cb_state);
+                    }
                 }
                 break;
             }

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2457,6 +2457,22 @@ StageInterfaceVariable::StageInterfaceVariable(const Module& module_state, const
       built_in_block(GetBuiltInBlock(*this, module_state)),
       total_built_in_components(GetBuiltInComponents(*this, module_state)) {}
 
+bool ResourceInterfaceVariable::IsImageAtIndexStaticallyAccessed(uint32_t index) const {
+    if (!IsImageAccessed()) {
+        return false;
+    }
+    // Non-array image is statically accessed (IsImageAccessed() == true)
+    if (!IsArray()) {
+        return true;
+    }
+    // With dynamic indexing or unresolved spec constants, any element may be accessed
+    if (!all_constant_integral_expressions || vvl::Contains(image_array_indices_accessed, kSpecConstant)) {
+        return true;
+    }
+    // Check whether this array element was accessed with a constant index
+    return vvl::Contains(image_array_indices_accessed, index);
+}
+
 bool ResourceInterfaceVariable::IsHeap() const {
     // It is only legal to not have a set/binding for descriptors if they are the heap
     // We might one day want to know which heap it is, and could just check for |ResourceHeapEXT| or |SamplerHeapEXT| but that will
@@ -2689,6 +2705,12 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
                 // Only tied to the image (not the sampler when using non-COMBINED_IMAGE_SAMPLER)
                 if (IsArray() && image_access.image_access_chain_index == kInvalidValue) {
                     all_constant_integral_expressions = false;
+                }
+
+                // Track array elements accessed with a statically known constant index,
+                // or kSpecConstant when indexing uses an unresolved spec constant
+                if (IsArray() && image_access.image_access_chain_index != kInvalidValue) {
+                    image_array_indices_accessed.emplace(image_access.image_access_chain_index);
                 }
 
                 // if not CombinedImageSampler, need to find all Samplers that were accessed with the image

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -447,6 +447,10 @@ struct ResourceInterfaceVariable : public VariableBase {
     // If there is no array, index 0 is marked if the single image is read
     vvl::unordered_set<uint32_t> input_attachment_index_read;
 
+    // For arrayed image variables, the elements the shader statically accesses with a constant index.
+    // Contains kSpecConstant if an unresolved spec constant is used for indexing.
+    vvl::unordered_set<uint32_t> image_array_indices_accessed;
+
     // Type once array/pointer are stripped
     // most likely will be OpTypeImage, OpTypeStruct, OpTypeSampler, OpTypeSampledImage, or OpTypeAccelerationStructureKHR
     const Instruction &base_type;
@@ -455,6 +459,10 @@ struct ResourceInterfaceVariable : public VariableBase {
     // NOTE - This just checks if there is ANY non-costant access
     bool all_constant_integral_expressions{true};
     uint32_t non_constant_id{0};
+
+    // Returns true if the image at array element |index| (0 for non-arrayed images) is statically accessed by the
+    // shader (vkspec.html#shaders-staticuse). Only a false result is certain: the element is provably not accessed.
+    bool IsImageAtIndexStaticallyAccessed(uint32_t index) const;
 
     // All info regarding what will be validated from requirements imposed by the pipeline on a descriptor. These
     // can't be checked at pipeline creation time as they depend on the object bound (Image/Tensor) or its view.

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -2527,3 +2527,85 @@ TEST_F(PositiveDescriptors, Image1DArrayAliasSingleLayer) {
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 }
+
+TEST_F(PositiveDescriptors, TransitionImageUnusedByShader) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5603");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init())
+
+    vkt::Image unused_by_shader_image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM,
+                                      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::ImageView unused_by_shader_view = unused_by_shader_image.CreateView();
+
+    vkt::Image sampled_image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::ImageView sampled_view = sampled_image.CreateView();
+
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+
+    const VkDescriptorSetLayoutBinding s_binding = {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL};
+    const VkDescriptorSetLayoutBinding t_binding = {1, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 2, VK_SHADER_STAGE_ALL};
+    OneOffDescriptorSet descriptor_set(m_device, {s_binding, t_binding});
+    descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    descriptor_set.WriteDescriptorImageInfo(1, unused_by_shader_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
+    descriptor_set.WriteDescriptorImageInfo(1, sampled_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
+    descriptor_set.UpdateDescriptorSets();
+
+    const char* fragment_shader = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform sampler s;
+        layout(set = 0, binding = 1) uniform texture2D t[2];
+        layout(location = 0) out vec4 color;
+        void main() {
+            color = texture(sampler2D(t[1], s), vec2(0));
+        }
+    )glsl";
+
+    VkShaderObj vs(*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs(*m_device, fragment_shader, VK_SHADER_STAGE_FRAGMENT_BIT);
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
+
+    const VkFormat attachment_format = VK_FORMAT_R8G8B8A8_UNORM;
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
+    pipeline_rendering_info.colorAttachmentCount = 1;
+    pipeline_rendering_info.pColorAttachmentFormats = &attachment_format;
+
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.gp_ci_.layout = pipeline_layout;
+    pipe.CreateGraphicsPipeline();
+
+    vkt::Image attachment(*m_device, 32, 32, attachment_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::ImageView attachment_view = attachment.CreateView();
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = attachment_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {32, 32};
+    rendering_info.layerCount = 1;
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkImageMemoryBarrier2 transition = vku::InitStructHelper();
+    transition.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+    transition.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
+    transition.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    transition.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    transition.image = unused_by_shader_image;
+    transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(rendering_info);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
+                              nullptr);
+    vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
+    m_command_buffer.EndRendering();
+    m_command_buffer.Barrier(transition);
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5603

`UpdateImageLayoutDrawStates` tracked image layout specified by descriptor for every element of an image descriptor array, including ones that are provably never accessed (which caused false positive in the scenario from the issue). This tracks which indices are provably never accessed.