### PR TITLE
gpuav: Hotfix Sampler breaking inst_it

### DIFF
--- a/layers/gpuav/spirv/descriptor_heap_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_heap_pass.cpp
@@ -159,6 +159,37 @@ uint32_t DescriptorHeapPass::GetMinBufferAlignment(const InstructionMeta& meta) 
 
 uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta,
                                                 bool is_seperate_sampler) {
+    // TODO - This logic is not obvious and should be either fixed or moved to a common util
+    // If dealing with a seperate sampler, only need to do it on the resource
+    // To add to the fire, this needs to go first otherwise the Function::CreateInstruction will break the inst_it
+    if (meta.access_path.image_load_inst && !is_seperate_sampler) {
+        const uint32_t opcode = meta.target_instruction->Opcode();
+        if (opcode != spv::OpImageRead && opcode != spv::OpImageFetch && opcode != spv::OpImageWrite) {
+            // if not a direct read/write/fetch, will be a OpSampledImage
+            // "All OpSampledImage instructions must be in the same block in which their Result <id> are consumed"
+            // the simple way around this is to add a OpCopyObject to be consumed by the target instruction
+            uint32_t image_id = meta.target_instruction->Operand(0);
+            const Instruction* sampled_image_inst = block.function_->FindInstruction(image_id);
+            // TODO - Add tests to understand what else can be here other then OpSampledImage
+            if (sampled_image_inst->Opcode() == spv::OpSampledImage) {
+                const uint32_t type_id = sampled_image_inst->TypeId();
+                const uint32_t copy_id = module_.TakeNextId();
+                const_cast<Instruction*>(meta.target_instruction)->ReplaceOperandId(image_id, copy_id);
+
+                // incase the OpSampledImage is shared, copy the previous OpCopyObject
+                auto copied = copy_object_map_.find(image_id);
+                if (copied != copy_object_map_.end()) {
+                    image_id = copied->second;
+                    block.CreateInstruction(spv::OpCopyObject, {type_id, copy_id, image_id}, inst_it);
+                } else {
+                    copy_object_map_.emplace(image_id, copy_id);
+                    // slower, but need to guarantee it is placed after a OpSampledImage
+                    block.function_->CreateInstruction(spv::OpCopyObject, {type_id, copy_id, image_id}, image_id, inst_it);
+                }
+            }
+        }
+    }
+
     const Variable& descriptor_variable = is_seperate_sampler ? *meta.access_path.sampler_variable : *meta.access_path.variable;
     const uint32_t descriptor_index =
         is_seperate_sampler ? meta.access_path.sampler_descriptor_index_id : meta.access_path.descriptor_index_id;
@@ -196,36 +227,6 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
 
     uint32_t function_result = module_.TakeNextId();
     const uint32_t bool_type = type_manager_.GetTypeBool().Id();
-
-    // TODO - This logic is not obvious and should be either fixed or moved to a common util
-    // If dealing with a seperate sampler, only need to do it on the resource
-    if (meta.access_path.image_load_inst && !is_seperate_sampler) {
-        const uint32_t opcode = meta.target_instruction->Opcode();
-        if (opcode != spv::OpImageRead && opcode != spv::OpImageFetch && opcode != spv::OpImageWrite) {
-            // if not a direct read/write/fetch, will be a OpSampledImage
-            // "All OpSampledImage instructions must be in the same block in which their Result <id> are consumed"
-            // the simple way around this is to add a OpCopyObject to be consumed by the target instruction
-            uint32_t image_id = meta.target_instruction->Operand(0);
-            const Instruction* sampled_image_inst = block.function_->FindInstruction(image_id);
-            // TODO - Add tests to understand what else can be here other then OpSampledImage
-            if (sampled_image_inst->Opcode() == spv::OpSampledImage) {
-                const uint32_t type_id = sampled_image_inst->TypeId();
-                const uint32_t copy_id = module_.TakeNextId();
-                const_cast<Instruction*>(meta.target_instruction)->ReplaceOperandId(image_id, copy_id);
-
-                // incase the OpSampledImage is shared, copy the previous OpCopyObject
-                auto copied = copy_object_map_.find(image_id);
-                if (copied != copy_object_map_.end()) {
-                    image_id = copied->second;
-                    block.CreateInstruction(spv::OpCopyObject, {type_id, copy_id, image_id}, inst_it);
-                } else {
-                    copy_object_map_.emplace(image_id, copy_id);
-                    // slower, but need to guarantee it is placed after a OpSampledImage
-                    block.function_->CreateInstruction(spv::OpCopyObject, {type_id, copy_id, image_id}, image_id, inst_it);
-                }
-            }
-        }
-    }
 
     const uint32_t binding_offset = mapping ? descriptor_variable.interface_.binding - mapping->firstBinding : 0;
     const bool combined_index = meta.access_path.is_combined_image_sampler && mapping && HasCombinedImageSamplerIndex(*mapping);

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -51,11 +51,9 @@ uint32_t DescriptorIndexingOOBPass::GetLinkFunctionId(bool is_combined_image_sam
 }
 
 uint32_t DescriptorIndexingOOBPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta) {
-    const DescriptorInterface& interface = meta.access_path.variable->interface_;
-    const Constant& set_constant = type_manager_.GetConstantUInt32(interface.set);
-    const Constant& binding_constant = type_manager_.GetConstantUInt32(interface.binding);
-    const uint32_t descriptor_index_id = CastToUint32(meta.access_path.descriptor_index_id, block, inst_it);  // might be int32
-
+    // TODO - This logic is not obvious and should be either fixed or moved to a common util
+    // If dealing with a seperate sampler, only need to do it on the resource
+    // To add to the fire, this needs to go first otherwise the Function::CreateInstruction will break the inst_it
     if (meta.access_path.image_load_inst) {
         const uint32_t opcode = meta.target_instruction->Opcode();
         if (opcode != spv::OpImageRead && opcode != spv::OpImageFetch && opcode != spv::OpImageWrite) {
@@ -83,6 +81,11 @@ uint32_t DescriptorIndexingOOBPass::CreateFunctionCall(BasicBlock& block, Instru
             }
         }
     }
+
+    const DescriptorInterface& interface = meta.access_path.variable->interface_;
+    const Constant& set_constant = type_manager_.GetConstantUInt32(interface.set);
+    const Constant& binding_constant = type_manager_.GetConstantUInt32(interface.binding);
+    const uint32_t descriptor_index_id = CastToUint32(meta.access_path.descriptor_index_id, block, inst_it);  // might be int32
 
     const auto& layout_lut = module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut;
     BindingLayout binding_layout = layout_lut[interface.set][interface.binding];

--- a/tests/unit/gpu_av_descriptor_heap_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_heap_positive.cpp
@@ -33,7 +33,7 @@ void GpuAVDescriptorHeap::InitGpuAVDescriptorHeap(std::vector<VkLayerSettingEXT>
 TEST_F(PositiveGpuAVDescriptorHeap, BufferPointerOffset) {
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     InitRenderTarget();
 
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
@@ -65,7 +65,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, SamplerPointerOffset) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     InitRenderTarget();
 
     const uint32_t buffer_index = 16u;
@@ -149,7 +149,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, SamplerPointerOffset) {
 
 TEST_F(PositiveGpuAVDescriptorHeap, HeapBoundInMultimpleCmdBuffers) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     InitRenderTarget();
 
     const VkDeviceSize heap_size = 256;
@@ -174,7 +174,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, HeapBoundInMultimpleCmdBuffers) {
 
 TEST_F(PositiveGpuAVDescriptorHeap, PushAddress) {
     AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     InitRenderTarget();
 
     vkt::Buffer read_buffer(*m_device, sizeof(uint32_t) * 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
@@ -275,7 +275,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, ResourceHeapImage) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     InitRenderTarget();
 
     const uint32_t buffer_index = 16u;
@@ -491,7 +491,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, CombinedAndSeparateImageSampler) {
 
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4874
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitPushIndex) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride * 4);
 
@@ -532,7 +532,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitPushIndex) {
 
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4874
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitIndirectIndex) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride * 4);
 
