### PR TITLE
layers: Add missing opacity micromap build VUs

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -733,6 +733,12 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
                                          uint64_t(geometry_build_range_primitive_count - 1) + uint64_t(micromap_khr->baseTriangle));
                         }
                     }
+                } else if (micromap_khr->micromap != VK_NULL_HANDLE) {
+                    skip |= LogError("VUID-VkAccelerationStructureTrianglesOpacityMicromapKHR-micromap-parameter", cb_objlist,
+                                     p_geom_geom_triangles_loc.pNext(Struct::VkAccelerationStructureTrianglesOpacityMicromapKHR,
+                                                                     Field::micromap),
+                                     "(%s) is not a valid VkAccelerationStructureKHR handle.",
+                                     FormatHandle(micromap_khr->micromap).c_str());
                 }
             }
         } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
@@ -1318,6 +1324,7 @@ bool CoreChecks::ValidateAccelerationStructureTrianglesOpacityMicromapKHR(
                              pInfo.indexStride, vvl::kU32Max);
         }
     }
+
     return skip;
 }
 
@@ -1336,11 +1343,36 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
 
         if (src_as_state) {
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
-                skip |= ValidateAccelStructBufferMemoryIsHostVisible(*src_as_state, info_loc.dot(Field::srcAccelerationStructure),
+                bool src_memory_is_bound = true;
+
+                if (src_as_state->UsesCreateInfo1()) {
+                    const auto src_as_buffer = src_as_state->GetFirstValidBuffer(*device_state);
+                    if (!src_as_buffer) {
+                        const LogObjectList objlist(device, info.srcAccelerationStructure);
+                        skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03708", objlist, info_loc.dot(Field::mode),
+                                         "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
+                                         "srcAccelerationStructure is not valid.");
+                        src_memory_is_bound = false;
+                    } else {
+                        const bool memory_not_bound = ValidateMemoryIsBoundToBuffer(
+                            device, *src_as_buffer.state, info_loc.dot(Field::srcAccelerationStructure),
+                            "VUID-vkBuildAccelerationStructuresKHR-pInfos-03708");
+                        skip |= memory_not_bound;
+                        if (memory_not_bound) {
+                            src_memory_is_bound = false;
+                        }
+                    }
+                }
+
+                if (src_memory_is_bound) {
+                    skip |=
+                        ValidateAccelStructBufferMemoryIsHostVisible(*src_as_state, info_loc.dot(Field::srcAccelerationStructure),
                                                                      "VUID-vkBuildAccelerationStructuresKHR-pInfos-03723");
-                skip |=
-                    ValidateAccelStructBufferMemoryIsNotMultiInstance(*src_as_state, info_loc.dot(Field::srcAccelerationStructure),
-                                                                      "VUID-vkBuildAccelerationStructuresKHR-pInfos-03776");
+                    skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*src_as_state,
+                                                                              info_loc.dot(Field::srcAccelerationStructure),
+                                                                              "VUID-vkBuildAccelerationStructuresKHR-pInfos-03776");
+                }
+
                 skip |= ValidateAccelerationStructureBuildGeometryInfoUpdate(*src_as_state, info, info_loc, error_obj.handle);
             }
         }
@@ -1621,11 +1653,22 @@ bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevic
         auto as_state = Get<vvl::AccelerationStructureKHR>(pAccelerationStructures[i]);
         ASSERT_AND_CONTINUE(as_state);
 
-        skip |= ValidateAccelStructBufferMemoryIsHostVisible(*as_state, as_loc,
-                                                             "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03733");
+        const auto as_buffer = as_state->GetFirstValidBuffer(*device_state);
+        bool memory_is_bound = false;
+        if (as_buffer && !as_buffer.state->Destroyed()) {
+            const bool memory_not_bound =
+                ValidateMemoryIsBoundToBuffer(device, *as_buffer.state, as_loc.dot(Field::buffer),
+                                              "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03736");
+            skip |= memory_not_bound;
+            memory_is_bound = !memory_not_bound;
+        }
 
