### PR TITLE
layers: Fix GPL PipelineLayoutStateUnion

### DIFF
--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -833,7 +833,7 @@ std::vector<std::shared_ptr<const vvl::PipelineLayout>> Pipeline::PipelineLayout
     // Only need to check pre-raster _or_ fragment shader layout; if either one is not merged_graphics_layout, then
     // merged_graphics_layout is a union
     if (pre_raster_state) {
-        if (pre_raster_state->pipeline_layout != fragment_shader_state->pipeline_layout) {
+        if (fragment_shader_state && (pre_raster_state->pipeline_layout != fragment_shader_state->pipeline_layout)) {
             return {pre_raster_state->pipeline_layout, fragment_shader_state->pipeline_layout};
         } else {
             return {pre_raster_state->pipeline_layout};

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -3977,3 +3977,71 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetLayoutNullMismatch) {
         m_errorMonitor->VerifyFound();
     }
 }
+
+TEST_F(NegativeGraphicsLibrary, InvalidDescriptorSet) {
+    RETURN_IF_SKIP(InitBasicGraphicsLibrary());
+    InitRenderTarget();
+
+    const char* const vs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform buff {
+            float x;
+        };
+        void main() {
+            gl_Position = vec4(x);
+        }
+    )glsl";
+
+    OneOffDescriptorSet ds1(m_device, {
+                                          {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+                                      });
+    OneOffDescriptorSet ds2(m_device, {
+                                          {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                      });
+    vkt::Buffer uniform_buffer(*m_device, sizeof(float), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    ds1.WriteDescriptorBufferInfo(0, uniform_buffer, 0, sizeof(float));
+    ds1.UpdateDescriptorSets();
+    ds2.WriteDescriptorBufferInfo(0, uniform_buffer, 0, sizeof(float));
+    ds2.UpdateDescriptorSets();
+
+    vkt::PipelineLayout pipeline_layout1(*m_device, {&ds1.layout_});
+    vkt::PipelineLayout pipeline_layout2(*m_device, {&ds2.layout_});
+
+    CreatePipelineHelper vertex_input_lib(*this);
+    vertex_input_lib.InitVertexInputLibInfo();
+    vertex_input_lib.CreateGraphicsPipeline(false);
+
+    CreatePipelineHelper pre_raster_lib(*this);
+    {
+        const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source);
+        vkt::GraphicsPipelineLibraryStage vs_stage(spv, VK_SHADER_STAGE_VERTEX_BIT);
+        pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
+        pre_raster_lib.gp_ci_.layout = pipeline_layout1;
+        pre_raster_lib.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
+        pre_raster_lib.CreateGraphicsPipeline(false);
+    }
+
+    VkPipeline libraries[2] = {
+        vertex_input_lib,
+        pre_raster_lib,
+        // Missing fragment shader/output
+    };
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
+    link_info.libraryCount = 2u;
+    link_info.pLibraries = libraries;
+
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
+    exe_pipe_ci.layout = pipeline_layout1;
+    exe_pipe_ci.renderPass = RenderPass();
+    vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout2, 0, 1, &ds2.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08600");
+    vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12562

PipelineLayoutStateUnion is only used in error messages to get the pipeline layout to print