@@ -578,7 +578,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitIndirectIndex) {
 
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4874
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitHeapData) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride * 4);
 
@@ -629,7 +629,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitHeapData) {
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitPushData) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredFeature(vkt::Feature::scalarBlockLayout);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride);
 
@@ -674,7 +674,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitPushData) {
 
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4874
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitPushAddress) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
     VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
@@ -709,7 +709,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitPushAddress) {
 
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4874
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitIndirectAddress) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
     VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
@@ -747,7 +747,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitIndirectAddress) {
 
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4874
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitShader) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride);
 
@@ -791,7 +791,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitShader) {
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4874
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitShaderAndMapping) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
 
     vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
@@ -835,7 +835,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitShaderAndMapping) {
 TEST_F(PositiveGpuAVDescriptorHeap, DISABLED_PushDataLimitMulitipleDispatch) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredFeature(vkt::Feature::scalarBlockLayout);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride * 2);
 
@@ -894,7 +894,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, PushDataLimitNoShaderInstrumentation) {
     std::vector<VkLayerSettingEXT> layer_settings = {
         {OBJECT_LAYER_NAME, "gpuav_shader_instrumentation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkFalse},
     };
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap(layer_settings));
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap(layer_settings, false));
     vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
     VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
@@ -928,7 +928,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, PushDataLimitNoShaderInstrumentation) {
 }
 
 TEST_F(PositiveGpuAVDescriptorHeap, SamplerHeapOffset) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
 
     const VkDeviceSize resource_stride = heap_props.imageDescriptorSize;
     const VkDeviceSize sampler_stride = heap_props.samplerDescriptorSize;
