### PR TITLE
layers: Warn if user seems to think they are appending flags

### DIFF
--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -700,6 +700,15 @@ bool Device::ValidateCreatePipelinesFlags2(const VkPipelineCreateFlags flags1, c
                            "has flags set to zero.",
                            string_VkPipelineCreateFlags(flags1).c_str());
     }
+    // From a real world user who thought flags2 would "append" and not override.
+    // To prevent noise, we only report if there is no shared flags which would indicate this behavior
+    if (flags2 != 0 && flags1 != 0 && ((flags1 & flags2) == 0)) {
+        skip |= LogWarning(
+            "WARNING-VkPipelineCreateFlags2-flags-appending", device, flags1_loc,
+            "is %s and pNext<VkPipelineCreateFlags2CreateInfo>.flags is %s\nIf VkPipelineCreateFlags2CreateInfo is included in the "
+            "pNext chain, those flags are used INSTEAD of the original flags. This struct does NOT append flags.",
+            string_VkPipelineCreateFlags(flags1).c_str(), string_VkPipelineCreateFlags2(flags2).c_str());
+    }
     return skip;
 }
 
@@ -901,7 +910,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
             skip |= context.ValidateFlags(flags_loc, vvl::FlagBitmask::VkPipelineCreateFlagBits, AllVkPipelineCreateFlagBits,
                                           create_info.flags, kOptionalFlags, "VUID-VkGraphicsPipelineCreateInfo-None-09497");
         } else {
-            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, flags_loc);
+            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, create_info_loc.dot(Field::flags));
         }
         skip |= ValidateCreatePipelinesFlagsCommon(flags, flags_loc, pipelineCache, create_info.layout);
 
@@ -1896,7 +1905,7 @@ bool Device::manual_PreCallValidateCreateComputePipelines(VkDevice device, VkPip
             skip |= context.ValidateFlags(flags_loc, vvl::FlagBitmask::VkPipelineCreateFlagBits, AllVkPipelineCreateFlagBits,
                                           create_info.flags, kOptionalFlags, "VUID-VkComputePipelineCreateInfo-None-09497");
         } else {
-            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, flags_loc);
+            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, create_info_loc.dot(Field::flags));
         }
         skip |= ValidateCreatePipelinesFlagsCommon(flags, flags_loc, pipelineCache, create_info.layout);
 

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -254,7 +254,7 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device,
             skip |= context.ValidateFlags(flags_loc, vvl::FlagBitmask::VkPipelineCreateFlagBits, AllVkPipelineCreateFlagBits,
                                           create_info.flags, kOptionalFlags, "VUID-VkRayTracingPipelineCreateInfoKHR-None-09497");
         } else {
-            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, flags_loc);
+            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, create_info_loc.dot(Field::flags));
         }
         skip |= ValidateCreatePipelinesFlagsCommon(flags, flags_loc, pipelineCache, create_info.layout);
 

--- a/layers/stateless/sl_ray_tracing_nv.cpp
+++ b/layers/stateless/sl_ray_tracing_nv.cpp
@@ -338,7 +338,7 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, 
             skip |= context.ValidateFlags(flags_loc, vvl::FlagBitmask::VkPipelineCreateFlagBits, AllVkPipelineCreateFlagBits,
                                           create_info.flags, kOptionalFlags, "VUID-VkRayTracingPipelineCreateInfoNV-None-09497");
         } else {
-            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, flags_loc);
+            skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, create_info_loc.dot(Field::flags));
         }
         skip |= ValidateCreatePipelinesFlagsCommon(flags, flags_loc, pipelineCache, create_info.layout);
 

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "layer_validation_tests.h"
+#include "pipeline_helper.h"
 #include <cstdlib>
 
 class PositiveOther : public VkLayerTest {};
@@ -727,4 +728,19 @@ TEST_F(PositiveOther, GetDeviceFaultReportsWithTimeout) {
     uint32_t fault_counts = 0;
     VkResult result = vk::GetDeviceFaultReportsKHR(device(), 1000u, &fault_counts, nullptr);
     ASSERT_EQ(VK_TIMEOUT, result);
+}
+
+TEST_F(PositiveOther, AppendingPipelineCreateFlags2) {
+    SetTargetApiVersion(VK_API_VERSION_1_4);
+    AddRequiredFeature(vkt::Feature::maintenance5);
+    RETURN_IF_SKIP(Init());
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    // If the values overlap, we don't want to risk noise
+    VkPipelineCreateFlags2CreateInfo flags2 = vku::InitStructHelper();
+    flags2.flags = VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT | VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT;
+
+    CreateComputePipelineHelper pipe(*this, &flags2);
+    pipe.cp_ci_.flags = VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT;
+    pipe.CreateComputePipeline();
 }

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include "layer_validation_tests.h"
 #include "pipeline_helper.h"
+#include "shader_templates.h"
 #include "utils/hash_util.h"
 #include "generated/vk_validation_error_messages.h"
 
@@ -1426,7 +1427,7 @@ TEST_F(NegativeOther, MissingExtensionPipelineCreateFlags2) {
 }
 
 TEST_F(NegativeOther, OverridePipelineCreateFlags2) {
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetTargetApiVersion(VK_API_VERSION_1_4);
     AddRequiredFeature(vkt::Feature::maintenance5);
     RETURN_IF_SKIP(Init());
 
@@ -1440,7 +1441,27 @@ TEST_F(NegativeOther, OverridePipelineCreateFlags2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeOther, UnkonwnStructType) {
+TEST_F(NegativeOther, AppendingPipelineCreateFlags2) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    RETURN_IF_SKIP(Init());
+
+    VkPipelineCreateFlags2CreateInfo flags2 = vku::InitStructHelper();
+    flags2.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    CreateComputePipelineHelper pipe(*this, &flags2);
+    pipe.cp_ci_.flags = VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
+    VkShaderObj cs_module = VkShaderObj(*m_device, kMinimalShaderGlsl, VK_SHADER_STAGE_COMPUTE_BIT);
+    pipe.cp_ci_.stage = cs_module.GetStageCreateInfo();
+    pipe.cp_ci_.layout = VK_NULL_HANDLE;
+    m_errorMonitor->SetDesiredWarning("WARNING-VkPipelineCreateFlags2-flags-appending");
+    pipe.CreateComputePipeline(false);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeOther, UnknownStructType) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkBaseOutStructure bogus_struct{};


### PR DESCRIPTION
Will report 

```
Validation Warning: [ WARNING-VkPipelineCreateFlags2-flags-appending ] | MessageID = 0x1a26e290
vkCreateComputePipelines(): pCreateInfos[0].flags is VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT and pNext<VkPipelineCreateFlags2CreateInfo>.flags is VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT
If VkPipelineCreateFlags2CreateInfo is included in the pNext chain, those flags are used INSTEAD of the original flags. This struct does NOT append flags.
```