### PR TITLE
layers: Report thread name in thread-safety messages

### DIFF
--- a/layers/thread_tracker/thread_safety_validation.cpp
+++ b/layers/thread_tracker/thread_safety_validation.cpp
@@ -20,14 +20,71 @@
 #include "containers/span.h"
 #include "containers/container_utils.h"
 
+// Get current thread description on Windows
+#if defined(_WIN32)
+#include <windows.h>
+#include <vector>
+static std::string GetWin32ThreadDescription() {
+    // GetThreadDescription is missing before Windows 10 1607 so resolve at runtime
+    using GetThreadDescriptionFunc = HRESULT(WINAPI*)(HANDLE, PWSTR*);
+    static const GetThreadDescriptionFunc get_thread_description = reinterpret_cast<GetThreadDescriptionFunc>(
+        (void*)::GetProcAddress(::GetModuleHandleW(L"kernel32.dll"), "GetThreadDescription"));
+
+    if (!get_thread_description) {
+        return {};
+    }
+    PWSTR description = nullptr;
+    if (FAILED(get_thread_description(::GetCurrentThread(), &description))) {
+        return {};
+    }
+    const int buffer_size = ::WideCharToMultiByte(CP_UTF8, 0, description, -1, nullptr, 0, nullptr, nullptr);
+    if (buffer_size <= 0) {
+        ::LocalFree(description);
+        return {};
+    }
+    std::vector<char> buffer(buffer_size);
+    const int bytes_written = ::WideCharToMultiByte(CP_UTF8, 0, description, -1, buffer.data(), buffer_size, nullptr, nullptr);
+    ::LocalFree(description);
+    if (bytes_written <= 0) {
+        return {};
+    }
+    return std::string(buffer.data());
+}
+#endif
+
+// Get thread name on Linux, Android (API >= 26) and Mac
+#if defined(__linux__) || defined(__APPLE__)
+#include <pthread.h>
+static std::string GetPThreadName() {
+    char name[64] = {};  // on linux only 16 bytes are used, on Mac it can be more
+    if (pthread_getname_np(pthread_self(), name, sizeof(name)) != 0) {
+        return {};
+    }
+    // On Linux unnamed thread goes with default name (executable).
+    // On Mac default thread name is empty (similar to Windows)
+    return name;
+}
+#endif
+
 namespace threadsafety {
 
 static std::atomic_uint32_t next_thread_id{1};  // 0 is reserved as default state (no thread)
-static vvl::concurrent_unordered_map<uint32_t, std::thread::id, 4> thread_id_map;
+static vvl::concurrent_unordered_map<uint32_t, ThreadInfo, 4> thread_id_map;
+
+std::string GetCurrentThreadName() {
+#if defined(_WIN32)
+    return GetWin32ThreadDescription();
+#elif defined(__linux__) || defined(__APPLE__)  // this also includes Android
+    return GetPThreadName();
+#else
+    return {};
+#endif
+}
 
 static uint32_t RegisterCurrentThread() {
     const uint32_t id = next_thread_id.fetch_add(1);
-    thread_id_map.insert(id, std::this_thread::get_id());
+    const std::string thread_name = GetCurrentThreadName();
+    thread_id_map.insert(id, ThreadInfo{std::this_thread::get_id(), thread_name});
     return id;
 }
 
@@ -36,9 +93,9 @@ uint32_t GetCurrentInternalThreadId() {
     return tls_id;
 }
 
-std::thread::id GetStdThreadIdFromInternal(uint32_t internal_thread_id) {
+ThreadInfo GetThreadInfo(uint32_t internal_thread_id) {
     auto it = thread_id_map.find(internal_thread_id);
-    return it != thread_id_map.end() ? it->second : std::thread::id{};
+    return it != thread_id_map.end() ? it->second : ThreadInfo{};
 }
 
 ReadLockGuard Device::ReadLock() const { return ReadLockGuard(validation_object_mutex, std::defer_lock); }

--- a/layers/thread_tracker/thread_safety_validation.h
+++ b/layers/thread_tracker/thread_safety_validation.h
@@ -45,13 +45,10 @@ static_assert(std::is_same<uint64_t, DISTINCT_NONDISPATCHABLE_PHONY_HANDLE>::val
               "Mismatched non-dispatchable handle handle, expected uint64_t.");
 #endif
 
-// Align ObjectUseData to a cache line to avoid false sharing of its atomics.
-// Some CPUs (e.g. Apple M1) have 128-byte lines. We still use 64 to save memory,
-// accepting possible false sharing there.
-inline constexpr size_t kObjectUseDataAlignment = 64;
-
-// Sanity check on the build machine
-static_assert(vku::concurrent::get_hardware_destructive_interference_size() % kObjectUseDataAlignment == 0);
+struct ThreadInfo {
+    std::thread::id tid;
+    std::string thread_name;
+};
 
 // Alternative to std::thread::id that is guaranteed to be uint32_t.
 // Internally implemented as atomic counter.
@@ -59,7 +56,19 @@ static_assert(vku::concurrent::get_hardware_destructive_interference_size() % kO
 uint32_t GetCurrentInternalThreadId();
 
 // Map internal id to std::thread::id
-std::thread::id GetStdThreadIdFromInternal(uint32_t internal_thread_id);
+ThreadInfo GetThreadInfo(uint32_t internal_thread_id);
+
+// Return OS name of the calling thread or an empty string if the thread is unnamed
+// or the name cannot be retrieved
+std::string GetCurrentThreadName();
+
+// Align ObjectUseData to a cache line to avoid false sharing of its atomics.
+// Some CPUs (e.g. Apple M1) have 128-byte lines. We still use 64 to save memory,
+// accepting possible false sharing there.
+inline constexpr size_t kObjectUseDataAlignment = 64;
+
+// Sanity check on the build machine
+static_assert(vku::concurrent::get_hardware_destructive_interference_size() % kObjectUseDataAlignment == 0);
 
 class alignas(kObjectUseDataAlignment) ObjectUseData {
   public:
@@ -199,15 +208,25 @@ class Counter {
         const uint64_t value = use_data->thread_and_func.load();
         const uint32_t other_internal_tid = value & 0xffffffff;
         const vvl::Func other_func = static_cast<vvl::Func>(value >> 32);
+
         const std::thread::id current_tid = std::this_thread::get_id();
+        const std::string current_name = GetCurrentThreadName();
 
         std::ostringstream ss;
         ss << "THREADING ERROR : object of type " << string_VulkanObjectType(object_type)
-           << " is simultaneously used in current thread " << current_tid << " (" << vvl::String(loc.function) << ") and ";
+           << " is simultaneously used in current thread " << current_tid;
+        if (!current_name.empty()) {
+            ss << " \"" << current_name << "\"";
+        }
+        ss << " (" << vvl::String(loc.function) << ") and ";
 
         if (other_internal_tid != 0) {  // common case
-            const std::thread::id other_tid = GetStdThreadIdFromInternal(other_internal_tid);
-            ss << "thread " << other_tid << " (" << vvl::String(other_func) << ")";
+            const ThreadInfo other_info = GetThreadInfo(other_internal_tid);
+            ss << "thread " << other_info.tid;
+            if (!other_info.thread_name.empty()) {
+                ss << " \"" << other_info.thread_name << "\"";
+            }
+            ss << " (" << vvl::String(other_func) << ")";
         } else {  // rare case
             // The object was just created and two racing threads access it for the first time.
             // The other side of the race is not recorded yet (other_internal_tid == 0).


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8446

This is very platform specific but simple way (except windows) to get thread names. I did not want to grab existing snippets from other software/libs - they usually more involved and add dependency (checked few and did not like them). This supports Windows, Linux, Android 26+, Mac (unixes not supproted). Tested on Windows and Linux.

Linux has one difference comparing to Windows/Mac. The latter have default thread name as empty string. Only when you set custom name it will be visible in the error message (which is nice). Linux has default thread name which matches executable name truncated to 15 characters. Current implementation will print those default names if custom name is not assigned. It's possible to read executable name and then filter out default thread names but that's some linux system programming and I'd rather do this in a seprate PR if needed.

> Validation Error: [ UNASSIGNED-Threading-MultipleThreads-Write ] | MessageID = 0xa05b236e
vkCmdSetEvent(): THREADING ERROR : object of type VkCommandPool is simultaneously used in current thread 34476 "Worker-thread" (vkCmdSetEvent) and thread 44924 "VVL-test-main-thread" (vkCmdSetEvent)
