### PR TITLE
layers: Add opacity micromap query checks

### DIFF
--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -594,6 +594,15 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const Qu
                              FormatHandle(query_obj.pool).c_str(), string_VkQueryType(query_pool_ci.queryType));
             break;
         }
+        case VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT:
+        case VK_QUERY_TYPE_MICROMAP_COMPACTED_SIZE_EXT: {
+            const char* vuid =
+                is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-08972" : "VUID-vkCmdBeginQuery-queryType-08972";
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
+            skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with queryType %s.",
+                             FormatHandle(query_obj.pool).c_str(), string_VkQueryType(query_pool_ci.queryType));
+            break;
+        }
         case VK_QUERY_TYPE_PIPELINE_STATISTICS: {
             if ((cb_state.command_pool.queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
                 if (query_pool_ci.pipelineStatistics &
@@ -881,6 +890,8 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer& cb_state, const Qu
                            : (command == Func::vkCmdEncodeVideoKHR)       ? "VUID-vkCmdEncodeVideoKHR-pNext-08361"
                            : (command == Func::vkCmdWriteAccelerationStructuresPropertiesKHR)
                                ? "VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryPool-02494"
+                           : (command == Func::vkCmdWriteMicromapsPropertiesEXT)
+                               ? "VUID-vkCmdWriteMicromapsPropertiesEXT-None-12417"
                                : unexpected_caller_vuid;
         assert(strcmp(vuid, unexpected_caller_vuid) != 0);
 

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -1638,6 +1638,17 @@ bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevic
             }
         }
 
+        if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR) {
+            if (as_state->GetType() != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
+                const LogObjectList objlist(device, pAccelerationStructures[i]);
+                skip |= LogError("VUID-vkWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-12425", objlist, as_loc,
+                                 "was created with type %s, but queryType is "
+                                 "VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR which requires "
+                                 "VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR.",
+                                 string_VkAccelerationStructureTypeKHR(as_state->GetType()));
+            }
+        }
+
         if (as_state->UsesCreateInfo2()) {
             skip |= LogError("VUID-vkWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-11592",
                              pAccelerationStructures[i], as_loc,
@@ -1690,6 +1701,17 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
                     LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431", commandBuffer,
                              as_loc, "was built with %s, but queryType is VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR.",
                              string_VkBuildAccelerationStructureFlagsKHR(as_state->GetBuildInfo()->flags).c_str());
+            }
+        }
+
+        if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR) {
+            if (as_state->GetType() != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
+                skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-12425", commandBuffer,
+                                 as_loc,
+                                 "was created with type %s, but queryType is "
+                                 "VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR which requires "
+                                 "VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR.",
+                                 string_VkAccelerationStructureTypeKHR(as_state->GetType()));
             }
         }
     }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3887,6 +3887,14 @@ void DeviceState::PostCallRecordCmdWriteAccelerationStructuresPropertiesKHR(
     cb_state->RecordWriteAccelerationStructuresProperties(queryPool, firstQuery, accelerationStructureCount, record_obj.location);
 }
 
+void DeviceState::PostCallRecordCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuffer, uint32_t micromapCount,
+                                                               const VkMicromapEXT* pMicromaps, VkQueryType queryType,
+                                                               VkQueryPool queryPool, uint32_t firstQuery,
+                                                               const RecordObject& record_obj) {
+    auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
+    cb_state->RecordWriteAccelerationStructuresProperties(queryPool, firstQuery, micromapCount, record_obj.location);
+}
+
 void DeviceState::PostCallRecordCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession,
                                                       const RecordObject& record_obj) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1649,6 +1649,9 @@ class DeviceState : public vvl::BaseDevice {
                                                                    const VkAccelerationStructureKHR* pAccelerationStructures,
                                                                    VkQueryType queryType, VkQueryPool queryPool,
                                                                    uint32_t firstQuery, const RecordObject& record_obj) override;
+    void PostCallRecordCmdWriteMicromapsPropertiesEXT(VkCommandBuffer commandBuffer, uint32_t micromapCount,
+                                                      const VkMicromapEXT* pMicromaps, VkQueryType queryType, VkQueryPool queryPool,
+                                                      uint32_t firstQuery, const RecordObject& record_obj) override;
     void PostCallRecordCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                                 const VkViewportWScalingNV* pViewportWScalings,
                                                 const RecordObject& record_obj) override;

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -2802,6 +2802,58 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1Devi
     m_command_buffer.End();
 }
 
+TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesBottomLevelPointers) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructureHostCommands);
+    AddRequiredFeature(vkt::Feature::rayTracingMaintenance1);
+    RETURN_IF_SKIP(Init());
+
+    auto blas = vkt::as::blueprint::AccelStructSimpleOnHostBottomLevel(*m_device, 4096);
+    blas->Create();
+
+    constexpr size_t stride = sizeof(VkDeviceSize);
+    constexpr size_t data_size = sizeof(VkDeviceSize);
+    uint8_t data[data_size];
+
+    m_errorMonitor->SetDesiredError("VUID-vkWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-12425");
+    vk::WriteAccelerationStructuresPropertiesKHR(*m_device, 1, &blas->handle(),
+                                                 VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR,
+                                                 data_size, data, stride);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeRayTracing, CmdWriteAccelerationStructuresPropertiesBottomLevelPointers) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayTracingMaintenance1);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+
+    m_command_buffer.Begin();
+    blas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+    m_device->Wait();
+
+    vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR, 1);
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-12425");
+    vk::CmdWriteAccelerationStructuresPropertiesKHR(m_command_buffer, 1, &blas.GetDstAS()->handle(),
+                                                    VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR,
+                                                    query_pool, 0);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDataSizeTooSmall) {
     TEST_DESCRIPTION(
         "Call vkWriteAccelerationStructuresPropertiesKHR with a dataSize that is smaller that VkDeviceSize for relevant query "

--- a/tests/unit/ray_tracing_micromap.cpp
+++ b/tests/unit/ray_tracing_micromap.cpp
@@ -2293,3 +2293,82 @@ TEST_F(NegativeRayTracingMicromap, DISABLED_TraceRaysOMMPipelineFlagMissing) {
 
     vk::DestroyPipeline(device(), rt_pipeline, nullptr);
 }
+
+TEST_F(NegativeRayTracingMicromap, BeginQueryQueryPoolType) {
+    TEST_DESCRIPTION("Test CmdBeginQuery with invalid micromap queryPool queryType");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME);
+    AddOptionalExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::micromap);
+    RETURN_IF_SKIP(Init());
+
+    const bool ext_transform_feedback = IsExtensionsEnabled(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
+
+    auto cmd_begin_query_micromap = [this, ext_transform_feedback](VkQueryType query_type, auto vuid_begin_query,
+                                                                   auto vuid_begin_query_indexed) {
+        vkt::QueryPool query_pool(*m_device, query_type, 1);
+
+        m_command_buffer.Begin();
+        m_errorMonitor->SetDesiredError(vuid_begin_query);
+        vk::CmdBeginQuery(m_command_buffer, query_pool, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        if (ext_transform_feedback) {
+            m_errorMonitor->SetDesiredError(vuid_begin_query_indexed);
+            vk::CmdBeginQueryIndexedEXT(m_command_buffer, query_pool, 0, 0, 0);
+            m_errorMonitor->VerifyFound();
+        }
+        m_command_buffer.End();
+    };
+
+    cmd_begin_query_micromap(VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT, "VUID-vkCmdBeginQuery-queryType-08972",
+                             "VUID-vkCmdBeginQueryIndexedEXT-queryType-08972");
+    cmd_begin_query_micromap(VK_QUERY_TYPE_MICROMAP_COMPACTED_SIZE_EXT, "VUID-vkCmdBeginQuery-queryType-08972",
+                             "VUID-vkCmdBeginQueryIndexedEXT-queryType-08972");
+}
+
+TEST_F(NegativeRayTracingMicromap, WriteMicromapsPropertiesQueryNotReset) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DEVICE_ADDRESS_COMMANDS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME);
+    VkPhysicalDeviceOpacityMicromapFeaturesEXT ext_features = vku::InitStructHelper();
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&ext_features);
+    RETURN_IF_SKIP(InitFramework());
+    vk::GetPhysicalDeviceFeatures2(Gpu(), &features2);
+    if (!ext_features.micromap) {
+        GTEST_SKIP() << "micromap feature not supported";
+    }
+    ext_features.micromap = VK_TRUE;
+    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT);
+
+    VkMicromapCreateInfoEXT mm_ci = vku::InitStructHelper();
+    mm_ci.createFlags = 0;
+    mm_ci.buffer = buffer;
+    mm_ci.offset = 0;
+    mm_ci.size = 4096;
+    mm_ci.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    mm_ci.deviceAddress = 0ull;
+
+    VkMicromapEXT micromap = VK_NULL_HANDLE;
+    vk::CreateMicromapEXT(device(), &mm_ci, nullptr, &micromap);
+
+    vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT, 1);
+
+    m_command_buffer.Begin();
+    vk::CmdWriteMicromapsPropertiesEXT(m_command_buffer, 1, &micromap, VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT, query_pool,
+                                       0);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdWriteMicromapsPropertiesEXT-None-12417");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyMicromapEXT(device(), micromap, nullptr);
+}

--- a/tests/unit/ray_tracing_micromap_positive.cpp
+++ b/tests/unit/ray_tracing_micromap_positive.cpp
@@ -736,3 +736,101 @@ TEST_F(PositiveRayTracingMicromap, OpacityMicromapPipelineFlagAndTrace) {
     vk::DestroyAccelerationStructureKHR(*m_device, bottomAS, NULL);
     vk::DestroyAccelerationStructureKHR(*m_device, micromapAS, NULL);
 }
