### PR TITLE
gpuav: Deduplicate Heap instrumentation in unsafe mode

### DIFF
--- a/layers/gpuav/spirv/descriptor_heap_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_heap_pass.cpp
@@ -401,23 +401,32 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
         }
     }
 
-    // If there is a sampler, we have another descriptor at this spot we need to validate
-    if (!is_seperate_sampler && meta.access_path.HasSampler() && !meta.has_embedded_sampler) {
-        const uint32_t valid_image = function_result;
-        uint32_t valid_sampler = 0;
-        if (meta.access_path.is_combined_image_sampler) {
-            assert(mapping);  // not allowed with untyped pointers
-            valid_sampler = CreateFunctionCallCombinedSampler(block, inst_it, meta, *mapping, descriptor_index_id);
-        } else {
-            valid_sampler = CreateFunctionCall(block, inst_it, meta, true);
-        }
+    return function_result;
+}
 
-        if (module_.settings_.safe_mode) {
-            function_result = module_.TakeNextId();
-            block.CreateInstruction(spv::OpLogicalAnd, {bool_type, function_result, valid_image, valid_sampler}, inst_it);
-        }
+// If there is a sampler, we have another descriptor at this spot we need to validate
+uint32_t DescriptorHeapPass::CreateFunctionCallSampler(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta,
+                                                       uint32_t non_sampler_result) {
+    uint32_t valid_sampler = 0;
+    if (meta.access_path.is_combined_image_sampler) {
+        assert(meta.mapping_ptr);  // not allowed with untyped pointers
+        valid_sampler =
+            CreateFunctionCallCombinedSampler(block, inst_it, meta, *meta.mapping_ptr, meta.access_path.descriptor_index_id);
+    } else {
+        valid_sampler = CreateFunctionCall(block, inst_it, meta, true);
     }
 
+    // This is just a dumb hack around iterators, for samplers we call a second function
+    if (inst_it && meta.access_path.HasSampler()) {
+        inst_it++;
+    }
+
+    uint32_t function_result = 0;
+    if (module_.settings_.safe_mode) {
+        const uint32_t bool_type = type_manager_.GetTypeBool().Id();
+        function_result = module_.TakeNextId();
+        block.CreateInstruction(spv::OpLogicalAnd, {bool_type, function_result, non_sampler_result, valid_sampler}, inst_it);
+    }
     return function_result;
 }
 
@@ -425,10 +434,12 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
 uint32_t DescriptorHeapPass::CreateFunctionCallCombinedSampler(BasicBlock& block, InstructionIt* inst_it,
                                                                const InstructionMeta& meta,
                                                                const VkDescriptorSetAndBindingMappingEXT& mapping,
-                                                               const uint32_t descriptor_index_id) {
+                                                               uint32_t descriptor_index_id) {
     const uint32_t inst_position = meta.target_instruction->GetPositionOffset();
     const uint32_t inst_position_id = type_manager_.CreateConstantUInt32(inst_position).Id();
     const uint32_t is_sampler_id = type_manager_.GetConstantBool(true).Id();
+
+    descriptor_index_id = CastToUint32(descriptor_index_id, block, inst_it);  // might be int32
 
     uint32_t desc_encoding_id = 0;
     const uint32_t desc_size_value = (uint32_t)descriptor_heap_props.samplerDescriptorSize;
@@ -573,11 +584,13 @@ bool DescriptorHeapPass::RequiresInstrumentation(const Function& function, const
         }
     };
 
+    bool has_embedded_sampler = false;
     if (meta.mapping_ptr_sampler) {
-        meta.has_embedded_sampler = GetEmbeddedSampler(*meta.mapping_ptr_sampler) != nullptr;
+        has_embedded_sampler = GetEmbeddedSampler(*meta.mapping_ptr_sampler) != nullptr;
     } else if (meta.mapping_ptr) {
-        meta.has_embedded_sampler = GetEmbeddedSampler(*meta.mapping_ptr) != nullptr;
+        has_embedded_sampler = GetEmbeddedSampler(*meta.mapping_ptr) != nullptr;
     }
