### PR TITLE
layers: Add opacity micromap pUsageCount checks

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -3147,6 +3147,12 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
                          device_state->physical_device_count);
     }
 
+    if (!enabled_features.accelerationStructure && pInfo->accelerationStructure != VK_NULL_HANDLE) {
+        skip |= LogError("VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-None-12430", device,
+                         error_obj.location.dot(Field::pInfo).dot(Field::accelerationStructure),
+                         "is not VK_NULL_HANDLE, but the accelerationStructure feature was not enabled.");
+    }
+
     if (pInfo->accelerationStructure != VK_NULL_HANDLE) {
         if (auto acceleration_structure_state = Get<vvl::AccelerationStructureKHR>(pInfo->accelerationStructure)) {
             if (!(acceleration_structure_state->GetCreateFlags() &

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -894,6 +894,18 @@ bool Device::ValidateAccelerationStructureGeometry(const Context& context, const
                     "pointer, the other must be NULL.",
                     omm_ext->pUsageCounts, omm_ext->ppUsageCounts);
             }
+
+            if (omm_ext->micromap != VK_NULL_HANDLE && (omm_ext->pUsageCounts || omm_ext->ppUsageCounts)) {
+                const Field usage_field = omm_ext->pUsageCounts ? Field::pUsageCounts : Field::ppUsageCounts;
+                for (uint32_t usage_i = 0; usage_i < omm_ext->usageCountsCount; ++usage_i) {
+                    const VkMicromapUsageEXT& usage =
+                        omm_ext->pUsageCounts ? omm_ext->pUsageCounts[usage_i] : *omm_ext->ppUsageCounts[usage_i];
+                    skip |= context.ValidateRangedEnum(omm_ext_loc.dot(usage_field, usage_i).dot(Field::format),
+                                                       vvl::Enum::VkOpacityMicromapFormatKHR,
+                                                       static_cast<VkOpacityMicromapFormatKHR>(usage.format),
+                                                       "VUID-VkAccelerationStructureTrianglesOpacityMicromapEXT-format-11679");
+                }
+            }
         }
     } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
         const Location instances_loc = geometry_loc.dot(Field::instances);

--- a/layers/stateless/sl_ray_tracing_micromap.cpp
+++ b/layers/stateless/sl_ray_tracing_micromap.cpp
@@ -27,6 +27,29 @@
 
 namespace stateless {
 
+bool Device::ValidateMicromapBuildInfo(const Context& context, const VkMicromapBuildInfoEXT& build_info,
+                                       const Location& build_info_loc) const {
+    bool skip = false;
+
+    if (build_info.pUsageCounts && build_info.ppUsageCounts) {
+        skip |= LogError("VUID-VkMicromapBuildInfoEXT-pUsageCounts-07516", device, build_info_loc,
+                         "both pUsageCounts and ppUsageCounts are not NULL.");
+    }
+
+    if (build_info.type == VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT && (build_info.pUsageCounts || build_info.ppUsageCounts)) {
+        const Field usage_field = build_info.pUsageCounts ? Field::pUsageCounts : Field::ppUsageCounts;
+        for (uint32_t usage_i = 0; usage_i < build_info.usageCountsCount; ++usage_i) {
+            const VkMicromapUsageEXT& usage =
+                build_info.pUsageCounts ? build_info.pUsageCounts[usage_i] : *build_info.ppUsageCounts[usage_i];
+            skip |= context.ValidateRangedEnum(
+                build_info_loc.dot(usage_field, usage_i).dot(Field::format), vvl::Enum::VkOpacityMicromapFormatKHR,
+                static_cast<VkOpacityMicromapFormatKHR>(usage.format), "VUID-VkMicromapBuildInfoEXT-format-11652");
+        }
+    }
+
+    return skip;
+}
+
 bool Device::manual_PreCallValidateCreateMicromapEXT(VkDevice device, const VkMicromapCreateInfoEXT* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkMicromapEXT* pMicromap,
                                                      const Context& context) const {
@@ -99,10 +122,8 @@ bool Device::manual_PreCallValidateCmdBuildMicromapsEXT(VkCommandBuffer commandB
                              info_loc.dot(Field::data).dot(Field::deviceAddress), "(0x%" PRIx64 ") must be aligned to 256.",
                              info.data.deviceAddress);
         }
-        if (info.pUsageCounts && info.ppUsageCounts) {
-            skip |= LogError("VUID-VkMicromapBuildInfoEXT-pUsageCounts-07516", commandBuffer, info_loc,
-                             "both pUsageCounts and ppUsageCounts are not NULL.");
-        }
+
+        skip |= ValidateMicromapBuildInfo(context, info, info_loc);
     }
 
     return skip;
@@ -128,6 +149,8 @@ bool Device::manual_PreCallValidateBuildMicromapsEXT(VkDevice device, VkDeferred
             skip |= LogError("VUID-vkBuildMicromapsEXT-pInfos-07554", device,
                              info_loc.dot(Field::triangleArray).dot(Field::hostAddress), "is zero.");
         }
+
+        skip |= ValidateMicromapBuildInfo(context, info, info_loc);
     }
 
     return skip;
