### PR TITLE
docs: Add syncval queue progress section

### DIFF
--- a/docs/syncval_development.md
+++ b/docs/syncval_development.md
@@ -2,9 +2,7 @@
 
 This document contains miscellaneous information related to development of synchronization validation.
 
-## Error messages
-
-### How to diff-compare error messages before and after the change
+## SyncVal error messages (how to diff them)
 
 The syncval error reporting code uses helper routines to generate the parts of the error messages. One potential issues with this shared code is when modifying a specific error message it's possible to accidentally break another one. The easiest way to validate the scope of the changes is to compare the output of all negative tests before and after the change.
 
@@ -32,3 +30,13 @@ If `VVL_ENABLE_SYNCVAL_STATS=1` environment variable is also set, statistics wil
 If the *mimalloc* allocator is used, syncval statistics can also collect allocation information using the mimalloc stats system. The mimalloc dependency must be build with `MI_STAT=1` preprocessor definition. The total amount of allocated memory is tracked in `Stats::total_allocated_memory`, and all mimalloc stats are stored in `Stats::mi_stats`.
 
 The mimalloc statistics are updated at fixed points: `vkQueueSubmit`, `vkQueuePresent`, and when generating a report via `Stats::CreateReport()`. To update mimalloc stats manually at arbitrary point, call `Stats::UpdateMemoryStats`.
+
+## Queue progress tracking in SyncVal and Core Checks
+
+Core Checks and SyncVal use different models of queue progress.
+
+Core Checks simulates queue forward progress to track whether resources are still in use. A submission can take an arbitrarily long time to complete, so Core Checks cannot assume progress just because enough time has passed or many more submissions were made. Only a host synchronization operation, such as `vkWaitForFences`, moves the simulated queue forward.
+
+SyncVal simulates queue forward progress to track resource accesses in submitted GPU commands. Once a submission's semaphore dependencies are resolved, SyncVal can process it without waiting for the device. No host synchronization operation is needed. A submission is usually processed during its own `QueueSubmit` call. For timeline semaphores, a wait-before-signal submission remains pending until the matching signal is submitted in a later `QueueSubmit` call.
+
+Core Checks and SyncVal share the same `vvl::Semaphore` state. Because this state also supports the Core Checks progress model, its `timeline_` map keeps timepoints until a host synchronization operation moves the queue forward. SyncVal's own queue progress tracking does not need this full history. If an application continues submitting timeline semaphore operations without host synchronization, timepoints accumulate in the `timeline_` map. This is expected behavior of the shared progress model, not a practical memory issue.

--- a/tests/stress/sync_val_stress.cpp
+++ b/tests/stress/sync_val_stress.cpp
@@ -144,3 +144,28 @@ TEST_F(StressSyncVal, CopyPagesInSmallChunksNoQueueSync) {
     }
     m_default_queue->Wait();
 }
+
+// Stress resolved signal and QueueBatchContext lifetime. Leaking these objects would cause
+// gigabytes of memory growth at this scale.
+// NOTE: vvl::Semaphore timepoints also accumulate until the final device wait, but their
+// memory use is much lower than that of QueueBatchContext objects. This growth is expected.
+TEST_F(StressSyncVal, TimelineSemaphoreMemoryStress) {
+    TEST_DESCRIPTION("Stress resolved signal and QueueBatchContext lifetime");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    constexpr uint64_t kSubmitCount = 100'000;
+
+    vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+    vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Copy(buffer_a, buffer_b);
+    m_command_buffer.End();
+
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+    for (uint64_t i = 1; i <= kSubmitCount; i++) {
+        m_default_queue->Submit(m_command_buffer, vkt::TimelineWait(semaphore, i - 1), vkt::TimelineSignal(semaphore, i));
+    }
+    m_device->Wait();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8369

I can't think of specific action points for that issue and `vvl::Semaphore` state tracking works well in practice even with stress workloads.

The information in the issue is worth to add to the documentation. Also added a memory stress test.