+    meta.instrument_seperate_sampler = meta.access_path.HasSampler() && !has_embedded_sampler;
 
     if (meta.mapping_index_resource == glsl::kInst_DescriptorHeap_MappingIndexUntyped) {
         const Type* descriptor_array = nullptr;
@@ -603,52 +616,79 @@ bool DescriptorHeapPass::RequiresInstrumentation(const Function& function, const
     return true;
 }
 
-// TODO - hash seperatly for Samplers
-uint32_t DescriptorHeapPass::InstructionMeta::Hash(const uint32_t descriptor_index) const {
+uint32_t DescriptorHeapPass::InstructionMeta::Hash(const uint32_t descriptor_index, VkDescriptorType vk_type) const {
     const uint32_t source_id = mapping_ptr ? (uint32_t)mapping_ptr->source : 0;
-    const uint32_t desc_type = (uint32_t)access_path.descriptor_type;
-    ;
+    const uint32_t desc_type = (uint32_t)vk_type;
 
+    uint32_t hash = 0;
     if (mapping_index_resource == glsl::kInst_DescriptorHeap_MappingIndexUntyped) {
         uint32_t hash_content[4] = {desc_type, descriptor_index, untyped_heap_offset_id, untyped_array_stride_id};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
         const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping_ptr->sourceData.constantOffset;
         uint32_t hash_content[5] = {source_id, desc_type, descriptor_index, map_data.heapOffset, map_data.heapArrayStride};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 5);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 5);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
         const VkDescriptorMappingSourcePushIndexEXT& map_data = mapping_ptr->sourceData.pushIndex;
         uint32_t hash_content[7] = {
             source_id,           desc_type,          descriptor_index, map_data.heapOffset, map_data.heapArrayStride,
             map_data.heapOffset, map_data.pushOffset};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 7);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 7);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
         const VkDescriptorMappingSourceIndirectIndexEXT& map_data = mapping_ptr->sourceData.indirectIndex;
         uint32_t hash_content[8] = {
             source_id,           desc_type,           descriptor_index,      map_data.heapOffset, map_data.heapArrayStride,
             map_data.heapOffset, map_data.pushOffset, map_data.addressOffset};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 8);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 8);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
         const VkDescriptorMappingSourceIndirectIndexArrayEXT& map_data = mapping_ptr->sourceData.indirectIndexArray;
         uint32_t hash_content[7] = {source_id,           desc_type,           descriptor_index,      map_data.heapOffset,
                                     map_data.heapOffset, map_data.pushOffset, map_data.addressOffset};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 7);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 7);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT) {
         const VkDescriptorMappingSourceHeapDataEXT& map_data = mapping_ptr->sourceData.heapData;
         uint32_t hash_content[4] = {source_id, desc_type, map_data.heapOffset, map_data.pushOffset};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT) {
         uint32_t hash_content[3] = {source_id, desc_type, mapping_ptr->sourceData.pushDataOffset};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 3);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 3);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT) {
         uint32_t hash_content[3] = {source_id, desc_type, mapping_ptr->sourceData.pushAddressOffset};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 3);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 3);
     } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT) {
         const VkDescriptorMappingSourceIndirectAddressEXT& map_data = mapping_ptr->sourceData.indirectAddress;
         uint32_t hash_content[4] = {source_id, desc_type, map_data.pushOffset, map_data.addressOffset};
-        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
+        hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
     }