@@ -325,10 +348,7 @@ bool Device::manual_PreCallValidateGetMicromapBuildSizesEXT(VkDevice device, VkA
                          "The VkPhysicalDeviceOpacityMicromapFeaturesEXT::micromap feature was not enabled.");
     }
 
-    if (pBuildInfo->pUsageCounts && pBuildInfo->ppUsageCounts) {
-        skip |= LogError("VUID-VkMicromapBuildInfoEXT-pUsageCounts-07516", device, error_obj.location,
-                         "both pUsageCounts and ppUsageCounts are not NULL.");
-    }
+    skip |= ValidateMicromapBuildInfo(context, *pBuildInfo, error_obj.location.dot(Field::pBuildInfo));
 
     return skip;
 }

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1281,6 +1281,9 @@ class Device : public vvl::BaseDevice {
                                                               const VkGeneratedCommandsInfoEXT *pGeneratedCommandsInfo,
                                                               const Context &context) const;
 
+    bool ValidateMicromapBuildInfo(const Context &context, const VkMicromapBuildInfoEXT &build_info,
+                                   const Location &build_info_loc) const;
+
     bool manual_PreCallValidateCreateMicromapEXT(VkDevice device, const VkMicromapCreateInfoEXT *pCreateInfo,
                                                  const VkAllocationCallbacks *pAllocator, VkMicromapEXT *pMicromap,
                                                  const Context &context) const;

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -363,6 +363,29 @@ TEST_F(NegativeDescriptorBuffer, NotEnabledGetSamplerOpaqueCaptureDescriptorData
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeDescriptorBuffer, AccelerationStructureCaptureDescriptorDataInfoFeatureDisabled) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
+
+    uint8_t data[256];
+
+    // Using a dummy non-null handle - the accelerationStructure feature is not enabled
+    VkAccelerationStructureKHR dummy_as = CastToHandle<VkAccelerationStructureKHR, uintptr_t>(0xbad00000);
+    VkAccelerationStructureCaptureDescriptorDataInfoEXT ascddi = vku::InitStructHelper();
+    ascddi.accelerationStructure = dummy_as;
+
+    m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-None-12430");
+    m_errorMonitor->SetAllowedFailureMsg(
+        "VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-accelerationStructure-parameter");
+    vk::GetAccelerationStructureOpaqueCaptureDescriptorDataEXT(device(), &ascddi, &data);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeDescriptorBuffer, NotEnabledGetAccelerationStructureOpaqueCaptureDescriptorDataEXT) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);

--- a/tests/unit/ray_tracing_micromap.cpp
+++ b/tests/unit/ray_tracing_micromap.cpp
@@ -2366,6 +2366,124 @@ TEST_F(NegativeRayTracingMicromap, DISABLED_TraceRaysOMMPipelineFlagMissing) {
     vk::DestroyPipeline(device(), rt_pipeline, nullptr);
 }
 
