### PR TITLE
gpuav: Temp fix for Array of BDA with runtime arrays

### DIFF
--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -179,6 +179,17 @@ bool BufferDeviceAddressPass::RequiresInstrumentation(const Function& function, 
 }
 
 bool BufferDeviceAddressPass::Instrument() {
+    // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12629
+    // We need to just move BDA over to use AccessPath instead so we can find this information there
+    // Then we can remove this function and burn it
+    //
+    // We need to detect structs with a VERY specific case
+    // If there is an array-of-structs where that struct has a runtime array inside of it
+    vvl::unordered_set<uint32_t> struct_id_temp_workaround;
+    if (!module_.settings_.safe_mode) {
+        type_manager_.FindArrayOfPSBStructWithRuntime(struct_id_temp_workaround);
+    }
+
     // Can safely loop function list as there is no injecting of new Functions until linking time
     for (Function& function : module_.functions_) {
         if (!function.called_from_target_) {
@@ -239,6 +250,10 @@ bool BufferDeviceAddressPass::Instrument() {
                             const Instruction* last_access = access_chain_insts.front();
                             if (!last_access->IsNonPtrAccessChain() && last_access->TypeId() == load_type_pointer->Id()) {
                                 root_struct_id = load_type_pointer->Id();
+                            }
+
+                            if (struct_id_temp_workaround.find(root_struct_id) != struct_id_temp_workaround.end()) {
+                                continue;
                             }
 
                             const uint32_t struct_offset = FindOffsetInStruct(root_struct_id, nullptr, false, access_chain_insts);

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -1220,6 +1220,29 @@ void TypeManager::AddUndef(std::unique_ptr<Instruction> new_inst) {
 
 bool TypeManager::IsUndef(uint32_t id) const { return undef_ids_.find(id) != undef_ids_.end(); }
 
+// Hopefully can remove this function when BDA is fixed
+void TypeManager::FindArrayOfPSBStructWithRuntime(vvl::unordered_set<uint32_t>& out_struct_ids) {
+    if (runtime_array_types_.empty()) {
+        return;
+    }
+    for (const Type* array_type : array_types_) {
+        const Type* ptr_type = FindTypeById(array_type->inst_.Word(2));
+        if (ptr_type->inst_.StorageClass() != spv::StorageClassPhysicalStorageBuffer) {
+            continue;
+        }
+        const Type* struct_type = FindTypeById(ptr_type->inst_.Word(3));
+        if (!struct_type || struct_type->spv_type_ != SpvType::kStruct) {
+            continue;
+        }
+        for (uint32_t i = 2; i < struct_type->inst_.Length(); i++) {
+            const Type* element_type = FindTypeById(struct_type->inst_.Word(i));
+            if (element_type && element_type->spv_type_ == SpvType::kRuntimeArray) {
+                out_struct_ids.insert(struct_type->Id());
+            }
+        }
+    }
+}
+
 // Not ideal to use, the caller really should already know which type it wants
 const Type* TypeManager::FindChildType(const Type& type, uint32_t idx) const {
     switch (type.spv_type_) {

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -288,6 +288,8 @@ class TypeManager {
     void AddUndef(std::unique_ptr<Instruction> new_inst);
     bool IsUndef(uint32_t id) const;
 
+    void FindArrayOfPSBStructWithRuntime(vvl::unordered_set<uint32_t>& out_struct_ids);
+
   private:
     Module& module_;
 

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -2604,3 +2604,62 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LinkingSameStruct) {
     pipe.cs_ = VkShaderObj(*m_device, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 }
+
+TEST_F(PositiveGpuAVBufferDeviceAddress, SharingStructWithDifferPSB) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12629");
+    RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
+
+    const char* shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_buffer_reference : enable
+        struct sA
+        {
+            uint mA;
+            vec3 mB;
+            vec2 mC;
+        };
+
+        layout(buffer_reference) buffer BDA
+        {
+            sA a;
+            mat3 b;
+            mat2 c;
+            uint d[]; // [0] is a 116 byte offset
+        };
+
+        layout (push_constant) uniform PC {
+            BDA ptr[3];
+        };
+
+        void main (void)
+        {
+            uint a = ptr[0].a.mA;
+            ptr[2].d[100] = a;
+        }
+    )glsl";
+
+    VkPushConstantRange push_range;
+    push_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    push_range.offset = 0u;
+    push_range.size = sizeof(VkDeviceAddress) * 3u;
+    const vkt::PipelineLayout pipeline_layout(*m_device, {}, {push_range});
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cp_ci_.layout = pipeline_layout;
+    pipe.cs_ = VkShaderObj(*m_device, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer block_b0(*m_device, 128u, 0, vkt::device_address);
+    vkt::Buffer block_b1(*m_device, 128u, 0, vkt::device_address);  // unused
+    vkt::Buffer block_b2(*m_device, 1024u, 0, vkt::device_address);
+
+    VkDeviceAddress push_constants[3] = {block_b0.Address(), block_b1.Address(), block_b2.Address()};
+
+    m_command_buffer.Begin();
+    vk::CmdPushConstants(m_command_buffer, pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0u, push_range.size, push_constants);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}


### PR DESCRIPTION
this is a "quick fix" for @ziga-lunarg for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12629 (But keeping the issue open as it needs a "real" fix)

This is a VERY specific edge case so was able to isolate it, but I need to revisit the whole BDA pass once I finalize Heaps