### PR TITLE
dump: Remove gpu_dump_device_copy

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -196,7 +196,7 @@
                         { "key": "descriptor_hashing", "value": false },
                         { "key": "printf_enable", "value": false },
                         { "key": "debug_action",  "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT" ] },
-                        { "key": "report_flags",  "value": [ "warn", "info" ] },
+                        { "key": "report_flags",  "value": [ "warn" ] },
                         { "key": "enable_message_limit", "value": false }
                     ]
                 },
@@ -1169,14 +1169,6 @@
                                     "key": "gpu_dump_to_stdout",
                                     "label": "Redirect all GPU Dump to stdout",
                                     "description": "Instead of using the debug callback with information severity, redirect to stdout instead.",
-                                    "type": "BOOL",
-                                    "default": false
-                                },
-                                {
-                                    "key": "gpu_dump_device_copy",
-                                    "label": "Force Device Copy",
-                                    "view": "DEBUG",
-                                    "description": "[Very experimental] For non-host visible memory, try and do a device copy during command recording to view the data inside a buffer.",
                                     "type": "BOOL",
                                     "default": false
                                 }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -259,8 +259,6 @@ const char* VK_LAYER_GPU_DUMP_COPY_MEMORY_INDIRECT = "gpu_dump_copy_memory_indir
 const char* VK_LAYER_GPU_DUMP_DEVICE_GENERATED_COMMANDS = "gpu_dump_device_generated_commands";
 // Print to stdout
 const char* VK_LAYER_GPU_DUMP_TO_STDOUT = "gpu_dump_to_stdout";
-// Experimental
-const char* VK_LAYER_GPU_DUMP_DEVICE_COPY = "gpu_dump_device_copy";
 
 // Legacy Detection
 // ---
@@ -1277,10 +1275,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings* settings_data) {
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPU_DUMP_TO_STDOUT)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPU_DUMP_TO_STDOUT, gpu_dump_settings.to_stdout);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPU_DUMP_DEVICE_COPY)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPU_DUMP_DEVICE_COPY, gpu_dump_settings.device_copy);
     }
 
     LegacyDetectionSettings& legacy_detection_settings = *settings_data->legacy_detection_settings;

--- a/layers/layer_options_validation.h
+++ b/layers/layer_options_validation.h
@@ -59,7 +59,6 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT &la
         else if (strcmp(VK_LAYER_FINE_GRAINED_LOCKING, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_GPU_DUMP_COPY_MEMORY_INDIRECT, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_GPU_DUMP_DESCRIPTORS, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
-        else if (strcmp(VK_LAYER_GPU_DUMP_DEVICE_COPY, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_GPU_DUMP_DEVICE_GENERATED_COMMANDS, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_GPU_DUMP_TO_STDOUT, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }
         else if (strcmp(VK_LAYER_GPUAV_ACCELERATION_STRUCTURES_BUILDS, name) == 0) { required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT; }

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -45,11 +45,6 @@ khronos_validation.gpu_dump_copy_memory_indirect = false
 # Dump all the information at every draw/dispatch when recording VK_EXT_descriptor_heap or VK_EXT_descriptor_buffer
 khronos_validation.gpu_dump_descriptors = false
 
-# Force Device Copy
-# =====================
-# [Very experimental] For non-host visible memory, try and do a device copy during command recording to view the data inside a buffer.
-khronos_validation.gpu_dump_device_copy = false
-
 # Dump VK_EXT_device_generated_commands
 # =====================
 # Dump information at each vkCmdExecuteGeneratedCommands when recording

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -293,68 +293,6 @@ TEST_F(NegativeGpuDump, CopyMemoryIndirect) {
     m_command_buffer.End();
 }
 
-// TODO - Add and test the feature
-TEST_F(NegativeGpuDump, DISABLED_DeviceCopy) {
-    const VkLayerSettingEXT layer_settings[2] = {
-        {OBJECT_LAYER_NAME, "gpu_dump_copy_memory_indirect", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
-        {OBJECT_LAYER_NAME, "gpu_dump_device_copy", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
-    };
-    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2, layer_settings};
-    AddRequiredExtensions(VK_KHR_COPY_MEMORY_INDIRECT_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::indirectMemoryCopy);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
-    RETURN_IF_SKIP(InitState());
-
-    vkt::Buffer src_buffer(*m_device, 64, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, vkt::device_address);
-    vkt::Buffer dst_buffer(*m_device, 64, VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
-
-    const VkDeviceAddress src_address = src_buffer.Address();
-    const VkDeviceAddress dst_address = dst_buffer.Address();
-    VkCopyMemoryIndirectCommandKHR cmds = {src_address, dst_address, 16};
-    const VkDeviceSize indirect_buffer_size = sizeof(VkCopyMemoryIndirectCommandKHR);
-
-    vkt::Buffer indirect_buffer_stage(*m_device, 128, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-                                      vkt::device_address);
-    void* indirect_buffer_data = indirect_buffer_stage.Memory().Map();
-    memcpy(indirect_buffer_data, &cmds, indirect_buffer_size);
-    VkMappedMemoryRange flush_ranges = vku::InitStructHelper();
-    flush_ranges.memory = indirect_buffer_stage.Memory();
-    flush_ranges.offset = 0;
-    flush_ranges.size = VK_WHOLE_SIZE;
-    vk::FlushMappedMemoryRanges(*m_device, 1, &flush_ranges);
-
-    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
-    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
-    vkt::Buffer indirect_buffer_device(
-        *m_device, 128,
-        VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
-
-    m_command_buffer.Begin();
-    VkBufferCopy copy_region{0, 0, 128};
-    vk::CmdCopyBuffer(m_command_buffer, indirect_buffer_stage, indirect_buffer_device, 1, &copy_region);
-    m_command_buffer.FullMemoryBarrier();
-    m_command_buffer.End();
-    m_default_queue->SubmitAndWait(m_command_buffer);
-
-    VkStridedDeviceAddressRangeKHR address_range = {};
-    address_range.address = indirect_buffer_device.Address();
-    address_range.size = indirect_buffer_size;
-    address_range.stride = sizeof(VkCopyMemoryIndirectCommandKHR);
-
-    VkCopyMemoryIndirectInfoKHR copy_info = vku::InitStructHelper();
-    copy_info.copyCount = 1;
-    copy_info.copyAddressRange = address_range;
-    copy_info.srcCopyFlags = VK_ADDRESS_COPY_DEVICE_LOCAL_BIT_KHR;
-    copy_info.dstCopyFlags = VK_ADDRESS_COPY_DEVICE_LOCAL_BIT_KHR;
-
-    m_command_buffer.Begin();
-    m_command_buffer.FullMemoryBarrier();
-    vk::CmdCopyMemoryIndirectKHR(m_command_buffer, &copy_info);
-    m_command_buffer.End();
-}
-
 TEST_F(NegativeGpuDump, DescriptorHeapDescriptorIndexing) {
     RETURN_IF_SKIP(InitDescriptorHeap());
 


### PR DESCRIPTION
I originally thought we could do this, but now think this is just too much for GPU-Dump and left for GPU-AV