### PR TITLE
Force 8byte alignment for the Slot.entry member in descriptor hashing.

### DIFF
--- a/layers/state_tracker/descriptor_hashing.h
+++ b/layers/state_tracker/descriptor_hashing.h
@@ -84,7 +84,7 @@ struct DescriptorHashTable {
     // Represents single "slot" in our linear buffer allocation
     struct Slot {
         uint64_t key;
-        Entry entry;
+        alignas(8) Entry entry;
     };
     // Want to keep 32-byte aligned for better GPU read accessing
     static_assert(sizeof(Slot) == 32, "DescriptorHashTable::Slot exceeds the 32-byte limit!");


### PR DESCRIPTION
On 32-bit builds, it can be 4-byte aligned in GCC and Clang.

This should fix the static assert that sizeof(Slot)==32.

Bug: crbug.com/533445607