### PR TITLE
layers: Checks and tests for VUIDs 9974, 9975, 9963, 9978, 9979

### DIFF
--- a/layers/core_checks/cc_data_graph.cpp
+++ b/layers/core_checks/cc_data_graph.cpp
@@ -147,52 +147,143 @@ bool CoreChecks::ValidateTensorSemiStructuredSparsityInfo(VkDevice device, const
     return skip;
 }
 
-bool CoreChecks::ValidateOpticalFlowCreateInfo(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
-                                               const Location& optical_flow_ci_loc) const {
+bool CoreChecks::ValidateOpticalFlowFormats(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                            const Location& optical_flow_ci_loc) const {
     bool skip = false;
 
-    auto list_formats = [](const std::vector<VkFormat>& list) {
+    auto list_formats = [](const vvl::unordered_set<VkFormat>& set) {
         std::ostringstream ss;
-
-        for (const auto f : list) {
-            ss << string_VkFormat(f) << ", ";
+        for (const auto f : set) {
+            if (ss.tellp() > 0) {
+                ss << ", ";
+            }
+            ss << string_VkFormat(f);
         }
-
-        std::string ret = ss.str();
-
-        if (ret.size() >= 2) {
-            ret.resize(ret.size() - 2);
-        }
-
-        return ret;
+        return ss.str();
     };
 
-    const VkFormat imageFormat = optical_flow_ci.imageFormat;
-    std::vector<VkFormat> formats = device_state->optical_flow_formats.input;
+    auto all_values = [](const vvl::PhysicalDevice::QueueAndEngineMap<vvl::unordered_set<VkFormat>>& map) {
+        vvl::unordered_set<VkFormat> formats;
+        for (const auto& entry : map) {
+            formats.insert(entry.second.begin(), entry.second.end());
+        }
+        return formats;
+    };
 
-    if (std::find(formats.begin(), formats.end(), imageFormat) == formats.end()) {
+    vvl::unordered_set<VkFormat> formats = all_values(physical_device_state->optical_flow_formats.input);
+    if (std::find(formats.begin(), formats.end(), optical_flow_ci.imageFormat) == formats.end()) {
         skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-imageFormat-09968", device,
-                         optical_flow_ci_loc.dot(Field::imageFormat), "(%s) is not supported.\nSupported formats: %s.",
-                         string_VkFormat(imageFormat), list_formats(formats).c_str());
+                         optical_flow_ci_loc.dot(Field::imageFormat), "(%s) is not supported for input images.\nSupported formats: %s.",
+                         string_VkFormat(optical_flow_ci.imageFormat), list_formats(formats).c_str());
     }
 
-    const VkFormat flowVectorFormat = optical_flow_ci.flowVectorFormat;
-    formats = device_state->optical_flow_formats.output;
-
-    if (std::find(formats.begin(), formats.end(), flowVectorFormat) == formats.end()) {
+    formats = all_values(physical_device_state->optical_flow_formats.output);
+    if (std::find(formats.begin(), formats.end(), optical_flow_ci.flowVectorFormat) == formats.end()) {
         skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-flowVectorFormat-09969", device,
-                         optical_flow_ci_loc.dot(Field::flowVectorFormat), "(%s) is not supported.\nSupported formats: %s.",
-                         string_VkFormat(flowVectorFormat), list_formats(formats).c_str());
+                         optical_flow_ci_loc.dot(Field::flowVectorFormat), "(%s) is not supported for output images.\nSupported formats: %s.",
+                         string_VkFormat(optical_flow_ci.flowVectorFormat), list_formats(formats).c_str());
     }
 
     if (optical_flow_ci.flags & VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM) {
-        const VkFormat costFormat = optical_flow_ci.costFormat;
-        formats = device_state->optical_flow_formats.cost;
-
-        if (std::find(formats.begin(), formats.end(), costFormat) == formats.end()) {
+        formats = all_values(physical_device_state->optical_flow_formats.cost);
+        if (std::find(formats.begin(), formats.end(), optical_flow_ci.costFormat) == formats.end()) {
             skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-costFormat-09970", device,
-                             optical_flow_ci_loc.dot(Field::costFormat), "(%s) is not supported.\nSupported formats: %s.",
-                             string_VkFormat(costFormat), list_formats(formats).c_str());
+                             optical_flow_ci_loc.dot(Field::costFormat), "(%s) is not supported for cost images.\nSupported formats: %s.",
+                             string_VkFormat(optical_flow_ci.costFormat), list_formats(formats).c_str());
+        }
+    }
+
+    return skip;
+}
+
+bool CoreChecks::ValidateOpticalFlowFlags(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                          const Location& optical_flow_ci_loc) const {
+    bool skip = false;
+
+    bool any_queue_supports_hint = false;
+    bool any_queue_supports_cost = false;
+    for (const auto& entry : physical_device_state->data_graph_optical_flow_properties) {
+        any_queue_supports_hint |= static_cast<bool>(entry.second.hintSupported);
+        any_queue_supports_cost |= static_cast<bool>(entry.second.costSupported);
+    }
+    const LogObjectList& objList = LogObjectList(device, physical_device);
+    if (optical_flow_ci.flags & VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM && !any_queue_supports_hint) {
+        skip |= LogError(
+            "VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-flags-09974", objList, optical_flow_ci_loc.dot(Field::flags),
+            "(%s) includes VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM which is not supported by the physical device.\n",
+            string_VkDataGraphOpticalFlowCreateFlagsARM(optical_flow_ci.flags).c_str());
+    }
+    if (optical_flow_ci.flags & VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM && !any_queue_supports_cost) {
+        skip |= LogError(
+            "VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-flags-09975", objList, optical_flow_ci_loc.dot(Field::flags),
+            "(%s) includes VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM which is not supported by the physical device.\n",
+            string_VkDataGraphOpticalFlowCreateFlagsARM(optical_flow_ci.flags).c_str());
+    }
+
+    return skip;
+}
+
+bool CoreChecks::ValidateOpticalFlowConnections(const VkDataGraphPipelineSingleNodeCreateInfoARM& single_node_ci,
+                                                const Location& single_node_ci_loc,
+                                                VkDataGraphOpticalFlowGridSizeFlagsARM hint_grid_size) const {
+    auto print_connections = [](const auto& list) {
+        std::ostringstream ss;
+        for (uint32_t i = 0; i < list.size(); i++) {
+            const auto& [index, connection] = list[i];
+            ss << "\n- pConnections[" << index << "]: set = " << connection.set << ", binding = " << connection.binding;
+        }
+        return ss.str();
+    };
+
+    bool skip = false;
+
+    if (single_node_ci.nodeType == VK_DATA_GRAPH_PIPELINE_NODE_TYPE_OPTICAL_FLOW_ARM) {
+        std::vector<std::pair<uint32_t, const VkDataGraphPipelineSingleNodeConnectionARM&>> input_connection_idx;
+        std::vector<std::pair<uint32_t, const VkDataGraphPipelineSingleNodeConnectionARM&>> reference_connection_idx;
+        std::vector<std::pair<uint32_t, const VkDataGraphPipelineSingleNodeConnectionARM&>> output_connection_idx;
+        std::vector<std::pair<uint32_t, const VkDataGraphPipelineSingleNodeConnectionARM&>> hint_connection_idx;
+        for (uint32_t i = 0; i < single_node_ci.connectionCount; i++) {
+            const VkDataGraphPipelineSingleNodeConnectionARM& connection = single_node_ci.pConnections[i];
+            switch (connection.connection) {
+                case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_INPUT_ARM:
+                    input_connection_idx.push_back({i, connection});
+                    break;
+                case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_REFERENCE_ARM:
+                    reference_connection_idx.push_back({i, connection});
+                    break;
+                case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_FLOW_VECTOR_ARM:
+                    output_connection_idx.push_back({i, connection});
+                    break;
+                case VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_HINT_ARM:
+                    hint_connection_idx.push_back({i, connection});
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (input_connection_idx.size() != 1) {
+            skip |= LogError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09978", device,
+                single_node_ci_loc.dot(Field::pConnections), "includes %" PRIu32 " input connections "
+                "(type VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_INPUT_ARM)%s",
+                static_cast<uint32_t>(input_connection_idx.size()), print_connections(input_connection_idx).c_str());
+        }
+        if (reference_connection_idx.size() != 1) {
+            skip |= LogError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09978", device,
+                single_node_ci_loc.dot(Field::pConnections), "includes %" PRIu32 " reference connections "
+                "(type VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_REFERENCE_ARM)%s",
+                static_cast<uint32_t>(reference_connection_idx.size()), print_connections(reference_connection_idx).c_str());
+        }
+        if (output_connection_idx.size() != 1) {
+            skip |= LogError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09978", device,
+                single_node_ci_loc.dot(Field::pConnections), "includes %" PRIu32 " output connections "
+                "(type VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_FLOW_VECTOR_ARM)%s",
+                static_cast<uint32_t>(output_connection_idx.size()), print_connections(output_connection_idx).c_str());
+        }
+        if (hint_grid_size > 0 && hint_connection_idx.size() != 1) {
+            skip |= LogError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09979", device,
+                single_node_ci_loc.dot(Field::pConnections), "includes %" PRIu32 " hint connections "
+                "(type VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_HINT_ARM)%s",
+                static_cast<uint32_t>(hint_connection_idx.size()), print_connections(hint_connection_idx).c_str());
         }
     }
 
@@ -213,7 +304,7 @@ bool CoreChecks::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkD
         ASSERT_AND_RETURN_SKIP(pipeline);
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
 
-        // three different ways to define a datagraph:
+        // a datagraph can be defined through one of these structures:
         const auto* dg_shader_ci = vku::FindStructInPNextChain<VkDataGraphPipelineShaderModuleCreateInfoARM>(create_info.pNext);
         const auto* dg_pipeline_identifier_ci =
             vku::FindStructInPNextChain<VkDataGraphPipelineIdentifierCreateInfoARM>(create_info.pNext);
@@ -309,8 +400,16 @@ bool CoreChecks::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkD
 
             if (optical_flow_ci) {
                 const Location optical_flow_ci_loc = create_info_loc.pNext(Struct::VkDataGraphPipelineOpticalFlowCreateInfoARM);
+                skip |= ValidateOpticalFlowFormats(*optical_flow_ci, optical_flow_ci_loc);
+                skip |= ValidateOpticalFlowFlags(*optical_flow_ci, optical_flow_ci_loc);
 
-                skip |= ValidateOpticalFlowCreateInfo(*optical_flow_ci, optical_flow_ci_loc);
+                const Location single_node_ci_loc = create_info_loc.pNext(Struct::VkDataGraphPipelineSingleNodeCreateInfoARM);
+                skip |= ValidateOpticalFlowConnections(*single_node_ci, single_node_ci_loc, optical_flow_ci->hintGridSize);
+            } else if (VK_DATA_GRAPH_PIPELINE_NODE_TYPE_OPTICAL_FLOW_ARM == single_node_ci->nodeType) {
+                skip |= LogError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09963", device, create_info_loc,
+                                 "Datagraph create info includes a node for optical flow, but there is no optical flow create info "
+                                 "in the pNext chain.\n%s",
+                                 PrintPNextChain(Struct::VkDataGraphPipelineSingleNodeCreateInfoARM, create_info.pNext).c_str());
             }
         }
         // common checks

