### PR TITLE
gpuav: Remove false assertion

### DIFF
--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -894,7 +894,6 @@ const AccessPath TypeManager::BuildAccessPath(const Function& function, const In
             }
         } else if (next_access_chain->Opcode() == spv::OpFunctionParameter) {
             // TODO - Need to handle walking all function callers
-            assert(FindTypeById(next_access_chain->TypeId())->spv_type_ == SpvType::kUntypedPointerKHR);
             return path;
         }
     }


### PR DESCRIPTION
... so you can pass in AS as parameter... scary

this fix now has us pass `dEQP-VK.binding_model.descriptor_heap*` (with GPU-AV) with no assertions