### PR TITLE
sync: Stop using SyncOpBase::Validate for pipeline barriers

### DIFF
--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -200,6 +200,28 @@ class FilteredGeneratorGenerator {
 
 using EventImageRangeGenerator = FilteredGeneratorGenerator<subresource_adapter::ImageRangeGenerator>;
 
+BarrierSet::BarrierSet(const SyncValidator& sync_state, VkQueueFlags queue_flags, const VkDependencyInfo& dep_info) {
+    const ExecScopes stage_masks = sync_utils::GetExecScopes(dep_info);
+    src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stage_masks.src);
+    dst_exec_scope = SyncExecScope::MakeDst(queue_flags, stage_masks.dst);
+
+    MakeMemoryBarriers(queue_flags, dep_info);
+    MakeBufferMemoryBarriers(sync_state, queue_flags, dep_info.bufferMemoryBarrierCount, dep_info.pBufferMemoryBarriers);
+    MakeImageMemoryBarriers(sync_state, queue_flags, dep_info.imageMemoryBarrierCount, dep_info.pImageMemoryBarriers,
+                            sync_state.device_state->extensions);
+}
+
+BarrierSet::BarrierSet(const SyncValidator& sync_state, const SyncExecScope& src_exec_scope, const SyncExecScope& dst_exec_scope,
+                       uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
+                       const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
+                       const VkImageMemoryBarrier* image_barriers)
+    : src_exec_scope(src_exec_scope), dst_exec_scope(dst_exec_scope) {
+    MakeMemoryBarriers(src_exec_scope, dst_exec_scope, memory_barrier_count, memory_barriers);
+    MakeBufferMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, buffer_barrier_count, buffer_barriers);
+    MakeImageMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, image_barrier_count, image_barriers,
+                            sync_state.device_state->extensions);
+}
+
 void BarrierSet::MakeMemoryBarriers(const SyncExecScope& src, const SyncExecScope& dst, uint32_t barrier_count,
                                     const VkMemoryBarrier* barriers) {
     memory_barriers.reserve(std::max<uint32_t>(1, barrier_count));
@@ -338,60 +360,15 @@ SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValida
                                              uint32_t buffer_barrier_count, const VkBufferMemoryBarrier* buffer_barriers,
                                              uint32_t image_barrier_count, const VkImageMemoryBarrier* image_barriers)
     : SyncOpBase(command) {
-    const auto src_exec_scope = SyncExecScope::MakeSrc(queue_flags, src_stage_mask);
-    const auto dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dst_stage_mask);
-
-    barrier_set_.src_exec_scope = src_exec_scope;
-    barrier_set_.dst_exec_scope = dst_exec_scope;
-
-    barrier_set_.MakeMemoryBarriers(src_exec_scope, dst_exec_scope, memory_barrier_count, memory_barriers);
-    barrier_set_.MakeBufferMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, buffer_barrier_count, buffer_barriers);
-    barrier_set_.MakeImageMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, image_barrier_count, image_barriers,
-                                         sync_state.device_state->extensions);
+    const SyncExecScope src_exec_scope(SyncExecScope::MakeSrc(queue_flags, src_stage_mask));
+    const SyncExecScope dst_exec_scope(SyncExecScope::MakeDst(queue_flags, dst_stage_mask));
+    barrier_set_ = BarrierSet(sync_state, src_exec_scope, dst_exec_scope, memory_barrier_count, memory_barriers,
+                              buffer_barrier_count, buffer_barriers, image_barrier_count, image_barriers);
 }
 
 SyncOpPipelineBarrier::SyncOpPipelineBarrier(vvl::Func command, const SyncValidator& sync_state, VkQueueFlags queue_flags,
                                              const VkDependencyInfo& dep_info)
