### PR TITLE
gpuav: Various Heap/Buffer fixes from testing

### DIFF
--- a/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
+++ b/layers/gpu_dump/gpu_dump_descriptor_heap.cpp
@@ -70,6 +70,7 @@ struct DumpInfo {
     const VkPhysicalDeviceDescriptorHeapPropertiesEXT& heap_props;
     const spirv::ResourceInterfaceVariable& resource_variable;
     const bool is_sampler;
+    const bool is_embedded_sampler;
     const vvl::range<VkDeviceAddress>& heap_range;
     const vvl::range<VkDeviceAddress>& heap_reserved;
 
@@ -100,6 +101,7 @@ struct DumpInfo {
           heap_props(dev_data.phys_dev_ext_props.descriptor_heap_props),
           resource_variable(*mapping_info.resource_variable),
           is_sampler(resource_variable.is_sampler),
+          is_embedded_sampler(GetEmbeddedSampler(*mapping_info.mapping) != nullptr),
           heap_range(is_sampler ? heap.sampler_range : heap.resource_range),
           heap_reserved(is_sampler ? heap.sampler_reserved : heap.resource_reserved),
           sampler_range(heap.sampler_range),
@@ -126,22 +128,7 @@ struct DumpInfo {
         required_alignment = GetDescriptorHeapAlignment(heap_props, descriptor_type);
         alignment_name = GetDescriptorHeapAlignmentField(descriptor_type);
 
-        if (mapping_info.mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
-            inspect_sampler = resource_variable.is_combined_image_sampler &&
-                              mapping_info.mapping->sourceData.constantOffset.pEmbeddedSampler == nullptr;
-        } else if (mapping_info.mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
-            inspect_sampler = resource_variable.is_combined_image_sampler &&
-                              mapping_info.mapping->sourceData.pushIndex.pEmbeddedSampler == nullptr;
-        } else if (mapping_info.mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
-            inspect_sampler = resource_variable.is_combined_image_sampler &&
-                              mapping_info.mapping->sourceData.indirectIndex.pEmbeddedSampler == nullptr;
-        } else if (mapping_info.mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
-            inspect_sampler = resource_variable.is_combined_image_sampler &&
-                              mapping_info.mapping->sourceData.indirectIndexArray.pEmbeddedSampler == nullptr;
-        } else if (mapping_info.mapping->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT) {
-            inspect_sampler = resource_variable.is_combined_image_sampler &&
-                              mapping_info.mapping->sourceData.shaderRecordIndex.pEmbeddedSampler == nullptr;
-        }
+        inspect_sampler = resource_variable.is_combined_image_sampler && !is_embedded_sampler;
     }
 };
 
@@ -190,7 +177,7 @@ struct WarnInfo {
     void AlignmentIndexArraySampler(std::vector<uint32_t>& bad_indexes);
     void ReservedRangeIndexArray(std::vector<uint32_t>& bad_indexes);
     void ReservedRangeFinal();
-    std::string ValidateDescriptor(VkDeviceAddress address);
+    std::string ValidateDescriptor(VkDeviceAddress address, bool from_resource);
 };
 
 void WarnInfo::HeapOOB(VkDeviceSize offset, bool from_sampler) {
@@ -421,14 +408,14 @@ void WarnInfo::ReservedRangeFinal() {
     }
 };
 
-std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address) {
+std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address, bool from_resource) {
     if (!dump.dev_data.global_settings.descriptor_hashing) {
         return "";
     }
     if (FoundWarning()) {
         return "";  // no point checking if we know something else is wrong
     }
-
+    const VkDeviceSize descriptor_size = from_resource ? dump.descriptor_size : dump.sampler_descriptor_size;
     const auto& descriptor_hashing = *dump.dev_data.device_state->descriptor_hashing;
 
     // For VK_EXT_descriptor_heap where each descriptor type might be a different size.
@@ -441,7 +428,9 @@ std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address) {
     bool check_larger_sizes = true;
     std::vector<uint8_t> descriptor_bytes = dump.dev_data.CopyDataFromMemory(address, descriptor_hashing.heap_max_descriptor_size);
     if (descriptor_bytes.empty()) {
-        descriptor_bytes = dump.dev_data.CopyDataFromMemory(address, dump.descriptor_size);
+        if (descriptor_size < descriptor_hashing.heap_max_descriptor_size) {
+            descriptor_bytes = dump.dev_data.CopyDataFromMemory(address, descriptor_size);
+        }
         if (descriptor_bytes.empty()) {
             return "";  // heap buffer might not be visible
         } else {
@@ -451,14 +440,14 @@ std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address) {
     }
     ReadLockGuard guard(descriptor_hashing.map_lock);
 
-    uint64_t key = descriptor_hashing.Hash(descriptor_bytes.data(), dump.descriptor_size);
+    uint64_t key = descriptor_hashing.Hash(descriptor_bytes.data(), descriptor_size);
     const vvl::DescriptorHashTable::Entry* entry = descriptor_hashing.table.Find(key);
     if (!entry) {
         // Before saying we can't find it, check the other descriptor sizes if we can spot the wrong descriptor type
         for (VkDeviceSize size : descriptor_hashing.heap_all_descriptor_sizes) {
-            if (size == dump.descriptor_size) {
+            if (size == descriptor_size) {
                 continue;
-            } else if (!check_larger_sizes && size > dump.descriptor_size) {
+            } else if (!check_larger_sizes && size > descriptor_size) {
                 continue;
             }
             key = descriptor_hashing.Hash(descriptor_bytes.data(), size);
@@ -473,6 +462,7 @@ std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address) {
         }
     }
 
+    const VkDescriptorType descriptor_type = from_resource ? dump.descriptor_type : VK_DESCRIPTOR_TYPE_SAMPLER;
     if (entry->IsNullDescriptor()) {
         if (descriptor_hashing.null_descriptor_allowed) {
             return "[Null Descriptor]";
@@ -481,9 +471,9 @@ std::string WarnInfo::ValidateDescriptor(VkDeviceAddress address) {
            << "[WARNING] NO DESCRIPTOR - Found descriptor mapped to [Null Descriptor] but the nullDescriptor feature was not "
               "enabled";
         return "";
-    } else if (!entry->HasType(dump.descriptor_type)) {
+    } else if (!entry->HasType(descriptor_type)) {
         ss << new_bullet_line << "[WARNING] WRONG DESCRIPTOR - At 0x" << std::hex << address << " expected a "
-           << string_VkDescriptorType(dump.descriptor_type)
+           << string_VkDescriptorType(descriptor_type)
            << " descriptor, but instead found a descriptor for: " << descriptor_hashing.Describe(*dump.dev_data.device_state, key);
         return "";
     }
@@ -581,7 +571,7 @@ void CommandBufferSubState::DumpDescriptorHeapConstantOffset(std::ostringstream&
     // accessed will have a valid descriptor ready.
     // Also want at the end after everything has been checked so we don't try and access invalid memory
     if (!dump.is_array) {
-        std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address);
+        std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address, true);
         if (!descriptor_entry.empty()) {
             ss << new_bullet_line << "Found descriptor mapped to: " << descriptor_entry;
         }
@@ -649,7 +639,7 @@ void CommandBufferSubState::DumpDescriptorHeapConstantOffset(std::ostringstream&
         warn.HeapOOB(index_zero_offset + dump.sampler_descriptor_size, true);
 
         if (!dump.is_array) {
-            std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address);
+            std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address, false);
             if (!descriptor_entry.empty()) {
                 ss << new_bullet_line << "Found descriptor mapped to: " << descriptor_entry;
             }
@@ -730,7 +720,7 @@ void CommandBufferSubState::DumpDescriptorHeapPushIndex(std::ostringstream& ss, 
     warn.HeapOOB(index_zero_offset + dump.descriptor_size, false);
 
     if (!dump.is_array) {
-        std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address);
+        std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address, true);
         if (!descriptor_entry.empty()) {
             ss << new_bullet_line << "Found descriptor mapped to: " << descriptor_entry;
         }
@@ -814,7 +804,7 @@ void CommandBufferSubState::DumpDescriptorHeapPushIndex(std::ostringstream& ss, 
         warn.HeapOOB(index_zero_offset + dump.sampler_descriptor_size, true);
 
         if (!dump.is_array) {
-            std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address);
+            std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address, false);
             if (!descriptor_entry.empty()) {
                 ss << new_bullet_line << "Found descriptor mapped to: " << descriptor_entry;
             }
@@ -914,7 +904,7 @@ void CommandBufferSubState::DumpDescriptorHeapIndirectIndex(std::ostringstream& 
             }
         }
 
-        std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address);
+        std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address, true);
         if (!descriptor_entry.empty()) {
             ss << new_bullet_line << "Found descriptor mapped to: " << descriptor_entry;
         }
@@ -1029,7 +1019,7 @@ void CommandBufferSubState::DumpDescriptorHeapIndirectIndex(std::ostringstream& 
                 }
             }
 
-            std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address);
+            std::string descriptor_entry = warn.ValidateDescriptor(index_zero_address, false);
             if (!descriptor_entry.empty()) {
                 ss << new_bullet_line << "Found descriptor mapped to: " << descriptor_entry;
             }