-        skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*as_state, as_loc,
-                                                                  "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03784");
+        if (memory_is_bound) {
+            skip |= ValidateAccelStructBufferMemoryIsHostVisible(*as_state, as_loc,
+                                                                 "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03733");
+            skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(
+                *as_state, as_loc, "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03784");
+        }
 
         if (as_state->GetBuildInfo().has_value()) {
             if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR) {

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1524,6 +1524,14 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
                     context, geometry, build_range, geometry_ptr_loc,
                     error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i));
             }
+
+            if (info.type != VK_ACCELERATION_STRUCTURE_TYPE_OPACITY_MICROMAP_KHR &&
+                geometry.geometryType != VK_GEOMETRY_TYPE_DENSE_GEOMETRY_FORMAT_TRIANGLES_AMDX) {
+                skip |= context.ValidateArray(info_loc.dot(Field::geometryCount),
+                                              error_obj.location.dot(Field::ppBuildRangeInfos, info_i), info.geometryCount,
+                                              &ppBuildRangeInfos[info_i], false, true, kVUIDUndefined,
+                                              "VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-11543");
+            }
         }
     }
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -889,6 +889,33 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructure) {
     vk::DestroyAccelerationStructureKHR(device(), as, NULL);
 }
 
+TEST_F(NegativeRayTracing, BuildAccelerationStructureKHRSrcUnbound) {
+    TEST_DESCRIPTION("vkBuildAccelerationStructuresKHR with srcAccelerationStructure buffer not bound to memory");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::accelerationStructureHostCommands);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    RETURN_IF_SKIP(Init());
+
+    auto src_blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnHostBottomLevel(*m_device);
+    src_blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
+    src_blas.BuildHost();
+
+    src_blas.GetDstAS()->GetBuffer().Memory().Destroy();
+
+    auto update_blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnHostBottomLevel(*m_device);
+    update_blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
+    update_blas.SetSrcAS(src_blas.GetDstAS());
+    update_blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
+
+    m_errorMonitor->SetDesiredError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03708");
+    update_blas.BuildHost();
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate buffers used in vkBuildAccelerationStructureKHR");
 
@@ -946,6 +973,33 @@ TEST_F(NegativeRayTracing, DISABLED_BuildAccelerationStructureModeUpdate) {
 
     m_errorMonitor->SetDesiredError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03667");
     host_cached_blas.BuildHost();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDestroyedMemory) {
+    TEST_DESCRIPTION("vkWriteAccelerationStructuresPropertiesKHR with acceleration structure buffer memory destroyed");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::accelerationStructureHostCommands);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(Init());
+
+    auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnHostBottomLevel(*m_device);
+    blas.SetFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR);
+    blas.BuildHost();
+
+    blas.GetDstAS()->GetBuffer().Memory().Destroy();
+
+    constexpr size_t stride = sizeof(VkDeviceSize);
+    constexpr size_t data_size = sizeof(VkDeviceSize) * stride;
+    uint8_t data[data_size];
+
+    m_errorMonitor->SetDesiredError("VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03736");
+    vk::WriteAccelerationStructuresPropertiesKHR(*m_device, 1, &blas.GetDstAS()->handle(),
+                                                 VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR, data_size, data, stride);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/ray_tracing_micromap.cpp
+++ b/tests/unit/ray_tracing_micromap.cpp
@@ -813,6 +813,46 @@ TEST_F(NegativeRayTracingMicromap, CmdBuildAccelerationStructureTriangleMicromap
         m_errorMonitor->VerifyFound();
         m_command_buffer.End();
     }
