### PR TITLE
layers: Add user handle to event in-use message

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1801,11 +1801,7 @@ bool CoreChecks::PreCallValidateCmdPipelineBarrier2KHR(VkCommandBuffer commandBu
 bool CoreChecks::PreCallValidateSetEvent(VkDevice device, VkEvent event, const ErrorObject& error_obj) const {
     bool skip = false;
     if (auto event_state = Get<vvl::Event>(event)) {
-        if (event_state->InUse()) {
-            skip |= LogError("VUID-vkSetEvent-event-09543", event, error_obj.location.dot(Field::event),
-                             "(%s) that is already in use by a command buffer.%s", FormatHandle(event).c_str(),
-                             is_device_lost ? "\n(a VK_ERROR_DEVICE_LOST has occurred, the event must be destroyed)" : "");
-        }
+        skip |= ValidateObjectNotInUse(event_state.get(), error_obj.location, "VUID-vkSetEvent-event-09543");
         if (event_state->flags & VK_EVENT_CREATE_DEVICE_ONLY_BIT) {
             skip |= LogError("VUID-vkSetEvent-event-03941", event, error_obj.location.dot(Field::event),
                              "(%s) was created with VK_EVENT_CREATE_DEVICE_ONLY_BIT.", FormatHandle(event).c_str());

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1073,7 +1073,7 @@ NON_DISPATCHABLE_HANDLE_DTOR(Event, vk::DestroyEvent)
 void Event::Init(const Device& dev, const VkEventCreateInfo& info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateEvent, dev, &info); }
 
 VkResult Event::GetStatus() const { return vk::GetEventStatus(device(), handle()); }
-void Event::Set() { ASSERT_EQ(VK_SUCCESS, vk::SetEvent(device(), handle())); }
+void Event::Set() { vk::SetEvent(device(), handle()); }
 void Event::Reset() { vk::ResetEvent(device(), handle()); }
 
 NON_DISPATCHABLE_HANDLE_DTOR(QueryPool, vk::DestroyQueryPool)

--- a/tests/unit/event.cpp
+++ b/tests/unit/event.cpp
@@ -739,48 +739,58 @@ TEST_F(NegativeEvent, WaitEventRenderPassHostBit) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeEvent, ResetEventThenSet) {
-    TEST_DESCRIPTION("Reset an event then set it after the reset has been submitted.");
+TEST_F(NegativeEvent, ResetEventThenHostSet) {
+    TEST_DESCRIPTION("Submit event reset then set it on the host");
     RETURN_IF_SKIP(Init());
 
     vkt::Event event(*m_device);
 
     m_command_buffer.Begin();
-    vk::CmdResetEvent(m_command_buffer, event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-    m_command_buffer.End();
-    m_default_queue->Submit(m_command_buffer);
-
-    m_errorMonitor->SetDesiredError("VUID-vkSetEvent-event-09543");
-    vk::SetEvent(device(), event);
-    m_errorMonitor->VerifyFound();
-
-    m_default_queue->Wait();
-}
-
-// This test should only be used for manual inspection
-// Because a command buffer with vkCmdWaitEvents is submitted with an
-// event that is never signaled, the test results in a VK_ERROR_DEVICE_LOST
-TEST_F(NegativeEvent, DISABLED_WaitEventThenSet) {
-#if defined(VVL_ENABLE_TSAN)
-    // NOTE: This test in particular has failed sporadically on CI when TSAN is enabled.
-    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
-#endif
-    TEST_DESCRIPTION("Wait on a event then set it after the wait has been submitted.");
-
-    SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(Init());
-    vkt::Event event(*m_device);
-
-    m_command_buffer.Begin();
-    vk::CmdWaitEvents(m_command_buffer, 1, &event.handle(), VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
-                      nullptr, 0, nullptr, 0, nullptr);
-    vk::CmdResetEvent(m_command_buffer, event, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+    m_command_buffer.ResetEvent(event);
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     m_errorMonitor->SetDesiredError("VUID-vkSetEvent-event-09543");
     event.Set();
     m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeEvent, SetEventThenHostSet) {
+    TEST_DESCRIPTION("Submit event set then set it on the host");
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer);
+
+    m_errorMonitor->SetDesiredError("VUID-vkSetEvent-event-09543");
+    event.Set();
+    m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
+}
+
+TEST_F(NegativeEvent, WaitEventThenHostSet) {
+    TEST_DESCRIPTION("Submit event wait then set it on the host");
+    RETURN_IF_SKIP(Init());
+    vkt::Event event(*m_device);
+
+    m_command_buffer.Begin();
+    m_command_buffer.SetEvent(event);
+    m_command_buffer.WaitEvent(event);
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer);
+
+    m_errorMonitor->SetDesiredError("VUID-vkSetEvent-event-09543");
+    event.Set();
+    m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
 }
 
 TEST_F(NegativeEvent, OwnershipTransferUseAllStagesNoFeature) {


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7383
Related to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12624 (reports command buffers but for wider range of in-use errors, this one is event specific VUIDs)

> vkSetEvent(): VkEvent 0x40000000004 is already in use by a VkCommandBuffer 0x22c8592ead0.

Also opened https://gitlab.khronos.org/vulkan/vulkan/-/issues/4902 which might affect the scope of `VUID-vkSetEvent-event-09543` (but not this fix)