-    return 0;
+
+    if (access_path.is_combined_image_sampler) {
+        if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
+            const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping_ptr->sourceData.constantOffset;
+            uint32_t hash_content[3] = {hash, map_data.samplerHeapOffset, map_data.samplerHeapArrayStride};
+            hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 3);
+        } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
+            const VkDescriptorMappingSourcePushIndexEXT& map_data = mapping_ptr->sourceData.pushIndex;
+            uint32_t hash_content[5] = {hash, map_data.samplerHeapOffset, map_data.samplerHeapArrayStride,
+                                        map_data.samplerHeapOffset, map_data.samplerPushOffset};
+            hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 5);
+        } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
+            const VkDescriptorMappingSourceIndirectIndexEXT& map_data = mapping_ptr->sourceData.indirectIndex;
+            uint32_t hash_content[6] = {hash,
+                                        map_data.samplerHeapOffset,
+                                        map_data.samplerHeapArrayStride,
+                                        map_data.samplerHeapOffset,
+                                        map_data.samplerPushOffset,
+                                        map_data.samplerAddressOffset};
+            hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 6);
+        } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
+            const VkDescriptorMappingSourceIndirectIndexArrayEXT& map_data = mapping_ptr->sourceData.indirectIndexArray;
+            uint32_t hash_content[5] = {hash, map_data.samplerHeapOffset, map_data.samplerHeapOffset, map_data.samplerPushOffset,
+                                        map_data.samplerAddressOffset};
+            hash = hash_util::Hash32(hash_content, sizeof(uint32_t) * 5);
+        }
+    }
+
+    return hash;
 }
 
 bool DescriptorHeapPass::Instrument() {
@@ -686,12 +726,27 @@ bool DescriptorHeapPass::Instrument() {
                 if (!RequiresInstrumentation(function, *(inst_it->get()), meta)) {
                     continue;
                 }
+
+                bool skip_resource = false;
+                bool skip_sampler = !meta.instrument_seperate_sampler;
                 if (!module_.settings_.safe_mode) {
                     const uint32_t hash_descriptor_index_id = pc_access.next_alias_id == meta.access_path.descriptor_index_id
                                                                   ? pc_access.descriptor_index_id
                                                                   : meta.access_path.descriptor_index_id;
-                    const uint32_t hash = meta.Hash(hash_descriptor_index_id);
-                    if (hash != 0 && function_duplicate_tracker.FindAndUpdate(block_duplicate_tracker, hash)) {
+                    const uint32_t resource_hash = meta.Hash(hash_descriptor_index_id, meta.access_path.descriptor_type);
+                    if (resource_hash != 0 && function_duplicate_tracker.FindAndUpdate(block_duplicate_tracker, resource_hash)) {
+                        skip_resource = true;
+                    }
+
+                    if (meta.instrument_seperate_sampler) {
+                        const uint32_t sampler_hash =
+                            meta.Hash(meta.access_path.sampler_descriptor_index_id, VK_DESCRIPTOR_TYPE_SAMPLER);
+                        if (sampler_hash != 0 && function_duplicate_tracker.FindAndUpdate(block_duplicate_tracker, sampler_hash)) {
+                            skip_sampler = true;
+                        }
+                    }
+
+                    if (skip_resource && skip_sampler) {
                         continue;  // duplicate detected
                     }
                 }
@@ -702,14 +757,19 @@ bool DescriptorHeapPass::Instrument() {
                 instrumentations_count_++;
 
                 if (!module_.settings_.safe_mode) {
-                    CreateFunctionCall(current_block, &inst_it, meta, false);
-                    // This is just a dumb hack around iterators, for samplers we call a second function
-                    if (meta.access_path.HasSampler()) {
-                        inst_it++;
+                    if (!skip_resource) {
+                        CreateFunctionCall(current_block, &inst_it, meta, false);
+                    }
+                    if (!skip_sampler) {
+                        CreateFunctionCallSampler(current_block, &inst_it, meta, 0);
                     }
                 } else {
                     InjectConditionalData ic_data = InjectFunctionPre(function, block_it, inst_it);
                     ic_data.function_result_id = CreateFunctionCall(current_block, nullptr, meta, false);
+                    if (meta.instrument_seperate_sampler) {
+                        ic_data.function_result_id =
+                            CreateFunctionCallSampler(current_block, nullptr, meta, ic_data.function_result_id);
+                    }
                     InjectFunctionPost(current_block, ic_data);
                     // Skip the newly added valid and invalid block. Start searching again from newly split merge block
                     block_it++;

--- a/layers/gpuav/spirv/descriptor_heap_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_heap_pass.cpp
@@ -208,7 +208,7 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
     const uint32_t inst_position_id = type_manager_.CreateConstantUInt32(inst_position).Id();
     const uint32_t is_sampler_id = type_manager_.GetConstantBool(is_seperate_sampler).Id();
 
-    const VkDescriptorSetAndBindingMappingEXT* mapping = nullptr;
+    const VkDescriptorSetAndBindingMappingEXT* mapping = is_seperate_sampler ? meta.mapping_ptr_sampler : meta.mapping_ptr;
 
     // We try and encode a lot of information in a single uint32_t
     uint32_t desc_encoding_id = 0;
@@ -222,8 +222,6 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
         assert(desc_alignment_shift <= glsl::kInst_DescriptorHeap_AlignmentShiftMask);
 
         const uint32_t mapping_index_encoded = is_seperate_sampler ? meta.mapping_index_sampler : meta.mapping_index_resource;
-        const bool is_untyped = mapping_index_encoded == glsl::kInst_DescriptorHeap_MappingIndexUntyped;
-        mapping = is_untyped ? nullptr : &module_.out_status.device.heap_mappings[mapping_index_encoded].mapping_data;
 
         const uint32_t desc_encoding = (desc_type_mask << glsl::kInst_DescriptorHeap_DescriptorTypeShift) |
                                        (desc_size_value << glsl::kInst_DescriptorHeap_DescriptorSizeShift) |
@@ -241,30 +239,16 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
     const uint32_t binding_offset = mapping ? descriptor_variable.interface_.binding - mapping->firstBinding : 0;
     const bool combined_index = meta.access_path.is_combined_image_sampler && mapping && HasCombinedImageSamplerIndex(*mapping);
 
-    bool has_embedded_sampler = false;
     if (!mapping) {
         assert(descriptor_variable.interface_.IsHeap());  // Untyped
-        uint32_t heap_offset_id = 0;
-        const Type* descriptor_array = nullptr;
-        if (meta.access_path.pointer_type->spv_type_ == SpvType::kStruct) {
-            const Instruction* offset_decoration = GetMemberDecoration(
-                meta.access_path.pointer_type->Id(), meta.access_path.heap_offset_member_index, spv::DecorationOffsetIdEXT);
-            assert(offset_decoration);
-            heap_offset_id = offset_decoration->Word(4);
-            heap_offset_id = CastToUint32(heap_offset_id, block, inst_it);
-
-            descriptor_array =
-                type_manager_.FindTypeById(meta.access_path.pointer_type->inst_.Operand(meta.access_path.heap_offset_member_index));
-        } else {
-            descriptor_array = meta.access_path.pointer_type;
-            heap_offset_id = type_manager_.GetConstantZeroUint32().Id();
+        uint32_t heap_offset_id = type_manager_.GetConstantZeroUint32().Id();
+        if (meta.untyped_heap_offset_id != 0) {
+            heap_offset_id = CastToUint32(meta.untyped_heap_offset_id, block, inst_it);  // might be int32
         }
 
         uint32_t array_stride_id = type_manager_.GetConstantZeroUint32().Id();
-        if (descriptor_array->IsArray()) {
-            const uint32_t array_stride_dec = GetDecoration(descriptor_array->Id(), spv::DecorationArrayStrideIdEXT)->Word(3);
-            const Constant* array_stride = type_manager_.FindConstantById(array_stride_dec);
-            array_stride_id = CastToUint32(array_stride->Id(), block, inst_it);  // might be int32
+        if (meta.untyped_array_stride_id != 0) {
+            array_stride_id = CastToUint32(meta.untyped_array_stride_id, block, inst_it);  // might be int32
         }
 
         const uint32_t function_def = GetLinkFunctionId(UNTYPED);
@@ -276,7 +260,6 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
         return_uint = true;
     } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
         const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping->sourceData.constantOffset;
-        has_embedded_sampler = map_data.pEmbeddedSampler != nullptr;
 
         const uint32_t heap_offset = map_data.heapOffset + (binding_offset * map_data.heapArrayStride);
         const uint32_t heap_offset_id = type_manager_.GetConstantUInt32(heap_offset).Id();
@@ -291,7 +274,6 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
         return_uint = true;
     } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
         const VkDescriptorMappingSourcePushIndexEXT& map_data = mapping->sourceData.pushIndex;
-        has_embedded_sampler = map_data.pEmbeddedSampler != nullptr;
 
         const uint32_t heap_offset = map_data.heapOffset + (binding_offset * map_data.heapArrayStride);
         const uint32_t heap_offset_id = type_manager_.GetConstantUInt32(heap_offset).Id();
@@ -312,7 +294,6 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
         return_uint = true;
     } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
         const VkDescriptorMappingSourceIndirectIndexEXT& map_data = mapping->sourceData.indirectIndex;
-        has_embedded_sampler = map_data.pEmbeddedSampler != nullptr;
 
         const uint32_t heap_offset = map_data.heapOffset + (binding_offset * map_data.heapArrayStride);
         const uint32_t heap_offset_id = type_manager_.GetConstantUInt32(heap_offset).Id();
@@ -334,7 +315,6 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
         return_uint = true;
     } else if (mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
         const VkDescriptorMappingSourceIndirectIndexArrayEXT& map_data = mapping->sourceData.indirectIndexArray;
-        has_embedded_sampler = map_data.pEmbeddedSampler != nullptr;
 
         const uint32_t heap_offset_id = type_manager_.GetConstantUInt32(map_data.heapOffset).Id();
         // VU enforces pushOffset to multiple of 8, and the GLSL is using a uint array
@@ -422,7 +402,7 @@ uint32_t DescriptorHeapPass::CreateFunctionCall(BasicBlock& block, InstructionIt
     }
 
     // If there is a sampler, we have another descriptor at this spot we need to validate
-    if (!is_seperate_sampler && meta.access_path.HasSampler() && !has_embedded_sampler) {
+    if (!is_seperate_sampler && meta.access_path.HasSampler() && !meta.has_embedded_sampler) {
         const uint32_t valid_image = function_result;
         uint32_t valid_sampler = 0;
         if (meta.access_path.is_combined_image_sampler) {
@@ -583,7 +563,92 @@ bool DescriptorHeapPass::RequiresInstrumentation(const Function& function, const
 
     meta.target_instruction = &inst;
 
+    if (meta.mapping_index_resource != glsl::kInst_DescriptorHeap_MappingIndexUntyped) {
+        meta.mapping_ptr = &module_.out_status.device.heap_mappings[meta.mapping_index_resource].mapping_data;
+    }
+    // Get to do it again... because samplers
+    if (meta.access_path.sampler_variable) {
+        if (meta.mapping_index_sampler != glsl::kInst_DescriptorHeap_MappingIndexUntyped) {
+            meta.mapping_ptr_sampler = &module_.out_status.device.heap_mappings[meta.mapping_index_sampler].mapping_data;
+        }
+    };
+
+    if (meta.mapping_ptr_sampler) {
+        meta.has_embedded_sampler = GetEmbeddedSampler(*meta.mapping_ptr_sampler) != nullptr;
+    } else if (meta.mapping_ptr) {
+        meta.has_embedded_sampler = GetEmbeddedSampler(*meta.mapping_ptr) != nullptr;
+    }
+
+    if (meta.mapping_index_resource == glsl::kInst_DescriptorHeap_MappingIndexUntyped) {
+        const Type* descriptor_array = nullptr;
+        if (meta.access_path.pointer_type->spv_type_ == SpvType::kStruct) {
+            const Instruction* offset_decoration = GetMemberDecoration(
+                meta.access_path.pointer_type->Id(), meta.access_path.heap_offset_member_index, spv::DecorationOffsetIdEXT);
+            assert(offset_decoration);
+            meta.untyped_heap_offset_id = offset_decoration->Word(4);
+
+            descriptor_array =
+                type_manager_.FindTypeById(meta.access_path.pointer_type->inst_.Operand(meta.access_path.heap_offset_member_index));
+        } else {
+            descriptor_array = meta.access_path.pointer_type;
+        }
+
+        if (descriptor_array->IsArray()) {
+            const uint32_t array_stride_dec = GetDecoration(descriptor_array->Id(), spv::DecorationArrayStrideIdEXT)->Word(3);
+            const Constant* array_stride = type_manager_.FindConstantById(array_stride_dec);
+            meta.untyped_array_stride_id = array_stride->Id();
+        }
+    }
+
     return true;
+}
+
+// TODO - hash seperatly for Samplers
+uint32_t DescriptorHeapPass::InstructionMeta::Hash(const uint32_t descriptor_index) const {
+    const uint32_t source_id = mapping_ptr ? (uint32_t)mapping_ptr->source : 0;
+    const uint32_t desc_type = (uint32_t)access_path.descriptor_type;
+    ;
+
+    if (mapping_index_resource == glsl::kInst_DescriptorHeap_MappingIndexUntyped) {
+        uint32_t hash_content[4] = {desc_type, descriptor_index, untyped_heap_offset_id, untyped_array_stride_id};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
+        const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping_ptr->sourceData.constantOffset;
+        uint32_t hash_content[5] = {source_id, desc_type, descriptor_index, map_data.heapOffset, map_data.heapArrayStride};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 5);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
+        const VkDescriptorMappingSourcePushIndexEXT& map_data = mapping_ptr->sourceData.pushIndex;
+        uint32_t hash_content[7] = {
+            source_id,           desc_type,          descriptor_index, map_data.heapOffset, map_data.heapArrayStride,
+            map_data.heapOffset, map_data.pushOffset};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 7);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
+        const VkDescriptorMappingSourceIndirectIndexEXT& map_data = mapping_ptr->sourceData.indirectIndex;
+        uint32_t hash_content[8] = {
+            source_id,           desc_type,           descriptor_index,      map_data.heapOffset, map_data.heapArrayStride,
+            map_data.heapOffset, map_data.pushOffset, map_data.addressOffset};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 8);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
+        const VkDescriptorMappingSourceIndirectIndexArrayEXT& map_data = mapping_ptr->sourceData.indirectIndexArray;
+        uint32_t hash_content[7] = {source_id,           desc_type,           descriptor_index,      map_data.heapOffset,
+                                    map_data.heapOffset, map_data.pushOffset, map_data.addressOffset};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 7);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT) {
+        const VkDescriptorMappingSourceHeapDataEXT& map_data = mapping_ptr->sourceData.heapData;
+        uint32_t hash_content[4] = {source_id, desc_type, map_data.heapOffset, map_data.pushOffset};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_DATA_EXT) {
+        uint32_t hash_content[3] = {source_id, desc_type, mapping_ptr->sourceData.pushDataOffset};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 3);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT) {
+        uint32_t hash_content[3] = {source_id, desc_type, mapping_ptr->sourceData.pushAddressOffset};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 3);
+    } else if (mapping_ptr->source == VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT) {
+        const VkDescriptorMappingSourceIndirectAddressEXT& map_data = mapping_ptr->sourceData.indirectAddress;
+        uint32_t hash_content[4] = {source_id, desc_type, map_data.pushOffset, map_data.addressOffset};
+        return hash_util::Hash32(hash_content, sizeof(uint32_t) * 4);
+    }
+    return 0;
 }
 
 bool DescriptorHeapPass::Instrument() {
@@ -591,6 +656,8 @@ bool DescriptorHeapPass::Instrument() {
         if (!function.called_from_target_) {
             continue;
         }
+
+        FunctionDuplicateTracker function_duplicate_tracker;
 
         for (auto block_it = function.blocks_.begin(); block_it != function.blocks_.end(); ++block_it) {
             BasicBlock& current_block = **block_it;
@@ -605,11 +672,28 @@ bool DescriptorHeapPass::Instrument() {
             }
             auto& block_instructions = current_block.instructions_;
 
+            // We only need to instrument the set/binding/index combo once per block (in unsafe mode)
+            BlockDuplicateTracker& block_duplicate_tracker = function_duplicate_tracker.GetAndUpdate(current_block);
+            DescriptroIndexPushConstantAccess pc_access;
+
             for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
+                if (!module_.settings_.safe_mode) {
+                    pc_access.Update(module_, inst_it);
+                }
+
                 InstructionMeta meta;
                 // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
                 if (!RequiresInstrumentation(function, *(inst_it->get()), meta)) {
                     continue;
+                }
+                if (!module_.settings_.safe_mode) {
+                    const uint32_t hash_descriptor_index_id = pc_access.next_alias_id == meta.access_path.descriptor_index_id
+                                                                  ? pc_access.descriptor_index_id
+                                                                  : meta.access_path.descriptor_index_id;
+                    const uint32_t hash = meta.Hash(hash_descriptor_index_id);
+                    if (hash != 0 && function_duplicate_tracker.FindAndUpdate(block_duplicate_tracker, hash)) {
+                        continue;  // duplicate detected
+                    }
                 }
 
                 if (MaxInstrumentationsCountReached()) {

--- a/layers/gpuav/spirv/descriptor_heap_pass.h
+++ b/layers/gpuav/spirv/descriptor_heap_pass.h
@@ -41,6 +41,17 @@ class DescriptorHeapPass : public Pass {
         // Internal encoded index to map into InstrumentationStatus::Device
         uint32_t mapping_index_resource = 0;
         uint32_t mapping_index_sampler = 0;
+
+        // This is information we "could" find at CreateFunctionCall but want done earlier to so we can hash it
+        // ----
+        // Null if untyped pointers
+        const VkDescriptorSetAndBindingMappingEXT* mapping_ptr = nullptr;
+        const VkDescriptorSetAndBindingMappingEXT* mapping_ptr_sampler = nullptr;
+        bool has_embedded_sampler = false;
+        // If zero, means it is implicitly zero
+        uint32_t untyped_heap_offset_id = 0;
+        uint32_t untyped_array_stride_id = 0;
+        uint32_t Hash(const uint32_t descriptor_index) const;
     };
 
     bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta);

--- a/layers/gpuav/spirv/descriptor_heap_pass.h
+++ b/layers/gpuav/spirv/descriptor_heap_pass.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <vulkan/vulkan_core.h>
 #include "type_manager.h"
 #include "pass.h"
 
@@ -47,15 +48,18 @@ class DescriptorHeapPass : public Pass {
         // Null if untyped pointers
         const VkDescriptorSetAndBindingMappingEXT* mapping_ptr = nullptr;
         const VkDescriptorSetAndBindingMappingEXT* mapping_ptr_sampler = nullptr;
-        bool has_embedded_sampler = false;
         // If zero, means it is implicitly zero
         uint32_t untyped_heap_offset_id = 0;
         uint32_t untyped_array_stride_id = 0;
-        uint32_t Hash(const uint32_t descriptor_index) const;
+        uint32_t Hash(const uint32_t descriptor_index, VkDescriptorType vk_type) const;
+
+        bool instrument_seperate_sampler = false;
     };
 
     bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta);
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta, bool is_seperate_sampler);
+    uint32_t CreateFunctionCallSampler(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta,
+                                       uint32_t non_sampler_result);
     uint32_t CreateFunctionCallCombinedSampler(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta,
                                                const VkDescriptorSetAndBindingMappingEXT& mapping,
                                                const uint32_t descriptor_index_id);

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -218,7 +218,7 @@ bool DescriptorIndexingOOBPass::Instrument() {
             DescriptroIndexPushConstantAccess pc_access;
 
             for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
-                if (module_.settings_.safe_mode) {
+                if (!module_.settings_.safe_mode) {
                     pc_access.Update(module_, inst_it);
                 }
 

--- a/tests/unit/gpu_av_descriptor_heap_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_heap_positive.cpp
@@ -1557,3 +1557,107 @@ TEST_F(PositiveGpuAVDescriptorHeap, HashingTombstone) {
         ssbo_address += alignment;
     }
 }
+
+TEST_F(PositiveGpuAVDescriptorHeap, Deduplication) {
+    TEST_DESCRIPTION("Make sure we deduplicate multiple access when safe mode is off");
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
+    vkt::DescriptorHeap desc_heap(*this);
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    desc_heap.CreateResourceHeap(resource_stride * 4);
+
+    vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    vkt::Buffer ssbo2_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+
+    VkDeviceSize offset_0 = desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    VkDeviceSize offset_1 = desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    VkDeviceSize offset_2 = desc_heap.WriteBufferDescriptor(ssbo2_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    VkDeviceSize offset_3 = desc_heap.WriteBufferDescriptor(ssbo2_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+
+    VkDescriptorSetAndBindingMappingEXT mappings[4];
+    mappings[0] = MakeSetAndBindingMapping(1, 2);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = (uint32_t)offset_0;
+    mappings[1] = MakeSetAndBindingMapping(0, 2);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset.heapOffset = (uint32_t)offset_3;
+    mappings[2] = MakeSetAndBindingMapping(1, 0);
+    mappings[2].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[2].sourceData.constantOffset.heapOffset = (uint32_t)offset_1;
+    mappings[3] = MakeSetAndBindingMapping(0, 1);
+    mappings[3].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[3].sourceData.constantOffset.heapOffset = (uint32_t)offset_2;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 4;
+    mapping_info.pMappings = mappings;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(local_size_x = 1) in;
+        layout(set = 0, binding = 1) buffer A { uint a; };
+        layout(set = 0, binding = 2) buffer B { uint b; };
+        layout(set = 1, binding = 0) buffer C { uint c; };
+        layout(set = 1, binding = 2) buffer D { uint d; };
+        void main() {
+            uint x = a;
+            a += 3;
+            b = 2;
+            c = b + a * (a + d);
+            d = b - a;
+            if (d == 0) {
+                c = 0;
+                b = 0;
+            }
+            a = 0;
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveGpuAVDescriptorHeap, DeduplicationUntyped) {
+    TEST_DESCRIPTION("Make sure we deduplicate multiple access when safe mode is off");
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
+    vkt::DescriptorHeap desc_heap(*this);
+    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    desc_heap.CreateResourceHeap(resource_stride * 4);
+
+    vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+
+    char const* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_descriptor_heap : require
+        layout(descriptor_heap) buffer A { uint x; } heap[];
+        void main() {
+            uint x = heap[0].x;
+            heap[0].x += 3;
+            heap[1].x = 2;
+            heap[2].x = heap[1].x + heap[0].x * (heap[0].x + heap[3].x);
+            heap[3].x = heap[1].x - heap[0].x;
+            if (heap[3].x == 0) {
+                heap[2].x = 0;
+                heap[1].x = 0;
+            }
+            heap[0].x = 0;
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr);
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}

--- a/tests/unit/gpu_av_descriptor_heap_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_heap_positive.cpp
@@ -1661,3 +1661,163 @@ TEST_F(PositiveGpuAVDescriptorHeap, DeduplicationUntyped) {
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
+
+TEST_F(PositiveGpuAVDescriptorHeap, SamplerStressUnsafe) {
+    TEST_DESCRIPTION("Samplers suck, do as much crazy stuff as possible");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, false));
+
+    VkDescriptorSetAndBindingMappingEXT mappings[3];
+    mappings[0] = MakeSetAndBindingMapping(0, 0, 2);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[0].sourceData.constantOffset.heapArrayStride = 256;  // max aligned
+    mappings[1] = MakeSetAndBindingMapping(1, 0);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset.heapOffset = 256;  // max aligned
+    mappings[2] = MakeSetAndBindingMapping(1, 1);
+    mappings[2].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
+    mappings[2].sourceData.pushIndex.heapOffset = 0;
+    mappings[2].sourceData.pushIndex.heapArrayStride = 256;  // max aligned
+    mappings[2].sourceData.pushIndex.pushOffset = 0;
+    mappings[2].sourceData.pushIndex.heapIndexStride = 1;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 3;
+    mapping_info.pMappings = mappings;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_descriptor_heap : require
+        #extension GL_EXT_nonuniform_qualifier : require
+        layout(set = 0, binding = 0) uniform texture2D t;
+        layout(set = 0, binding = 1) uniform sampler s;
+        layout(set = 1, binding = 0) uniform texture2D t_array[];
+        layout(set = 1, binding = 1) uniform sampler s_array[];
+        layout(descriptor_heap) uniform texture2D t_heap[];
+        layout(descriptor_heap) uniform sampler s_heap[];
+
+        layout(push_constant) uniform PC {
+            uint u_index;
+            int s_index;
+        };
+
+        void main() {
+            vec4 data = vec4(0);
+            vec2 uv = vec2(0.5f);
+            data += texture(sampler2D(t, s), uv);
+
+            // scalar + array
+            data += texture(sampler2D(t, s_array[0]), uv);
+            data += texture(sampler2D(t_array[0], s), uv);
+            data += texture(sampler2D(t, s_array[u_index]), uv);
+            data += texture(sampler2D(t_array[u_index], s), uv);
+            data += texture(sampler2D(t, s_array[s_index]), uv);
+            data += texture(sampler2D(t_array[s_index], s), uv);
+
+            // scalar + heap
+            data += texture(sampler2D(t, s_heap[0]), uv);
+            data += texture(sampler2D(t_heap[0], s), uv);
+            data += texture(sampler2D(t, s_heap[u_index]), uv);
+            data += texture(sampler2D(t_heap[u_index], s), uv);
+            data += texture(sampler2D(t, s_heap[s_index]), uv);
+            data += texture(sampler2D(t_heap[s_index], s), uv);
+
+            // array + heap
+            data += texture(sampler2D(t_heap[0], s_array[0]), uv);
+            data += texture(sampler2D(t_array[0], s_heap[0]), uv);
+            data += texture(sampler2D(t_heap[u_index], s_array[u_index]), uv);
+            data += texture(sampler2D(t_array[u_index], s_heap[u_index]), uv);
+            data += texture(sampler2D(t_heap[s_index], s_array[s_index]), uv);
+            data += texture(sampler2D(t_array[s_index], s_heap[s_index]), uv);
+
+            // Heap
+            data += texture(sampler2D(t_heap[0], s_heap[0]), uv);
+            data += texture(sampler2D(t_heap[u_index], s_heap[u_index]), uv);
+            data += texture(sampler2D(t_heap[s_index], s_heap[s_index]), uv);
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, &mapping_info);
+}
+
+TEST_F(PositiveGpuAVDescriptorHeap, SamplerStressSafe) {
+    TEST_DESCRIPTION("Samplers suck, do as much crazy stuff as possible");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({}, true));
+
+    VkDescriptorSetAndBindingMappingEXT mappings[3];
+    mappings[0] = MakeSetAndBindingMapping(0, 0, 2);
+    mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[0].sourceData.constantOffset.heapArrayStride = 256;  // max aligned
+    mappings[1] = MakeSetAndBindingMapping(1, 0);
+    mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mappings[1].sourceData.constantOffset.heapOffset = 256;  // max aligned
+    mappings[2] = MakeSetAndBindingMapping(1, 1);
+    mappings[2].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
+    mappings[2].sourceData.pushIndex.heapOffset = 0;
+    mappings[2].sourceData.pushIndex.heapArrayStride = 256;  // max aligned
+    mappings[2].sourceData.pushIndex.pushOffset = 0;
+    mappings[2].sourceData.pushIndex.heapIndexStride = 1;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 3;
+    mapping_info.pMappings = mappings;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_descriptor_heap : require
+        #extension GL_EXT_nonuniform_qualifier : require
+        layout(set = 0, binding = 0) uniform texture2D t;
+        layout(set = 0, binding = 1) uniform sampler s;
+        layout(set = 1, binding = 0) uniform texture2D t_array[];
+        layout(set = 1, binding = 1) uniform sampler s_array[];
+        layout(descriptor_heap) uniform texture2D t_heap[];
+        layout(descriptor_heap) uniform sampler s_heap[];
+
+        layout(push_constant) uniform PC {
+            uint u_index;
+            int s_index;
+        };
+
+        void main() {
+            vec4 data = vec4(0);
+            vec2 uv = vec2(0.5f);
+            data += texture(sampler2D(t, s), uv);
+
+            // scalar + array
+            data += texture(sampler2D(t, s_array[0]), uv);
+            data += texture(sampler2D(t_array[0], s), uv);
+            data += texture(sampler2D(t, s_array[u_index]), uv);
+            data += texture(sampler2D(t_array[u_index], s), uv);
+            data += texture(sampler2D(t, s_array[s_index]), uv);
+            data += texture(sampler2D(t_array[s_index], s), uv);
+
+            // scalar + heap
+            data += texture(sampler2D(t, s_heap[0]), uv);
+            data += texture(sampler2D(t_heap[0], s), uv);
+            data += texture(sampler2D(t, s_heap[u_index]), uv);
+            data += texture(sampler2D(t_heap[u_index], s), uv);
+            data += texture(sampler2D(t, s_heap[s_index]), uv);
+            data += texture(sampler2D(t_heap[s_index], s), uv);
+
+            // array + heap
+            data += texture(sampler2D(t_heap[0], s_array[0]), uv);
+            data += texture(sampler2D(t_array[0], s_heap[0]), uv);
+            data += texture(sampler2D(t_heap[u_index], s_array[u_index]), uv);
+            data += texture(sampler2D(t_array[u_index], s_heap[u_index]), uv);
+            data += texture(sampler2D(t_heap[s_index], s_array[s_index]), uv);
+            data += texture(sampler2D(t_array[s_index], s_heap[s_index]), uv);
+
+            // Heap
+            data += texture(sampler2D(t_heap[0], s_heap[0]), uv);
+            data += texture(sampler2D(t_heap[u_index], s_heap[u_index]), uv);
+            data += texture(sampler2D(t_heap[s_index], s_heap[s_index]), uv);
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, &mapping_info);
+}


### PR DESCRIPTION
tested with CTS with unsafe and safe mode

This REALLY reduces checks (the same we do for Descriptor Indexing... we even had nice global utils!)