@@ -992,7 +992,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, GraphicsPipelineLibraryInlined) {
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::graphicsPipelineLibrary);
     AddRequiredFeature(vkt::Feature::fragmentStoresAndAtomics);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     InitRenderTarget();
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride * 4);
@@ -1103,7 +1103,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, GraphicsPipelineLibraryWithShaderModule) {
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::graphicsPipelineLibrary);
     AddRequiredFeature(vkt::Feature::fragmentStoresAndAtomics);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     InitRenderTarget();
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride * 4);
@@ -1218,7 +1218,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, GraphicsPipelineLibraryWithShaderModule) {
 TEST_F(PositiveGpuAVDescriptorHeap, UntypedPointersOffsetIdNonArray) {
     AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
 
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride * 3);
@@ -1301,7 +1301,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, UntypedPointersOffsetIdNonArray) {
 }
 
 TEST_F(PositiveGpuAVDescriptorHeap, SecondaryInheritance) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride);
 
@@ -1351,7 +1351,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, SecondaryInheritance) {
 }
 
 TEST_F(PositiveGpuAVDescriptorHeap, ImageSamplerDynamicIndex) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize image_stride = heap_props.imageDescriptorSize;
     const VkDeviceSize sampler_stride = heap_props.samplerDescriptorSize;
     const VkDeviceSize buffer_offset = AlignResource(image_stride * 2u);
@@ -1394,7 +1394,7 @@ TEST_F(PositiveGpuAVDescriptorHeap, ImageSamplerDynamicIndex) {
 }
 
 TEST_F(PositiveGpuAVDescriptorHeap, SecondaryBind) {
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     CreateResourceHeap(resource_stride);
 


### PR DESCRIPTION
This is a quick fix to close https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12615

I plan to clean up this Sampler madness soon, proved this was/would have broke on classic Descriptors as well, just we happened to spot it first with heaps