### PR TITLE
scripts: Better checking for actual VUIDs in TODO and Notes comments

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -93,7 +93,8 @@ class ValidationSource:
                 for line in f:
                     line_num = line_num + 1
                     if True in [line.strip().startswith(comment) for comment in ['//', '/*']]:
-                        if 'VUID-' not in line or 'TODO:' in line or 'Note:' in line:
+                        vuid_pattern = r"VUID-\w+-\w+"
+                        if 'TODO:' in line or 'Note:' in line or not re.search(vuid_pattern, line):
                             continue
                     # Find vuid strings
                     if prepend is not None:


### PR DESCRIPTION
Currently there is a line in layers/core_checks/cc_vuid_maps.cpp that has 'Get*VUID-based' which will trip up the vk_validation_stats.py script thinking it is an actual VUID.

scripts/vk_validation_stats.py
- slightly better checking for VUIDs in comments