### PR TITLE
gpuav: Fix dangling reference to command buffer handle in error logger

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -671,7 +671,7 @@ void PreCallSetupShaderInstrumentationResources(Validator& gpuav, CommandBufferS
 
         const VkCommandBuffer cb_handle = cb_state.VkHandle();
         CommandBufferSubState::ErrorLoggerFunc error_logger =
-            [&gpuav, &cb_handle, common_error_info, error_loggers = std::move(error_loggers)](
+            [&gpuav, cb_handle, common_error_info, error_loggers = std::move(error_loggers)](
                 const uint32_t* error_record, const Location& loc_with_debug_region, const LogObjectList& objlist) {
                 bool skip = false;
                 skip |= LogInstrumentationError(gpuav, cb_handle, objlist, common_error_info, error_record, loc_with_debug_region,


### PR DESCRIPTION
closes #12664.

`cb_handle` was captured by reference in the error logger lambda, but it's a local variable that goes out of scope before the lambda is invoked (during `OnCompletion` after GPU execution). This resulted in GPU-AV error messages printing garbage command buffer handles (e.g. `0xcccccccccccccccc` on MSVC debug builds).

Changed capture from `&cb_handle` to `cb_handle` (by value).