### PR TITLE
dump: Handle passing in untyped descriptors into functions

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_buffer.cpp
@@ -201,7 +201,15 @@ bool CommandBufferSubState::DumpDescriptorBuffer(std::ostringstream& ss, const L
     ss << "- vkCmdBindDescriptorBuffersEXT last bound the following descriptor buffers:\n";
 
     vvl::unordered_map<uint32_t, VkBufferUsageFlagBits2> binding_usage_flags;
-    for (uint32_t binding_i = 0; binding_i < cb_state.descriptor_buffer.binding_info.size(); binding_i++) {
+    uint32_t binding_info_count = (uint32_t)cb_state.descriptor_buffer.binding_info.size();
+    if (dev_data.enabled[gpu_validation] && dev_data.gpuav_settings.IsShaderInstrumentationEnabled()) {
+        // We warn the users to not have both enabled, but if this occurs GPU-AV currently adds a buffer
+        // but it is not tracked in any state tracking. (nor are the instrumented variables)
+        // We just ignore the last binding
+        binding_info_count--;
+    }
+
+    for (uint32_t binding_i = 0; binding_i < binding_info_count; binding_i++) {
         const VkDeviceAddress address = cb_state.descriptor_buffer.binding_info[binding_i].address;
 
         VkBufferUsageFlagBits2 usage_flags = 0;

--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -1442,6 +1442,9 @@ struct HeapAccess {
     };
     std::vector<Index> descriptor_indexes;
 
+    // Lets us know this access is done inside a function
+    bool function_call = false;
+
     struct compare {
         bool operator()(HeapAccess const& lhs, HeapAccess const& rhs) const {
             return lhs.descriptor_type == rhs.descriptor_type && lhs.heap_offset == rhs.heap_offset &&
@@ -1463,8 +1466,65 @@ struct HeapAccess {
 };
 using HeapAccesses = vvl::unordered_set<HeapAccess, HeapAccess::hash, HeapAccess::compare>;
 
-static uint32_t GetUntypedHeapOffset(const spirv::Module& module, const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
-                                     const uint32_t struct_id, uint32_t struct_member_index) {
+// Tracks all the OpFunction/OpFunctionCall/OpFunctionParameter info we need
+struct FunctionInfo {
+    struct ParamInfo {
+        uint32_t function_id;  // OpFunction
+        uint32_t index;        // of the parameters
+    };
+    // < OpFunctionParameter ID, ParamInfo >
+    vvl::unordered_map<uint32_t, ParamInfo> param_map;
+    // < OpFunction ID, vector<OpFunctionCall ID>>
+    vvl::unordered_map<uint32_t, std::vector<uint32_t>> call_map;
+};
+
+struct UntypedContext {
+    const vvl::DeviceState& device_state;
+    const spirv::Module& module;
+    const spirv::EntryPoint& entrypoint;
+    const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props;
+
+    // The idea is to go through and find all the access and afterwards sort/group them to make sense to the user
+    // < variable id, [accesses]>
+    vvl::unordered_map<uint32_t, HeapAccesses> accesses;
+
+    FunctionInfo function_info;
+
+    UntypedContext(GpuDump& dev_data, const spirv::Module& module, const spirv::EntryPoint& entrypoint)
+        : device_state(*dev_data.device_state),
+          module(module),
+          entrypoint(entrypoint),
+          props(dev_data.phys_dev_ext_props.descriptor_heap_props) {
+        if (module.static_data_.has_untyped_pointer_function_params) {
+            uint32_t current_function = 0;
+            uint32_t param_index = 0;
+            for (const spirv::Instruction& inst : module.static_data_.instructions) {
+                if (inst.Opcode() == spv::OpFunction) {
+                    current_function = inst.ResultId();
+                    param_index = 0;
+                } else if (inst.Opcode() == spv::OpFunctionParameter) {
+                    function_info.param_map[inst.ResultId()] = FunctionInfo::ParamInfo{current_function, param_index};
+                    param_index++;
+                } else if (inst.Opcode() == spv::OpFunctionCall) {
+                    function_info.call_map[inst.Word(3)].emplace_back(inst.ResultId());
+                }
+            }
+        }
+    }
+
+    void GetUntypedDescriptorIndexes(std::vector<HeapAccess::Index>& out_descriptor_indexes,
+                                     std::vector<const spirv::Instruction*>& ac_indexes, const spirv::Instruction& type_array_inst);
+    uint32_t GetUntypedArrayStride(uint32_t type_array_id);
+    uint32_t GetUntypedHeapOffset(const uint32_t struct_id, uint32_t struct_member_index);
+
+    std::vector<const spirv::Instruction*> FindFunctionCallers(const spirv::Instruction& func_param_inst);
+    void AddAccess(const VkDescriptorType descriptor_type, const spirv::Instruction* ac_inst, bool function_call);
+    void FindAccess(const spirv::Instruction* next_inst, bool image_access, bool from_function_call);
+
+    bool Print(std::ostringstream& ss, vvl::CommandBuffer& cb_state);
+};
+
+uint32_t UntypedContext::GetUntypedHeapOffset(const uint32_t struct_id, uint32_t struct_member_index) {
     for (const auto& type_struct : module.static_data_.type_structs) {
         if (type_struct->id == struct_id) {
             const auto& member = type_struct->members[struct_member_index];
@@ -1479,8 +1539,7 @@ static uint32_t GetUntypedHeapOffset(const spirv::Module& module, const VkPhysic
     return 0;
 }
 
-static uint32_t GetUntypedArrayStride(const spirv::Module& module, const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
-                                      uint32_t type_array_id) {
+uint32_t UntypedContext::GetUntypedArrayStride(uint32_t type_array_id) {
     const auto decoration_set = module.GetDecorationSet(type_array_id);
     if (decoration_set.array_stride_id == spirv::kInvalidValue) {
         return 0;  // struct with no array in it
@@ -1490,14 +1549,13 @@ static uint32_t GetUntypedArrayStride(const spirv::Module& module, const VkPhysi
     return module.GetHeapUntypedSize(props, *array_stride_inst);
 }
 
-static void GetUntypedDescriptorIndexes(const spirv::Module& module, std::vector<HeapAccess::Index>& out_descriptor_indexes,
-                                        const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props,
-                                        std::vector<const spirv::Instruction*>& ac_indexes,
-                                        const spirv::Instruction& type_array_inst) {
+void UntypedContext::GetUntypedDescriptorIndexes(std::vector<HeapAccess::Index>& out_descriptor_indexes,
+                                                 std::vector<const spirv::Instruction*>& ac_indexes,
+                                                 const spirv::Instruction& type_array_inst) {
     assert(type_array_inst.IsArray());
     const uint32_t type_array_id = type_array_inst.ResultId();
 
-    const uint32_t array_stride_value = GetUntypedArrayStride(module, props, type_array_id);
+    const uint32_t array_stride_value = GetUntypedArrayStride(type_array_id);
 
     uint32_t element = vvl::kNoIndex32;  // dynamic index
     if (ac_indexes.empty()) {
@@ -1513,152 +1571,276 @@ static void GetUntypedDescriptorIndexes(const spirv::Module& module, std::vector
     // Keep checking for multidimensional arrays
     const spirv::Instruction* element_type_inst = module.FindDef(type_array_inst.Word(2));
     if (element_type_inst->IsArray()) {
-        GetUntypedDescriptorIndexes(module, out_descriptor_indexes, props, ac_indexes, *element_type_inst);
+        GetUntypedDescriptorIndexes(out_descriptor_indexes, ac_indexes, *element_type_inst);
     }
+}
+
+void UntypedContext::AddAccess(const VkDescriptorType descriptor_type, const spirv::Instruction* ac_inst, bool function_call) {
+    if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
+        // will happen when mixing typed (set/binding) and untyped
+        // just a dirty way to detect it is not going to be from the heap
+        //
+        // Also will occur from OpFunctionCall someone passing something else
+        return;
+    }
+
+    const spirv::Instruction* base_type_inst = module.FindDef(ac_inst->Word(3));
+    if (base_type_inst->Opcode() != spv::OpTypeBufferEXT && base_type_inst->Opcode() != spv::OpTypeStruct &&
+        !base_type_inst->IsArray()) {
+        // Can hit this if using OpUntypedAccessChainKHR on Set/Binding descriptors
+        return;
+    }
+
+    // walk the Access chains, build up the indexes
+    // [0] == farest from heap
+    // [size] == closest to the heap
+    std::vector<const spirv::Instruction*> ac_indexes;
+    const uint32_t untyped_ac_index_start = 5;
+    const spirv::Instruction* base_inst = ac_inst;
+    while (base_inst->Opcode() == spv::OpUntypedAccessChainKHR) {
+        // there is a chance there are no indexes, that is an implicit 0
+        for (uint32_t i = base_inst->Length() - 1; i >= untyped_ac_index_start; i--) {
+            ac_indexes.emplace_back(module.FindDef(base_inst->Word(i)));
+        }
+        base_type_inst = module.FindDef(base_inst->Word(3));
+        base_inst = module.FindDef(base_inst->Word(4));
+    }
+    if (base_inst->Opcode() != spv::OpUntypedVariableKHR) {
+        assert(false);
+        return;
+    }
+    const uint32_t variable_id = base_inst->ResultId();
+
+    uint32_t heap_offset = 0;
+    std::vector<HeapAccess::Index> descriptor_indexes;
+
+    if (base_type_inst->Opcode() == spv::OpTypeBufferEXT) {
+        // single element
+    } else if (base_type_inst->Opcode() == spv::OpTypeStruct) {
+        const uint32_t struct_id = base_type_inst->ResultId();
+        uint32_t struct_member_index = 0;
+        if (!ac_indexes.empty()) {
+            struct_member_index = ac_indexes.back()->GetConstantValue();
+            ac_indexes.pop_back();
+        }
+        heap_offset = GetUntypedHeapOffset(struct_id, struct_member_index);
+
+        const uint32_t struct_member_id = base_type_inst->Word(2 + struct_member_index);
+        const spirv::Instruction* struct_member_insn = module.FindDef(struct_member_id);
+        if (struct_member_insn->IsArray()) {
+            GetUntypedDescriptorIndexes(descriptor_indexes, ac_indexes, *struct_member_insn);
+        }
+    } else if (base_type_inst->IsArray()) {
+        GetUntypedDescriptorIndexes(descriptor_indexes, ac_indexes, *base_type_inst);
+    }
+
+    accesses[variable_id].insert(HeapAccess{descriptor_type, heap_offset, descriptor_indexes, function_call});
+}
+
+std::vector<const spirv::Instruction*> UntypedContext::FindFunctionCallers(const spirv::Instruction& func_param_inst) {
+    std::vector<const spirv::Instruction*> callers;
+    const spirv::Instruction* param_type = module.FindDef(func_param_inst.TypeId());
+    if (param_type->Opcode() == spv::OpTypeUntypedPointerKHR) {
+        assert(function_info.param_map.find(func_param_inst.ResultId()) != function_info.param_map.end());
+        FunctionInfo::ParamInfo param_info = function_info.param_map[func_param_inst.ResultId()];
+
+        auto func_it = function_info.call_map.find(param_info.function_id);
+        // There is a chance no one calls this functions, will be dead code eliminated
+        if (func_it != function_info.call_map.end()) {
+            for (uint32_t function_call_id : func_it->second) {
+                const spirv::Instruction* function_call = module.FindDef(function_call_id);
+                assert(function_call->Opcode() == spv::OpFunctionCall);
+                const uint32_t param_index_operand = function_call->Word(4 + param_info.index);
+                const spirv::Instruction* called_param = module.FindDef(param_index_operand);
+                callers.emplace_back(called_param);
+            }
+        }
+    }
+    return callers;
 }
 
 // "Friends to let friends become compiler engineers" ~Spencer
-static vvl::unordered_map<uint32_t, HeapAccesses> DumpDescriptorHeapUntypedFindAccess(
-    const spirv::Module& module, const spirv::EntryPoint& entrypoint, const VkPhysicalDeviceDescriptorHeapPropertiesEXT& props) {
-    vvl::unordered_map<uint32_t, HeapAccesses> accesses;
+void UntypedContext::FindAccess(const spirv::Instruction* next_inst, bool image_access, bool from_function_call) {
+    if (image_access) {
+        const spirv::Instruction* sampler_load_inst = nullptr;
 
-    auto add_access = [&](const VkDescriptorType descriptor_type, const spirv::Instruction* ac_inst) {
-        if (ac_inst->Opcode() != spv::OpUntypedAccessChainKHR) {
-            // will happen when mixing typed (set/binding) and untyped
-            // just a dirty way to detect it is not going to be from the heap
-            return;
+        while (next_inst && (next_inst->Opcode() == spv::OpSampledImage || next_inst->Opcode() == spv::OpImage ||
+                             next_inst->Opcode() == spv::OpCopyObject)) {
+            if (next_inst->Opcode() == spv::OpSampledImage) {
+                sampler_load_inst = module.FindDef(next_inst->Operand(1));
+            }
+            next_inst = module.FindDef(next_inst->Operand(0));
         }
-
-        const spirv::Instruction* base_type_inst = module.FindDef(ac_inst->Word(3));
-        if (base_type_inst->Opcode() != spv::OpTypeBufferEXT && base_type_inst->Opcode() != spv::OpTypeStruct &&
-            !base_type_inst->IsArray()) {
+        const spirv::Instruction* image_load_inst = next_inst;
+        if (!image_load_inst || image_load_inst->Opcode() != spv::OpLoad) {
             assert(false);
             return;
         }
 
-        // walk the Access chains, build up the indexes
-        // [0] == farest from heap
-        // [size] == closest to the heap
-        std::vector<const spirv::Instruction*> ac_indexes;
-        const uint32_t untyped_ac_index_start = 5;
-        const spirv::Instruction* base_inst = ac_inst;
-        while (base_inst->Opcode() == spv::OpUntypedAccessChainKHR) {
-            // there is a chance there are no indexes, that is an implicit 0
-            for (uint32_t i = base_inst->Length() - 1; i >= untyped_ac_index_start; i--) {
-                ac_indexes.emplace_back(module.FindDef(base_inst->Word(i)));
-            }
-            base_type_inst = module.FindDef(base_inst->Word(3));
-            base_inst = module.FindDef(base_inst->Word(4));
-        }
-        if (base_inst->Opcode() != spv::OpUntypedVariableKHR) {
-            assert(false);
-            return;
-        }
-        const uint32_t variable_id = base_inst->ResultId();
+        // From here two types of images, sampled and non-sampled images
+        if (sampler_load_inst) {
+            // TODO - Assertion sampled images are 1D
+            const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
+            AddAccess(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, ac_inst, from_function_call);
 
-        uint32_t heap_offset = 0;
-        std::vector<HeapAccess::Index> descriptor_indexes;
-
-        if (base_type_inst->Opcode() == spv::OpTypeBufferEXT) {
-            // single element
-        } else if (base_type_inst->Opcode() == spv::OpTypeStruct) {
-            const uint32_t struct_id = base_type_inst->ResultId();
-            uint32_t struct_member_index = 0;
-            if (!ac_indexes.empty()) {
-                struct_member_index = ac_indexes.back()->GetConstantValue();
-                ac_indexes.pop_back();
-            }
-            heap_offset = GetUntypedHeapOffset(module, props, struct_id, struct_member_index);
-
-            const uint32_t struct_member_id = base_type_inst->Word(2 + struct_member_index);
-            const spirv::Instruction* struct_member_insn = module.FindDef(struct_member_id);
-            if (struct_member_insn->IsArray()) {
-                GetUntypedDescriptorIndexes(module, descriptor_indexes, props, ac_indexes, *struct_member_insn);
-            }
-        } else if (base_type_inst->IsArray()) {
-            GetUntypedDescriptorIndexes(module, descriptor_indexes, props, ac_indexes, *base_type_inst);
-        }
-
-        accesses[variable_id].insert(HeapAccess{descriptor_type, heap_offset, descriptor_indexes});
-    };
-
-    for (const spirv::Instruction* memory_access_inst : entrypoint.accessible.memory_accesses) {
-        // Basically there are 2 flows, images and non-images
-        uint32_t ptr_id = OpcodeImageAccessPosition(memory_access_inst->Opcode());
-        const bool image_access = ptr_id != 0;
-
-        if (image_access) {
-            const spirv::Instruction* sampler_load_inst = nullptr;
-
-            const spirv::Instruction* next_inst = module.FindDef(memory_access_inst->Word(ptr_id));
-            while (next_inst && (next_inst->Opcode() == spv::OpSampledImage || next_inst->Opcode() == spv::OpImage ||
-                                 next_inst->Opcode() == spv::OpCopyObject)) {
-                if (next_inst->Opcode() == spv::OpSampledImage) {
-                    sampler_load_inst = module.FindDef(next_inst->Operand(1));
+            ac_inst = module.FindDef(sampler_load_inst->Word(3));
+            if (ac_inst->Opcode() == spv::OpFunctionParameter) {
+                auto callers = FindFunctionCallers(*ac_inst);
+                for (const spirv::Instruction* caller : callers) {
+                    AddAccess(VK_DESCRIPTOR_TYPE_SAMPLER, caller, true);
                 }
-                next_inst = module.FindDef(next_inst->Operand(0));
-            }
-            const spirv::Instruction* image_load_inst = next_inst;
-            if (!image_load_inst || image_load_inst->Opcode() != spv::OpLoad) {
-                assert(false);
-                continue;
-            }
-
-            // From here two types of images, sampled and non-sampled images
-            if (sampler_load_inst) {
-                // TODO - Assertion sampled images are 1D
-                const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
-                add_access(VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, ac_inst);
-
-                ac_inst = module.FindDef(sampler_load_inst->Word(3));
-                add_access(VK_DESCRIPTOR_TYPE_SAMPLER, ac_inst);
             } else {
-                const spirv::Instruction* image_type = module.FindDef(image_load_inst->TypeId());
-                assert(image_type->Opcode() == spv::OpTypeImage);
-                const VkDescriptorType image_descriptor_type = image_type->GetImageType();
-
-                const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
-                add_access(image_descriptor_type, ac_inst);
+                AddAccess(VK_DESCRIPTOR_TYPE_SAMPLER, ac_inst, from_function_call);
             }
         } else {
-            // |Operand 0| works for both Store/Load
-            ptr_id = memory_access_inst->Operand(0);
+            const spirv::Instruction* image_type = module.FindDef(image_load_inst->TypeId());
+            assert(image_type->Opcode() == spv::OpTypeImage);
+            const VkDescriptorType image_descriptor_type = image_type->GetImageType();
 
-            // We need to walk down possibly multiple chained OpAccessChains
-            const spirv::Instruction* next_access_chain = module.FindDef(ptr_id);
-            while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
-                const uint32_t base_operand = next_access_chain->IsUntypedAccessChain() ? 1 : 0;
-                const uint32_t access_chain_base_id = next_access_chain->Operand(base_operand);
-                next_access_chain = module.FindDef(access_chain_base_id);
+            const spirv::Instruction* ac_inst = module.FindDef(image_load_inst->Word(3));
+            if (ac_inst->Opcode() == spv::OpFunctionParameter) {
+                // Not sure this is 100% correct, but only way I could find passing a image
+                // descriptor heap as a parameter.
+                // If worse case, and this is wrong, we will just not detect accesses.
+                auto callers = FindFunctionCallers(*ac_inst);
+                for (const spirv::Instruction* caller : callers) {
+                    AddAccess(image_descriptor_type, caller, true);
+                }
+            } else {
+                AddAccess(image_descriptor_type, ac_inst, from_function_call);
             }
-            const spirv::Instruction* base_type = next_access_chain;
-            if (!base_type) {
-                continue;
-            }
+        }
+    } else {
+        // We need to walk down possibly multiple chained OpAccessChains
+        const spirv::Instruction* next_access_chain = next_inst;
+        while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
+            const uint32_t base_operand = next_access_chain->IsUntypedAccessChain() ? 1 : 0;
+            const uint32_t access_chain_base_id = next_access_chain->Operand(base_operand);
+            next_access_chain = module.FindDef(access_chain_base_id);
+        }
+        const spirv::Instruction* base_type = next_access_chain;
+        if (!base_type) {
+            return;
+        }
 
-            if (base_type->Opcode() == spv::OpBufferPointerEXT) {
-                // Ignore old BufferBlock + Uniform
-                const VkDescriptorType descriptor_type =
-                    module.FindDef(base_type->TypeId())->StorageClass() == spv::StorageClassUniform
-                        ? VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
-                        : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        if (base_type->Opcode() == spv::OpBufferPointerEXT) {
+            // Ignore old BufferBlock + Uniform
+            const VkDescriptorType descriptor_type = module.FindDef(base_type->TypeId())->StorageClass() == spv::StorageClassUniform
+                                                         ? VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+                                                         : VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 
-                const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(3));
-                add_access(descriptor_type, ac_inst);
-            } else if (base_type->Opcode() == spv::OpUntypedImageTexelPointerEXT) {
-                // Atomic storage image
-                const VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-                const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(4));
-                add_access(descriptor_type, ac_inst);
+            const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(3));
+            AddAccess(descriptor_type, ac_inst, from_function_call);
+        } else if (base_type->Opcode() == spv::OpUntypedImageTexelPointerEXT) {
+            // Atomic storage image
+            const VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+            const spirv::Instruction* ac_inst = module.FindDef(base_type->Word(4));
+            AddAccess(descriptor_type, ac_inst, from_function_call);
+        } else if (base_type->Opcode() == spv::OpFunctionParameter) {
+            auto callers = FindFunctionCallers(*base_type);
+            for (const spirv::Instruction* caller : callers) {
+                FindAccess(caller, image_access, true);
             }
         }
     }
-    return accesses;
+}
+
+bool UntypedContext::Print(std::ostringstream& ss, vvl::CommandBuffer& cb_state) {
+    bool found_warning = false;
+
+    // We print out the variables, but the real "value" comes from scaning the accesses
+    // (due to how untyped pointers work)
+    for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
+        if (!resource_variable.IsHeap()) {
+            continue;
+        }
+        ss << "  - " << resource_variable.DescribeDescriptor() << " accesses detected:\n";
+        auto it = accesses.find(resource_variable.id);
+        if (it == accesses.end()) {
+            ss << "    - No accesses found to this heap variable\n";
+            continue;
+        }
+
+        const bool is_sampler = resource_variable.is_sampler_heap;
+        auto heap_range = is_sampler ? cb_state.descriptor_heap.sampler_range : cb_state.descriptor_heap.resource_range;
+        auto reserve_range = is_sampler ? cb_state.descriptor_heap.sampler_reserved : cb_state.descriptor_heap.resource_reserved;
+
+        for (const HeapAccess& access : it->second) {
+            ss << "    - heap offset: 0x" << std::hex << access.heap_offset;
+            VkDeviceSize final_address = 0;
+
+            const bool is_array = !access.descriptor_indexes.empty();
+            if (!is_array) {
+                ss << ", single element\n";
+                final_address = heap_range.begin + access.heap_offset;
+            } else {
+                ss << ", array stride: ";
+                for (const auto& descriptor_index : access.descriptor_indexes) {
+                    ss << "[" << std::dec << descriptor_index.array_stride << "]";
+                }
+
+                VkDeviceSize final_offset = access.heap_offset;
+                bool dynamic_index = false;
+                ss << ", array index: ";
+                for (const auto& descriptor_index : access.descriptor_indexes) {
+                    if (descriptor_index.element == vvl::kNoIndex32) {
+                        dynamic_index = true;
+                        ss << "[dynamic]";
+                    } else {
+                        ss << "[" << std::dec << descriptor_index.element << "]";
+                        final_offset += descriptor_index.array_stride * descriptor_index.element;
+                    }
+                }
+
+                if (access.function_call) {
+                    // TODO - print the functions passed in
+                    ss << " (is a function argument)";
+                }
+
+                ss << '\n';
+                if (!dynamic_index) {
+                    final_address = heap_range.begin + final_offset;
+                }
+            }
+
+            if (final_address != 0) {
+                ss << "      - " << (is_sampler ? "Sampler" : "Resource") << " heap address: 0x" << std::hex << final_address
+                   << '\n';
+            }
+
+            const VkDeviceSize descriptor_size = device_state.cached_descriptor_size.GetSize(access.descriptor_type);
+            ss << "      - descriptor size: " << std::dec << descriptor_size << " ("
+               << string_VkDescriptorType(access.descriptor_type) << ")\n";
+
+            // if we know the real address, see if invalid
+            if (final_address != vvl::kNoIndex32) {
+                if (final_address > heap_range.end) {
+                    ss << "      - [WARNING] OUT OF BOUNDS - the descriptor is not in the " << (is_sampler ? "sampler" : "resource")
+                       << " heap\n";
+                    found_warning = true;
+                }
+                if (!reserve_range.empty()) {
+                    vvl::range<VkDeviceAddress> final_range{final_address, final_address + descriptor_size};
+                    if (final_range.intersects(reserve_range)) {
+                        ss << "      - [WARNING] RESERVED RANGE - this descriptor overlaps with the reserved range\n";
+                        found_warning = true;
+                    }
+                }
+
+                VkDeviceSize required_alignment = GetDescriptorHeapAlignment(props, access.descriptor_type);
+                if (!IsPointerAligned(final_address, required_alignment)) {
+                    vvl::Field alignment_name = GetDescriptorHeapAlignmentField(access.descriptor_type);
+                    ss << "      - [WARNING] MISALIGNED - the descriptor is not aligned to " << String(alignment_name);
+                    ss << " (" << std::dec << required_alignment << ")\n";
+                    found_warning = true;
+                }
+            }
+        }
+    }
+    return found_warning;
 }
 
 bool CommandBufferSubState::DumpDescriptorHeapUntyped(std::ostringstream& ss, const ShaderStageState& stage) const {
-    bool found_warning = false;
-
     std::shared_ptr<const spirv::Module> module_state_ptr = stage.spirv_state;
     std::shared_ptr<const spirv::EntryPoint> entrypoint_ptr = stage.entrypoint;
 
@@ -1710,98 +1892,23 @@ bool CommandBufferSubState::DumpDescriptorHeapUntyped(std::ostringstream& ss, co
         }
     }
 
-    const spirv::Module& module = *module_state_ptr;
-    const spirv::EntryPoint& entrypoint = *entrypoint_ptr;
+    UntypedContext context(dev_data, *module_state_ptr, *entrypoint_ptr);
 
-    // The idea is to go through and find all the access and afterwards sort/group them to make sense to the user
-    // < variable id, [accesses]>
-    vvl::unordered_map<uint32_t, HeapAccesses> accesses =
-        DumpDescriptorHeapUntypedFindAccess(module, entrypoint, dev_data.phys_dev_ext_props.descriptor_heap_props);
-
-    // We print out the variables, but the real "value" comes from scaning the accesses
-    // (due to how untyped pointers work)
-    for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
-        if (!resource_variable.IsHeap()) {
-            continue;
+    for (const spirv::Instruction* memory_access_inst : context.entrypoint.accessible.memory_accesses) {
+        // Basically there are 2 flows, images and non-images
+        uint32_t ptr_id = OpcodeImageAccessPosition(memory_access_inst->Opcode());
+        const bool image_access = ptr_id != 0;
+        if (image_access) {
+            ptr_id = memory_access_inst->Word(ptr_id);
+        } else {
+            // |Operand 0| works for both Store/Load
+            ptr_id = memory_access_inst->Operand(0);
         }
-        ss << "  - " << resource_variable.DescribeDescriptor() << " accesses detected:\n";
-        auto it = accesses.find(resource_variable.id);
-        if (it == accesses.end()) {
-            ss << "    - No accesses found to this heap variable\n";
-            continue;
-        }
-
-        const bool is_sampler = resource_variable.is_sampler_heap;
-        auto heap_range = is_sampler ? base.descriptor_heap.sampler_range : base.descriptor_heap.resource_range;
-        auto reserve_range = is_sampler ? base.descriptor_heap.sampler_reserved : base.descriptor_heap.resource_reserved;
-
-        for (const HeapAccess& access : it->second) {
-            ss << "    - heap offset: 0x" << std::hex << access.heap_offset;
-            VkDeviceSize final_address = 0;
-
-            const bool is_array = !access.descriptor_indexes.empty();
-            if (!is_array) {
-                ss << ", single element\n";
-                final_address = heap_range.begin + access.heap_offset;
-            } else {
-                ss << ", array stride: ";
-                for (const auto& descriptor_index : access.descriptor_indexes) {
-                    ss << "[" << std::dec << descriptor_index.array_stride << "]";
-                }
-
-                VkDeviceSize final_offset = access.heap_offset;
-                bool dynamic_index = false;
-                ss << ", array index: ";
-                for (const auto& descriptor_index : access.descriptor_indexes) {
-                    if (descriptor_index.element == vvl::kNoIndex32) {
-                        dynamic_index = true;
-                        ss << "[dynamic]";
-                    } else {
-                        ss << "[" << std::dec << descriptor_index.element << "]";
-                        final_offset += descriptor_index.array_stride * descriptor_index.element;
-                    }
-                }
-                ss << '\n';
-                if (!dynamic_index) {
-                    final_address = heap_range.begin + final_offset;
-                }
-            }
-
-            if (final_address != 0) {
-                ss << "      - " << (is_sampler ? "Sampler" : "Resource") << " heap address: 0x" << std::hex << final_address
-                   << '\n';
-            }
-
-            const VkDeviceSize descriptor_size = dev_data.device_state->cached_descriptor_size.GetSize(access.descriptor_type);
-            ss << "      - descriptor size: " << std::dec << descriptor_size << " ("
-               << string_VkDescriptorType(access.descriptor_type) << ")\n";
-
-            // if we know the real address, see if invalid
-            if (final_address != vvl::kNoIndex32) {
-                if (final_address > heap_range.end) {
-                    ss << "      - [WARNING] OUT OF BOUNDS - the descriptor is not in the " << (is_sampler ? "sampler" : "resource")
-                       << " heap\n";
-                    found_warning = true;
-                }
-                if (!reserve_range.empty()) {
-                    vvl::range<VkDeviceAddress> final_range{final_address, final_address + descriptor_size};
-                    if (final_range.intersects(reserve_range)) {
-                        ss << "      - [WARNING] RESERVED RANGE - this descriptor overlaps with the reserved range\n";
-                        found_warning = true;
-                    }
-                }
-
-                VkDeviceSize required_alignment =
-                    GetDescriptorHeapAlignment(dev_data.phys_dev_ext_props.descriptor_heap_props, access.descriptor_type);
-                if (!IsPointerAligned(final_address, required_alignment)) {
-                    vvl::Field alignment_name = GetDescriptorHeapAlignmentField(access.descriptor_type);
-                    ss << "      - [WARNING] MISALIGNED - the descriptor is not aligned to " << String(alignment_name);
-                    ss << " (" << std::dec << required_alignment << ")\n";
-                    found_warning = true;
-                }
-            }
-        }
+        const spirv::Instruction* next_inst = context.module.FindDef(ptr_id);
+        context.FindAccess(next_inst, image_access, false);
     }
+
+    bool found_warning = context.Print(ss, base);
 
     return found_warning;
 }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -766,6 +766,8 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuL
     }
 
     if (settings_data->enabled[gpu_dump]) {
+        const bool has_info_bit = (report_flags & kInformationBit) != 0;
+        const bool has_warn_bit = (report_flags & kWarningBit) != 0;
         if (settings_data->gpu_dump_settings->to_stdout) {
             if ((debug_action & VK_DBG_LAYER_ACTION_LOG_MSG)) {
                 if (is_stdout) {
@@ -779,8 +781,6 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuL
                 }
             }
         } else if (!settings_data->gpu_dump_settings->to_stdout) {
-            const bool has_info_bit = (report_flags & kInformationBit) != 0;
-            const bool has_warn_bit = (report_flags & kWarningBit) != 0;
             // If the user ONLY wants warning, don't turn on info
             // If they forgot both, turn both on
             if (!has_info_bit && !has_warn_bit) {
@@ -791,6 +791,13 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings* settings_data, VkuL
                 report_flags |= kInformationBit;
                 report_flags |= kWarningBit;
             }
+        }
+
+        // If the user has only info on to get information, that could be seen as a legit usecase
+        if (has_warn_bit && settings_data->enabled[gpu_validation]) {
+            setting_warnings.emplace_back(
+                "GPU Dump and GPU-AV are both enabled and this is NOT desired. GPU Dump warnings are designed to find everything "
+                "GPU-AV does but in a 'CPU best attempt' fashion. Only use GPU Dump or GPU-AV, not both together.");
         }
     }
 

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -16,9 +16,11 @@
  */
 
 #include "state_tracker/shader_module.h"
+#include "containers/custom_containers.h"
 #include "state_tracker/shader_instruction.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <queue>
@@ -972,6 +974,7 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
     uint32_t last_func_id = 0;
     // < Function ID, OpFunctionParameter Ids >
     vvl::unordered_map<uint32_t, std::vector<uint32_t>> func_parameter_list;
+    vvl::unordered_set<uint32_t> func_parameter_types;
 
     // Loop through once and build up the static data
     // Also process the entry points
@@ -1282,6 +1285,7 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
                 break;
             case spv::OpFunctionParameter:
                 func_parameter_list[last_func_id].push_back(insn.ResultId());
+                func_parameter_types.insert(insn.TypeId());
                 break;
             case spv::OpFunctionCall:
                 func_call_instructions.push_back(&insn);
@@ -1340,6 +1344,15 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
                 const uint32_t arg = func_call->Word(first_arg_word + i);
                 const uint32_t param = func_def.second[i];
                 func_parameter_map[param].push_back(arg);
+            }
+        }
+    }
+
+    if (module_state.HasCapability(spv::CapabilityUntypedPointersKHR)) {
+        for (uint32_t param_type : func_parameter_types) {
+            if (module_state.FindDef(param_type)->Opcode() == spv::OpTypeUntypedPointerKHR) {
+                has_untyped_pointer_function_params = true;
+                break;
             }
         }
     }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -748,6 +748,11 @@ struct Module {
         bool has_specialization_constants{false};
         bool uses_interpolate_at_sample{false};
 
+        // GPU Dump will want the |FuncParameterMap| if someone is trying to pass an untyped descriptor
+        // into a function. Instead of tracking the memory for everyone, GPU Dump will just rebuild the info,
+        // but only if it is actually needed
+        bool has_untyped_pointer_function_params{false};
+
         // Will check if there is source debug information
         // Won't save any other info and will retrieve the debug info if requested in a VU error message
         bool using_legacy_debug_info{false};

--- a/tests/unit/descriptor_heap_untyped_positive.cpp
+++ b/tests/unit/descriptor_heap_untyped_positive.cpp
@@ -1224,3 +1224,188 @@ TEST_F(PositiveDescriptorHeapUntyped, MultidimensionalArray) {
         ASSERT_EQ(data[0], 42);
     }
 }
+
+TEST_F(PositiveDescriptorHeapUntyped, BufferAsFunctionParameter) {
+    AddRequiredFeature(vkt::Feature::variablePointers);
+    AddRequiredFeature(vkt::Feature::variablePointersStorageBuffer);
+    RETURN_IF_SKIP(InitUntypedDescriptorHeap());
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 4);
+
+    vkt::Buffer buffer_0(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    vkt::Buffer buffer_1(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    vkt::Buffer buffer_2(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    desc_heap.WriteBufferDescriptor(buffer_0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    desc_heap.WriteBufferDescriptor(buffer_1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    desc_heap.WriteBufferDescriptor(buffer_2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+
+    uint32_t* data = static_cast<uint32_t*>(buffer_1.Memory().Map());
+    data[0] = 11;
+    data = static_cast<uint32_t*>(buffer_2.Memory().Map());
+    data[0] = 22;
+
+    // layout(descriptor_heap) buffer SSBO {
+    //     uint data;
+    // } buf[];
+    //
+    // layout(push_constant) uniform PC {
+    //     uint pc_index;
+    // };
+    //
+    // uint foo(uint index, uint* data_a, uint* data_b) {
+    //     if (index == 1) {
+    //         return *data_a;
+    //     } else if (index < 10) {
+    //         return *data_b;
+    //     }
+    //     return 42;
+    // }
+    //
+    // void main() {
+    //     uint x = foo(pc_index, &buf[1], &buf[pc_index]);
+    //     buf[0].data = x;
+    // }
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpCapability VariablePointers
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap %pc_var
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %PC Block
+               OpMemberDecorate %PC 0 Offset 0
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorateId %buffer_stride ArrayStrideIdEXT %buffer_size
+
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+        %int = OpTypeInt 32 1
+       %uint = OpTypeInt 32 0
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+    %uint_10 = OpConstant %uint 10
+    %uint_42 = OpConstant %uint 42
+         %PC = OpTypeStruct %uint
+     %ptr_pc = OpTypePointer PushConstant %PC
+     %pc_var = OpVariable %ptr_pc PushConstant
+       %SSBO = OpTypeStruct %uint
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+%_ptr_PushConstant_uint = OpTypePointer PushConstant %uint
+%_ptr_StorageBuffer = OpTypeUntypedPointerKHR StorageBuffer
+%type_buffer = OpTypeBufferEXT StorageBuffer
+%buffer_size = OpConstantSizeOfEXT %int %type_buffer
+%buffer_stride = OpTypeRuntimeArray %type_buffer
+
+  %main_type = OpTypeFunction %void
+   %foo_type = OpTypeFunction %uint %_ptr_StorageBuffer %_ptr_StorageBuffer
+
+        %foo = OpFunction %uint None %foo_type
+    %param_a = OpFunctionParameter %_ptr_StorageBuffer
+    %param_b = OpFunctionParameter %_ptr_StorageBuffer
+      %foo_l = OpLabel
+         %44 = OpAccessChain %_ptr_PushConstant_uint %pc_var %int_0
+   %pc_index = OpLoad %uint %44
+         %17 = OpIEqual %bool %pc_index %uint_1
+               OpSelectionMerge %19 None
+               OpBranchConditional %17 %18 %22
+         %18 = OpLabel
+         %20 = OpLoad %uint %param_a
+               OpReturnValue %20
+         %22 = OpLabel
+         %25 = OpULessThan %bool %pc_index %uint_10
+               OpSelectionMerge %27 None
+               OpBranchConditional %25 %26 %27
+         %26 = OpLabel
+         %28 = OpLoad %uint %param_b
+               OpReturnValue %28
+         %27 = OpLabel
+               OpBranch %19
+         %19 = OpLabel
+               OpReturnValue %uint_42
+               OpFunctionEnd
+
+       %main = OpFunction %void None %main_type
+     %main_l = OpLabel
+          %x = OpVariable %_ptr_Function_uint Function
+         %50 = OpAccessChain %_ptr_PushConstant_uint %pc_var %int_0
+  %pc_index_ = OpLoad %uint %50
+
+   %ptr_buf_1 = OpUntypedAccessChainKHR %_ptr_UniformConstant %buffer_stride %resource_heap %int_1
+       %buf_a = OpBufferPointerEXT %_ptr_StorageBuffer %ptr_buf_1
+  %buf_a_data = OpUntypedAccessChainKHR %_ptr_StorageBuffer %SSBO %buf_a %int_0
+  %ptr_buf_pc = OpUntypedAccessChainKHR %_ptr_UniformConstant %buffer_stride %resource_heap %pc_index_
+       %buf_b = OpBufferPointerEXT %_ptr_StorageBuffer %ptr_buf_pc
+  %buf_b_data = OpUntypedAccessChainKHR %_ptr_StorageBuffer %SSBO %buf_b %int_0
+
+         %66 = OpFunctionCall %uint %foo %buf_a_data %buf_b_data
+               OpStore %x %66
+         %68 = OpLoad %uint %x
+         %69 = OpUntypedAccessChainKHR %_ptr_UniformConstant %buffer_stride %resource_heap %int_0
+         %72 = OpBufferPointerEXT %_ptr_StorageBuffer %69
+         %73 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %SSBO %72 %int_0
+               OpStore %73 %68
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    data = static_cast<uint32_t*>(buffer_0.Memory().Map());
+
+    // skips loading both
+    uint32_t pc_index = 100;
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.PushData(0, sizeof(uint32_t), &pc_index);
+        desc_heap.BindResourceHeap(m_command_buffer);
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+        vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+        m_command_buffer.End();
+        m_default_queue->SubmitAndWait(m_command_buffer);
+
+        if (!IsPlatformMockICD()) {
+            ASSERT_EQ(data[0], 42);
+        }
+    }
+
+    // load buffer_1
+    pc_index = 1;
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.PushData(0, sizeof(uint32_t), &pc_index);
+        desc_heap.BindResourceHeap(m_command_buffer);
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+        vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+        m_command_buffer.End();
+        m_default_queue->SubmitAndWait(m_command_buffer);
+
+        if (!IsPlatformMockICD()) {
+            ASSERT_EQ(data[0], 11);
+        }
+    }
+
+    // load buffer_2
+    pc_index = 2;
+    {
+        m_command_buffer.Begin();
+        m_command_buffer.PushData(0, sizeof(uint32_t), &pc_index);
+        desc_heap.BindResourceHeap(m_command_buffer);
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+        vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+        m_command_buffer.End();
+        m_default_queue->SubmitAndWait(m_command_buffer);
+
+        if (!IsPlatformMockICD()) {
+            ASSERT_EQ(data[0], 22);
+        }
+    }
+}

--- a/tests/unit/gpu_av_descriptor_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <vulkan/vulkan_core.h>
+#include "binding.h"
 #include "layer_validation_tests.h"
 #include "pipeline_helper.h"
 #include "test_framework.h"
@@ -216,8 +217,8 @@ TEST_F(NegativeGpuAVDescriptorBuffer, DISABLED_PostProcesingOnly) {
 }
 
 TEST_F(NegativeGpuAVDescriptorBuffer, DescriptorHashingNoDescriptor) {
-    static const VkLayerSettingEXT layer_settings = {OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
-                                                     &kVkTrue};
+    const VkLayerSettingEXT layer_settings = {OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
+                                              &kVkTrue};
     RETURN_IF_SKIP(InitBasicDescriptorBuffer({layer_settings}));
 
     vkt::DescriptorSetLayout ds_layout(*m_device, {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -263,8 +264,8 @@ TEST_F(NegativeGpuAVDescriptorBuffer, DescriptorHashingNoDescriptor) {
 }
 
 TEST_F(NegativeGpuAVDescriptorBuffer, DescriptorHashingNoDescriptorIndexing) {
-    static const VkLayerSettingEXT layer_settings = {OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
-                                                     &kVkTrue};
+    const VkLayerSettingEXT layer_settings = {OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
+                                              &kVkTrue};
     RETURN_IF_SKIP(InitBasicDescriptorBuffer({layer_settings}));
 
     std::vector<VkDescriptorSetLayoutBinding> bindings = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -324,4 +325,56 @@ TEST_F(NegativeGpuAVDescriptorBuffer, DescriptorHashingNoDescriptorIndexing) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08116");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeGpuAVDescriptorBuffer, GpuDump) {
+    std::vector<VkLayerSettingEXT> layer_settings = {
+        {OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "gpu_dump_descriptors", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue}};
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer({layer_settings}));
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
+
+    vkt::Buffer descriptor_buffer(*m_device, 256, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
+
+    vkt::Buffer ssbo_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    vkt::DescriptorGetInfo get_info(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, ssbo_buffer, 16u);
+    uint8_t* mapped_descriptor_data = (uint8_t*)descriptor_buffer.Memory().Map();
+    vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
+
+    vkt::DescriptorSetLayout ds_layout(*m_device, {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                       VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+    vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout});
+
+    const char* cs_source = R"glsl(
+        #version 450
+        layout (set = 0, binding = 0) buffer SSBO_0 {
+            uint a;
+        };
+        void main() {
+            a = 0;
+        }
+    )glsl";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    pipe.cp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipe.cp_ci_.layout = pipeline_layout;
+    pipe.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+
+    VkDescriptorBufferBindingInfoEXT descriptor_buffer_binding_info = vku::InitStructHelper();
+    descriptor_buffer_binding_info.address = descriptor_buffer.Address();
+    descriptor_buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+    vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &descriptor_buffer_binding_info);
+
+    uint32_t buffer_index = 0;
+    VkDeviceSize buffer_offset = 0;
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1, &buffer_index,
+                                         &buffer_offset);
+    m_errorMonitor->SetDesiredInfo("GPU-DUMP");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
 }

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -3273,7 +3273,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, HashingNullDescriptor) {
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::nullDescriptor);
     const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}, false));
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}));
 
     if (vk::GetPhysicalDeviceDescriptorSizeEXT(Gpu(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) !=
         vk::GetPhysicalDeviceDescriptorSizeEXT(Gpu(), VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)) {
@@ -3341,7 +3341,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, HashingToManyDescriptors) {
 
 TEST_F(NegativeGpuAVDescriptorHeap, HashingDeviceLocal) {
     const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}, false));
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}));
     vkt::DescriptorHeap desc_heap(*this);
 
     VkDeviceSize resource_heap_size_app = Align(heap_props.bufferDescriptorSize, heap_props.bufferDescriptorAlignment);
@@ -3420,7 +3420,7 @@ TEST_F(NegativeGpuAVDescriptorHeap, HashingDeviceLocal) {
 
 TEST_F(NegativeGpuAVDescriptorHeap, ResourceOOBWithHashingOn) {
     const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
-    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}, false));
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}));
     vkt::DescriptorHeap desc_heap(*this);
     const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
     desc_heap.CreateResourceHeap(resource_stride, true);

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -2551,7 +2551,13 @@ TEST_F(NegativeGpuDump, DescriptorHeapUntypedPointersImageFunctionParam) {
     RETURN_IF_SKIP(InitDescriptorHeap());
 
     vkt::DescriptorHeap desc_heap(*this);
-    desc_heap.CreateResourceHeap(4096);
+    desc_heap.CreateResourceHeap(heap_props.imageDescriptorSize);
+
+    // TODO - vkt::DescriptorHeap needs to be fixed to make sure the heap memory is allocated to
+    // imageDescriptorAlignment
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "issues with alignment";
+    }
 
     VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0, 2);
     mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -2544,3 +2544,89 @@ TEST_F(NegativeGpuDump, DescriptorHeapNullDescriptor) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
+
+TEST_F(NegativeGpuDump, DescriptorHeapUntypedPointersImageFunctionParam) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitDescriptorHeap());
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(4096);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0, 2);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability SampledBuffer
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %2 "main" %3 %4 %5
+               OpExecutionMode %2 LocalSize 1 1 1
+               OpDecorate %3 BuiltIn ResourceHeapEXT
+               OpDecorateId %6 ArrayStrideIdEXT %7
+               OpDecorate %4 Binding 0
+               OpDecorate %4 DescriptorSet 0
+               OpDecorate %8 Block
+               OpMemberDecorate %8 0 Offset 0
+               OpDecorate %5 Binding 1
+               OpDecorate %5 DescriptorSet 0
+          %9 = OpTypeVoid
+         %10 = OpTypeFunction %9
+         %11 = OpTypeInt 32 0
+         %12 = OpTypeImage %11 Buffer 0 0 0 1 Unknown
+         %13 = OpTypePointer UniformConstant %12
+         %14 = OpTypeUntypedPointerKHR UniformConstant
+         %15 = OpTypeFunction %11 %14
+         %16 = OpConstant %11 0
+         %17 = OpTypeVector %11 4
+         %18 = OpTypeVector %11 2
+          %3 = OpUntypedVariableKHR %14 UniformConstant
+          %7 = OpConstantSizeOfEXT %11 %12
+          %6 = OpTypeRuntimeArray %12
+         %19 = OpTypePointer Function %11
+          %4 = OpVariable %13 UniformConstant
+         %20 = OpConstant %11 1
+          %8 = OpTypeStruct %18
+         %21 = OpTypePointer StorageBuffer %8
+          %5 = OpVariable %21 StorageBuffer
+         %22 = OpTypePointer StorageBuffer %18
+         %23 = OpTypeVector %11 3
+         %24 = OpConstantComposite %23 %20 %20 %20
+         %25 = OpFunction %11 None %15
+         %26 = OpFunctionParameter %14
+         %27 = OpLabel
+         %28 = OpLoad %12 %26
+         %29 = OpImageFetch %17 %28 %16 ZeroExtend
+         %30 = OpCompositeExtract %11 %29 0
+               OpReturnValue %30
+               OpFunctionEnd
+          %2 = OpFunction %9 None %10
+         %31 = OpLabel
+         %32 = OpUntypedAccessChainKHR %14 %6 %3 %16
+         %33 = OpUntypedAccessChainKHR %14 %12 %4
+         %34 = OpFunctionCall %11 %25 %32
+         %35 = OpFunctionCall %11 %25 %33
+         %36 = OpCompositeConstruct %18 %34 %35
+         %37 = OpAccessChain %22 %5 %16
+               OpStore %37 %36
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, &mapping_info, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredInfo("(is a function argument)");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
unlocked some new crazy ways of using Untyped Pointers... want a way to have GPU Dump print these accesses (otherwise it will be a bit misleading)