### PR TITLE
layers: Use correct feature name

### DIFF
--- a/layers/core_checks/cc_sync_vuid_maps.cpp
+++ b/layers/core_checks/cc_sync_vuid_maps.cpp
@@ -36,7 +36,7 @@ const vvl::unordered_map<VkPipelineStageFlags2, std::string>& GetFeatureNameMap(
         {VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT, "taskShader"},
         {VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI, "subpassShading"},
         {VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI, "invocationMask"},
-        {VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR, "rayTracing"},
+        {VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR, "rayTracingPipeline"},
         {VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, "shadingRate"},
         {VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, "accelerationStructure"},
         {VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR, "rayTracingMaintenance1"},


### PR DESCRIPTION
was getting

```
Validation Error: [ VUID-VkBufferMemoryBarrier2-dstStageMask-07946 ] | MessageID = 0xe7954a28
vkCmdPipelineBarrier2(): pDependencyInfo->pBufferMemoryBarriers[0].dstStageMask includes VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR when the device does not have rayTracing feature enabled.
```