### PR TITLE
sync: Fix submit-time validation of final layout transition

### DIFF
--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -27,15 +27,6 @@ namespace vvl {
 class ImageView;
 }  // namespace vvl
 
-static inline uint32_t GetSubpassDepthStencilAttachmentIndex(const vku::safe_VkPipelineDepthStencilStateCreateInfo *pipe_ds_ci,
-                                                             const vku::safe_VkAttachmentReference2 *depth_stencil_ref) {
-    uint32_t depth_stencil_attachment = VK_ATTACHMENT_UNUSED;
-    if (pipe_ds_ci && depth_stencil_ref) {
-        depth_stencil_attachment = depth_stencil_ref->attachment;
-    }
-    return depth_stencil_attachment;
-}
-
 struct SubpassDependencyInfo {
     // For dependencies between subpasses this is a dstSubpass.
     // For external dependencies this can be either srcSubpass or dstSubpass
@@ -130,7 +121,6 @@ class RenderPass : public StateObject {
     explicit RenderPass(const VkRenderingInfo& rendering_info);
     // vkBeginCommandBuffer (dynamic rendering in secondary commadn buffer)
     explicit RenderPass(VkCommandBufferInheritanceRenderingInfo const *pInheritanceRenderingInfo);
-
     // vkCreateGraphicsPipelines (dynamic rendering state tied to pipeline state)
     explicit RenderPass(const VkPipelineRenderingCreateInfo& rendering_ci);
 

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1215,18 +1215,21 @@ ResourceUsageTag SyncOpEndRenderPass::Record(CommandBufferAccessContext* cb_cont
 }
 
 bool SyncOpEndRenderPass::ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const {
-    // Any store/resolve operations happen before the EndRenderPass tag so we can ignore them
-    // Only the layout transitions happen at the replay tag
+    // The record_tag is the final layout transition. Any store/resolve operations happen before
+    // the EndRenderPass tag so we can ignore them here.
+    //
+    // The final layout transition is recorded in command buffer context (not render pass context).
+    // Do a render pass cleanup. This also switches replay to command buffer context where we can
+    // validate layout transition.
+    CommandExecutionContext& exec_context = replay.GetExecutionContext();
+    assert(exec_context.Handle().type == kVulkanObjectTypeQueue);  // not allowed in secondary command buffers
+    auto& batch_context = static_cast<QueueBatchContext&>(exec_context);
+    batch_context.EndRenderPassReplayCleanup(replay);
+
+    // Validate final layout transition
     ResourceUsageRange first_use_range = {recorded_tag, recorded_tag + 1};
     bool skip = false;
     skip |= replay.DetectFirstUseHazard(first_use_range);
-
-    // We can cleanup here as the recorded tag represents the final layout transition (which is the last operation or the RP)
-    CommandExecutionContext& exec_context = replay.GetExecutionContext();
-    // this operation is not allowed in secondary command buffers
-    assert(exec_context.Handle().type == kVulkanObjectTypeQueue);
-    auto& batch_context = static_cast<QueueBatchContext&>(exec_context);
-    batch_context.EndRenderPassReplayCleanup(replay);
 
     return skip;
 }

--- a/layers/sync/sync_render_pass.cpp
+++ b/layers/sync/sync_render_pass.cpp
@@ -566,6 +566,11 @@ void RenderPassAccessContext::RecordLayoutTransitions(const vvl::RenderPass& rp_
     }
 }
 
+static uint32_t GetSubpassDepthStencilAttachmentIndex(const vku::safe_VkPipelineDepthStencilStateCreateInfo* pipe_ds_ci,
+                                                      const vku::safe_VkAttachmentReference2* depth_stencil_ref) {
+    return (pipe_ds_ci && depth_stencil_ref) ? depth_stencil_ref->attachment : VK_ATTACHMENT_UNUSED;
+}
+
 bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferAccessContext& cb_context, vvl::Func command) const {
     bool skip = false;
     const vvl::CommandBuffer& cmd_buffer = cb_context.GetCBState();

--- a/tests/unit/sync_val_render_pass.cpp
+++ b/tests/unit/sync_val_render_pass.cpp
@@ -749,6 +749,92 @@ TEST_F(NegativeSyncValRenderPass, UnusedAttachmentFinalLayoutTransitionRecorded)
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeSyncValRenderPass, UnusedAttachmentFinalLayoutTransitionSubmitHazard) {
+    TEST_DESCRIPTION("Submit-time validation detects unused attachment final layout transition hazards");
+    RETURN_IF_SKIP(InitSyncVal());
+
+    vkt::Buffer buffer(*m_device, 32 * 32 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+    vkt::ImageView image_view = image.CreateView();
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE);
+    rp.CreateRenderPass();
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {32, 32, 1};
+
+    vkt::CommandBuffer write_cb(*m_device, m_command_pool);
+    write_cb.Begin();
+    vk::CmdCopyBufferToImage(write_cb, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+    write_cb.End();
+
+    vkt::CommandBuffer render_pass_cb(*m_device, m_command_pool);
+    render_pass_cb.Begin();
+    render_pass_cb.BeginRenderPass(rp, framebuffer, 32, 32);
+    render_pass_cb.EndRenderPass();
+    render_pass_cb.End();
+
+    m_default_queue->Submit(write_cb);
+
+    // The attachment is not referenced by any subpass, so the only access in this command
+    // buffer is the final layout transition from initialLayout to finalLayout
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    m_default_queue->Submit(render_pass_cb);
+    m_errorMonitor->VerifyFound();
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeSyncValRenderPass, FinalLayoutTransitionSubmitHazard) {
+    TEST_DESCRIPTION("Submit-time validation detects final layout transition hazards");
+    SetTargetApiVersion(VK_API_VERSION_1_4);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    vkt::Buffer buffer(*m_device, 32 * 32 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+    vkt::ImageView image_view = image.CreateView();
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                VK_ATTACHMENT_LOAD_OP_NONE, VK_ATTACHMENT_STORE_OP_NONE);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.CreateRenderPass();
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {32, 32, 1};
+
+    vkt::CommandBuffer write_cb(*m_device, m_command_pool);
+    write_cb.Begin();
+    vk::CmdCopyBufferToImage(write_cb, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+    write_cb.End();
+
+    vkt::CommandBuffer render_pass_cb(*m_device, m_command_pool);
+    render_pass_cb.Begin();
+    render_pass_cb.BeginRenderPass(rp, framebuffer, 32, 32);
+    render_pass_cb.EndRenderPass();
+    render_pass_cb.End();
+
+    m_default_queue->Submit(write_cb);
+
+    // The attachment is referenced by the subpass, but loadOp/storeOp are NONE,
+    // so the only access in this command buffer is the final layout transition.
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    m_default_queue->Submit(render_pass_cb);
+    m_errorMonitor->VerifyFound();
+    m_default_queue->Wait();
+}
+
 TEST_F(NegativeSyncValRenderPass, MultiviewSameView) {
     TEST_DESCRIPTION("Two async subpasses render to the same view");
     SetTargetApiVersion(VK_API_VERSION_1_1);


### PR DESCRIPTION
Follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12662. Fix submit-time validation of render pass final layout transitions.
  
Final layout transitions are recorded in the command buffer context, but submit-time validation checked them while still using the render pass context. Because of that, hazards were missed. This changes the order: first clean up render pass replay, then validate the final layout transition.

Claude endorsement 🎖️:
> Reviewed — this is the submit-time gap fix, and it's correct and pleasingly minimal