@@ -1372,6 +1362,11 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
         }
     }
 
+    if (dump.is_embedded_sampler) {
+        ss << new_bullet_line << "Embedded Sampler\n";
+        return false;
+    }
+
     ss << new_bullet_line;
     if (mapping.source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
         const VkDescriptorMappingSourceConstantOffsetEXT& map_data = mapping.sourceData.constantOffset;
@@ -1407,7 +1402,7 @@ bool CommandBufferSubState::DumpDescriptorHeapMapping(std::ostringstream& ss, co
     if (dump.descriptor_type != VK_DESCRIPTOR_TYPE_MAX_ENUM) {
         if (dump.inspect_sampler) {
             ss << new_bullet_line << "Descriptor size: " << std::dec << dump.descriptor_size << " (imageDescriptorSize) and "
-               << dump.sampler_descriptor_size << " (samplerDescriptorAlignment)";
+               << dump.sampler_descriptor_size << " (samplerDescriptorSize)";
         } else {
             ss << new_bullet_line << "Descriptor size: " << std::dec << dump.descriptor_size << " ("
                << string_VkDescriptorType(dump.descriptor_type) << ")";

--- a/layers/gpuav/spirv/descriptor_heap_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_heap_pass.cpp
@@ -597,8 +597,16 @@ bool DescriptorHeapPass::RequiresInstrumentation(const Function& function, const
         if (meta.access_path.pointer_type->spv_type_ == SpvType::kStruct) {
             const Instruction* offset_decoration = GetMemberDecoration(
                 meta.access_path.pointer_type->Id(), meta.access_path.heap_offset_member_index, spv::DecorationOffsetIdEXT);
-            assert(offset_decoration);
-            meta.untyped_heap_offset_id = offset_decoration->Word(4);
+            if (offset_decoration) {
+                meta.untyped_heap_offset_id = offset_decoration->Word(4);
+            } else {
+                // user has hardcoded offsets, if still can't find, then we can assume an implicit zero value
+                offset_decoration = GetMemberDecoration(meta.access_path.pointer_type->Id(),
+                                                        meta.access_path.heap_offset_member_index, spv::DecorationOffset);
+                if (offset_decoration) {
+                    meta.untyped_heap_offset_id = type_manager_.CreateConstantUInt32(offset_decoration->Word(4)).Id();
+                }
+            }
 
             descriptor_array =
                 type_manager_.FindTypeById(meta.access_path.pointer_type->inst_.Operand(meta.access_path.heap_offset_member_index));
@@ -607,6 +615,11 @@ bool DescriptorHeapPass::RequiresInstrumentation(const Function& function, const
         }
 
         if (descriptor_array->IsArray()) {
+            const Type* element_type = type_manager_.FindTypeById(descriptor_array->inst_.Word(2));
+            if (element_type->IsArray()) {
+                // TODO - Handle MultidimensionalArray (GPU Dump has support for reference)
+                return false;
+            }
             const uint32_t array_stride_dec = GetDecoration(descriptor_array->Id(), spv::DecorationArrayStrideIdEXT)->Word(3);
             const Constant* array_stride = type_manager_.FindConstantById(array_stride_dec);
             meta.untyped_array_stride_id = array_stride->Id();

--- a/layers/state_tracker/descriptor_hashing.cpp
+++ b/layers/state_tracker/descriptor_hashing.cpp
@@ -18,6 +18,7 @@
 #include "descriptor_hashing.h"
 #include <vulkan/vk_enum_string_helper.h>
 #include <vulkan/vulkan_core.h>
+#include <cstdint>
 #include "containers/limits.h"
 #include "error_message/error_location.h"
 #include "state_tracker/buffer_state.h"
@@ -217,6 +218,15 @@ std::string DescriptorHashing::Describe(const DeviceState& device_state, uint64_
     return ss.str();
 }
 
+// Samplers aare nasty because it can be both seperate or combined.
+// We have |vvlDescriptorType::CombinedSampler| purely to pass in |desc_encoding| to let the error message know it was a combined
+// image sampler. I don't have 1 bit to spare in |desc_encoding|
+// We could find this information in some lookup, but that would add overhead.
+//
+// The "simple fix" is we will just mark |types| with both such that the find() check will work as expected
+DescriptorHashTable::Entry::Entry(EntrySampler s)
+    : types(1 << (uint8_t)vvlDescriptorType::Sampler | 1 << (uint8_t)vvlDescriptorType::CombinedSampler), data(s) {}
+
 void DescriptorHashTable::Entry::Describe(const DeviceState& device_state, std::ostringstream& ss) const {
     vvlDescriptorType vvl_type = vvlDescriptorType::Invalid;
 
@@ -227,6 +237,9 @@ void DescriptorHashTable::Entry::Describe(const DeviceState& device_state, std::
             // ok to set the second time (if more than one type)
             // as they should be in the same group below
             vvl_type = static_cast<vvlDescriptorType>(i);
+            if (vvl_type == vvlDescriptorType::CombinedSampler) {
+                continue;
+            }
             VkDescriptorType vk_type = GetDescriptorTypeFromMask(vvl_type);
             if (!first) {
                 ss << " | ";
@@ -266,6 +279,7 @@ void DescriptorHashTable::Entry::Describe(const DeviceState& device_state, std::
             break;
         }
         case vvlDescriptorType::Sampler:
+        case vvlDescriptorType::CombinedSampler:
             // currently nothing extra to print
             break;
         case vvlDescriptorType::ImageSampled:
@@ -281,7 +295,6 @@ void DescriptorHashTable::Entry::Describe(const DeviceState& device_state, std::
             ss << ", address 0x" << std::hex << range.address << ", size " << std::dec << range.size;
             break;
         }
-        case vvlDescriptorType::CombinedSampler:
         case vvlDescriptorType::Invalid:
             assert(false);  // this should not be hit
             break;

--- a/layers/state_tracker/descriptor_hashing.h
+++ b/layers/state_tracker/descriptor_hashing.h
@@ -73,7 +73,8 @@ struct DescriptorHashTable {
         // Pass in vvlDescriptorType
         Entry(uint8_t t, EntryBuffer b) : types(1 << t), data(b) {}
         Entry(uint8_t t, EntryImage i) : types(1 << t), data(i) {}
-        Entry(uint8_t t, EntrySampler s) : types(1 << t), data(s) {}
+        // Handle in .cpp file to not include descriptor_utils.h to everyone
+        Entry(EntrySampler s);
         Entry(uint8_t t, EntryNull n) : types((1 << t) | NULL_DESCRIPTOR_MASK), data(n) {}
         // allow us to resize the vector
         Entry() : types(0), data() {}

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -7364,7 +7364,6 @@ void DeviceState::PostCallRecordWriteSamplerDescriptorsEXT(VkDevice device, uint
 
         const VkDeviceSize descriptor_size = phys_dev_ext_props.descriptor_heap_props.samplerDescriptorSize;
         const uint64_t key = descriptor_hashing->Hash(host_range.address, descriptor_size);
-        const uint8_t vvl_type = (uint8_t)GetMaskFromDescriptorType(VK_DESCRIPTOR_TYPE_SAMPLER);
 
         if (const auto* debug_info = vku::FindStructInPNextChain<VkDebugUtilsObjectNameInfoEXT>(pSamplers->pNext)) {
             if (debug_info->pObjectName) {
@@ -7374,7 +7373,7 @@ void DeviceState::PostCallRecordWriteSamplerDescriptorsEXT(VkDevice device, uint
 
         // Because there is no concept of a VkSampler anymore, there is no way to know if the user will be done using this sampler
         // descriptor. This means we will never be able to remove this descriptor from the hash map.
-        descriptor_hashing->table.Insert(key, DescriptorHashTable::Entry(vvl_type, DescriptorHashTable::EntrySampler{}), *this,
+        descriptor_hashing->table.Insert(key, DescriptorHashTable::Entry(DescriptorHashTable::EntrySampler{}), *this,
                                          record_obj.location);
     }
 }
@@ -7425,8 +7424,8 @@ void DeviceState::PostCallRecordGetDescriptorEXT(VkDevice device, const VkDescri
         } break;
         case VK_DESCRIPTOR_TYPE_SAMPLER:
             if (pDescriptorInfo->data.pSampler) {
-                descriptor_hashing->table.Insert(key, DescriptorHashTable::Entry(vvl_type, DescriptorHashTable::EntrySampler{}),
-                                                 *this, record_obj.location);
+                descriptor_hashing->table.Insert(key, DescriptorHashTable::Entry(DescriptorHashTable::EntrySampler{}), *this,
+                                                 record_obj.location);
             }
             break;
         case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:

--- a/tests/framework/descriptor_heap_object.cpp
+++ b/tests/framework/descriptor_heap_object.cpp
@@ -116,13 +116,22 @@ VkDeviceSize DescriptorHeap::WriteBufferDescriptorAtOffset(VkDeviceAddressRangeK
     return WriteDescriptorAtOffset(addr_range, desc_type, heap_offset);
 }
 
-VkDeviceSize DescriptorHeap::WriteImageDescriptor(const vkt::Image& image, VkDescriptorType desc_type) {
+VkDeviceSize DescriptorHeap::WriteImageDescriptorAtOffset(const vkt::Image& image, VkDeviceSize heap_offset,
+                                                          VkDescriptorType desc_type, VkImageLayout layout) {
+    VkImageViewCreateInfo view_info = image.BasicViewCreatInfo();
+    VkImageDescriptorInfoEXT image_info = vku::InitStructHelper();
+    image_info.pView = &view_info;
+    image_info.layout = layout;
+    return WriteDescriptorAtOffset(&image_info, desc_type, heap_offset);
+}
+
+VkDeviceSize DescriptorHeap::WriteImageDescriptor(const vkt::Image& image, VkDescriptorType desc_type, VkImageLayout layout) {
     heap_offset_ = Align(heap_offset_, heap_props.imageDescriptorAlignment);
 
     VkImageViewCreateInfo view_info = image.BasicViewCreatInfo();
     VkImageDescriptorInfoEXT image_info = vku::InitStructHelper();
     image_info.pView = &view_info;
-    image_info.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    image_info.layout = layout;
 
     const VkDeviceSize write_offset = WriteDescriptorAtOffset(&image_info, desc_type, heap_offset_);
 
@@ -146,6 +155,24 @@ VkDeviceSize DescriptorHeap::WriteAccelerationStructureDescriptor(VkDeviceAddres
 
     heap_offset_ += heap_props.bufferDescriptorSize;
     assert(heap_offset_ <= resource_heap_.CreateInfo().size);
+
+    return write_offset;
+}
+
+VkDeviceSize DescriptorHeap::WriteSamplerDescriptor(VkSamplerCreateInfo* sampler_create_info) {
+    VkSamplerCreateInfo safe_create_info = SafeSaneSamplerCreateInfo();
+
+    sampler_heap_offset_ = Align(sampler_heap_offset_, heap_props.samplerHeapAlignment);
+    const VkDeviceSize write_offset = sampler_heap_offset_;
+
+    VkHostAddressRangeEXT sampler_host_data{};
+    sampler_host_data.address = sampler_heap_data_ + write_offset;
+    sampler_host_data.size = static_cast<size_t>(heap_props.samplerDescriptorSize);
+    vk::WriteSamplerDescriptorsEXT(*test_->DeviceObj(), 1u, sampler_create_info ? sampler_create_info : &safe_create_info,
+                                   &sampler_host_data);
+
+    sampler_heap_offset_ += heap_props.samplerDescriptorSize;
+    assert(sampler_heap_offset_ <= sampler_heap_.CreateInfo().size);
 
     return write_offset;
 }
@@ -236,6 +263,7 @@ VkDeviceSize DescriptorHeap::WriteDescriptorAtOffset(VkDeviceAddressRangeKHR add
     return heap_offset;
 }
 
+// Image variation
 VkDeviceSize DescriptorHeap::WriteDescriptorAtOffset(const VkImageDescriptorInfoEXT* image_info, VkDescriptorType desc_type,
                                                      VkDeviceSize heap_offset) {
     assert(resource_heap_.handle() != VK_NULL_HANDLE);

--- a/tests/framework/descriptor_heap_object.h
+++ b/tests/framework/descriptor_heap_object.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <vulkan/vulkan_core.h>
 #include "binding.h"
 
 class VkLayerTest;
@@ -44,14 +45,19 @@ class DescriptorHeap {
     // Returns write offset.
     VkDeviceSize WriteBufferDescriptor(const vkt::Buffer& buffer, VkDescriptorType desc_type);
     VkDeviceSize WriteBufferDescriptor(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type);
-    VkDeviceSize WriteImageDescriptor(const vkt::Image& image, VkDescriptorType tydesc_typepe = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    VkDeviceSize WriteImageDescriptor(const vkt::Image& image, VkDescriptorType desc_type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                      VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     VkDeviceSize WriteAccelerationStructureDescriptor(vkt::as::AccelerationStructureKHR& as);
     VkDeviceSize WriteAccelerationStructureDescriptor(VkDeviceAddress as_addr);
+    VkDeviceSize WriteSamplerDescriptor(VkSamplerCreateInfo* sampler_create_info = nullptr);
     // Write at supplied heap offset
     // *Warning* Internally maintained heap write offset will not be touched at all,
     // so this probably should not be used with the above functions.
     VkDeviceSize WriteBufferDescriptorAtOffset(VkDeviceAddressRangeKHR addr_range, VkDescriptorType desc_type,
                                                VkDeviceSize heap_offset);
+    VkDeviceSize WriteImageDescriptorAtOffset(const vkt::Image& image, VkDeviceSize heap_offset,
+                                              VkDescriptorType desc_type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                              VkImageLayout layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     VkDeviceSize WriteNullDescriptorAtOffset(VkDescriptorType desc_type, VkDeviceSize heap_offset);
 
     VkDeviceSize AlignResource(VkDeviceSize offset);
@@ -83,6 +89,7 @@ class DescriptorHeap {
     bool sampler_reserved_range_in_front_ = false;
     bool embedded_samplers = false;
     VkDeviceSize heap_offset_ = 0;
+    VkDeviceSize sampler_heap_offset_ = 0;
 };
 
 }  // namespace vkt

--- a/tests/unit/descriptor_heap_positive.cpp
+++ b/tests/unit/descriptor_heap_positive.cpp
@@ -737,41 +737,18 @@ TEST_F(PositiveDescriptorHeap, Sampler) {
 TEST_F(PositiveDescriptorHeap, CombinedImageSampler) {
     RETURN_IF_SKIP(InitBasicDescriptorHeap());
 
+    vkt::DescriptorHeap desc_heap(*this);
     const VkDeviceSize image_offset = 0u;
     const VkDeviceSize buffer_offset = Align(heap_props.imageDescriptorSize, heap_props.resourceHeapAlignment);
-    CreateResourceHeap(buffer_offset + heap_props.bufferDescriptorSize);
-    CreateSamplerHeap(heap_props.samplerDescriptorAlignment);
+    desc_heap.CreateResourceHeap(buffer_offset + heap_props.bufferDescriptorSize);
+    desc_heap.CreateSamplerHeap(heap_props.samplerDescriptorSize);
 
     vkt::Buffer buffer(*m_device, sizeof(float) * 4u, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
     vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
 
-    VkHostAddressRangeEXT resource_host[2];
-    resource_host[0].address = resource_heap_data_ + image_offset;
-    resource_host[0].size = static_cast<size_t>(heap_props.imageDescriptorSize);
-    resource_host[1].address = resource_heap_data_ + buffer_offset;
-    resource_host[1].size = static_cast<size_t>(heap_props.bufferDescriptorSize);
-
-    VkImageViewCreateInfo view_info = image.BasicViewCreatInfo(VK_IMAGE_ASPECT_COLOR_BIT);
-
-    VkImageDescriptorInfoEXT image_info = vku::InitStructHelper();
-    image_info.pView = &view_info;
-    image_info.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-    VkDeviceAddressRangeEXT buffer_address_range = buffer.AddressRange();
-
-    VkResourceDescriptorInfoEXT descriptor_info[2];
-    descriptor_info[0] = vku::InitStructHelper();
-    descriptor_info[0].type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    descriptor_info[0].data.pImage = &image_info;
-    descriptor_info[1] = vku::InitStructHelper();
-    descriptor_info[1].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    descriptor_info[1].data.pAddressRange = &buffer_address_range;
-    vk::WriteResourceDescriptorsEXT(*m_device, 2u, descriptor_info, resource_host);
-
-    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-
-    VkHostAddressRangeEXT sampler_host = {sampler_heap_data_, static_cast<size_t>(heap_props.samplerDescriptorSize)};
-    vk::WriteSamplerDescriptorsEXT(*m_device, 1u, &sampler_info, &sampler_host);
+    desc_heap.WriteImageDescriptorAtOffset(image, image_offset);
+    desc_heap.WriteBufferDescriptorAtOffset(buffer.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_offset);
+    desc_heap.WriteSamplerDescriptor();
 
     char const* cs_source = R"glsl(
         #version 450
@@ -787,7 +764,8 @@ TEST_F(PositiveDescriptorHeap, CombinedImageSampler) {
     VkDescriptorSetAndBindingMappingEXT mappings[2];
     mappings[0] = MakeSetAndBindingMapping(0, 0, 1, VK_SPIRV_RESOURCE_TYPE_COMBINED_SAMPLED_IMAGE_BIT_EXT);
     mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
-    mappings[0].sourceData.constantOffset = {};
+    mappings[0].sourceData.constantOffset.heapOffset = 0;
+    mappings[0].sourceData.constantOffset.samplerHeapOffset = 0;
     mappings[1] = MakeSetAndBindingMapping(1, 0);
     mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
     mappings[1].sourceData.constantOffset = {};
@@ -810,8 +788,8 @@ TEST_F(PositiveDescriptorHeap, CombinedImageSampler) {
     m_command_buffer.TransitionLayout(image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-    BindResourceHeap();
-    BindSamplerHeap();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    desc_heap.BindSamplerHeap(m_command_buffer);
     vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -1200,43 +1178,30 @@ TEST_F(PositiveDescriptorHeap, EmbeddedSamplerNoBoundHeap) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11558");
     RETURN_IF_SKIP(InitBasicDescriptorHeap());
 
-    // Resource descriptor heap buffer
-    const VkDeviceSize resource_stride = Align(heap_props.bufferDescriptorSize, heap_props.samplerDescriptorAlignment);
-    const VkDeviceSize resource_descriptor_count = 4;
-    const VkDeviceSize resource_heap_size_app = AlignResource(resource_descriptor_count * resource_stride);
-    const VkDeviceSize resource_heap_size = resource_heap_size_app + heap_props.minResourceHeapReservedRange;
-    const VkDeviceSize out_data_buffer_size = 256;
+    vkt::DescriptorHeap desc_heap(*this);
+    const VkDeviceSize buffer_offset = 0u;
+    const VkDeviceSize image_offset = Align(heap_props.bufferDescriptorSize, heap_props.resourceHeapAlignment);
+    desc_heap.CreateResourceHeap(image_offset + heap_props.imageDescriptorSize);
 
-    vkt::Buffer resource_heap(*m_device, resource_heap_size, VK_BUFFER_USAGE_2_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
-    const auto resource_heap_ptr = static_cast<char*>(resource_heap.Memory().Map());
+    vkt::Buffer ssbo_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
 
-    // Output buffer descriptor
-    vkt::Buffer out_buffer(*m_device, out_data_buffer_size, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
-
-    VkHostAddressRangeEXT out_descriptor{resource_heap_ptr, static_cast<size_t>(resource_stride)};
-    VkDeviceAddressRangeEXT out_address_range = out_buffer.AddressRange();
-    VkResourceDescriptorInfoEXT out_descriptor_info = vku::InitStructHelper();
-    out_descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    out_descriptor_info.data.pAddressRange = &out_address_range;
-    vk::WriteResourceDescriptorsEXT(*m_device, 1, &out_descriptor_info, &out_descriptor);
+    desc_heap.WriteBufferDescriptorAtOffset(ssbo_buffer.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_offset);
+    desc_heap.WriteImageDescriptorAtOffset(image, image_offset);
 
     VkDescriptorSetAndBindingMappingEXT mappings[3];
     mappings[0] = MakeSetAndBindingMapping(0, 0);
     mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
-    mappings[0].sourceData.constantOffset.heapOffset = 0u * (uint32_t)resource_stride;
-    mappings[0].sourceData.constantOffset.heapArrayStride = 0;
+    mappings[0].sourceData.constantOffset.heapOffset = (uint32_t)buffer_offset;
 
     VkSamplerCreateInfo embedded_sampler = SafeSaneSamplerCreateInfo();
     mappings[1] = MakeSetAndBindingMapping(0, 1);
     mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
-    mappings[1].sourceData.constantOffset.heapOffset = 1u * (uint32_t)resource_stride;
-    mappings[1].sourceData.constantOffset.heapArrayStride = 0;
     mappings[1].sourceData.constantOffset.pEmbeddedSampler = &embedded_sampler;
 
     mappings[2] = MakeSetAndBindingMapping(0, 2);
     mappings[2].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
-    mappings[2].sourceData.constantOffset.heapOffset = 2u * (uint32_t)resource_stride;
-    mappings[2].sourceData.constantOffset.heapArrayStride = 0;
+    mappings[2].sourceData.constantOffset.heapOffset = (uint32_t)image_offset;
 
     VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
     mapping_info.mappingCount = 3;
@@ -1259,13 +1224,7 @@ TEST_F(PositiveDescriptorHeap, EmbeddedSamplerNoBoundHeap) {
 
     // Don't need to call vkCmdBindSamplerHeapEXT if only using embedded
     m_command_buffer.Begin();
-
-    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
-    bind_resource_info.heapRange = resource_heap.AddressRange();
-    bind_resource_info.reservedRangeOffset = resource_heap_size_app;
-    bind_resource_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
-    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
-
+    desc_heap.BindResourceHeap(m_command_buffer);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
@@ -1522,41 +1481,32 @@ TEST_F(PositiveDescriptorHeap, MappingSourceHeapData) {
     RETURN_IF_SKIP(InitBasicDescriptorHeap());
     InitRenderTarget();
 
-    vkt::Buffer write_buffer(*m_device, sizeof(uint32_t) * 4, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
+    // Heap will look like
+    // [ padding, read_data, padding, write_data descriptor]
+    const uint32_t read_data_alignment = static_cast<uint32_t>(physDevProps_.limits.minUniformBufferOffsetAlignment);
 
-    const uint32_t read_heap_offset = static_cast<uint32_t>(physDevProps_.limits.minUniformBufferOffsetAlignment);
-    const int32_t read_push_offset = 8;
-    const uint32_t read_push_data_offset = 48u;
-    const uint32_t read_offset = read_heap_offset + read_push_offset;
-    const VkDeviceSize write_offset = Align(read_offset + heap_props.bufferDescriptorSize * 7u, heap_props.bufferDescriptorSize);
-    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
+    vkt::DescriptorHeap desc_heap(*this);
+    // large enought to hold everything
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 8);
 
-    CreateResourceHeap(write_offset + resource_stride);
-
-    uint32_t* read_data = reinterpret_cast<uint32_t*>(resource_heap_data_ + read_offset);
+    uint32_t* read_data = reinterpret_cast<uint32_t*>(desc_heap.resource_heap_data_ + read_data_alignment);
     for (uint32_t i = 0; i < 4; ++i) {
         read_data[i] = i + 1;
     }
 
-    VkHostAddressRangeEXT descriptor_host = {resource_heap_data_ + write_offset, static_cast<size_t>(resource_stride)};
-    VkDeviceAddressRangeEXT device_range = write_buffer.AddressRange();
+    const VkDeviceSize write_data_offset = heap_props.bufferDescriptorSize * 4;
+    vkt::Buffer write_buffer(*m_device, sizeof(uint32_t) * 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    desc_heap.WriteBufferDescriptorAtOffset(write_buffer.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, write_data_offset);
 
-    VkResourceDescriptorInfoEXT descriptor_info = vku::InitStructHelper();
-    descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    descriptor_info.data.pAddressRange = &device_range;
-
-    vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
-
+    const uint32_t push_data_offset = 48u;
     VkDescriptorSetAndBindingMappingEXT mappings[2];
     mappings[0] = MakeSetAndBindingMapping(0, 0, 1, VK_SPIRV_RESOURCE_TYPE_UNIFORM_BUFFER_BIT_EXT);
     mappings[0].source = VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT;
-    mappings[0].sourceData.heapData.heapOffset = static_cast<uint32_t>(read_heap_offset);
-    mappings[0].sourceData.heapData.pushOffset = static_cast<uint32_t>(read_push_data_offset);
+    mappings[0].sourceData.heapData.heapOffset = 0;
+    mappings[0].sourceData.heapData.pushOffset = push_data_offset;
     mappings[1] = MakeSetAndBindingMapping(1, 0, 1, VK_SPIRV_RESOURCE_TYPE_READ_WRITE_STORAGE_BUFFER_BIT_EXT);
     mappings[1].source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
-    mappings[1].sourceData.constantOffset.heapOffset = static_cast<uint32_t>(write_offset);
-    mappings[1].sourceData.constantOffset.heapArrayStride = 0u;
-
+    mappings[1].sourceData.constantOffset.heapOffset = static_cast<uint32_t>(write_data_offset);
     VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
     mapping_info.mappingCount = 2u;
     mapping_info.pMappings = mappings;
@@ -1564,6 +1514,7 @@ TEST_F(PositiveDescriptorHeap, MappingSourceHeapData) {
     char const* vert_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform ReadData {
+            // use vec4 as quick way to get scalar layout
             uvec4 read_data;
         };
         layout(set = 1, binding = 0) buffer WriteData {
@@ -1600,8 +1551,8 @@ TEST_F(PositiveDescriptorHeap, MappingSourceHeapData) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, descriptor_heap_pipe);
-    BindResourceHeap();
-    m_command_buffer.PushData(read_push_data_offset, sizeof(read_push_offset), &read_push_offset);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    m_command_buffer.PushData(push_data_offset, sizeof(read_data_alignment), &read_data_alignment);
     vk::CmdDraw(m_command_buffer, 3u, 1u, 0u, 0u);
 
     m_command_buffer.EndRenderPass();

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -13,6 +13,7 @@
 #include <vulkan/vulkan_core.h>
 #include <cstdint>
 #include <cstring>
+#include <vector>
 #include "descriptor_heap_object.h"
 #include "generated/vk_function_pointers.h"
 #include "layer_validation_tests.h"
@@ -3447,6 +3448,201 @@ TEST_F(NegativeGpuAVDescriptorHeap, ResourceOOBWithHashingOn) {
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11309");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeGpuAVDescriptorHeap, HardcodedOffsetOOB) {
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize);
+    if (desc_heap.resource_heap_.CreateInfo().size > 131072) {
+        GTEST_SKIP() << "too much reserved range";
+    }
+
+    vkt::Buffer ssbo_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+
+    // What the shader looks like
+    //
+    // layout(descriptor_heap) struct {
+    //    layout(offset = 0) buffer a { uint data; } x;
+    //    layout(offset = 131072) buffer b { uint data; } y;
+    // };
+    // layout(push_constant) uniform PushConstant { uint payload; };
+    // void main() {
+    //     heap.y.data = heap.x.data;
+    // }
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorate %A Block
+               OpMemberDecorate %A 0 Offset 0
+
+               ; Use hardcoded offset
+               OpMemberDecorate %heap_struct 0 Offset 0
+               OpMemberDecorate %heap_struct 1 Offset 131072
+
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+      %int_2 = OpConstant %int 2
+       %uint = OpTypeInt 32 0
+          %A = OpTypeStruct %uint
+%_ptr_StorageBuffer = OpTypeUntypedPointerKHR StorageBuffer
+         %21 = OpTypeBufferEXT StorageBuffer
+%heap_struct = OpTypeStruct %21 %21
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %20 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_struct %resource_heap %int_0
+         %24 = OpBufferPointerEXT %_ptr_StorageBuffer %20
+         %25 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %A %24 %int_0
+         %30 = OpUntypedAccessChainKHR %_ptr_UniformConstant %heap_struct %resource_heap %int_1
+         %34 = OpBufferPointerEXT %_ptr_StorageBuffer %30
+         %35 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %A %34 %int_0
+       %load = OpLoad %uint %35
+               OpStore %25 %load
+               OpReturn
+               OpFunctionEnd
+
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11309");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+// Currently don't handle logic to get stride of multiple arrays
+TEST_F(NegativeGpuAVDescriptorHeap, DISABLED_MultidimensionalArrayOOB) {
+    TEST_DESCRIPTION("https://gitlab.khronos.org/Tracker/vk-gl-cts/-/issues/6645");
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    // To hard to test OOB with reserved range
+    if (heap_props.minResourceHeapReservedRange != 0) {
+        GTEST_SKIP() << "minResourceHeapReservedRange is not zero";
+    }
+
+    vkt::DescriptorHeap desc_heap(*this);
+    // one less than needed
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize * 4);
+
+    // layout(descriptor_heap) buffer Heap { uint data; } heap[3][3];
+    // void main() {
+    //     heap[1][2].data = 42;
+    // }
+    char const* cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability DescriptorHeapEXT
+               OpExtension "SPV_EXT_descriptor_heap"
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %resource_heap
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %resource_heap BuiltIn ResourceHeapEXT
+               OpDecorate %Heap Block
+               OpMemberDecorate %Heap 0 Offset 0
+               OpDecorateId %in_array ArrayStrideIdEXT %buf_size
+               OpDecorateId %out_array ArrayStrideIdEXT %stride_3
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+       %uint = OpTypeInt 32 0
+      %uint_0 = OpConstant %uint 0
+      %uint_1 = OpConstant %uint 1
+      %uint_2 = OpConstant %uint 2
+      %uint_3 = OpConstant %uint 3
+    %uint_42 = OpConstant %uint 42
+%_ptr_UniformConstant = OpTypeUntypedPointerKHR UniformConstant
+%resource_heap = OpUntypedVariableKHR %_ptr_UniformConstant UniformConstant
+       %Heap = OpTypeStruct %uint
+%_ptr_StorageBuffer = OpTypeUntypedPointerKHR StorageBuffer
+   %buf_type = OpTypeBufferEXT StorageBuffer
+   %buf_size = OpConstantSizeOfEXT %uint %buf_type
+   %stride_3 = OpSpecConstantOp %int IMul %buf_size %uint_3
+ %in_array = OpTypeArray %buf_type %uint_3
+%out_array = OpTypeArray %in_array %uint_3
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %15 = OpUntypedAccessChainKHR %_ptr_UniformConstant %out_array %resource_heap %uint_1 %uint_2
+         %19 = OpBufferPointerEXT %_ptr_StorageBuffer %15
+         %20 = OpUntypedAccessChainKHR %_ptr_StorageBuffer %Heap %19 %uint_0
+               OpStore %20 %uint_42
+               OpReturn
+               OpFunctionEnd
+    )";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_2, nullptr, SPV_SOURCE_ASM);
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11309");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeGpuAVDescriptorHeap, HashingCombinedSampler) {
+    const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}));
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.imageDescriptorSize);
+    desc_heap.CreateSamplerHeap(heap_props.samplerDescriptorSize);
+
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    desc_heap.WriteImageDescriptor(image);
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform sampler2D tex;
+        void main() {
+            vec4 data = texture(tex, vec2(0.5f));
+        }
+    )glsl";
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    mapping.sourceData.constantOffset.samplerHeapOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    desc_heap.BindSamplerHeap(m_command_buffer);
+    vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("UNASSIGNED-DescriptorHeap-No-Descriptor");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/gpu_av_descriptor_heap_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_heap_positive.cpp
@@ -73,50 +73,19 @@ TEST_F(PositiveGpuAVDescriptorHeap, SamplerPointerOffset) {
     const uint32_t buffer_index = 16u;
 
     const VkDeviceSize image_offset = 0u;
-    const VkDeviceSize image_size = heap_props.imageDescriptorSize;
     const VkDeviceSize buffer_offset = heap_props.bufferDescriptorSize * buffer_index;
-    const VkDeviceSize buffer_size = heap_props.bufferDescriptorSize;
-    const VkDeviceSize resource_heap_app_size = buffer_offset + buffer_size;
+    const VkDeviceSize resource_heap_app_size = buffer_offset + heap_props.bufferDescriptorSize;
 
-    CreateResourceHeap(resource_heap_app_size);
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(resource_heap_app_size);
+    desc_heap.CreateSamplerHeap(heap_props.samplerDescriptorSize);
 
     vkt::Buffer buffer(*m_device, sizeof(float) * 4u, VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR, vkt::device_address);
-    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_STORAGE_BIT);
 
-    VkHostAddressRangeEXT resource_host[2];
-    resource_host[0].address = resource_heap_data_ + image_offset;
-    resource_host[0].size = image_size;
-    resource_host[1].address = resource_heap_data_ + buffer_offset;
-    resource_host[1].size = buffer_size;
-
-    VkImageViewCreateInfo view_info = image.BasicViewCreatInfo(VK_IMAGE_ASPECT_COLOR_BIT);
-
-    VkImageDescriptorInfoEXT image_info = vku::InitStructHelper();
-    image_info.pView = &view_info;
-    image_info.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-
-    VkDeviceAddressRangeEXT buffer_address_range = buffer.AddressRange();
-
-    VkResourceDescriptorInfoEXT descriptor_info[2];
-    descriptor_info[0] = vku::InitStructHelper();
-    descriptor_info[0].type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    descriptor_info[0].data.pImage = &image_info;
-    descriptor_info[1] = vku::InitStructHelper();
-    descriptor_info[1].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    descriptor_info[1].data.pAddressRange = &buffer_address_range;
-    vk::WriteResourceDescriptorsEXT(*m_device, 2u, descriptor_info, resource_host);
-
-    const VkDeviceSize sampler_offset = 0u;
-    const VkDeviceSize sampler_size = heap_props.samplerDescriptorSize;
-
-    CreateSamplerHeap(sampler_size);
-
-    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-
-    VkHostAddressRangeEXT sampler_host;
-    sampler_host.address = sampler_heap_data_ + sampler_offset;
-    sampler_host.size = sampler_size;
-    vk::WriteSamplerDescriptorsEXT(*m_device, 1u, &sampler_info, &sampler_host);
+    desc_heap.WriteImageDescriptorAtOffset(image, image_offset, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
+    desc_heap.WriteBufferDescriptorAtOffset(buffer.AddressRange(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, buffer_offset);
+    desc_heap.WriteSamplerDescriptor();
 
     char const *cs_source = R"glsl(
         #version 450
@@ -139,11 +108,11 @@ TEST_F(PositiveGpuAVDescriptorHeap, SamplerPointerOffset) {
     VkImageSubresourceRange sub_range = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 1u, 0u, 1u};
     vk::CmdClearColorImage(m_command_buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &color, 1u, &sub_range);
 
-    m_command_buffer.TransitionLayout(image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    m_command_buffer.TransitionLayout(image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-    BindResourceHeap();
-    BindSamplerHeap();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    desc_heap.BindSamplerHeap(m_command_buffer);
     vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -1826,4 +1795,44 @@ TEST_F(PositiveGpuAVDescriptorHeap, SamplerStressSafe) {
         }
     )glsl";
     vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_3, &mapping_info);
+}
+
+TEST_F(PositiveGpuAVDescriptorHeap, CombinedSampler) {
+    const VkLayerSettingEXT layer_setting{OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap({layer_setting}, false));
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.imageDescriptorSize);
+    desc_heap.CreateSamplerHeap(heap_props.samplerDescriptorSize);
+
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    desc_heap.WriteImageDescriptor(image);
+    desc_heap.WriteSamplerDescriptor();
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform sampler2D tex;
+        void main() {
+            vec4 data = texture(tex, vec2(0.5f));
+        }
+    )glsl";
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    mapping.sourceData.constantOffset.samplerHeapOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    desc_heap.BindSamplerHeap(m_command_buffer);
+    vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
 }

--- a/tests/unit/gpu_dump.cpp
+++ b/tests/unit/gpu_dump.cpp
@@ -1892,6 +1892,51 @@ TEST_F(NegativeGpuDump, DescriptorHeapWrongDescriptorNotSampler) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeGpuDump, DescriptorHeapNoDescriptorCombinedSampler) {
+    static const VkLayerSettingEXT layer_settings[2] = {
+        {OBJECT_LAYER_NAME, "gpu_dump_descriptors", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+        {OBJECT_LAYER_NAME, "descriptor_hashing", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},
+    };
+    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 2, layer_settings};
+    RETURN_IF_SKIP(InitDescriptorHeap(&layer_setting_ci));
+
+    if (heap_props.minResourceHeapReservedRange != 0 || heap_props.minSamplerHeapReservedRange != 0) {
+        GTEST_SKIP() << "heapReservedRange is not zero";
+    }
+
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.imageDescriptorSize);
+    desc_heap.CreateSamplerHeap(heap_props.samplerDescriptorSize);
+
+    vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    desc_heap.WriteImageDescriptor(image);
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform sampler2D tex;
+        void main() {
+            vec4 data = texture(tex, vec2(0.5f));
+        }
+    )glsl";
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    mapping.sourceData.constantOffset.samplerHeapOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    desc_heap.BindResourceHeap(m_command_buffer);
+    desc_heap.BindSamplerHeap(m_command_buffer);
+    vk::CmdDispatch(m_command_buffer, 1u, 1u, 1u);
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeGpuDump, DescriptorHeapWrongDescriptorDebugNames) {
     static const VkLayerSettingEXT layer_settings[2] = {
         {OBJECT_LAYER_NAME, "gpu_dump_descriptors", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue},


### PR DESCRIPTION
- Some tests were wrong and Descriptor Hashing caught it!!!
- Fix embedded samplers for Dump and Descriptor Hashing
- Untyped fixes for GPU-AV
- More tests using `vkt::DescriptorHeap`