-    : SyncOpBase(command) {
-    const ExecScopes stage_masks = sync_utils::GetExecScopes(dep_info);
-
-    barrier_set_.src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stage_masks.src);
-    barrier_set_.dst_exec_scope = SyncExecScope::MakeDst(queue_flags, stage_masks.dst);
-
-    barrier_set_.MakeMemoryBarriers(queue_flags, dep_info);
-    barrier_set_.MakeBufferMemoryBarriers(sync_state, queue_flags, dep_info.bufferMemoryBarrierCount,
-                                          dep_info.pBufferMemoryBarriers);
-    barrier_set_.MakeImageMemoryBarriers(sync_state, queue_flags, dep_info.imageMemoryBarrierCount, dep_info.pImageMemoryBarriers,
-                                         sync_state.device_state->extensions);
-}
-
-bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext& cb_context) const {
-    bool skip = false;
-    const AccessContext& context = cb_context.GetCurrentAccessContext();
-
-    // Validate Image Layout transitions
-    for (const auto& image_barrier : barrier_set_.image_barriers) {
-        if (!image_barrier.layout_transition) {
-            continue;
-        }
-        const vvl::Image& image_state = *image_barrier.image;
-        const bool can_transition_depth_slices =
-            CanTransitionDepthSlices(cb_context.GetSyncState().extensions, image_state.GetImageType(), image_state.create_flags);
-        const auto hazard = context.DetectImageBarrierHazard(
-            image_state, image_barrier.barrier.src_exec_scope.exec_scope, image_barrier.barrier.src_access_scope,
-            image_barrier.subresource_range, can_transition_depth_slices, AccessContext::kDetectAll);
-        if (hazard.IsHazard()) {
-            LogObjectList objlist(cb_context.GetCBState().Handle(), image_state.Handle());
-            const Location loc(command_);
-            const SyncValidator& sync_state = cb_context.GetSyncState();
-            const std::string resource_description = sync_state.FormatHandle(image_state.Handle());
-            const std::string error =
-                sync_state.error_messages_.ImageBarrierError(hazard, cb_context, command_, resource_description, image_barrier);
-            skip |= sync_state.SyncError(hazard.Hazard(), objlist, loc, error);
-        }
-    }
-    return skip;
-}
+    : SyncOpBase(command), barrier_set_(sync_state, queue_flags, dep_info) {}
 
 ResourceUsageTag SyncOpPipelineBarrier::Record(CommandBufferAccessContext& cb_context) {
     const auto tag = cb_context.NextCommandTag(command_);
@@ -575,19 +552,10 @@ SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator& sync_
                                    const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
                                    const VkImageMemoryBarrier* pImageMemoryBarriers)
     : SyncOpBase(command), barrier_sets_(1) {
-    auto& barrier_set = barrier_sets_[0];
-    const auto src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
-    const auto dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
-
-    barrier_set.src_exec_scope = src_exec_scope;
-    barrier_set.dst_exec_scope = dst_exec_scope;
-
-    barrier_set.MakeMemoryBarriers(src_exec_scope, dst_exec_scope, memoryBarrierCount, pMemoryBarriers);
-    barrier_set.MakeBufferMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, bufferMemoryBarrierCount,
-                                         pBufferMemoryBarriers);
-    barrier_set.MakeImageMemoryBarriers(sync_state, src_exec_scope, dst_exec_scope, imageMemoryBarrierCount, pImageMemoryBarriers,
-                                        sync_state.device_state->extensions);
-
+    const SyncExecScope src_exec_scope = SyncExecScope::MakeSrc(queue_flags, srcStageMask);
+    const SyncExecScope dst_exec_scope = SyncExecScope::MakeDst(queue_flags, dstStageMask);
+    barrier_sets_[0] = BarrierSet(sync_state, src_exec_scope, dst_exec_scope, memoryBarrierCount, pMemoryBarriers,
+                                  bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
     MakeEventsList(sync_state, eventCount, pEvents);
 }
 