--- a/layers/core_checks/cc_data_graph.cpp
+++ b/layers/core_checks/cc_data_graph.cpp
@@ -162,7 +162,7 @@ bool CoreChecks::ValidateOpticalFlowFormats(const VkDataGraphPipelineOpticalFlow
         return ss.str();
     };
 
-    auto all_values = [](const vvl::PhysicalDevice::QueueAndEngineMap<vvl::unordered_set<VkFormat>>& map) {
+    auto all_values = [](const vvl::PhysicalDevice::DataGraph::QueueAndEngineMap<vvl::unordered_set<VkFormat>>& map) {
         vvl::unordered_set<VkFormat> formats;
         for (const auto& entry : map) {
             formats.insert(entry.second.begin(), entry.second.end());
@@ -170,14 +170,15 @@ bool CoreChecks::ValidateOpticalFlowFormats(const VkDataGraphPipelineOpticalFlow
         return formats;
     };
 
-    vvl::unordered_set<VkFormat> formats = all_values(physical_device_state->optical_flow_formats.input);
+    const vvl::PhysicalDevice::DataGraph::OpticalFlowFormats& of_formats = physical_device_state->data_graph.optical_flow_formats;
+    vvl::unordered_set<VkFormat> formats = all_values(of_formats.input);
     if (std::find(formats.begin(), formats.end(), optical_flow_ci.imageFormat) == formats.end()) {
         skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-imageFormat-09968", device,
                          optical_flow_ci_loc.dot(Field::imageFormat), "(%s) is not supported for input images.\nSupported formats: %s.",
                          string_VkFormat(optical_flow_ci.imageFormat), list_formats(formats).c_str());
     }
 
-    formats = all_values(physical_device_state->optical_flow_formats.output);
+    formats = all_values(of_formats.output);
     if (std::find(formats.begin(), formats.end(), optical_flow_ci.flowVectorFormat) == formats.end()) {
         skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-flowVectorFormat-09969", device,
                          optical_flow_ci_loc.dot(Field::flowVectorFormat), "(%s) is not supported for output images.\nSupported formats: %s.",
@@ -185,7 +186,7 @@ bool CoreChecks::ValidateOpticalFlowFormats(const VkDataGraphPipelineOpticalFlow
     }
 
     if (optical_flow_ci.flags & VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM) {
-        formats = all_values(physical_device_state->optical_flow_formats.cost);
+        formats = all_values(of_formats.cost);
         if (std::find(formats.begin(), formats.end(), optical_flow_ci.costFormat) == formats.end()) {
             skip |= LogError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-costFormat-09970", device,
                              optical_flow_ci_loc.dot(Field::costFormat), "(%s) is not supported for cost images.\nSupported formats: %s.",
@@ -202,7 +203,7 @@ bool CoreChecks::ValidateOpticalFlowFlags(const VkDataGraphPipelineOpticalFlowCr
 
     bool any_queue_supports_hint = false;
     bool any_queue_supports_cost = false;
-    for (const auto& entry : physical_device_state->data_graph_optical_flow_properties) {
+    for (const auto& entry : physical_device_state->data_graph.optical_flow_properties) {
         any_queue_supports_hint |= static_cast<bool>(entry.second.hintSupported);
         any_queue_supports_cost |= static_cast<bool>(entry.second.costSupported);
     }

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -3188,8 +3188,9 @@ bool CoreChecks::ValidateDataGraphOperations(const vvl::Pipeline& pipeline, uint
     bool queue_uses_tosa_1_0 = false;
     // no properties for the specified family index means NO support for TOSA 1.0, i.e. VUID 9941
     // this also covers completely empty properties, meaning VK_ARM_data_graph extension not supported
-    if (queueFamilyIndex <= device_state->queue_family_data_graph_properties.size()) {
-        for (const auto& p : device_state->queue_family_data_graph_properties.at(queueFamilyIndex)) {
+    const auto properties_it = physical_device_state->queue_family_data_graph_properties.find(queueFamilyIndex);
+    if (properties_it != physical_device_state->queue_family_data_graph_properties.end()) {
+        for (const auto& p : properties_it->second) {
             if (CompareVkQueueFamilyDataGraphPropertiesARM(tosa_1_0_property, p)) {
                 queue_uses_tosa_1_0 = true;
                 break;
@@ -3204,12 +3205,11 @@ bool CoreChecks::ValidateDataGraphOperations(const vvl::Pipeline& pipeline, uint
               "required property:\n"
            << string_VkQueueFamilyDataGraphPropertiesARM(tosa_1_0_property)
            << "vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM for queueFamilyIndex " << queueFamilyIndex << "returned:\n";
-        auto properties = device_state->queue_family_data_graph_properties.at(queueFamilyIndex);
-        for (const auto& p : properties) {
-            ss << string_VkQueueFamilyDataGraphPropertiesARM(p) << '\n';
-        }
-        if (properties.empty()) {
-            // with just a blank it's unclear if the function is wrong or there really are no properties.
+        if (properties_it != physical_device_state->queue_family_data_graph_properties.end() && !properties_it->second.empty()) {
+            for (const auto& p : properties_it->second) {
+                ss << string_VkQueueFamilyDataGraphPropertiesARM(p) << '\n';
+            }
+        } else {
             ss << "EMPTY\n";
         }
         skip |= LogError("VUID-vkCmdDispatchDataGraphARM-commandBuffer-09941", device, loc, "%s", ss.str().c_str());

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -3188,8 +3188,8 @@ bool CoreChecks::ValidateDataGraphOperations(const vvl::Pipeline& pipeline, uint
     bool queue_uses_tosa_1_0 = false;
     // no properties for the specified family index means NO support for TOSA 1.0, i.e. VUID 9941
     // this also covers completely empty properties, meaning VK_ARM_data_graph extension not supported
-    const auto properties_it = physical_device_state->queue_family_data_graph_properties.find(queueFamilyIndex);
-    if (properties_it != physical_device_state->queue_family_data_graph_properties.end()) {
+    const auto properties_it = physical_device_state->data_graph.queue_family_properties.find(queueFamilyIndex);
+    if (properties_it != physical_device_state->data_graph.queue_family_properties.end()) {
         for (const auto& p : properties_it->second) {
             if (CompareVkQueueFamilyDataGraphPropertiesARM(tosa_1_0_property, p)) {
                 queue_uses_tosa_1_0 = true;
@@ -3205,7 +3205,7 @@ bool CoreChecks::ValidateDataGraphOperations(const vvl::Pipeline& pipeline, uint
               "required property:\n"
            << string_VkQueueFamilyDataGraphPropertiesARM(tosa_1_0_property)
            << "vkGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM for queueFamilyIndex " << queueFamilyIndex << "returned:\n";
-        if (properties_it != physical_device_state->queue_family_data_graph_properties.end() && !properties_it->second.empty()) {
+        if (properties_it != physical_device_state->data_graph.queue_family_properties.end() && !properties_it->second.empty()) {
             for (const auto& p : properties_it->second) {
                 ss << string_VkQueueFamilyDataGraphPropertiesARM(p) << '\n';
             }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1074,8 +1074,13 @@ class CoreChecks : public vvl::DeviceProxy {
                                                     const vvl::Pipeline& pipeline) const;
     bool ValidateDataGraphOperations(const vvl::Pipeline& pipeline, uint32_t queueFamilyIndex, const Location& loc) const;
 
-    bool ValidateOpticalFlowCreateInfo(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
-                                       const Location& optical_flow_ci_loc) const;
+    bool ValidateOpticalFlowFormats(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                    const Location& optical_flow_ci_loc) const;
+    bool ValidateOpticalFlowFlags(const VkDataGraphPipelineOpticalFlowCreateInfoARM& optical_flow_ci,
+                                  const Location& optical_flow_ci_loc) const;
+    bool ValidateOpticalFlowConnections(const VkDataGraphPipelineSingleNodeCreateInfoARM& single_node_ci,
+                                        const Location& single_node_ci_loc,
+                                        VkDataGraphOpticalFlowGridSizeFlagsARM hint_grid_size) const;
 
     bool PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                     VkPipelineCache pipelineCache, uint32_t createInfoCount,

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -45,6 +45,34 @@ enum class CallState {
 
 class PhysicalDevice : public StateObject {
   public:
+    // helper struct used to index properties and formats for data graph engine/queue pairs
+    struct QueueAndEngine {
+        uint32_t queue_index{};
+        VkPhysicalDeviceDataGraphProcessingEngineARM engine{VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM,
+                                                            false};
+
+        bool operator==(const QueueAndEngine& other) const {
+            return queue_index == other.queue_index && engine.type == other.engine.type &&
+                   engine.isForeign == other.engine.isForeign;
+        };
+        struct hash {
+            size_t operator()(const QueueAndEngine& value) const {
+                hash_util::HashCombiner hc;
+                hc << value.queue_index << value.engine.type << value.engine.isForeign;
+                return hc.Value();
+            }
+        };
+    };
+
+    template <typename T>
+    using QueueAndEngineMap = vvl::unordered_map<QueueAndEngine, T, QueueAndEngine::hash>;
+
+    struct OpticalFlowFormatsARM {
+        QueueAndEngineMap<vvl::unordered_set<VkFormat>> input;   // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM
+        QueueAndEngineMap<vvl::unordered_set<VkFormat>> output;  // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM
+        QueueAndEngineMap<vvl::unordered_set<VkFormat>> cost;    // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM
+    };
+
     uint32_t queue_family_known_count = 1;  // spec implies one QF must always be supported
     const std::vector<VkQueueFamilyProperties> queue_family_properties;
     const VkQueueFlags supported_queues;
@@ -54,6 +82,11 @@ class PhysicalDevice : public StateObject {
 
     // Map of queue family index to QueueFamilyPerfCounters
     vvl::unordered_map<uint32_t, std::unique_ptr<QueueFamilyPerfCounters>> perf_counters;
+
+    vvl::unordered_map<uint32_t, std::vector<VkQueueFamilyDataGraphPropertiesARM>> queue_family_data_graph_properties;
+    QueueAndEngineMap<VkQueueFamilyDataGraphOpticalFlowPropertiesARM> data_graph_optical_flow_properties;
+    QueueAndEngineMap<VkQueueFamilyDataGraphTOSAPropertiesARM> data_graph_tosa_properties;
+    OpticalFlowFormatsARM optical_flow_formats;
 
     // Surfaceless Query extension needs 'global' surface_state data
     SurfacelessQueryState surfaceless_query_state{};

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -45,34 +45,6 @@ enum class CallState {
 
 class PhysicalDevice : public StateObject {
   public:
-    // helper struct used to index properties and formats for data graph engine/queue pairs
-    struct QueueAndEngine {
-        uint32_t queue_index{};
-        VkPhysicalDeviceDataGraphProcessingEngineARM engine{VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM,
-                                                            false};
-
-        bool operator==(const QueueAndEngine& other) const {
-            return queue_index == other.queue_index && engine.type == other.engine.type &&
-                   engine.isForeign == other.engine.isForeign;
-        };
-        struct hash {
-            size_t operator()(const QueueAndEngine& value) const {
-                hash_util::HashCombiner hc;
-                hc << value.queue_index << value.engine.type << value.engine.isForeign;
-                return hc.Value();
-            }
-        };
-    };
-
-    template <typename T>
-    using QueueAndEngineMap = vvl::unordered_map<QueueAndEngine, T, QueueAndEngine::hash>;
-
-    struct OpticalFlowFormatsARM {
-        QueueAndEngineMap<vvl::unordered_set<VkFormat>> input;   // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM
-        QueueAndEngineMap<vvl::unordered_set<VkFormat>> output;  // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM
-        QueueAndEngineMap<vvl::unordered_set<VkFormat>> cost;    // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM
-    };
-
     uint32_t queue_family_known_count = 1;  // spec implies one QF must always be supported
     const std::vector<VkQueueFamilyProperties> queue_family_properties;
     const VkQueueFlags supported_queues;
@@ -83,13 +55,42 @@ class PhysicalDevice : public StateObject {
     // Map of queue family index to QueueFamilyPerfCounters
     vvl::unordered_map<uint32_t, std::unique_ptr<QueueFamilyPerfCounters>> perf_counters;
 
-    vvl::unordered_map<uint32_t, std::vector<VkQueueFamilyDataGraphPropertiesARM>> queue_family_data_graph_properties;
-    QueueAndEngineMap<VkQueueFamilyDataGraphOpticalFlowPropertiesARM> data_graph_optical_flow_properties;
-    QueueAndEngineMap<VkQueueFamilyDataGraphTOSAPropertiesARM> data_graph_tosa_properties;
-    OpticalFlowFormatsARM optical_flow_formats;
-
     // Surfaceless Query extension needs 'global' surface_state data
     SurfacelessQueryState surfaceless_query_state{};
+
+    // VK_ARM_data_graph
+    struct DataGraph {
+        // helper struct used to index properties and formats for data graph engine/queue pairs
+        struct QueueAndEngine {
+            uint32_t queue_index{};
+            VkPhysicalDeviceDataGraphProcessingEngineARM engine{VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM,
+                                                                false};
+
+            bool operator==(const QueueAndEngine& other) const {
+                return queue_index == other.queue_index && engine.type == other.engine.type &&
+                       engine.isForeign == other.engine.isForeign;
+            };
+            struct hash {
+                size_t operator()(const QueueAndEngine& value) const {
+                    hash_util::HashCombiner hc;
+                    hc << value.queue_index << value.engine.type << value.engine.isForeign;
+                    return hc.Value();
+                }
+            };
+        };
+
+        template <typename T>
+        using QueueAndEngineMap = vvl::unordered_map<QueueAndEngine, T, QueueAndEngine::hash>;
+
+        vvl::unordered_map<uint32_t, std::vector<VkQueueFamilyDataGraphPropertiesARM>> queue_family_properties;
+        QueueAndEngineMap<VkQueueFamilyDataGraphOpticalFlowPropertiesARM> optical_flow_properties;
+        QueueAndEngineMap<VkQueueFamilyDataGraphTOSAPropertiesARM> tosa_properties;
+        struct OpticalFlowFormats {
+            QueueAndEngineMap<vvl::unordered_set<VkFormat>> input;   // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM
+            QueueAndEngineMap<vvl::unordered_set<VkFormat>> output;  // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM
+            QueueAndEngineMap<vvl::unordered_set<VkFormat>> cost;    // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM
+        } optical_flow_formats;
+    } data_graph;
 
     PhysicalDevice(VkPhysicalDevice handle);
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1198,36 +1198,35 @@ std::shared_ptr<Queue> DeviceState::CreateQueue(VkQueue handle, uint32_t family_
     return std::make_shared<Queue>(*this, handle, family_index, queue_index, flags, queueFamilyProperties);
 }
 
-static std::vector<VkFormat> GetOpticalFlowFormats(const VkPhysicalDevice physical_device,
-                                                   const VkDataGraphOpticalFlowImageUsageFlagsARM usage) {
-    VkQueueFamilyDataGraphPropertiesARM data_graph_props = vku::InitStructHelper();
-    strcpy(data_graph_props.operation.name, "OpticalFlow");
+vvl::unordered_set<VkFormat> DeviceState::GetOpticalFlowFormats(const uint32_t queue_index,
+                                                                const VkPhysicalDeviceDataGraphProcessingEngineARM engine,
+                                                                const VkDataGraphOpticalFlowImageUsageFlagsARM usage) {
+    // make sure we have filled this in
+    assert(!physical_device_state->queue_family_data_graph_properties.empty());
 
     VkDataGraphOpticalFlowImageFormatInfoARM format_info = vku::InitStructHelper();
     format_info.usage = usage;
+    vvl::unordered_set<VkFormat> formats;  // set because we might have duplications between queue families
+    for (const auto& prop : physical_device_state->queue_family_data_graph_properties[queue_index]) {
+        if (prop.operation.operationType != VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM ||
+            prop.engine.type != engine.type || prop.engine.isForeign != engine.isForeign) {
+            continue;
+        }
 
-    uint32_t format_count = 0;
+        uint32_t format_count = 0;
+        [[maybe_unused]] VkResult result = DispatchGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+            physical_device, queue_index, &prop, &format_info, &format_count, nullptr);
+        assert(VK_SUCCESS == result);
+        std::vector<VkDataGraphOpticalFlowImageFormatPropertiesARM> format_properties(format_count,
+            vku::InitStruct<VkDataGraphOpticalFlowImageFormatPropertiesARM>());
+        result = DispatchGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
+            physical_device, queue_index, &prop, &format_info, &format_count, format_properties.data());
+        assert(VK_SUCCESS == result);
 
-    [[maybe_unused]] VkResult result = DispatchGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
-        physical_device, 0, &data_graph_props, &format_info, &format_count, nullptr);
-
-    assert(VK_SUCCESS == result);
-
-    std::vector<VkDataGraphOpticalFlowImageFormatPropertiesARM> format_properties(format_count);
-    for (auto& fmt_prop : format_properties) {
-        fmt_prop = vku::InitStructHelper();
+        for (auto& fp : format_properties) {
+            formats.insert(fp.format);
+        }
     }
-
-    result = DispatchGetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
-        physical_device, 0, &data_graph_props, &format_info, &format_count, format_properties.data());
-
-    assert(VK_SUCCESS == result);
-
-    std::vector<VkFormat> formats(format_properties.size());
-    for (size_t i = 0; i < format_properties.size(); ++i) {
-        formats[i] = format_properties[i].format;
-    }
-
     return formats;
 }
 
@@ -1247,10 +1246,11 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
         physical_device_count = 1;
     }
 
+    uint32_t num_queue_families = 0;
+    DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, nullptr);
+
     // Store queue family data
     if (pCreateInfo->pQueueCreateInfos != nullptr) {
-        uint32_t num_queue_families = 0;
-        DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, nullptr);
         std::vector<VkQueueFamilyProperties> queue_family_properties_list(num_queue_families);
         DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, queue_family_properties_list.data());
 
@@ -1364,22 +1364,66 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
     }
 
     if (IsExtEnabled(extensions.vk_arm_data_graph)) {
-        uint32_t n_families{0};
-        DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &n_families, nullptr);
-        for (uint32_t i = 0; i < n_families; i++) {
+        for (uint32_t i = 0; i < num_queue_families; i++) {
             std::vector<VkQueueFamilyDataGraphPropertiesARM> family_properties;
             uint32_t n_properties{0};
             DispatchGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(physical_device, i, &n_properties, nullptr);
             family_properties.resize(n_properties, vku::InitStruct<VkQueueFamilyDataGraphPropertiesARM>());
             DispatchGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(physical_device, i, &n_properties, family_properties.data());
-            queue_family_data_graph_properties.try_emplace(i, std::move(family_properties));
+            physical_device_state->queue_family_data_graph_properties.try_emplace(i, std::move(family_properties));
         }
     }
 
     if (IsExtEnabled(extensions.vk_arm_data_graph_optical_flow)) {
-        optical_flow_formats.input = GetOpticalFlowFormats(physical_device, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM);
-        optical_flow_formats.output = GetOpticalFlowFormats(physical_device, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM);
-        optical_flow_formats.cost = GetOpticalFlowFormats(physical_device, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM);
+        // VK_ARM_data_graph_optical_flow depends on VK_ARM_data_graph
+        assert(IsExtEnabled(extensions.vk_arm_data_graph));
+
+        // make sure we have filled this in
+        assert(!physical_device_state->queue_family_data_graph_properties.empty());
+
+        for (uint32_t i = 0; i < num_queue_families; i++) {
+            for (const auto& prop : physical_device_state->queue_family_data_graph_properties[i]) {
+                if (prop.operation.operationType != VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM) {
+                    continue;
+                }
+                VkQueueFamilyDataGraphOpticalFlowPropertiesARM op_flow_properties = vku::InitStructHelper();
+                VkBaseOutStructure* base_properties = reinterpret_cast<VkBaseOutStructure*>(&op_flow_properties);
+                DispatchGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(physical_device, i, &prop,
+                                                                                          base_properties);
+
+                vvl::PhysicalDevice::QueueAndEngine queue_and_engine{i, prop.engine};
+                physical_device_state->data_graph_optical_flow_properties.try_emplace(queue_and_engine, op_flow_properties);
+
+                physical_device_state->optical_flow_formats.input.try_emplace(
+                    queue_and_engine, GetOpticalFlowFormats(i, prop.engine, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM));
+                physical_device_state->optical_flow_formats.output.try_emplace(
+                    queue_and_engine, GetOpticalFlowFormats(i, prop.engine, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM));
+                physical_device_state->optical_flow_formats.cost.try_emplace(
+                    queue_and_engine, GetOpticalFlowFormats(i, prop.engine, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM));
+            }
+        }
+    }
+
+    if (IsExtEnabled(extensions.vk_arm_data_graph_instruction_set_tosa)) {
+        // VK_ARM_data_graph_instruction_set_tosa depends on VK_ARM_data_graph
+        assert(IsExtEnabled(extensions.vk_arm_data_graph));
+
+        // make sure we have filled this in
+        assert(!physical_device_state->queue_family_data_graph_properties.empty());
+
+        for (uint32_t i = 0; i < num_queue_families; i++) {
+            VkQueueFamilyDataGraphTOSAPropertiesARM tosa_properties = vku::InitStructHelper();
+            for (const auto& prop : physical_device_state->queue_family_data_graph_properties[i]) {
+                if (prop.operation.operationType !=
+                    VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM) {
+                    continue;
+                }
+                auto* base_properties = reinterpret_cast<VkBaseOutStructure*>(&tosa_properties);
+                DispatchGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(physical_device, i, &prop,
+                                                                                          base_properties);
+                physical_device_state->data_graph_tosa_properties.try_emplace({i, prop.engine}, tosa_properties);
+            }
+        }
     }
 
     if (IsExtEnabled(extensions.vk_ext_descriptor_heap) || IsExtEnabled(extensions.vk_ext_descriptor_buffer)) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1202,12 +1202,12 @@ vvl::unordered_set<VkFormat> DeviceState::GetOpticalFlowFormats(const uint32_t q
                                                                 const VkPhysicalDeviceDataGraphProcessingEngineARM engine,
                                                                 const VkDataGraphOpticalFlowImageUsageFlagsARM usage) {
     // make sure we have filled this in
-    assert(!physical_device_state->queue_family_data_graph_properties.empty());
+    assert(!physical_device_state->data_graph.queue_family_properties.empty());
 
     VkDataGraphOpticalFlowImageFormatInfoARM format_info = vku::InitStructHelper();
     format_info.usage = usage;
     vvl::unordered_set<VkFormat> formats;  // set because we might have duplications between queue families
-    for (const auto& prop : physical_device_state->queue_family_data_graph_properties[queue_index]) {
+    for (const auto& prop : physical_device_state->data_graph.queue_family_properties[queue_index]) {
         if (prop.operation.operationType != VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM ||
             prop.engine.type != engine.type || prop.engine.isForeign != engine.isForeign) {
             continue;
@@ -1370,7 +1370,7 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
             DispatchGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(physical_device, i, &n_properties, nullptr);
             family_properties.resize(n_properties, vku::InitStruct<VkQueueFamilyDataGraphPropertiesARM>());
             DispatchGetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(physical_device, i, &n_properties, family_properties.data());
-            physical_device_state->queue_family_data_graph_properties.try_emplace(i, std::move(family_properties));
+            physical_device_state->data_graph.queue_family_properties.try_emplace(i, std::move(family_properties));
         }
     }
 
@@ -1379,10 +1379,10 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
         assert(IsExtEnabled(extensions.vk_arm_data_graph));
 
         // make sure we have filled this in
-        assert(!physical_device_state->queue_family_data_graph_properties.empty());
+        assert(!physical_device_state->data_graph.queue_family_properties.empty());
 
         for (uint32_t i = 0; i < num_queue_families; i++) {
-            for (const auto& prop : physical_device_state->queue_family_data_graph_properties[i]) {
+            for (const auto& prop : physical_device_state->data_graph.queue_family_properties[i]) {
                 if (prop.operation.operationType != VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM) {
                     continue;
                 }
@@ -1391,14 +1391,16 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
                 DispatchGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(physical_device, i, &prop,
                                                                                           base_properties);
 
-                vvl::PhysicalDevice::QueueAndEngine queue_and_engine{i, prop.engine};
-                physical_device_state->data_graph_optical_flow_properties.try_emplace(queue_and_engine, op_flow_properties);
+                vvl::PhysicalDevice::DataGraph::QueueAndEngine queue_and_engine{i, prop.engine};
+                physical_device_state->data_graph.optical_flow_properties.try_emplace(queue_and_engine, op_flow_properties);
 
-                physical_device_state->optical_flow_formats.input.try_emplace(
+                vvl::PhysicalDevice::DataGraph::OpticalFlowFormats& of_formats =
+                    physical_device_state->data_graph.optical_flow_formats;
+                of_formats.input.try_emplace(
                     queue_and_engine, GetOpticalFlowFormats(i, prop.engine, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM));
-                physical_device_state->optical_flow_formats.output.try_emplace(
+                of_formats.output.try_emplace(
                     queue_and_engine, GetOpticalFlowFormats(i, prop.engine, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM));
-                physical_device_state->optical_flow_formats.cost.try_emplace(
+                of_formats.cost.try_emplace(
                     queue_and_engine, GetOpticalFlowFormats(i, prop.engine, VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM));
             }
         }
@@ -1409,11 +1411,11 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
         assert(IsExtEnabled(extensions.vk_arm_data_graph));
 
         // make sure we have filled this in
-        assert(!physical_device_state->queue_family_data_graph_properties.empty());
+        assert(!physical_device_state->data_graph.queue_family_properties.empty());
 
         for (uint32_t i = 0; i < num_queue_families; i++) {
             VkQueueFamilyDataGraphTOSAPropertiesARM tosa_properties = vku::InitStructHelper();
-            for (const auto& prop : physical_device_state->queue_family_data_graph_properties[i]) {
+            for (const auto& prop : physical_device_state->data_graph.queue_family_properties[i]) {
                 if (prop.operation.operationType !=
                     VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM) {
                     continue;
@@ -1421,7 +1423,7 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const
                 auto* base_properties = reinterpret_cast<VkBaseOutStructure*>(&tosa_properties);
                 DispatchGetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(physical_device, i, &prop,
                                                                                           base_properties);
-                physical_device_state->data_graph_tosa_properties.try_emplace({i, prop.engine}, tosa_properties);
+                physical_device_state->data_graph.tosa_properties.try_emplace({i, prop.engine}, tosa_properties);
             }
         }
     }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -2028,6 +2028,10 @@ class DeviceState : public vvl::BaseDevice {
     // Get device-specific canonical id for the provided set layout definition
     DescriptorSetLayoutId GetCanonicalId(const VkDescriptorSetLayoutCreateInfo* p_create_info);
 
+    vvl::unordered_set<VkFormat> GetOpticalFlowFormats(const uint32_t queue_index,
+                                                       const VkPhysicalDeviceDataGraphProcessingEngineARM engine,
+                                                       const VkDataGraphOpticalFlowImageUsageFlagsARM usage);
+
     // the VK_EXTERNAL_*_HANDLE_TYPE_OPAQUE_* handles are designed to created/exported in Vulkan, that means we can track the
     // values and compare when re-importing later. While FD and Win32 have differnt handles to access the struct, the information
     // needed is non-platform specific Vulkan values.
@@ -2079,14 +2083,6 @@ class DeviceState : public vvl::BaseDevice {
     std::vector<VkCooperativeMatrixFlexibleDimensionsPropertiesNV> cooperative_matrix_flexible_dimensions_properties;
 
     std::vector<VkCooperativeVectorPropertiesNV> cooperative_vector_properties_nv;
-
-    vvl::unordered_map<uint32_t, std::vector<VkQueueFamilyDataGraphPropertiesARM>> queue_family_data_graph_properties;
-
-    struct OpticalFlowFormatsARM {
-        std::vector<VkFormat> input;   // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM
-        std::vector<VkFormat> output;  // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM
-        std::vector<VkFormat> cost;    // VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM
-    } optical_flow_formats;
 
     // Features and properties that depend on platforms being defined
     // They will be false if platform is not defined

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -447,90 +447,70 @@ void DataGraphPipelineHelper::Destroy() {
 
 DataGraphPipelineHelper::~DataGraphPipelineHelper() { Destroy(); }
 
-namespace of {
-void OpticalFlowHelper::QueryOpticalFlowProperties() {
+std::optional<VkQueueFamilyDataGraphPropertiesARM> OpticalFlowHelper::GetOpticalFlowSupportProperty(VkLayerTest& test,
+                                                                                                      uint32_t queue_index) {
+    VkPhysicalDevice gpu = test.Gpu();
     uint32_t n_properties = 0;
-    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
-                              layer_test_.Gpu(), device_->graphics_queue_node_index_, &n_properties, nullptr));
+    [[maybe_unused]] VkResult result =
+        vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(gpu, queue_index, &n_properties, nullptr);
+    assert(VK_SUCCESS == result);
     std::vector<VkQueueFamilyDataGraphPropertiesARM> properties(n_properties,
                                                                 {VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_PROPERTIES_ARM});
-    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(
-                              layer_test_.Gpu(), device_->graphics_queue_node_index_, &n_properties, properties.data()));
+    result = vk::GetPhysicalDeviceQueueFamilyDataGraphPropertiesARM(gpu, queue_index, &n_properties, properties.data());
+    assert(VK_SUCCESS == result);
+
     for (uint32_t i = 0; i < n_properties; i++) {
-        if (properties[i].operation.operationType != VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM) {
-            continue;
+        if (properties[i].operation.operationType == VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM) {
+            return properties[i];
         }
-
-        VkQueueFamilyDataGraphOpticalFlowPropertiesARM properties_query = vku::InitStructHelper();
-        if (vk::GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
-                layer_test_.Gpu(), device_->graphics_queue_node_index_, &properties[i],
-                reinterpret_cast<VkBaseOutStructure*>(&properties_query)) != VK_SUCCESS) {
-            continue;
-        }
-
-        const VkDataGraphOpticalFlowGridSizeFlagsARM supported_grid_sizes =
-            properties_query.supportedOutputGridSizes & properties_query.supportedHintGridSizes;
-        if (!properties_query.hintSupported || supported_grid_sizes == VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM) {
-            continue;
-        }
-
-        for (const VkDataGraphOpticalFlowGridSizeFlagsARM grid_size :
-             {VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM, VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM,
-              VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM, VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM}) {
-            if (supported_grid_sizes & grid_size) {
-                optical_flow_grid_size_ = grid_size;
-                break;
-            }
-        }
-        break;
     }
+
+    return std::nullopt;
 }
 
-std::vector<VkFormat> OpticalFlowHelper::GetAllOpticalFlowFormats(VkDataGraphOpticalFlowImageUsageFlagsARM usage) {
-    VkQueueFamilyDataGraphPropertiesARM data_graph_props = vku::InitStructHelper();
-    strcpy(data_graph_props.operation.name, "OpticalFlow");
-
-    VkDataGraphOpticalFlowImageFormatInfoARM format_info = vku::InitStructHelper();
-    format_info.usage = usage;
-
-    uint32_t format_count = 0;
-
-    [[maybe_unused]] VkResult result = vk::GetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
-        layer_test_.Gpu(), 0, &data_graph_props, &format_info, &format_count, nullptr);
-
+VkQueueFamilyDataGraphOpticalFlowPropertiesARM OpticalFlowHelper::QueryOpticalFlowProperties(VkLayerTest& test,
+                                                                                             uint32_t queue_index) {
+    auto of_support_property = GetOpticalFlowSupportProperty(test, queue_index);
+    assert(std::nullopt != of_support_property);
+    VkQueueFamilyDataGraphOpticalFlowPropertiesARM properties_query = vku::InitStructHelper();
+    [[maybe_unused]] VkResult result = vk::GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+        test.Gpu(), queue_index, &of_support_property.value(), reinterpret_cast<VkBaseOutStructure*>(&properties_query));
     assert(VK_SUCCESS == result);
 
-    std::vector<VkDataGraphOpticalFlowImageFormatPropertiesARM> format_properties(format_count);
-    for (auto& fmt_prop : format_properties) {
-        fmt_prop = vku::InitStructHelper();
-    }
+    return properties_query;
+}
 
-    result = vk::GetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
-        layer_test_.Gpu(), 0, &data_graph_props, &format_info, &format_count, format_properties.data());
+VkDataGraphOpticalFlowGridSizeFlagBitsARM OpticalFlowHelper::GetAnyOpticalFlowGridSize(
+    VkQueueFamilyDataGraphOpticalFlowPropertiesARM properties, VkDataGraphOpticalFlowGridSizeFlagBitsARM first_size) {
+    // we need first_size to be a single bit, but enums don't enforce that
+    assert(first_size == VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM ||
+           first_size == VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM ||
+           first_size == VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM ||
+           first_size == VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM);
 
-    assert(VK_SUCCESS == result);
+    VkDataGraphOpticalFlowGridSizeFlagsARM supported_grid_sizes =
+        properties.supportedOutputGridSizes & properties.supportedHintGridSizes;
 
-    std::vector<VkFormat> formats(format_properties.size());
-    for (size_t i = 0; i < format_properties.size(); ++i) {
-        formats[i] = format_properties[i].format;
-    }
+    const auto first_size_mask = static_cast<VkDataGraphOpticalFlowGridSizeFlagsARM>(first_size);
+    const VkDataGraphOpticalFlowGridSizeFlagsARM eligible_grid_sizes =
+        (first_size_mask == 0) ? supported_grid_sizes : (supported_grid_sizes & ~(first_size_mask - 1));
 
-    return formats;
+    return (eligible_grid_sizes == 0)
+               ? VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM
+               : static_cast<VkDataGraphOpticalFlowGridSizeFlagBitsARM>(eligible_grid_sizes & (0u - eligible_grid_sizes));
 }
 
 VkFormat OpticalFlowHelper::GetAnyOpticalFlowFormat(VkDataGraphOpticalFlowImageUsageFlagsARM usage) {
-    VkQueueFamilyDataGraphPropertiesARM data_graph_props = vku::InitStructHelper();
-    strcpy(data_graph_props.operation.name, "OpticalFlow");
-
+    auto of_support_property = GetOpticalFlowSupportProperty(dg_pipeline_.layer_test_, queue_index_);
+    assert(std::nullopt != of_support_property);
     VkDataGraphOpticalFlowImageFormatInfoARM format_info = vku::InitStructHelper();
     format_info.usage = usage;
-
     VkDataGraphOpticalFlowImageFormatPropertiesARM format_properties = vku::InitStructHelper();
-
     uint32_t format_count = 1;
 
     VkResult result = vk::GetPhysicalDeviceQueueFamilyDataGraphOpticalFlowImageFormatsARM(
-        layer_test_.Gpu(), 0, &data_graph_props, &format_info, &format_count, &format_properties);
+        dg_pipeline_.layer_test_.Gpu(), queue_index_, &of_support_property.value(),
+        &format_info, &format_count, &format_properties);
 
     return result == VK_SUCCESS || result == VK_INCOMPLETE ? format_properties.format : VK_FORMAT_UNDEFINED;
 }
@@ -539,105 +519,168 @@ void OpticalFlowHelper::CreateOpticalFlow() {
     single_node_ci_ = vku::InitStructHelper();
     single_node_ci_.nodeType = VK_DATA_GRAPH_PIPELINE_NODE_TYPE_OPTICAL_FLOW_ARM;
 
+    params_.n_hints = optical_flow_properties_.hintSupported ? params_.n_hints : 0;
+    params_.n_costs = optical_flow_properties_.costSupported ? params_.n_costs : 0;
+
+    uint32_t kResourceCount = 0;
+    kResourceCount += params_.n_inputs;
+    kResourceCount += params_.n_references;
+    kResourceCount += params_.n_outputs;
+    kResourceCount += params_.n_hints;
+    kResourceCount += params_.n_costs;
     connections_.resize(kResourceCount, vku::InitStruct<VkDataGraphPipelineSingleNodeConnectionARM>());
 
-    connections_[0].set = 0;
-    connections_[0].binding = 0;
-    connections_[0].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_INPUT_ARM;
-    connections_[1].set = 0;
-    connections_[1].binding = 1;
-    connections_[1].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_REFERENCE_ARM;
-    connections_[2].set = 0;
-    connections_[2].binding = 2;
-    connections_[2].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_FLOW_VECTOR_ARM;
-    connections_[3].set = 0;
-    connections_[3].binding = 3;
-    connections_[3].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_HINT_ARM;
-    connections_[4].set = 0;
-    connections_[4].binding = 4;
-    connections_[4].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_COST_ARM;
+    uint32_t nc = 0;
+    for (uint32_t i = 0; i < params_.n_inputs; i++, nc++) {
+        connections_[nc].set = 0;
+        connections_[nc].binding = nc;
+        connections_[nc].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_INPUT_ARM;
+    }
+    for (uint32_t i = 0; i < params_.n_references; i++, nc++) {
+        connections_[nc].set = 0;
+        connections_[nc].binding = nc;
+        connections_[nc].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_REFERENCE_ARM;
+    }
+    for (uint32_t i = 0; i < params_.n_outputs; i++, nc++) {
+        connections_[nc].set = 0;
+        connections_[nc].binding = nc;
+        connections_[nc].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_FLOW_VECTOR_ARM;
+    }
+    for (uint32_t i = 0; i < params_.n_hints; i++, nc++) {
+        connections_[nc].set = 0;
+        connections_[nc].binding = nc;
+        connections_[nc].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_HINT_ARM;
+    }
+    for (uint32_t i = 0; i < params_.n_costs; i++, nc++) {
+        connections_[nc].set = 0;
+        connections_[nc].binding = nc;
+        connections_[nc].connection = VK_DATA_GRAPH_PIPELINE_NODE_CONNECTION_TYPE_OPTICAL_FLOW_COST_ARM;
+    }
 
     single_node_ci_.connectionCount = static_cast<uint32_t>(connections_.size());
     single_node_ci_.pConnections = connections_.data();
 
     optical_flow_ci_ = vku::InitStructHelper(&single_node_ci_);
+    optical_flow_ci_.flags = 0;
     optical_flow_ci_.height = params_.height;
     optical_flow_ci_.width = params_.width;
     optical_flow_ci_.imageFormat = GetAnyOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM);
     optical_flow_ci_.flowVectorFormat = GetAnyOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM);
-    optical_flow_ci_.costFormat = GetAnyOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM);
-    optical_flow_ci_.outputGridSize = params_.outputGridSize ? params_.outputGridSize : optical_flow_grid_size_;
-    optical_flow_ci_.hintGridSize = params_.hintGridSize ? params_.hintGridSize : optical_flow_grid_size_;
+    optical_flow_ci_.outputGridSize = params_.outputGridSize ? params_.outputGridSize
+        : static_cast<VkDataGraphOpticalFlowGridSizeFlagsARM>(GetAnyOpticalFlowGridSize(optical_flow_properties_));
+    optical_flow_ci_.hintGridSize = params_.hintGridSize ? params_.hintGridSize : optical_flow_ci_.outputGridSize;
+    if (optical_flow_properties_.hintSupported) {
+        optical_flow_ci_.flags |= VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM;
+    }
+    if (optical_flow_properties_.costSupported) {
+        optical_flow_ci_.costFormat = GetAnyOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM);
+        optical_flow_ci_.flags |= VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM;
+    }
     optical_flow_ci_.performanceLevel = VK_DATA_GRAPH_OPTICAL_FLOW_PERFORMANCE_LEVEL_MEDIUM_ARM;
-    optical_flow_ci_.flags =
-        VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM;
+}
+
+static uint32_t scaled_size(uint32_t in_size, VkDataGraphOpticalFlowGridSizeFlagsARM grid_size) {
+    switch (grid_size) {
+        case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM:
+            return in_size;
+        case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM:
+            return (in_size + 1) / 2;
+        case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM:
+            return (in_size + 3) / 4;
+        case VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM:
+            return (in_size + 7) / 8;
+    }
+    assert(false);
+    return UINT32_MAX;
 }
 
 void OpticalFlowHelper::SetupImageDescriptors() {
-    images_.resize(kResourceCount);
-
-    // Input
-    images_[0].Init(*device_, optical_flow_ci_.width, optical_flow_ci_.height, 1, optical_flow_ci_.imageFormat,
-                    VK_IMAGE_USAGE_SAMPLED_BIT);
-    images_[0].SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-
-    // Reference
-    images_[1].Init(*device_, optical_flow_ci_.width, optical_flow_ci_.height, 1, optical_flow_ci_.imageFormat,
-                    VK_IMAGE_USAGE_SAMPLED_BIT);
-    images_[1].SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-
-    // Flow (output)
-    images_[2].Init(*device_, optical_flow_ci_.width, optical_flow_ci_.height, 1, optical_flow_ci_.flowVectorFormat,
-                    VK_IMAGE_USAGE_STORAGE_BIT);
-    images_[2].SetLayout(VK_IMAGE_LAYOUT_GENERAL);
-
-    // Hint
-    images_[3].Init(*device_, optical_flow_ci_.width, optical_flow_ci_.height, 1, optical_flow_ci_.flowVectorFormat,
-                    VK_IMAGE_USAGE_SAMPLED_BIT);
-    images_[3].SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-
-    // Cost
-    images_[4].Init(*device_, optical_flow_ci_.width, optical_flow_ci_.height, 1, optical_flow_ci_.costFormat,
-                    VK_IMAGE_USAGE_STORAGE_BIT);
-    images_[4].SetLayout(VK_IMAGE_LAYOUT_GENERAL);
-
+    images_.resize(connections_.size());
     image_views_.resize(images_.size());
-    for (size_t i = 0; i < image_views_.size(); ++i) {
-        image_views_[i] = images_[i].CreateView();
+
+    // image size: hint
+    auto hint_w = scaled_size(optical_flow_ci_.width, optical_flow_ci_.hintGridSize);
+    auto hint_h = scaled_size(optical_flow_ci_.height, optical_flow_ci_.hintGridSize);
+    // output and cost
+    auto out_w = scaled_size(optical_flow_ci_.width, optical_flow_ci_.outputGridSize);
+    auto out_h = scaled_size(optical_flow_ci_.height, optical_flow_ci_.outputGridSize);
+
+    uint32_t nc = 0;
+    for (uint32_t i = 0; i < params_.n_inputs; i++, nc++) {
+        images_[nc].Init(*dg_pipeline_.device_, optical_flow_ci_.width, optical_flow_ci_.height, 1, optical_flow_ci_.imageFormat, VK_IMAGE_USAGE_SAMPLED_BIT);
+        images_[nc].SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        image_views_[nc] = images_[nc].CreateView();
+        dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(nc, image_views_[nc], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     }
 
-    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(0, image_views_[0], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(1, image_views_[1], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(2, image_views_[2], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                           VK_IMAGE_LAYOUT_GENERAL);
-    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(3, image_views_[3], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-    dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(4, image_views_[4], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
-                                                           VK_IMAGE_LAYOUT_GENERAL);
+    for (uint32_t i = 0; i < params_.n_references; i++, nc++) {
+        images_[nc].Init(*dg_pipeline_.device_, optical_flow_ci_.width, optical_flow_ci_.height, 1, optical_flow_ci_.imageFormat,
+                                VK_IMAGE_USAGE_SAMPLED_BIT);
+        images_[nc].SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        image_views_[nc] = images_[nc].CreateView();
+        dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(nc, image_views_[nc], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    }
+
+    for (uint32_t i = 0; i < params_.n_outputs; i++, nc++) {
+        images_[nc].Init(*dg_pipeline_.device_, out_w, out_h, 1, optical_flow_ci_.flowVectorFormat, VK_IMAGE_USAGE_STORAGE_BIT);
+        images_[nc].SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+        image_views_[nc] = images_[nc].CreateView();
+        dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(nc, image_views_[nc], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
+    }
+
+    for (uint32_t i = 0; i < params_.n_hints; i++, nc++) {
+        images_[nc].Init(*dg_pipeline_.device_, hint_w, hint_h, 1, optical_flow_ci_.flowVectorFormat, VK_IMAGE_USAGE_SAMPLED_BIT);
+        images_[nc].SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        image_views_[nc] = images_[nc].CreateView();
+        dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(nc, image_views_[nc], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    }
+
+    for (uint32_t i = 0; i < params_.n_costs; i++, nc++) {
+        images_[nc].Init(*dg_pipeline_.device_, out_w, out_h, 1, optical_flow_ci_.costFormat, VK_IMAGE_USAGE_STORAGE_BIT);
+        images_[nc].SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+        image_views_[nc] = images_[nc].CreateView();
+        dg_pipeline_.descriptor_set_->WriteDescriptorImageInfo(nc, image_views_[nc], VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
+                                                               VK_IMAGE_LAYOUT_GENERAL);
+    }
+
     dg_pipeline_.descriptor_set_->UpdateDescriptorSets();
 }
 
 void OpticalFlowHelper::InitDataGraphPipeline() {
-    dg_pipeline_.descriptor_set_layout_bindings_ = {
-        {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
-        {1, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
-        {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
-        {3, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
-        {4, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+
+    image_layouts_.resize(connections_.size(), vku::InitStruct<VkDataGraphPipelineResourceInfoImageLayoutARM>());
+    dg_pipeline_.descriptor_set_layout_bindings_.clear();
+    uint32_t nc = 0;
+    for (uint32_t i = 0; i < params_.n_inputs; i++, nc++) {
+        dg_pipeline_.descriptor_set_layout_bindings_.push_back(
+            {nc, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr});
+        image_layouts_[nc].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    }
+    for (uint32_t i = 0; i < params_.n_references; i++, nc++) {
+        dg_pipeline_.descriptor_set_layout_bindings_.push_back(
+            {nc, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr});
+        image_layouts_[nc].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    }
+    for (uint32_t i = 0; i < params_.n_outputs; i++, nc++) {
+        dg_pipeline_.descriptor_set_layout_bindings_.push_back(
+            {nc, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr});
+        image_layouts_[nc].layout = VK_IMAGE_LAYOUT_GENERAL;
+    }
+    for (uint32_t i = 0; i < params_.n_hints; i++, nc++) {
+        dg_pipeline_.descriptor_set_layout_bindings_.push_back(
+            {nc, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr});
+        image_layouts_[nc].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    };
+    for (uint32_t i = 0; i < params_.n_costs; i++, nc++) {
+        dg_pipeline_.descriptor_set_layout_bindings_.push_back(
+            {nc, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr});
+        image_layouts_[nc].layout = VK_IMAGE_LAYOUT_GENERAL;
     };
 
-    dg_pipeline_.descriptor_set_.reset(new OneOffDescriptorSet(device_, dg_pipeline_.descriptor_set_layout_bindings_));
-
+    dg_pipeline_.descriptor_set_.reset(new OneOffDescriptorSet(dg_pipeline_.device_, dg_pipeline_.descriptor_set_layout_bindings_));
     dg_pipeline_.CreatePipelineLayout();
 
-    image_layouts_.resize(kResourceCount, vku::InitStruct<VkDataGraphPipelineResourceInfoImageLayoutARM>());
-
-    image_layouts_[0].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    image_layouts_[1].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    image_layouts_[2].layout = VK_IMAGE_LAYOUT_GENERAL;
-    image_layouts_[3].layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    image_layouts_[4].layout = VK_IMAGE_LAYOUT_GENERAL;
-
-    dg_pipeline_.resources_.resize(kResourceCount);
+    dg_pipeline_.resources_.resize(image_layouts_.size());
     for (uint32_t i = 0; i < dg_pipeline_.resources_.size(); i++) {
         dg_pipeline_.resources_[i] = vku::InitStructHelper(&image_layouts_[i]);
         dg_pipeline_.resources_[i].descriptorSet = 0;
@@ -651,13 +694,12 @@ void OpticalFlowHelper::InitDataGraphPipeline() {
 
 VkResult OpticalFlowHelper::CreateDataGraphPipeline() { return dg_pipeline_.CreateDataGraphPipeline(); }
 
-OpticalFlowHelper::OpticalFlowHelper(VkLayerTest& test, const HelperParameters& params)
-    : params_(params), dg_pipeline_(test), layer_test_(test) {
-    device_ = layer_test_.DeviceObj();
-    QueryOpticalFlowProperties();
+OpticalFlowHelper::OpticalFlowHelper(VkLayerTest& test, const OfHelperParameters& params)
+    : params_(params), dg_pipeline_(test) {
+    queue_index_ = dg_pipeline_.layer_test_.DefaultQueue()->family_index;  // add to params_ if we ever need to change this
+    optical_flow_properties_ = QueryOpticalFlowProperties(test, queue_index_);
     CreateOpticalFlow();
     InitDataGraphPipeline();
 }
-}  // namespace of
 }  // namespace dg
 }  // namespace vkt

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -131,36 +131,41 @@ class DataGraphPipelineHelper {
     HelperParameters params_ = HelperParameters();
 };
 
-namespace of {
-struct HelperParameters {
+struct OfHelperParameters {
     uint32_t height = 100;
     uint32_t width = 100;
     VkDataGraphOpticalFlowGridSizeFlagsARM outputGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
     VkDataGraphOpticalFlowGridSizeFlagsARM hintGridSize = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    uint32_t n_inputs = 1;
+    uint32_t n_references = 1;
+    uint32_t n_outputs = 1;
+    uint32_t n_hints = 1;
+    uint32_t n_costs = 1;
 };
 
 class OpticalFlowHelper {
   private:
-    static constexpr uint32_t kResourceCount = 5u;
-    HelperParameters params_ = HelperParameters();
+    OfHelperParameters params_ = OfHelperParameters();
 
   public:
-    std::vector<VkDataGraphPipelineSingleNodeConnectionARM> connections_;
-    VkDataGraphPipelineSingleNodeCreateInfoARM single_node_ci_ = {};
-    VkDataGraphPipelineOpticalFlowCreateInfoARM optical_flow_ci_ = {};
-    VkDataGraphOpticalFlowGridSizeFlagsARM optical_flow_grid_size_ = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_ARM;
+    DataGraphPipelineHelper dg_pipeline_;
     std::vector<vkt::Image> images_;
     std::vector<vkt::ImageView> image_views_;
+    std::vector<VkDataGraphPipelineSingleNodeConnectionARM> connections_;
     std::vector<VkDataGraphPipelineResourceInfoImageLayoutARM> image_layouts_;
-    DataGraphPipelineHelper dg_pipeline_;
+    VkDataGraphPipelineOpticalFlowCreateInfoARM optical_flow_ci_{};
+    VkDataGraphPipelineSingleNodeCreateInfoARM single_node_ci_{};
+    VkQueueFamilyDataGraphOpticalFlowPropertiesARM optical_flow_properties_{};
+    uint32_t queue_index_ = 0;
 
-    VkLayerTest &layer_test_;
-    vkt::Device *device_ = nullptr;
+    explicit OpticalFlowHelper(VkLayerTest &test, const OfHelperParameters &params = OfHelperParameters());
 
-    explicit OpticalFlowHelper(VkLayerTest &test, const HelperParameters &params = HelperParameters());
-
-    void QueryOpticalFlowProperties();
-    std::vector<VkFormat> GetAllOpticalFlowFormats(VkDataGraphOpticalFlowImageUsageFlagsARM usage);
+    static std::optional<VkQueueFamilyDataGraphPropertiesARM> GetOpticalFlowSupportProperty(VkLayerTest &test,
+                                                                                              uint32_t queue_index);
+    static VkQueueFamilyDataGraphOpticalFlowPropertiesARM QueryOpticalFlowProperties(VkLayerTest &test, uint32_t queue_index);
+    static VkDataGraphOpticalFlowGridSizeFlagBitsARM GetAnyOpticalFlowGridSize(
+        VkQueueFamilyDataGraphOpticalFlowPropertiesARM properties,
+        VkDataGraphOpticalFlowGridSizeFlagBitsARM first_size = VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM);
     VkFormat GetAnyOpticalFlowFormat(VkDataGraphOpticalFlowImageUsageFlagsARM usage);
     void CreateOpticalFlow();
     void SetupImageDescriptors();
@@ -170,6 +175,5 @@ class OpticalFlowHelper {
     VkPipelineLayout PipelineLayout() const { return dg_pipeline_.pipeline_layout_; };
     const VkDescriptorSet* DescriptorSet() const { return &dg_pipeline_.descriptor_set_.get()->set_; };
 };
-}  // namespace of
 }  // namespace dg
 }  // namespace vkt

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -1475,21 +1475,52 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphPrope
 static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
     VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
     const VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties, VkBaseOutStructure* pProperties) {
-    if (pProperties->sType == VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_OPTICAL_FLOW_PROPERTIES_ARM) {
-        auto* properties = reinterpret_cast<VkQueueFamilyDataGraphOpticalFlowPropertiesARM*>(pProperties);
-        properties->supportedOutputGridSizes =
-            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM |
-            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM;
-        properties->supportedHintGridSizes =
-            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM |
-            VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM;
-        properties->hintSupported = VK_TRUE;
-        properties->costSupported = VK_TRUE;
-        properties->minWidth = 10;
-        properties->minHeight = 10;
-        properties->maxWidth = 10000;
-        properties->maxHeight = 10000;
+
+    if (pQueueFamilyDataGraphProperties->engine.type == VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM &&
+        pQueueFamilyDataGraphProperties->engine.isForeign == false) {
+
+        // ARM engine properties per operation type
+        const char *op_flow_operation_name = "OpticalFlow";
+        const char *tosa_operation_name = "TOSA";
+
+        if (pQueueFamilyDataGraphProperties->operation.operationType == VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_OPTICAL_FLOW_ARM &&
+            strncmp(pQueueFamilyDataGraphProperties->operation.name, op_flow_operation_name, strlen(op_flow_operation_name)) == 0 &&
+            pProperties->sType == VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_OPTICAL_FLOW_PROPERTIES_ARM) {
+
+            auto* pOpticalFlowProperties = reinterpret_cast<VkQueueFamilyDataGraphOpticalFlowPropertiesARM*>(pProperties);
+            pOpticalFlowProperties->supportedOutputGridSizes =
+                VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM |
+                VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM;
+            pOpticalFlowProperties->supportedHintGridSizes =
+                VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_1X1_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_2X2_BIT_ARM |
+                VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_4X4_BIT_ARM | VK_DATA_GRAPH_OPTICAL_FLOW_GRID_SIZE_8X8_BIT_ARM;
+            pOpticalFlowProperties->hintSupported = VK_TRUE;
+            pOpticalFlowProperties->costSupported = VK_TRUE;
+            pOpticalFlowProperties->minWidth = 10;
+            pOpticalFlowProperties->minHeight = 10;
+            pOpticalFlowProperties->maxWidth = 10000;
+            pOpticalFlowProperties->maxHeight = 10000;
+        } else if (pQueueFamilyDataGraphProperties->operation.operationType == VK_PHYSICAL_DEVICE_DATA_GRAPH_OPERATION_TYPE_SPIRV_EXTENDED_INSTRUCTION_SET_ARM &&
+            strncmp(pQueueFamilyDataGraphProperties->operation.name, tosa_operation_name, strlen(tosa_operation_name)) == 0 &&
+            pProperties->sType == VK_STRUCTURE_TYPE_QUEUE_FAMILY_DATA_GRAPH_TOSA_PROPERTIES_ARM) {
+
+            auto *pTOSAProperties = reinterpret_cast<VkQueueFamilyDataGraphTOSAPropertiesARM *>(pProperties);
+            static constexpr VkDataGraphTOSANameQualityARM graphTOSANameQualityProfiles[] = {
+                { "PRO-INT", VK_DATA_GRAPH_TOSA_QUALITY_CONFORMANT_ARM },
+                { "PRO-FP", VK_DATA_GRAPH_TOSA_QUALITY_CONFORMANT_ARM },
+            };
+            pTOSAProperties->profileCount = static_cast<uint32_t>(std::size(graphTOSANameQualityProfiles));
+            pTOSAProperties->pProfiles = graphTOSANameQualityProfiles;
+            pTOSAProperties->extensionCount = 0;
+            pTOSAProperties->pExtensions = nullptr;
+            pTOSAProperties->level = VK_DATA_GRAPH_TOSA_LEVEL_8K_ARM;
+        }
+    } else if (pQueueFamilyDataGraphProperties->engine.type == VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_COMPUTE_QCOM) {
+        // TODO: add properties for this processing engine
+    } else if (pQueueFamilyDataGraphProperties->engine.type == VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_NEURAL_QCOM) {
+        // TODO: add properties for this processing engine
     }
+
     return VK_SUCCESS;
 }
 
@@ -1498,42 +1529,54 @@ static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceQueueFamilyDataGraphOptic
     const VkQueueFamilyDataGraphPropertiesARM* pQueueFamilyDataGraphProperties,
     const VkDataGraphOpticalFlowImageFormatInfoARM* pOpticalFlowImageFormatInfo, uint32_t* pFormatCount,
     VkDataGraphOpticalFlowImageFormatPropertiesARM* pImageFormatProperties) {
-    switch (pOpticalFlowImageFormatInfo->usage) {
-        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM: {
-            static constexpr std::array<VkFormat, 6> input_formats = {
-                VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8_UNORM,
-                VK_FORMAT_B8G8R8_UNORM,   VK_FORMAT_R8_UNORM,       VK_FORMAT_B10G11R11_UFLOAT_PACK32,
-            };
-            if (pImageFormatProperties != nullptr) {
-                for (uint32_t i = 0; i < *pFormatCount; ++i) {
-                    pImageFormatProperties[i].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
-                    pImageFormatProperties[i].format = input_formats[i];
+
+    if (pQueueFamilyDataGraphProperties->engine.type == VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_DEFAULT_ARM &&
+        pQueueFamilyDataGraphProperties->engine.isForeign == false) {
+
+        switch (pOpticalFlowImageFormatInfo->usage) {
+            case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_INPUT_BIT_ARM: {
+                static constexpr std::array<VkFormat, 6> input_formats = {
+                    VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8_UNORM,
+                    VK_FORMAT_B8G8R8_UNORM,   VK_FORMAT_R8_UNORM,       VK_FORMAT_B10G11R11_UFLOAT_PACK32,
+                };
+                if (pImageFormatProperties != nullptr) {
+                    for (uint32_t i = 0; i < *pFormatCount; ++i) {
+                        pImageFormatProperties[i].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+                        pImageFormatProperties[i].format = input_formats[i];
+                    }
+                } else {
+                    *pFormatCount = static_cast<uint32_t>(input_formats.size());
                 }
-            } else {
-                *pFormatCount = static_cast<uint32_t>(input_formats.size());
+                break;
             }
-            break;
+            case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM:
+            case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_HINT_BIT_ARM:
+                if (pImageFormatProperties != nullptr) {
+                    pImageFormatProperties[0].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+                    pImageFormatProperties[0].format = VK_FORMAT_R16G16_SFLOAT;
+                } else {
+                    *pFormatCount = 1;
+                }
+                break;
+            case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM:
+                if (pImageFormatProperties != nullptr) {
+                    pImageFormatProperties[0].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
+                    pImageFormatProperties[0].format = VK_FORMAT_R16_UINT;
+                } else {
+                    *pFormatCount = 1;
+                }
+                break;
+            default:
+                break;
         }
-        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_OUTPUT_BIT_ARM:
-        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_HINT_BIT_ARM:
-            if (pImageFormatProperties != nullptr) {
-                pImageFormatProperties[0].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
-                pImageFormatProperties[0].format = VK_FORMAT_R16G16_SFLOAT;
-            } else {
-                *pFormatCount = 1;
-            }
-            break;
-        case VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM:
-            if (pImageFormatProperties != nullptr) {
-                pImageFormatProperties[0].sType = VK_STRUCTURE_TYPE_DATA_GRAPH_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_ARM;
-                pImageFormatProperties[0].format = VK_FORMAT_R16_UINT;
-            } else {
-                *pFormatCount = 1;
-            }
-            break;
-        default:
-            break;
+    } else if (pQueueFamilyDataGraphProperties->engine.type == VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_COMPUTE_QCOM) {
+        // TODO: add formats sopported by this processing engine. Currently none
+        *pFormatCount = 0;
+    } else if (pQueueFamilyDataGraphProperties->engine.type == VK_PHYSICAL_DEVICE_DATA_GRAPH_PROCESSING_ENGINE_TYPE_NEURAL_QCOM) {
+        // TODO: add formats sopported by this processing engine. Currently none
+        *pFormatCount = 0;
     }
+
     return VK_SUCCESS;
 }
 

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -1538,7 +1538,7 @@ TEST_F(NegativeDataGraph, ResourceInfoImageLayoutsNoUnifiedImageLayouts) {
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
     // Need to create a data graph with image resources instead of the usual tensors, so use optical flow.
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     /* Fail to chain a VkDataGraphPipelineResourceInfoImageLayoutARM structure. Since the unifiedImageLayouts feature is not
      * enabled this is invalid usage. */
     optical_flow.dg_pipeline_.resources_[0].pNext = nullptr;
@@ -2329,8 +2329,10 @@ TEST_F(NegativeDataGraph, CmdDispatchWrongQueue) {
     }
 
     if (UINT32_MAX == queue_without_tosa_1_0_idx) {
-        GTEST_SKIP() << "All queues support TOSA, impossible to create the error condition, skip.";
+        GTEST_SKIP() << "All the queues support TOSA, impossible to create the error condition, skip.";
     }
+
+    // TODO: use queue with index queue_without_tosa_1_0_idx
 
     vkt::dg::DataGraphPipelineHelper pipeline(*this);
     pipeline.CreateDataGraphPipeline();
@@ -2363,7 +2365,7 @@ TEST_F(NegativeDataGraph, OpticalFlowWrongImageFormat) {
 
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
 
     /* Set an unsupported imageFormat. ASTC are block formats, incompatible with optical flow operations. */
     optical_flow.optical_flow_ci_.imageFormat = VK_FORMAT_ASTC_4x4_UNORM_BLOCK;
@@ -2378,7 +2380,7 @@ TEST_F(NegativeDataGraph, OpticalFlowWrongFlowVectorFormat) {
 
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
 
     /* Set an unsupported flowVectorFormat. ASTC are block formats, incompatible with optical flow operations. */
     optical_flow.optical_flow_ci_.flowVectorFormat = VK_FORMAT_ASTC_4x4_UNORM_BLOCK;
@@ -2393,8 +2395,12 @@ TEST_F(NegativeDataGraph, OpticalFlowWrongCostFormat) {
 
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    auto opt_flow_properties = vkt::dg::OpticalFlowHelper::QueryOpticalFlowProperties(*this, DefaultQueue()->family_index);
+    if (!opt_flow_properties.costSupported) {
+        GTEST_SKIP() << "Cost not supported, skip.";
+    }
 
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     /* Set an unsupported costFormat. ASTC are block formats, incompatible with optical flow operations. */
     optical_flow.optical_flow_ci_.costFormat = VK_FORMAT_ASTC_4x4_UNORM_BLOCK;
 
@@ -2407,7 +2413,12 @@ TEST_F(NegativeDataGraph, OpticalFlowWrongHint) {
     TEST_DESCRIPTION("Execute optical flow with a wrong meanFlowL1NormHint value");
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    auto opt_flow_properties = vkt::dg::OpticalFlowHelper::QueryOpticalFlowProperties(*this, DefaultQueue()->family_index);
+    if (!opt_flow_properties.hintSupported) {
+        GTEST_SKIP() << "Hint not supported, skip.";
+    }
+
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     optical_flow.CreateDataGraphPipeline();
     optical_flow.SetupImageDescriptors();
 
@@ -2439,7 +2450,7 @@ TEST_F(NegativeDataGraph, OpticalFlowWrongHint) {
 TEST_F(NegativeDataGraph, OpticalFlowNoCacheSession) {
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     optical_flow.CreateDataGraphPipeline();
     optical_flow.SetupImageDescriptors();
 
@@ -2511,7 +2522,7 @@ TEST_F(NegativeDataGraph, OpticalFlowDispatchWithoutOpticalFlowCreateInfo) {
 TEST_F(NegativeDataGraph, OpticalFlowConnectionsImageLayoutsNoUnifiedImageLayouts) {
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     // Set the resource info image layout to VK_IMAGE_LAYOUT_GENERAL, where the connection references a descriptor in the
     // VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL layout. Since unifiedImageLayouts feature is not enabled this is invalid usage.
     optical_flow.image_layouts_[0].layout = VK_IMAGE_LAYOUT_GENERAL;
@@ -2548,7 +2559,7 @@ TEST_F(NegativeDataGraph, OpticalFlowConnectionsImageLayoutsUnifiedImageLayouts)
     AddRequiredFeature(vkt::Feature::unifiedImageLayouts);
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     // Set the resource info image layout to VK_IMAGE_LAYOUT_UNDEFINED, where the connection references a descriptor in the
     // VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL layout.
     optical_flow.image_layouts_[0].layout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -2578,4 +2589,162 @@ TEST_F(NegativeDataGraph, OpticalFlowConnectionsImageLayoutsUnifiedImageLayouts)
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.End();
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowMissingOpticalFlowCreateInfo) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph without a VkDataGraphPipelineOpticalFlowCreateInfoARM structure");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
+
+    // pipeline_ci_.pNext points to optical_flow_ci_: skip one link to remove it from the chain
+    optical_flow.dg_pipeline_.pipeline_ci_.pNext = optical_flow.optical_flow_ci_.pNext;
+
+    m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09963");
+    ASSERT_EQ(VK_ERROR_VALIDATION_FAILED, optical_flow.dg_pipeline_.CreateDataGraphPipeline());
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowWrongNumberOfInputs) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with a missing or too many input connections");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    for (uint32_t n : {0, 2}) {
+        vkt::dg::OfHelperParameters params;
+        params.n_inputs = n;
+        vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+
+        m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09978");
+        ASSERT_EQ(VK_ERROR_VALIDATION_FAILED, optical_flow.dg_pipeline_.CreateDataGraphPipeline());
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowWrongNumberOfReferences) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with a missing or too many reference connections");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    for (uint32_t n : {0, 2}) {
+        vkt::dg::OfHelperParameters params;
+        params.n_references = n;
+        vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+
+        m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09978");
+        ASSERT_EQ(VK_ERROR_VALIDATION_FAILED, optical_flow.dg_pipeline_.CreateDataGraphPipeline());
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowWrongNumberOfOutputs) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with a missing or too many output connections");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    for (uint32_t n : {0, 2}) {
+        vkt::dg::OfHelperParameters params;
+        params.n_outputs = n;
+        vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+
+        m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09978");
+        ASSERT_EQ(VK_ERROR_VALIDATION_FAILED, optical_flow.dg_pipeline_.CreateDataGraphPipeline());
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowWrongNumberOfHints) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph with hintGridSize > 0 but missing or too many hint connections");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    uint32_t queue_index = DefaultQueue()->family_index;
+
+    auto opt_flow_properties = vkt::dg::OpticalFlowHelper::QueryOpticalFlowProperties(*this, queue_index);
+    if (!opt_flow_properties.hintSupported) {
+        GTEST_SKIP() << "Hint not supported, skip.";
+    }
+    uint32_t hint_grid_size = vkt::dg::OpticalFlowHelper::GetAnyOpticalFlowGridSize(opt_flow_properties);
+
+    for (uint32_t n : {0, 2}) {
+        vkt::dg::OfHelperParameters params;
+        params.n_hints = n;  // force the wrong number of hint images
+        params.hintGridSize = hint_grid_size;
+        vkt::dg::OpticalFlowHelper optical_flow(*this, params);
+
+        m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineSingleNodeCreateInfoARM-nodeType-09979");
+        ASSERT_EQ(VK_ERROR_VALIDATION_FAILED, optical_flow.dg_pipeline_.CreateDataGraphPipeline());
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowNoHint) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph using a hint image but the feature is not supported");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    uint32_t n_queue_families;
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &n_queue_families, nullptr);
+    uint32_t no_hint_index = UINT32_MAX;
+    for (uint32_t qfi = 0; qfi < n_queue_families; qfi++) {
+        auto of_support_property = vkt::dg::OpticalFlowHelper::GetOpticalFlowSupportProperty(*this, qfi);
+        if (std::nullopt == of_support_property) {
+            continue;
+        }
+
+        VkQueueFamilyDataGraphOpticalFlowPropertiesARM op_flow_properties = vku::InitStructHelper();
+        ASSERT_EQ(VK_SUCCESS,
+                  vk::GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+                      Gpu(), qfi, &of_support_property.value(), reinterpret_cast<VkBaseOutStructure*>(&op_flow_properties)));
+        if (!op_flow_properties.hintSupported) {
+            no_hint_index = qfi;
+            break;
+        }
+    }
+    if (UINT32_MAX == no_hint_index) {
+        GTEST_SKIP() << "All the queues support optical flow hint, impossible to create the error condition, skip.";
+    }
+
+    // TODO: use queue with index no_hint_index
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
+
+    // force the hint flag
+    optical_flow.optical_flow_ci_.flags |= VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_HINT_BIT_ARM;
+
+    m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-flags-09974");
+    ASSERT_EQ(VK_ERROR_VALIDATION_FAILED, optical_flow.CreateDataGraphPipeline());
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDataGraph, OpticalFlowNoCost) {
+    TEST_DESCRIPTION("Try to create an optical flow datagraph using a cost image but the feature is not supported");
+    RETURN_IF_SKIP(InitBasicDataGraph(true));
+
+    uint32_t n_queue_families;
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &n_queue_families, nullptr);
+    uint32_t no_cost_index = UINT32_MAX;
+    for (uint32_t qfi = 0; qfi < n_queue_families; qfi++) {
+        auto of_support_property = vkt::dg::OpticalFlowHelper::GetOpticalFlowSupportProperty(*this, qfi);
+        if (std::nullopt == of_support_property) {
+            continue;
+        }
+
+        VkQueueFamilyDataGraphOpticalFlowPropertiesARM op_flow_properties = vku::InitStructHelper();
+        ASSERT_EQ(VK_SUCCESS,
+                  vk::GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM(
+                      Gpu(), qfi, &of_support_property.value(), reinterpret_cast<VkBaseOutStructure*>(&op_flow_properties)));
+        if (!op_flow_properties.costSupported) {
+            no_cost_index = qfi;
+            break;
+        }
+    }
+    if (UINT32_MAX == no_cost_index) {
+        GTEST_SKIP() << "All the queues support optical flow cost, impossible to create the error condition, skip.";
+    }
+
+    // TODO: use queue with index no_cost_index
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
+
+    // force the cost flag, and also a format to avoid 9970
+    optical_flow.optical_flow_ci_.flags |= VK_DATA_GRAPH_OPTICAL_FLOW_CREATE_ENABLE_COST_BIT_ARM;
+    optical_flow.optical_flow_ci_.costFormat = optical_flow.GetAnyOpticalFlowFormat(VK_DATA_GRAPH_OPTICAL_FLOW_IMAGE_USAGE_COST_BIT_ARM);
+
+    m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineOpticalFlowCreateInfoARM-flags-09975");
+    ASSERT_EQ(VK_ERROR_VALIDATION_FAILED, optical_flow.CreateDataGraphPipeline());
+    m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -310,7 +310,7 @@ TEST_F(PositiveDataGraph, ResourceInfoImageLayoutsUnifiedImageLayouts) {
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
     // Need to create a data graph with image resources instead of the usual tensors, so use optical flow.
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     /* Fail to chain a VkDataGraphPipelineResourceInfoImageLayoutARM structure. Since the unifiedImageLayouts feature is enabled
      * this is valid usage. */
     optical_flow.dg_pipeline_.resources_[0].pNext = nullptr;
@@ -342,7 +342,7 @@ TEST_F(PositiveDataGraph, OpticalFlow) {
     TEST_DESCRIPTION("Execute a datagraph with an optical flow node");
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     optical_flow.CreateDataGraphPipeline();
     optical_flow.SetupImageDescriptors();
 
@@ -377,7 +377,7 @@ TEST_F(PositiveDataGraph, OpticalFlowConnectionsImageLayoutsUnifiedImageLayouts)
     AddRequiredFeature(vkt::Feature::unifiedImageLayouts);
     RETURN_IF_SKIP(InitBasicDataGraph(true));
 
-    vkt::dg::of::OpticalFlowHelper optical_flow(*this);
+    vkt::dg::OpticalFlowHelper optical_flow(*this);
     optical_flow.image_layouts_[0].layout = VK_IMAGE_LAYOUT_GENERAL;
     optical_flow.CreateDataGraphPipeline();
     optical_flow.SetupImageDescriptors();


### PR DESCRIPTION
includes general "framework" changes for optical flow:
- fix GetPhysicalDeviceQueueFamilyDataGraphEngineOperationPropertiesARM in test_icd.cpp to check pQueueFamilyDataGraphProperties and also return TOSA properties
- cache optical flow formats and properties per (queue,engine) in physycal device initialization
- OpticalFlowHelper:
  - methods for optical flow properties and formats
  - skip hint and cost images if feature unsupported
  - allow changing number of images per connection type