### PR TITLE
layers: Fix ASSERT in ValidateDescriptor (Tensor); includes unit test

### DIFF
--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -1510,10 +1510,10 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet& set_state, const vvl::Dev
             break;
         }
         case vvl::DescriptorClass::Tensor: {
-            const auto tensor_desc = static_cast<const MutableDescriptor*>(&src);
-            tensor_view_count_ = tensor_desc->GetTensorViewCount();
-            tensor_views_ = tensor_desc->GetTensorViews();
-            ReplaceStatePtr(set_state, tensor_view_state_, std::shared_ptr<vvl::TensorView>(), is_bindless);
+            const auto tensor_desc = static_cast<const MutableDescriptor&>(src);
+            tensor_view_count_ = tensor_desc.GetTensorViewCount();
+            tensor_views_ = tensor_desc.GetTensorViews();
+            ReplaceStatePtr(set_state, tensor_view_state_, tensor_desc.tensor_view_state_, is_bindless);
         } break;
         case vvl::DescriptorClass::InlineUniform:
         case vvl::DescriptorClass::Invalid:
@@ -1683,16 +1683,16 @@ void vvl::TensorDescriptor::WriteUpdate(DescriptorSet& set_state, const DeviceSt
 void vvl::TensorDescriptor::CopyUpdate(DescriptorSet& set_state, const DeviceState& dev_data, const Descriptor& src,
                                        bool is_bindless, VkDescriptorType type) {
     if (src.GetClass() == vvl::DescriptorClass::Mutable) {
-        const auto tensor_desc = static_cast<const MutableDescriptor*>(&src);
-        tensor_view_count_ = tensor_desc->GetTensorViewCount();
-        tensor_views_ = tensor_desc->GetTensorViews();
-        ReplaceStatePtr(set_state, tensor_view_state_, std::shared_ptr<vvl::TensorView>(), is_bindless);
+        const auto tensor_desc = static_cast<const MutableDescriptor&>(src);
+        tensor_view_count_ = tensor_desc.GetTensorViewCount();
+        tensor_views_ = tensor_desc.GetTensorViews();
+        ReplaceStatePtr(set_state, tensor_view_state_, tensor_desc.GetSharedTensorView(), is_bindless);
         return;
     }
-    const auto tensor_desc = static_cast<const TensorDescriptor*>(&src);
-    tensor_view_count_ = tensor_desc->tensor_view_count_;
-    tensor_views_ = tensor_desc->tensor_views_;
-    ReplaceStatePtr(set_state, tensor_view_state_, std::shared_ptr<vvl::TensorView>(), is_bindless);
+    const auto tensor_desc = static_cast<const TensorDescriptor&>(src);
+    tensor_view_count_ = tensor_desc.tensor_view_count_;
+    tensor_views_ = tensor_desc.tensor_views_;
+    ReplaceStatePtr(set_state, tensor_view_state_, tensor_desc.tensor_view_state_, is_bindless);
 }
 
 const vvl::Tensor* vvl::TensorDescriptor::GetTensorState() const { return tensor_view_state_->tensor_state.get(); }

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -402,3 +402,64 @@ TEST_F(PositiveDataGraph, OpticalFlowConnectionsImageLayoutsUnifiedImageLayouts)
     vk::CmdDispatchDataGraphARM(m_command_buffer, session, &pipeline_di);
     m_command_buffer.End();
 }
+
+// unit test to verify the fix for bug in descriptor copying
+TEST_F(PositiveDataGraph, CopyUpdateDescriptor) {
+    TEST_DESCRIPTION("Dispatch a datagraph where a descriptor has been copy-updated after creation");
+    RETURN_IF_SKIP(InitBasicDataGraph());
+
+    vkt::dg::DataGraphPipelineHelper pipeline(*this);
+    pipeline.CreateDataGraphPipeline();
+
+    VkDataGraphPipelineSessionCreateInfoARM session_ci = vku::InitStructHelper();
+    session_ci.dataGraphPipeline = pipeline;
+    vkt::DataGraphPipelineSession session(*m_device, session_ci);
+
+    auto& bind_point_reqs = session.BindPointReqs();
+    std::vector<vkt::DeviceMemory> device_mem(bind_point_reqs.size());
+    session.AllocSessionMem(device_mem);
+    auto session_bind_infos = InitSessionBindInfo(session, device_mem);
+    vk::BindDataGraphPipelineSessionMemoryARM(*m_device, session_bind_infos.size(), session_bind_infos.data());
+
+    pipeline.descriptor_set_->WriteDescriptorTensorInfo(0, &pipeline.tensor_views_[0]->handle(), 0);
+    pipeline.descriptor_set_->WriteDescriptorTensorInfo(1, &pipeline.tensor_views_[1]->handle(), 0);
+    pipeline.descriptor_set_->UpdateDescriptorSets();
+
+    // create a new tensor and copy it into the input tensor
+
+    VkTensorDescriptionARM desc = pipeline.tensors_[0]->Description();
+    desc.usage |= VK_TENSOR_USAGE_TRANSFER_SRC_BIT_ARM | VK_TENSOR_USAGE_TRANSFER_DST_BIT_ARM;
+    VkTensorCreateInfoARM info = vku::InitStructHelper();
+    info.pDescription = &desc;
+    info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    vkt::Tensor tensor_src(*m_device, info);
+    tensor_src.BindToMem();
+
+    VkTensorViewCreateInfoARM tensor_view_create_info_src = vku::InitStructHelper();
+    tensor_view_create_info_src.tensor = tensor_src;
+    tensor_view_create_info_src.format = tensor_src.Format();
+    vkt::TensorView view_src(*m_device, tensor_view_create_info_src);
+
+    OneOffDescriptorSet descriptor_set_src(m_device, {{0, VK_DESCRIPTOR_TYPE_TENSOR_ARM, 1, VK_SHADER_STAGE_ALL, nullptr}});
+    descriptor_set_src.WriteDescriptorTensorInfo(0, &view_src.handle());
+    descriptor_set_src.UpdateDescriptorSets();
+
+    VkCopyDescriptorSet copy_set = vku::InitStructHelper();
+    copy_set.srcSet = descriptor_set_src.set_;
+    copy_set.srcBinding = 0;
+    copy_set.dstSet = pipeline.descriptor_set_->set_;
+    copy_set.dstBinding = 0;
+    copy_set.descriptorCount = 1;
+    vk::UpdateDescriptorSets(*m_device, 0, nullptr, 1, &copy_set);
+
+    // continue as normal to dispatch
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_DATA_GRAPH_ARM, pipeline.pipeline_layout_, 0, 1,
+                              &pipeline.descriptor_set_.get()->set_, 0, nullptr);
+    vk::CmdDispatchDataGraphARM(m_command_buffer, session, nullptr);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}


### PR DESCRIPTION
- fix null pointer passed in TensorDescriptor::CopyUpdate
- assert at dispatch time on layers/drawdispatch/descriptor_validator.cpp:1553
- bug never hit in current unit tests, new test for coverage for tensors
