### PR TITLE
sync: Validate layout transition of unused attachment

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -60,7 +60,6 @@ namespace core {
 class CommandBufferSubState;
 }  // namespace core
 
-struct SubpassLayout;
 struct SemaphoreSubmitState;
 struct LastBound;
 struct ShaderStageState;

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -273,7 +273,9 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
         for (uint32_t attachment = 0; attachment < attachment_count; ++attachment) {
             const VkImageLayout final_layout = rp.create_info.pAttachments[attachment].finalLayout;
             const uint32_t last_transition_subpass = get_last_subpass(last[attachment]);
-            if (last_transition_subpass != VK_SUBPASS_EXTERNAL && final_layout != attachment_layout[attachment]) {
+            if (final_layout != attachment_layout[attachment]) {
+                // NOTE: If last_transition_subpass is VK_SUBPASS_EXTERNAL, the attachment is unused.
+                // The spec still requires its initialLayout -> finalLayout transition.
                 auto& final_transitions = subpass_transitions[rp.create_info.subpassCount];
                 final_transitions.emplace_back(vvl::RenderPass::AttachmentTransition{last_transition_subpass, attachment,
                                                                                      attachment_layout[attachment], final_layout});

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -198,16 +198,18 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
         for (uint32_t j = 0; j < count; j++) {
             const auto attachment = attach_ref[j].attachment;
             if (attachment != VK_ATTACHMENT_UNUSED) {
-                const auto layout = attach_ref[j].layout;
-                const auto initial_layout = rp.create_info.pAttachments[attachment].initialLayout;
+                const VkImageLayout layout = attach_ref[j].layout;
+                const VkImageLayout initial_layout = rp.create_info.pAttachments[attachment].initialLayout;
                 bool no_external_transition = true;
 
                 // Initial transition
                 bool first_transition = true;
-                for (uint32_t subpass_per_view : first[attachment]) {
+                const vvl::RenderPass::SubpassPerView& first_subpass_per_view = first[attachment];
+                for (uint32_t first_subpass : first_subpass_per_view) {
                     // Check if earlier or this subpass already registered transition
-                    if (subpass_per_view != VK_SUBPASS_EXTERNAL) {
-                        assert(subpass_per_view <= subpass);
+                    // (first state is updated at the end of this iteration)
+                    if (first_subpass != VK_SUBPASS_EXTERNAL) {
+                        assert(first_subpass <= subpass);
                         first_transition = false;
                         break;
                     }
@@ -269,7 +271,7 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
         // Final transitions
         const uint32_t attachment_count = rp.create_info.attachmentCount;
         for (uint32_t attachment = 0; attachment < attachment_count; ++attachment) {
-            const auto final_layout = rp.create_info.pAttachments[attachment].finalLayout;
+            const VkImageLayout final_layout = rp.create_info.pAttachments[attachment].finalLayout;
             const uint32_t last_transition_subpass = get_last_subpass(last[attachment]);
             if (last_transition_subpass != VK_SUBPASS_EXTERNAL && final_layout != attachment_layout[attachment]) {
                 auto& final_transitions = subpass_transitions[rp.create_info.subpassCount];

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -62,11 +62,6 @@ struct SubpassDependencyInfo {
     VkSubpassDependency2 implicit_barrier_to_external;
 };
 
-struct SubpassLayout {
-    uint32_t index;
-    VkImageLayout layout;
-};
-
 namespace vvl {
 
 // Vulkan 1.0 has a VkRenderPass object, things like dynamic rendering moved the handle to be across various other structs/calls.

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1112,14 +1112,14 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext& cb_contex
     // More broadly we could look at thread specific state shared between Validate and Record as is done for other heavyweight
     // operations (though it's currently a messy approach)
     const AttachmentViewGenVector view_gens = RenderPassAccessContext::CreateAttachmentViewGen(render_area, attachments_);
-    skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_area,
-                                                               render_pass_instance_id, subpass, view_mask, view_gens, command_);
+    skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_pass_instance_id, subpass,
+                                                               view_mask, view_gens, command_);
 
     // Validate load operations if there were no layout transition hazards
     if (!skip) {
         RenderPassAccessContext::RecordLayoutTransitions(rp_state, subpass, view_gens, kInvalidTag, temp_context);
-        skip |= RenderPassAccessContext::ValidateLoadOperation(cb_context, temp_context, rp_state, render_area,
-                                                               render_pass_instance_id, subpass, view_mask, view_gens, command_);
+        skip |= RenderPassAccessContext::ValidateLoadOperation(cb_context, temp_context, rp_state, render_pass_instance_id, subpass,
+                                                               view_mask, view_gens, command_);
     }
 
     return skip;

--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -774,24 +774,33 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
     // to apply and only copy then, if this proves a hot spot.
     std::unique_ptr<AccessContext> proxy_for_current;
 
+    const AccessContext* context = nullptr;
+
     // Validate the "finalLayout" transitions to external
     // Get them from where there we're hidding in the extra entry.
     const auto& final_transitions = rp_state_->subpass_transitions.back();
     for (const auto& transition : final_transitions) {
+        SyncBarrier merged_barrier;
         const auto& view_gen = attachment_views_[transition.attachment];
-        const SubpassBarrier& subpass_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
-        const AccessContext* context = subpass_barrier.src_subpass_context;
-
-        if (transition.src_subpass == current_subpass_) {
-            if (!proxy_for_current) {
-                // We haven't recorded resolve ofor the current_subpass, so we need to copy current and update it *as if*
-                proxy_for_current.reset(CreateStoreResolveProxy());
+        if (transition.src_subpass != VK_SUBPASS_EXTERNAL) {
+            const SubpassBarrier& subpass_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
+            merged_barrier = SyncBarrier(subpass_barrier.barriers);
+            if (transition.src_subpass != current_subpass_) {
+                context = subpass_barrier.src_subpass_context;
+            } else {
+                if (!proxy_for_current) {
+                    // We haven't recorded resolve ofor the current_subpass, so we need to copy current and update it *as if*
+                    proxy_for_current.reset(CreateStoreResolveProxy());
+                }
+                context = proxy_for_current.get();
             }
-            context = proxy_for_current.get();
+        } else {
+            context = external_context_;
+            // NOTE: Unused attachments still transition from initialLayout to finalLayout, but no
+            // subpass uses them, so there is no external subpass dependency barrier to merge.
         }
 
         // Use the merged barrier for the hazard check (safe since it just considers the src (first) scope.
-        const SyncBarrier merged_barrier(subpass_barrier.barriers);
         auto hazard = context->DetectImageBarrierHazard(view_gen, merged_barrier, AccessContext::DetectOptions::kDetectPrevious);
         if (hazard.IsHazard()) {
             const SyncValidator& sync_state = cb_context.GetSyncState();
@@ -896,6 +905,7 @@ RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass& rp_state
                                                  const AccessContext& external_context, uint32_t render_pass_instance_id)
     : rp_state_(&rp_state),
       attachment_views_(CreateAttachmentViewGen(render_area, attachment_views)),
+      external_context_(&external_context),
       subpass_contexts_(InitSubpassContexts(queue_flags, rp_state, external_context)),
       render_pass_instance_id_(render_pass_instance_id),
       current_subpass_(0) {}
@@ -953,9 +963,6 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext* external_contex
     const auto& final_transitions = rp_state_->subpass_transitions.back();
     for (const auto& transition : final_transitions) {
         const AttachmentViewGen& view_gen = attachment_views_[transition.attachment];
-        const SubpassBarrier& dst_external_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
-        assert(&subpass_contexts_[transition.src_subpass] == dst_external_barrier.src_subpass_context);
-
         ImageRangeGen range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kViewSubresource);
 
         ImageRangeGen markup_range_gen = range_gen;  // second copy, preserve range_gen to use later
@@ -963,10 +970,21 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext* external_contex
         external_context->UpdateMemoryAccessState(markup_action, markup_range_gen);
 
         PendingBarriers pending_barriers;
-        for (const auto& barrier : dst_external_barrier.barriers) {
-            const BarrierScope barrier_scope(barrier);
-            CollectBarriersFunctor collect_barriers(*external_context, barrier_scope, barrier, true, vvl::kNoIndex32,
-                                                    pending_barriers);
+        if (transition.src_subpass != VK_SUBPASS_EXTERNAL) {
+            const SubpassBarrier& dst_external_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
+            assert(&subpass_contexts_[transition.src_subpass] == dst_external_barrier.src_subpass_context);
+            for (const auto& barrier : dst_external_barrier.barriers) {
+                const BarrierScope barrier_scope(barrier);
+                CollectBarriersFunctor collect_barriers(*external_context, barrier_scope, barrier, true, vvl::kNoIndex32,
+                                                        pending_barriers);
+                external_context->UpdateMemoryAccessState(collect_barriers, range_gen);
+            }
+        } else {
+            // Unused attachments still transition from initialLayout to finalLayout, but no subpass
+            // uses them, so record the transition without applying a subpass dependency barrier.
+            const SyncBarrier empty_barrier;
+            CollectBarriersFunctor collect_barriers(*external_context, BarrierScope(empty_barrier), empty_barrier, true,
+                                                    vvl::kNoIndex32, pending_barriers);
             external_context->UpdateMemoryAccessState(collect_barriers, range_gen);
         }
         pending_barriers.Apply(transition_tag);

--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -165,8 +165,7 @@ static AccessContext* CreateStoreResolveProxyContext(const AccessContext& contex
 // Layout transitions are handled as if the were occuring in the beginning of the next subpass
 bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAccessContext& cb_context,
                                                         const AccessContext& access_context, const vvl::RenderPass& rp_state,
-                                                        const VkRect2D& render_area, uint32_t render_pass_instance_id,
-                                                        uint32_t subpass, uint32_t view_mask,
+                                                        uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
                                                         const AttachmentViewGenVector& attachment_views, vvl::Func command) {
     bool skip = false;
     // As validation methods are const and precede the record/update phase, for any tranistions from the immediately
@@ -232,9 +231,8 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
 
 bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessContext& cb_context,
                                                     const AccessContext& access_context, const vvl::RenderPass& rp_state,
-                                                    const VkRect2D& render_area, uint32_t render_pass_instance_id, uint32_t subpass,
-                                                    uint32_t view_mask, const AttachmentViewGenVector& attachment_views,
-                                                    vvl::Func command) {
+                                                    uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
+                                                    const AttachmentViewGenVector& attachment_views, vvl::Func command) {
     bool skip = false;
 
     AttachmentAccess attachment_access;
@@ -738,7 +736,7 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
     }
     const uint32_t next_subpass_view_mask = rp_state_->create_info.pSubpasses[next_subpass].viewMask;
     const auto& next_context = subpass_contexts_[next_subpass];
-    skip |= ValidateLayoutTransitions(cb_context, next_context, *rp_state_, render_area_, render_pass_instance_id_, next_subpass,
+    skip |= ValidateLayoutTransitions(cb_context, next_context, *rp_state_, render_pass_instance_id_, next_subpass,
                                       next_subpass_view_mask, attachment_views_, command);
     if (!skip) {
         // To avoid complex (and buggy) duplication of the affect of layout transitions on load operations, we'll record them
@@ -747,7 +745,7 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
         AccessContext temp_context(cb_context.GetSyncState());
         temp_context.InitFrom(next_context);
         RecordLayoutTransitions(*rp_state_, next_subpass, attachment_views_, kInvalidTag, temp_context);
-        skip |= ValidateLoadOperation(cb_context, temp_context, *rp_state_, render_area_, render_pass_instance_id_, next_subpass,
+        skip |= ValidateLoadOperation(cb_context, temp_context, *rp_state_, render_pass_instance_id_, next_subpass,
                                       next_subpass_view_mask, attachment_views_, command);
     }
     return skip;
@@ -897,7 +895,6 @@ RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass& rp_state
                                                  const std::vector<const vvl::ImageView*>& attachment_views,
                                                  const AccessContext& external_context, uint32_t render_pass_instance_id)
     : rp_state_(&rp_state),
-      render_area_(render_area),
       attachment_views_(CreateAttachmentViewGen(render_area, attachment_views)),
       subpass_contexts_(InitSubpassContexts(queue_flags, rp_state, external_context)),
       render_pass_instance_id_(render_pass_instance_id),

--- a/layers/sync/sync_render_pass.h
+++ b/layers/sync/sync_render_pass.h
@@ -90,7 +90,8 @@ class RenderPassAccessContext {
   public:
     static AttachmentViewGenVector CreateAttachmentViewGen(const VkRect2D& render_area,
                                                            const std::vector<const vvl::ImageView*>& attachment_views);
-    RenderPassAccessContext() : rp_state_(nullptr), render_pass_instance_id_(vvl::kNoIndex32), current_subpass_(0) {}
+    RenderPassAccessContext()
+        : rp_state_(nullptr), external_context_(nullptr), render_pass_instance_id_(vvl::kNoIndex32), current_subpass_(0) {}
     RenderPassAccessContext(const vvl::RenderPass& rp_state, const VkRect2D& render_area, VkQueueFlags queue_flags,
                             const std::vector<const vvl::ImageView*>& attachment_views, const AccessContext& external_context,
                             uint32_t render_pass_instance_id);
@@ -148,6 +149,7 @@ private:
   private:
     const vvl::RenderPass *rp_state_;
     const AttachmentViewGenVector attachment_views_;
+    const AccessContext* external_context_;
     const std::unique_ptr<AccessContext[]> subpass_contexts_;
     const uint32_t render_pass_instance_id_;
     uint32_t current_subpass_;

--- a/layers/sync/sync_render_pass.h
+++ b/layers/sync/sync_render_pass.h
@@ -88,23 +88,20 @@ using AttachmentViewGenVector = std::vector<AttachmentViewGen>;
 
 class RenderPassAccessContext {
   public:
-    static AttachmentViewGenVector CreateAttachmentViewGen(const VkRect2D &render_area,
-                                                           const std::vector<const vvl::ImageView *> &attachment_views);
-    RenderPassAccessContext()
-        : rp_state_(nullptr), render_area_(VkRect2D()), render_pass_instance_id_(vvl::kNoIndex32), current_subpass_(0) {}
-    RenderPassAccessContext(const vvl::RenderPass &rp_state, const VkRect2D &render_area, VkQueueFlags queue_flags,
-                            const std::vector<const vvl::ImageView *> &attachment_views, const AccessContext &external_context,
+    static AttachmentViewGenVector CreateAttachmentViewGen(const VkRect2D& render_area,
+                                                           const std::vector<const vvl::ImageView*>& attachment_views);
+    RenderPassAccessContext() : rp_state_(nullptr), render_pass_instance_id_(vvl::kNoIndex32), current_subpass_(0) {}
+    RenderPassAccessContext(const vvl::RenderPass& rp_state, const VkRect2D& render_area, VkQueueFlags queue_flags,
+                            const std::vector<const vvl::ImageView*>& attachment_views, const AccessContext& external_context,
                             uint32_t render_pass_instance_id);
 
-    static bool ValidateLayoutTransitions(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
-                                          const vvl::RenderPass &rp_state, const VkRect2D &render_area,
-                                          uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
-                                          const AttachmentViewGenVector &attachment_views, vvl::Func command);
+    static bool ValidateLayoutTransitions(const CommandBufferAccessContext& cb_context, const AccessContext& access_context,
+                                          const vvl::RenderPass& rp_state, uint32_t render_pass_instance_id, uint32_t subpass,
+                                          uint32_t view_mask, const AttachmentViewGenVector& attachment_views, vvl::Func command);
 
-    static bool ValidateLoadOperation(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
-                                      const vvl::RenderPass &rp_state, const VkRect2D &render_area,
-                                      uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
-                                      const AttachmentViewGenVector &attachment_views, vvl::Func command);
+    static bool ValidateLoadOperation(const CommandBufferAccessContext& cb_context, const AccessContext& access_context,
+                                      const vvl::RenderPass& rp_state, uint32_t render_pass_instance_id, uint32_t subpass,
+                                      uint32_t view_mask, const AttachmentViewGenVector& attachment_views, vvl::Func command);
 
     bool ValidateStoreOperation(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
     bool ValidateResolveOperations(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
@@ -150,7 +147,6 @@ private:
 
   private:
     const vvl::RenderPass *rp_state_;
-    const VkRect2D render_area_;
     const AttachmentViewGenVector attachment_views_;
     const std::unique_ptr<AccessContext[]> subpass_contexts_;
     const uint32_t render_pass_instance_id_;

--- a/tests/unit/sync_val_render_pass.cpp
+++ b/tests/unit/sync_val_render_pass.cpp
@@ -688,6 +688,67 @@ TEST_F(NegativeSyncValRenderPass, FinalLayoutTransitionHazard) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeSyncValRenderPass, UnusedAttachmentFinalLayoutTransitionHazard) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5179");
+    RETURN_IF_SKIP(InitSyncVal());
+
+    vkt::Buffer buffer(*m_device, 32 * 32 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE);
+    rp.CreateRenderPass();
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {32, 32, 1};
+
+    m_command_buffer.Begin();
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32);
+
+    // The attachment is not referenced by the subpass, so loadOp/storeOp are ignored.
+    // The final layout transition from initialLayout to finalLayout still executes and
+    // hazards with the previous copy.
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    m_command_buffer.EndRenderPass();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeSyncValRenderPass, UnusedAttachmentFinalLayoutTransitionRecorded) {
+    TEST_DESCRIPTION("Test that unused attachment final layout transition is recorded");
+    RETURN_IF_SKIP(InitSyncVal());
+
+    vkt::Buffer buffer(*m_device, 32 * 32 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE);
+    rp.CreateRenderPass();
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {32, 32, 1};
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32);
+    m_command_buffer.EndRenderPass();
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeSyncValRenderPass, MultiviewSameView) {
     TEST_DESCRIPTION("Two async subpasses render to the same view");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/sync_val_render_pass_positive.cpp
+++ b/tests/unit/sync_val_render_pass_positive.cpp
@@ -1289,3 +1289,55 @@ TEST_F(PositiveSyncValRenderPass, MultiviewStoreOpSubpassSelection) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }
+
+TEST_F(PositiveSyncValRenderPass, UnusedAttachmentFinalLayoutTransitionSubmit) {
+    TEST_DESCRIPTION("Unused attachment layout transition as the first access of a submitted command buffer");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    vkt::Buffer buffer(*m_device, 32 * 32 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView();
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE);
+    rp.CreateRenderPass();
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {32, 32, 1};
+
+    VkImageMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    barrier.dstAccessMask = VK_ACCESS_2_MEMORY_READ_BIT | VK_ACCESS_2_MEMORY_WRITE_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.image = image;
+    barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    vkt::CommandBuffer cb0(*m_device, m_command_pool);
+    cb0.Begin();
+    vk::CmdCopyBufferToImage(cb0, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+    // Guard the unused attachment's layout transition in the next command buffer
+    cb0.Barrier(barrier);
+    cb0.End();
+
+    // The unused attachment's final layout transition is the FIRST access to the image
+    // in this command buffer, so submit-time validation replays it as a first access.
+    vkt::CommandBuffer cb1(*m_device, m_command_pool);
+    cb1.Begin();
+    cb1.BeginRenderPass(rp, framebuffer, 32, 32);
+    cb1.EndRenderPass();
+    cb1.End();
+
+    m_default_queue->Submit({cb0, cb1});
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5179

There is a submit-time validation gap for final layout transitions (I have a repro test) and it will be addressed separately (likely a general case and not related to a specific scenario of unused attachments we handle in this PR).