@@ -595,18 +563,7 @@ SyncOpWaitEvents::SyncOpWaitEvents(vvl::Func command, const SyncValidator& sync_
                                    uint32_t eventCount, const VkEvent* pEvents, const VkDependencyInfo* pDependencyInfo)
     : SyncOpBase(command), barrier_sets_(eventCount) {
     for (uint32_t i = 0; i < eventCount; i++) {
-        const auto& dep_info = pDependencyInfo[i];
-        auto& barrier_set = barrier_sets_[i];
-        auto stage_masks = sync_utils::GetExecScopes(dep_info);
-
-        barrier_set.src_exec_scope = SyncExecScope::MakeSrc(queue_flags, stage_masks.src);
-        barrier_set.dst_exec_scope = SyncExecScope::MakeDst(queue_flags, stage_masks.dst);
-
-        barrier_set.MakeMemoryBarriers(queue_flags, dep_info);
-        barrier_set.MakeBufferMemoryBarriers(sync_state, queue_flags, dep_info.bufferMemoryBarrierCount,
-                                             dep_info.pBufferMemoryBarriers);
-        barrier_set.MakeImageMemoryBarriers(sync_state, queue_flags, dep_info.imageMemoryBarrierCount,
-                                            dep_info.pImageMemoryBarriers, sync_state.device_state->extensions);
+        barrier_sets_[i] = BarrierSet(sync_state, queue_flags, pDependencyInfo[i]);
     }
     MakeEventsList(sync_state, eventCount, pEvents);
 }

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -152,19 +152,27 @@ struct BarrierSet {
     // barrier command specifies no barriers (only exec scopes). Used for statistics tracking.
     uint32_t execution_dependency_barrier_count = 0;
 
-    void MakeMemoryBarriers(const SyncExecScope &src, const SyncExecScope &dst, uint32_t barrier_count,
-                            const VkMemoryBarrier *barriers);
-    void MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo &dep_info);
+    BarrierSet() = default;
+    BarrierSet(const SyncValidator& sync_state, VkQueueFlags queue_flags, const VkDependencyInfo& dep_info);
+    BarrierSet(const SyncValidator& sync_state, const SyncExecScope& src_exec_scope, const SyncExecScope& dst_exec_scope,
+               uint32_t memory_barrier_count, const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
+               const VkBufferMemoryBarrier* buffer_barriers, uint32_t image_barrier_count,
+               const VkImageMemoryBarrier* image_barriers);
 
-    void MakeBufferMemoryBarriers(const SyncValidator &sync_state, const SyncExecScope &src, const SyncExecScope &dst,
-                                  uint32_t barrier_count, const VkBufferMemoryBarrier *barriers);
-    void MakeBufferMemoryBarriers(const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                  const VkBufferMemoryBarrier2 *barriers);
+  private:
+    void MakeMemoryBarriers(const SyncExecScope& src, const SyncExecScope& dst, uint32_t barrier_count,
+                            const VkMemoryBarrier* barriers);
+    void MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo& dep_info);
 
