### PR TITLE
layers: Deprecated Core sub settings

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -350,6 +350,7 @@
                                     "label": "Image Layout",
                                     "description": "Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.",
                                     "type": "BOOL",
+                                    "view": "HIDDEN",
                                     "default": true,
                                     "dependence": {
                                         "mode": "ALL",
@@ -363,6 +364,7 @@
                                     "label": "Command Buffer State",
                                     "description": "Check that all Vulkan objects used by a command buffer have not been destroyed. These checks can be CPU intensive for some applications.",
                                     "type": "BOOL",
+                                    "view": "HIDDEN",
                                     "default": true,
                                     "dependence": {
                                         "mode": "ALL",
@@ -376,6 +378,7 @@
                                     "label": "Object in Use",
                                     "description": "Check that Vulkan objects are not in use by a command buffer when they are destroyed.",
                                     "type": "BOOL",
+                                    "view": "HIDDEN",
                                     "default": true,
                                     "dependence": {
                                         "mode": "ALL",
@@ -389,6 +392,7 @@
                                     "label": "Query",
                                     "description": "Checks for commands that use VkQueryPool objects.",
                                     "type": "BOOL",
+                                    "view": "HIDDEN",
                                     "default": true,
                                     "dependence": {
                                         "mode": "ALL",

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -159,6 +159,10 @@ const char* VK_LAYER_CHECK_SHADERS_CACHING = "check_shaders_caching";
 
 // Additional checks exposed in vkconfig, but not in VkValidationFeatureDisableEXT
 // ---
+// [DEPRECATED]
+// After the 1.4.350 SDK we found these were 10 years old and not sure if valuable anymore
+// These have not been tested and seem no one is properly checking they are used for newer extensions
+// Plan is to remove them, unless we find people are indeed using them
 const char* VK_LAYER_CHECK_COMMAND_BUFFER = "check_command_buffer";
 const char* VK_LAYER_CHECK_OBJECT_IN_USE = "check_object_in_use";
 const char* VK_LAYER_CHECK_QUERY = "check_query";
@@ -1407,6 +1411,27 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
             "Descriptor Hashing was turned on, but neither GPU-AV nor GPU Dump are enabled. Turning off as this setting has no "
             "effect.");
         global_settings.descriptor_hashing = false;
+    }
+
+    if (settings_data->disabled[command_buffer_state]) {
+        setting_warnings.emplace_back(
+            "VK_LAYER_CHECK_COMMAND_BUFFER (check_command_buffer) is deprecated and planned to be removed in the future. Please "
+            "inform us if you are still using this setting!");
+    }
+    if (settings_data->disabled[object_in_use]) {
+        setting_warnings.emplace_back(
+            "VK_LAYER_CHECK_OBJECT_IN_USE (check_object_in_use) is deprecated and planned to be removed in the future. Please "
+            "inform us if you are still using this setting!");
+    }
+    if (settings_data->disabled[query_validation]) {
+        setting_warnings.emplace_back(
+            "VK_LAYER_CHECK_QUERY (check_query) is deprecated and planned to be removed in the future. Please inform us if you are "
+            "still using this setting!");
+    }
+    if (settings_data->disabled[image_layout_validation]) {
+        setting_warnings.emplace_back(
+            "VK_LAYER_CHECK_IMAGE_LAYOUT (check_image_layout) is deprecated and planned to be removed in the future. Please inform "
+            "us if you are still using this setting!");
     }
 
     // Last as previous settings are needed so we can make sure they line up with the DebugReport settings

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -5,26 +5,6 @@
 
 # VK_LAYER_KHRONOS_validation
 
-# Command Buffer State
-# =====================
-# Check that all Vulkan objects used by a command buffer have not been destroyed. These checks can be CPU intensive for some applications.
-khronos_validation.check_command_buffer = true
-
-# Image Layout
-# =====================
-# Check that the layout of each image subresource is correct whenever it is used by a command buffer. These checks are very CPU intensive for some applications.
-khronos_validation.check_image_layout = true
-
-# Object in Use
-# =====================
-# Check that Vulkan objects are not in use by a command buffer when they are destroyed.
-khronos_validation.check_object_in_use = true
-
-# Query
-# =====================
-# Checks for commands that use VkQueryPool objects.
-khronos_validation.check_query = true
-
 # Shader
 # =====================
 # This will validate the contents of the SPIR-V which can be CPU intensive during application start up. This does internal checks as well as calling spirv-val. (Same effect using VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT)


### PR DESCRIPTION
Found these date back 10 years https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/a003ce8d15db93d6305567109dcd7c9a24350141

We have never tested these and are very ad-hoc about when they get added or not (as shown in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12573/files) 

Will wait a few SDK cycles and if no one is using these, would be good to remove

I feel VVL is fast enough now that people are not trying to disable these various sub settings... but could be wrong, so will roll them out slowly