### PR TITLE
gpuav: Detect if PushData was not set correctly

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -2004,7 +2004,7 @@ bool CoreChecks::ValidateActionStateDescriptorHeap(const LastBound& last_bound_s
 
     // TODO - Currently at this level we don't know if the sampler is embedded or not
     // If there is only embedded samplers, the sampler heap isn't required to be bound
-    if (stage_state.uses_sampler_heap && !has_embedded_samplers && !cb_state.descriptor_heap.sampler_bound) {
+    if (stage_state.heap.uses_sampler_heap && !has_embedded_samplers && !cb_state.descriptor_heap.sampler_bound) {
         if (cb_state.descriptor_heap.is_sampler_invalidated) {
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::DESCRIPTOR_HEAP_11308),
                              cb_state.GetObjectList(last_bound_state.bind_point), loc,
@@ -2030,7 +2030,7 @@ bool CoreChecks::ValidateActionStateDescriptorHeap(const LastBound& last_bound_s
                              entry_point.Describe().c_str(), print_used_variables(true).c_str());
         }
     }
-    if (stage_state.uses_resource_heap && !cb_state.descriptor_heap.resource_bound) {
+    if (stage_state.heap.uses_resource_heap && !cb_state.descriptor_heap.resource_bound) {
         if (cb_state.descriptor_heap.is_resource_invalidated) {
             skip |= LogError(CreateActionVuid(loc.function, vvl::ActionVUID::DESCRIPTOR_HEAP_11308),
                              cb_state.GetObjectList(last_bound_state.bind_point), loc,

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -147,7 +147,7 @@ bool CoreChecks::ValidatePushConstantUsage(const spirv::Module& module_state, co
         return skip;
     }
 
-    if (stage_state.descriptor_heap_mode) {
+    if (stage_state.heap.descriptor_heap_mode) {
         // In DescriptorModeClassic, this is normally caught binding pipeline layouts (with ranges in them)
         const VkDeviceSize max_size = phys_dev_ext_props.descriptor_heap_props.maxPushDataSize;
         if (push_constant_variable->size > max_size) {
@@ -1610,7 +1610,7 @@ bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module& module_
     bool skip = false;
     if (!stage_state.descriptor_set_layouts) {
         return skip;
-    } else if (stage_state.descriptor_heap_mode) {
+    } else if (stage_state.heap.descriptor_heap_mode) {
         return skip;
     }
 
@@ -3513,7 +3513,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
     // resource variables are untyped (not using set/binding)
     if (!mapping_info) {
         // If not flag, this is just a "normal" vulkan 1.0 situtation
-        if (stage_state.descriptor_heap_mode) {
+        if (stage_state.heap.descriptor_heap_mode) {
             for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint.resource_interface_variables) {
                 if (!resource_variable.IsHeap()) {
                     skip |= LogError(
@@ -3533,7 +3533,7 @@ bool CoreChecks::ValidateShaderDescriptorSetAndBindingMappingInfo(const spirv::M
             }
         }
         return skip;  // rest of checks require actual mapping
-    } else if (!stage_state.descriptor_heap_mode && mapping_info->mappingCount > 0) {
+    } else if (!stage_state.heap.descriptor_heap_mode && mapping_info->mappingCount > 0) {
         // If they are here, the pipeline layout would also have to be non-null
         // Provide a warning here incase people are trying to go from normal descriptor to heap and don't realize their mappings are
         // ignored

--- a/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks_heap.cpp
@@ -120,15 +120,19 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                                                                           const LastBound& last_bound) {
         // Capture the last index into the snapshot on record time
         uint32_t heap_binding_index = vvl::kNoIndex32;  // if no heap was ever bound
+        uint32_t push_data_index = vvl::kNoIndex32;     // if no push data was ever captured
         const DescriptorHeapBindings& desc_heap_bindings = cb.shared_resources_cache.Get<DescriptorHeapBindings>();
         if (!desc_heap_bindings.bound_heap_snapshots.empty()) {
             heap_binding_index = uint32_t(desc_heap_bindings.bound_heap_snapshots.size() - 1);
         }
+        if (!desc_heap_bindings.push_data_snapshots.empty()) {
+            push_data_index = uint32_t(desc_heap_bindings.push_data_snapshots.size() - 1);
+        }
 
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger =
-            [&cb, heap_binding_index](Validator& gpuav, const Location& loc, const uint32_t* error_record,
-                                      const InstrumentedShader* instrumented_shader, std::string& out_error_msg,
-                                      std::string& out_vuid_msg) {
+            [&cb, heap_binding_index, push_data_index](Validator& gpuav, const Location& loc, const uint32_t* error_record,
+                                                       const InstrumentedShader* instrumented_shader, std::string& out_error_msg,
+                                                       std::string& out_vuid_msg) {
                 using namespace glsl;
 
                 bool error_found = false;
@@ -192,6 +196,52 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                 const bool is_source_heap_data =
                     mapping_info && mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT;
                 const bool is_combined_index = mapping_info && HasCombinedImageSamplerIndex(*mapping_info);
+
+                // If mapping uses push data, provide the value to the user (or show they just forgot to set it!)
+                uint32_t push_offset = 0;
+                const bool use_sampler_push_offset = is_combined_sampler && !is_combined_index;
+                const gpuav::DescriptorHeapBindings::PushDataSnapshot* push_data_snapshot = nullptr;
+                bool push_data_set = true;
+                bool has_two_push_dwords = false;
+                if (mapping_info) {
+                    if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT) {
+                        push_offset = use_sampler_push_offset ? mapping_info->sourceData.pushIndex.samplerPushOffset
+                                                              : mapping_info->sourceData.pushIndex.pushOffset;
+                    } else if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
+                        push_offset = use_sampler_push_offset ? mapping_info->sourceData.indirectIndex.samplerPushOffset
+                                                              : mapping_info->sourceData.indirectIndex.pushOffset;
+                        has_two_push_dwords = true;
+                    } else if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
+                        push_offset = use_sampler_push_offset ? mapping_info->sourceData.indirectIndexArray.samplerPushOffset
+                                                              : mapping_info->sourceData.indirectIndexArray.pushOffset;
+                        has_two_push_dwords = true;
+                    } else if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT) {
+                        push_offset = mapping_info->sourceData.heapData.pushOffset;
+                    } else if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_PUSH_ADDRESS_EXT) {
+                        push_offset = mapping_info->sourceData.pushAddressOffset;
+                        has_two_push_dwords = true;
+                    } else if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT) {
+                        push_offset = mapping_info->sourceData.indirectAddress.pushOffset;
+                        has_two_push_dwords = true;
+                    }
+
+                    if (push_data_index != vvl::kNoIndex32) {
+                        const DescriptorHeapBindings& desc_heap_bindings = cb.shared_resources_cache.Get<DescriptorHeapBindings>();
+                        push_data_snapshot = &desc_heap_bindings.push_data_snapshots[push_data_index];
+
+                        const uint32_t push_offset_dword = push_offset / 4;
+                        const bool dword_0_set = (push_offset_dword < push_data_snapshot->dword_mask.size() &&
+                                                  push_data_snapshot->dword_mask[push_offset_dword]);
+                        const bool dword_1_set =
+                            !has_two_push_dwords || (push_offset_dword + 1 < push_data_snapshot->dword_mask.size() &&
+                                                     push_data_snapshot->dword_mask[push_offset_dword + 1]);
+                        push_data_set = dword_0_set && dword_1_set;
+                    } else if (mapping_info->source != VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
+                        // This means they just never called it once
+                        // CONSTANT_DATA is the only mapping that doesn't use push data
+                        push_data_set = false;
+                    }
+                }
 
                 const uint32_t error_sub_code = GetSubError(error_record);
                 switch (error_sub_code) {
@@ -260,34 +310,31 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                             const uint32_t descriptor_index = error_record[kInst_LogError_ParameterOffset_0];
                             ss << "descriptor index " << std::dec << descriptor_index << " ";
                         }
-                        const bool use_sampler_push_offset = is_combined_sampler && !is_combined_index;
                         ss << "has a " << (use_sampler_push_offset ? "samplerPushOffset" : "pushOffset") << " of ";
 
-                        uint32_t push_offset = 0;
                         if (mapping_info) {
-                            if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT) {
-                                push_offset = mapping_info->sourceData.indirectAddress.pushOffset;
-                            } else if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT) {
-                                push_offset = use_sampler_push_offset ? mapping_info->sourceData.indirectIndex.samplerPushOffset
-                                                                      : mapping_info->sourceData.indirectIndex.pushOffset;
-                            } else if (mapping_info->source == VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT) {
-                                push_offset = use_sampler_push_offset
-                                                  ? mapping_info->sourceData.indirectIndexArray.samplerPushOffset
-                                                  : mapping_info->sourceData.indirectIndexArray.pushOffset;
-                            }
                             ss << std::dec << push_offset;
                         } else {
                             ss << "(unknown offset)";
                         }
 
-                        // TODO - this will report the wrong pushData, see above about capturing the cb state
-                        const VkDeviceAddress push_data = *((VkDeviceAddress*)&cb.push_data_value[push_offset]);
-
-                        ss << " which holds the VkDeviceAddress 0x" << std::hex << push_data << " which is not a multiple of ";
-                        if (error_sub_code == kErrorSubCode_DescriptorHeap_IndirectIndexPushAlignment) {
-                            ss << "4 needed to access the uint32_t in the indirect buffer\n";
+                        ss << " that value at this time is ";
+                        if (!push_data_snapshot) {
+                            ss << "[unknown] which";
                         } else {
+                            if (push_data_set) {
+                                const VkDeviceAddress push_data = *((VkDeviceAddress*)&push_data_snapshot->value[push_offset]);
+                                ss << "the VkDeviceAddress 0x" << std::hex << push_data << " which";
+                            } else {
+                                ss << "[unknown] because vkCmdPushDataEXT was not called and the undefined value";
+                            }
+                        }
+
+                        ss << " is not a multiple of ";
+                        if (has_two_push_dwords) {
                             ss << "8 needed to access the VkDeviceAddress in the indirect buffer\n";
+                        } else {
+                            ss << "4 needed to access the uint32_t in the indirect buffer\n";
                         }
 
                         vvl::ActionVUID action_vuid = (error_sub_code == kErrorSubCode_DescriptorHeap_IndirectIndexPushAlignment)
@@ -373,7 +420,14 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                 }
 
                 if (mapping_info) {
-                    ss << "Mapped with pMapping[" << std::dec << heap_status->mapping_index << "] with "
+                    // only can occur if have mappings
+                    if (!push_data_set) {
+                        ss << "- vkCmdPushDataEXT[" << std::dec << push_offset << ":"
+                           << (has_two_push_dwords ? push_offset + 7 : push_offset + 3)
+                           << "] was not called and the values are undefined\n";
+                    }
+
+                    ss << "- Mapped with pMapping[" << std::dec << heap_status->mapping_index << "] with "
                        << string_VkDescriptorMappingSourceEXT(mapping_info->source) << std::hex;
                     const uint32_t bind_offset = heap_status->binding - mapping_info->firstBinding;
                     if (bind_offset != 0) {
@@ -468,8 +522,8 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                     ss << '\n';
                 }
 
-                ss << "Descriptor type: " << string_VkDescriptorType(GetDescriptorTypeFromMask(desc_type)) << ", size " << std::dec
-                   << desc_size;
+                ss << "- Descriptor type: " << string_VkDescriptorType(GetDescriptorTypeFromMask(desc_type)) << ", size "
+                   << std::dec << desc_size;
                 if (is_untyped) {
                     if (is_buffer) {
                         ss << " (bufferDescriptorSize)";
@@ -484,7 +538,7 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
                 ss << '\n';
 
                 // Unless find otherwise, this information is useful for all errors
-                ss << "The " << (is_sampler ? "sampler" : "resource") << " heap was ";
+                ss << "- The " << (is_sampler ? "sampler" : "resource") << " heap was ";
                 if (is_sampler) {
                     if (!heap_cb_state || !heap_cb_state->sampler_bound) {
                         ss << "not bound with vkCmdBindSamplerHeapEXT";
@@ -508,9 +562,10 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
         return inst_error_logger;
     });
 
-    cb.on_instrumentation_common_desc_update_functions.emplace_back([&gpuav](CommandBufferSubState& cb, const LastBound&,
+    cb.on_instrumentation_common_desc_update_functions.emplace_back([&gpuav](CommandBufferSubState& cb, const LastBound& last_bound,
                                                                              const Location&,
                                                                              CommonDescriptorUpdate& out_update) mutable {
+        // struct DescriptorHeapEncoding
         const uint32_t bound_heap_info_size = sizeof(VkDeviceAddress) * 3;
         uint32_t buffer_size = bound_heap_info_size + (uint32_t)gpuav.phys_dev_ext_props.descriptor_heap_props.maxPushDataSize;
         vko::BufferRange output_range = cb.gpu_resources_manager.GetHostCoherentBufferRange(buffer_size);
@@ -537,6 +592,21 @@ void RegisterDescriptorChecksHeapValidation(Validator& gpuav, CommandBufferSubSt
 
         uint8_t* gpu_push_data_ptr = ((uint8_t*)output_range.offset_mapped_ptr) + bound_heap_info_size;
         memcpy(gpu_push_data_ptr, cb.push_data_value.data(), cb.push_data_value.size());
+
+        // If using the same vkCmdPushData, can use last snapshot
+        if (cb.push_data_updated) {
+            // If people are using only CONSTANT_DATA mapping or untyped, no reason to waste memory copying this
+            small_vector<const ShaderStageState*, 3> stages = last_bound.GetStages();
+            bool update_push_data = false;
+            for (const ShaderStageState* stage : stages) {
+                update_push_data |= stage->heap.uses_push_data;
+            }
+            if (update_push_data) {
+                DescriptorHeapBindings& desc_heap_bindings = cb.shared_resources_cache.Get<DescriptorHeapBindings>();
+                DescriptorHeapBindings::PushDataSnapshot push_data_snapshot{cb.base.push_data_dword_mask, cb.push_data_value};
+                desc_heap_bindings.push_data_snapshots.emplace_back(std::move(push_data_snapshot));
+            }
+        }
 
         out_update.buffer = output_range.buffer;
         out_update.offset = output_range.offset;

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1473,7 +1473,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
             }
         }
 
-        if (stage_state.descriptor_heap_mode) {
+        if (stage_state.heap.descriptor_heap_mode) {
             const VkShaderStageFlagBits stage = stage_state.GetStage();
             auto& stage_ci =
                 GetShaderStageCI<SafeCreateInfo, vku::safe_VkPipelineShaderStageCreateInfo>(modified_pipeline_ci, stage);
@@ -1704,7 +1704,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
 
                 // We only need to apply the mappings for the pipeline creation, not shader module creation
                 // Also doing here prevents adding extra (but still valid) mappings for no reason if they will never be used
-                if (modified_stage_state.descriptor_heap_mode) {
+                if (modified_stage_state.heap.descriptor_heap_mode) {
                     const VkShaderStageFlagBits stage = modified_stage_state.GetStage();
                     for (uint32_t i = 0; i < new_lib_ci.stageCount; ++i) {
                         if (new_lib_ci.pStages[i].stage == stage) {

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -94,6 +94,8 @@ void CommandBufferSubState::AllocateResources(const Location& loc) {
 void CommandBufferSubState::RecordActionCommand(LastBound& last_bound, const Location&) {
     PostCallSetupShaderInstrumentationResources(gpuav_, *this, last_bound);
     IncrementActionCommandCount(last_bound.bind_point);
+
+    push_data_updated = false;
 }
 
 void CommandBufferSubState::UpdateLastBoundDescriptorSets(VkPipelineBindPoint bind_point, const Location& loc) {
@@ -150,6 +152,7 @@ void CommandBufferSubState::RecordPushData(const VkPushDataInfoEXT& push_data_in
     }
 
     memcpy(push_data_value.data() + push_data_info.offset, push_data_info.data.address, push_data_info.data.size);
+    push_data_updated = true;
 }
 
 void CommandBufferSubState::ClearPushData() { push_data_value.clear(); }
@@ -210,6 +213,8 @@ void CommandBufferSubState::ResetCBState(bool should_destroy) {
     trace_rays_index = 0;
 
     resource_descriptor_buffer_index_ = 0;
+
+    push_data_updated = false;
 
     ClearPushConstants();
 }

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -172,6 +172,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     // Track which index we have bound our Descriptor Buffer in CmdBindDescriptorBuffersEXT
     uint32_t resource_descriptor_buffer_index_;
 
+    // At draw time if there was a vkCmdPushData called since last draw
+    bool push_data_updated = false;
+
     Validator& gpuav_;
 
   private:
@@ -229,6 +232,13 @@ class DescriptorHeapBindings {
     using OnDescriptorHeapBindingFunc =
         stdext::inplace_function<void(Validator& gpuav, CommandBufferSubState& cb, BindingCommand&, bool)>;
     OnDescriptorHeapBindingFunc on_update_bound_descriptor_heap;
+
+    // We capture the PushData each action command so the error message can reference it correctly
+    struct PushDataSnapshot {
+        std::vector<bool> dword_mask;
+        std::vector<uint8_t> value;
+    };
+    std::vector<PushDataSnapshot> push_data_snapshots;
 };
 
 class QueueSubState : public vvl::QueueSubState {

--- a/layers/state_tracker/shader_stage_state.cpp
+++ b/layers/state_tracker/shader_stage_state.cpp
@@ -79,65 +79,60 @@ const void* ShaderStageState::GetPNext() const {
     return (pipeline_create_info) ? pipeline_create_info->pNext : shader_object_create_info->pNext;
 }
 
-bool ShaderStageState::ResourceHeapIsUsed() {
-    if (!entrypoint || !spirv_state) {
-        return false;
+ShaderStageState::Heap ShaderStageState::GetHeapInfo(bool descriptor_heap_mode) {
+    Heap result;
+    if (!descriptor_heap_mode || !entrypoint || !spirv_state) {
+        return result;
     }
+    result.descriptor_heap_mode = true;
+
     const auto mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(GetPNext());
     if (!mapping_info && !spirv_state->static_data_.has_descriptor_heap) {
-        return false;  // if not using heaps at all
+        return result;  // if not using heaps at all
     }
 
     for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint->resource_interface_variables) {
-        if (!resource_variable.IsHeap() && !resource_variable.is_sampler && mapping_info) {
-            for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
-                const auto& mapping = mapping_info->pMappings[i];
-                if (IsResourceVaribleInMapping(mapping, resource_variable) &&
-                    IsValueIn(mapping.source, {VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT})) {
-                    return true;
-                }
-            }
-        } else if (resource_variable.is_resource_heap) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool ShaderStageState::SamplerHeapIsUsed() {
-    if (!entrypoint || !spirv_state) {
-        return false;
-    }
-    const auto mapping_info = vku::FindStructInPNextChain<VkShaderDescriptorSetAndBindingMappingInfoEXT>(GetPNext());
-    if (!mapping_info && !spirv_state->static_data_.has_descriptor_heap) {
-        return false;  // if not using heaps at all
-    }
-
-    for (const spirv::ResourceInterfaceVariable& resource_variable : entrypoint->resource_interface_variables) {
-        if (!resource_variable.IsHeap() && (resource_variable.is_sampler || resource_variable.is_combined_image_sampler) &&
-            mapping_info) {
-            for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
-                const auto& mapping = mapping_info->pMappings[i];
-                if (IsResourceVaribleInMapping(mapping, resource_variable) &&
-                    IsValueIn(mapping.source, {VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT,
-                                               VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT})) {
-                    return true;
-                }
-            }
+        if (resource_variable.is_resource_heap) {
+            result.uses_resource_heap = true;
+            continue;
         } else if (resource_variable.is_sampler_heap) {
-            return true;
+            result.uses_sampler_heap = true;
+            continue;
+        } else if (!mapping_info || resource_variable.IsHeap()) {
+            continue;
+        }
+
+        const bool potential_resource = (!resource_variable.is_sampler);
+        const bool potential_sampler = (resource_variable.is_sampler || resource_variable.is_combined_image_sampler);
+
+        for (uint32_t i = 0; i < mapping_info->mappingCount; i++) {
+            const auto& mapping = mapping_info->pMappings[i];
+            if (!IsResourceVaribleInMapping(mapping, resource_variable)) {
+                continue;
+            }
+
+            if (mapping.source != VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT) {
+                result.uses_push_data = true;
+            }
+
+            if (IsValueIn(mapping.source, {VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT,
+                                           VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT,
+                                           VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT,
+                                           VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_ARRAY_EXT,
+                                           VK_DESCRIPTOR_MAPPING_SOURCE_RESOURCE_HEAP_DATA_EXT,
+                                           VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_SHADER_RECORD_INDEX_EXT})) {
+                // might be both with combined image sampler
+                if (potential_resource) {
+                    result.uses_resource_heap = true;
+                }
+                if (potential_sampler) {
+                    result.uses_sampler_heap = true;
+                }
+            }
         }
     }
-    return false;
+
+    return result;
 }
 
 ShaderStageState::ShaderStageState(const vku::safe_VkPipelineShaderStageCreateInfo* pipeline_create_info,
@@ -153,6 +148,4 @@ ShaderStageState::ShaderStageState(const vku::safe_VkPipelineShaderStageCreateIn
       descriptor_set_layouts(descriptor_set_layouts),
       pipeline_layout(pipeline_layout),
       entrypoint(spirv_state ? spirv_state->FindEntrypoint(GetPName(), GetStage()) : nullptr),
-      descriptor_heap_mode(descriptor_heap_mode),
-      uses_resource_heap(ResourceHeapIsUsed()),
-      uses_sampler_heap(SamplerHeapIsUsed()) {}
+      heap(GetHeapInfo(descriptor_heap_mode)) {}

--- a/layers/state_tracker/shader_stage_state.h
+++ b/layers/state_tracker/shader_stage_state.h
@@ -59,11 +59,16 @@ struct ShaderStageState {
     VkPipelineLayout pipeline_layout;
     // If null, means it is an empty object, no SPIR-V backing it
     std::shared_ptr<const spirv::EntryPoint> entrypoint;
-    // Because this can come from a different struct depending on the Pipeline type, have it passed on creation
-    const bool descriptor_heap_mode;
-    // If the heap is used by any variable (mapping or untyped)
-    const bool uses_resource_heap;
-    const bool uses_sampler_heap;
+    // VK_EXT_descriptor_heap
+    const struct Heap {
+        // Because this can come from a different struct depending on the Pipeline type, have it passed on creation
+        bool descriptor_heap_mode = false;
+        // If the heap is used by any variable (mapping or untyped)
+        bool uses_resource_heap = false;
+        bool uses_sampler_heap = false;
+
+        bool uses_push_data = false;
+    } heap;
 
     ShaderStageState(const vku::safe_VkPipelineShaderStageCreateInfo* pipeline_create_info,
                      const vku::safe_VkShaderCreateInfoEXT* shader_object_create_info,
@@ -81,8 +86,7 @@ struct ShaderStageState {
     bool HasSpirv() const { return spirv_state.get() != nullptr && entrypoint.get() != nullptr; }
 
   private:
-    bool ResourceHeapIsUsed();
-    bool SamplerHeapIsUsed();
+    Heap GetHeapInfo(bool descriptor_heap_mode);
 };
 
 namespace spirv {

--- a/tests/unit/gpu_av_descriptor_heap.cpp
+++ b/tests/unit/gpu_av_descriptor_heap.cpp
@@ -2391,17 +2391,16 @@ TEST_F(NegativeGpuAVDescriptorHeap, SamplerReservedRange) {
 
 TEST_F(NegativeGpuAVDescriptorHeap, IndirectIndexPushDataAlignment) {
     RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
-    const VkDeviceSize resource_stride = heap_props.bufferDescriptorSize;
-    CreateResourceHeap(resource_stride, true);
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize, true);
 
     vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
-    WriteBufferToHeap(ssbo_buffer);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
 
     VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
     mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT;
     mapping.sourceData.indirectIndex.heapOffset = (uint32_t)heap_props.minResourceHeapReservedRange;
     mapping.sourceData.indirectIndex.pushOffset = 0;
-
     VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
     mapping_info.mappingCount = 1;
     mapping_info.pMappings = &mapping;
@@ -2419,12 +2418,135 @@ TEST_F(NegativeGpuAVDescriptorHeap, IndirectIndexPushDataAlignment) {
     VkDeviceAddress indirect_address = indirect_buffer.Address() + 1;
 
     m_command_buffer.Begin();
-    BindResourceHeap();
+    desc_heap.BindResourceHeap(m_command_buffer);
     m_command_buffer.PushData(0, sizeof(VkDeviceAddress), &indirect_address);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-11300");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeGpuAVDescriptorHeap, IndirectIndexPushDataAlignment2) {
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize, true);
+
+    vkt::Buffer ssbo_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    desc_heap.WriteBufferDescriptor(ssbo_buffer, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_INDIRECT_INDEX_EXT;
+    mapping.sourceData.indirectIndex.heapOffset = (uint32_t)heap_props.minResourceHeapReservedRange;
+    mapping.sourceData.indirectIndex.pushOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1;
+    mapping_info.pMappings = &mapping;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) buffer A { uint a; };
+        void main() {
+            a = 2;
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    vkt::Buffer indirect_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, vkt::device_address);
+    uint32_t* indirect_data = (uint32_t*)indirect_buffer.Memory().Map();
+    indirect_data[0] = 0;
+    indirect_data[1] = 0;
+    VkDeviceAddress indirect_address_0 = indirect_buffer.Address();
+    VkDeviceAddress indirect_address_1 = indirect_buffer.Address() + 4;
+    VkDeviceAddress indirect_address_2 = 0x12340001;
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_command_buffer.PushData(0, sizeof(VkDeviceAddress), &indirect_address_0);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.PushData(0, sizeof(VkDeviceAddress), &indirect_address_1);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    // bad
+    m_command_buffer.PushData(0, sizeof(VkDeviceAddress), &indirect_address_2);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    // good again
+    m_command_buffer.PushData(0, sizeof(VkDeviceAddress), &indirect_address_1);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+    // VUID-vkCmdDispatch-None-11300
+    m_errorMonitor->SetDesiredError("VkDeviceAddress 0x12340001");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeGpuAVDescriptorHeap, PushDataNotSet) {
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT;
+    mapping.sourceData.indirectAddress.pushOffset = 0;
+    mapping.sourceData.indirectAddress.addressOffset = 0;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1;
+    mapping_info.pMappings = &mapping;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) buffer A { uint a; };
+        void main() {
+            a = 2;
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    // only update one of the dwords to force it to be non-aligned
+    uint32_t bad_dword = 0x11111111;
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_command_buffer.PushData(0, sizeof(uint32_t), &bad_dword);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+    // VUID-vkCmdDispatch-None-11300
+    m_errorMonitor->SetDesiredError("because vkCmdPushDataEXT was not called and the undefined value");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeGpuAVDescriptorHeap, PushDataNotSetOOB) {
+    RETURN_IF_SKIP(InitGpuAVDescriptorHeap());
+    vkt::DescriptorHeap desc_heap(*this);
+    desc_heap.CreateResourceHeap(heap_props.bufferDescriptorSize, true);
+
+    VkDescriptorSetAndBindingMappingEXT mapping = MakeSetAndBindingMapping(0, 0);
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
+    // Will be OOB regardless
+    mapping.sourceData.pushIndex.heapOffset = (uint32_t)desc_heap.resource_heap_.CreateInfo().size * 2;
+    mapping.sourceData.pushIndex.heapArrayStride = 0;
+    mapping.sourceData.pushIndex.pushOffset = 8;
+    mapping.sourceData.pushIndex.heapIndexStride = 2;
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1;
+    mapping_info.pMappings = &mapping;
+
+    char const* cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) buffer A { uint a; };
+        void main() {
+            a = 2;
+        }
+    )glsl";
+    vkt::HeapComputePipeline pipe(*m_device, cs_source, SPV_ENV_VULKAN_1_0, &mapping_info);
+
+    m_command_buffer.Begin();
+    desc_heap.BindResourceHeap(m_command_buffer);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+    // VUID-vkCmdDispatch-None-11309
+    m_errorMonitor->SetDesiredError("vkCmdPushDataEXT[8:11] was not called and the values are undefined");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
1. Will know print out the correct PushData used in the shader (we currently had a TODO as we printed the last copy, which is super misleading)
2. All errors will now have what we have in GPU Dump where we warn the push data was never updated!

```
Validation Error: [ VUID-vkCmdDispatch-None-11309 ] | MessageID = 0x9fd1d538
vkCmdDispatch(): [Set 0, Binding 0, Variable ""] descriptor index 0 is accessing the resource heap at offset 0x80 (address 0x300000080) which is OOB of the heap memory.
- vkCmdPushDataEXT[8:11] was not called and the values are undefined
```

3. More test... call me CTS v2 at this point