-    void MakeImageMemoryBarriers(const SyncValidator &sync_state, const SyncExecScope &src, const SyncExecScope &dst,
-                                 uint32_t barrier_count, const VkImageMemoryBarrier *barriers, const DeviceExtensions &extensions);
-    void MakeImageMemoryBarriers(const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
-                                 const VkImageMemoryBarrier2 *barriers, const DeviceExtensions &extensions);
+    void MakeBufferMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                  uint32_t barrier_count, const VkBufferMemoryBarrier* barriers);
+    void MakeBufferMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                  const VkBufferMemoryBarrier2* barriers);
+
+    void MakeImageMemoryBarriers(const SyncValidator& sync_state, const SyncExecScope& src, const SyncExecScope& dst,
+                                 uint32_t barrier_count, const VkImageMemoryBarrier* barriers, const DeviceExtensions& extensions);
+    void MakeImageMemoryBarriers(const SyncValidator& sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
+                                 const VkImageMemoryBarrier2* barriers, const DeviceExtensions& extensions);
 };
 
 class SyncOpBase {
@@ -175,7 +183,6 @@ class SyncOpBase {
 
     const char *CmdName() const { return vvl::String(command_); }
 
-    virtual bool Validate(const CommandBufferAccessContext &cb_context) const = 0;
     virtual ResourceUsageTag Record(CommandBufferAccessContext& cb_context) = 0;
     virtual bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const = 0;
     virtual void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const = 0;
@@ -195,12 +202,9 @@ class SyncOpPipelineBarrier : public SyncOpBase {
                           const VkDependencyInfo& pDependencyInfo);
     ~SyncOpPipelineBarrier() override = default;
 
-    bool Validate(const CommandBufferAccessContext& cb_context) const override;
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const override;
-
-    uint32_t GetExecutionDependencyBarrierCount() const { return barrier_set_.execution_dependency_barrier_count; }
 
   private:
     // A single barrier can be applied more efficently (immidiately) compared to multiple barrier.
@@ -232,7 +236,8 @@ class SyncOpWaitEvents : public SyncOpBase {
                      const VkEvent *pEvents, const VkDependencyInfo *pDependencyInfo);
     ~SyncOpWaitEvents() override = default;
 
-    bool Validate(const CommandBufferAccessContext& cb_context) const override;
+    bool Validate(const CommandBufferAccessContext& cb_context) const;
+
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
@@ -256,7 +261,8 @@ class SyncOpResetEvent : public SyncOpBase {
                      VkPipelineStageFlags2 stageMask);
     ~SyncOpResetEvent() override = default;
 
-    bool Validate(const CommandBufferAccessContext& cb_context) const override;
+    bool Validate(const CommandBufferAccessContext& cb_context) const;
+
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState& replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext& exec_context, ResourceUsageTag exec_tag) const override;
@@ -275,7 +281,8 @@ class SyncOpSetEvent : public SyncOpBase {
                    const VkDependencyInfo &dep_info, const AccessContext *access_context);
     ~SyncOpSetEvent() override = default;
 
-    bool Validate(const CommandBufferAccessContext& cb_context) const override;
+    bool Validate(const CommandBufferAccessContext& cb_context) const;
+
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
@@ -298,7 +305,8 @@ class SyncOpBeginRenderPass : public SyncOpBase {
                           const VkSubpassBeginInfo* p_subpass_begin_info);
     ~SyncOpBeginRenderPass() override = default;
 
-    bool Validate(const CommandBufferAccessContext& cb_context) const override;
+    bool Validate(const CommandBufferAccessContext& cb_context) const;
+
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
@@ -319,7 +327,8 @@ class SyncOpNextSubpass : public SyncOpBase {
                       const VkSubpassEndInfo *pSubpassEndInfo);
     ~SyncOpNextSubpass() override = default;
 
-    bool Validate(const CommandBufferAccessContext& cb_context) const override;
+    bool Validate(const CommandBufferAccessContext& cb_context) const;
+
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;
@@ -334,7 +343,8 @@ class SyncOpEndRenderPass : public SyncOpBase {
     SyncOpEndRenderPass(vvl::Func command, const SyncValidator &sync_state, const VkSubpassEndInfo *pSubpassEndInfo);
     ~SyncOpEndRenderPass() override = default;
 
-    bool Validate(const CommandBufferAccessContext& cb_context) const override;
+    bool Validate(const CommandBufferAccessContext& cb_context) const;
+
     ResourceUsageTag Record(CommandBufferAccessContext& cb_context) override;
     bool ReplayValidate(ReplayState &replay, ResourceUsageTag recorded_tag) const override;
     void ReplayRecord(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const override;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -26,6 +26,7 @@
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/ray_tracing_state.h"
 #include "utils/convert_utils.h"
+#include "utils/image_utils.h"
 #include "utils/ray_tracing_utils.h"
 #include "utils/text_utils.h"
 #include "vk_layer_config.h"
@@ -544,21 +545,53 @@ bool SyncValidator::PreCallValidateCmdCopyImage2KHR(VkCommandBuffer commandBuffe
     return PreCallValidateCmdCopyImage2(commandBuffer, pCopyImageInfo, error_obj);
 }
 
+bool SyncValidator::ValidatePipelineBarrier(const CommandBufferAccessContext& cb_context, const BarrierSet& barrier_set,
+                                            const Location& loc) const {
+    bool skip = false;
+    const AccessContext& context = cb_context.GetCurrentAccessContext();
+
+    // Validate Image Layout transitions
+    for (const auto& image_barrier : barrier_set.image_barriers) {
+        if (!image_barrier.layout_transition) {
+            continue;
+        }
+        const vvl::Image& image_state = *image_barrier.image;
+        const bool can_transition_depth_slices =
+            CanTransitionDepthSlices(cb_context.GetSyncState().extensions, image_state.GetImageType(), image_state.create_flags);
+        const auto hazard = context.DetectImageBarrierHazard(
+            image_state, image_barrier.barrier.src_exec_scope.exec_scope, image_barrier.barrier.src_access_scope,
+            image_barrier.subresource_range, can_transition_depth_slices, AccessContext::kDetectAll);
+        if (hazard.IsHazard()) {
+            LogObjectList objlist(cb_context.GetCBState().Handle(), image_state.Handle());
+            const SyncValidator& sync_state = cb_context.GetSyncState();
+            const std::string resource_description = sync_state.FormatHandle(image_state.Handle());
+            const std::string error =
+                sync_state.error_messages_.ImageBarrierError(hazard, cb_context, loc.function, resource_description, image_barrier);
+            skip |= sync_state.SyncError(hazard.Hazard(), objlist, loc, error);
+        }
+    }
+    return skip;
+}
+
 bool SyncValidator::PreCallValidateCmdPipelineBarrier(
     VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers, const ErrorObject& error_obj) const {
     bool skip = false;
+
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const auto* cb_access_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_access_context->GetQueueFlags();
 
-    SyncOpPipelineBarrier pipeline_barrier(error_obj.location.function, *this, cb_access_context->GetQueueFlags(), srcStageMask,
-                                           dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount,
-                                           pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+    const SyncExecScope src_exec_scope(SyncExecScope::MakeSrc(queue_flags, srcStageMask));
+    const SyncExecScope dst_exec_scope(SyncExecScope::MakeDst(queue_flags, dstStageMask));
+    const BarrierSet barrier_set(*this, src_exec_scope, dst_exec_scope, memoryBarrierCount, pMemoryBarriers,
+                                 bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+
+    skip |= ValidatePipelineBarrier(*cb_access_context, barrier_set, error_obj.location);
     stats.OnBarrierCommand(memoryBarrierCount, bufferMemoryBarrierCount, imageMemoryBarrierCount,
-                           pipeline_barrier.GetExecutionDependencyBarrierCount());
-    skip |= pipeline_barrier.Validate(*cb_access_context);
+                           barrier_set.execution_dependency_barrier_count);
     return skip;
 }
 
@@ -583,14 +616,19 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier2KHR(VkCommandBuffer comman
 bool SyncValidator::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
                                                        const ErrorObject& error_obj) const {
     bool skip = false;
+
+    if (!pDependencyInfo) {
+        return skip;
+    }
     const auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     const auto* cb_access_context = GetAccessContext(*cb_state);
+    const VkQueueFlags queue_flags = cb_access_context->GetQueueFlags();
 
-    SyncOpPipelineBarrier pipeline_barrier(error_obj.location.function, *this, cb_access_context->GetQueueFlags(),
-                                           *pDependencyInfo);
+    const BarrierSet barrier_set(*this, queue_flags, *pDependencyInfo);
+
+    skip |= ValidatePipelineBarrier(*cb_access_context, barrier_set, error_obj.location);
     stats.OnBarrierCommand(pDependencyInfo->memoryBarrierCount, pDependencyInfo->bufferMemoryBarrierCount,
-                           pDependencyInfo->imageMemoryBarrierCount, pipeline_barrier.GetExecutionDependencyBarrierCount());
-    skip |= pipeline_barrier.Validate(*cb_access_context);
+                           pDependencyInfo->imageMemoryBarrierCount, barrier_set.execution_dependency_barrier_count);
     return skip;
 }
 

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -170,6 +170,8 @@ class SyncValidator : public vvl::DeviceProxy {
     bool PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
                                       const ErrorObject &error_obj) const override;
 
+    bool ValidatePipelineBarrier(const CommandBufferAccessContext& cb_context, const BarrierSet& barrier_set,
+                                 const Location& loc) const;
     bool PreCallValidateCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
                                            VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
                                            uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,


### PR DESCRIPTION
This final goal here is to do something (probably disappear in a smart way) with`ReplayState` in `sync_op.h` (because it's ugly and confusing). To better understand  this area I started with the adjacent `SyncOpBase`.

`SyncOpBase::Validate` was virtual but not really used in a polymorphic way. Instead a `SyncOpBase`-derived object was created whenever  something needed to be validated at *record time*. This PR starts with pipeline barriers. Instead of creating `SyncOp` to call Validate from it, the new approach implements validation in `ValidatePipelineBarrier` helper shared between sync1/sync2. Initialization of `BarrierSet` is also simplified - in most cases it's enough to use sync1 or sync2 constructor.