### PR TITLE
legacy: Provide levels of detection

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -285,6 +285,7 @@ vvl_sources = [
   "layers/layer_options.h",
   "layers/layer_options_validation.h",
   "layers/legacy/legacy_manual.cpp",
+  "layers/legacy/legacy_settings.h",
   "layers/object_tracker/object_lifetime_validation.cpp",
   "layers/object_tracker/object_lifetime_validation.h",
   "layers/state_tracker/bind_point.h",

--- a/docs/legacy_detection.md
+++ b/docs/legacy_detection.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2025 LunarG, Inc. -->
+<!-- Copyright 2025-2026 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -48,14 +48,36 @@ instance_ci.pNext = &layer_settings_create_info;
 
 ```bash
 # Windows
-set VK_VALIDATION_LEGACY_DETECTION=1
+set VK_LAYER_LEGACY_DETECTION=1
 
 # Linux
-export VK_VALIDATION_LEGACY_DETECTION=1
+export VK_LAYER_LEGACY_DETECTION=1
 
 # Android
 adb shell setprop debug.vulkan.khronos_validation.legacy_detection=1
 ```
+
+## Why is it reporting extensions my device doesn't even support?
+
+By default, if the user is using `VK_EXT_foo` and there is a `VK_KHR_foo` in the current headers VVL was built with, it will warn the user. Some people will not want this warning unless their local device actually supports `VK_KHR_foo`.
+
+For this case, there is an additional `VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED` setting, that when set, will only give a warning if the `VkInstance`/`VkDevice` actually supports `VK_KHR_foo`.
+
+There is even a `VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED` setting, that goes further and will only give a warning you have enabled `VK_KHR_foo`, but still using `VK_EXT_foo`.
+
+The argument for the default being to still report `VK_KHR_foo` is that an application developer can always opt out of warnings for things they know they want to ignore, but opting in to warnings requires them to already know those things exist, which would mean they didn't need the extension to tell them about them in the first place.
+
+## Can I mute warnings?
+
+Yes, if the user wants to mute a certain error they can simply go `VK_LAYER_MESSAGE_ID_FILTER=WARNING-legacy-gpdp2`
+
+## Should I keep this on all the time?
+
+The layer is very simple and likely will cause very little overhead and you likely **could**.
+
+**Should** you... likely no.
+
+The goal of this Legacy Detection was to provide a tool so people could learn about newer Vulkan functionality. Just turning it on once and awhile and seeing what it reports might be enough for the majority of people.
 
 ## Extra reference
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -376,6 +376,7 @@ target_sources(vvl PRIVATE
     gpu_dump/gpu_dump_state.h
     gpu_dump/gpu_dump_state.cpp
     legacy/legacy_manual.cpp
+    legacy/legacy_settings.h
     object_tracker/object_lifetime_validation.cpp
     object_tracker/object_lifetime_validation.h
     state_tracker/bind_point.h

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -213,6 +213,8 @@
                         { "key": "thread_safety", "value": false },
                         { "key": "unique_handles", "value": false },
                         { "key": "legacy_detection", "value": true },
+                            { "key": "legacy_detection_only_supported", "value": false },
+                            { "key": "legacy_detection_only_enabled", "value": false },
                         { "key": "validate_best_practices", "value": false },
                         { "key": "gpuav_enable", "value": false },
                         { "key": "gpu_dump_descriptors", "value": false },
@@ -525,7 +527,37 @@
                             "label": "Legacy Detection",
                             "description": "Give warnings when using legacy parts of the API.",
                             "type": "BOOL",
-                            "default": false
+                            "default": false,
+                            "settings": [
+                                {
+                                    "key": "legacy_detection_only_supported",
+                                    "label": "Only warn if supported",
+                                    "description": "Only give warning if the instance/device supports the superseded functionality.",
+                                    "type": "BOOL",
+                                    "default": false,
+                                    "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ],
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            { "key": "legacy_detection", "value": true }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "legacy_detection_only_enabled",
+                                    "label": "Only warn if enabled",
+                                    "description": "Only give warning if you enabled the superseded functionality extensions/version.",
+                                    "type": "BOOL",
+                                    "default": false,
+                                    "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ],
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            { "key": "legacy_detection", "value": true }
+                                        ]
+                                    }
+                                }
+                            ]
                         },
                         {
                             "key": "validate_best_practices",

--- a/layers/chassis/dispatch_object.h
+++ b/layers/chassis/dispatch_object.h
@@ -35,6 +35,7 @@
 #include "gpuav/core/gpuav_settings.h"
 #include "sync/sync_settings.h"
 #include "gpu_dump/gpu_dump_settings.h"
+#include "legacy/legacy_settings.h"
 #include "generated/device_features.h"
 #include "generated/vk_api_version.h"
 #include "generated/vk_extension_helper.h"
@@ -181,6 +182,7 @@ struct Settings {
     GpuAVSettings gpuav_settings = {};
     SyncValSettings syncval_settings = {};
     GpuDumpSettings gpu_dump_settings = {};
+    LegacyDetectionSettings legacy_detection_settings = {};
 
     ValidationDisabled disabled = {};
     ValidationEnabled enabled = {};

--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -713,7 +713,8 @@ DispatchInstance::DispatchInstance(const VkInstanceCreateInfo* pCreateInfo) : Ha
                                                       &settings.global_settings,
                                                       &settings.gpuav_settings,
                                                       &settings.syncval_settings,
-                                                      &settings.gpu_dump_settings};
+                                                      &settings.gpu_dump_settings,
+                                                      &settings.legacy_detection_settings};
     ProcessConfigAndEnvSettings(&config_and_env_settings_data);
 
     if (settings.disabled[handle_wrapping]) {

--- a/layers/chassis/validation_object.h
+++ b/layers/chassis/validation_object.h
@@ -69,6 +69,7 @@ struct GlobalSettings;
 struct GpuAVSettings;
 struct SyncValSettings;
 struct GpuDumpSettings;
+struct LegacyDetectionSettings;
 
 // Because of GPL, we currently create our Pipeline state objects before the PreCallValidate
 // Each chassis layer will need to track its own state
@@ -94,6 +95,7 @@ class BaseInstance : public Logger {
     GpuAVSettings& gpuav_settings;
     const SyncValSettings& syncval_settings;
     const GpuDumpSettings& gpu_dump_settings;
+    const LegacyDetectionSettings& legacy_detection_settings;
 
     const ValidationDisabled& disabled;
     const ValidationEnabled& enabled;
@@ -110,6 +112,7 @@ class BaseInstance : public Logger {
           gpuav_settings(instance->settings.gpuav_settings),
           syncval_settings(instance->settings.syncval_settings),
           gpu_dump_settings(instance->settings.gpu_dump_settings),
+          legacy_detection_settings(instance->settings.legacy_detection_settings),
           disabled(instance->settings.disabled),
           enabled(instance->settings.enabled),
           instance(instance->instance),
@@ -156,6 +159,7 @@ class BaseDevice : public Logger {
     GpuAVSettings& gpuav_settings;
     const SyncValSettings& syncval_settings;
     const GpuDumpSettings& gpu_dump_settings;
+    const LegacyDetectionSettings& legacy_detection_settings;
 
     const ValidationDisabled& disabled;
     const ValidationEnabled& enabled;
@@ -191,6 +195,7 @@ class BaseDevice : public Logger {
           gpuav_settings(dispatch_dev->settings.gpuav_settings),
           syncval_settings(dispatch_dev->settings.syncval_settings),
           gpu_dump_settings(dispatch_dev->settings.gpu_dump_settings),
+          legacy_detection_settings(dispatch_dev->settings.legacy_detection_settings),
           disabled(dispatch_dev->settings.disabled),
           enabled(dispatch_dev->settings.enabled),
           instance(instance->instance),

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -35,6 +35,7 @@
 #include "gpuav/core/gpuav_settings.h"
 #include "sync/sync_settings.h"
 #include "gpu_dump/gpu_dump_settings.h"
+#include "legacy/legacy_settings.h"
 
 #include "vk_layer_config.h"
 
@@ -122,8 +123,9 @@ const std::vector<std::string>& GetEnableFlagNameHelper() {
         "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA",                      // vendor_specific_nvidia,
         "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",                       // debug_printf,
         "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",         // sync_validation,
-        "VK_VALIDATION_LEGACY_DETECTION",                                      // legacy_detection,
-        "VK_VALIDATION_GPU_DUMP",                                              // gpu_dump,
+        // These were added after we got rid of VkValidationFeatureDisableEXT
+        "VK_LAYER_LEGACY_DETECTION",      // legacy_detection,
+        "VK_LAYER_GPU_DUMP_DESCRIPTORS",  // gpu_dump,
     };
     return enable_flag_name_helper;
 }
@@ -152,7 +154,6 @@ const char* VK_LAYER_DISABLES = "disables";
 const char* VK_LAYER_CHECK_SHADERS = "check_shaders";
 const char* VK_LAYER_THREAD_SAFETY = "thread_safety";
 const char* VK_LAYER_STATELESS_PARAM = "stateless_param";
-const char* VK_LAYER_LEGACY_DETECTION = "legacy_detection";
 const char* VK_LAYER_OBJECT_LIFETIME = "object_lifetime";
 const char* VK_LAYER_VALIDATE_CORE = "validate_core";
 const char* VK_LAYER_UNIQUE_HANDLES = "unique_handles";
@@ -259,6 +260,12 @@ const char* VK_LAYER_GPU_DUMP_DEVICE_GENERATED_COMMANDS = "gpu_dump_device_gener
 const char* VK_LAYER_GPU_DUMP_TO_STDOUT = "gpu_dump_to_stdout";
 // Experimental
 const char* VK_LAYER_GPU_DUMP_DEVICE_COPY = "gpu_dump_device_copy";
+
+// Legacy Detection
+// ---
+const char* VK_LAYER_LEGACY_DETECTION = "legacy_detection";
+const char* VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED = "legacy_detection_only_supported";
+const char* VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED = "legacy_detection_only_enabled";
 
 // Don't need any setting helper when using self vvl and don't want unused function warnings
 #if !defined(BUILD_SELF_VVL)
@@ -1269,6 +1276,22 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPU_DUMP_DEVICE_COPY, gpu_dump_settings.device_copy);
     }
 
+    LegacyDetectionSettings& legacy_detection_settings = *settings_data->legacy_detection_settings;
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED,
+                                legacy_detection_settings.only_supported);
+    }
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED, legacy_detection_settings.only_enabled);
+    }
+    if (legacy_detection_settings.only_supported && legacy_detection_settings.only_enabled) {
+        setting_warnings.emplace_back(
+            "Having both VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED and VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED both enable makes "
+            "non-sense because you must first have something supported before it can be enabled.");
+    }
+    legacy_detection_settings.always = !legacy_detection_settings.only_supported && !legacy_detection_settings.only_enabled;
+
+    // Feel safe to remove by end of 2026, will have enough SDK cycles by then
     const char* REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_message_extra_properties_pretty_print";
     if (vkuHasLayerSetting(layer_setting_set, REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT)) {
         setting_warnings.emplace_back(std::string(REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT) +
@@ -1297,10 +1320,11 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
         SetValidationSetting(layer_setting_set, settings_data->enabled, vendor_specific_nvidia,
                              VK_LAYER_VALIDATE_BEST_PRACTICES_NVIDIA);
         SetValidationSetting(layer_setting_set, settings_data->enabled, sync_validation, VK_LAYER_VALIDATE_SYNC);
-        SetValidationSetting(layer_setting_set, settings_data->enabled, legacy_detection, VK_LAYER_LEGACY_DETECTION);
-
-        settings_data->enabled[gpu_dump] = gpu_dump_settings.EnableLayer();
     }
+
+    // These don't have a VkValidationFeaturesEXT equivalent, so always check these
+    SetValidationSetting(layer_setting_set, settings_data->enabled, legacy_detection, VK_LAYER_LEGACY_DETECTION);
+    settings_data->enabled[gpu_dump] = gpu_dump_settings.EnableLayer();
 
     // Only read the legacy disables flags when used, not their replacement.
     // Avoid Android C.I. performance regression from reading Android env variables
@@ -1429,6 +1453,9 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
 
     // Our way to to try and get rid of these settings
     // Detect if people have core, but manually turned off these settings
+    //
+    // These were added 10 years ago and were not properly maintained nor tested
+    // We added this warning at 1.4.355 and want to give a few SDK cycles before fully removing
     if (!settings_data->disabled[core_checks]) {
         if (settings_data->disabled[command_buffer_state]) {
             setting_warnings.emplace_back(

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -112,6 +112,7 @@ class DebugReport;
 struct GpuAVSettings;
 struct SyncValSettings;
 struct GpuDumpSettings;
+struct LegacyDetectionSettings;
 struct MessageFormatSettings;
 struct ConfigAndEnvSettings {
     // Matches up with what is passed down to VK_EXT_layer_settings
@@ -133,6 +134,7 @@ struct ConfigAndEnvSettings {
     GpuAVSettings *gpuav_settings;
     SyncValSettings *syncval_settings;
     GpuDumpSettings* gpu_dump_settings;
+    LegacyDetectionSettings* legacy_detection_settings;
 };
 const std::vector<std::string> &GetDisableFlagNameHelper();
 const std::vector<std::string> &GetEnableFlagNameHelper();

--- a/layers/layer_options_validation.h
+++ b/layers/layer_options_validation.h
@@ -93,6 +93,8 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT &la
         else if (strcmp(VK_LAYER_GPUAV_VALIDATE_TRACE_RAY, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_GPUAV_VERTEX_ATTRIBUTE_FETCH_OOB, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_LEGACY_DETECTION, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
+        else if (strcmp(VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
+        else if (strcmp(VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_LOG_FILENAME, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_STRING_EXT; }
         else if (strcmp(VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_MESSAGE_FORMAT_JSON, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }

--- a/layers/legacy/legacy_manual.cpp
+++ b/layers/legacy/legacy_manual.cpp
@@ -1,8 +1,8 @@
 /***************************************************************************
  *
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@
 #include "generated/legacy.h"
 
 namespace legacy {
-
-static const char* kLegacyExtensionVUID = "WARNING-legacy-extension";
 
 bool Instance::ValidateLegacyExtensions(const Location& loc, vvl::Extension extension, APIVersion version) const {
     bool skip = false;
@@ -45,19 +43,41 @@ bool Instance::ValidateLegacyExtensions(const Location& loc, vvl::Extension exte
             (dep_info.target.version == vvl::Version::_VK_VERSION_1_2 && (version >= VK_API_VERSION_1_2)) ||
             (dep_info.target.version == vvl::Version::_VK_VERSION_1_3 && (version >= VK_API_VERSION_1_3)) ||
             (dep_info.target.version == vvl::Version::_VK_VERSION_1_4 && (version >= VK_API_VERSION_1_4))) {
-            skip |= LogWarning(kLegacyExtensionVUID, instance, loc,
+            // Due to the sheer number of extension that get promoted, only warn currently if the user min version matches it
+            skip |= LogWarning("WARNING-legacy-extension-version", instance, loc,
                                "Attempting to enable legacy extension %s, but this extension has been %s %s.", String(extension),
                                reason_to_string(dep_info.reason), String(dep_info.target).c_str());
         } else if (dep_info.target.version == vvl::Version::Empty) {
             if (dep_info.target.extension == vvl::Extension::Empty) {
-                skip |= LogWarning(kLegacyExtensionVUID, instance, loc,
+                skip |= LogWarning("WARNING-legacy-extension-no-replacement", instance, loc,
                                    "Attempting to enable legacy extension %s, but this extension has been deprecated "
                                    "without replacement.",
                                    String(extension));
             } else {
-                skip |= LogWarning(kLegacyExtensionVUID, instance, loc,
-                                   "Attempting to enable legacy extension %s, but this extension has been %s %s.",
-                                   String(extension), reason_to_string(dep_info.reason), String(dep_info.target).c_str());
+                auto info = extensions.GetInfo(dep_info.target.extension);
+                // unknown extensions can't be enabled in extension struct
+                ExtEnabled state = info.state ? extensions.*(info.state) : kNotSupported;
+                if (legacy_detection_settings.only_enabled && IsExtEnabled(state)) {
+                    skip |= LogWarning(
+                        "WARNING-legacy-extension-new", instance, loc,
+                        "Attempting to enable legacy extension %s, but this extension has been %s the enabled extension %s.",
+                        String(extension), reason_to_string(dep_info.reason), String(dep_info.target).c_str());
+                } else if (legacy_detection_settings.only_supported && IsExtSupported(state)) {
+                    skip |= LogWarning(
+                        "WARNING-legacy-extension-new", instance, loc,
+                        "Attempting to enable legacy extension %s, but this extension has been %s the supported extension %s.",
+                        String(extension), reason_to_string(dep_info.reason), String(dep_info.target).c_str());
+                } else if (legacy_detection_settings.always) {
+                    skip |= LogWarning("WARNING-legacy-extension-new", instance, loc,
+                                       "Attempting to enable legacy extension %s, but this extension has been %s the extension "
+                                       "%s.\nTo limit warnings "
+                                       "by only what the VkDevice currently supports/enables, you can turn on the "
+                                       "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                                       "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                                       "(legacy_detection_only_enabled) "
+                                       "setting.",
+                                       String(extension), reason_to_string(dep_info.reason), String(dep_info.target).c_str());
+                }
             }
         }
     }

--- a/layers/legacy/legacy_settings.h
+++ b/layers/legacy/legacy_settings.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// Default values for those settings should match layers/VkLayer_khronos_validation.json.in
+
+struct LegacyDetectionSettings {
+    // makes logic simpler in code gen having a single boolean
+    bool always = true;
+
+    // These are off by default
+    // Argument found in https://gitlab.khronos.org/vulkan/vulkan/-/issues/4876
+    bool only_supported = false;
+    bool only_enabled = false;
+};

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -185,6 +185,16 @@ khronos_validation.gpuav_vertex_attribute_fetch_oob = true
 # Give warnings when using legacy parts of the API.
 khronos_validation.legacy_detection = false
 
+# Only warn if enabled
+# =====================
+# Only give warning if you enabled the superseded functionality extensions/version.
+khronos_validation.legacy_detection_only_enabled = false
+
+# Only warn if supported
+# =====================
+# Only give warning if the instance/device supports the superseded functionality.
+khronos_validation.legacy_detection_only_supported = false
+
 # Log Filename
 # =====================
 # Specifies the output filename

--- a/layers/vulkan/generated/legacy.cpp
+++ b/layers/vulkan/generated/legacy.cpp
@@ -30,7 +30,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceFeatures(VkPhysicalDevice physica
                                                         const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceFeatures) return false;
 
-    if (api_version >= VK_API_VERSION_1_1) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_1) {
         reported_GetPhysicalDeviceFeatures = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceFeatures is a legacy command and this VkInstance was created with VK_VERSION_1_1 which "
@@ -38,7 +38,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceFeatures(VkPhysicalDevice physica
                    "(such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" to their VUID "
                    "Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
-    } else if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         reported_GetPhysicalDeviceFeatures = true;
         LogWarning(
             "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
@@ -47,6 +47,26 @@ bool Instance::PreCallValidateGetPhysicalDeviceFeatures(VkPhysicalDevice physica
             "instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. One may "
             "add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this legacy "
             "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_physical_device_properties2)) {
+        reported_GetPhysicalDeviceFeatures = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceFeatures is a legacy command and this VkInstance supports the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceFeatures2KHR that can be used "
+            "instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. One may "
+            "add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this legacy "
+            "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceFeatures = true;
+        LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+                   "vkGetPhysicalDeviceFeatures is a legacy command and there is now the VK_KHR_get_physical_device_properties2 "
+                   "extension which contains vkGetPhysicalDeviceFeatures2KHR that can be used instead.\nNOTE: Many implicit layers "
+                   "and libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" "
+                   "to their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2\nTo limit warnings by only what the "
+                   "VkInstance currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -56,7 +76,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceFormatProperties(VkPhysicalDevice
                                                                 const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceFormatProperties) return false;
 
-    if (api_version >= VK_API_VERSION_1_1) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_1) {
         reported_GetPhysicalDeviceFormatProperties = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceFormatProperties is a legacy command and this VkInstance was created with VK_VERSION_1_1 "
@@ -64,7 +84,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceFormatProperties(VkPhysicalDevice
                    "libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" to "
                    "their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
-    } else if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         reported_GetPhysicalDeviceFormatProperties = true;
         LogWarning(
             "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
@@ -73,6 +93,27 @@ bool Instance::PreCallValidateGetPhysicalDeviceFormatProperties(VkPhysicalDevice
             "used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
             "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_physical_device_properties2)) {
+        reported_GetPhysicalDeviceFormatProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceFormatProperties is a legacy command and this VkInstance supports the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceFormatProperties2KHR that can be "
+            "used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
+            "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceFormatProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceFormatProperties is a legacy command and there is now the VK_KHR_get_physical_device_properties2 "
+            "extension which contains vkGetPhysicalDeviceFormatProperties2KHR that can be used instead.\nNOTE: Many implicit "
+            "layers and libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" "
+            "to their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
+            "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2\nTo limit warnings by only what the "
+            "VkInstance currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+            "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) "
+            "setting.");
     }
     return false;
 }
@@ -84,7 +125,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceImageFormatProperties(VkPhysicalD
                                                                      const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceImageFormatProperties) return false;
 
-    if (api_version >= VK_API_VERSION_1_1) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_1) {
         reported_GetPhysicalDeviceImageFormatProperties = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceImageFormatProperties is a legacy command and this VkInstance was created with "
@@ -92,7 +133,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceImageFormatProperties(VkPhysicalD
                    "implicit layers and libraries (such as VMA) are known to still be using these functions. One may add "
                    "\"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this "
                    "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
-    } else if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         reported_GetPhysicalDeviceImageFormatProperties = true;
         LogWarning(
             "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
@@ -101,6 +142,27 @@ bool Instance::PreCallValidateGetPhysicalDeviceImageFormatProperties(VkPhysicalD
             "be used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
             "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_physical_device_properties2)) {
+        reported_GetPhysicalDeviceImageFormatProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceImageFormatProperties is a legacy command and this VkInstance supports the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceImageFormatProperties2KHR that can "
+            "be used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
+            "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceImageFormatProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceImageFormatProperties is a legacy command and there is now the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceImageFormatProperties2KHR that can "
+            "be used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
+            "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2\nTo limit "
+            "warnings by only what the VkInstance currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -109,7 +171,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceProperties(VkPhysicalDevice physi
                                                           const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceProperties) return false;
 
-    if (api_version >= VK_API_VERSION_1_1) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_1) {
         reported_GetPhysicalDeviceProperties = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceProperties is a legacy command and this VkInstance was created with VK_VERSION_1_1 which "
@@ -117,7 +179,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceProperties(VkPhysicalDevice physi
                    "(such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" to their VUID "
                    "Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
-    } else if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         reported_GetPhysicalDeviceProperties = true;
         LogWarning(
             "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
@@ -126,6 +188,26 @@ bool Instance::PreCallValidateGetPhysicalDeviceProperties(VkPhysicalDevice physi
             "instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. One may "
             "add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this legacy "
             "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_physical_device_properties2)) {
+        reported_GetPhysicalDeviceProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceProperties is a legacy command and this VkInstance supports the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceProperties2KHR that can be used "
+            "instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. One may "
+            "add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this legacy "
+            "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceProperties = true;
+        LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+                   "vkGetPhysicalDeviceProperties is a legacy command and there is now the VK_KHR_get_physical_device_properties2 "
+                   "extension which contains vkGetPhysicalDeviceProperties2KHR that can be used instead.\nNOTE: Many implicit "
+                   "layers and libraries (such as VMA) are known to still be using these functions. One may add "
+                   "\"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this "
+                   "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2\nTo limit "
+                   "warnings by only what the VkInstance currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -136,7 +218,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceQueueFamilyProperties(VkPhysicalD
                                                                      const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceQueueFamilyProperties) return false;
 
-    if (api_version >= VK_API_VERSION_1_1) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_1) {
         reported_GetPhysicalDeviceQueueFamilyProperties = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceQueueFamilyProperties is a legacy command and this VkInstance was created with "
@@ -144,7 +226,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceQueueFamilyProperties(VkPhysicalD
                    "implicit layers and libraries (such as VMA) are known to still be using these functions. One may add "
                    "\"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this "
                    "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
-    } else if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         reported_GetPhysicalDeviceQueueFamilyProperties = true;
         LogWarning(
             "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
@@ -153,6 +235,27 @@ bool Instance::PreCallValidateGetPhysicalDeviceQueueFamilyProperties(VkPhysicalD
             "be used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
             "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_physical_device_properties2)) {
+        reported_GetPhysicalDeviceQueueFamilyProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceQueueFamilyProperties is a legacy command and this VkInstance supports the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceQueueFamilyProperties2KHR that can "
+            "be used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
+            "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceQueueFamilyProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceQueueFamilyProperties is a legacy command and there is now the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceQueueFamilyProperties2KHR that can "
+            "be used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
+            "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2\nTo limit "
+            "warnings by only what the VkInstance currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -162,7 +265,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceMemoryProperties(VkPhysicalDevice
                                                                 const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceMemoryProperties) return false;
 
-    if (api_version >= VK_API_VERSION_1_1) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_1) {
         reported_GetPhysicalDeviceMemoryProperties = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceMemoryProperties is a legacy command and this VkInstance was created with VK_VERSION_1_1 "
@@ -170,7 +273,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceMemoryProperties(VkPhysicalDevice
                    "libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" to "
                    "their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
-    } else if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         reported_GetPhysicalDeviceMemoryProperties = true;
         LogWarning(
             "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
@@ -179,6 +282,27 @@ bool Instance::PreCallValidateGetPhysicalDeviceMemoryProperties(VkPhysicalDevice
             "used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
             "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_physical_device_properties2)) {
+        reported_GetPhysicalDeviceMemoryProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceMemoryProperties is a legacy command and this VkInstance supports the "
+            "VK_KHR_get_physical_device_properties2 extension which contains vkGetPhysicalDeviceMemoryProperties2KHR that can be "
+            "used instead.\nNOTE: Many implicit layers and libraries (such as VMA) are known to still be using these functions. "
+            "One may add \"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceMemoryProperties = true;
+        LogWarning(
+            "WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceMemoryProperties is a legacy command and there is now the VK_KHR_get_physical_device_properties2 "
+            "extension which contains vkGetPhysicalDeviceMemoryProperties2KHR that can be used instead.\nNOTE: Many implicit "
+            "layers and libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" "
+            "to their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
+            "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2\nTo limit warnings by only what the "
+            "VkInstance currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+            "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) "
+            "setting.");
     }
     return false;
 }
@@ -198,18 +322,40 @@ bool Device::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, con
                                         const ErrorObject& error_obj) const {
     if (reported_QueueSubmit) return false;
 
-    if (api_version >= VK_API_VERSION_1_3) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_3) {
         reported_QueueSubmit = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkQueueSubmit is a legacy command and this VkDevice was created with VK_VERSION_1_3 which contains "
                    "vkQueueSubmit2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
-    } else if (IsExtEnabled(extensions.vk_khr_synchronization2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_3) {
+        reported_QueueSubmit = true;
+        LogWarning(
+            "WARNING-deprecation-sync2", device, error_obj.location,
+            "vkQueueSubmit is a legacy command and this VkDevice supports VK_VERSION_1_3 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains vkQueueSubmit2 that can be used instead.\nSee more information "
+            "about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_synchronization2)) {
         reported_QueueSubmit = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkQueueSubmit is a legacy command and this VkDevice enabled the VK_KHR_synchronization2 extension which "
                    "contains vkQueueSubmit2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_synchronization2)) {
+        reported_QueueSubmit = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkQueueSubmit is a legacy command and this VkDevice supports the VK_KHR_synchronization2 extension which "
+                   "contains vkQueueSubmit2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.always) {
+        reported_QueueSubmit = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkQueueSubmit is a legacy command and there is now the VK_KHR_synchronization2 extension which contains "
+                   "vkQueueSubmit2KHR that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -222,7 +368,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceSparseImageFormatProperties(VkPhy
                                                                            const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceSparseImageFormatProperties) return false;
 
-    if (api_version >= VK_API_VERSION_1_1) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_1) {
         reported_GetPhysicalDeviceSparseImageFormatProperties = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceSparseImageFormatProperties is a legacy command and this VkInstance was created with "
@@ -230,7 +376,7 @@ bool Instance::PreCallValidateGetPhysicalDeviceSparseImageFormatProperties(VkPhy
                    "Many implicit layers and libraries (such as VMA) are known to still be using these functions. One may add "
                    "\"WARNING-legacy-gpdp2\" to their VUID Mute Message list to ignore these.\nSee more information about this "
                    "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
-    } else if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) {
         reported_GetPhysicalDeviceSparseImageFormatProperties = true;
         LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceSparseImageFormatProperties is a legacy command and this VkInstance enabled the "
@@ -239,6 +385,27 @@ bool Instance::PreCallValidateGetPhysicalDeviceSparseImageFormatProperties(VkPhy
                    "libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" to "
                    "their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_physical_device_properties2)) {
+        reported_GetPhysicalDeviceSparseImageFormatProperties = true;
+        LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+                   "vkGetPhysicalDeviceSparseImageFormatProperties is a legacy command and this VkInstance supports the "
+                   "VK_KHR_get_physical_device_properties2 extension which contains "
+                   "vkGetPhysicalDeviceSparseImageFormatProperties2KHR that can be used instead.\nNOTE: Many implicit layers and "
+                   "libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" to "
+                   "their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceSparseImageFormatProperties = true;
+        LogWarning("WARNING-legacy-gpdp2", physicalDevice, error_obj.location,
+                   "vkGetPhysicalDeviceSparseImageFormatProperties is a legacy command and there is now the "
+                   "VK_KHR_get_physical_device_properties2 extension which contains "
+                   "vkGetPhysicalDeviceSparseImageFormatProperties2KHR that can be used instead.\nNOTE: Many implicit layers and "
+                   "libraries (such as VMA) are known to still be using these functions. One may add \"WARNING-legacy-gpdp2\" to "
+                   "their VUID Mute Message list to ignore these.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdp2\nTo limit warnings by only what the "
+                   "VkInstance currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -247,12 +414,27 @@ bool Device::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuf
                                             VkDeviceSize dataSize, const void* pData, const ErrorObject& error_obj) const {
     if (reported_CmdUpdateBuffer) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdUpdateBuffer = true;
         LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
                    "vkCmdUpdateBuffer is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
                    "which contains vkCmdUpdateMemoryKHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdUpdateBuffer = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdUpdateBuffer is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdUpdateMemoryKHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdUpdateBuffer = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdUpdateBuffer is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+                   "contains vkCmdUpdateMemoryKHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -261,12 +443,27 @@ bool Device::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffe
                                           VkDeviceSize size, uint32_t data, const ErrorObject& error_obj) const {
     if (reported_CmdFillBuffer) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdFillBuffer = true;
         LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
                    "vkCmdFillBuffer is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
                    "which contains vkCmdFillMemoryKHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdFillBuffer = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdFillBuffer is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdFillMemoryKHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdFillBuffer = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdFillBuffer is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+                   "contains vkCmdFillMemoryKHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -280,18 +477,40 @@ bool Device::PreCallValidateCmdPipelineBarrier(VkCommandBuffer commandBuffer, Vk
                                                const ErrorObject& error_obj) const {
     if (reported_CmdPipelineBarrier) return false;
 
-    if (api_version >= VK_API_VERSION_1_3) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_3) {
         reported_CmdPipelineBarrier = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdPipelineBarrier is a legacy command and this VkDevice was created with VK_VERSION_1_3 which contains "
                    "vkCmdPipelineBarrier2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
-    } else if (IsExtEnabled(extensions.vk_khr_synchronization2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_3) {
+        reported_CmdPipelineBarrier = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdPipelineBarrier is a legacy command and this VkDevice supports VK_VERSION_1_3 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdPipelineBarrier2 that can be used instead.\nSee "
+                   "more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_synchronization2)) {
         reported_CmdPipelineBarrier = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdPipelineBarrier is a legacy command and this VkDevice enabled the VK_KHR_synchronization2 extension which "
                    "contains vkCmdPipelineBarrier2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_synchronization2)) {
+        reported_CmdPipelineBarrier = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdPipelineBarrier is a legacy command and this VkDevice supports the VK_KHR_synchronization2 extension "
+                   "which contains vkCmdPipelineBarrier2KHR that can be used instead.\nSee more information about this legacy in "
+                   "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdPipelineBarrier = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdPipelineBarrier is a legacy command and there is now the VK_KHR_synchronization2 extension which contains "
+                   "vkCmdPipelineBarrier2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2\nTo limit warnings "
+                   "by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -300,18 +519,40 @@ bool Device::PreCallValidateCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkP
                                               VkQueryPool queryPool, uint32_t query, const ErrorObject& error_obj) const {
     if (reported_CmdWriteTimestamp) return false;
 
-    if (api_version >= VK_API_VERSION_1_3) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_3) {
         reported_CmdWriteTimestamp = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdWriteTimestamp is a legacy command and this VkDevice was created with VK_VERSION_1_3 which contains "
                    "vkCmdWriteTimestamp2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
-    } else if (IsExtEnabled(extensions.vk_khr_synchronization2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_3) {
+        reported_CmdWriteTimestamp = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdWriteTimestamp is a legacy command and this VkDevice supports VK_VERSION_1_3 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdWriteTimestamp2 that can be used instead.\nSee "
+                   "more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_synchronization2)) {
         reported_CmdWriteTimestamp = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdWriteTimestamp is a legacy command and this VkDevice enabled the VK_KHR_synchronization2 extension which "
                    "contains vkCmdWriteTimestamp2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_synchronization2)) {
+        reported_CmdWriteTimestamp = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdWriteTimestamp is a legacy command and this VkDevice supports the VK_KHR_synchronization2 extension which "
+                   "contains vkCmdWriteTimestamp2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdWriteTimestamp = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdWriteTimestamp is a legacy command and there is now the VK_KHR_synchronization2 extension which contains "
+                   "vkCmdWriteTimestamp2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2\nTo limit warnings "
+                   "by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -322,13 +563,30 @@ bool Device::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandBuffe
                                                     const ErrorObject& error_obj) const {
     if (reported_CmdCopyQueryPoolResults) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdCopyQueryPoolResults = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdCopyQueryPoolResults is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdCopyQueryPoolResultsToMemoryKHR that can be used instead.\nSee more information about this legacy "
             "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdCopyQueryPoolResults = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdCopyQueryPoolResults is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+            "which contains vkCmdCopyQueryPoolResultsToMemoryKHR that can be used instead.\nSee more information about this legacy "
+            "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdCopyQueryPoolResults = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdCopyQueryPoolResults is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+            "contains vkCmdCopyQueryPoolResultsToMemoryKHR that can be used instead.\nSee more information about this legacy in "
+            "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+            "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -338,12 +596,27 @@ bool Device::PreCallValidateCreateBufferView(VkDevice device, const VkBufferView
                                              const ErrorObject& error_obj) const {
     if (reported_CreateBufferView) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CreateBufferView = true;
         LogWarning("WARNING-legacy-resource-objects", device, error_obj.location,
                    "vkCreateBufferView is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension which "
                    "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-resource-objects");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CreateBufferView = true;
+        LogWarning("WARNING-legacy-resource-objects", device, error_obj.location,
+                   "vkCreateBufferView is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-resource-objects");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateBufferView = true;
+        LogWarning("WARNING-legacy-resource-objects", device, error_obj.location,
+                   "vkCreateBufferView is a legacy command and there is now the VK_EXT_descriptor_heap extension which contains "
+                   "the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-resource-objects\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -353,12 +626,27 @@ bool Device::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipeli
                                                  const ErrorObject& error_obj) const {
     if (reported_CreatePipelineLayout) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CreatePipelineLayout = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCreatePipelineLayout is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension "
                    "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CreatePipelineLayout = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCreatePipelineLayout is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CreatePipelineLayout = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCreatePipelineLayout is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -368,12 +656,27 @@ bool Device::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreate
                                           const ErrorObject& error_obj) const {
     if (reported_CreateSampler) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CreateSampler = true;
         LogWarning("WARNING-legacy-resource-objects", device, error_obj.location,
                    "vkCreateSampler is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension which "
                    "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-resource-objects");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CreateSampler = true;
+        LogWarning("WARNING-legacy-resource-objects", device, error_obj.location,
+                   "vkCreateSampler is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-resource-objects");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateSampler = true;
+        LogWarning("WARNING-legacy-resource-objects", device, error_obj.location,
+                   "vkCreateSampler is a legacy command and there is now the VK_EXT_descriptor_heap extension which contains the "
+                   "new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-resource-objects\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -383,12 +686,27 @@ bool Device::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const VkD
                                                       const ErrorObject& error_obj) const {
     if (reported_CreateDescriptorSetLayout) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CreateDescriptorSetLayout = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCreateDescriptorSetLayout is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension "
                    "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CreateDescriptorSetLayout = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCreateDescriptorSetLayout is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateDescriptorSetLayout = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCreateDescriptorSetLayout is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -398,12 +716,27 @@ bool Device::PreCallValidateCreateDescriptorPool(VkDevice device, const VkDescri
                                                  const ErrorObject& error_obj) const {
     if (reported_CreateDescriptorPool) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CreateDescriptorPool = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCreateDescriptorPool is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension "
                    "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CreateDescriptorPool = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCreateDescriptorPool is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateDescriptorPool = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCreateDescriptorPool is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -412,12 +745,27 @@ bool Device::PreCallValidateResetDescriptorPool(VkDevice device, VkDescriptorPoo
                                                 const ErrorObject& error_obj) const {
     if (reported_ResetDescriptorPool) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_ResetDescriptorPool = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkResetDescriptorPool is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension which "
                    "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_ResetDescriptorPool = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkResetDescriptorPool is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_ResetDescriptorPool = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkResetDescriptorPool is a legacy command and there is now the VK_EXT_descriptor_heap extension which contains "
+                   "the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -426,12 +774,27 @@ bool Device::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDesc
                                                    VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj) const {
     if (reported_AllocateDescriptorSets) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_AllocateDescriptorSets = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkAllocateDescriptorSets is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension "
                    "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_AllocateDescriptorSets = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkAllocateDescriptorSets is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_AllocateDescriptorSets = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkAllocateDescriptorSets is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -441,12 +804,27 @@ bool Device::PreCallValidateUpdateDescriptorSets(VkDevice device, uint32_t descr
                                                  const VkCopyDescriptorSet* pDescriptorCopies, const ErrorObject& error_obj) const {
     if (reported_UpdateDescriptorSets) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_UpdateDescriptorSets = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkUpdateDescriptorSets is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension "
                    "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_UpdateDescriptorSets = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkUpdateDescriptorSets is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_UpdateDescriptorSets = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkUpdateDescriptorSets is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -457,12 +835,27 @@ bool Device::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuffer,
                                                   const uint32_t* pDynamicOffsets, const ErrorObject& error_obj) const {
     if (reported_CmdBindDescriptorSets) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdBindDescriptorSets = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCmdBindDescriptorSets is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension "
                    "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdBindDescriptorSets = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorSets is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindDescriptorSets = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorSets is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -471,13 +864,29 @@ bool Device::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffer, V
                                                 const ErrorObject& error_obj) const {
     if (reported_CmdDispatchIndirect) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDispatchIndirect = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdDispatchIndirect is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdDispatchIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDispatchIndirect = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDispatchIndirect is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+            "which contains vkCmdDispatchIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDispatchIndirect = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdDispatchIndirect is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+                   "contains vkCmdDispatchIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -486,18 +895,40 @@ bool Device::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent e
                                         const ErrorObject& error_obj) const {
     if (reported_CmdSetEvent) return false;
 
-    if (api_version >= VK_API_VERSION_1_3) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_3) {
         reported_CmdSetEvent = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdSetEvent is a legacy command and this VkDevice was created with VK_VERSION_1_3 which contains "
                    "vkCmdSetEvent2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
-    } else if (IsExtEnabled(extensions.vk_khr_synchronization2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_3) {
+        reported_CmdSetEvent = true;
+        LogWarning(
+            "WARNING-deprecation-sync2", device, error_obj.location,
+            "vkCmdSetEvent is a legacy command and this VkDevice supports VK_VERSION_1_3 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdSetEvent2 that can be used instead.\nSee more information "
+            "about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_synchronization2)) {
         reported_CmdSetEvent = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdSetEvent is a legacy command and this VkDevice enabled the VK_KHR_synchronization2 extension which "
                    "contains vkCmdSetEvent2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_synchronization2)) {
+        reported_CmdSetEvent = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdSetEvent is a legacy command and this VkDevice supports the VK_KHR_synchronization2 extension which "
+                   "contains vkCmdSetEvent2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdSetEvent = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdSetEvent is a legacy command and there is now the VK_KHR_synchronization2 extension which contains "
+                   "vkCmdSetEvent2KHR that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -506,18 +937,40 @@ bool Device::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent
                                           const ErrorObject& error_obj) const {
     if (reported_CmdResetEvent) return false;
 
-    if (api_version >= VK_API_VERSION_1_3) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_3) {
         reported_CmdResetEvent = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdResetEvent is a legacy command and this VkDevice was created with VK_VERSION_1_3 which contains "
                    "vkCmdResetEvent2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
-    } else if (IsExtEnabled(extensions.vk_khr_synchronization2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_3) {
+        reported_CmdResetEvent = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdResetEvent is a legacy command and this VkDevice supports VK_VERSION_1_3 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdResetEvent2 that can be used instead.\nSee more "
+                   "information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_synchronization2)) {
         reported_CmdResetEvent = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdResetEvent is a legacy command and this VkDevice enabled the VK_KHR_synchronization2 extension which "
                    "contains vkCmdResetEvent2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_synchronization2)) {
+        reported_CmdResetEvent = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdResetEvent is a legacy command and this VkDevice supports the VK_KHR_synchronization2 extension which "
+                   "contains vkCmdResetEvent2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdResetEvent = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdResetEvent is a legacy command and there is now the VK_KHR_synchronization2 extension which contains "
+                   "vkCmdResetEvent2KHR that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -530,18 +983,40 @@ bool Device::PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_
                                           const ErrorObject& error_obj) const {
     if (reported_CmdWaitEvents) return false;
 
-    if (api_version >= VK_API_VERSION_1_3) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_3) {
         reported_CmdWaitEvents = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdWaitEvents is a legacy command and this VkDevice was created with VK_VERSION_1_3 which contains "
                    "vkCmdWaitEvents2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
-    } else if (IsExtEnabled(extensions.vk_khr_synchronization2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_3) {
+        reported_CmdWaitEvents = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdWaitEvents is a legacy command and this VkDevice supports VK_VERSION_1_3 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdWaitEvents2 that can be used instead.\nSee more "
+                   "information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_synchronization2)) {
         reported_CmdWaitEvents = true;
         LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
                    "vkCmdWaitEvents is a legacy command and this VkDevice enabled the VK_KHR_synchronization2 extension which "
                    "contains vkCmdWaitEvents2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_synchronization2)) {
+        reported_CmdWaitEvents = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdWaitEvents is a legacy command and this VkDevice supports the VK_KHR_synchronization2 extension which "
+                   "contains vkCmdWaitEvents2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdWaitEvents = true;
+        LogWarning("WARNING-deprecation-sync2", device, error_obj.location,
+                   "vkCmdWaitEvents is a legacy command and there is now the VK_KHR_synchronization2 extension which contains "
+                   "vkCmdWaitEvents2KHR that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#deprecation-sync2\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -551,12 +1026,27 @@ bool Device::PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPi
                                              const ErrorObject& error_obj) const {
     if (reported_CmdPushConstants) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdPushConstants = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCmdPushConstants is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension which "
                    "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdPushConstants = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdPushConstants is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdPushConstants = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdPushConstants is a legacy command and there is now the VK_EXT_descriptor_heap extension which contains "
+                   "the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -566,18 +1056,40 @@ bool Device::PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebuff
                                               const ErrorObject& error_obj) const {
     if (reported_CreateFramebuffer) return false;
 
-    if (api_version >= VK_API_VERSION_1_4) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_4) {
         reported_CreateFramebuffer = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCreateFramebuffer is a legacy command and this VkDevice was created with VK_VERSION_1_4 which contains the "
                    "new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
-    } else if (IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_4) {
+        reported_CreateFramebuffer = true;
+        LogWarning(
+            "WARNING-legacy-dynamicrendering", device, error_obj.location,
+            "vkCreateFramebuffer is a legacy command and this VkDevice supports VK_VERSION_1_4 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains the new feature to replace it.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
         reported_CreateFramebuffer = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCreateFramebuffer is a legacy command and this VkDevice enabled the VK_KHR_dynamic_rendering_local_read "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_dynamic_rendering_local_read)) {
+        reported_CreateFramebuffer = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCreateFramebuffer is a legacy command and this VkDevice supports the VK_KHR_dynamic_rendering_local_read "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateFramebuffer = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCreateFramebuffer is a legacy command and there is now the VK_KHR_dynamic_rendering_local_read extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -587,18 +1099,40 @@ bool Device::PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPass
                                              const ErrorObject& error_obj) const {
     if (reported_CreateRenderPass) return false;
 
-    if (api_version >= VK_API_VERSION_1_2) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_2) {
         reported_CreateRenderPass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCreateRenderPass is a legacy command and this VkDevice was created with VK_VERSION_1_2 which contains "
                    "vkCreateRenderPass2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
-    } else if (IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_2) {
+        reported_CreateRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCreateRenderPass is a legacy command and this VkDevice supports VK_VERSION_1_2 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCreateRenderPass2 that can be used instead.\nSee more "
+                   "information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
         reported_CreateRenderPass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCreateRenderPass is a legacy command and this VkDevice enabled the VK_KHR_create_renderpass2 extension which "
                    "contains vkCreateRenderPass2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_create_renderpass2)) {
+        reported_CreateRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCreateRenderPass is a legacy command and this VkDevice supports the VK_KHR_create_renderpass2 extension "
+                   "which contains vkCreateRenderPass2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCreateRenderPass is a legacy command and there is now the VK_KHR_create_renderpass2 extension which contains "
+                   "vkCreateRenderPass2KHR that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -607,19 +1141,42 @@ bool Device::PreCallValidateGetRenderAreaGranularity(VkDevice device, VkRenderPa
                                                      const ErrorObject& error_obj) const {
     if (reported_GetRenderAreaGranularity) return false;
 
-    if (api_version >= VK_API_VERSION_1_4) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_4) {
         reported_GetRenderAreaGranularity = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkGetRenderAreaGranularity is a legacy command and this VkDevice was created with VK_VERSION_1_4 which "
                    "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
-    } else if (IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_4) {
+        reported_GetRenderAreaGranularity = true;
+        LogWarning(
+            "WARNING-legacy-dynamicrendering", device, error_obj.location,
+            "vkGetRenderAreaGranularity is a legacy command and this VkDevice supports VK_VERSION_1_4 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains the new feature to replace it.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
         reported_GetRenderAreaGranularity = true;
         LogWarning(
             "WARNING-legacy-dynamicrendering", device, error_obj.location,
             "vkGetRenderAreaGranularity is a legacy command and this VkDevice enabled the VK_KHR_dynamic_rendering_local_read "
             "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
             "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_dynamic_rendering_local_read)) {
+        reported_GetRenderAreaGranularity = true;
+        LogWarning(
+            "WARNING-legacy-dynamicrendering", device, error_obj.location,
+            "vkGetRenderAreaGranularity is a legacy command and this VkDevice supports the VK_KHR_dynamic_rendering_local_read "
+            "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+            "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.always) {
+        reported_GetRenderAreaGranularity = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkGetRenderAreaGranularity is a legacy command and there is now the VK_KHR_dynamic_rendering_local_read "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -628,12 +1185,27 @@ bool Device::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuf
                                             uint32_t stride, const ErrorObject& error_obj) const {
     if (reported_CmdDrawIndirect) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDrawIndirect = true;
         LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
                    "vkCmdDrawIndirect is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
                    "which contains vkCmdDrawIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDrawIndirect = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdDrawIndirect is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdDrawIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDrawIndirect = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdDrawIndirect is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+                   "contains vkCmdDrawIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -642,13 +1214,29 @@ bool Device::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer
                                                    uint32_t drawCount, uint32_t stride, const ErrorObject& error_obj) const {
     if (reported_CmdDrawIndexedIndirect) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDrawIndexedIndirect = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdDrawIndexedIndirect is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdDrawIndexedIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDrawIndexedIndirect = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawIndexedIndirect is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+            "which contains vkCmdDrawIndexedIndirect2KHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDrawIndexedIndirect = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdDrawIndexedIndirect is a legacy command and there is now the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdDrawIndexedIndirect2KHR that can be used instead.\nSee more information about this legacy "
+                   "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo "
+                   "limit warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -657,18 +1245,40 @@ bool Device::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
                                                VkSubpassContents contents, const ErrorObject& error_obj) const {
     if (reported_CmdBeginRenderPass) return false;
 
-    if (api_version >= VK_API_VERSION_1_2) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_2) {
         reported_CmdBeginRenderPass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCmdBeginRenderPass is a legacy command and this VkDevice was created with VK_VERSION_1_2 which contains "
                    "vkCmdBeginRenderPass2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
-    } else if (IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_2) {
+        reported_CmdBeginRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdBeginRenderPass is a legacy command and this VkDevice supports VK_VERSION_1_2 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdBeginRenderPass2 that can be used instead.\nSee "
+                   "more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
         reported_CmdBeginRenderPass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCmdBeginRenderPass is a legacy command and this VkDevice enabled the VK_KHR_create_renderpass2 extension "
                    "which contains vkCmdBeginRenderPass2KHR that can be used instead.\nSee more information about this legacy in "
                    "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_create_renderpass2)) {
+        reported_CmdBeginRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdBeginRenderPass is a legacy command and this VkDevice supports the VK_KHR_create_renderpass2 extension "
+                   "which contains vkCmdBeginRenderPass2KHR that can be used instead.\nSee more information about this legacy in "
+                   "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBeginRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdBeginRenderPass is a legacy command and there is now the VK_KHR_create_renderpass2 extension which "
+                   "contains vkCmdBeginRenderPass2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -677,18 +1287,40 @@ bool Device::PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubp
                                            const ErrorObject& error_obj) const {
     if (reported_CmdNextSubpass) return false;
 
-    if (api_version >= VK_API_VERSION_1_2) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_2) {
         reported_CmdNextSubpass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCmdNextSubpass is a legacy command and this VkDevice was created with VK_VERSION_1_2 which contains "
                    "vkCmdNextSubpass2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
-    } else if (IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_2) {
+        reported_CmdNextSubpass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdNextSubpass is a legacy command and this VkDevice supports VK_VERSION_1_2 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdNextSubpass2 that can be used instead.\nSee more "
+                   "information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
         reported_CmdNextSubpass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCmdNextSubpass is a legacy command and this VkDevice enabled the VK_KHR_create_renderpass2 extension which "
                    "contains vkCmdNextSubpass2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_create_renderpass2)) {
+        reported_CmdNextSubpass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdNextSubpass is a legacy command and this VkDevice supports the VK_KHR_create_renderpass2 extension which "
+                   "contains vkCmdNextSubpass2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdNextSubpass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdNextSubpass is a legacy command and there is now the VK_KHR_create_renderpass2 extension which contains "
+                   "vkCmdNextSubpass2KHR that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -696,18 +1328,40 @@ bool Device::PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubp
 bool Device::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const {
     if (reported_CmdEndRenderPass) return false;
 
-    if (api_version >= VK_API_VERSION_1_2) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_2) {
         reported_CmdEndRenderPass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCmdEndRenderPass is a legacy command and this VkDevice was created with VK_VERSION_1_2 which contains "
                    "vkCmdEndRenderPass2 that can be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
-    } else if (IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_2) {
+        reported_CmdEndRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdEndRenderPass is a legacy command and this VkDevice supports VK_VERSION_1_2 (from "
+                   "VkPhysicalDeviceProperties::apiVersion) which contains vkCmdEndRenderPass2 that can be used instead.\nSee more "
+                   "information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_create_renderpass2)) {
         reported_CmdEndRenderPass = true;
         LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
                    "vkCmdEndRenderPass is a legacy command and this VkDevice enabled the VK_KHR_create_renderpass2 extension which "
                    "contains vkCmdEndRenderPass2KHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_create_renderpass2)) {
+        reported_CmdEndRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdEndRenderPass is a legacy command and this VkDevice supports the VK_KHR_create_renderpass2 extension "
+                   "which contains vkCmdEndRenderPass2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdEndRenderPass = true;
+        LogWarning("WARNING-legacy-renderpass2", device, error_obj.location,
+                   "vkCmdEndRenderPass is a legacy command and there is now the VK_KHR_create_renderpass2 extension which contains "
+                   "vkCmdEndRenderPass2KHR that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-renderpass2\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -717,13 +1371,29 @@ bool Device::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, 
                                                  uint32_t stride, const ErrorObject& error_obj) const {
     if (reported_CmdDrawIndirectCount) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDrawIndirectCount = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdDrawIndirectCount is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdDrawIndirectCount2KHR that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDrawIndirectCount = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawIndirectCount is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+            "which contains vkCmdDrawIndirectCount2KHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDrawIndirectCount = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdDrawIndirectCount is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+                   "contains vkCmdDrawIndirectCount2KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -733,13 +1403,30 @@ bool Device::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandB
                                                         uint32_t stride, const ErrorObject& error_obj) const {
     if (reported_CmdDrawIndexedIndirectCount) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDrawIndexedIndirectCount = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdDrawIndexedIndirectCount is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdDrawIndexedIndirectCount2KHR that can be used instead.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDrawIndexedIndirectCount = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawIndexedIndirectCount is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdDrawIndexedIndirectCount2KHR that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDrawIndexedIndirectCount = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawIndexedIndirectCount is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+            "contains vkCmdDrawIndexedIndirectCount2KHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit warnings "
+            "by only what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+            "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) "
+            "setting.");
     }
     return false;
 }
@@ -749,18 +1436,40 @@ bool Device::PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPas
                                               const ErrorObject& error_obj) const {
     if (reported_CreateRenderPass2) return false;
 
-    if (api_version >= VK_API_VERSION_1_4) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_4) {
         reported_CreateRenderPass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCreateRenderPass2 is a legacy command and this VkDevice was created with VK_VERSION_1_4 which contains the "
                    "new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
-    } else if (IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_4) {
+        reported_CreateRenderPass2 = true;
+        LogWarning(
+            "WARNING-legacy-dynamicrendering", device, error_obj.location,
+            "vkCreateRenderPass2 is a legacy command and this VkDevice supports VK_VERSION_1_4 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains the new feature to replace it.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
         reported_CreateRenderPass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCreateRenderPass2 is a legacy command and this VkDevice enabled the VK_KHR_dynamic_rendering_local_read "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_dynamic_rendering_local_read)) {
+        reported_CreateRenderPass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCreateRenderPass2 is a legacy command and this VkDevice supports the VK_KHR_dynamic_rendering_local_read "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateRenderPass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCreateRenderPass2 is a legacy command and there is now the VK_KHR_dynamic_rendering_local_read extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -769,18 +1478,40 @@ bool Device::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, c
                                                 const VkSubpassBeginInfo* pSubpassBeginInfo, const ErrorObject& error_obj) const {
     if (reported_CmdBeginRenderPass2) return false;
 
-    if (api_version >= VK_API_VERSION_1_4) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_4) {
         reported_CmdBeginRenderPass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCmdBeginRenderPass2 is a legacy command and this VkDevice was created with VK_VERSION_1_4 which contains the "
                    "new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
-    } else if (IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_4) {
+        reported_CmdBeginRenderPass2 = true;
+        LogWarning(
+            "WARNING-legacy-dynamicrendering", device, error_obj.location,
+            "vkCmdBeginRenderPass2 is a legacy command and this VkDevice supports VK_VERSION_1_4 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains the new feature to replace it.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
         reported_CmdBeginRenderPass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCmdBeginRenderPass2 is a legacy command and this VkDevice enabled the VK_KHR_dynamic_rendering_local_read "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_dynamic_rendering_local_read)) {
+        reported_CmdBeginRenderPass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCmdBeginRenderPass2 is a legacy command and this VkDevice supports the VK_KHR_dynamic_rendering_local_read "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBeginRenderPass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCmdBeginRenderPass2 is a legacy command and there is now the VK_KHR_dynamic_rendering_local_read extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -789,18 +1520,40 @@ bool Device::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer, const
                                             const VkSubpassEndInfo* pSubpassEndInfo, const ErrorObject& error_obj) const {
     if (reported_CmdNextSubpass2) return false;
 
-    if (api_version >= VK_API_VERSION_1_4) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_4) {
         reported_CmdNextSubpass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCmdNextSubpass2 is a legacy command and this VkDevice was created with VK_VERSION_1_4 which contains the new "
                    "feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
-    } else if (IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_4) {
+        reported_CmdNextSubpass2 = true;
+        LogWarning(
+            "WARNING-legacy-dynamicrendering", device, error_obj.location,
+            "vkCmdNextSubpass2 is a legacy command and this VkDevice supports VK_VERSION_1_4 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains the new feature to replace it.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
         reported_CmdNextSubpass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCmdNextSubpass2 is a legacy command and this VkDevice enabled the VK_KHR_dynamic_rendering_local_read "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_dynamic_rendering_local_read)) {
+        reported_CmdNextSubpass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCmdNextSubpass2 is a legacy command and this VkDevice supports the VK_KHR_dynamic_rendering_local_read "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdNextSubpass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCmdNextSubpass2 is a legacy command and there is now the VK_KHR_dynamic_rendering_local_read extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -809,18 +1562,40 @@ bool Device::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, con
                                               const ErrorObject& error_obj) const {
     if (reported_CmdEndRenderPass2) return false;
 
-    if (api_version >= VK_API_VERSION_1_4) {
+    if (legacy_detection_settings.only_enabled && api_version >= VK_API_VERSION_1_4) {
         reported_CmdEndRenderPass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCmdEndRenderPass2 is a legacy command and this VkDevice was created with VK_VERSION_1_4 which contains the "
                    "new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
-    } else if (IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
+    } else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= VK_API_VERSION_1_4) {
+        reported_CmdEndRenderPass2 = true;
+        LogWarning(
+            "WARNING-legacy-dynamicrendering", device, error_obj.location,
+            "vkCmdEndRenderPass2 is a legacy command and this VkDevice supports VK_VERSION_1_4 (from "
+            "VkPhysicalDeviceProperties::apiVersion) which contains the new feature to replace it.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_dynamic_rendering_local_read)) {
         reported_CmdEndRenderPass2 = true;
         LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
                    "vkCmdEndRenderPass2 is a legacy command and this VkDevice enabled the VK_KHR_dynamic_rendering_local_read "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_dynamic_rendering_local_read)) {
+        reported_CmdEndRenderPass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCmdEndRenderPass2 is a legacy command and this VkDevice supports the VK_KHR_dynamic_rendering_local_read "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdEndRenderPass2 = true;
+        LogWarning("WARNING-legacy-dynamicrendering", device, error_obj.location,
+                   "vkCmdEndRenderPass2 is a legacy command and there is now the VK_KHR_dynamic_rendering_local_read extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-dynamicrendering\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -829,12 +1604,27 @@ bool Device::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const 
                                            const ErrorObject& error_obj) const {
     if (reported_CmdCopyBuffer2) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdCopyBuffer2 = true;
         LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
                    "vkCmdCopyBuffer2 is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
                    "which contains vkCmdCopyMemoryKHR that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdCopyBuffer2 = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdCopyBuffer2 is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdCopyMemoryKHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdCopyBuffer2 = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdCopyBuffer2 is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+                   "contains vkCmdCopyMemoryKHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -844,13 +1634,29 @@ bool Device::PreCallValidateCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                                   const ErrorObject& error_obj) const {
     if (reported_CmdCopyBufferToImage2) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdCopyBufferToImage2 = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdCopyBufferToImage2 is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdCopyMemoryToImageKHR that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdCopyBufferToImage2 = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdCopyBufferToImage2 is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+            "which contains vkCmdCopyMemoryToImageKHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdCopyBufferToImage2 = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdCopyBufferToImage2 is a legacy command and there is now the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdCopyMemoryToImageKHR that can be used instead.\nSee more information about this legacy in "
+                   "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -860,13 +1666,29 @@ bool Device::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                                   const ErrorObject& error_obj) const {
     if (reported_CmdCopyImageToBuffer2) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdCopyImageToBuffer2 = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdCopyImageToBuffer2 is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdCopyImageToMemoryKHR that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdCopyImageToBuffer2 = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdCopyImageToBuffer2 is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+            "which contains vkCmdCopyImageToMemoryKHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdCopyImageToBuffer2 = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdCopyImageToBuffer2 is a legacy command and there is now the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdCopyImageToMemoryKHR that can be used instead.\nSee more information about this legacy in "
+                   "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -876,12 +1698,27 @@ bool Device::PreCallValidateCmdBindDescriptorSets2(VkCommandBuffer commandBuffer
                                                    const ErrorObject& error_obj) const {
     if (reported_CmdBindDescriptorSets2) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdBindDescriptorSets2 = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCmdBindDescriptorSets2 is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension "
                    "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdBindDescriptorSets2 = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorSets2 is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindDescriptorSets2 = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorSets2 is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -890,12 +1727,27 @@ bool Device::PreCallValidateCmdPushConstants2(VkCommandBuffer commandBuffer, con
                                               const ErrorObject& error_obj) const {
     if (reported_CmdPushConstants2) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdPushConstants2 = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCmdPushConstants2 is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension which "
                    "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdPushConstants2 = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdPushConstants2 is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdPushConstants2 = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdPushConstants2 is a legacy command and there is now the VK_EXT_descriptor_heap extension which contains "
+                   "the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -904,13 +1756,29 @@ bool Device::PreCallValidateCmdBindIndexBuffer2(VkCommandBuffer commandBuffer, V
                                                 VkDeviceSize size, VkIndexType indexType, const ErrorObject& error_obj) const {
     if (reported_CmdBindIndexBuffer2) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdBindIndexBuffer2 = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdBindIndexBuffer2 is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdBindIndexBuffer3KHR that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdBindIndexBuffer2 = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdBindIndexBuffer2 is a legacy command and this VkDevice supports the VK_KHR_device_address_commands extension "
+            "which contains vkCmdBindIndexBuffer3KHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindIndexBuffer2 = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdBindIndexBuffer2 is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+                   "contains vkCmdBindIndexBuffer3KHR that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -920,13 +1788,30 @@ bool Instance::PreCallValidateGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysical
                                                                       const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceSurfaceCapabilitiesKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_get_surface_capabilities2)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_surface_capabilities2)) {
         reported_GetPhysicalDeviceSurfaceCapabilitiesKHR = true;
         LogWarning("WARNING-legacy-gpdsc2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceSurfaceCapabilitiesKHR is a legacy command and this VkInstance enabled the "
                    "VK_KHR_get_surface_capabilities2 extension which contains vkGetPhysicalDeviceSurfaceCapabilities2KHR that can "
                    "be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdsc2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_surface_capabilities2)) {
+        reported_GetPhysicalDeviceSurfaceCapabilitiesKHR = true;
+        LogWarning("WARNING-legacy-gpdsc2", physicalDevice, error_obj.location,
+                   "vkGetPhysicalDeviceSurfaceCapabilitiesKHR is a legacy command and this VkInstance supports the "
+                   "VK_KHR_get_surface_capabilities2 extension which contains vkGetPhysicalDeviceSurfaceCapabilities2KHR that can "
+                   "be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdsc2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceSurfaceCapabilitiesKHR = true;
+        LogWarning(
+            "WARNING-legacy-gpdsc2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceSurfaceCapabilitiesKHR is a legacy command and there is now the VK_KHR_get_surface_capabilities2 "
+            "extension which contains vkGetPhysicalDeviceSurfaceCapabilities2KHR that can be used instead.\nSee more information "
+            "about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdsc2\nTo "
+            "limit warnings by only what the VkInstance currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -936,13 +1821,30 @@ bool Instance::PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevic
                                                                  const ErrorObject& error_obj) const {
     if (reported_GetPhysicalDeviceSurfaceFormatsKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_get_surface_capabilities2)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_get_surface_capabilities2)) {
         reported_GetPhysicalDeviceSurfaceFormatsKHR = true;
         LogWarning("WARNING-legacy-gpdsc2", physicalDevice, error_obj.location,
                    "vkGetPhysicalDeviceSurfaceFormatsKHR is a legacy command and this VkInstance enabled the "
                    "VK_KHR_get_surface_capabilities2 extension which contains vkGetPhysicalDeviceSurfaceFormats2KHR that can be "
                    "used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdsc2");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_get_surface_capabilities2)) {
+        reported_GetPhysicalDeviceSurfaceFormatsKHR = true;
+        LogWarning("WARNING-legacy-gpdsc2", physicalDevice, error_obj.location,
+                   "vkGetPhysicalDeviceSurfaceFormatsKHR is a legacy command and this VkInstance supports the "
+                   "VK_KHR_get_surface_capabilities2 extension which contains vkGetPhysicalDeviceSurfaceFormats2KHR that can be "
+                   "used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdsc2");
+    } else if (legacy_detection_settings.always) {
+        reported_GetPhysicalDeviceSurfaceFormatsKHR = true;
+        LogWarning(
+            "WARNING-legacy-gpdsc2", physicalDevice, error_obj.location,
+            "vkGetPhysicalDeviceSurfaceFormatsKHR is a legacy command and there is now the VK_KHR_get_surface_capabilities2 "
+            "extension which contains vkGetPhysicalDeviceSurfaceFormats2KHR that can be used instead.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-gpdsc2\nTo limit "
+            "warnings by only what the VkInstance currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -952,12 +1854,27 @@ bool Device::PreCallValidateCmdSetDescriptorBufferOffsets2EXT(
     const ErrorObject& error_obj) const {
     if (reported_CmdSetDescriptorBufferOffsets2EXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdSetDescriptorBufferOffsets2EXT = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCmdSetDescriptorBufferOffsets2EXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdSetDescriptorBufferOffsets2EXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdSetDescriptorBufferOffsets2EXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdSetDescriptorBufferOffsets2EXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdSetDescriptorBufferOffsets2EXT is a legacy command and there is now the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -967,13 +1884,29 @@ bool Device::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplers2EXT(
     const ErrorObject& error_obj) const {
     if (reported_CmdBindDescriptorBufferEmbeddedSamplers2EXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdBindDescriptorBufferEmbeddedSamplers2EXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkCmdBindDescriptorBufferEmbeddedSamplers2EXT is a legacy command and this VkDevice enabled the "
             "VK_EXT_descriptor_heap extension which contains the new feature to replace it.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdBindDescriptorBufferEmbeddedSamplers2EXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkCmdBindDescriptorBufferEmbeddedSamplers2EXT is a legacy command and this VkDevice supports the "
+            "VK_EXT_descriptor_heap extension which contains the new feature to replace it.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindDescriptorBufferEmbeddedSamplers2EXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorBufferEmbeddedSamplers2EXT is a legacy command and there is now the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -984,13 +1917,30 @@ bool Device::PreCallValidateCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer c
                                                                const ErrorObject& error_obj) const {
     if (reported_CmdBindTransformFeedbackBuffersEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdBindTransformFeedbackBuffersEXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdBindTransformFeedbackBuffersEXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdBindTransformFeedbackBuffers2EXT that can be used instead.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdBindTransformFeedbackBuffersEXT = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdBindTransformFeedbackBuffersEXT is a legacy command and this VkDevice supports the "
+                   "VK_KHR_device_address_commands extension which contains vkCmdBindTransformFeedbackBuffers2EXT that can be used "
+                   "instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindTransformFeedbackBuffersEXT = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdBindTransformFeedbackBuffersEXT is a legacy command and there is now the VK_KHR_device_address_commands "
+                   "extension which contains vkCmdBindTransformFeedbackBuffers2EXT that can be used instead.\nSee more information "
+                   "about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1001,13 +1951,30 @@ bool Device::PreCallValidateCmdBeginTransformFeedbackEXT(VkCommandBuffer command
                                                          const ErrorObject& error_obj) const {
     if (reported_CmdBeginTransformFeedbackEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdBeginTransformFeedbackEXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdBeginTransformFeedbackEXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdBeginTransformFeedback2EXT that can be used instead.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdBeginTransformFeedbackEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdBeginTransformFeedbackEXT is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdBeginTransformFeedback2EXT that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBeginTransformFeedbackEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdBeginTransformFeedbackEXT is a legacy command and there is now the VK_KHR_device_address_commands extension "
+            "which contains vkCmdBeginTransformFeedback2EXT that can be used instead.\nSee more information about this legacy in "
+            "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+            "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1018,13 +1985,29 @@ bool Device::PreCallValidateCmdEndTransformFeedbackEXT(VkCommandBuffer commandBu
                                                        const ErrorObject& error_obj) const {
     if (reported_CmdEndTransformFeedbackEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdEndTransformFeedbackEXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdEndTransformFeedbackEXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdEndTransformFeedback2EXT that can be used instead.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdEndTransformFeedbackEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdEndTransformFeedbackEXT is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdEndTransformFeedback2EXT that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdEndTransformFeedbackEXT = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdEndTransformFeedbackEXT is a legacy command and there is now the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdEndTransformFeedback2EXT that can be used instead.\nSee more information about this legacy "
+                   "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo "
+                   "limit warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1035,13 +2018,30 @@ bool Device::PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer commandB
                                                         uint32_t vertexStride, const ErrorObject& error_obj) const {
     if (reported_CmdDrawIndirectByteCountEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDrawIndirectByteCountEXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdDrawIndirectByteCountEXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdDrawIndirectByteCount2EXT that can be used instead.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDrawIndirectByteCountEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawIndirectByteCountEXT is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdDrawIndirectByteCount2EXT that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDrawIndirectByteCountEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawIndirectByteCountEXT is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+            "contains vkCmdDrawIndirectByteCount2EXT that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit warnings "
+            "by only what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+            "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) "
+            "setting.");
     }
     return false;
 }
@@ -1051,13 +2051,30 @@ bool Device::PreCallValidateCmdBeginConditionalRenderingEXT(VkCommandBuffer comm
                                                             const ErrorObject& error_obj) const {
     if (reported_CmdBeginConditionalRenderingEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdBeginConditionalRenderingEXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdBeginConditionalRenderingEXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdBeginConditionalRendering2EXT that can be used instead.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdBeginConditionalRenderingEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdBeginConditionalRenderingEXT is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdBeginConditionalRendering2EXT that can be used instead.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBeginConditionalRenderingEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdBeginConditionalRenderingEXT is a legacy command and there is now the VK_KHR_device_address_commands extension "
+            "which contains vkCmdBeginConditionalRendering2EXT that can be used instead.\nSee more information about this legacy "
+            "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+            "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1066,13 +2083,29 @@ bool Device::PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuff
                                                      VkDeviceSize dstOffset, uint32_t marker, const ErrorObject& error_obj) const {
     if (reported_CmdWriteBufferMarker2AMD) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdWriteBufferMarker2AMD = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdWriteBufferMarker2AMD is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdWriteMarkerToMemoryAMD that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdWriteBufferMarker2AMD = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdWriteBufferMarker2AMD is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdWriteMarkerToMemoryAMD that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdWriteBufferMarker2AMD = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdWriteBufferMarker2AMD is a legacy command and there is now the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdWriteMarkerToMemoryAMD that can be used instead.\nSee more information about this legacy "
+                   "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo "
+                   "limit warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1083,13 +2116,29 @@ bool Device::PreCallValidateCmdBindVertexBuffers2EXT(VkCommandBuffer commandBuff
                                                      const ErrorObject& error_obj) const {
     if (reported_CmdBindVertexBuffers2EXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdBindVertexBuffers2EXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdBindVertexBuffers2EXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands extension "
             "which contains vkCmdBindVertexBuffers3KHR that can be used instead.\nSee more information about this legacy in the "
             "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdBindVertexBuffers2EXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdBindVertexBuffers2EXT is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdBindVertexBuffers3KHR that can be used instead.\nSee more information about this legacy "
+            "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindVertexBuffers2EXT = true;
+        LogWarning("WARNING-legacy-buffer-commands", device, error_obj.location,
+                   "vkCmdBindVertexBuffers2EXT is a legacy command and there is now the VK_KHR_device_address_commands extension "
+                   "which contains vkCmdBindVertexBuffers3KHR that can be used instead.\nSee more information about this legacy in "
+                   "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1098,12 +2147,27 @@ bool Device::PreCallValidateGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDes
                                                           VkDeviceSize* pLayoutSizeInBytes, const ErrorObject& error_obj) const {
     if (reported_GetDescriptorSetLayoutSizeEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetDescriptorSetLayoutSizeEXT = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkGetDescriptorSetLayoutSizeEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetDescriptorSetLayoutSizeEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetDescriptorSetLayoutSizeEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetDescriptorSetLayoutSizeEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetDescriptorSetLayoutSizeEXT is a legacy command and there is now the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1112,13 +2176,29 @@ bool Device::PreCallValidateGetDescriptorSetLayoutBindingOffsetEXT(VkDevice devi
                                                                    VkDeviceSize* pOffset, const ErrorObject& error_obj) const {
     if (reported_GetDescriptorSetLayoutBindingOffsetEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetDescriptorSetLayoutBindingOffsetEXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkGetDescriptorSetLayoutBindingOffsetEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
             "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
             "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetDescriptorSetLayoutBindingOffsetEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkGetDescriptorSetLayoutBindingOffsetEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+            "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+            "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetDescriptorSetLayoutBindingOffsetEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetDescriptorSetLayoutBindingOffsetEXT is a legacy command and there is now the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1127,12 +2207,27 @@ bool Device::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptor
                                              void* pDescriptor, const ErrorObject& error_obj) const {
     if (reported_GetDescriptorEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetDescriptorEXT = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkGetDescriptorEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap extension which "
                    "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetDescriptorEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetDescriptorEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetDescriptorEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetDescriptorEXT is a legacy command and there is now the VK_EXT_descriptor_heap extension which contains "
+                   "the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1142,12 +2237,27 @@ bool Device::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer commandB
                                                         const ErrorObject& error_obj) const {
     if (reported_CmdBindDescriptorBuffersEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdBindDescriptorBuffersEXT = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCmdBindDescriptorBuffersEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdBindDescriptorBuffersEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorBuffersEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindDescriptorBuffersEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorBuffersEXT is a legacy command and there is now the VK_EXT_descriptor_heap extension which "
+                   "contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1158,12 +2268,27 @@ bool Device::PreCallValidateCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer com
                                                              const ErrorObject& error_obj) const {
     if (reported_CmdSetDescriptorBufferOffsetsEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdSetDescriptorBufferOffsetsEXT = true;
         LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
                    "vkCmdSetDescriptorBufferOffsetsEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
                    "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdSetDescriptorBufferOffsetsEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdSetDescriptorBufferOffsetsEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdSetDescriptorBufferOffsetsEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdSetDescriptorBufferOffsetsEXT is a legacy command and there is now the VK_EXT_descriptor_heap extension "
+                   "which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit warnings by only "
+                   "what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1174,13 +2299,29 @@ bool Device::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommand
                                                                        const ErrorObject& error_obj) const {
     if (reported_CmdBindDescriptorBufferEmbeddedSamplersEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_CmdBindDescriptorBufferEmbeddedSamplersEXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkCmdBindDescriptorBufferEmbeddedSamplersEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
             "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
             "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_CmdBindDescriptorBufferEmbeddedSamplersEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkCmdBindDescriptorBufferEmbeddedSamplersEXT is a legacy command and this VkDevice supports the "
+            "VK_EXT_descriptor_heap extension which contains the new feature to replace it.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdBindDescriptorBufferEmbeddedSamplersEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkCmdBindDescriptorBufferEmbeddedSamplersEXT is a legacy command and there is now the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1190,13 +2331,29 @@ bool Device::PreCallValidateGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice dev
                                                                     const ErrorObject& error_obj) const {
     if (reported_GetBufferOpaqueCaptureDescriptorDataEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetBufferOpaqueCaptureDescriptorDataEXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkGetBufferOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
             "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
             "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetBufferOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkGetBufferOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+            "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+            "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetBufferOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetBufferOpaqueCaptureDescriptorDataEXT is a legacy command and there is now the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1206,13 +2363,29 @@ bool Device::PreCallValidateGetImageOpaqueCaptureDescriptorDataEXT(VkDevice devi
                                                                    const ErrorObject& error_obj) const {
     if (reported_GetImageOpaqueCaptureDescriptorDataEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetImageOpaqueCaptureDescriptorDataEXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkGetImageOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
             "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
             "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetImageOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkGetImageOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+            "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+            "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetImageOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetImageOpaqueCaptureDescriptorDataEXT is a legacy command and there is now the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1222,13 +2395,29 @@ bool Device::PreCallValidateGetImageViewOpaqueCaptureDescriptorDataEXT(VkDevice 
                                                                        void* pData, const ErrorObject& error_obj) const {
     if (reported_GetImageViewOpaqueCaptureDescriptorDataEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetImageViewOpaqueCaptureDescriptorDataEXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkGetImageViewOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
             "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
             "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetImageViewOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkGetImageViewOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice supports the "
+            "VK_EXT_descriptor_heap extension which contains the new feature to replace it.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetImageViewOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetImageViewOpaqueCaptureDescriptorDataEXT is a legacy command and there is now the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1238,13 +2427,29 @@ bool Device::PreCallValidateGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevice de
                                                                      void* pData, const ErrorObject& error_obj) const {
     if (reported_GetSamplerOpaqueCaptureDescriptorDataEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetSamplerOpaqueCaptureDescriptorDataEXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkGetSamplerOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice enabled the VK_EXT_descriptor_heap "
             "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
             "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetSamplerOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkGetSamplerOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice supports the VK_EXT_descriptor_heap "
+            "extension which contains the new feature to replace it.\nSee more information about this legacy in the specification: "
+            "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetSamplerOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning("WARNING-legacy-descriptor-sets", device, error_obj.location,
+                   "vkGetSamplerOpaqueCaptureDescriptorDataEXT is a legacy command and there is now the VK_EXT_descriptor_heap "
+                   "extension which contains the new feature to replace it.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1254,13 +2459,30 @@ bool Device::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorDataE
     const ErrorObject& error_obj) const {
     if (reported_GetAccelerationStructureOpaqueCaptureDescriptorDataEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_descriptor_heap)) {
         reported_GetAccelerationStructureOpaqueCaptureDescriptorDataEXT = true;
         LogWarning(
             "WARNING-legacy-descriptor-sets", device, error_obj.location,
             "vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice enabled the "
             "VK_EXT_descriptor_heap extension which contains the new feature to replace it.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_descriptor_heap)) {
+        reported_GetAccelerationStructureOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT is a legacy command and this VkDevice supports the "
+            "VK_EXT_descriptor_heap extension which contains the new feature to replace it.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets");
+    } else if (legacy_detection_settings.always) {
+        reported_GetAccelerationStructureOpaqueCaptureDescriptorDataEXT = true;
+        LogWarning(
+            "WARNING-legacy-descriptor-sets", device, error_obj.location,
+            "vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT is a legacy command and there is now the "
+            "VK_EXT_descriptor_heap extension which contains the new feature to replace it.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-descriptor-sets\nTo "
+            "limit warnings by only what the VkDevice currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1269,12 +2491,27 @@ bool Device::PreCallValidateBuildMicromapsEXT(VkDevice device, VkDeferredOperati
                                               const VkMicromapBuildInfoEXT* pInfos, const ErrorObject& error_obj) const {
     if (reported_BuildMicromapsEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
         reported_BuildMicromapsEXT = true;
         LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
                    "vkBuildMicromapsEXT is a legacy command and this VkDevice enabled the VK_EXT_opacity_micromap extension which "
                    "contains vkCmdBuildMicromapsEXT that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_opacity_micromap)) {
+        reported_BuildMicromapsEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkBuildMicromapsEXT is a legacy command and this VkDevice supports the VK_EXT_opacity_micromap extension which "
+                   "contains vkCmdBuildMicromapsEXT that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_BuildMicromapsEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkBuildMicromapsEXT is a legacy command and there is now the VK_EXT_opacity_micromap extension which contains "
+                   "vkCmdBuildMicromapsEXT that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1283,12 +2520,27 @@ bool Device::PreCallValidateCopyMicromapEXT(VkDevice device, VkDeferredOperation
                                             const VkCopyMicromapInfoEXT* pInfo, const ErrorObject& error_obj) const {
     if (reported_CopyMicromapEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
         reported_CopyMicromapEXT = true;
         LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
                    "vkCopyMicromapEXT is a legacy command and this VkDevice enabled the VK_EXT_opacity_micromap extension which "
                    "contains vkCmdCopyMicromapEXT that can be used instead.\nSee more information about this legacy in the "
                    "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_opacity_micromap)) {
+        reported_CopyMicromapEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMicromapEXT is a legacy command and this VkDevice supports the VK_EXT_opacity_micromap extension which "
+                   "contains vkCmdCopyMicromapEXT that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_CopyMicromapEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMicromapEXT is a legacy command and there is now the VK_EXT_opacity_micromap extension which contains "
+                   "vkCmdCopyMicromapEXT that can be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1298,12 +2550,27 @@ bool Device::PreCallValidateCopyMicromapToMemoryEXT(VkDevice device, VkDeferredO
                                                     const ErrorObject& error_obj) const {
     if (reported_CopyMicromapToMemoryEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
         reported_CopyMicromapToMemoryEXT = true;
         LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
                    "vkCopyMicromapToMemoryEXT is a legacy command and this VkDevice enabled the VK_EXT_opacity_micromap extension "
                    "which contains vkCmdCopyMicromapToMemoryEXT that can be used instead.\nSee more information about this legacy "
                    "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_opacity_micromap)) {
+        reported_CopyMicromapToMemoryEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMicromapToMemoryEXT is a legacy command and this VkDevice supports the VK_EXT_opacity_micromap extension "
+                   "which contains vkCmdCopyMicromapToMemoryEXT that can be used instead.\nSee more information about this legacy "
+                   "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_CopyMicromapToMemoryEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMicromapToMemoryEXT is a legacy command and there is now the VK_EXT_opacity_micromap extension which "
+                   "contains vkCmdCopyMicromapToMemoryEXT that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1313,12 +2580,27 @@ bool Device::PreCallValidateCopyMemoryToMicromapEXT(VkDevice device, VkDeferredO
                                                     const ErrorObject& error_obj) const {
     if (reported_CopyMemoryToMicromapEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
         reported_CopyMemoryToMicromapEXT = true;
         LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
                    "vkCopyMemoryToMicromapEXT is a legacy command and this VkDevice enabled the VK_EXT_opacity_micromap extension "
                    "which contains vkCmdCopyMemoryToMicromapEXT that can be used instead.\nSee more information about this legacy "
                    "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_opacity_micromap)) {
+        reported_CopyMemoryToMicromapEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMemoryToMicromapEXT is a legacy command and this VkDevice supports the VK_EXT_opacity_micromap extension "
+                   "which contains vkCmdCopyMemoryToMicromapEXT that can be used instead.\nSee more information about this legacy "
+                   "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_CopyMemoryToMicromapEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMemoryToMicromapEXT is a legacy command and there is now the VK_EXT_opacity_micromap extension which "
+                   "contains vkCmdCopyMemoryToMicromapEXT that can be used instead.\nSee more information about this legacy in the "
+                   "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1328,13 +2610,29 @@ bool Device::PreCallValidateWriteMicromapsPropertiesEXT(VkDevice device, uint32_
                                                         const ErrorObject& error_obj) const {
     if (reported_WriteMicromapsPropertiesEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_ext_opacity_micromap)) {
         reported_WriteMicromapsPropertiesEXT = true;
         LogWarning(
             "WARNING-legacy-host-builds", device, error_obj.location,
             "vkWriteMicromapsPropertiesEXT is a legacy command and this VkDevice enabled the VK_EXT_opacity_micromap extension "
             "which contains vkCmdWriteMicromapsPropertiesEXT that can be used instead.\nSee more information about this legacy in "
             "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_ext_opacity_micromap)) {
+        reported_WriteMicromapsPropertiesEXT = true;
+        LogWarning(
+            "WARNING-legacy-host-builds", device, error_obj.location,
+            "vkWriteMicromapsPropertiesEXT is a legacy command and this VkDevice supports the VK_EXT_opacity_micromap extension "
+            "which contains vkCmdWriteMicromapsPropertiesEXT that can be used instead.\nSee more information about this legacy in "
+            "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_WriteMicromapsPropertiesEXT = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkWriteMicromapsPropertiesEXT is a legacy command and there is now the VK_EXT_opacity_micromap extension which "
+                   "contains vkCmdWriteMicromapsPropertiesEXT that can be used instead.\nSee more information about this legacy in "
+                   "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit "
+                   "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+                   "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1345,13 +2643,30 @@ bool Device::PreCallValidateCreateAccelerationStructureKHR(VkDevice device, cons
                                                            const ErrorObject& error_obj) const {
     if (reported_CreateAccelerationStructureKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CreateAccelerationStructureKHR = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCreateAccelerationStructureKHR is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCreateAccelerationStructure2KHR that can be used instead.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CreateAccelerationStructureKHR = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCreateAccelerationStructureKHR is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCreateAccelerationStructure2KHR that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CreateAccelerationStructureKHR = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCreateAccelerationStructureKHR is a legacy command and there is now the VK_KHR_device_address_commands extension "
+            "which contains vkCreateAccelerationStructure2KHR that can be used instead.\nSee more information about this legacy in "
+            "the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+            "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1363,13 +2678,30 @@ bool Device::PreCallValidateBuildAccelerationStructuresKHR(VkDevice device, VkDe
                                                            const ErrorObject& error_obj) const {
     if (reported_BuildAccelerationStructuresKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
         reported_BuildAccelerationStructuresKHR = true;
         LogWarning(
             "WARNING-legacy-host-builds", device, error_obj.location,
             "vkBuildAccelerationStructuresKHR is a legacy command and this VkDevice enabled the VK_KHR_acceleration_structure "
             "extension which contains vkCmdBuildAccelerationStructuresKHR that can be used instead.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_acceleration_structure)) {
+        reported_BuildAccelerationStructuresKHR = true;
+        LogWarning(
+            "WARNING-legacy-host-builds", device, error_obj.location,
+            "vkBuildAccelerationStructuresKHR is a legacy command and this VkDevice supports the VK_KHR_acceleration_structure "
+            "extension which contains vkCmdBuildAccelerationStructuresKHR that can be used instead.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_BuildAccelerationStructuresKHR = true;
+        LogWarning(
+            "WARNING-legacy-host-builds", device, error_obj.location,
+            "vkBuildAccelerationStructuresKHR is a legacy command and there is now the VK_KHR_acceleration_structure extension "
+            "which contains vkCmdBuildAccelerationStructuresKHR that can be used instead.\nSee more information about this legacy "
+            "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit "
+            "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1379,13 +2711,30 @@ bool Device::PreCallValidateCopyAccelerationStructureKHR(VkDevice device, VkDefe
                                                          const ErrorObject& error_obj) const {
     if (reported_CopyAccelerationStructureKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
         reported_CopyAccelerationStructureKHR = true;
         LogWarning(
             "WARNING-legacy-host-builds", device, error_obj.location,
             "vkCopyAccelerationStructureKHR is a legacy command and this VkDevice enabled the VK_KHR_acceleration_structure "
             "extension which contains vkCmdCopyAccelerationStructureKHR that can be used instead.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_acceleration_structure)) {
+        reported_CopyAccelerationStructureKHR = true;
+        LogWarning(
+            "WARNING-legacy-host-builds", device, error_obj.location,
+            "vkCopyAccelerationStructureKHR is a legacy command and this VkDevice supports the VK_KHR_acceleration_structure "
+            "extension which contains vkCmdCopyAccelerationStructureKHR that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_CopyAccelerationStructureKHR = true;
+        LogWarning(
+            "WARNING-legacy-host-builds", device, error_obj.location,
+            "vkCopyAccelerationStructureKHR is a legacy command and there is now the VK_KHR_acceleration_structure extension which "
+            "contains vkCmdCopyAccelerationStructureKHR that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit warnings by "
+            "only what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+            "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) "
+            "setting.");
     }
     return false;
 }
@@ -1395,13 +2744,30 @@ bool Device::PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice device
                                                                  const ErrorObject& error_obj) const {
     if (reported_CopyAccelerationStructureToMemoryKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
         reported_CopyAccelerationStructureToMemoryKHR = true;
         LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
                    "vkCopyAccelerationStructureToMemoryKHR is a legacy command and this VkDevice enabled the "
                    "VK_KHR_acceleration_structure extension which contains vkCmdCopyAccelerationStructureToMemoryKHR that can be "
                    "used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_acceleration_structure)) {
+        reported_CopyAccelerationStructureToMemoryKHR = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyAccelerationStructureToMemoryKHR is a legacy command and this VkDevice supports the "
+                   "VK_KHR_acceleration_structure extension which contains vkCmdCopyAccelerationStructureToMemoryKHR that can be "
+                   "used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_CopyAccelerationStructureToMemoryKHR = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyAccelerationStructureToMemoryKHR is a legacy command and there is now the VK_KHR_acceleration_structure "
+                   "extension which contains vkCmdCopyAccelerationStructureToMemoryKHR that can be used instead.\nSee more "
+                   "information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1411,13 +2777,30 @@ bool Device::PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevice device
                                                                  const ErrorObject& error_obj) const {
     if (reported_CopyMemoryToAccelerationStructureKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
         reported_CopyMemoryToAccelerationStructureKHR = true;
         LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
                    "vkCopyMemoryToAccelerationStructureKHR is a legacy command and this VkDevice enabled the "
                    "VK_KHR_acceleration_structure extension which contains vkCmdCopyMemoryToAccelerationStructureKHR that can be "
                    "used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_acceleration_structure)) {
+        reported_CopyMemoryToAccelerationStructureKHR = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMemoryToAccelerationStructureKHR is a legacy command and this VkDevice supports the "
+                   "VK_KHR_acceleration_structure extension which contains vkCmdCopyMemoryToAccelerationStructureKHR that can be "
+                   "used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_CopyMemoryToAccelerationStructureKHR = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkCopyMemoryToAccelerationStructureKHR is a legacy command and there is now the VK_KHR_acceleration_structure "
+                   "extension which contains vkCmdCopyMemoryToAccelerationStructureKHR that can be used instead.\nSee more "
+                   "information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1428,13 +2811,30 @@ bool Device::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevice de
                                                                      size_t stride, const ErrorObject& error_obj) const {
     if (reported_WriteAccelerationStructuresPropertiesKHR) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_acceleration_structure)) {
         reported_WriteAccelerationStructuresPropertiesKHR = true;
         LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
                    "vkWriteAccelerationStructuresPropertiesKHR is a legacy command and this VkDevice enabled the "
                    "VK_KHR_acceleration_structure extension which contains vkCmdWriteAccelerationStructuresPropertiesKHR that can "
                    "be used instead.\nSee more information about this legacy in the specification: "
                    "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_acceleration_structure)) {
+        reported_WriteAccelerationStructuresPropertiesKHR = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkWriteAccelerationStructuresPropertiesKHR is a legacy command and this VkDevice supports the "
+                   "VK_KHR_acceleration_structure extension which contains vkCmdWriteAccelerationStructuresPropertiesKHR that can "
+                   "be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds");
+    } else if (legacy_detection_settings.always) {
+        reported_WriteAccelerationStructuresPropertiesKHR = true;
+        LogWarning("WARNING-legacy-host-builds", device, error_obj.location,
+                   "vkWriteAccelerationStructuresPropertiesKHR is a legacy command and there is now the "
+                   "VK_KHR_acceleration_structure extension which contains vkCmdWriteAccelerationStructuresPropertiesKHR that can "
+                   "be used instead.\nSee more information about this legacy in the specification: "
+                   "https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-host-builds\nTo limit warnings by only what "
+                   "the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+                   "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED "
+                   "(legacy_detection_only_enabled) setting.");
     }
     return false;
 }
@@ -1443,13 +2843,30 @@ bool Device::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandB
                                                         uint32_t drawCount, uint32_t stride, const ErrorObject& error_obj) const {
     if (reported_CmdDrawMeshTasksIndirectEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDrawMeshTasksIndirectEXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdDrawMeshTasksIndirectEXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdDrawMeshTasksIndirect2EXT that can be used instead.\nSee more information about this "
             "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDrawMeshTasksIndirectEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawMeshTasksIndirectEXT is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdDrawMeshTasksIndirect2EXT that can be used instead.\nSee more information about this "
+            "legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDrawMeshTasksIndirectEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawMeshTasksIndirectEXT is a legacy command and there is now the VK_KHR_device_address_commands extension which "
+            "contains vkCmdDrawMeshTasksIndirect2EXT that can be used instead.\nSee more information about this legacy in the "
+            "specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit warnings "
+            "by only what the VkDevice currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED "
+            "(legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) "
+            "setting.");
     }
     return false;
 }
@@ -1460,13 +2877,30 @@ bool Device::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer com
                                                              const ErrorObject& error_obj) const {
     if (reported_CmdDrawMeshTasksIndirectCountEXT) return false;
 
-    if (IsExtEnabled(extensions.vk_khr_device_address_commands)) {
+    if (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.vk_khr_device_address_commands)) {
         reported_CmdDrawMeshTasksIndirectCountEXT = true;
         LogWarning(
             "WARNING-legacy-buffer-commands", device, error_obj.location,
             "vkCmdDrawMeshTasksIndirectCountEXT is a legacy command and this VkDevice enabled the VK_KHR_device_address_commands "
             "extension which contains vkCmdDrawMeshTasksIndirectCount2EXT that can be used instead.\nSee more information about "
             "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.vk_khr_device_address_commands)) {
+        reported_CmdDrawMeshTasksIndirectCountEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawMeshTasksIndirectCountEXT is a legacy command and this VkDevice supports the VK_KHR_device_address_commands "
+            "extension which contains vkCmdDrawMeshTasksIndirectCount2EXT that can be used instead.\nSee more information about "
+            "this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands");
+    } else if (legacy_detection_settings.always) {
+        reported_CmdDrawMeshTasksIndirectCountEXT = true;
+        LogWarning(
+            "WARNING-legacy-buffer-commands", device, error_obj.location,
+            "vkCmdDrawMeshTasksIndirectCountEXT is a legacy command and there is now the VK_KHR_device_address_commands extension "
+            "which contains vkCmdDrawMeshTasksIndirectCount2EXT that can be used instead.\nSee more information about this legacy "
+            "in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#legacy-buffer-commands\nTo limit "
+            "warnings by only what the VkDevice currently supports/enables, you can turn on the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the "
+            "VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
     }
     return false;
 }

--- a/scripts/generators/legacy_generator.py
+++ b/scripts/generators/legacy_generator.py
@@ -190,26 +190,34 @@ class LegacyGenerator(BaseGenerator):
                     if ({reportedMember}) return false;
                 ''')
 
-            firstCheck = True
             if command.legacy.version:
-                logic = 'if' if firstCheck else 'else if'
-                if firstCheck:
-                    firstCheck = False
+                # We assume if there is a version its because the extension was promoted
+                assert(command.legacy.extensions)
 
                 if command.legacy.supersededBy:
                     replacement = f'which contains {command.legacy.supersededBy} that can be used instead'
 
+                # For instance level |only_supported| is the same as |always|
+                # and consider pApplicationInfo->apiVersion as |only_enabled|
+                #
+                # For device level |only_supported| is found in VkPhysicalDeviceProperties::apiVersion
                 out.append(f'''
-                    {logic} (api_version >= {command.legacy.version.nameApi}) {{
+                    if (legacy_detection_settings.only_enabled && api_version >= {command.legacy.version.nameApi}) {{
                         {reportedMember} = true;
                         LogWarning("WARNING-{command.legacy.link}", {objName}, error_obj.location,
                             "{command.name} is a legacy command and this {handleName} was created with {command.legacy.version.name} {replacement}.{extra}\\nSee more information about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#{command.legacy.link}");
                     }}''')
 
+                if command.device:
+                    out.append(f'''
+                        else if (legacy_detection_settings.only_supported && phys_dev_props.apiVersion >= {command.legacy.version.nameApi}) {{
+                            {reportedMember} = true;
+                            LogWarning("WARNING-{command.legacy.link}", {objName}, error_obj.location,
+                                "{command.name} is a legacy command and this {handleName} supports {command.legacy.version.name} (from VkPhysicalDeviceProperties::apiVersion) {replacement}.{extra}\\nSee more information about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#{command.legacy.link}");
+                        }}''')
+
             for extension in command.legacy.extensions:
-                logic = 'if' if firstCheck else 'else if'
-                if firstCheck:
-                    firstCheck = False
+                logic = 'else if' if command.legacy.version else 'if'
 
                 if command.legacy.supersededBy:
                     # Currenty the |supersededBy| only has the version
@@ -225,12 +233,28 @@ class LegacyGenerator(BaseGenerator):
                         print(f'WARNING - need to fix supersededBy logic for {command.name} with {command.legacy.supersededBy}')
                     replacement = f'which contains {new_command} that can be used instead'
 
+                # seperate message depending on legacy_detection_settings
                 out.append(f'''
-                    {logic} (IsExtEnabled(extensions.{extension.lower()})) {{
+                    {logic} (legacy_detection_settings.only_enabled && IsExtEnabled(extensions.{extension.lower()})) {{
                         {reportedMember} = true;
                         LogWarning("WARNING-{command.legacy.link}", {objName}, error_obj.location,
                             "{command.name} is a legacy command and this {handleName} enabled the {extension} extension {replacement}.{extra}\\nSee more information about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#{command.legacy.link}");
                     }}''')
+
+                out.append(f'''
+                    else if (legacy_detection_settings.only_supported && IsExtSupported(extensions.{extension.lower()})) {{
+                        {reportedMember} = true;
+                        LogWarning("WARNING-{command.legacy.link}", {objName}, error_obj.location,
+                            "{command.name} is a legacy command and this {handleName} supports the {extension} extension {replacement}.{extra}\\nSee more information about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#{command.legacy.link}");
+                    }}''')
+
+                out.append(f'''
+                    else if (legacy_detection_settings.always) {{
+                        {reportedMember} = true;
+                        LogWarning("WARNING-{command.legacy.link}", {objName}, error_obj.location,
+                            "{command.name} is a legacy command and there is now the {extension} extension {replacement}.{extra}\\nSee more information about this legacy in the specification: https://docs.vulkan.org/spec/latest/appendices/legacy.html#{command.legacy.link}\\nTo limit warnings by only what the {handleName} currently supports/enables, you can turn on the VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED (legacy_detection_only_supported) or the VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED (legacy_detection_only_enabled) setting.");
+                    }}''')
+
 
             # For things mark as legacy in Vulkan 1.0
             if command.legacy.version is None and len(command.legacy.extensions) == 0:

--- a/tests/unit/legacy.cpp
+++ b/tests/unit/legacy.cpp
@@ -146,7 +146,7 @@ TEST_F(NegativeLegacy, UseDeprecatedInstanceExtensions) {
     }
 }
 
-TEST_F(NegativeLegacy, UseDeprecatedDeviceExtensions) {
+TEST_F(NegativeLegacy, UseDeprecatedDeviceExtensionsVersion) {
     // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
     AllowPromotedExtensions();
 
@@ -165,14 +165,41 @@ TEST_F(NegativeLegacy, UseDeprecatedDeviceExtensions) {
     dev_info.queueCreateInfoCount = 1;
     dev_info.pQueueCreateInfos = &queue_info;
     dev_info.enabledLayerCount = 0;
-    dev_info.ppEnabledLayerNames = NULL;
+    dev_info.ppEnabledLayerNames = nullptr;
     dev_info.enabledExtensionCount = m_device_extension_names.size();
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     // One for VK_KHR_buffer_device_address
     // One for the dependency extension VK_KHR_device_group
     m_errorMonitor->SetDesiredWarning("WARNING-legacy-extension", 2);
-    vk::CreateDevice(this->Gpu(), &dev_info, NULL, &local_device);
+    vk::CreateDevice(this->Gpu(), &dev_info, nullptr, &local_device);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeLegacy, UseDeprecatedDeviceExtensionsPromoted) {
+    // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
+    AllowPromotedExtensions();
+
+    AddRequiredExtensions(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitFramework(&kLegacySettingCreateInfo));
+    RETURN_IF_SKIP(InitState());
+
+    VkDevice local_device;
+    VkDeviceCreateInfo dev_info = vku::InitStructHelper();
+    VkDeviceQueueCreateInfo queue_info = vku::InitStructHelper();
+    queue_info.queueFamilyIndex = 0;
+    queue_info.queueCount = 1;
+    float qp = 1;
+    queue_info.pQueuePriorities = &qp;
+    dev_info.queueCreateInfoCount = 1;
+    dev_info.pQueueCreateInfos = &queue_info;
+    dev_info.enabledLayerCount = 0;
+    dev_info.ppEnabledLayerNames = nullptr;
+    dev_info.enabledExtensionCount = m_device_extension_names.size();
+    dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
+
+    m_errorMonitor->SetDesiredWarning("WARNING-legacy-extension");
+    vk::CreateDevice(this->Gpu(), &dev_info, nullptr, &local_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -212,4 +239,66 @@ TEST_F(NegativeLegacy, LoadDeprecatedExtension) {
     if (device) {
         vk::DestroyDevice(device, nullptr);
     }
+}
+
+TEST_F(NegativeLegacy, DescriptorHeapAlways) {
+    RETURN_IF_SKIP(InitFramework(&kLegacySettingCreateInfo));
+    RETURN_IF_SKIP(InitState());
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1};
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
+    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+
+    m_errorMonitor->SetDesiredWarning("WARNING-legacy-descriptor-sets");
+    vkt::DescriptorPool(*m_device, ds_pool_ci);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeLegacy, DescriptorHeapOnlySupport) {
+    VkLayerSettingEXT layer_settings[2] = {
+        kLegacySetting, {OBJECT_LAYER_NAME, "legacy_detection_only_supported", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &kVkTrue}};
+    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2, layer_settings};
+    RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
+    RETURN_IF_SKIP(InitState());
+    if (!DeviceExtensionSupported(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME << " not supported.";
+    }
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1};
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
+    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+
+    m_errorMonitor->SetDesiredWarning("WARNING-legacy-descriptor-sets");
+    vkt::DescriptorPool(*m_device, ds_pool_ci);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeLegacy, DescriptorHeapOnlyEnabled) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    const char* ids[] = {"WARNING-legacy-gpdp2"};
+    VkLayerSettingEXT layer_settings[3] = {
+        kLegacySetting,
+        {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids},
+        {OBJECT_LAYER_NAME, "legacy_detection_only_enabled", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &kVkTrue}};
+    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 3, layer_settings};
+    RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
+    RETURN_IF_SKIP(InitState());
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1};
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
+    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+
+    m_errorMonitor->SetDesiredWarning("WARNING-legacy-descriptor-sets");
+    vkt::DescriptorPool(*m_device, ds_pool_ci);
+    m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/legacy_positive.cpp
+++ b/tests/unit/legacy_positive.cpp
@@ -11,6 +11,8 @@
  */
 // stype-check off
 #include <vulkan/vulkan_core.h>
+#include "binding.h"
+#include "generated/vk_function_pointers.h"
 #include "layer_validation_tests.h"
 
 void LegacyTest::CreateRenderPass() {
@@ -85,9 +87,11 @@ TEST_F(PositiveLegacy, MuteMultipleWarnings) {
 
 TEST_F(PositiveLegacy, GetPhysicalDeviceProperties2Extension) {
     TEST_DESCRIPTION("Show Instance extensions currently only detected if enabled, not if supported");
-    const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &layer_setting};
-
+    VkLayerSettingEXT layer_setting[2] = {
+        {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "legacy_detection_only_enabled", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue}};
+    static VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2,
+                                                            layer_setting};
     RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
@@ -96,4 +100,83 @@ TEST_F(PositiveLegacy, GetPhysicalDeviceProperties2Extension) {
 
     VkFormatProperties format_properties{};
     vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &format_properties);
+}
+
+TEST_F(PositiveLegacy, DescriptorHeapOnlySupported) {
+    VkLayerSettingEXT layer_setting[2] = {
+        {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "legacy_detection_only_supported", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue}};
+    static VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2,
+                                                            layer_setting};
+    RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
+    RETURN_IF_SKIP(InitState());
+    if (DeviceExtensionSupported(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME << " is supported.";
+    }
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1};
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
+    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+    vkt::DescriptorPool(*m_device, ds_pool_ci);
+}
+
+TEST_F(PositiveLegacy, DescriptorHeapOnlyEnabled) {
+    VkLayerSettingEXT layer_setting[2] = {
+        {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "legacy_detection_only_enabled", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue}};
+    static VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2,
+                                                            layer_setting};
+    RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
+    RETURN_IF_SKIP(InitState());
+    if (!DeviceExtensionSupported(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME << " is not supported.";
+    }
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1};
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
+    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+    vkt::DescriptorPool(*m_device, ds_pool_ci);
+}
+
+TEST_F(PositiveLegacy, UseDeprecatedDeviceExtensionsPromoted) {
+    // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
+    AllowPromotedExtensions();
+
+    AddRequiredExtensions(VK_EXT_DEVICE_FAULT_EXTENSION_NAME);
+    const char* ids[] = {"WARNING-legacy-gpdp2"};
+    VkLayerSettingEXT layer_settings[3] = {
+        {OBJECT_LAYER_NAME, "legacy_detection", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "legacy_detection_only_supported", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids}};
+    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 3, layer_settings};
+    RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
+    RETURN_IF_SKIP(InitState());
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    if (DeviceExtensionSupported(VK_KHR_DEVICE_FAULT_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_KHR_DEVICE_FAULT_EXTENSION_NAME << " is supported.";
+    }
+
+    VkDevice local_device;
+    VkDeviceCreateInfo dev_info = vku::InitStructHelper();
+    VkDeviceQueueCreateInfo queue_info = vku::InitStructHelper();
+    queue_info.queueFamilyIndex = 0;
+    queue_info.queueCount = 1;
+    float qp = 1;
+    queue_info.pQueuePriorities = &qp;
+    dev_info.queueCreateInfoCount = 1;
+    dev_info.pQueueCreateInfos = &queue_info;
+    dev_info.enabledLayerCount = 0;
+    dev_info.ppEnabledLayerNames = nullptr;
+    dev_info.enabledExtensionCount = m_device_extension_names.size();
+    dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
+
+    vk::CreateDevice(this->Gpu(), &dev_info, nullptr, &local_device);
+    vk::DestroyDevice(local_device, nullptr);
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12373

This is a refactor of the whole `Legacy Detection` idea

From here it will be start reporting more (so not backward breaking). It will detect anything that is found in the headers built with VVL

If people find this too much noise, they can turn on `VK_LAYER_LEGACY_DETECTION_ONLY_SUPPORTED` or `VK_LAYER_LEGACY_DETECTION_ONLY_ENABLED` to tune the warnings to what they want

<img width="216" height="86" alt="image" src="https://github.com/user-attachments/assets/4eb5cfbd-c844-4e3a-b222-3c60918c76f8" />