+
+    {
+        vkt::Buffer temp_as_buffer(*m_device, 4096, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR, vkt::device_address);
+        VkAccelerationStructureCreateInfoKHR temp_as_ci = vku::InitStructHelper();
+        temp_as_ci.buffer = temp_as_buffer;
+        temp_as_ci.offset = 0;
+        temp_as_ci.size = 4096;
+        temp_as_ci.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+        VkAccelerationStructureKHR invalid_micromap;
+        vk::CreateAccelerationStructureKHR(device(), &temp_as_ci, nullptr, &invalid_micromap);
+        vk::DestroyAccelerationStructureKHR(device(), invalid_micromap, nullptr);
+
+        VkAccelerationStructureTrianglesOpacityMicromapKHR triangle_mm = vku::InitStructHelper();
+        triangle_mm.indexType = VK_INDEX_TYPE_UINT16;
+        triangle_mm.indexBuffer = micromap_buffer.Address();
+        triangle_mm.indexStride = 2;
+        triangle_mm.micromap = invalid_micromap;
+
+        VkAccelerationStructureGeometryKHR geometry = vku::InitStructHelper();
+        geometry.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+        geometry.geometry.triangles = vku::InitStructHelper(&triangle_mm);
+        geometry.geometry.triangles.indexType = VK_INDEX_TYPE_NONE_KHR;
+        geometry.geometry.triangles.maxVertex = 3;
+        geometry.geometry.triangles.transformData.deviceAddress = triangle_buffer.Address();
+        geometry.geometry.triangles.vertexData.deviceAddress = triangle_buffer.Address();
+        geometry.geometry.triangles.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
+
+        build_info.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+        build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+        build_info.srcAccelerationStructure = nullptr;
+        build_info.dstAccelerationStructure = blas1->handle();
+        build_info.geometryCount = 1;
+        build_info.pGeometries = &geometry;
+
+        m_command_buffer.Begin();
+        m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureTrianglesOpacityMicromapKHR-micromap-parameter");
+        vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1, &build_info, &range_info_ptr);
+        m_errorMonitor->VerifyFound();
+        m_command_buffer.End();
+    }
 }
 
 TEST_F(NegativeRayTracingMicromap, CmdBuildAccelerationStructureTriangleMicromapIndexValidation) {
@@ -1024,6 +1064,38 @@ TEST_F(NegativeRayTracingMicromap, CmdBuildAccelerationStructureIndexType) {
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkCmdBuildAccelerationStructuresKHR-commandBuffer-cmdpool");
     m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureTrianglesOpacityMicromapKHR-indexType-11570");
     vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1, &build_info, &range_info_ptr);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeRayTracingMicromap, CmdBuildAccelerationStructuresBuildRangeInfosNull) {
+    RETURN_IF_SKIP(InitMicromapTest());
+
+    auto tlas = vkt::as::blueprint::AccelStructSimpleOnDeviceTopLevel(*m_device, 4096);
+    tlas->Create();
+
+    vkt::Buffer scratch_buffer(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+                               vkt::device_address);
+
+    VkAccelerationStructureGeometryKHR geometry = vku::InitStructHelper();
+    geometry.geometryType = VK_GEOMETRY_TYPE_INSTANCES_KHR;
+    geometry.geometry.instances = vku::InitStructHelper();
+    geometry.geometry.instances.arrayOfPointers = VK_FALSE;
+    geometry.geometry.instances.data.deviceAddress = 0;
+
+    VkAccelerationStructureBuildGeometryInfoKHR build_info = vku::InitStructHelper();
+    build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
+    build_info.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+    build_info.geometryCount = 1;
+    build_info.pGeometries = &geometry;
+    build_info.dstAccelerationStructure = tlas->handle();
+    build_info.scratchData.deviceAddress = scratch_buffer.Address();
+
+    const VkAccelerationStructureBuildRangeInfoKHR* range_info_null = nullptr;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-11543");
+    vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1, &build_info, &range_info_null);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }


### PR DESCRIPTION
Adding the following missing VUs and corresponding negative unit tests:

- VUID-VkAccelerationStructureTrianglesOpacityMicromapKHR-micromap-parameter
- VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-11543
- VUID-vkBuildAccelerationStructuresKHR-pInfos-03708
- VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03736