+
+TEST_F(PositiveRayTracingMicromap, WriteMicromapsProperties) {
+    TEST_DESCRIPTION(
+        "Use vkWriteMicromapsPropertiesEXT (host) with VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT "
+        "and vkCmdWriteMicromapsPropertiesEXT (device) with VK_QUERY_TYPE_MICROMAP_COMPACTED_SIZE_EXT");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    VkPhysicalDeviceOpacityMicromapFeaturesEXT ext_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&ext_features);
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&buffer_features);
+    vk::GetPhysicalDeviceFeatures2(Gpu(), &features2);
+    if (!ext_features.micromap) {
+        GTEST_SKIP() << "micromap feature not supported";
+    }
+    ext_features.micromap = VK_TRUE;
+    accel_features.accelerationStructure = VK_TRUE;
+    buffer_features.bufferDeviceAddress = VK_TRUE;
+    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Test not supported by MockICD";
+    }
+
+    VkMicromapUsageEXT mm_usage = {};
+    mm_usage.count = 1;
+    mm_usage.subdivisionLevel = 0;
+    mm_usage.format = VK_OPACITY_MICROMAP_FORMAT_2_STATE_EXT;
+
+    VkMicromapBuildInfoEXT mm_build_info = vku::InitStructHelper();
+    mm_build_info.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    mm_build_info.flags = 0;
+    mm_build_info.mode = VK_BUILD_MICROMAP_MODE_BUILD_EXT;
+    mm_build_info.usageCountsCount = 1;
+    mm_build_info.pUsageCounts = &mm_usage;
+
+    VkMicromapBuildSizesInfoEXT size_info = vku::InitStructHelper();
+    vk::GetMicromapBuildSizesEXT(device(), VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &mm_build_info, &size_info);
+
+    // Micromap buffer must be host-visible for vkWriteMicromapsPropertiesEXT
+    vkt::Buffer micromap_buffer(*m_device, size_info.micromapSize, VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+    VkMicromapCreateInfoEXT mm_ci = vku::InitStructHelper();
+    mm_ci.buffer = micromap_buffer;
+    mm_ci.size = size_info.micromapSize;
+    mm_ci.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+
+    VkMicromapEXT micromap = VK_NULL_HANDLE;
+    vk::CreateMicromapEXT(device(), &mm_ci, nullptr, &micromap);
+
+    vkt::Buffer data_buffer(*m_device, 512,
+                            VK_BUFFER_USAGE_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+                            vkt::device_address);
+    {
+        uint8_t* data = (uint8_t*)data_buffer.Memory().Map();
+        memset(data, 0, 512);
+        VkMicromapTriangleEXT* tri = (VkMicromapTriangleEXT*)data;
+        tri->dataOffset = 0;
+        tri->subdivisionLevel = 0;
+        tri->format = VK_OPACITY_MICROMAP_FORMAT_2_STATE_EXT;
+        data[256] = 0x01;
+        data_buffer.Memory().Unmap();
+    }
+
+    vkt::Buffer scratch_buffer(*m_device, std::max(size_info.buildScratchSize, VkDeviceSize(4)),
+                               VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, vkt::device_address);
+
+    mm_build_info.dstMicromap = micromap;
+    mm_build_info.data.deviceAddress = data_buffer.Address() + 256;
+    mm_build_info.triangleArray.deviceAddress = data_buffer.Address();
+    mm_build_info.triangleArrayStride = sizeof(VkMicromapTriangleEXT);
+    mm_build_info.scratchData.deviceAddress = scratch_buffer.Address();
+
+    m_command_buffer.Begin();
+    vk::CmdBuildMicromapsEXT(m_command_buffer, 1, &mm_build_info);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    // Use vkWriteMicromapsPropertiesEXT (host command) with SERIALIZATION_SIZE
+    VkDeviceSize serialization_size = 0;
+    vk::WriteMicromapsPropertiesEXT(device(), 1, &micromap, VK_QUERY_TYPE_MICROMAP_SERIALIZATION_SIZE_EXT, sizeof(VkDeviceSize),
+                                    &serialization_size, sizeof(VkDeviceSize));
+
+    // Use vkCmdWriteMicromapsPropertiesEXT (device command) with COMPACTED_SIZE
+    vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_MICROMAP_COMPACTED_SIZE_EXT, 1);
+
+    m_command_buffer.Begin();
+    vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 1);
+    vk::CmdWriteMicromapsPropertiesEXT(m_command_buffer, 1, &micromap, VK_QUERY_TYPE_MICROMAP_COMPACTED_SIZE_EXT, query_pool, 0);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    vk::DestroyMicromapEXT(device(), micromap, nullptr);
+}


### PR DESCRIPTION
Adding the following missing VUs and corresponding negative unit tests:

- VUID-vkCmdBeginQuery-queryType-08972
- VUID-vkCmdBeginQueryIndexedEXT-queryType-08972
- VUID-vkCmdWriteMicromapsPropertiesEXT-None-12417
- VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-12425
- VUID-vkWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-12425