+TEST_F(NegativeRayTracingMicromap, MicromapBuildInfoInvalidFormat) {
+    TEST_DESCRIPTION("Test VkMicromapBuildInfoEXT with invalid format");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME);
+    VkPhysicalDeviceOpacityMicromapFeaturesEXT ext_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&ext_features);
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&accel_features);
+    RETURN_IF_SKIP(InitFramework());
+    vk::GetPhysicalDeviceFeatures2(Gpu(), &features2);
+    if (!ext_features.micromap) {
+        GTEST_SKIP() << "micromap feature not supported";
+    }
+    ext_features.micromap = VK_TRUE;
+    accel_features.accelerationStructure = VK_TRUE;
+    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    VkMicromapUsageEXT usage = {};
+    usage.count = 1;
+    usage.subdivisionLevel = 0;
+    usage.format = 0;  // Invalid
+
+    VkMicromapBuildInfoEXT build_info = vku::InitStructHelper();
+    build_info.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    build_info.usageCountsCount = 1;
+    build_info.pUsageCounts = &usage;
+
+    VkMicromapBuildSizesInfoEXT size_info = vku::InitStructHelper();
+
+    m_errorMonitor->SetDesiredError("VUID-VkMicromapBuildInfoEXT-format-11652");
+    vk::GetMicromapBuildSizesEXT(device(), VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &build_info, &size_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeRayTracingMicromap, TrianglesOpacityMicromapEXTInvalidFormat) {
+    TEST_DESCRIPTION("Test VkAccelerationStructureTrianglesOpacityMicromapEXT with invalid format");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DEVICE_ADDRESS_COMMANDS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME);
+    VkPhysicalDeviceOpacityMicromapFeaturesEXT ext_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&ext_features);
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceDeviceAddressCommandsFeaturesKHR dac_features = vku::InitStructHelper(&buffer_features);
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&dac_features);
+    RETURN_IF_SKIP(InitFramework());
+    vk::GetPhysicalDeviceFeatures2(Gpu(), &features2);
+    if (!ext_features.micromap) {
+        GTEST_SKIP() << "micromap feature not supported";
+    }
+    ext_features.micromap = VK_TRUE;
+    accel_features.accelerationStructure = VK_TRUE;
+    buffer_features.bufferDeviceAddress = VK_TRUE;
+    dac_features.deviceAddressCommands = VK_TRUE;
+    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    vkt::Buffer micromap_storage_buffer(*m_device, 4096, VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT);
+    VkMicromapCreateInfoEXT mm_ci = vku::InitStructHelper();
+    mm_ci.buffer = micromap_storage_buffer;
+    mm_ci.size = 4096;
+    mm_ci.type = VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT;
+    VkMicromapEXT micromap = VK_NULL_HANDLE;
+    vk::CreateMicromapEXT(device(), &mm_ci, nullptr, &micromap);
+
+    auto blas = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096);
+    blas->Create();
+
+    vkt::Buffer triangle_buffer(
+        *m_device, 4096, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        vkt::device_address);
+    vkt::Buffer scratch_buffer(*m_device, 4096,
+                               VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
+                                   VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+                               vkt::device_address);
+
+    VkMicromapUsageEXT usage = {};
+    usage.count = 1;
+    usage.subdivisionLevel = 0;
+    usage.format = 0;  // Invalid
+
+    VkAccelerationStructureTrianglesOpacityMicromapEXT triangle_mm = vku::InitStructHelper();
+    triangle_mm.indexType = VK_INDEX_TYPE_NONE_KHR;
+    triangle_mm.micromap = micromap;
+    triangle_mm.usageCountsCount = 1;
+    triangle_mm.pUsageCounts = &usage;
+
+    VkAccelerationStructureGeometryKHR geometry = vku::InitStructHelper();
+    geometry.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
+    geometry.geometry.triangles = vku::InitStructHelper(&triangle_mm);
+    geometry.geometry.triangles.indexType = VK_INDEX_TYPE_NONE_KHR;
+    geometry.geometry.triangles.maxVertex = 3;
+    geometry.geometry.triangles.vertexData.deviceAddress = triangle_buffer.Address();
+    geometry.geometry.triangles.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
+
+    VkAccelerationStructureBuildGeometryInfoKHR build_info = vku::InitStructHelper();
+    build_info.mode = VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR;
+    build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+    build_info.srcAccelerationStructure = VK_NULL_HANDLE;
+    build_info.dstAccelerationStructure = blas->handle();
+    build_info.geometryCount = 1;
+    build_info.pGeometries = &geometry;
+    build_info.scratchData.deviceAddress = scratch_buffer.Address();
+
+    VkAccelerationStructureBuildRangeInfoKHR range_info = {};
+    range_info.primitiveCount = 1;
+    const VkAccelerationStructureBuildRangeInfoKHR* range_info_ptr = &range_info;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureTrianglesOpacityMicromapEXT-format-11679");
+    vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1, &build_info, &range_info_ptr);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+
+    vk::DestroyMicromapEXT(device(), micromap, nullptr);
+}
+
 TEST_F(NegativeRayTracingMicromap, BeginQueryQueryPoolType) {
     TEST_DESCRIPTION("Test CmdBeginQuery with invalid micromap queryPool queryType");
 


### PR DESCRIPTION
Adding the following VUs and corresponding negative unit tests:

- VUID-VkMicromapBuildInfoEXT-format-11652
- VUID-VkAccelerationStructureTrianglesOpacityMicromapEXT-format-11679
- VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-None-12430

https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12584